### PR TITLE
Make default priority "snapshot" for snapshot recovery

### DIFF
--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -18,8 +18,8 @@ use crate::operations::types::CollectionResult;
 #[serde(rename_all = "snake_case")]
 pub enum SnapshotPriority {
     NoSync,
-    Snapshot,
     #[default]
+    Snapshot,
     Replica,
     // `ShardTransfer` is for internal use only, and should not be exposed/used in public API
     #[serde(skip)]


### PR DESCRIPTION
This is a breaking change, but it looks like nobody uses "priority=replica" and default behavior just creates a lot of confusion