### PR TITLE
Fix wrong multivectors count in storage

### DIFF
--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -298,7 +298,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
     }
 
     fn total_vector_count(&self) -> usize {
-        self.vectors.len()
+        self.vectors_metadata.len()
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -1,5 +1,4 @@
 use common::types::{PointOffsetType, ScoreType};
-use ordered_float::OrderedFloat;
 
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::TypedMultiDenseVectorRef;
@@ -26,21 +25,20 @@ pub fn score_max_similarity<T: PrimitiveVectorElement, TMetric: Metric<T>>(
     multi_dense_a: TypedMultiDenseVectorRef<T>,
     multi_dense_b: TypedMultiDenseVectorRef<T>,
 ) -> ScoreType {
-    // TODO(colbert) add user input validation
     debug_assert!(!multi_dense_a.is_empty());
     debug_assert!(!multi_dense_b.is_empty());
     let mut sum = 0.0;
     for dense_a in multi_dense_a.multi_vectors() {
-        let mut max_sim = OrderedFloat(ScoreType::NEG_INFINITY);
+        let mut max_sim = ScoreType::NEG_INFINITY;
         // manual `max_by` for performance
         for dense_b in multi_dense_b.multi_vectors() {
-            let sim = OrderedFloat(TMetric::similarity(dense_a, dense_b));
+            let sim = TMetric::similarity(dense_a, dense_b);
             if sim > max_sim {
                 max_sim = sim;
             }
         }
         // sum of max similarity
-        sum += max_sim.into_inner();
+        sum += max_sim;
     }
     sum
 }

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -23,6 +23,7 @@ use segment::types::{
     VectorStorageType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
+use segment::vector_storage::VectorStorage;
 use serde_json::json;
 use tempfile::Builder;
 
@@ -154,6 +155,13 @@ fn test_multi_filterable_hnsw(
             .set_full_payload(n as SeqNumberType, idx, &payload)
             .unwrap();
     }
+    assert_eq!(
+        segment.vector_data[DEFAULT_VECTOR_NAME]
+            .vector_storage
+            .borrow()
+            .total_vector_count(),
+        num_points as usize
+    );
 
     let payload_index_ptr = segment.payload_index.clone();
 


### PR DESCRIPTION
Vector storage should return vectors count, not all inner vectors count. Because `0..self.total_vector_count()` is a range of valid internal ID's. Also removed obsolete `OrderedFloat` usage

