### PR TITLE
universal-query: New `QueriedPoint` struct with extendable `Score` enum

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2972,7 +2972,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | id | [PointId](#qdrant-PointId) |  | Point id |
 | payload | [QueriedPoint.PayloadEntry](#qdrant-QueriedPoint-PayloadEntry) | repeated | Payload |
-| score | [Score](#qdrant-Score) |  | Score to order against other points |
+| score | [Score](#qdrant-Score) | optional | Score to order against other points, if not present, the point is ordered by its ID. |
 | version | [uint64](#uint64) |  | Last update operation applied to this point |
 | vectors | [Vectors](#qdrant-Vectors) | optional | Vectors to search |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
@@ -3236,10 +3236,8 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [PointId](#qdrant-PointId) |  |  |
-| similarity | [float](#float) |  |  |
-| int_value | [int64](#int64) |  |  |
-| float_value | [double](#double) |  |  |
+| int | [int64](#int64) |  |  |
+| float | [double](#double) |  |  |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -172,6 +172,8 @@
     - [PointsUpdateOperation.SetPayload.PayloadEntry](#qdrant-PointsUpdateOperation-SetPayload-PayloadEntry)
     - [PointsUpdateOperation.UpdateVectors](#qdrant-PointsUpdateOperation-UpdateVectors)
     - [QuantizationSearchParams](#qdrant-QuantizationSearchParams)
+    - [QueriedPoint](#qdrant-QueriedPoint)
+    - [QueriedPoint.PayloadEntry](#qdrant-QueriedPoint-PayloadEntry)
     - [Range](#qdrant-Range)
     - [ReadConsistency](#qdrant-ReadConsistency)
     - [RecommendBatchPoints](#qdrant-RecommendBatchPoints)
@@ -184,6 +186,7 @@
     - [RepeatedStrings](#qdrant-RepeatedStrings)
     - [RetrievedPoint](#qdrant-RetrievedPoint)
     - [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry)
+    - [Score](#qdrant-Score)
     - [ScoredPoint](#qdrant-ScoredPoint)
     - [ScoredPoint.PayloadEntry](#qdrant-ScoredPoint-PayloadEntry)
     - [ScrollPoints](#qdrant-ScrollPoints)
@@ -2959,6 +2962,42 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 
 
+<a name="qdrant-QueriedPoint"></a>
+
+### QueriedPoint
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [PointId](#qdrant-PointId) |  | Point id |
+| payload | [QueriedPoint.PayloadEntry](#qdrant-QueriedPoint-PayloadEntry) | repeated | Payload |
+| score | [Score](#qdrant-Score) |  | Score to order against other points |
+| version | [uint64](#uint64) |  | Last update operation applied to this point |
+| vectors | [Vectors](#qdrant-Vectors) | optional | Vectors to search |
+| shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
+
+
+
+
+
+
+<a name="qdrant-QueriedPoint-PayloadEntry"></a>
+
+### QueriedPoint.PayloadEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [Value](#qdrant-Value) |  |  |
+
+
+
+
+
+
 <a name="qdrant-Range"></a>
 
 ### Range
@@ -3183,6 +3222,24 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | key | [string](#string) |  |  |
 | value | [Value](#qdrant-Value) |  |  |
+
+
+
+
+
+
+<a name="qdrant-Score"></a>
+
+### Score
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [PointId](#qdrant-PointId) |  |  |
+| similarity | [float](#float) |  |  |
+| int_value | [int64](#int64) |  |  |
+| float_value | [double](#double) |  |  |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2973,7 +2973,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | id | [PointId](#qdrant-PointId) |  | Point id |
 | payload | [QueriedPoint.PayloadEntry](#qdrant-QueriedPoint-PayloadEntry) | repeated | Payload |
 | score | [Score](#qdrant-Score) | optional | Score to order against other points, if not present, the point is ordered by its ID. |
-| version | [uint64](#uint64) |  | Last update operation applied to this point |
+| version | [uint64](#uint64) | optional | Last update operation applied to this point |
 | vectors | [Vectors](#qdrant-Vectors) | optional | Vectors to search |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
 

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1778,13 +1778,11 @@ impl TryFrom<Score> for segment::types::Score {
 
         let variant = value
             .variant
-            .ok_or_else(|| Status::invalid_argument("grpc Score is missing score variant"))?;
+            .ok_or_else(|| Status::invalid_argument("grpc Score is missing its variant"))?;
 
         let score = match variant {
-            Variant::Similarity(sim) => Self::Similarity(sim),
-            Variant::IntValue(i) => Self::IntValue(i),
-            Variant::FloatValue(f) => Self::FloatValue(f),
-            Variant::Id(id) => Self::Id(segment::types::PointIdType::try_from(id)?),
+            Variant::Int(i) => Self::Int(i),
+            Variant::Float(f) => Self::Float(f),
         };
 
         Ok(score)

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -683,7 +683,7 @@ message QueriedPoint {
   PointId id = 1; // Point id
   map<string, Value> payload = 2; // Payload
   optional Score score = 3; // Score to order against other points, if not present, the point is ordered by its ID.
-  uint64 version = 4; // Last update operation applied to this point
+  optional uint64 version = 4; // Last update operation applied to this point
   optional Vectors vectors = 5; // Vectors to search
   optional ShardKey shard_key = 6; // Shard key
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -674,17 +674,15 @@ message UpdateBatchResponse {
 
 message Score {
   oneof variant {
-    PointId id = 1;
-    float similarity = 2;
-    int64 int_value = 3;
-    double float_value = 4;
+    int64 int = 1;
+    double float = 2;
   }
 }
 
 message QueriedPoint {
   PointId id = 1; // Point id
   map<string, Value> payload = 2; // Payload
-  Score score = 3; // Score to order against other points
+  optional Score score = 3; // Score to order against other points, if not present, the point is ordered by its ID.
   uint64 version = 4; // Last update operation applied to this point
   optional Vectors vectors = 5; // Vectors to search
   optional ShardKey shard_key = 6; // Shard key

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -672,6 +672,24 @@ message UpdateBatchResponse {
   double time = 2; // Time spent to process
 }
 
+message Score {
+  oneof variant {
+    PointId id = 1;
+    float similarity = 2;
+    int64 int_value = 3;
+    double float_value = 4;
+  }
+}
+
+message QueriedPoint {
+  PointId id = 1; // Point id
+  map<string, Value> payload = 2; // Payload
+  Score score = 3; // Score to order against other points
+  uint64 version = 4; // Last update operation applied to this point
+  optional Vectors vectors = 5; // Vectors to search
+  optional ShardKey shard_key = 6; // Shard key
+}
+
 // ---------------------------------------------
 // ------------- Filter Conditions -------------
 // ---------------------------------------------

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -278,10 +278,10 @@ message QueryPointsInternal {
 }
 
 message IntermediateResult {
-  repeated ScoredPoint result = 1;
+  repeated QueriedPoint result = 1;
 }
 
 message QueryResponse {
-  repeated IntermediateResult result = 1;
+  repeated IntermediateResult results = 1;
   double time = 2; // Time spent to process
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5164,8 +5164,8 @@ pub struct QueriedPoint {
     #[prost(message, optional, tag = "3")]
     pub score: ::core::option::Option<Score>,
     /// Last update operation applied to this point
-    #[prost(uint64, tag = "4")]
-    pub version: u64,
+    #[prost(uint64, optional, tag = "4")]
+    pub version: ::core::option::Option<u64>,
     /// Vectors to search
     #[prost(message, optional, tag = "5")]
     pub vectors: ::core::option::Option<Vectors>,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5131,6 +5131,52 @@ pub struct UpdateBatchResponse {
     #[prost(double, tag = "2")]
     pub time: f64,
 }
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Score {
+    #[prost(oneof = "score::Variant", tags = "1, 2, 3, 4")]
+    pub variant: ::core::option::Option<score::Variant>,
+}
+/// Nested message and enum types in `Score`.
+pub mod score {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(message, tag = "1")]
+        Id(super::PointId),
+        #[prost(float, tag = "2")]
+        Similarity(f32),
+        #[prost(int64, tag = "3")]
+        IntValue(i64),
+        #[prost(double, tag = "4")]
+        FloatValue(f64),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueriedPoint {
+    /// Point id
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<PointId>,
+    /// Payload
+    #[prost(map = "string, message", tag = "2")]
+    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
+    /// Score to order against other points
+    #[prost(message, optional, tag = "3")]
+    pub score: ::core::option::Option<Score>,
+    /// Last update operation applied to this point
+    #[prost(uint64, tag = "4")]
+    pub version: u64,
+    /// Vectors to search
+    #[prost(message, optional, tag = "5")]
+    pub vectors: ::core::option::Option<Vectors>,
+    /// Shard key
+    #[prost(message, optional, tag = "6")]
+    pub shard_key: ::core::option::Option<ShardKey>,
+}
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -8177,14 +8223,14 @@ pub struct QueryPointsInternal {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IntermediateResult {
     #[prost(message, repeated, tag = "1")]
-    pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
+    pub result: ::prost::alloc::vec::Vec<QueriedPoint>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryResponse {
     #[prost(message, repeated, tag = "1")]
-    pub result: ::prost::alloc::vec::Vec<IntermediateResult>,
+    pub results: ::prost::alloc::vec::Vec<IntermediateResult>,
     /// Time spent to process
     #[prost(double, tag = "2")]
     pub time: f64,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5160,7 +5160,7 @@ pub struct QueriedPoint {
     /// Payload
     #[prost(map = "string, message", tag = "2")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
-    /// Score to order against other points
+    /// Score to order against other points, if not present, the point is ordered by its ID.
     #[prost(message, optional, tag = "3")]
     pub score: ::core::option::Option<Score>,
     /// Last update operation applied to this point

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5135,7 +5135,7 @@ pub struct UpdateBatchResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Score {
-    #[prost(oneof = "score::Variant", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "score::Variant", tags = "1, 2")]
     pub variant: ::core::option::Option<score::Variant>,
 }
 /// Nested message and enum types in `Score`.
@@ -5144,14 +5144,10 @@ pub mod score {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Variant {
-        #[prost(message, tag = "1")]
-        Id(super::PointId),
-        #[prost(float, tag = "2")]
-        Similarity(f32),
-        #[prost(int64, tag = "3")]
-        IntValue(i64),
-        #[prost(double, tag = "4")]
-        FloatValue(f64),
+        #[prost(int64, tag = "1")]
+        Int(i64),
+        #[prost(double, tag = "2")]
+        Float(f64),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -3,7 +3,7 @@ use common::types::ScoreType;
 use itertools::Itertools;
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{NamedQuery, NamedVectorStruct, Vector, DEFAULT_VECTOR_NAME};
-use segment::types::{Filter, ScoredPoint, SearchParams, WithPayloadInterface, WithVector};
+use segment::types::{Filter, QueriedPoint, SearchParams, WithPayloadInterface, WithVector};
 use segment::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery};
 use tonic::Status;
 
@@ -13,7 +13,7 @@ use crate::operations::types::OrderByInterface;
 /// Internal response type for a universal query request.
 ///
 /// Capable of returning multiple intermediate results if needed, like the case of RRF (Reciprocal Rank Fusion)
-pub type ShardQueryResponse = Vec<Vec<ScoredPoint>>;
+pub type ShardQueryResponse = Vec<Vec<QueriedPoint>>;
 
 /// Internal representation of a universal query request.
 ///

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -456,11 +456,7 @@ pub fn try_queried_point_from_grpc(
         tonic::Status::invalid_argument("grpc QueriedPoint does not have an ID")
     })?)?;
 
-    let score = Score::try_from(
-        point
-            .score
-            .ok_or_else(|| Status::invalid_argument("grpc QueriedPoint does not have a score"))?,
-    )?;
+    let score = point.score.map(Score::try_from).transpose()?;
 
     let payload = if with_payload {
         Some(api::grpc::conversions::proto_to_payloads(point.payload)?)

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -15,7 +15,7 @@ use crate::operations::types::{
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
 };
 use crate::operations::universal_query::planned_query::PlannedQuery;
-use crate::operations::universal_query::shard_query::ShardQueryRequest;
+use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
@@ -178,7 +178,7 @@ impl ShardOperation for LocalShard {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         self.do_planned_query(
             PlannedQuery::try_from(request.as_ref().to_owned())?,
             search_runtime_handle,

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -583,7 +583,7 @@ impl ShardOperation for Inner {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         self.wrapped_shard
             .query(request, search_runtime_handle)
             .await

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -270,7 +270,7 @@ pub struct QueriedPoint {
     /// Point id
     pub id: PointIdType,
     /// Point version
-    pub version: SeqNumberType,
+    pub version: Option<SeqNumberType>,
     /// Points vector distance to the query vector
     pub score: Option<Score>,
     /// Payload - values assigned to the point


### PR DESCRIPTION
- Introduces a `QueriedPoint` struct, which is equivalent to a `ScoredPoint`, but has a `Score` enum, which can be used to be the output of scroll-like requests, like when specifying `order_by`.
- Changes the output elements of `query` to be of `QueriedPoint` type.
- Also adds this types as external grpc types and in internal grpc service

