### PR TITLE
universal-query: Test and fix `PlannedQuery` conversion

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -239,8 +239,9 @@ message RawQuery {
 message QueryShardPoints {
   message Query {
     oneof score {
-      RawQuery vector = 1;
-      // TODO(universal-query): Add fusion and order-by
+      RawQuery vector = 1; // (re)score against a vector query
+      bool rrf = 2; // Reciprocal Rank Fusion
+      // TODO(universal-query): Add order-by
     }
   }
   

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -8121,7 +8121,7 @@ pub mod query_shard_points {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Query {
-        #[prost(oneof = "query::Score", tags = "1")]
+        #[prost(oneof = "query::Score", tags = "1, 2")]
         pub score: ::core::option::Option<query::Score>,
     }
     /// Nested message and enum types in `Query`.
@@ -8130,9 +8130,12 @@ pub mod query_shard_points {
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Score {
-            /// TODO(universal-query): Add fusion and order-by
+            /// (re)score against a vector query
             #[prost(message, tag = "1")]
             Vector(super::super::RawQuery),
+            /// Reciprocal Rank Fusion
+            #[prost(bool, tag = "2")]
+            Rrf(bool),
         }
     }
     #[derive(serde::Serialize)]

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -19,6 +19,7 @@ rstest = "0.19.0"
 approx = "0.5.1"
 collection = { path = ".", features = ["testing"] }
 common = { path = "../common/common", features = ["testing"] }
+segment = { path = "../segment", features = ["testing"] }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { workspace = true }

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -29,7 +29,7 @@ pub struct ShardQueryRequest {
     pub with_payload: WithPayloadInterface,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ScoringQuery {
     /// Score points against some vector(s)
     Vector(QueryEnum),

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -554,7 +554,8 @@ impl Named for NamedVectorStruct {
 }
 
 impl NamedVectorStruct {
-    pub fn new_from_vector(vector: Vector, name: String) -> Self {
+    pub fn new_from_vector(vector: Vector, name: impl Into<String>) -> Self {
+        let name = name.into();
         match vector {
             Vector::Dense(vector) => NamedVectorStruct::Dense(NamedVector { name, vector }),
             Vector::Sparse(vector) => NamedVectorStruct::Sparse(NamedSparseVector { name, vector }),


### PR DESCRIPTION
Needs #4245 

- Tests and fixes the `TryFrom<ShardQueryRequest> for PlannedQuery` implementation
- Adds `ScoringQuery::Rrf` variant

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
