### PR TITLE
Add `ReshardingOperation::Start` consensus message

### DIFF
--- a/lib/collection/benches/hash_ring_bench.rs
+++ b/lib/collection/benches/hash_ring_bench.rs
@@ -1,15 +1,15 @@
 #[cfg(not(target_os = "windows"))]
 mod prof;
 
-use collection::hash_ring::HashRing;
+use collection::hash_ring::Inner;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
 fn hash_ring_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("hash-ring-bench");
 
-    let mut ring_raw = HashRing::raw();
-    let mut ring_fair = HashRing::fair(100);
+    let mut ring_raw = Inner::raw();
+    let mut ring_fair = Inner::fair(100);
 
     // add 10 shards to ring
     for i in 0..10 {

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -658,6 +658,7 @@ impl Collection {
         &self,
         peer_id: PeerId,
         shard_id: ShardId,
+        shard_key: Option<ShardKey>,
     ) -> CollectionResult<()> {
         // TODO: Improve error handling?
 
@@ -681,7 +682,7 @@ impl Collection {
             .create_replica_set(shard_id, &[peer_id], Some(ReplicaState::Resharding))
             .await?;
 
-        shard_holder.start_resharding(shard_id, replica_set)?;
+        shard_holder.start_resharding(shard_id, replica_set, shard_key.clone())?;
 
         self.resharding_state.write(|state| {
             debug_assert!(
@@ -690,7 +691,7 @@ impl Collection {
                 self.id
             );
 
-            *state = Some(resharding::State::new(peer_id, shard_id));
+            *state = Some(resharding::State::new(peer_id, shard_id, shard_key));
         })?;
 
         Ok(())

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -101,7 +101,7 @@ impl Collection {
     ) -> Result<Self, CollectionError> {
         let start_time = std::time::Instant::now();
 
-        let mut shard_holder = ShardHolder::new(path)?;
+        let mut shard_holder = ShardHolder::new(path, None)?;
 
         let shared_collection_config = Arc::new(RwLock::new(collection_config.clone()));
         for (shard_id, mut peers) in shard_distribution.shards {
@@ -208,7 +208,14 @@ impl Collection {
         });
         collection_config.validate_and_warn();
 
-        let mut shard_holder = ShardHolder::new(path).expect("Can not create shard holder");
+        let resharding_state = Self::load_resharding_state(path)
+            .expect("Can't load or initialize resharding progress");
+
+        let mut shard_holder = ShardHolder::new(
+            path,
+            resharding_state.read().as_ref().map(|state| state.shard_id),
+        )
+        .expect("Can not create shard holder");
 
         let shared_collection_config = Arc::new(RwLock::new(collection_config.clone()));
 
@@ -232,9 +239,6 @@ impl Collection {
 
         let payload_index_schema = Self::load_payload_index_schema(path)
             .expect("Can't load or initialize payload index schema");
-
-        let resharding_state = Self::load_resharding_state(path)
-            .expect("Can't load or initialize resharding progress");
 
         Self {
             id: collection_id.clone(),
@@ -646,6 +650,48 @@ impl Collection {
                 break;
             }
         }
+
+        Ok(())
+    }
+
+    pub async fn start_resharding(
+        &self,
+        peer_id: PeerId,
+        shard_id: ShardId,
+    ) -> CollectionResult<()> {
+        // TODO: Improve error handling?
+
+        let mut shard_holder = self.shards_holder.write().await;
+
+        if self.resharding_state.read().is_some() {
+            return Err(CollectionError::bad_request(format!(
+                "resharding of collection {} is already in progress",
+                self.id
+            )));
+        }
+
+        if shard_holder.get_shard(&shard_id).is_some() {
+            return Err(CollectionError::bad_shard_selection(format!(
+                "shard {shard_id} already exists in collection {}",
+                self.id
+            )));
+        }
+
+        let replica_set = self
+            .create_replica_set(shard_id, &[peer_id], Some(ReplicaState::Resharding))
+            .await?;
+
+        shard_holder.start_resharding(shard_id, replica_set)?;
+
+        self.resharding_state.write(|state| {
+            debug_assert!(
+                state.is_none(),
+                "resharding of collection {} is already in progress",
+                self.id
+            );
+
+            *state = Some(resharding::State::new(peer_id, shard_id));
+        })?;
 
         Ok(())
     }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -22,6 +22,7 @@ use semver::Version;
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
 
+use self::resharding::ReshardingState;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_state::{ShardInfo, State};
 use crate::common::is_ready::IsReady;
@@ -52,7 +53,7 @@ pub struct Collection {
     pub(crate) collection_config: Arc<RwLock<CollectionConfig>>,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
     pub(crate) payload_index_schema: SaveOnDisk<PayloadIndexSchema>,
-    resharding_state: SaveOnDisk<Option<resharding::State>>,
+    resharding_state: SaveOnDisk<Option<ReshardingState>>,
     this_peer_id: PeerId,
     path: PathBuf,
     snapshots_path: PathBuf,
@@ -270,7 +271,7 @@ impl Collection {
 
     fn load_resharding_state(
         collection_path: &Path,
-    ) -> CollectionResult<SaveOnDisk<Option<resharding::State>>> {
+    ) -> CollectionResult<SaveOnDisk<Option<ReshardingState>>> {
         let resharding_state_file = Self::resharding_state_file(collection_path);
         let resharding_state = SaveOnDisk::load_or_init(resharding_state_file)?;
         Ok(resharding_state)
@@ -691,7 +692,7 @@ impl Collection {
                 self.id
             );
 
-            *state = Some(resharding::State::new(peer_id, shard_id, shard_key));
+            *state = Some(ReshardingState::new(peer_id, shard_id, shard_key));
         })?;
 
         Ok(())

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -660,7 +660,7 @@ impl Collection {
         shard_id: ShardId,
         shard_key: Option<ShardKey>,
     ) -> CollectionResult<()> {
-        // TODO: Improve error handling?
+        // TODO(resharding): Improve error handling?
 
         let mut shard_holder = self.shards_holder.write().await;
 

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -1,3 +1,4 @@
+use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
 
 use crate::shards::shard::{PeerId, ShardId};
@@ -6,11 +7,16 @@ use crate::shards::shard::{PeerId, ShardId};
 pub struct State {
     pub peer_id: PeerId,
     pub shard_id: ShardId,
+    pub shard_key: Option<ShardKey>,
 }
 
 impl State {
     #[allow(dead_code)]
-    pub fn new(peer_id: PeerId, shard_id: ShardId) -> Self {
-        Self { peer_id, shard_id }
+    pub fn new(peer_id: PeerId, shard_id: ShardId, shard_key: Option<ShardKey>) -> Self {
+        Self {
+            peer_id,
+            shard_id,
+            shard_key,
+        }
     }
 }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -4,13 +4,13 @@ use serde::{Deserialize, Serialize};
 use crate::shards::shard::{PeerId, ShardId};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct State {
+pub struct ReshardingState {
     pub peer_id: PeerId,
     pub shard_id: ShardId,
     pub shard_key: Option<ShardKey>,
 }
 
-impl State {
+impl ReshardingState {
     #[allow(dead_code)]
     pub fn new(peer_id: PeerId, shard_id: ShardId, shard_key: Option<ShardKey>) -> Self {
         Self {

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -16,6 +16,7 @@ impl Collection {
         &self,
         shard_id: ShardId,
         replicas: &[PeerId],
+        init_state: Option<ReplicaState>,
     ) -> Result<ShardReplicaSet, CollectionError> {
         let is_local = replicas.contains(&self.this_peer_id);
 
@@ -40,7 +41,7 @@ impl Collection {
             self.update_runtime.clone(),
             self.search_runtime.clone(),
             self.optimizer_cpu_budget.clone(),
-            Some(ReplicaState::Active),
+            init_state.or(Some(ReplicaState::Active)),
         )
         .await
     }
@@ -100,7 +101,7 @@ impl Collection {
             let shard_id = max_shard_id + idx as ShardId + 1;
 
             let replica_set = self
-                .create_replica_set(shard_id, shard_replicas_placement)
+                .create_replica_set(shard_id, shard_replicas_placement, None)
                 .await?;
 
             for (field_name, field_schema) in payload_schema.iter() {

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -92,7 +92,9 @@ impl Collection {
                 Some(replica_set) => replica_set.apply_state(shard_info.replicas).await?,
                 None => {
                     let shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
-                    let replica_set = self.create_replica_set(shard_id, &shard_replicas).await?;
+                    let replica_set = self
+                        .create_replica_set(shard_id, &shard_replicas, None)
+                        .await?;
                     replica_set.apply_state(shard_info.replicas).await?;
                     extra_shards.insert(shard_id, replica_set);
                 }

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,4 +1,5 @@
 use std::hash::Hash;
+use std::mem;
 
 #[derive(Clone)]
 pub enum HashRing<T: Hash + Copy> {
@@ -10,6 +11,28 @@ pub enum HashRing<T: Hash + Copy> {
 }
 
 impl<T: Hash + Copy> HashRing<T> {
+    // `hashring::HashRing` does not implement `Clone`, so we have to do this... 🤦‍♀️
+    pub fn clone(&mut self) -> Self {
+        match self {
+            HashRing::Raw(ring) => {
+                let (this, other) = duplicate(mem::take(ring));
+                *ring = this;
+
+                Self::Raw(other)
+            }
+
+            HashRing::Fair { ring, scale } => {
+                let (this, other) = duplicate(mem::take(ring));
+                *ring = this;
+
+                Self::Fair {
+                    ring: other,
+                    scale: *scale,
+                }
+            }
+        }
+    }
+
     pub fn raw() -> Self {
         Self::Raw(hashring::HashRing::new())
     }
@@ -70,6 +93,22 @@ impl<T: Hash + Copy> HashRing<T> {
             HashRing::Fair { ring, .. } => ring.is_empty(),
         }
     }
+}
+
+// `hashring::HashRing` does not implement `Clone`, so we have to do this... 🤦‍♀️
+fn duplicate<T>(ring: hashring::HashRing<T>) -> (hashring::HashRing<T>, hashring::HashRing<T>)
+where
+    T: Clone + Hash,
+{
+    let nodes: Vec<_> = ring.into_iter().collect();
+
+    let mut first = hashring::HashRing::new();
+    first.batch_add(nodes.clone());
+
+    let mut second = hashring::HashRing::new();
+    second.batch_add(nodes);
+
+    (first, second)
 }
 
 #[cfg(test)]

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -11,28 +11,6 @@ pub enum HashRing<T: Hash + Copy> {
 }
 
 impl<T: Hash + Copy> HashRing<T> {
-    // `hashring::HashRing` does not implement `Clone`, so we have to do this... 🤦‍♀️
-    pub fn clone(&mut self) -> Self {
-        match self {
-            HashRing::Raw(ring) => {
-                let (this, other) = duplicate(mem::take(ring));
-                *ring = this;
-
-                Self::Raw(other)
-            }
-
-            HashRing::Fair { ring, scale } => {
-                let (this, other) = duplicate(mem::take(ring));
-                *ring = this;
-
-                Self::Fair {
-                    ring: other,
-                    scale: *scale,
-                }
-            }
-        }
-    }
-
     pub fn raw() -> Self {
         Self::Raw(hashring::HashRing::new())
     }
@@ -93,22 +71,6 @@ impl<T: Hash + Copy> HashRing<T> {
             HashRing::Fair { ring, .. } => ring.is_empty(),
         }
     }
-}
-
-// `hashring::HashRing` does not implement `Clone`, so we have to do this... 🤦‍♀️
-fn duplicate<T>(ring: hashring::HashRing<T>) -> (hashring::HashRing<T>, hashring::HashRing<T>)
-where
-    T: Clone + Hash,
-{
-    let nodes: Vec<_> = ring.into_iter().collect();
-
-    let mut first = hashring::HashRing::new();
-    first.batch_add(nodes.clone());
-
-    let mut second = hashring::HashRing::new();
-    second.batch_add(nodes);
-
-    (first, second)
 }
 
 #[cfg(test)]

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -7,7 +7,7 @@ use crate::shards::shard::ShardId;
 const HASH_RING_SHARD_SCALE: u32 = 100;
 
 #[derive(Clone)]
-pub enum ShardHashRing {
+pub enum HashRing {
     /// Single hashring
     Single(Inner<ShardId>),
 
@@ -19,7 +19,7 @@ pub enum ShardHashRing {
     },
 }
 
-impl ShardHashRing {
+impl HashRing {
     /// Create a new single hashring.
     ///
     /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,5 +1,105 @@
 use std::hash::Hash;
-use std::mem;
+
+use smallvec::SmallVec;
+
+use crate::shards::shard::ShardId;
+
+const HASH_RING_SHARD_SCALE: u32 = 100;
+
+#[derive(Clone)]
+pub enum ShardHashRing {
+    /// Single hashring
+    Single(HashRing<ShardId>),
+
+    /// Two hashrings when transitioning during resharding
+    /// Depending on the current resharding state, points may be in either or both shards.
+    Resharding {
+        old: HashRing<ShardId>,
+        new: HashRing<ShardId>,
+    },
+}
+
+impl ShardHashRing {
+    /// Create a new single hashring.
+    ///
+    /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.
+    pub fn single() -> Self {
+        Self::Single(HashRing::fair(HASH_RING_SHARD_SCALE))
+    }
+
+    /// Create a new resharding hashring, with resharding shard already added into `new` hashring.
+    ///
+    /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.
+    pub fn resharding(shard_id: ShardId) -> Self {
+        let mut ring = Self::Resharding {
+            old: HashRing::fair(HASH_RING_SHARD_SCALE),
+            new: HashRing::fair(HASH_RING_SHARD_SCALE),
+        };
+
+        ring.add_resharding(shard_id);
+
+        ring
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Single(ring) => ring.is_empty(),
+            Self::Resharding { old, new } => old.is_empty() && new.is_empty(),
+        }
+    }
+
+    pub fn is_resharding(&self) -> bool {
+        matches!(self, Self::Resharding { .. })
+    }
+
+    pub fn add(&mut self, shard: ShardId) {
+        match self {
+            Self::Single(ring) => ring.add(shard),
+            Self::Resharding { old, new } => {
+                if new.get(&shard).is_none() {
+                    old.add(shard);
+                    new.add(shard);
+                }
+            }
+        }
+    }
+
+    pub fn add_resharding(&mut self, shard: ShardId) {
+        if let Self::Single(ring) = self {
+            let (old, new) = (ring.clone(), ring.clone());
+            *self = Self::Resharding { old, new };
+        }
+
+        let Self::Resharding { new, .. } = self else {
+            unreachable!();
+        };
+
+        new.add(shard);
+    }
+
+    pub fn get<U: Hash>(&self, key: &U) -> ShardIds {
+        match self {
+            Self::Single(ring) => ring.get(key).into_iter().cloned().collect(),
+            // TODO(resharding): just use the old hash ring for now, never route to two shards
+            // TODO(resharding): switch to both as commented below once read folding is implemented
+            Self::Resharding { old, new: _ } => old.get(key).into_iter().cloned().collect(),
+            // Self::Resharding { old, new } => old
+            //     .get(key)
+            //     .into_iter()
+            //     .chain(new.get(key))
+            //     // Both hash rings may return the same shard ID, take it once
+            //     .dedup()
+            //     .cloned()
+            //     .collect(),
+        }
+    }
+}
+
+/// List type for shard IDs
+///
+/// Uses a `SmallVec` putting two IDs on the stack. That's the maximum number of shards we expect
+/// with the current resharding implementation.
+pub type ShardIds = SmallVec<[ShardId; 2]>;
 
 #[derive(Clone)]
 pub enum HashRing<T: Hash + Copy> {

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
-use crate::hash_ring::{ShardHashRing, ShardIds};
+use crate::hash_ring::{HashRing, ShardIds};
 use crate::shards::shard::{PeerId, ShardId};
 
 pub type ClockToken = u64;
@@ -216,7 +216,7 @@ impl Validate for CollectionUpdateOperations {
 /// # Panics
 ///
 /// Panics if the hash ring is empty and there is no shard for the given point ID.
-fn point_to_shards(point_id: &ExtendedPointId, ring: &ShardHashRing) -> ShardIds {
+fn point_to_shards(point_id: &ExtendedPointId, ring: &HashRing) -> ShardIds {
     let shard_ids = ring.get(point_id);
     assert!(
         !shard_ids.is_empty(),
@@ -229,7 +229,7 @@ fn point_to_shards(point_id: &ExtendedPointId, ring: &ShardHashRing) -> ShardIds
 fn split_iter_by_shard<I, F, O: Clone>(
     iter: I,
     id_extractor: F,
-    ring: &ShardHashRing,
+    ring: &HashRing,
 ) -> OperationToShard<Vec<O>>
 where
     I: IntoIterator<Item = O>,
@@ -249,13 +249,13 @@ where
 
 /// Trait for Operation enums to split them by shard.
 pub trait SplitByShard {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self>
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self>
     where
         Self: Sized;
 }
 
 impl SplitByShard for CollectionUpdateOperations {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         match self {
             CollectionUpdateOperations::PointOperation(operation) => operation
                 .split_by_shard(ring)

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -26,8 +26,8 @@ use serde::{Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
+use crate::hash_ring::{ShardHashRing, ShardIds};
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_holder::{ShardHashRing, ShardIds};
 
 pub type ClockToken = u64;
 

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -7,7 +7,7 @@ use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{split_iter_by_shard, OperationToShard, SplitByShard};
-use crate::hash_ring::ShardHashRing;
+use crate::hash_ring::HashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
 
 /// This data structure is used in API interface and applied across multiple shards
@@ -175,7 +175,7 @@ impl Validate for PayloadOps {
 }
 
 impl SplitByShard for PayloadOps {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         match self {
             PayloadOps::SetPayload(operation) => {
                 operation.split_by_shard(ring).map(PayloadOps::SetPayload)
@@ -194,7 +194,7 @@ impl SplitByShard for PayloadOps {
 }
 
 impl SplitByShard for DeletePayloadOp {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         match (&self.points, &self.filter) {
             (Some(_), _) => {
                 split_iter_by_shard(self.points.unwrap(), |id| *id, ring).map(|points| {
@@ -212,7 +212,7 @@ impl SplitByShard for DeletePayloadOp {
 }
 
 impl SplitByShard for SetPayloadOp {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         match (&self.points, &self.filter) {
             (Some(_), _) => {
                 split_iter_by_shard(self.points.unwrap(), |id| *id, ring).map(|points| {

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -7,8 +7,8 @@ use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{split_iter_by_shard, OperationToShard, SplitByShard};
+use crate::hash_ring::ShardHashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
-use crate::shards::shard_holder::ShardHashRing;
 
 /// This data structure is used in API interface and applied across multiple shards
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -13,7 +13,7 @@ use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{point_to_shards, split_iter_by_shard, OperationToShard, SplitByShard};
-use crate::hash_ring::ShardHashRing;
+use crate::hash_ring::HashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::operations::types::Record;
 use crate::shards::shard::ShardId;
@@ -295,7 +295,7 @@ impl Validate for Batch {
 }
 
 impl SplitByShard for PointInsertOperationsInternal {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         match self {
             PointInsertOperationsInternal::PointsBatch(batch) => batch
                 .split_by_shard(ring)
@@ -374,7 +374,7 @@ impl Validate for PointOperations {
 }
 
 impl SplitByShard for Batch {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         let batch = self;
         let mut batch_by_shard: HashMap<ShardId, Batch> = HashMap::new();
         let Batch {
@@ -486,13 +486,13 @@ impl SplitByShard for Batch {
 }
 
 impl SplitByShard for Vec<PointStruct> {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         split_iter_by_shard(self, |point| point.id, ring)
     }
 }
 
 impl SplitByShard for PointOperations {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         match self {
             PointOperations::UpsertPoints(upsert_points) => upsert_points
                 .split_by_shard(ring)

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -13,10 +13,10 @@ use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{point_to_shards, split_iter_by_shard, OperationToShard, SplitByShard};
+use crate::hash_ring::ShardHashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::operations::types::Record;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::ShardHashRing;
 
 /// Defines write ordering guarantees for collection operations
 ///

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -9,8 +9,8 @@ use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::point_ops::PointIdsList;
 use super::{point_to_shards, split_iter_by_shard, OperationToShard, SplitByShard};
+use crate::hash_ring::ShardHashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
-use crate::shards::shard_holder::ShardHashRing;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 pub struct UpdateVectors {

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -9,7 +9,7 @@ use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::point_ops::PointIdsList;
 use super::{point_to_shards, split_iter_by_shard, OperationToShard, SplitByShard};
-use crate::hash_ring::ShardHashRing;
+use crate::hash_ring::HashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
@@ -101,13 +101,13 @@ impl Validate for VectorOperations {
 }
 
 impl SplitByShard for Vec<PointVectors> {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         split_iter_by_shard(self, |point| point.id, ring)
     }
 }
 
 impl SplitByShard for VectorOperations {
-    fn split_by_shard(self, ring: &ShardHashRing) -> OperationToShard<Self> {
+    fn split_by_shard(self, ring: &HashRing) -> OperationToShard<Self> {
         match self {
             VectorOperations::UpdateVectors(update_vectors) => {
                 let shard_points = update_vectors

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -8,7 +7,6 @@ use common::cpu::CpuBudget;
 use itertools::Itertools;
 // TODO rename ReplicaShard to ReplicaSetShard
 use segment::types::ShardKey;
-use smallvec::SmallVec;
 use tar::Builder as TarBuilder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
@@ -17,7 +15,7 @@ use super::replica_set::AbortShardTransfer;
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
 use crate::common::validate_snapshot_archive::validate_open_snapshot_archive;
 use crate::config::{CollectionConfig, ShardingMethod};
-use crate::hash_ring::HashRing;
+use crate::hash_ring::ShardHashRing;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::snapshot_ops::SnapshotDescription;
@@ -33,18 +31,10 @@ use crate::shards::shard_versioning::latest_shard_paths;
 use crate::shards::transfer::{ShardTransfer, ShardTransferKey};
 use crate::shards::CollectionId;
 
-const HASH_RING_SHARD_SCALE: u32 = 100;
-
 const SHARD_TRANSFERS_FILE: &str = "shard_transfers";
 pub const SHARD_KEY_MAPPING_FILE: &str = "shard_key_mapping.json";
 
 pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
-
-/// List type for shard IDs
-///
-/// Uses a `SmallVec` putting two IDs on the stack. That's the maximum number of shards we expect
-/// with the current resharding implementation.
-pub type ShardIds = SmallVec<[ShardId; 2]>;
 
 pub struct ShardHolder {
     shards: HashMap<ShardId, ShardReplicaSet>,
@@ -55,95 +45,6 @@ pub struct ShardHolder {
     // Duplicates the information from `key_mapping` for faster access
     // Do not require locking
     shard_id_to_key_mapping: HashMap<ShardId, ShardKey>,
-}
-
-#[derive(Clone)]
-pub enum ShardHashRing {
-    /// Single hashring
-    Single(HashRing<ShardId>),
-
-    /// Two hashrings when transitioning during resharding
-    /// Depending on the current resharding state, points may be in either or both shards.
-    Resharding {
-        old: HashRing<ShardId>,
-        new: HashRing<ShardId>,
-    },
-}
-
-impl ShardHashRing {
-    /// Create a new single hashring.
-    ///
-    /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.
-    pub fn single() -> Self {
-        Self::Single(HashRing::fair(HASH_RING_SHARD_SCALE))
-    }
-
-    /// Create a new resharding hashring, with resharding shard already added into `new` hashring.
-    ///
-    /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.
-    pub fn resharding(shard_id: ShardId) -> Self {
-        let mut ring = Self::Resharding {
-            old: HashRing::fair(HASH_RING_SHARD_SCALE),
-            new: HashRing::fair(HASH_RING_SHARD_SCALE),
-        };
-
-        ring.add_resharding(shard_id);
-
-        ring
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Self::Single(ring) => ring.is_empty(),
-            Self::Resharding { old, new } => old.is_empty() && new.is_empty(),
-        }
-    }
-
-    pub fn is_resharding(&self) -> bool {
-        matches!(self, Self::Resharding { .. })
-    }
-
-    pub fn add(&mut self, shard: ShardId) {
-        match self {
-            Self::Single(ring) => ring.add(shard),
-            Self::Resharding { old, new } => {
-                if new.get(&shard).is_none() {
-                    old.add(shard);
-                    new.add(shard);
-                }
-            }
-        }
-    }
-
-    pub fn add_resharding(&mut self, shard: ShardId) {
-        if let Self::Single(ring) = self {
-            let (old, new) = (ring.clone(), ring.clone());
-            *self = Self::Resharding { old, new };
-        }
-
-        let Self::Resharding { new, .. } = self else {
-            unreachable!();
-        };
-
-        new.add(shard);
-    }
-
-    pub fn get<U: Hash>(&self, key: &U) -> ShardIds {
-        match self {
-            Self::Single(ring) => ring.get(key).into_iter().cloned().collect(),
-            // TODO(resharding): just use the old hash ring for now, never route to two shards
-            // TODO(resharding): switch to both as commented below once read folding is implemented
-            Self::Resharding { old, new: _ } => old.get(key).into_iter().cloned().collect(),
-            // Self::Resharding { old, new } => old
-            //     .get(key)
-            //     .into_iter()
-            //     .chain(new.get(key))
-            //     // Both hash rings may return the same shard ID, take it once
-            //     .dedup()
-            //     .cloned()
-            //     .collect(),
-        }
-    }
 }
 
 pub type LockedShardHolder = RwLock<ShardHolder>;

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::{fmt, mem};
 
 use common::cpu::CpuBudget;
 use itertools::Itertools;
@@ -116,10 +116,8 @@ impl ShardHashRing {
     }
 
     pub fn add_resharding(&mut self, shard: ShardId) {
-        if let Self::Single(old) = self {
-            let mut old = mem::replace(old, HashRing::raw());
-            let new = old.clone();
-
+        if let Self::Single(ring) = self {
+            let (old, new) = (ring.clone(), ring.clone());
             *self = Self::Resharding { old, new };
         }
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
-use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{fmt, mem};
 
 use common::cpu::CpuBudget;
 use itertools::Itertools;
@@ -223,9 +223,14 @@ impl ShardHolder {
 
         let Some(ring) = self.rings.get_mut(&shard_key) else {
             // TODO(resharding): `CollectionError::service_error`? 🤔
-            return Err(CollectionError::bad_request(
-                "shard holder does not contain default hashring".into(),
-            ));
+            return Err(CollectionError::bad_request(format!(
+                "shard holder does not contain {} hashring",
+                if let Some(shard_key) = &shard_key {
+                    shard_key as &dyn fmt::Display
+                } else {
+                    &"default"
+                }
+            )));
         };
 
         if ring.is_resharding() {

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -213,8 +213,16 @@ impl ShardHolder {
         shard: ShardReplicaSet,
         shard_key: Option<ShardKey>,
     ) -> Result<(), CollectionError> {
+        // TODO(resharding):
+        //
+        // `CollectionError::service_error` seems more fitting here... but if `start_resharding`
+        // returns `service_error` here, it will crash consensus thread.
+        //
+        // So it's seems less annoying to allow all of these errors be `bad_request`s for now, and
+        // (maybe) switch (some of) them to `service_error`s later.
+
         let Some(ring) = self.rings.get_mut(&shard_key) else {
-            // TODO: `CollectionError::service_error`? 🤔
+            // TODO(resharding): `CollectionError::service_error`? 🤔
             return Err(CollectionError::bad_request(
                 "shard holder does not contain default hashring".into(),
             ));
@@ -227,7 +235,7 @@ impl ShardHolder {
                 self.resharding
             );
 
-            // TODO: `CollectionError::service_error`? 🤔
+            // TODO(resharding): `CollectionError::service_error`? 🤔
             return Err(CollectionError::bad_request(
                 "shard holder already contains resharding hashring".into(),
             ));
@@ -240,7 +248,7 @@ impl ShardHolder {
         );
 
         if self.shards.contains_key(&shard_id) {
-            // TODO: `CollectionError::service_error`? 🤔
+            // TODO(resharding): `CollectionError::service_error`? 🤔
             return Err(CollectionError::bad_request(format!(
                 "shard holder already contains shard {shard_id} replica set"
             )));

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -291,6 +291,11 @@ pub struct ChangeAliasesOperation {
 #[serde(rename_all = "snake_case")]
 pub struct DeleteCollectionOperation(pub String);
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub enum ReshardingOperation {
+    Start { peer_id: PeerId, shard_id: ShardId },
+}
+
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
 pub enum ShardTransferOperations {
     Start(ShardTransfer),
@@ -368,6 +373,7 @@ pub enum CollectionMetaOperations {
     UpdateCollection(UpdateCollectionOperation),
     DeleteCollection(DeleteCollectionOperation),
     ChangeAliases(ChangeAliasesOperation),
+    Resharding(CollectionId, ReshardingOperation),
     TransferShard(CollectionId, ShardTransferOperations),
     SetShardReplicaState(SetShardReplicaState),
     CreateShardKey(CreateShardKey),

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -293,7 +293,11 @@ pub struct DeleteCollectionOperation(pub String);
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub enum ReshardingOperation {
-    Start { peer_id: PeerId, shard_id: ShardId },
+    Start {
+        peer_id: PeerId,
+        shard_id: ShardId,
+        shard_key: Option<ShardKey>,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -274,8 +274,14 @@ impl TableOfContent {
         let collection = self.get_collection_unchecked(&collection).await?;
 
         match operation {
-            ReshardingOperation::Start { peer_id, shard_id } => {
-                collection.start_resharding(peer_id, shard_id).await?;
+            ReshardingOperation::Start {
+                peer_id,
+                shard_id,
+                shard_key,
+            } => {
+                collection
+                    .start_resharding(peer_id, shard_id, shard_key)
+                    .await?;
             }
         }
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -66,6 +66,13 @@ impl TableOfContent {
                 log::debug!("Changing aliases");
                 self.update_aliases(operation).await
             }
+            CollectionMetaOperations::Resharding(collection, operation) => {
+                log::debug!("Resharding {operation:?} of {collection}");
+
+                self.handle_resharding(collection, operation)
+                    .await
+                    .map(|_| true)
+            }
             CollectionMetaOperations::TransferShard(collection, operation) => {
                 log::debug!("Transfer shard {:?} of {}", operation, collection);
 
@@ -257,6 +264,22 @@ impl TableOfContent {
             };
         }
         Ok(true)
+    }
+
+    async fn handle_resharding(
+        &self,
+        collection: CollectionId,
+        operation: ReshardingOperation,
+    ) -> Result<(), StorageError> {
+        let collection = self.get_collection_unchecked(&collection).await?;
+
+        match operation {
+            ReshardingOperation::Start { peer_id, shard_id } => {
+                collection.start_resharding(peer_id, shard_id).await?;
+            }
+        }
+
+        Ok(())
     }
 
     async fn handle_transfer(

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -253,7 +253,7 @@ impl TableOfContent {
         };
         // resolve_name already checked collection existence, unwrap is safe here
         Ok(RwLockReadGuard::map(read_collection, |collection| {
-            collection.get(&real_collection_name).unwrap()
+            collection.get(&real_collection_name).unwrap() // TODO: WTF!?
         }))
     }
 

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -241,7 +241,7 @@ impl TableOfContent {
     /// Intended for internal use only.
     ///
     /// **Do no make public**
-    pub(self) async fn get_collection_unchecked(
+    async fn get_collection_unchecked(
         &self,
         collection_name: &str,
     ) -> Result<RwLockReadGuard<Collection>, StorageError> {

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -125,6 +125,7 @@ impl Dispatcher {
                 // Sync nodes after collection or shard key creation
                 CollectionMetaOperations::CreateCollection(_)
                 | CollectionMetaOperations::CreateShardKey(_) => true,
+
                 // Sync nodes when creating or renaming collection aliases
                 CollectionMetaOperations::ChangeAliases(changes) => {
                     changes.actions.iter().any(|change| match change {
@@ -132,6 +133,10 @@ impl Dispatcher {
                         AliasOperations::DeleteAlias(_) => false,
                     })
                 }
+
+                // TODO: Do we need/want to synchronize `Resharding` operations?
+                CollectionMetaOperations::Resharding(_, _) => false,
+
                 // No need to sync nodes for other operations
                 CollectionMetaOperations::UpdateCollection(_)
                 | CollectionMetaOperations::DeleteCollection(_)

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -134,7 +134,7 @@ impl Dispatcher {
                     })
                 }
 
-                // TODO: Do we need/want to synchronize `Resharding` operations?
+                // TODO(resharding): Do we need/want to synchronize `Resharding` operations?
                 CollectionMetaOperations::Resharding(_, _) => false,
 
                 // No need to sync nodes for other operations

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -50,6 +50,7 @@ impl Access {
             | CollectionMetaOperations::UpdateCollection(_)
             | CollectionMetaOperations::DeleteCollection(_)
             | CollectionMetaOperations::ChangeAliases(_)
+            | CollectionMetaOperations::Resharding(_, _)
             | CollectionMetaOperations::TransferShard(_, _)
             | CollectionMetaOperations::SetShardReplicaState(_)
             | CollectionMetaOperations::CreateShardKey(_)


### PR DESCRIPTION
Tracked in #4213.

This PR adds `ReshardingOperation::Start` consensus message. And also (in the most trivial way) disables splitting read operations to the resharding shard.

Important TODO to be fixed in some future PR: consensus snapshot does not handle resharding in any way *yet*.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
