### PR TITLE
Add `ReshardingOperation::Abort` consensus message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,9 +5105,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
@@ -5145,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6992,3 +6992,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "hashring"
+version = "0.3.4"
+source = "git+https://github.com/qdrant/hashring-rs?branch=hashring-partial-eq#d0157180aa05a89667c73ca9a7f5f86a12e438d8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,8 +6992,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "hashring"
-version = "0.3.4"
-source = "git+https://github.com/qdrant/hashring-rs?branch=hashring-partial-eq#d0157180aa05a89667c73ca9a7f5f86a12e438d8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,3 +194,5 @@ opt-level = 3
 [patch.crates-io]
 # Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
 tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }
+# Temporary patch until <https://github.com/jeromefroe/hashring-rs/pull/27> is merged
+hashring = { git = 'https://github.com/qdrant/hashring-rs', branch = "hashring-partial-eq" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,5 +194,3 @@ opt-level = 3
 [patch.crates-io]
 # Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
 tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }
-# Temporary patch until <https://github.com/jeromefroe/hashring-rs/pull/27> is merged
-hashring = { git = 'https://github.com/qdrant/hashring-rs', branch = "hashring-partial-eq" }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -731,7 +731,7 @@ impl Collection {
             log::warn!(
                 "aborting resharding of collection {} ({peer_id}/{shard_id}/{shard_key:?}), \
                  but shard {shard_id} does not exist in collection",
-                 self.id,
+                self.id,
             );
         }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -714,20 +714,33 @@ impl Collection {
                 && state.shard_key == shard_key;
 
             if !is_in_progress {
-                return Err(CollectionError::bad_request(format!("TODO")));
+                return Err(CollectionError::bad_request(format!(
+                    "resharding of collection {} is not in progress",
+                    self.id,
+                )));
             }
         } else {
-            log::warn!("resharding of collection {} is not in progress", self.id);
+            log::warn!(
+                "aborting resharding of collection {} ({peer_id}/{shard_id}/{shard_key:?}),\
+                 but resharding is not in progress",
+                self.id,
+            );
         };
 
         if shard_holder.get_shard(&shard_id).is_none() {
-            log::warn!("shard {shard_id} does not exist in collection {}", self.id);
+            log::warn!(
+                "aborting resharding of collection {} ({peer_id}/{shard_id}/{shard_key:?}), \
+                 but shard {shard_id} does not exist in collection",
+                 self.id,
+            );
         }
 
+        // TODO: Contextualize errors? 🤔
         shard_holder
             .abort_resharding(shard_id, peer_id, shard_key.clone())
             .await?;
 
+        // TODO: Contextualize errors? 🤔
         self.resharding_state.write(|state| {
             *state = None;
         })?;

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -743,12 +743,12 @@ impl Collection {
             );
         }
 
-        // TODO: Contextualize errors? 🤔
+        // TODO(resharding): Contextualize errors? 🤔
         shard_holder
             .abort_resharding(shard_id, peer_id, shard_key.clone(), is_in_progress)
             .await?;
 
-        // TODO: Contextualize errors? 🤔
+        // TODO(resharding): Contextualize errors? 🤔
         self.resharding_state.write(|state| {
             *state = None;
         })?;

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -657,6 +657,10 @@ impl Collection {
         Ok(())
     }
 
+    pub fn resharding_state(&self) -> Option<ReshardingState> {
+        self.resharding_state.read().clone()
+    }
+
     pub async fn start_resharding(
         &self,
         peer_id: PeerId,

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -667,9 +667,9 @@ impl Collection {
 
         let mut shard_holder = self.shards_holder.write().await;
 
-        if self.resharding_state.read().is_some() {
+        if let Some(state) = self.resharding_state.read().deref() {
             return Err(CollectionError::bad_request(format!(
-                "resharding of collection {} is already in progress",
+                "resharding of collection {} is already in progress: {state:?}",
                 self.id
             )));
         }
@@ -690,7 +690,7 @@ impl Collection {
         self.resharding_state.write(|state| {
             debug_assert!(
                 state.is_none(),
-                "resharding of collection {} is already in progress",
+                "resharding of collection {} is already in progress: {state:?}",
                 self.id
             );
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -712,7 +712,7 @@ impl Collection {
     ) -> CollectionResult<()> {
         let mut shard_holder = self.shards_holder.write().await;
 
-        if let Some(state) = self.resharding_state.read().deref() {
+        let is_in_progress = if let Some(state) = self.resharding_state.read().deref() {
             let is_in_progress = state.peer_id == peer_id
                 && state.shard_id == shard_id
                 && state.shard_key == shard_key;
@@ -723,12 +723,16 @@ impl Collection {
                     self.id,
                 )));
             }
+
+            is_in_progress
         } else {
             log::warn!(
                 "aborting resharding of collection {} ({peer_id}/{shard_id}/{shard_key:?}),\
                  but resharding is not in progress",
                 self.id,
             );
+
+            false
         };
 
         if shard_holder.get_shard(&shard_id).is_none() {
@@ -741,7 +745,7 @@ impl Collection {
 
         // TODO: Contextualize errors? 🤔
         shard_holder
-            .abort_resharding(shard_id, peer_id, shard_key.clone())
+            .abort_resharding(shard_id, peer_id, shard_key.clone(), is_in_progress)
             .await?;
 
         // TODO: Contextualize errors? 🤔

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -74,6 +74,46 @@ impl<T: Hash + Copy> HashRing<T> {
         new.add(shard);
     }
 
+    pub fn remove_resharding(&mut self, shard: T) {
+        let Self::Resharding { old, new } = self else {
+            log::warn!("TODO");
+            return;
+        };
+
+        let mut old = old.clone();
+        let mut new = new.clone();
+
+        let removed_from_old = old.remove(&shard);
+        let removed_from_new = new.remove(&shard);
+
+        match (removed_from_old, removed_from_new) {
+            (false, true) => {
+                log::debug!("TODO");
+            }
+
+            (false, false) => {
+                log::warn!("TODO");
+            }
+
+            (true, true) => {
+                log::error!("TODO");
+                return;
+            }
+
+            (true, false) => {
+                log::error!("TODO");
+                return;
+            }
+        }
+
+        if old.len() != new.len() {
+            log::warn!("TODO");
+            return;
+        }
+
+        *self = Self::Single(old);
+    }
+
     pub fn get<U: Hash>(&self, key: &U) -> ShardIds<T> {
         match self {
             Self::Single(ring) => ring.get(key).into_iter().cloned().collect(),

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -29,6 +29,9 @@ pub enum ClusterOperations {
     /// Start resharding
     #[schemars(skip)]
     StartResharding(StartReshardingOperation),
+    // Abort resharding
+    #[schemars(skip)]
+    AbortResharding(AbortReshardingOperation),
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
@@ -106,6 +109,7 @@ impl Validate for ClusterOperations {
             ClusterOperations::DropShardingKey(op) => op.validate(),
             ClusterOperations::RestartTransfer(op) => op.validate(),
             ClusterOperations::StartResharding(op) => op.validate(),
+            ClusterOperations::AbortResharding(op) => op.validate(),
         }
     }
 }
@@ -140,8 +144,12 @@ pub struct AbortTransferOperation {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct StartReshardingOperation {
-    pub peer_id: Option<PeerId>,
-    pub shard_key: Option<ShardKey>,
+    pub start_resharding: StartResharding,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+pub struct AbortReshardingOperation {
+    pub abort_resharding: AbortResharding,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -196,3 +204,12 @@ pub struct AbortShardTransfer {
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,
 }
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+pub struct StartResharding {
+    pub peer_id: Option<PeerId>,
+    pub shard_key: Option<ShardKey>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+pub struct AbortResharding {}

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -172,34 +172,45 @@ impl ShardHolder {
         shard_key: Option<ShardKey>,
     ) -> Result<(), CollectionError> {
         if let Some(ring) = self.rings.get_mut(&shard_key) {
-            log::debug!("TODO");
+            log::debug!("removing peer {peer_id} from {shard_key:?} hashring");
             ring.remove_resharding(shard_id);
         } else {
-            log::warn!("TODO");
+            log::warn!(
+                "aborting resharding of shard {shard_id} ({peer_id}/{shard_key:?}), \
+                 but {shard_key:?} hashring does not exist"
+            );
         }
 
         if let Some(shard) = self.get_shard(&shard_id) {
             match shard.peer_state(&peer_id) {
                 Some(ReplicaState::Resharding) => {
-                    log::debug!("TODO");
+                    log::debug!("removing peer {peer_id} from {shard_id} replica set");
                     shard.remove_peer(peer_id).await?;
                 }
 
                 Some(state) => {
-                    log::error!("TODO");
+                    return Err(CollectionError::bad_request(format!(
+                        "peer {peer_id} is in {state:?} state"
+                    )));
                 }
 
                 None => {
-                    log::warn!("TODO");
+                    log::warn!(
+                        "aborting resharding of shard {shard_id} ({peer_id}/{shard_key:?}), \
+                         but peer {peer_id} does not exist in {shard_id} replica set"
+                    );
                 }
             }
 
             if shard.peers().is_empty() {
-                log::debug!("TODO");
+                log::debug!("removing {shard_id} replica set, because replica set is empty");
                 self.drop_and_remove_shard(shard_id).await?;
             }
         } else {
-            log::warn!("TODO");
+            log::warn!(
+                "aborting resharding of shard {shard_id} ({peer_id}/{shard_key:?}), \
+                 but shard holder does not contain {shard_id} replica set",
+            );
         }
 
         Ok(())

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -165,6 +165,46 @@ impl ShardHolder {
         Ok(())
     }
 
+    pub async fn abort_resharding(
+        &mut self,
+        shard_id: ShardId,
+        peer_id: PeerId,
+        shard_key: Option<ShardKey>,
+    ) -> Result<(), CollectionError> {
+        if let Some(ring) = self.rings.get_mut(&shard_key) {
+            log::debug!("TODO");
+            ring.remove_resharding(shard_id);
+        } else {
+            log::warn!("TODO");
+        }
+
+        if let Some(shard) = self.get_shard(&shard_id) {
+            match shard.peer_state(&peer_id) {
+                Some(ReplicaState::Resharding) => {
+                    log::debug!("TODO");
+                    shard.remove_peer(peer_id).await?;
+                }
+
+                Some(state) => {
+                    log::error!("TODO");
+                }
+
+                None => {
+                    log::warn!("TODO");
+                }
+            }
+
+            if shard.peers().is_empty() {
+                log::debug!("TODO");
+                self.drop_and_remove_shard(shard_id).await?;
+            }
+        } else {
+            log::warn!("TODO");
+        }
+
+        Ok(())
+    }
+
     pub fn add_shard(
         &mut self,
         shard_id: ShardId,

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -298,6 +298,12 @@ pub enum ReshardingOperation {
         shard_id: ShardId,
         shard_key: Option<ShardKey>,
     },
+
+    Abort {
+        peer_id: PeerId,
+        shard_id: ShardId,
+        shard_key: Option<ShardKey>,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -283,6 +283,16 @@ impl TableOfContent {
                     .start_resharding(peer_id, shard_id, shard_key)
                     .await?;
             }
+
+            ReshardingOperation::Abort {
+                peer_id,
+                shard_id,
+                shard_key,
+            } => {
+                collection
+                    .abort_resharding(peer_id, shard_id, shard_key)
+                    .await?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Tracked in #4213.

This PR:
- adds `ReshardingOperation::Abort` consensus message
- and `AbortResharding` operation to `update_collection_cluster` REST API
  - (currently not exposed in the OpenAPI spec)
- and also fixes incorrect serialization format of `StartResharding` operation for `update_collection_cluster` API
  - `#[serde(untagged)]` is annoying to work with 😒

Abort operation is structured so that it can be applied to a partial/inconsistent resharding state, so that you can cleanup a broken state if something went wrong.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
