### PR TITLE
Faster openapi-integration snapshot tests

### DIFF
--- a/tests/openapi/openapi_integration/helpers/collection_setup.py
+++ b/tests/openapi/openapi_integration/helpers/collection_setup.py
@@ -120,6 +120,7 @@ def basic_collection_setup(
         collection_name='test_collection',
         on_disk_payload=False,
         on_disk_vectors=False,
+        wal_capacity=None,
 ):
     drop_collection(collection_name)
 
@@ -136,7 +137,10 @@ def basic_collection_setup(
             "sparse_vectors": {
                 "sparse-text": {},
             },
-            "on_disk_payload": on_disk_payload
+            "on_disk_payload": on_disk_payload,
+            "wal_config": {
+                "wal_capacity_mb": wal_capacity,
+            }
         }
     )
     assert response.ok

--- a/tests/openapi/openapi_integration/test_shard_snapshot.py
+++ b/tests/openapi/openapi_integration/test_shard_snapshot.py
@@ -14,7 +14,7 @@ collection_name = 'test_collection_snapshot'
 
 @pytest.fixture(autouse=True)
 def setup(on_disk_vectors):
-    basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
+    basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors, wal_capacity=1)
     yield
     drop_collection(collection_name=collection_name)
 

--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -14,7 +14,7 @@ collection_name = 'test_collection_snapshot'
 
 @pytest.fixture(autouse=True)
 def setup(on_disk_vectors):
-    basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
+    basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors, wal_capacity=1)
     yield
     drop_snapshots(collection_name)
     drop_collection(collection_name=collection_name)


### PR DESCRIPTION
Locally these two tests were taking ~70s to run, but by setting a low wal capacity, they now take ~9.5s.

I also tried changing the setting globally, but it only reduces around 3s for the whole suite, so I don't think it is enough gain.
