### PR TITLE
Combine (re)sharding hash rings in a single type, update split-by-shard logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2",
+ "smallvec",
  "sparse",
  "strum",
  "tar",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -38,6 +38,7 @@ hashring = "0.3.3"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 bitvec = "1.0.1"
 lazy_static = "1.4.0"
+smallvec = "1.13.2"
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -208,14 +208,25 @@ impl Validate for CollectionUpdateOperations {
     }
 }
 
-fn point_to_shard(point_id: ExtendedPointId, ring: &ShardHashRing) -> ShardId {
-    *ring
-        .get(&point_id)
-        .expect("Hash ring is guaranteed to be non-empty")
+/// Get the shards for a point ID
+///
+/// Normally returns a single shard ID. Might return multiple if resharding is currently in
+/// progress.
+///
+/// # Panics
+///
+/// Panics if the hash ring is empty and there is no shard for the given point ID.
+fn point_to_shards(point_id: &ExtendedPointId, ring: &ShardHashRing) -> Vec<ShardId> {
+    let shard_ids = ring.get(point_id);
+    assert!(
+        !shard_ids.is_empty(),
+        "Hash ring is guaranteed to be non-empty",
+    );
+    shard_ids
 }
 
 /// Split iterator of items that have point ids by shard
-fn split_iter_by_shard<I, F, O>(
+fn split_iter_by_shard<I, F, O: Clone>(
     iter: I,
     id_extractor: F,
     ring: &ShardHashRing,
@@ -226,8 +237,12 @@ where
 {
     let mut op_vec_by_shard: HashMap<ShardId, Vec<O>> = HashMap::new();
     for operation in iter {
-        let shard_id = point_to_shard(id_extractor(&operation), ring);
-        op_vec_by_shard.entry(shard_id).or_default().push(operation);
+        for shard_id in point_to_shards(&id_extractor(&operation), ring) {
+            op_vec_by_shard
+                .entry(shard_id)
+                .or_default()
+                .push(operation.clone());
+        }
     }
     OperationToShard::by_shard(op_vec_by_shard)
 }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -27,7 +27,7 @@ use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_holder::ShardHashRing;
+use crate::shards::shard_holder::{ShardHashRing, ShardIds};
 
 pub type ClockToken = u64;
 
@@ -216,7 +216,7 @@ impl Validate for CollectionUpdateOperations {
 /// # Panics
 ///
 /// Panics if the hash ring is empty and there is no shard for the given point ID.
-fn point_to_shards(point_id: &ExtendedPointId, ring: &ShardHashRing) -> Vec<ShardId> {
+fn point_to_shards(point_id: &ExtendedPointId, ring: &ShardHashRing) -> ShardIds {
     let shard_ids = ring.get(point_id);
     assert!(
         !shard_ids.is_empty(),

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -7,9 +7,8 @@ use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{split_iter_by_shard, OperationToShard, SplitByShard};
-use crate::hash_ring::HashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
-use crate::shards::shard::ShardId;
+use crate::shards::shard_holder::ShardHashRing;
 
 /// This data structure is used in API interface and applied across multiple shards
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
@@ -176,7 +175,7 @@ impl Validate for PayloadOps {
 }
 
 impl SplitByShard for PayloadOps {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         match self {
             PayloadOps::SetPayload(operation) => {
                 operation.split_by_shard(ring).map(PayloadOps::SetPayload)
@@ -195,7 +194,7 @@ impl SplitByShard for PayloadOps {
 }
 
 impl SplitByShard for DeletePayloadOp {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         match (&self.points, &self.filter) {
             (Some(_), _) => {
                 split_iter_by_shard(self.points.unwrap(), |id| *id, ring).map(|points| {
@@ -213,7 +212,7 @@ impl SplitByShard for DeletePayloadOp {
 }
 
 impl SplitByShard for SetPayloadOp {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         match (&self.points, &self.filter) {
             (Some(_), _) => {
                 split_iter_by_shard(self.points.unwrap(), |id| *id, ring).map(|points| {

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -13,10 +13,10 @@ use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{point_to_shard, split_iter_by_shard, OperationToShard, SplitByShard};
-use crate::hash_ring::HashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::operations::types::Record;
 use crate::shards::shard::ShardId;
+use crate::shards::shard_holder::ShardHashRing;
 
 /// Defines write ordering guarantees for collection operations
 ///
@@ -295,7 +295,7 @@ impl Validate for Batch {
 }
 
 impl SplitByShard for PointInsertOperationsInternal {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         match self {
             PointInsertOperationsInternal::PointsBatch(batch) => batch
                 .split_by_shard(ring)
@@ -374,7 +374,7 @@ impl Validate for PointOperations {
 }
 
 impl SplitByShard for Batch {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         let batch = self;
         let mut batch_by_shard: HashMap<ShardId, Batch> = HashMap::new();
         let Batch {
@@ -482,13 +482,13 @@ impl SplitByShard for Batch {
 }
 
 impl SplitByShard for Vec<PointStruct> {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         split_iter_by_shard(self, |point| point.id, ring)
     }
 }
 
 impl SplitByShard for PointOperations {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         match self {
             PointOperations::UpsertPoints(upsert_points) => upsert_points
                 .split_by_shard(ring)

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -9,9 +9,8 @@ use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::point_ops::PointIdsList;
 use super::{point_to_shard, split_iter_by_shard, OperationToShard, SplitByShard};
-use crate::hash_ring::HashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
-use crate::shards::shard::ShardId;
+use crate::shards::shard_holder::ShardHashRing;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 pub struct UpdateVectors {
@@ -102,13 +101,13 @@ impl Validate for VectorOperations {
 }
 
 impl SplitByShard for Vec<PointVectors> {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         split_iter_by_shard(self, |point| point.id, ring)
     }
 }
 
 impl SplitByShard for VectorOperations {
-    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
         match self {
             VectorOperations::UpdateVectors(update_vectors) => {
                 let shard_points = update_vectors

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -40,41 +41,62 @@ pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
 pub struct ShardHolder {
     shards: HashMap<ShardId, ShardReplicaSet>,
     pub(crate) shard_transfers: SaveOnDisk<HashSet<ShardTransfer>>,
-    rings: HashMap<RingsKey, HashRing<ShardId>>,
+    rings: HashMap<Option<ShardKey>, ShardHashRing>,
     key_mapping: SaveOnDisk<ShardKeyMapping>,
     // Duplicates the information from `key_mapping` for faster access
     // Do not require locking
     shard_id_to_key_mapping: HashMap<ShardId, ShardKey>,
 }
 
-pub type LockedShardHolder = RwLock<ShardHolder>;
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub enum RingsKey {
-    Default,
-    ShardKey(ShardKey),
-    Resharding,
+pub enum ShardHashRing {
+    /// Single hashring
+    Single(HashRing<ShardId>),
+    /// Two hashrings when transitioning during resharding
+    /// Depending on the current resharding state, points may be in either or both shards.
+    Resharding {
+        old: HashRing<ShardId>,
+        new: HashRing<ShardId>,
+    },
 }
 
-impl From<Option<ShardKey>> for RingsKey {
-    fn from(shard_key: Option<ShardKey>) -> Self {
-        match shard_key {
-            Some(shard_key) => shard_key.into(),
-            None => Self::Default,
+impl ShardHashRing {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Single(ring) => ring.is_empty(),
+            Self::Resharding { old, new } => old.is_empty() && new.is_empty(),
+        }
+    }
+
+    pub fn add(&mut self, shard: ShardId) {
+        match self {
+            Self::Single(ring) => ring.add(shard),
+            // When resharding, update the new ring
+            Self::Resharding { old: _, new } => new.add(shard),
+        }
+    }
+
+    pub fn get<U: Hash>(&self, key: &U) -> Option<&ShardId> {
+        match self {
+            Self::Single(ring) => ring.get(key),
+            Self::Resharding { old, new: _ } => old.get(key),
         }
     }
 }
 
-impl From<ShardKey> for RingsKey {
-    fn from(shard_key: ShardKey) -> Self {
-        Self::ShardKey(shard_key)
+impl From<HashRing<ShardId>> for ShardHashRing {
+    fn from(ring: HashRing<ShardId>) -> Self {
+        Self::Single(ring)
     }
 }
 
+pub type LockedShardHolder = RwLock<ShardHolder>;
+
 impl ShardHolder {
     pub fn new(collection_path: &Path) -> CollectionResult<Self> {
-        let mut rings = HashMap::new();
-        rings.insert(RingsKey::Default, HashRing::fair(HASH_RING_SHARD_SCALE));
+        let rings = HashMap::from([(
+            None,
+            ShardHashRing::from(HashRing::fair(HASH_RING_SHARD_SCALE)),
+        )]);
         let shard_transfers = SaveOnDisk::load_or_init(collection_path.join(SHARD_TRANSFERS_FILE))?;
         let key_mapping: SaveOnDisk<ShardKeyMapping> =
             SaveOnDisk::load_or_init(collection_path.join(SHARD_KEY_MAPPING_FILE))?;
@@ -126,8 +148,8 @@ impl ShardHolder {
     ) -> Result<(), CollectionError> {
         self.shards.insert(shard_id, shard);
         self.rings
-            .entry(shard_key.clone().into())
-            .or_insert_with(|| HashRing::fair(HASH_RING_SHARD_SCALE))
+            .entry(shard_key.clone())
+            .or_insert_with(|| ShardHashRing::from(HashRing::fair(HASH_RING_SHARD_SCALE)))
             .add(shard_id);
 
         if let Some(shard_key) = shard_key {
@@ -176,14 +198,16 @@ impl ShardHolder {
     }
 
     fn rebuild_rings(&mut self) {
-        let mut rings = HashMap::new();
-        rings.insert(RingsKey::Default, HashRing::fair(HASH_RING_SHARD_SCALE));
+        let mut rings = HashMap::from([(
+            None,
+            ShardHashRing::from(HashRing::fair(HASH_RING_SHARD_SCALE)),
+        )]);
         let ids_to_key = self.get_shard_id_to_key_mapping();
         for shard_id in self.shards.keys() {
             let shard_key = ids_to_key.get(shard_id).cloned();
             rings
-                .entry(shard_key.into())
-                .or_insert_with(|| HashRing::fair(HASH_RING_SHARD_SCALE))
+                .entry(shard_key)
+                .or_insert_with(|| ShardHashRing::from(HashRing::fair(HASH_RING_SHARD_SCALE)))
                 .add(*shard_id);
         }
 
@@ -242,7 +266,7 @@ impl ShardHolder {
         operation: O,
         shard_keys_selection: &Option<ShardKey>,
     ) -> CollectionResult<Vec<(&ShardReplicaSet, O)>> {
-        let Some(hashring) = self.rings.get(&shard_keys_selection.clone().into()) else {
+        let Some(hashring) = self.rings.get(&shard_keys_selection.clone()) else {
             return if let Some(shard_key) = shard_keys_selection {
                 Err(CollectionError::bad_input(format!(
                     "Shard key {shard_key} not found"

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -75,10 +75,17 @@ impl ShardHashRing {
         }
     }
 
-    pub fn get<U: Hash>(&self, key: &U) -> Option<&ShardId> {
+    pub fn get<U: Hash>(&self, key: &U) -> Vec<ShardId> {
         match self {
-            Self::Single(ring) => ring.get(key),
-            Self::Resharding { old, new: _ } => old.get(key),
+            Self::Single(ring) => ring.get(key).into_iter().cloned().collect(),
+            Self::Resharding { old, new } => old
+                .get(key)
+                .into_iter()
+                .chain(new.get(key))
+                // Both hash rings may return the same shard ID, take it once
+                .dedup()
+                .cloned()
+                .collect(),
         }
     }
 }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -92,14 +92,17 @@ impl ShardHashRing {
     pub fn get<U: Hash>(&self, key: &U) -> ShardIds {
         match self {
             Self::Single(ring) => ring.get(key).into_iter().cloned().collect(),
-            Self::Resharding { old, new } => old
-                .get(key)
-                .into_iter()
-                .chain(new.get(key))
-                // Both hash rings may return the same shard ID, take it once
-                .dedup()
-                .cloned()
-                .collect(),
+            // TODO(resharding): just use the old hash ring for now, never route to two shards
+            // TODO(resharding): switch to both as commented below once read folding is implemented
+            Self::Resharding { old, new: _ } => old.get(key).into_iter().cloned().collect(),
+            // Self::Resharding { old, new } => old
+            //     .get(key)
+            //     .into_iter()
+            //     .chain(new.get(key))
+            //     // Both hash rings may return the same shard ID, take it once
+            //     .dedup()
+            //     .cloned()
+            //     .collect(),
         }
     }
 }


### PR DESCRIPTION
Tracked in #4213.

This combines (re)sharding hash rings in a single type, replacing the single hash ring we had before. It provides a consistent interface for all scenarios, whether we have a single hash ring or multiple while resharding. It keeping most of the existing logic intact, and allows us to extend and/or tweak behavior in a single place in the future.

Here I propose to replace the initial approach with a separate hash ring on a shared resharding key introduced in <https://github.com/qdrant/qdrant/pull/4216>. It seems more future proof, easier to manage, and remains on the shard key level. When working with shards, we always namespace to a specific shard key and so it makes sense to combine all necessary state in a single type with a single lookup.

It doesn't only replace the way of storing a resharding hash ring, but also updates all point-to-shard routing to spread to two shards in case of resharding.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?