### PR TITLE
quantization scorer with multivector support

### DIFF
--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -2,30 +2,25 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
+use itertools::Itertools;
 
+use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{DenseVector, TypedDenseVector};
+use crate::data_types::vectors::{
+    DenseVector, MultiDenseVector, TypedDenseVector, TypedMultiDenseVector,
+};
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
-pub struct QuantizedCustomQueryScorer<
-    'a,
-    TElement,
-    TMetric,
-    TEncodedQuery,
-    TEncodedVectors,
-    TQuery,
-    TOriginalQuery,
-> where
+pub struct QuantizedCustomQueryScorer<'a, TElement, TMetric, TEncodedQuery, TEncodedVectors, TQuery>
+where
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
     TQuery: Query<TEncodedQuery>,
-    TOriginalQuery: Query<TypedDenseVector<TElement>>,
 {
-    original_query: TOriginalQuery,
     query: TQuery,
     quantized_storage: &'a TEncodedVectors,
     phantom: PhantomData<TEncodedQuery>,
@@ -33,31 +28,23 @@ pub struct QuantizedCustomQueryScorer<
     element: PhantomData<TElement>,
 }
 
-impl<'a, TElement, TMetric, TEncodedQuery, TEncodedVectors, TQuery, TOriginalQuery>
-    QuantizedCustomQueryScorer<
-        'a,
-        TElement,
-        TMetric,
-        TEncodedQuery,
-        TEncodedVectors,
-        TQuery,
-        TOriginalQuery,
-    >
+impl<'a, TElement, TMetric, TEncodedQuery, TEncodedVectors, TQuery>
+    QuantizedCustomQueryScorer<'a, TElement, TMetric, TEncodedQuery, TEncodedVectors, TQuery>
 where
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
     TQuery: Query<TEncodedQuery>,
-    TOriginalQuery: Query<TypedDenseVector<TElement>>
-        + TransformInto<TQuery, TypedDenseVector<TElement>, TEncodedQuery>
-        + Clone,
 {
-    pub fn new<TInputQuery>(
+    pub fn new<TOriginalQuery, TInputQuery>(
         raw_query: TInputQuery,
         quantized_storage: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
     ) -> Self
     where
+        TOriginalQuery: Query<TypedDenseVector<TElement>>
+            + TransformInto<TQuery, TypedDenseVector<TElement>, TEncodedQuery>
+            + Clone,
         TInputQuery: Query<DenseVector>
             + TransformInto<TOriginalQuery, DenseVector, TypedDenseVector<TElement>>,
     {
@@ -70,7 +57,6 @@ where
                 Ok(original_vector)
             })
             .unwrap();
-
         let query: TQuery = original_query
             .clone()
             .transform(|original_vector| {
@@ -84,7 +70,55 @@ where
             .unwrap();
 
         Self {
-            original_query,
+            query,
+            quantized_storage,
+            phantom: PhantomData,
+            metric: PhantomData,
+            element: PhantomData,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn new_multi<TOriginalQuery, TInputQuery>(
+        raw_query: TInputQuery,
+        quantized_storage: &'a TEncodedVectors,
+        quantization_config: &QuantizationConfig,
+    ) -> Self
+    where
+        TOriginalQuery: Query<TypedMultiDenseVector<TElement>>
+            + TransformInto<TQuery, TypedMultiDenseVector<TElement>, TEncodedQuery>
+            + Clone,
+        TInputQuery: Query<MultiDenseVector>
+            + TransformInto<TOriginalQuery, MultiDenseVector, TypedMultiDenseVector<TElement>>,
+    {
+        let original_query: TOriginalQuery = raw_query
+            .transform(|vector| {
+                let slices = vector.multi_vectors();
+                let preprocessed = slices
+                    .into_iter()
+                    .flat_map(|slice| TMetric::preprocess(slice.to_vec()))
+                    .collect_vec();
+                let preprocessed = MultiDenseVector::new(preprocessed, vector.dim);
+                let converted =
+                    TElement::from_float_multivector(CowMultiVector::Owned(preprocessed))
+                        .to_owned();
+                Ok(converted)
+            })
+            .unwrap();
+
+        let query: TQuery = original_query
+            .clone()
+            .transform(|original_vector| {
+                let original_vector_prequantized = TElement::quantization_preprocess(
+                    quantization_config,
+                    TMetric::distance(),
+                    &original_vector.flattened_vectors,
+                );
+                Ok(quantized_storage.encode_query(&original_vector_prequantized))
+            })
+            .unwrap();
+
+        Self {
             query,
             quantized_storage,
             phantom: PhantomData,
@@ -94,23 +128,9 @@ where
     }
 }
 
-impl<
-        TElement,
-        TMetric,
-        TEncodedQuery,
-        TEncodedVectors,
-        TOriginalQuery: Query<TypedDenseVector<TElement>>,
-        TQuery: Query<TEncodedQuery>,
-    > QueryScorer<[TElement]>
-    for QuantizedCustomQueryScorer<
-        '_,
-        TElement,
-        TMetric,
-        TEncodedQuery,
-        TEncodedVectors,
-        TQuery,
-        TOriginalQuery,
-    >
+impl<TElement, TMetric, TEncodedQuery, TEncodedVectors, TQuery: Query<TEncodedQuery>>
+    QueryScorer<[TElement]>
+    for QuantizedCustomQueryScorer<'_, TElement, TMetric, TEncodedQuery, TEncodedVectors, TQuery>
 where
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
@@ -121,13 +141,8 @@ where
             .score_by(|this| self.quantized_storage.score_point(this, idx))
     }
 
-    fn score(&self, v2: &[TElement]) -> ScoreType {
-        debug_assert!(
-            false,
-            "This method is not expected to be called for quantized scorer"
-        );
-        self.original_query
-            .score_by(|this| TMetric::similarity(this, v2))
+    fn score(&self, _v2: &[TElement]) -> ScoreType {
+        unimplemented!("This method is not expected to be called for quantized scorer");
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -2,9 +2,10 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
+use itertools::Itertools;
 
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{DenseVector, TypedDenseVector};
+use crate::data_types::vectors::{DenseVector, MultiDenseVector};
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -15,10 +16,10 @@ where
     TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
 {
-    original_query: TypedDenseVector<TElement>,
     query: TEncodedQuery,
     quantized_data: &'a TEncodedVectors,
     metric: PhantomData<TMetric>,
+    element: PhantomData<TElement>,
 }
 
 impl<'a, TElement, TMetric, TEncodedQuery, TEncodedVectors>
@@ -43,14 +44,46 @@ where
         let query = quantized_data.encode_query(&original_query_prequantized);
 
         Self {
-            original_query: original_query.into_owned(),
             query,
             quantized_data,
             metric: PhantomData,
+            element: PhantomData,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn new_multi(
+        raw_query: MultiDenseVector,
+        quantized_data: &'a TEncodedVectors,
+        quantization_config: &QuantizationConfig,
+    ) -> Self {
+        let slices = raw_query.multi_vectors();
+        let query = slices
+            .into_iter()
+            .flat_map(|inner_vector| {
+                let inner_preprocessed = TMetric::preprocess(inner_vector.to_vec());
+                let inner_converted =
+                    TElement::slice_from_float_cow(Cow::Owned(inner_preprocessed));
+                let inner_prequantized = TElement::quantization_preprocess(
+                    quantization_config,
+                    TMetric::distance(),
+                    inner_converted.as_ref(),
+                )
+                .into_owned();
+                inner_prequantized.into_iter()
+            })
+            .collect_vec();
+
+        let query = quantized_data.encode_query(&query);
+
+        Self {
+            query,
+            quantized_data,
+            metric: PhantomData,
+            element: PhantomData,
         }
     }
 }
-
 impl<TElement, TMetric, TEncodedQuery, TEncodedVectors> QueryScorer<[TElement]>
     for QuantizedQueryScorer<'_, TElement, TMetric, TEncodedQuery, TEncodedVectors>
 where
@@ -62,12 +95,8 @@ where
         self.quantized_data.score_point(&self.query, idx)
     }
 
-    fn score(&self, v2: &[TElement]) -> ScoreType {
-        debug_assert!(
-            false,
-            "This method is not expected to be called for quantized scorer"
-        );
-        TMetric::similarity(&self.original_query, v2)
+    fn score(&self, _v2: &[TElement]) -> ScoreType {
+        unimplemented!("This method is not expected to be called for quantized scorer");
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -144,7 +144,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             }
             QueryVector::Recommend(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _>::new(
                     reco_query,
                     quantized_storage,
                     quantization_config,
@@ -154,7 +154,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<DenseVector> =
                     discovery_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _>::new(
                     discovery_query,
                     quantized_storage,
                     quantization_config,
@@ -163,7 +163,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _>::new(
                     context_query,
                     quantized_storage,
                     quantization_config,


### PR DESCRIPTION
This PR adds constructor from multivector for quantization scorers (through `new_multi` method for each quantization scorer). Also, this PR removes unnecessary fields `QuantizedQueryScorer.original_query` and `QuantizedCustomQueryScorer.original_query`.

No tests here because in dev there are no any quantization storage which allow to encode multivector - it will be added in next PR's