### PR TITLE
multivector storage iterate over all inner vectors

### DIFF
--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -148,6 +148,13 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
         }
     }
 
+    fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {
+        (0..self.total_vector_count()).flat_map(|key| {
+            let mmap_offset = self.offsets.get(key).unwrap().first().unwrap();
+            (0..mmap_offset.count).map(|i| self.vectors.get(mmap_offset.offset + i).unwrap())
+        })
+    }
+
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -275,6 +275,13 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
         }
     }
 
+    fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {
+        (0..self.total_vector_count()).flat_map(|key| {
+            let metadata = &self.vectors_metadata[key];
+            (0..metadata.size).map(|i| self.vectors.get(metadata.start as usize + i))
+        })
+    }
+
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -14,7 +14,7 @@ use crate::id_tracker::IdTrackerSS;
 use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage;
 use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
-use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{new_raw_scorer, MultiVectorStorage, VectorStorage, VectorStorageEnum};
 
 #[derive(Clone, Copy)]
 enum MultiDenseStorageType {
@@ -61,6 +61,36 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         let stored_vec = borrowed_storage.get_vector(i as PointOffsetType);
         let multi_dense: TypedMultiDenseVectorRef<_> = stored_vec.as_vec_ref().try_into().unwrap();
         assert_eq!(multi_dense.to_owned(), vec.clone());
+    }
+    // Check that all points are inserted #2
+    {
+        let orig_iter = points.iter().flat_map(|multivec| multivec.multi_vectors());
+        match &borrowed_storage as &VectorStorageEnum {
+            VectorStorageEnum::DenseSimple(_) => unreachable!(),
+            VectorStorageEnum::DenseSimpleByte(_) => unreachable!(),
+            VectorStorageEnum::DenseSimpleHalf(_) => unreachable!(),
+            VectorStorageEnum::DenseMemmap(_) => unreachable!(),
+            VectorStorageEnum::DenseMemmapByte(_) => unreachable!(),
+            VectorStorageEnum::DenseMemmapHalf(_) => unreachable!(),
+            VectorStorageEnum::DenseAppendableMemmap(_) => unreachable!(),
+            VectorStorageEnum::DenseAppendableMemmapByte(_) => unreachable!(),
+            VectorStorageEnum::DenseAppendableMemmapHalf(_) => unreachable!(),
+            VectorStorageEnum::SparseSimple(_) => unreachable!(),
+            VectorStorageEnum::MultiDenseSimple(v) => {
+                for (orig, vec) in orig_iter.zip(v.iterate_inner_vectors()) {
+                    assert_eq!(orig, vec);
+                }
+            }
+            VectorStorageEnum::MultiDenseSimpleByte(_) => unreachable!(),
+            VectorStorageEnum::MultiDenseSimpleHalf(_) => unreachable!(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                for (orig, vec) in orig_iter.zip(v.iterate_inner_vectors()) {
+                    assert_eq!(orig, vec);
+                }
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(_) => unreachable!(),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(_) => unreachable!(),
+        };
     }
 
     // Delete select number of points

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -114,6 +114,7 @@ pub trait SparseVectorStorage: VectorStorage {
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T>;
+    fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send;
     fn multi_vector_config(&self) -> &MultiVectorConfig;
 }
 


### PR DESCRIPTION
Quantization crate takes this dense vectors iterator as an input:
```
impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone + Send,
```
Example is here:
https://github.com/qdrant/quantization/blob/master/quantization/src/encoded_vectors_pq.rs#L57

To achieve multivectors quantization, this PR adds `iterate_inner_vectors` to multivector storage which is quantization-compatible. Test for ram and mmap were added
