### PR TITLE
Derive Clone on hash ring types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,8 +2272,7 @@ dependencies = [
 [[package]]
 name = "hashring"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa283406d74fcfeb4778f4e300beaae30db96793371da168d003cbc833e149e0"
+source = "git+https://github.com/qdrant/hashring-rs?branch=hashring-clone#41146f4bc135e01a27e2c4435213c2906c5149df"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,3 +194,5 @@ opt-level = 3
 [patch.crates-io]
 # Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
 tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }
+# Temporary patch until <https://github.com/jeromefroe/hashring-rs/pull/25> is merged
+hashring = { git = 'https://github.com/qdrant/hashring-rs', branch = "hashring-clone" }

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,5 +1,6 @@
 use std::hash::Hash;
 
+#[derive(Clone)]
 pub enum HashRing<T: Hash + Copy> {
     Raw(hashring::HashRing<T>),
     Fair {

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -55,6 +55,7 @@ pub struct ShardHolder {
     shard_id_to_key_mapping: HashMap<ShardId, ShardKey>,
 }
 
+#[derive(Clone)]
 pub enum ShardHashRing {
     /// Single hashring
     Single(HashRing<ShardId>),


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/4213>

Derive `Clone` on our hash ring types. This is needed for work on resharding.

For  this we temporarily switch to a patched crate until <https://github.com/jeromefroe/hashring-rs/pull/25> is merged.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?