### PR TITLE
Rescore universal query

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -867,7 +867,7 @@ pub struct CountResult {
     pub count: usize,
 }
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq)]
 #[error("{0}")]
 pub enum CollectionError {
     #[error("Wrong input: {description}")]

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -11,6 +11,7 @@ use crate::operations::types::{
     ScrollRequestInternal,
 };
 
+#[derive(Debug)]
 pub struct PlannedQuery {
     pub merge_plan: MergePlan,
     pub searches: Arc<CoreSearchRequestBatch>,
@@ -29,7 +30,7 @@ pub struct ResultsMerge {
     /// Use this filter
     pub filter: Option<Filter>,
 
-    /// Keep this much points from the top
+    /// Keep this many points from the top
     pub limit: usize,
 
     /// Keep only points with better score than this threshold

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -1,18 +1,20 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use itertools::Itertools as _;
-use segment::types::ScoredPoint;
+use segment::common::reciprocal_rank_fusion::rrf_scoring;
+use segment::types::{Filter, HasIdCondition, ScoredPoint};
 use tokio::runtime::Handle;
 
 use super::LocalShard;
-use crate::operations::types::CollectionResult;
+use crate::operations::types::{CollectionResult, CoreSearchRequest, CoreSearchRequestBatch};
 use crate::operations::universal_query::planned_query::{
     MergePlan, PlannedQuery, PrefetchSource, ResultsMerge,
 };
-use crate::operations::universal_query::shard_query::ShardQueryResponse;
+use crate::operations::universal_query::shard_query::{Fusion, ScoringQuery, ShardQueryResponse};
 
 impl LocalShard {
     #[allow(unreachable_code, clippy::diverging_sub_expression, unused_variables)]
@@ -31,13 +33,19 @@ impl LocalShard {
             .await?;
 
         let scrolls = todo!(); // TODO(universal-query): implement batch scrolling
-
-        let _merged_results = self
-            .recurse_prefetch(&request.merge_plan, &core_results, scrolls)
-            .await;
+        let merged_results = self
+            .recurse_prefetch(
+                &request.merge_plan,
+                &core_results,
+                scrolls,
+                search_runtime_handle,
+                timeout,
+            )
+            .await?;
 
         // TODO(universal-query): Implement with_vector and with_payload
-        todo!()
+        let results = vec![merged_results];
+        Ok(results)
     }
 
     fn recurse_prefetch<'shard, 'query>(
@@ -45,6 +53,8 @@ impl LocalShard {
         prefetch: &'query MergePlan,
         core_results: &'query Vec<Vec<ScoredPoint>>,
         scrolls: &'query Vec<Vec<ScoredPoint>>,
+        search_runtime_handle: &'shard Handle,
+        timeout: Option<Duration>,
     ) -> BoxFuture<'query, CollectionResult<Vec<ScoredPoint>>>
     where
         'shard: 'query,
@@ -61,34 +71,115 @@ impl LocalShard {
                         scrolls.get(*idx).cloned().unwrap_or_default() // TODO(universal-query): don't clone, by using something like a hashmap instead of a vec
                     }
                     PrefetchSource::Prefetch(prefetch) => {
-                        self.recurse_prefetch(prefetch, core_results, scrolls)
-                            .await?
+                        self.recurse_prefetch(
+                            prefetch,
+                            core_results,
+                            scrolls,
+                            search_runtime_handle,
+                            timeout,
+                        )
+                        .await?
                     }
                 };
                 sources.push(vec);
             }
 
-            self.merge_prefetches(sources, &prefetch.merge).await
+            self.merge_prefetches(sources, &prefetch.merge, search_runtime_handle, timeout)
+                .await
         }
         .boxed()
     }
 
+    /// Rescore list of scored points
+    async fn rescore(
+        &self,
+        sources: Vec<Vec<ScoredPoint>>,
+        rescore_query: &ScoringQuery,
+        limit: usize,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        match rescore_query {
+            ScoringQuery::Fusion(Fusion::Rrf) => {
+                let top_rrf = rrf_scoring(sources, limit);
+                Ok(top_rrf)
+            }
+            ScoringQuery::OrderBy(_) => {
+                // TODO implement order by
+                todo!()
+            }
+            ScoringQuery::Vector(query_enum) => {
+                // create batch search request for rescoring query
+                let search_requests = sources
+                    .into_iter()
+                    .map(|source| {
+                        // extract target point ids to score
+                        let point_ids: HashSet<_> =
+                            source.iter().map(|scored_point| scored_point.id).collect();
+                        // create filter for target point ids
+                        let filter = Filter::new_must(segment::types::Condition::HasId(
+                            HasIdCondition::from(point_ids),
+                        ));
+                        CoreSearchRequest {
+                            query: query_enum.clone(),
+                            filter: Some(filter),
+                            params: None,
+                            limit,
+                            offset: 0,
+                            with_payload: None, // the payload has already been fetched
+                            with_vector: None,  // the vector has already been fetched
+                            score_threshold: None,
+                        }
+                    })
+                    .collect();
+                let rescoring_core_search_request = CoreSearchRequestBatch {
+                    searches: search_requests,
+                };
+                let core_results = self
+                    .do_search(
+                        Arc::new(rescoring_core_search_request),
+                        search_runtime_handle,
+                        timeout,
+                    )
+                    .await?;
+                let top = core_results
+                    .into_iter()
+                    .flatten()
+                    .sorted_unstable()
+                    .take(limit)
+                    .collect();
+                Ok(top)
+            }
+        }
+    }
+
+    /// Merge multiple prefetches into a single result up to the limit.
+    /// Rescores if required.
     async fn merge_prefetches(
         &self,
         sources: Vec<Vec<ScoredPoint>>,
         merge: &ResultsMerge,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ScoredPoint>> {
-        if let Some(_rescore) = merge.rescore.as_ref() {
-            // TODO(universal-query): Implement rescore
+        if let Some(rescore) = &merge.rescore {
+            self.rescore(
+                sources,
+                rescore,
+                merge.limit,
+                search_runtime_handle,
+                timeout,
+            )
+            .await
+        } else {
+            // no rescore required - just merge, sort and limit
+            let top = sources
+                .into_iter()
+                .flatten()
+                .sorted_unstable()
+                .take(merge.limit)
+                .collect();
+            Ok(top)
         }
-
-        let top = sources
-            .into_iter()
-            .flatten()
-            .sorted()
-            .take(merge.limit)
-            .collect();
-
-        Ok(top)
     }
 }

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -32,7 +32,8 @@ impl LocalShard {
             )
             .await?;
 
-        let scrolls = todo!(); // TODO(universal-query): implement batch scrolling
+        // TODO(universal-query): implement batch scrolling
+        let scrolls = &vec![];
         let merged_results = self
             .recurse_prefetch(
                 &request.merge_plan,
@@ -104,9 +105,9 @@ impl LocalShard {
                 let top_rrf = rrf_scoring(sources, limit);
                 Ok(top_rrf)
             }
-            ScoringQuery::OrderBy(_) => {
+            ScoringQuery::OrderBy(o) => {
                 // TODO implement order by
-                todo!()
+                todo!("order by not implemented yet for {:?}", o)
             }
             ScoringQuery::Vector(query_enum) => {
                 // create batch search request for rescoring query

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -1,0 +1,104 @@
+use segment::data_types::vectors::VectorStruct;
+use segment::types::{Distance, PayloadFieldSchema, PayloadSchemaType};
+
+use crate::config::{CollectionConfig, CollectionParams, WalConfig};
+use crate::operations::point_ops::{PointOperations, PointStruct};
+use crate::operations::types::VectorsConfig;
+use crate::operations::vector_params_builder::VectorParamsBuilder;
+use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
+use crate::optimizers_builder::OptimizersConfig;
+
+pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
+    deleted_threshold: 0.9,
+    vacuum_min_vector_number: 1000,
+    default_segment_number: 2,
+    max_segment_size: None,
+    memmap_threshold: None,
+    indexing_threshold: Some(50_000),
+    flush_interval_sec: 30,
+    max_optimization_threads: Some(2),
+};
+
+pub fn create_collection_config() -> CollectionConfig {
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+    };
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
+        ..CollectionParams::empty()
+    };
+
+    let mut optimizer_config = TEST_OPTIMIZERS_CONFIG.clone();
+
+    optimizer_config.default_segment_number = 1;
+    optimizer_config.flush_interval_sec = 0;
+
+    CollectionConfig {
+        params: collection_params,
+        optimizer_config,
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+    }
+}
+
+pub fn upsert_operation() -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PointOperation(
+        vec![
+            PointStruct {
+                id: 1.into(),
+                vector: VectorStruct::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+                payload: Some(
+                    serde_json::from_str(r#"{ "location": { "lat": 10.12, "lon": 32.12  } }"#).unwrap(),
+                ),
+            },
+            PointStruct {
+                id: 2.into(),
+                vector: VectorStruct::from(vec![2.0, 1.0, 3.0, 4.0]).into(),
+                payload: Some(
+                    serde_json::from_str(r#"{ "location": { "lat": 11.12, "lon": 34.82  } }"#).unwrap(),
+                ),
+            },
+            PointStruct {
+                id: 3.into(),
+                vector: VectorStruct::from(vec![3.0, 2.0, 1.0, 4.0]).into(),
+                payload: Some(
+                    serde_json::from_str(r#"{ "location": [ { "lat": 12.12, "lon": 34.82  }, { "lat": 12.2, "lon": 12.82  }] }"#).unwrap(),
+                ),
+            },
+            PointStruct {
+                id: 4.into(),
+                vector: VectorStruct::from(vec![4.0, 2.0, 3.0, 1.0]).into(),
+                payload: Some(
+                    serde_json::from_str(r#"{ "location": { "lat": 13.12, "lon": 34.82  } }"#).unwrap(),
+                ),
+            },
+            PointStruct {
+                id: 5.into(),
+                vector: VectorStruct::from(vec![5.0, 2.0, 3.0, 4.0]).into(),
+                payload: Some(
+                    serde_json::from_str(r#"{ "location": { "lat": 14.12, "lon": 32.12  } }"#).unwrap(),
+                ),
+            },
+
+        ]
+            .into(),
+    )
+}
+
+pub fn create_payload_index_operation() -> CollectionUpdateOperations {
+    CollectionUpdateOperations::FieldIndexOperation(FieldIndexOperations::CreateIndex(
+        CreateIndex {
+            field_name: "location".parse().unwrap(),
+            field_schema: Some(PayloadFieldSchema::FieldType(PayloadSchemaType::Geo)),
+        },
+    ))
+}
+
+pub fn delete_point_operation(idx: u64) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+        ids: vec![idx.into()],
+    })
+}

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -1,4 +1,6 @@
+pub mod fixtures;
 mod sha_256_test;
+mod shard_query;
 mod snapshot_test;
 mod sparse_vectors_validation_tests;
 mod wal_recovery_test;

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use common::cpu::CpuBudget;
+use segment::data_types::vectors::{NamedVectorStruct, Vector, DEFAULT_VECTOR_NAME};
+use segment::types::{WithPayloadInterface, WithVector};
+use tempfile::Builder;
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+
+use crate::operations::query_enum::QueryEnum;
+use crate::operations::types::CollectionError;
+use crate::operations::universal_query::shard_query::{
+    Fusion, ScoringQuery, ShardPrefetch, ShardQueryRequest,
+};
+use crate::shards::local_shard::LocalShard;
+use crate::shards::shard_trait::ShardOperation;
+use crate::tests::fixtures::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shard_query_rescoring() {
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let config = create_collection_config();
+
+    let collection_name = "test".to_string();
+
+    let current_runtime: Handle = Handle::current();
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        current_runtime.clone(),
+        CpuBudget::default(),
+    )
+    .await
+    .unwrap();
+
+    let upsert_ops = upsert_operation();
+
+    shard.update(upsert_ops.into(), true).await.unwrap();
+
+    // RFF query without prefetches
+    let query = ShardQueryRequest {
+        prefetches: vec![],
+        query: ScoringQuery::Fusion(Fusion::Rrf),
+        filter: None,
+        score_threshold: None,
+        limit: 0,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(false),
+    };
+
+    let sources_scores = shard.query(Arc::new(query), &current_runtime).await;
+    let expected_error =
+        CollectionError::bad_request("cannot make RRF without prefetches".to_string());
+    assert!(matches!(sources_scores, Err(err) if err == expected_error));
+
+    // RFF query with prefetches
+    let nearest_query = QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+        Vector::Dense(vec![1.0, 2.0, 3.0, 4.0]),
+        DEFAULT_VECTOR_NAME,
+    ));
+    let inner_limit = 3;
+    let nearest_query_prefetch = ShardPrefetch {
+        prefetches: vec![], // no recursion here
+        query: ScoringQuery::Vector(nearest_query.clone()),
+        limit: inner_limit,
+        params: None,
+        filter: None,
+        score_threshold: None,
+    };
+    let outer_limit = 2;
+    let query = ShardQueryRequest {
+        prefetches: vec![nearest_query_prefetch.clone()],
+        query: ScoringQuery::Fusion(Fusion::Rrf),
+        filter: None,
+        score_threshold: None,
+        limit: outer_limit,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(false),
+    };
+
+    let sources_scores = shard
+        .query(Arc::new(query), &current_runtime)
+        .await
+        .unwrap();
+
+    // only one inner prefetch
+    assert_eq!(sources_scores.len(), 1);
+    // number of results is limited by the outer limit for rescoring
+    assert_eq!(sources_scores[0].len(), outer_limit);
+
+    // rescoring against a vector without prefetches
+    let outer_limit = 2;
+    let query = ShardQueryRequest {
+        prefetches: vec![],
+        query: ScoringQuery::Vector(nearest_query.clone()),
+        filter: None,
+        score_threshold: None,
+        limit: outer_limit,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(false),
+    };
+
+    let sources_scores = shard
+        .query(Arc::new(query), &current_runtime)
+        .await
+        .unwrap();
+
+    // only one inner result in absence of prefetches
+    assert_eq!(sources_scores.len(), 1);
+    // number of results is limited by the outer limit for rescoring
+    assert_eq!(sources_scores[0].len(), outer_limit);
+
+    // rescoring against a vector with prefetches
+    let outer_limit = 2;
+    let query = ShardQueryRequest {
+        prefetches: vec![nearest_query_prefetch],
+        query: ScoringQuery::Vector(nearest_query),
+        filter: None,
+        score_threshold: None,
+        limit: outer_limit,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(false),
+    };
+
+    let sources_scores = shard
+        .query(Arc::new(query), &current_runtime)
+        .await
+        .unwrap();
+
+    // only one inner result in absence of prefetches
+    assert_eq!(sources_scores.len(), 1);
+    // number of results is limited by the outer limit for rescoring
+    assert_eq!(sources_scores[0].len(), outer_limit);
+}

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -57,7 +57,7 @@ async fn test_shard_query_rescoring() {
 
     let sources_scores = shard.query(Arc::new(query), &current_runtime).await;
     let expected_error =
-        CollectionError::bad_request("cannot make RRF without prefetches".to_string());
+        CollectionError::bad_request("cannot apply Fusion without prefetches".to_string());
     assert!(matches!(sources_scores, Err(err) if err == expected_error));
 
     // RFF query with prefetches

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -11,21 +11,10 @@ use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{NodeType, VectorsConfig};
 use crate::operations::vector_params_builder::VectorParamsBuilder;
-use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::collection_shard_distribution::CollectionShardDistribution;
 use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState};
-
-pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
-    deleted_threshold: 0.9,
-    vacuum_min_vector_number: 1000,
-    default_segment_number: 2,
-    max_segment_size: None,
-    memmap_threshold: None,
-    indexing_threshold: Some(50_000),
-    flush_interval_sec: 30,
-    max_optimization_threads: Some(2),
-};
+use crate::tests::fixtures::TEST_OPTIMIZERS_CONFIG;
 
 pub fn dummy_on_replica_failure() -> ChangePeerState {
     Arc::new(move |_peer_id, _shard_id| {})

--- a/lib/segment/src/common/reciprocal_rank_fusion.rs
+++ b/lib/segment/src/common/reciprocal_rank_fusion.rs
@@ -22,7 +22,6 @@ fn position_score(position: usize) -> f32 {
 ///
 /// The output is a single sorted list of ScoredPoint.
 /// Does not break ties.
-#[allow(dead_code)] // TODO remove when used
 pub fn rrf_scoring(responses: Vec<Vec<ScoredPoint>>, limit: usize) -> Vec<ScoredPoint> {
     // track scored points by id
     let mut points_by_id: HashMap<ExtendedPointId, ScoredPoint> = HashMap::new();


### PR DESCRIPTION
This PR adds the implementation for re-scoring with RRF or a query at the shard level.

I took extra care make this testable by setting up test fixtures for shard tests.