### PR TITLE
Add shard transfer method for resharding

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -610,6 +610,7 @@ impl Collection {
                     from: replica_id,
                     to: *this_peer_id,
                     shard_id,
+                    to_shard_id: None,
                     sync: true,
                     // For automatic shard transfers, always select some default method from this point on
                     method: Some(shard_transfer_method),

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -84,8 +84,7 @@ impl Collection {
                 ShardTransferMethod::Snapshot | ShardTransferMethod::WalDelta => {
                     ReplicaState::Recovery
                 }
-                // TODO(resharding): use new resharding state here? shard should already be in this state
-                ShardTransferMethod::ReshardingStreamRecords => ReplicaState::Partial,
+                ShardTransferMethod::ReshardingStreamRecords => ReplicaState::Resharding,
             };
 
             // Create local shard if it does not exist on receiver, or simply set replica state otherwise

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -84,6 +84,8 @@ impl Collection {
                 ShardTransferMethod::Snapshot | ShardTransferMethod::WalDelta => {
                     ReplicaState::Recovery
                 }
+                // TODO(resharding): use new resharding state here? shard should already be in this state
+                ShardTransferMethod::ReshardingStreamRecords => ReplicaState::Partial,
             };
 
             // Create local shard if it does not exist on receiver, or simply set replica state otherwise

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -90,14 +90,15 @@ impl<T: Hash + Copy> HashRing<T> {
             //     .collect(),
         }
     }
-}
 
-impl<T: Hash + Copy + PartialEq> HashRing<T> {
     /// Check whether the given point has moved according to this hashring
     ///
     /// Returns true if this is a resharding hashring in which both hashrings place the given point
     /// ID in a different shard.
-    pub fn has_moved<U: Hash>(&self, key: &U) -> bool {
+    pub fn has_moved<U: Hash>(&self, key: &U) -> bool
+    where
+        T: PartialEq,
+    {
         match self {
             Self::Single(_) => false,
             Self::Resharding { old, new } => old.get(key) != new.get(key),

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -92,6 +92,19 @@ impl<T: Hash + Copy> HashRing<T> {
     }
 }
 
+impl<T: Hash + Copy + PartialEq> HashRing<T> {
+    /// Check whether the given point has moved according to this hashring
+    ///
+    /// Returns true if this is a resharding hashring in which both hashrings place the given point
+    /// ID in a different shard.
+    pub fn has_moved<U: Hash>(&self, key: &U) -> bool {
+        match self {
+            Self::Single(_) => false,
+            Self::Resharding { old, new } => old.get(key) != new.get(key),
+        }
+    }
+}
+
 /// List type for shard IDs
 ///
 /// Uses a `SmallVec` putting two IDs on the stack. That's the maximum number of shards we expect

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -11,7 +11,7 @@ use crate::shards::forward_proxy_shard::ForwardProxyShard;
 use crate::shards::local_shard::clock_map::RecoveryPoint;
 use crate::shards::queue_proxy_shard::QueueProxyShard;
 use crate::shards::remote_shard::RemoteShard;
-use crate::shards::shard::{Shard, ShardId};
+use crate::shards::shard::Shard;
 use crate::shards::transfer::transfer_tasks_pool::TransferTaskProgress;
 
 impl ShardReplicaSet {
@@ -332,7 +332,7 @@ impl ShardReplicaSet {
         &self,
         offset: Option<PointIdType>,
         batch_size: usize,
-        hashring_filter: Option<(&HashRing<ShardId>, &HashRing<ShardId>)>,
+        hashring_filter: Option<&HashRing>,
     ) -> CollectionResult<Option<PointIdType>> {
         let local = self.local.read().await;
 

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -5,12 +5,13 @@ use parking_lot::Mutex;
 use segment::types::PointIdType;
 
 use super::ShardReplicaSet;
+use crate::hash_ring::HashRing;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::forward_proxy_shard::ForwardProxyShard;
 use crate::shards::local_shard::clock_map::RecoveryPoint;
 use crate::shards::queue_proxy_shard::QueueProxyShard;
 use crate::shards::remote_shard::RemoteShard;
-use crate::shards::shard::Shard;
+use crate::shards::shard::{Shard, ShardId};
 use crate::shards::transfer::transfer_tasks_pool::TransferTaskProgress;
 
 impl ShardReplicaSet {
@@ -331,6 +332,7 @@ impl ShardReplicaSet {
         &self,
         offset: Option<PointIdType>,
         batch_size: usize,
+        hashring_filter: Option<(&HashRing<ShardId>, &HashRing<ShardId>)>,
     ) -> CollectionResult<Option<PointIdType>> {
         let local = self.local.read().await;
 
@@ -342,7 +344,7 @@ impl ShardReplicaSet {
         };
 
         proxy
-            .transfer_batch(offset, batch_size, &self.search_runtime)
+            .transfer_batch(offset, batch_size, hashring_filter, &self.search_runtime)
             .await
     }
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -39,7 +39,7 @@ pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
 pub struct ShardHolder {
     shards: HashMap<ShardId, ShardReplicaSet>,
     pub(crate) shard_transfers: SaveOnDisk<HashSet<ShardTransfer>>,
-    rings: HashMap<Option<ShardKey>, HashRing>,
+    pub(crate) rings: HashMap<Option<ShardKey>, HashRing>,
     resharding: Option<ShardId>,
     key_mapping: SaveOnDisk<ShardKeyMapping>,
     // Duplicates the information from `key_mapping` for faster access

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use parking_lot::Mutex;
 use tokio::time::sleep;
 
+use super::resharding_stream_records::transfer_resharding_stream_records;
 use super::snapshot::transfer_snapshot;
 use super::stream_records::transfer_stream_records;
 use super::transfer_tasks_pool::TransferTaskProgress;
@@ -60,6 +61,18 @@ pub async fn transfer_shard(
         // Transfer shard record in batches
         ShardTransferMethod::StreamRecords => {
             transfer_stream_records(
+                shard_holder.clone(),
+                progress,
+                shard_id,
+                remote_shard,
+                collection_name,
+            )
+            .await?;
+        }
+
+        // Transfer shard record in batches for resharding
+        ShardTransferMethod::ReshardingStreamRecords => {
+            transfer_resharding_stream_records(
                 shard_holder.clone(),
                 progress,
                 shard_id,

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -45,13 +45,12 @@ pub async fn transfer_shard(
     temp_dir: &Path,
 ) -> CollectionResult<bool> {
     // The remote might target a different shard ID depending on the shard transfer type
-    let shard_id = transfer_config
-        .to_shard_id
-        .unwrap_or(transfer_config.shard_id);
+    let local_shard_id = transfer_config.shard_id;
+    let remote_shard_id = transfer_config.to_shard_id.unwrap_or(local_shard_id);
 
     // Initiate shard on a remote peer
     let remote_shard = RemoteShard::new(
-        shard_id,
+        remote_shard_id,
         collection_id.clone(),
         transfer_config.to,
         channel_service.clone(),
@@ -66,7 +65,7 @@ pub async fn transfer_shard(
             transfer_stream_records(
                 shard_holder.clone(),
                 progress,
-                shard_id,
+                local_shard_id,
                 remote_shard,
                 collection_name,
             )
@@ -78,7 +77,7 @@ pub async fn transfer_shard(
             transfer_resharding_stream_records(
                 shard_holder.clone(),
                 progress,
-                shard_id,
+                local_shard_id,
                 remote_shard,
                 collection_name,
             )
@@ -91,7 +90,7 @@ pub async fn transfer_shard(
                 transfer_config,
                 shard_holder,
                 progress,
-                shard_id,
+                local_shard_id,
                 remote_shard,
                 channel_service,
                 consensus,
@@ -108,7 +107,7 @@ pub async fn transfer_shard(
                 transfer_config.clone(),
                 shard_holder,
                 progress,
-                shard_id,
+                local_shard_id,
                 remote_shard,
                 channel_service,
                 consensus,

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -44,7 +44,10 @@ pub async fn transfer_shard(
     snapshots_path: &Path,
     temp_dir: &Path,
 ) -> CollectionResult<bool> {
-    let shard_id = transfer_config.shard_id;
+    // The remote might target a different shard ID depending on the shard transfer type
+    let shard_id = transfer_config
+        .to_shard_id
+        .unwrap_or(transfer_config.shard_id);
 
     // Initiate shard on a remote peer
     let remote_shard = RemoteShard::new(

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -121,10 +121,7 @@ pub fn validate_transfer(
         )));
     }
 
-    if matches!(
-        transfer.method,
-        Some(ShardTransferMethod::ReshardingStreamRecords)
-    ) {
+    if transfer.method == Some(ShardTransferMethod::ReshardingStreamRecords) {
         match transfer.to_shard_id {
             Some(to_shard_id) if transfer.shard_id != to_shard_id => {}
             Some(to_shard_id) => {

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -76,7 +76,11 @@ where
 /// 1. If `from` and `to` exists
 /// 2. If `from` have local shard and it is active
 /// 3. If there is no active transfers which involve `from` or `to`
-/// 4. If a target shard is only set for resharding  transfers
+/// 4. If a target shard is only set for resharding transfers
+///
+/// For resharding transfers this also checks:
+/// 1. If the source and target shards are different
+/// 2. If the source and target shardsd share the same shard key
 ///
 /// If validation fails, return `BadRequest` error.
 pub fn validate_transfer(

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -15,6 +15,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 
 pub mod driver;
 pub mod helpers;
+pub mod resharding_stream_records;
 pub mod snapshot;
 pub mod stream_records;
 pub mod transfer_tasks_pool;
@@ -103,6 +104,9 @@ pub enum ShardTransferMethod {
     Snapshot,
     /// Attempt to transfer shard difference by WAL delta.
     WalDelta,
+    /// Shard transfer for resharding: stream all records in batches until all points are
+    /// transferred.
+    ReshardingStreamRecords,
 }
 
 /// Interface to consensus for shard transfer operations.

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -110,6 +110,8 @@ pub enum ShardTransferMethod {
     WalDelta,
     /// Shard transfer for resharding: stream all records in batches until all points are
     /// transferred.
+    #[doc(hidden)]
+    #[schemars(skip)]
     ReshardingStreamRecords,
 }
 

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -38,6 +38,10 @@ pub struct ShardTransfer {
     /// Method to transfer shard with. `None` to choose automatically.
     #[serde(default)]
     pub method: Option<ShardTransferMethod>,
+    /// For resharding, a different target shard ID may be configured
+    /// By default the shard ID on the target peer is the same.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
 }
 
 impl ShardTransfer {

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -1,0 +1,141 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use super::transfer_tasks_pool::TransferTaskProgress;
+use crate::operations::types::{CollectionError, CollectionResult, CountRequestInternal};
+use crate::shards::remote_shard::RemoteShard;
+use crate::shards::shard::ShardId;
+use crate::shards::shard_holder::LockedShardHolder;
+
+const TRANSFER_BATCH_SIZE: usize = 100;
+
+/// Orchestrate shard transfer by streaming records, but only the points that fall into the new
+/// shard.
+///
+/// This is called on the sender and will arrange all that is needed for the shard transfer
+/// process.
+///
+/// This first transfers configured indices. Then it transfers all point records in batches.
+/// Updates to the local shard are forwarded to the remote concurrently.
+///
+/// # Cancel safety
+///
+/// This function is cancel safe.
+pub(super) async fn transfer_resharding_stream_records(
+    shard_holder: Arc<LockedShardHolder>,
+    progress: Arc<Mutex<TransferTaskProgress>>,
+    shard_id: ShardId,
+    remote_shard: RemoteShard,
+    collection_name: &str,
+) -> CollectionResult<()> {
+    let remote_peer_id = remote_shard.peer_id;
+
+    // TODO: actually filter points here based on hashring!
+
+    log::debug!(
+        "Starting shard {shard_id} transfer to peer {remote_peer_id} by reshard streaming records"
+    );
+
+    // Proxify local shard and create payload indexes on remote shard
+    {
+        let shard_holder = shard_holder.read().await;
+
+        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+            return Err(CollectionError::service_error(format!(
+                "Shard {shard_id} cannot be proxied because it does not exist"
+            )));
+        };
+
+        replica_set.proxify_local(remote_shard.clone()).await?;
+
+        let Some(count_result) = replica_set
+            .count_local(Arc::new(CountRequestInternal {
+                filter: None,
+                exact: true,
+            }))
+            .await?
+        else {
+            return Err(CollectionError::service_error(format!(
+                "Shard {shard_id} not found"
+            )));
+        };
+        progress.lock().points_total = count_result.count;
+
+        replica_set.transfer_indexes().await?;
+    }
+
+    // Transfer contents batch by batch
+    log::trace!("Transferring points to shard {shard_id} by reshard streaming records");
+
+    let mut offset = None;
+
+    loop {
+        let shard_holder = shard_holder.read().await;
+
+        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+            // Forward proxy gone?!
+            // That would be a programming error.
+            return Err(CollectionError::service_error(format!(
+                "Shard {shard_id} is not found"
+            )));
+        };
+
+        // TODO: don't take all points, only take points that fall into the new shard
+
+        offset = replica_set
+            .transfer_batch(offset, TRANSFER_BATCH_SIZE)
+            .await?;
+
+        {
+            let mut progress = progress.lock();
+            let transferred =
+                (progress.points_transferred + TRANSFER_BATCH_SIZE).min(progress.points_total);
+            progress.points_transferred = transferred;
+            progress.eta.set_progress(transferred);
+        }
+
+        // If this is the last batch, finalize
+        if offset.is_none() {
+            break;
+        }
+    }
+
+    // Update cutoff point on remote shard, disallow recovery before our current last seen
+    {
+        let shard_holder = shard_holder.read().await;
+        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+            // Forward proxy gone?!
+            // That would be a programming error.
+            return Err(CollectionError::service_error(format!(
+                "Shard {shard_id} is not found"
+            )));
+        };
+
+        let cutoff = replica_set.shard_recovery_point().await?;
+        let result = remote_shard
+            .update_shard_cutoff_point(collection_name, shard_id, &cutoff)
+            .await;
+
+        // Warn and ignore if remote shard is running an older version, error otherwise
+        // TODO: this is fragile, improve this with stricter matches/checks
+        match result {
+            // This string match is fragile but there does not seem to be a better way
+            Err(err)
+                if err.to_string().starts_with(
+                    "Service internal error: Tonic status error: status: Unimplemented",
+                ) =>
+            {
+                log::warn!("Cannot update cutoff point on remote shard because it is running an older version, ignoring: {err}");
+            }
+            Err(err) => return Err(err),
+            Ok(()) => {}
+        }
+    }
+
+    log::debug!(
+        "Ending shard {shard_id} transfer to peer {remote_peer_id} by reshard streaming records"
+    );
+
+    Ok(())
+}

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -29,9 +29,6 @@ pub(super) async fn transfer_resharding_stream_records(
     remote_shard: RemoteShard,
     collection_name: &str,
 ) -> CollectionResult<()> {
-    // TODO: define shard key here!
-    let shard_key = None;
-
     let remote_peer_id = remote_shard.peer_id;
     let hashring;
 
@@ -49,6 +46,11 @@ pub(super) async fn transfer_resharding_stream_records(
             )));
         };
 
+        // Derive shard key scope for this transfer from the shard ID, get the hash ring
+        let shard_key = shard_holder
+            .get_shard_id_to_key_mapping()
+            .get(&shard_id)
+            .cloned();
         hashring = shard_holder.rings.get(&shard_key).cloned().ok_or_else(|| {
             CollectionError::service_error(format!(
                 "Shard {shard_id} cannot be transferred for resharding, failed to get shard hash rings"

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -7,8 +7,7 @@ use crate::operations::types::{CollectionError, CollectionResult, CountRequestIn
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
-
-const TRANSFER_BATCH_SIZE: usize = 100;
+use crate::shards::transfer::stream_records::TRANSFER_BATCH_SIZE;
 
 /// Orchestrate shard transfer by streaming records, but only the points that fall into the new
 /// shard.

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -77,7 +77,7 @@ pub(super) async fn transfer_stream_records(
         };
 
         offset = replica_set
-            .transfer_batch(offset, TRANSFER_BATCH_SIZE)
+            .transfer_batch(offset, TRANSFER_BATCH_SIZE, None)
             .await?;
 
         {

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -8,7 +8,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
 
-const TRANSFER_BATCH_SIZE: usize = 100;
+pub(super) const TRANSFER_BATCH_SIZE: usize = 100;
 
 /// Orchestrate shard transfer by streaming records
 ///

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -306,7 +306,10 @@ impl TableOfContent {
         match transfer_operation {
             ShardTransferOperations::Start(transfer) => {
                 let collection_state::State {
-                    shards, transfers, ..
+                    shards,
+                    transfers,
+                    shards_key_mapping,
+                    ..
                 } = collection.state().await;
                 let all_peers: HashSet<_> = self
                     .channel_service
@@ -332,6 +335,7 @@ impl TableOfContent {
                     &all_peers,
                     shard_state,
                     &transfers,
+                    &shards_key_mapping,
                 )?;
 
                 let on_finish = {

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -421,6 +421,7 @@ impl TableOfContent {
                     to: transfer_restart.to,
                     sync: old_transfer.sync, // Preserve sync flag from the old transfer
                     method: Some(transfer_restart.method),
+                    to_shard_id: None,
                 };
 
                 Box::pin(

--- a/lib/storage/src/content_manager/toc/snapshots.rs
+++ b/lib/storage/src/content_manager/toc/snapshots.rs
@@ -125,6 +125,7 @@ impl TableOfContent {
         if let Some(proposal_sender) = &self.consensus_proposal_sender {
             let transfer_request = ShardTransfer {
                 shard_id,
+                to_shard_id: None,
                 from: from_peer,
                 to: to_peer,
                 sync,

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -259,6 +259,7 @@ pub async fn do_update_collection_cluster(
                         collection_name,
                         Start(ShardTransfer {
                             shard_id: move_shard.shard_id,
+                            to_shard_id: None,
                             to: move_shard.to_peer_id,
                             from: move_shard.from_peer_id,
                             sync: false,
@@ -294,6 +295,7 @@ pub async fn do_update_collection_cluster(
                         collection_name,
                         Start(ShardTransfer {
                             shard_id: replicate_shard.shard_id,
+                            to_shard_id: None,
                             to: replicate_shard.to_peer_id,
                             from: replicate_shard.from_peer_id,
                             sync: true,


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>

Adds a `ReshardingStreamRecords` shard transfer method that will be utilized as part of resharding.

### Tasks
- [x] Propagate new hash ring configuration into shard method
- [x] Only transfer points that fall into the new shard based on the hashring

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?