### PR TITLE
add static lifetime to primirive type

### DIFF
--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -12,7 +12,7 @@ use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, Manhat
 use crate::types::{Distance, QuantizationConfig, VectorStorageDatatype};
 
 pub trait PrimitiveVectorElement:
-    Copy + Clone + Default + Serialize + for<'a> Deserialize<'a>
+    Copy + Clone + Default + Serialize + for<'a> Deserialize<'a> + Send + Sync + 'static
 {
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]>;
 

--- a/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
@@ -22,7 +22,7 @@ use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum
 const VECTORS_DIR_PATH: &str = "vectors";
 const DELETED_DIR_PATH: &str = "deleted";
 
-pub struct AppendableMmapDenseVectorStorage<T: PrimitiveVectorElement + 'static> {
+pub struct AppendableMmapDenseVectorStorage<T: PrimitiveVectorElement> {
     vectors: ChunkedMmapVectors<T>,
     deleted: DynamicMmapFlags,
     distance: Distance,
@@ -89,7 +89,7 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
     })
 }
 
-impl<T: PrimitiveVectorElement + 'static> AppendableMmapDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> AppendableMmapDenseVectorStorage<T> {
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> OperationResult<bool> {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -31,7 +31,7 @@ struct MultivectorMmapOffset {
     capacity: PointOffsetType,
 }
 
-pub struct AppendableMmapMultiDenseVectorStorage<T: PrimitiveVectorElement + 'static> {
+pub struct AppendableMmapMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     vectors: ChunkedMmapVectors<T>,
     offsets: ChunkedMmapVectors<MultivectorMmapOffset>,
     deleted: DynamicMmapFlags,
@@ -114,7 +114,7 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
     })
 }
 
-impl<T: PrimitiveVectorElement + 'static> AppendableMmapMultiDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> OperationResult<bool> {

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -87,7 +87,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
 
     pub fn build_with_metric<TElement, TMetric>(self) -> OperationResult<Box<dyn RawScorer + 'a>>
     where
-        TElement: PrimitiveVectorElement + 'a,
+        TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement> + 'a,
     {
         match self.quantized_storage {
@@ -118,7 +118,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
         quantized_storage: &'a impl EncodedVectors<TEncodedQuery>,
     ) -> OperationResult<Box<dyn RawScorer + 'a>>
     where
-        TElement: PrimitiveVectorElement + 'a,
+        TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement> + 'a,
         TEncodedQuery: 'a,
     {


### PR DESCRIPTION
This PR adds static lifetime to Primitive type. It's obvious because primitive types are `f32`, `f16` and `u8` which have static lifetime. It also adds `Send` and `Sync` for future quantization purpose
