### PR TITLE
Use Python 3.11 on CI for consensus tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: sudo apt-get install clang
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install python deps
         run: pip install -r ./tests/consensus_tests/requirements.txt
       - name: Build
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install requests python lib
         run: pip install requests
       - name: Set up Docker Buildx


### PR DESCRIPTION
This PR bumps the version of the Python runtime used on CI for consensus tests.

The rational is:
- we use 3.11 for openapi tests
- it is good to stay one version behind
- I use 3.11 locally :)