### PR TITLE
universal-query: Add `OrderBy` scoring, and add `scrolls` to `PlannedQuery`

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -241,7 +241,7 @@ message QueryShardPoints {
     oneof score {
       RawQuery vector = 1; // (re)score against a vector query
       bool rrf = 2; // Reciprocal Rank Fusion
-      // TODO(universal-query): Add order-by
+      OrderBy order_by = 3; // Order by a field
     }
   }
   

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -8121,7 +8121,7 @@ pub mod query_shard_points {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Query {
-        #[prost(oneof = "query::Score", tags = "1, 2")]
+        #[prost(oneof = "query::Score", tags = "1, 2, 3")]
         pub score: ::core::option::Option<query::Score>,
     }
     /// Nested message and enum types in `Query`.
@@ -8136,6 +8136,9 @@ pub mod query_shard_points {
             /// Reciprocal Rank Fusion
             #[prost(bool, tag = "2")]
             Rrf(bool),
+            /// Order by a field
+            #[prost(message, tag = "3")]
+            OrderBy(super::super::OrderBy),
         }
     }
     #[derive(serde::Serialize)]


### PR DESCRIPTION
Tracked in #4225 

- Adds `ScoringQuery::OrderBy` variant
- Modifies `PlannedQuery` to also store a list of scroll alongside the core search batch
- Adjusts the try_from conversion accordingly
- Internal grpc `QueryShardPoints` also gets the order-by variant

