### PR TITLE
Add test for OOD during indexing

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -195,10 +195,14 @@ jobs:
         working-directory: ./tests/low-ram
         shell: bash
         run: ./low-ram.sh
-      - name: Run low Disk test
+      - name: Run low Disk test - search
         working-directory: ./tests/low-disk
         shell: bash
         run: ./low-disk.sh
+      - name: Run low Disk test - indexing
+        working-directory: ./tests/low-disk
+        shell: bash
+        run: ./low-disk.sh indexing
 
   test-snapshot-operations-s3-minio:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,6 +5310,7 @@ dependencies = [
  "criterion",
  "dataset",
  "fnv",
+ "fs4",
  "fs_extra",
  "generic-tests",
  "geo",

--- a/lib/common/common/src/disk.rs
+++ b/lib/common/common/src/disk.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+/// How many bytes a directory takes.
+pub fn dir_size(path: impl Into<PathBuf>) -> std::io::Result<u64> {
+    fn dir_size(mut dir: std::fs::ReadDir) -> std::io::Result<u64> {
+        dir.try_fold(0, |acc, file| {
+            let file = file?;
+            let size = match file.metadata()? {
+                data if data.is_dir() => dir_size(std::fs::read_dir(file.path())?)?,
+                data => data.len(),
+            };
+            Ok(acc + size)
+        })
+    }
+
+    dir_size(std::fs::read_dir(path.into())?)
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cpu;
 pub mod defaults;
+pub mod disk;
 pub mod fixed_length_priority_queue;
 pub mod math;
 pub mod panic;

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -87,6 +87,7 @@ memory = { path = "../common/memory" }
 sparse = { path = "../sparse" }
 
 tracing = { workspace = true, optional = true }
+fs4 = "0.8.4"
 macro_rules_attribute = "0.2.0"
 generic-tests = { workspace = true }
 nom = "7.1.3"

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -20,7 +20,6 @@ use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::types::{SegmentConfig, SparseVectorDataConfig, VectorDataConfig};
 
 pub type Flusher = Box<dyn FnOnce() -> OperationResult<()> + Send>;
-
 /// Check that the given vector name is part of the segment config.
 ///
 /// Returns an error if incompatible.

--- a/tests/low-disk/create_and_search_items.py
+++ b/tests/low-disk/create_and_search_items.py
@@ -40,19 +40,17 @@ def update_collection(qdrant_host, collection_name, collection_json: dict):
 
 
 def wait_for_status(qdrant_host, collection_name, status: str):
-    counter = 0
     curr_status = ""
-    while counter < 30:
+    for i in range(30):
         resp = requests.get(
             f"{qdrant_host}/collections/{collection_name}")
-        counter += 1
         curr_status = resp.json()["result"]["status"]
         if resp.status_code != 200:
             print(f"Collection info fetching failed with response body:\n{resp.json()}")
             exit(-1)
         if curr_status == status:
             print(f"Status {status}: OK")
-            return
+            return "ok"
         sleep(1)
         print(f"Wait for status {status}")
     print(f"After 30s status is not {status}, found: {curr_status}. Stop waiting.")
@@ -105,7 +103,8 @@ def insert_points_and_search(qdrant_host, collection_name, points_amount):
     create_collection(qdrant_host, collection_name, collection_json)
     for points_batch in generate_points(points_amount):
         insert_points(qdrant_host, collection_name, points_batch)
-        search_point(qdrant_host, collection_name)
+
+    search_point(qdrant_host, collection_name)
 
 
 def insert_points_then_index(qdrant_host, collection_name, points_amount):
@@ -136,7 +135,6 @@ def insert_points_then_index(qdrant_host, collection_name, points_amount):
         res = insert_points(qdrant_host, collection_name, points_batch, quit_on_ood=True)
         if res == "ood":
             break
-        search_point(qdrant_host, collection_name)
 
     # start indexing
     collection_json = {

--- a/tests/low-disk/create_and_search_items.py
+++ b/tests/low-disk/create_and_search_items.py
@@ -1,8 +1,12 @@
 import argparse
 import random
 import uuid
+from time import sleep
 
 import requests
+
+
+VECTOR_SIZE = 4
 
 
 def generate_points(amount: int):
@@ -12,33 +16,55 @@ def generate_points(amount: int):
             result_item["points"].append(
                 {
                     "id": str(uuid.uuid4()),
-                    "vector": [round(random.uniform(0, 1), 2) for _ in range(4)],
+                    "vector": [round(random.uniform(0, 1), 2) for _ in range(VECTOR_SIZE)],
                     "payload": {"city": ["Berlin", "London"]}
                 }
             )
         yield result_item
 
 
-def create_collection(qdrant_host, collection_name):
+def create_collection(qdrant_host, collection_name, collection_json):
     resp = requests.put(
-        f"{qdrant_host}/collections/{collection_name}?timeout=60", json={
-            "vectors": {
-                "size": 4,
-                "distance": "Cosine"
-            }
-        })
+        f"{qdrant_host}/collections/{collection_name}?timeout=60", json=collection_json)
     if resp.status_code != 200:
         print(f"Collection creation failed with response body:\n{resp.json()}")
         exit(-1)
+
+
+def update_collection(qdrant_host, collection_name, collection_json: dict):
+    resp = requests.patch(
+        f"{qdrant_host}/collections/{collection_name}?timeout=60", json=collection_json)
+    if resp.status_code != 200:
+        print(f"Collection patching failed with response body:\n{resp.json()}")
+        exit(-1)
+
+
+def wait_for_status(qdrant_host, collection_name, status: str):
+    counter = 0
+    curr_status = ""
+    while counter < 30:
+        resp = requests.get(
+            f"{qdrant_host}/collections/{collection_name}")
+        counter += 1
+        curr_status = resp.json()["result"]["status"]
+        if resp.status_code != 200:
+            print(f"Collection info fetching failed with response body:\n{resp.json()}")
+            exit(-1)
+        if curr_status == status:
+            print(f"Status {status}: OK")
+            return
+        sleep(1)
+        print(f"Wait for status {status}")
+    print(f"After 30s status is not {status}, found: {curr_status}. Stop waiting.")
 
 
 def insert_points(qdrant_host, collection_name, batch_json):
     resp = requests.put(
         f"{qdrant_host}/collections/{collection_name}/points?wait=true", json=batch_json
     )
-    EXPECTED_ERROR_MESSAGE = "No space left on device"
+    expected_error_message = "No space left on device"
     if resp.status_code != 200:
-        if resp.status_code == 500 and EXPECTED_ERROR_MESSAGE in resp.text:
+        if resp.status_code == 500 and expected_error_message in resp.text:
             requests.put(f"{qdrant_host}/collections/{collection_name}/points?wait=true", json=batch_json)
         else:
             error_response = resp.json()
@@ -48,7 +74,7 @@ def insert_points(qdrant_host, collection_name, batch_json):
 
 def search_point(qdrant_host, collection_name):
     query = {
-        "vector": [round(random.uniform(0, 1), 2) for _ in range(4)],
+        "vector": [round(random.uniform(0, 1), 2) for _ in range(VECTOR_SIZE)],
         "top": 10,
         "filters": {
             "city": {
@@ -67,22 +93,65 @@ def search_point(qdrant_host, collection_name):
     return resp.json()
 
 
-def initialize_qdrant(qdrant_host, collection_name, points_amount):
-    create_collection(qdrant_host, collection_name)
+def insert_points_and_search(qdrant_host, collection_name, points_amount):
+    collection_json = {
+        "vectors": {
+            "size": VECTOR_SIZE,
+            "distance": "Cosine"
+        }
+    }
+    create_collection(qdrant_host, collection_name, collection_json)
     for points_batch in generate_points(points_amount):
         insert_points(qdrant_host, collection_name, points_batch)
         search_point(qdrant_host, collection_name)
 
 
+def insert_points_then_index(qdrant_host, collection_name, points_amount):
+    collection_json = {
+        "vectors": {
+            "size": VECTOR_SIZE,
+            "distance": "Cosine"
+        },
+        "optimizers_config": {
+            "indexing_threshold": 0,
+            "default_segment_number": 2
+        },
+        "wal_config": {
+            "wal_capacity_mb": 1
+        }
+    }
+    create_collection(qdrant_host, collection_name, collection_json)
+    for points_batch in generate_points(points_amount):
+        insert_points(qdrant_host, collection_name, points_batch)
+
+    # start indexing
+    collection_json = {
+        "optimizers_config": {
+            "indexing_threshold": 10
+        }
+    }
+    update_collection(qdrant_host, collection_name, collection_json)
+    wait_for_status(qdrant_host, collection_name, "yellow")
+    wait_for_status(qdrant_host, collection_name, "green")
+
+
 def main():
     parser = argparse.ArgumentParser("Create all required test items")
+    parser.add_argument("test_item")
     parser.add_argument("collection_name")
     parser.add_argument("points_amount", type=int)
     parser.add_argument("ports", type=int, nargs="+")
     args = parser.parse_args()
 
     qdrant_host = f"http://127.0.0.1:{args.ports[0]}"
-    initialize_qdrant(qdrant_host, args.collection_name, args.points_amount)
+    if args.test_item == "search":
+        print("run search test")
+        insert_points_and_search(qdrant_host, args.collection_name, args.points_amount)
+    elif args.test_item == "indexing":
+        print("run indexing test")
+        insert_points_then_index(qdrant_host, args.collection_name, args.points_amount)
+    else:
+        raise ValueError("Invalid test_item value, allowed: search|indexing")
     print("SUCCESS")
 
 


### PR DESCRIPTION
Automate a test scenario for OutOfDisk error during indexing.

Scenario:
Limit Qdrant container disk to ~10 MB
1. create collection with "indexing_threshold": 0 (disabled indexing)
2. add points
3. enable indexing
4. wait for indexing
5. send a search request

Expected behavior: indexing should gracefully fail without crushing a container and post a log message, the container should continue running and accept search requests. 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?