### PR TITLE
Use TypedMultiDenseVectorRef everywhere

### DIFF
--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
+use super::named_vectors::CowMultiVector;
 use super::vectors::TypedMultiDenseVector;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte};
 use crate::spaces::metric::Metric;
@@ -25,12 +26,12 @@ pub trait PrimitiveVectorElement:
     fn datatype() -> VectorStorageDatatype;
 
     fn from_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<VectorElementType>>,
-    ) -> Cow<TypedMultiDenseVector<Self>>;
+        multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self>;
 
     fn into_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<Self>>,
-    ) -> Cow<TypedMultiDenseVector<VectorElementType>>;
+        multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType>;
 }
 
 impl PrimitiveVectorElement for VectorElementType {
@@ -55,14 +56,14 @@ impl PrimitiveVectorElement for VectorElementType {
     }
 
     fn from_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<VectorElementType>>,
-    ) -> Cow<TypedMultiDenseVector<Self>> {
+        multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self> {
         multivector
     }
 
     fn into_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<Self>>,
-    ) -> Cow<TypedMultiDenseVector<VectorElementType>> {
+        multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType> {
         multivector
     }
 }
@@ -109,28 +110,30 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
     }
 
     fn from_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<VectorElementType>>,
-    ) -> Cow<TypedMultiDenseVector<Self>> {
-        Cow::Owned(TypedMultiDenseVector::new(
+        multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self> {
+        CowMultiVector::Owned(TypedMultiDenseVector::new(
             multivector
+                .as_vec_ref()
                 .flattened_vectors
                 .iter()
                 .map(|&x| x as Self)
                 .collect_vec(),
-            multivector.dim,
+            multivector.as_vec_ref().dim,
         ))
     }
 
     fn into_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<Self>>,
-    ) -> Cow<TypedMultiDenseVector<VectorElementType>> {
-        Cow::Owned(TypedMultiDenseVector::new(
+        multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType> {
+        CowMultiVector::Owned(TypedMultiDenseVector::new(
             multivector
+                .as_vec_ref()
                 .flattened_vectors
                 .iter()
                 .map(|&x| x as VectorElementType)
                 .collect_vec(),
-            multivector.dim,
+            multivector.as_vec_ref().dim,
         ))
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -1,9 +1,9 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
 
 use super::score_multi;
+use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
     DenseVector, MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef,
@@ -48,7 +48,8 @@ impl<
                     .collect();
                 let preprocessed = MultiDenseVector::new(preprocessed, vector.dim);
                 let converted =
-                    TElement::from_float_multivector(Cow::Owned(preprocessed)).into_owned();
+                    TElement::from_float_multivector(CowMultiVector::Owned(preprocessed))
+                        .to_owned();
                 Ok(converted)
             })
             .unwrap();
@@ -80,7 +81,7 @@ impl<
             score_multi::<TElement, TMetric>(
                 self.vector_storage.multi_vector_config(),
                 TypedMultiDenseVectorRef::from(example),
-                stored.clone(),
+                stored,
             )
         })
     }

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -1,9 +1,9 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
 
 use super::score_multi;
+use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
     DenseVector, MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef,
@@ -38,7 +38,7 @@ impl<
             .collect();
         let preprocessed = MultiDenseVector::new(preprocessed, query.dim);
         Self {
-            query: TElement::from_float_multivector(Cow::Owned(preprocessed)).into_owned(),
+            query: TElement::from_float_multivector(CowMultiVector::Owned(preprocessed)).to_owned(),
             vector_storage,
             metric: PhantomData,
         }

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 use tempfile::Builder;
 
 use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
-use crate::data_types::vectors::{MultiDenseVector, QueryVector};
+use crate::data_types::vectors::{MultiDenseVector, QueryVector, TypedMultiDenseVectorRef};
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
 use crate::types::{Distance, MultiVectorConfig};
@@ -59,8 +59,8 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     // Check that all points are inserted
     for (i, vec) in points.iter().enumerate() {
         let stored_vec = borrowed_storage.get_vector(i as PointOffsetType);
-        let multi_dense: &MultiDenseVector = stored_vec.as_vec_ref().try_into().unwrap();
-        assert_eq!(multi_dense, vec);
+        let multi_dense: TypedMultiDenseVectorRef<_> = stored_vec.as_vec_ref().try_into().unwrap();
+        assert_eq!(multi_dense.to_owned(), vec.clone());
     }
 
     // Delete select number of points

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -7,8 +7,8 @@ use rand::prelude::StdRng;
 use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use segment::data_types::vectors::{
-    only_default_vector, MultiDenseVector, QueryVector, VectorElementType, VectorRef,
-    DEFAULT_VECTOR_NAME,
+    only_default_vector, MultiDenseVector, QueryVector, TypedMultiDenseVectorRef,
+    VectorElementType, VectorRef, DEFAULT_VECTOR_NAME,
 };
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::index_fixtures::random_vector;
@@ -109,7 +109,10 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         let internal_id = segment.id_tracker.borrow().internal_id(idx).unwrap();
         multi_storage
             .borrow_mut()
-            .insert_vector(internal_id, VectorRef::MultiDense(&vector_multi))
+            .insert_vector(
+                internal_id,
+                VectorRef::MultiDense(TypedMultiDenseVectorRef::from(&vector_multi)),
+            )
             .unwrap();
     }
 

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -141,26 +141,6 @@ def test_multi_vector_float_persisted():
 
 
 def test_multi_vector_validation():
-    # fails because uses dense vector
-    response = request_with_validation(
-        api='/collections/{collection_name}/points',
-        method="PUT",
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={
-            "points": [
-                {
-                    "id": 1,
-                    "vector": {
-                        "my-multivec": [0.19, 0.81, 0.75, 0.11]
-                    }
-                }
-            ]
-        }
-    )
-    assert not response.ok
-    assert 'Wrong input: Conversion between multi and regular vectors failed' in response.json()["status"]["error"]
-
     # fails because it uses and empty multi vector
     response = request_with_validation(
         api='/collections/{collection_name}/points',
@@ -226,7 +206,7 @@ def test_multi_vector_validation():
     assert 'Validation error in JSON body: [points[0].vector.?.data: all vectors must be non-empty]' in \
            response.json()["status"]["error"]
 
-    # fails because it uses one inner vector
+    # fails because it uses inner vectors with different dimentions
     response = request_with_validation(
         api='/collections/{collection_name}/points',
         method="PUT",


### PR DESCRIPTION
`TypedMultiDenseVectorRef` replaces `&TypedMultiDenseVector`. `TypedMultiDenseVectorRef` is important because it allows referring multivector data from mmap or `ChunkedVectors`.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
