### PR TITLE
Migrate score field to `Score` enum

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -184,6 +184,7 @@
     - [RepeatedStrings](#qdrant-RepeatedStrings)
     - [RetrievedPoint](#qdrant-RetrievedPoint)
     - [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry)
+    - [Score](#qdrant-Score)
     - [ScoredPoint](#qdrant-ScoredPoint)
     - [ScoredPoint.PayloadEntry](#qdrant-ScoredPoint-PayloadEntry)
     - [ScrollPoints](#qdrant-ScrollPoints)
@@ -3189,6 +3190,22 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 
 
+<a name="qdrant-Score"></a>
+
+### Score
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| int | [int64](#int64) |  |  |
+| float | [double](#double) |  |  |
+
+
+
+
+
+
 <a name="qdrant-ScoredPoint"></a>
 
 ### ScoredPoint
@@ -3199,10 +3216,11 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | id | [PointId](#qdrant-PointId) |  | Point id |
 | payload | [ScoredPoint.PayloadEntry](#qdrant-ScoredPoint-PayloadEntry) | repeated | Payload |
-| score | [float](#float) |  | Similarity score |
+| float_score | [float](#float) |  | Similarity score. To be deprecated in favor of &#34;score&#34; field |
 | version | [uint64](#uint64) |  | Last update operation applied to this point |
 | vectors | [Vectors](#qdrant-Vectors) | optional | Vectors to search |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
+| score | [Score](#qdrant-Score) | optional | Score to compare against other scored points. If not provided, sorts by id. |
 
 
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -564,14 +564,22 @@ enum UpdateStatus {
   ClockRejected = 3; // Internal: update is rejected due to an outdated clock
 }
 
+message Score {
+  oneof variant {
+    int64 int = 1;
+    double float = 2;
+  }
+}
+
 message ScoredPoint {
   PointId id = 1; // Point id
   map<string, Value> payload = 2; // Payload
-  float score = 3; // Similarity score
+  float float_score = 3; // Similarity score. To be deprecated in favor of "score" field
   reserved 4; // deprecated "vector" field
   uint64 version = 5; // Last update operation applied to this point
   optional Vectors vectors = 6; // Vectors to search
   optional ShardKey shard_key = 7; // Shard key
+  optional Score score = 8; // Score to compare against other scored points. If not provided, sorts by id.
 }
 
 message GroupId {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4914,6 +4914,25 @@ pub struct UpdateResult {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Score {
+    #[prost(oneof = "score::Variant", tags = "1, 2")]
+    pub variant: ::core::option::Option<score::Variant>,
+}
+/// Nested message and enum types in `Score`.
+pub mod score {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(int64, tag = "1")]
+        Int(i64),
+        #[prost(double, tag = "2")]
+        Float(f64),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScoredPoint {
     /// Point id
     #[prost(message, optional, tag = "1")]
@@ -4921,9 +4940,9 @@ pub struct ScoredPoint {
     /// Payload
     #[prost(map = "string, message", tag = "2")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
-    /// Similarity score
+    /// Similarity score. To be deprecated in favor of "score" field
     #[prost(float, tag = "3")]
-    pub score: f32,
+    pub float_score: f32,
     /// Last update operation applied to this point
     #[prost(uint64, tag = "5")]
     pub version: u64,
@@ -4933,6 +4952,9 @@ pub struct ScoredPoint {
     /// Shard key
     #[prost(message, optional, tag = "7")]
     pub shard_key: ::core::option::Option<ShardKey>,
+    /// Score to compare against other scored points. If not provided, sorts by id.
+    #[prost(message, optional, tag = "8")]
+    pub score: ::core::option::Option<Score>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -1,3 +1,5 @@
+use segment::types::ScoreExt;
+
 use super::schema::{BatchVectorStruct, ScoredPoint, Vector, VectorStruct};
 use crate::rest::{DenseVector, NamedVectorStruct};
 
@@ -96,20 +98,7 @@ impl From<segment::types::ScoredPoint> for ScoredPoint {
         ScoredPoint {
             id: value.id,
             version: value.version,
-            score: value.score,
-            payload: value.payload,
-            vector: value.vector.map(From::from),
-            shard_key: value.shard_key,
-        }
-    }
-}
-
-impl From<ScoredPoint> for segment::types::ScoredPoint {
-    fn from(value: ScoredPoint) -> Self {
-        segment::types::ScoredPoint {
-            id: value.id,
-            version: value.version,
-            score: value.score,
+            score: value.score.to_float_score(),
             payload: value.payload,
             vector: value.vector.map(From::from),
             shard_key: value.shard_key,

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
+use segment::data_types::groups::GroupId;
 use serde::{Deserialize, Serialize};
 
 /// Type for dense vector
@@ -104,6 +105,22 @@ pub struct Record {
     /// Shard Key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<segment::types::ShardKey>,
+}
+
+#[derive(Debug, Serialize, JsonSchema, Clone)]
+pub struct PointGroup {
+    /// Scored points that have the same value of the group_by key
+    pub hits: Vec<ScoredPoint>,
+    /// Value of the group_by key, shared across all the hits in the group
+    pub id: GroupId,
+    /// Record that has been looked up using the group id
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lookup: Option<Record>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct GroupsResult {
+    pub groups: Vec<PointGroup>,
 }
 
 /// Vector data separator for named and unnamed modes

--- a/lib/collection/src/collection_manager/search_result_aggregator.rs
+++ b/lib/collection/src/collection_manager/search_result_aggregator.rs
@@ -2,8 +2,7 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
-use common::types::ScoreType;
-use segment::types::{PointIdType, ScoredPoint, SeqNumberType};
+use segment::types::{PointIdType, Score, ScoredPoint, SeqNumberType};
 
 pub struct SearchResultAggregator {
     queue: FixedLengthPriorityQueue<ScoredPoint>,
@@ -94,7 +93,7 @@ impl BatchResultAggregator {
     }
 
     /// Return lowest acceptable score for given batch id
-    pub fn batch_lowest_scores(&self, batch_id: usize) -> Option<ScoreType> {
+    pub fn batch_lowest_scores(&self, batch_id: usize) -> Option<Option<Score>> {
         let batch_scores = &self.batch_aggregators[batch_id];
         batch_scores.lowest().map(|x| x.score)
     }

--- a/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
+++ b/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
@@ -1,5 +1,5 @@
 use common::types::ScoreType;
-use segment::types::{PointIdType, ScoredPoint, SeqNumberType};
+use segment::types::{PointIdType, Score, ScoredPoint, SeqNumberType};
 
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 
@@ -7,11 +7,18 @@ fn score_point(id: usize, score: ScoreType, version: SeqNumberType) -> ScoredPoi
     ScoredPoint {
         id: PointIdType::NumId(id as u64),
         version,
-        score,
+        score: Some(Score::Float(score as f64)),
         payload: None,
         vector: None,
         shard_key: None,
     }
+}
+
+fn assert_score(score: Option<Score>, expected: f64) {
+    let Some(Score::Float(score)) = score else {
+        panic!("Expected a float score");
+    };
+    assert!((score - expected).abs() < 0.0001);
 }
 
 fn search_result_b0_s0() -> Vec<ScoredPoint> {
@@ -107,13 +114,13 @@ fn test_aggregation_of_batch_search_results() {
 
     assert_eq!(top_results[1][0].id, PointIdType::NumId(111));
     assert_eq!(top_results[1][0].version, 14);
-    assert_eq!(top_results[1][0].score, 0.91);
+    assert_score(top_results[1][0].score, 0.91);
 
     assert_eq!(top_results[1][1].id, PointIdType::NumId(112));
     assert_eq!(top_results[1][1].version, 23);
-    assert_eq!(top_results[1][1].score, 0.81);
+    assert_score(top_results[1][1].score, 0.81);
 
     assert_eq!(top_results[1][2].id, PointIdType::NumId(113));
     assert_eq!(top_results[1][2].version, 12);
-    assert_eq!(top_results[1][2].score, 0.71);
+    assert_score(top_results[1][2].score, 0.71);
 }

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -116,9 +116,7 @@ where
 
             // Put the lookups in their respective groups
             groups.iter_mut().for_each(|group| {
-                group.lookup = lookups
-                    .remove(&PseudoId::from(group.id.clone()))
-                    .map(api::rest::Record::from);
+                group.lookup = lookups.remove(&PseudoId::from(group.id.clone()));
             });
         }
 

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -6,7 +6,7 @@ use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
 use segment::json_path::{JsonPath, JsonPathInterface as _};
 use segment::types::{
-    AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
+    AnyVariants, Condition, FieldCondition, Filter, Match, Order, ScoredPoint, WithPayloadInterface
 };
 use serde_json::Value;
 use tokio::sync::RwLockReadGuard;
@@ -232,7 +232,9 @@ pub async fn group_by(
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
 ) -> CollectionResult<Vec<PointGroup>> {
-    let score_ordering = {
+    let score_ordering = if request.source.query.has_custom_scoring() {
+        Order::LargeBetter
+    } else {
         let vector_name = request.source.query.get_vector_name();
         let collection_params = collection.collection_config.read().await;
         let distance = collection_params.params.get_distance(vector_name)?;

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -6,7 +6,7 @@ use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
 use segment::json_path::{JsonPath, JsonPathInterface as _};
 use segment::types::{
-    AnyVariants, Condition, FieldCondition, Filter, Match, Order, ScoredPoint, WithPayloadInterface
+    AnyVariants, Condition, FieldCondition, Filter, Match, Order, ScoredPoint, WithPayloadInterface,
 };
 use serde_json::Value;
 use tokio::sync::RwLockReadGuard;
@@ -458,9 +458,20 @@ mod tests {
     use std::collections::HashMap;
 
     use segment::data_types::groups::GroupId;
-    use segment::types::{Payload, ScoredPoint};
+    use segment::types::{Payload, Score, ScoredPoint};
 
     use crate::grouping::types::Group;
+
+    fn make_scored_point(id: u64, score: f64, payload: Option<Payload>) -> ScoredPoint {
+        ScoredPoint {
+            id: id.into(),
+            version: 0,
+            score: Some(Score::Float(score)),
+            payload,
+            vector: None,
+            shard_key: None,
+        }
+    }
 
     #[test]
     fn test_hydrated_from() {
@@ -470,43 +481,15 @@ mod tests {
             (
                 "a",
                 [
-                    ScoredPoint {
-                        id: 1.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
-                    ScoredPoint {
-                        id: 2.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
+                    make_scored_point(1, 1.0, None),
+                    make_scored_point(2, 1.0, None),
                 ],
             ),
             (
                 "b",
                 [
-                    ScoredPoint {
-                        id: 3.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
-                    ScoredPoint {
-                        id: 4.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
+                    make_scored_point(3, 1.0, None),
+                    make_scored_point(4, 1.0, None),
                 ],
             ),
         ]
@@ -523,38 +506,10 @@ mod tests {
         let payload_b = Payload::from(serde_json::json!({"some_key": "some value b"}));
 
         let hydrated = vec![
-            ScoredPoint {
-                id: 1.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_a.clone()),
-                vector: None,
-                shard_key: None,
-            },
-            ScoredPoint {
-                id: 2.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_a.clone()),
-                vector: None,
-                shard_key: None,
-            },
-            ScoredPoint {
-                id: 3.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_b.clone()),
-                vector: None,
-                shard_key: None,
-            },
-            ScoredPoint {
-                id: 4.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_b.clone()),
-                vector: None,
-                shard_key: None,
-            },
+            make_scored_point(1, 1.0, Some(payload_a.clone())),
+            make_scored_point(2, 1.0, Some(payload_a.clone())),
+            make_scored_point(3, 1.0, Some(payload_b.clone())),
+            make_scored_point(4, 1.0, Some(payload_b.clone())),
         ];
 
         let set: HashMap<_, _> = hydrated.into_iter().map(|p| (p.id, p)).collect();

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -32,11 +32,7 @@ impl Group {
 impl From<Group> for PointGroup {
     fn from(group: Group) -> Self {
         Self {
-            hits: group
-                .hits
-                .into_iter()
-                .map(api::rest::ScoredPoint::from)
-                .collect(),
+            hits: group.hits,
             id: group.key,
             lookup: None,
         }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -20,9 +20,7 @@ use segment::data_types::vectors::{
     BatchVectorStruct, Named, NamedQuery, NamedVectorStruct, Vector, VectorStruct,
     DEFAULT_VECTOR_NAME,
 };
-use segment::types::{
-    DateTimeWrapper, Distance, MultiVectorConfig, QuantizationConfig, ScoredPoint,
-};
+use segment::types::{DateTimeWrapper, Distance, MultiVectorConfig, QuantizationConfig};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::{validate_sparse_vector_impl, SparseVector};
 use tonic::Status;
@@ -1389,13 +1387,10 @@ impl From<PointGroup> for api::grpc::qdrant::PointGroup {
             hits: group
                 .hits
                 .into_iter()
-                .map_into::<ScoredPoint>()
-                .map_into()
+                .map(api::grpc::qdrant::ScoredPoint::from)
                 .collect(),
             id: Some(group.id.into()),
-            lookup: group
-                .lookup
-                .map(|record| api::grpc::qdrant::RetrievedPoint::from(Record::from(record))),
+            lookup: group.lookup.map(api::grpc::qdrant::RetrievedPoint::from),
         }
     }
 }

--- a/lib/collection/src/operations/conversions_rest.rs
+++ b/lib/collection/src/operations/conversions_rest.rs
@@ -1,6 +1,6 @@
 use segment::data_types::vectors::VectorStruct;
 
-use super::types::Record;
+use super::types::{GroupsResult, PointGroup, Record};
 
 impl From<Record> for api::rest::Record {
     fn from(value: Record) -> Self {
@@ -20,6 +20,32 @@ impl From<api::rest::Record> for Record {
             payload: value.payload,
             vector: value.vector.map(VectorStruct::from),
             shard_key: value.shard_key,
+        }
+    }
+}
+
+impl From<GroupsResult> for api::rest::GroupsResult {
+    fn from(value: GroupsResult) -> Self {
+        Self {
+            groups: value
+                .groups
+                .into_iter()
+                .map(api::rest::PointGroup::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<PointGroup> for api::rest::PointGroup {
+    fn from(value: PointGroup) -> Self {
+        Self {
+            hits: value
+                .hits
+                .into_iter()
+                .map(api::rest::ScoredPoint::from)
+                .collect(),
+            id: value.id,
+            lookup: value.lookup.map(api::rest::Record::from),
         }
     }
 }

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -1,5 +1,4 @@
 use segment::data_types::vectors::{DenseVector, Named, NamedQuery, NamedVectorStruct, Vector};
-use segment::types::Order;
 use segment::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::SparseVector;
 
@@ -10,6 +9,16 @@ impl QueryEnum {
             QueryEnum::RecommendBestScore(reco_query) => reco_query.get_name(),
             QueryEnum::Discover(discovery_query) => discovery_query.get_name(),
             QueryEnum::Context(context_query) => context_query.get_name(),
+        }
+    }
+
+    /// Only when the distance is the scoring, this will return false.
+    pub fn has_custom_scoring(&self) -> bool {
+        match self {
+            QueryEnum::Nearest(_) => false,
+            QueryEnum::RecommendBestScore(_) | QueryEnum::Discover(_) | QueryEnum::Context(_) => {
+                true
+            }
         }
     }
 
@@ -60,18 +69,6 @@ pub enum QueryEnum {
     RecommendBestScore(NamedQuery<RecoQuery<Vector>>),
     Discover(NamedQuery<DiscoveryQuery<Vector>>),
     Context(NamedQuery<ContextQuery<Vector>>),
-}
-
-impl QueryEnum {
-    /// Only when the distance is the scoring, this will return false.
-    pub fn has_custom_scoring(&self) -> bool {
-        match self {
-            QueryEnum::Nearest(_) => false,
-            QueryEnum::RecommendBestScore(_) | QueryEnum::Discover(_) | QueryEnum::Context(_) => {
-                true
-            }
-        }
-    }
 }
 
 impl From<DenseVector> for QueryEnum {

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -1,4 +1,5 @@
 use segment::data_types::vectors::{DenseVector, Named, NamedQuery, NamedVectorStruct, Vector};
+use segment::types::Order;
 use segment::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::SparseVector;
 
@@ -59,6 +60,18 @@ pub enum QueryEnum {
     RecommendBestScore(NamedQuery<RecoQuery<Vector>>),
     Discover(NamedQuery<DiscoveryQuery<Vector>>),
     Context(NamedQuery<ContextQuery<Vector>>),
+}
+
+impl QueryEnum {
+    /// Only when the distance is the scoring, this will return false.
+    pub fn has_custom_scoring(&self) -> bool {
+        match self {
+            QueryEnum::Nearest(_) => false,
+            QueryEnum::RecommendBestScore(_) | QueryEnum::Discover(_) | QueryEnum::Context(_) => {
+                true
+            }
+        }
+    }
 }
 
 impl From<DenseVector> for QueryEnum {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -24,7 +24,7 @@ use segment::data_types::vectors::{
 use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{
     Distance, Filter, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType,
-    QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
+    QuantizationConfig, ScoredPoint, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
     WithPayloadInterface, WithVector,
 };
 use semver::Version;
@@ -814,18 +814,17 @@ pub struct DiscoverRequestBatch {
     pub searches: Vec<DiscoverRequest>,
 }
 
-#[derive(Debug, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Clone)]
 pub struct PointGroup {
     /// Scored points that have the same value of the group_by key
-    pub hits: Vec<api::rest::ScoredPoint>,
+    pub hits: Vec<ScoredPoint>,
     /// Value of the group_by key, shared across all the hits in the group
     pub id: GroupId,
     /// Record that has been looked up using the group id
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lookup: Option<api::rest::Record>,
+    pub lookup: Option<Record>,
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug)]
 pub struct GroupsResult {
     pub groups: Vec<PointGroup>,
 }

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -63,14 +63,8 @@ impl LocalShard {
                 let vector_name = req.query.get_vector_name();
                 let distance = collection_params.get_distance(vector_name).unwrap();
                 let processed_res = vector_res.into_iter().map(|mut scored_point| {
-                    match req.query {
-                        QueryEnum::Nearest(_) => {
-                            scored_point.score = distance.postprocess_score(scored_point.score);
-                        }
-                        // Don't post-process if we are dealing with custom scoring
-                        QueryEnum::RecommendBestScore(_)
-                        | QueryEnum::Discover(_)
-                        | QueryEnum::Context(_) => {}
+                    if req.query.has_custom_scoring() {
+                        scored_point.score = distance.postprocess_score(scored_point.score);
                     };
                     scored_point
                 });

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -35,6 +35,7 @@ use url::Url;
 
 use super::conversions::{
     internal_delete_vectors, internal_delete_vectors_by_filter, internal_update_vectors,
+    try_queried_point_from_grpc,
 };
 use super::local_shard::clock_map::RecoveryPoint;
 use super::replica_set::ReplicaState;
@@ -866,7 +867,7 @@ impl ShardOperation for RemoteShard {
                 intermediate
                     .result
                     .into_iter()
-                    .map(|point| try_scored_point_from_grpc(point, is_payload_required))
+                    .map(|point| try_queried_point_from_grpc(point, is_payload_required))
                     .collect()
             })
             .collect();

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -247,6 +247,7 @@ mod test {
     use std::fmt;
 
     use common::types::ScoreType;
+    use segment::types::Score;
 
     use super::*;
 
@@ -273,7 +274,7 @@ mod test {
         ScoredPoint {
             id: id.into(),
             version: 1,
-            score,
+            score: Some(Score::Float(score as f64)),
             payload: None,
             vector: None,
             shard_key: None,
@@ -331,7 +332,9 @@ mod test {
                 }
 
                 Action::Modify(index) => {
-                    batch[index - offset].score += 1.0;
+                    if let Some(Score::Float(score)) = &mut batch[index - offset].score {
+                        *score += 1.0;
+                    }
                 }
             }
         }

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -23,6 +23,7 @@ fn rand_dense_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
 mod group_by {
     use collection::grouping::GroupBy;
     use segment::data_types::vectors::BatchVectorStruct;
+    use segment::types::Score;
 
     use super::*;
 
@@ -112,12 +113,12 @@ mod group_by {
         assert_eq!(result[0].hits.len(), group_req.group_size);
 
         // is sorted?
-        let mut last_group_best_score = f32::MAX;
+        let mut last_group_best_score = Some(Score::Float(f64::MAX));
         for group in result {
             assert!(group.hits[0].score <= last_group_best_score);
             last_group_best_score = group.hits[0].score;
 
-            let mut last_score = f32::MAX;
+            let mut last_score = Some(Score::Float(f64::MAX));
             for hit in group.hits {
                 assert!(hit.score <= last_score);
                 last_score = hit.score;
@@ -160,7 +161,7 @@ mod group_by {
 
         assert_eq!(result.len(), request.limit);
 
-        let mut last_group_best_score = f32::MAX;
+        let mut last_group_best_score = Some(Score::Float(f64::MAX));
         for group in result {
             assert_eq!(group.hits.len(), request.group_size);
 
@@ -168,7 +169,7 @@ mod group_by {
             assert!(group.hits[0].score <= last_group_best_score);
             last_group_best_score = group.hits[0].score;
 
-            let mut last_score = f32::MAX;
+            let mut last_score = Some(Score::Float(f64::MAX));
             for hit in group.hits {
                 assert!(hit.score <= last_score);
                 last_score = hit.score;

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -40,7 +40,7 @@ use crate::spaces::tools::{peek_top_largest_iterable, peek_top_smallest_iterable
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadIndexInfo, PayloadKeyType, PayloadKeyTypeRef,
-    PayloadSchemaType, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo,
+    PayloadSchemaType, PointIdType, Score, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo,
     SegmentState, SegmentType, SeqNumberType, VectorDataInfo, WithPayload, WithVector,
 };
 use crate::utils;
@@ -699,7 +699,7 @@ impl Segment {
                 Ok(ScoredPoint {
                     id: point_id,
                     version: point_version,
-                    score: scored_point_offset.score,
+                    score: Some(Score::Float(scored_point_offset.score as f64)),
                     payload,
                     vector,
                     shard_key: None,

--- a/lib/segment/src/spaces/metric_f16/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_dot.rs
@@ -60,5 +60,5 @@ pub fn dot_similarity_half(
     v1.iter()
         .zip(v2)
         .map(|(a, b)| f16::to_f32(a * b))
-        .sum::<f32>()
+        .sum::<ScoreType>()
 }

--- a/lib/segment/src/spaces/metric_f16/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_euclid.rs
@@ -61,5 +61,5 @@ pub fn euclid_similarity_half(
     -v1.iter()
         .zip(v2)
         .map(|(a, b)| f16::to_f32((a - b).powi(2)))
-        .sum::<f32>()
+        .sum::<ScoreType>()
 }

--- a/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
@@ -61,5 +61,5 @@ pub fn manhattan_similarity_half(
     -v1.iter()
         .zip(v2)
         .map(|(a, b)| f16::to_f32((a - b).abs()))
-        .sum::<f32>()
+        .sum::<ScoreType>()
 }

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -212,17 +212,11 @@ impl MetricPostProcessing for CosineMetric {
 }
 
 pub fn euclid_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-    -v1.iter()
-        .zip(v2)
-        .map(|(a, b)| (a - b).powi(2))
-        .sum::<ScoreType>()
+    -v1.iter().zip(v2).map(|(a, b)| (a - b).powi(2)).sum::<f32>() as ScoreType
 }
 
 pub fn manhattan_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-    -v1.iter()
-        .zip(v2)
-        .map(|(a, b)| (a - b).abs())
-        .sum::<ScoreType>()
+    -v1.iter().zip(v2).map(|(a, b)| (a - b).abs()).sum::<f32>() as ScoreType
 }
 
 pub fn cosine_preprocess(vector: DenseVector) -> DenseVector {
@@ -235,7 +229,7 @@ pub fn cosine_preprocess(vector: DenseVector) -> DenseVector {
 }
 
 pub fn dot_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-    v1.iter().zip(v2).map(|(a, b)| a * b).sum()
+    v1.iter().zip(v2).map(|(a, b)| a * b).sum::<f32>() as ScoreType
 }
 
 #[cfg(test)]

--- a/lib/segment/src/spaces/simple_neon.rs
+++ b/lib/segment/src/spaces/simple_neon.rs
@@ -45,7 +45,7 @@ pub(crate) unsafe fn euclid_similarity_neon(
     for i in 0..n - m {
         result += (*ptr1.add(i) - *ptr2.add(i)).powi(2);
     }
-    -result
+    -result as ScoreType
 }
 
 #[cfg(target_feature = "neon")]
@@ -84,7 +84,7 @@ pub(crate) unsafe fn manhattan_similarity_neon(
     for i in 0..n - m {
         result += (*ptr1.add(i) - *ptr2.add(i)).abs();
     }
-    -result
+    -result as ScoreType
 }
 
 #[cfg(target_feature = "neon")]
@@ -153,7 +153,7 @@ pub(crate) unsafe fn dot_similarity_neon(
     for i in 0..n - m {
         result += (*ptr1.add(i)) * (*ptr2.add(i));
     }
-    result
+    result as ScoreType
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -118,7 +118,7 @@ where
 {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.query
-            .score_by(|this| self.quantized_storage.score_point(this, idx))
+            .score_by(|this| self.quantized_storage.score_point(this, idx) as ScoreType)
     }
 
     fn score(&self, v2: &[TElement]) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -59,7 +59,7 @@ where
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
 {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        self.quantized_data.score_point(&self.query, idx)
+        self.quantized_data.score_point(&self.query, idx) as ScoreType
     }
 
     fn score(&self, v2: &[TElement]) -> ScoreType {
@@ -71,6 +71,6 @@ where
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
-        self.quantized_data.score_internal(point_a, point_b)
+        self.quantized_data.score_internal(point_a, point_b) as ScoreType
     }
 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -37,6 +37,7 @@ use segment::types::{
 use serde_json::json;
 use tempfile::Builder;
 
+use crate::utils::assert_scores;
 use crate::utils::scored_point_ties::ScoredPointTies;
 
 const DIM: usize = 5;
@@ -347,7 +348,7 @@ fn validate_geo_filter(query_filter: Filter) {
             .zip(struct_result.iter())
             .for_each(|(r1, r2)| {
                 assert_eq!(r1.id, r2.id);
-                assert!((r1.score - r2.score) < 0.0001)
+                assert_scores(r1.score, r2.score);
             });
     }
 }
@@ -652,7 +653,7 @@ fn test_struct_payload_index() {
             .map(|(r1, r2)| (r1.scored_point, r2.scored_point))
             .for_each(|(r1, r2)| {
                 assert_eq!(r1.id, r2.id, "got different ScoredPoint {r1:?} and {r2:?} for\nquery vector {query_vector:?}\nquery filter {query_filter:?}\nplain result {plain_result:?}\nstruct result{struct_result:?}");
-                assert!((r1.score - r2.score) < 0.0001)
+                assert_scores(r1.score, r2.score);
             });
     }
 }
@@ -805,7 +806,7 @@ fn test_struct_payload_index_nested_fields() {
             .zip(struct_result.iter())
             .for_each(|(r1, r2)| {
                 assert_eq!(r1.id, r2.id, "got different ScoredPoint {r1:?} and {r2:?} for\nquery vector {query_vector:?}\nquery filter {query_filter:?}\nplain result {plain_result:?}\nstruct result{struct_result:?}");
-                assert!((r1.score - r2.score) < 0.0001)
+                assert_scores(r1.score, r2.score);
             });
     }
 }

--- a/lib/segment/tests/integration/utils/mod.rs
+++ b/lib/segment/tests/integration/utils/mod.rs
@@ -1,1 +1,14 @@
+use segment::types::Score;
+
 pub mod scored_point_ties;
+
+pub fn assert_scores(score1: Option<Score>, score2: Option<Score>) {
+    let (Some(Score::Float(score1)), Some(Score::Float(score2))) = (score1, score2) else {
+        panic!("got unexpected Scores {score1:?} and {score2:?}");
+    };
+    assert!((score1 - score2).abs() < 0.0001)
+}
+
+pub fn assert_score(score: Option<Score>, expected: f64) {
+    assert_eq!(score, Some(Score::Float(expected)));
+}

--- a/lib/segment/tests/integration/utils/scored_point_ties.rs
+++ b/lib/segment/tests/integration/utils/scored_point_ties.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 
-use ordered_float::OrderedFloat;
 use segment::types::ScoredPoint;
 
 // Newtype to provide alternative comparator for ScoredPoint which breaks ties by id
@@ -16,8 +15,7 @@ impl From<ScoredPoint> for ScoredPointTies {
 
 impl Ord for ScoredPointTies {
     fn cmp(&self, other: &Self) -> Ordering {
-        let res =
-            OrderedFloat(self.scored_point.score).cmp(&OrderedFloat(other.scored_point.score));
+        let res = self.scored_point.score.cmp(&other.scored_point.score);
         // for identical scores, we fallback to sorting by ids to have a stable output
         if res == Ordering::Equal {
             self.scored_point.id.cmp(&other.scored_point.id)

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -149,10 +149,12 @@ async fn recommend_point_groups(
         access,
         params.timeout(),
     )
-    .await;
+    .await
+    .map(api::rest::GroupsResult::from);
 
     process_response(response, timing)
 }
+
 // Configure services
 pub fn config_recommend_api(cfg: &mut web::ServiceConfig) {
     cfg.service(recommend_points)

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -138,7 +138,8 @@ async fn search_point_groups(
         access,
         params.timeout(),
     )
-    .await;
+    .await
+    .map(api::rest::GroupsResult::from);
 
     process_response(response, timing)
 }

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,5 +1,5 @@
 use api::grpc::models::{CollectionsResponse, VersionInfo};
-use api::rest::{Record, ScoredPoint};
+use api::rest::{GroupsResult, PointGroup, Record, ScoredPoint};
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
@@ -10,9 +10,8 @@ use collection::operations::snapshot_ops::{
 use collection::operations::types::{
     AliasDescription, CollectionClusterInfo, CollectionExistence, CollectionInfo,
     CollectionsAliasesResponse, CountRequest, CountResult, DiscoverRequest, DiscoverRequestBatch,
-    GroupsResult, PointGroup, PointRequest, RecommendGroupsRequest, RecommendRequest,
-    RecommendRequestBatch, ScrollRequest, ScrollResult, SearchGroupsRequest, SearchRequest,
-    SearchRequestBatch, UpdateResult,
+    PointRequest, RecommendGroupsRequest, RecommendRequest, RecommendRequestBatch, ScrollRequest,
+    ScrollResult, SearchGroupsRequest, SearchRequest, SearchRequestBatch, UpdateResult,
 };
 use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
 use schemars::gen::SchemaSettings;


### PR DESCRIPTION
Supersedes #4251 (potentially)

- fix ordering in groups api for discover and best_score reco
- decouple `GroupsResult` from rest interface
- use `Option<Score>` for `ScoredPoint`
- prepare grpc scored point for migration