### PR TITLE
Add `StartResharding` operation to `update_collection_cluster` REST API

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -1,7 +1,7 @@
 mod collection_ops;
 pub mod payload_index_schema;
 mod point_ops;
-mod resharding;
+pub mod resharding;
 mod search;
 mod shard_transfer;
 mod sharding_keys;
@@ -471,6 +471,7 @@ impl Collection {
                     (*shard_id, shard_info)
                 })
                 .collect(),
+            resharding: self.resharding_state.read().clone(),
             transfers,
             shards_key_mapping: shards_holder.get_shard_key_to_ids_mapping(),
             payload_index_schema: self.payload_index_schema.read().clone(),

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::shards::shard::{PeerId, ShardId};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ReshardingState {
     pub peer_id: PeerId,
     pub shard_id: ShardId,

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::collection::payload_index_schema::PayloadIndexSchema;
+use crate::collection::resharding::ReshardingState;
 use crate::config::CollectionConfig;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
@@ -20,6 +21,7 @@ pub struct State {
     #[validate]
     pub config: CollectionConfig,
     pub shards: HashMap<ShardId, ShardInfo>,
+    pub resharding: Option<ReshardingState>,
     #[serde(default)]
     pub transfers: HashSet<ShardTransfer>,
     #[serde(default)]

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -26,6 +26,9 @@ pub enum ClusterOperations {
     DropShardingKey(DropShardingKeyOperation),
     /// Restart transfer
     RestartTransfer(RestartTransferOperation),
+    /// Start resharding
+    #[schemars(skip)]
+    StartResharding(StartReshardingOperation),
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
@@ -102,6 +105,7 @@ impl Validate for ClusterOperations {
             ClusterOperations::CreateShardingKey(op) => op.validate(),
             ClusterOperations::DropShardingKey(op) => op.validate(),
             ClusterOperations::RestartTransfer(op) => op.validate(),
+            ClusterOperations::StartResharding(op) => op.validate(),
         }
     }
 }
@@ -132,6 +136,11 @@ pub struct DropReplicaOperation {
 pub struct AbortTransferOperation {
     #[validate]
     pub abort_transfer: AbortShardTransfer,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+pub struct StartReshardingOperation {
+    pub peer_id: Option<PeerId>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -141,6 +141,7 @@ pub struct AbortTransferOperation {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct StartReshardingOperation {
     pub peer_id: Option<PeerId>,
+    pub shard_key: Option<ShardKey>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -306,11 +306,7 @@ impl TableOfContent {
         match transfer_operation {
             ShardTransferOperations::Start(transfer) => {
                 let collection_state::State {
-                    config: _,
-                    shards,
-                    transfers,
-                    shards_key_mapping: _,
-                    payload_index_schema: _,
+                    shards, transfers, ..
                 } = collection.state().await;
                 let all_peers: HashSet<_> = self
                     .channel_service

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -545,11 +545,17 @@ pub async fn do_update_collection_cluster(
                 .max()
                 .map_or(0, |id| id + 1);
 
+            let shard_key = op.shard_key;
+
             dispatcher
                 .submit_collection_meta_op(
                     CollectionMetaOperations::Resharding(
                         collection_name.clone(),
-                        ReshardingOperation::Start { peer_id, shard_id },
+                        ReshardingOperation::Start {
+                            peer_id,
+                            shard_id,
+                            shard_key,
+                        },
                     ),
                     access,
                     wait_timeout,


### PR DESCRIPTION
Tracked in #4213.

This PR adds `StartResharding` operation to `update_collection_cluster` REST API.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
