### PR TITLE
Allow missing safety doc on half float similarity functions

### DIFF
--- a/lib/segment/src/spaces/metric_f16/neon/dot.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/dot.rs
@@ -26,6 +26,7 @@ pub unsafe fn neon_dot_similarity_half(
 }
 
 #[cfg(not(feature = "neon_fp16"))]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn neon_dot_similarity_half(
     v1: &[VectorElementTypeHalf],
     v2: &[VectorElementTypeHalf],

--- a/lib/segment/src/spaces/metric_f16/neon/euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/euclid.rs
@@ -26,6 +26,7 @@ pub unsafe fn neon_euclid_similarity_half(
 }
 
 #[cfg(not(feature = "neon_fp16"))]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn neon_euclid_similarity_half(
     v1: &[VectorElementTypeHalf],
     v2: &[VectorElementTypeHalf],

--- a/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
@@ -26,6 +26,7 @@ pub unsafe fn neon_manhattan_similarity_half(
 }
 
 #[cfg(not(feature = "neon_fp16"))]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn neon_manhattan_similarity_half(
     v1: &[VectorElementTypeHalf],
     v2: &[VectorElementTypeHalf],


### PR DESCRIPTION
Gets rid of the [`clippy::missing_safety_doc`](https://rust-lang.github.io/rust-clippy/master/index.html#/missing_safety_doc) warnings that appear while developing on mac, only for the newly added similarity metrics for half precision floats.