### PR TITLE
Make `Broker` test independent of a global dashboard

### DIFF
--- a/lib/common/issues/src/dashboard.rs
+++ b/lib/common/issues/src/dashboard.rs
@@ -36,13 +36,13 @@ impl AsRef<Code> for Code {
 }
 
 #[derive(Default)]
-struct Dashboard {
+pub(crate) struct Dashboard {
     pub issues: DashMap<Code, IssueRecord>,
 }
 
 impl Dashboard {
     /// Activates an issue, returning true if the issue was not active before
-    fn add_issue<I: Issue + 'static>(&self, issue: I) -> bool {
+    pub(crate) fn add_issue<I: Issue + 'static>(&self, issue: I) -> bool {
         let code = Code::of(&issue);
         if self.issues.contains_key(&code) {
             return false;
@@ -52,7 +52,7 @@ impl Dashboard {
     }
 
     /// Deactivates an issue by its code, returning true if the issue was active before
-    fn remove_issue<S: AsRef<Code>>(&self, code: S) -> bool {
+    pub(crate) fn remove_issue<S: AsRef<Code>>(&self, code: S) -> bool {
         if self.issues.contains_key(code.as_ref()) {
             return self.issues.remove(code.as_ref()).is_some();
         }
@@ -60,7 +60,7 @@ impl Dashboard {
     }
 
     /// Returns all issues in the dashboard. This operation clones every issue, so it is more expensive.
-    fn get_all_issues(&self) -> Vec<IssueRecord> {
+    pub(crate) fn get_all_issues(&self) -> Vec<IssueRecord> {
         self.issues.iter().map(|kv| kv.value().clone()).collect()
     }
 


### PR DESCRIPTION
I could not reproduce #4233 locally, but making it not global-state dependent is a better idea