### PR TITLE
universal-query: Introduce `order_value` field in `ScoredPoint`

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -150,6 +150,7 @@
     - [NamedVectors.VectorsEntry](#qdrant-NamedVectors-VectorsEntry)
     - [NestedCondition](#qdrant-NestedCondition)
     - [OrderBy](#qdrant-OrderBy)
+    - [OrderedValue](#qdrant-OrderedValue)
     - [PayloadExcludeSelector](#qdrant-PayloadExcludeSelector)
     - [PayloadIncludeSelector](#qdrant-PayloadIncludeSelector)
     - [PointGroup](#qdrant-PointGroup)
@@ -2589,6 +2590,22 @@ Additionally, the first and last points of each GeoLineString must be the same.
 
 
 
+<a name="qdrant-OrderedValue"></a>
+
+### OrderedValue
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| int | [int64](#int64) |  |  |
+| float | [double](#double) |  |  |
+
+
+
+
+
+
 <a name="qdrant-PayloadExcludeSelector"></a>
 
 ### PayloadExcludeSelector
@@ -3203,6 +3220,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | version | [uint64](#uint64) |  | Last update operation applied to this point |
 | vectors | [Vectors](#qdrant-Vectors) | optional | Vectors to search |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
+| order_value | [OrderedValue](#qdrant-OrderedValue) | optional | Order by value |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -150,7 +150,7 @@
     - [NamedVectors.VectorsEntry](#qdrant-NamedVectors-VectorsEntry)
     - [NestedCondition](#qdrant-NestedCondition)
     - [OrderBy](#qdrant-OrderBy)
-    - [OrderedValue](#qdrant-OrderedValue)
+    - [OrderValue](#qdrant-OrderValue)
     - [PayloadExcludeSelector](#qdrant-PayloadExcludeSelector)
     - [PayloadIncludeSelector](#qdrant-PayloadIncludeSelector)
     - [PointGroup](#qdrant-PointGroup)
@@ -2590,9 +2590,9 @@ Additionally, the first and last points of each GeoLineString must be the same.
 
 
 
-<a name="qdrant-OrderedValue"></a>
+<a name="qdrant-OrderValue"></a>
 
-### OrderedValue
+### OrderValue
 
 
 
@@ -3220,7 +3220,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | version | [uint64](#uint64) |  | Last update operation applied to this point |
 | vectors | [Vectors](#qdrant-Vectors) | optional | Vectors to search |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
-| order_value | [OrderedValue](#qdrant-OrderedValue) | optional | Order by value |
+| order_value | [OrderValue](#qdrant-OrderValue) | optional | Order by value |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7149,8 +7149,31 @@
                 "nullable": true
               }
             ]
+          },
+          "order_value": {
+            "description": "Order-by value",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrderedValue"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
+      },
+      "OrderedValue": {
+        "anyOf": [
+          {
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "type": "number",
+            "format": "double"
+          }
+        ]
       },
       "UpdateResult": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7154,7 +7154,7 @@
             "description": "Order-by value",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OrderedValue"
+                "$ref": "#/components/schemas/OrderValue"
               },
               {
                 "nullable": true
@@ -7163,7 +7163,7 @@
           }
         }
       },
-      "OrderedValue": {
+      "OrderValue": {
         "anyOf": [
           {
             "type": "integer",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use super::qdrant::raw_query::RawContextPair;
 use super::qdrant::{
     raw_query, start_from, BinaryQuantization, CompressionRatio, DatetimeRange, Direction,
-    GeoLineString, GroupId, MultiVectorComparator, MultiVectorConfig, OrderBy, OrderedValue, Range,
+    GeoLineString, GroupId, MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range,
     RawVector, SparseIndices, StartFrom,
 };
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
@@ -571,15 +571,15 @@ impl From<segment_vectors::VectorStruct> for Vectors {
     }
 }
 
-impl From<segment::data_types::order_by::OrderedValue> for OrderedValue {
-    fn from(value: segment::data_types::order_by::OrderedValue) -> Self {
+impl From<segment::data_types::order_by::OrderValue> for OrderValue {
+    fn from(value: segment::data_types::order_by::OrderValue) -> Self {
         use segment::data_types::order_by as segment;
 
-        use crate::grpc::qdrant::ordered_value::Variant;
+        use crate::grpc::qdrant::order_value::Variant;
 
         let variant = match value {
-            segment::OrderedValue::Float(value) => Variant::Float(value),
-            segment::OrderedValue::Int(value) => Variant::Int(value),
+            segment::OrderValue::Float(value) => Variant::Float(value),
+            segment::OrderValue::Int(value) => Variant::Int(value),
         };
 
         Self {
@@ -588,21 +588,21 @@ impl From<segment::data_types::order_by::OrderedValue> for OrderedValue {
     }
 }
 
-impl TryFrom<OrderedValue> for segment::data_types::order_by::OrderedValue {
+impl TryFrom<OrderValue> for segment::data_types::order_by::OrderValue {
     type Error = Status;
 
-    fn try_from(value: OrderedValue) -> Result<Self, Self::Error> {
+    fn try_from(value: OrderValue) -> Result<Self, Self::Error> {
         use segment::data_types::order_by as segment;
 
-        use crate::grpc::qdrant::ordered_value::Variant;
+        use crate::grpc::qdrant::order_value::Variant;
 
         let variant = value.variant.ok_or_else(|| {
             Status::invalid_argument("OrderedValue should have a variant".to_string())
         })?;
 
         let value = match variant {
-            Variant::Float(value) => segment::OrderedValue::Float(value),
-            Variant::Int(value) => segment::OrderedValue::Int(value),
+            Variant::Float(value) => segment::OrderValue::Float(value),
+            Variant::Int(value) => segment::OrderValue::Int(value),
         };
 
         Ok(value)

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -564,7 +564,7 @@ enum UpdateStatus {
   ClockRejected = 3; // Internal: update is rejected due to an outdated clock
 }
 
-message OrderedValue {
+message OrderValue {
   oneof variant {
     int64 int = 1;
     double float = 2;
@@ -579,7 +579,7 @@ message ScoredPoint {
   uint64 version = 5; // Last update operation applied to this point
   optional Vectors vectors = 6; // Vectors to search
   optional ShardKey shard_key = 7; // Shard key
-  optional OrderedValue order_value = 8; // Order by value
+  optional OrderValue order_value = 8; // Order by value
 }
 
 message GroupId {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -564,6 +564,13 @@ enum UpdateStatus {
   ClockRejected = 3; // Internal: update is rejected due to an outdated clock
 }
 
+message OrderedValue {
+  oneof variant {
+    int64 int = 1;
+    double float = 2;
+  }
+}
+
 message ScoredPoint {
   PointId id = 1; // Point id
   map<string, Value> payload = 2; // Payload
@@ -572,6 +579,7 @@ message ScoredPoint {
   uint64 version = 5; // Last update operation applied to this point
   optional Vectors vectors = 6; // Vectors to search
   optional ShardKey shard_key = 7; // Shard key
+  optional OrderedValue order_value = 8; // Order by value
 }
 
 message GroupId {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4914,12 +4914,12 @@ pub struct UpdateResult {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct OrderedValue {
-    #[prost(oneof = "ordered_value::Variant", tags = "1, 2")]
-    pub variant: ::core::option::Option<ordered_value::Variant>,
+pub struct OrderValue {
+    #[prost(oneof = "order_value::Variant", tags = "1, 2")]
+    pub variant: ::core::option::Option<order_value::Variant>,
 }
-/// Nested message and enum types in `OrderedValue`.
-pub mod ordered_value {
+/// Nested message and enum types in `OrderValue`.
+pub mod order_value {
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -4954,7 +4954,7 @@ pub struct ScoredPoint {
     pub shard_key: ::core::option::Option<ShardKey>,
     /// Order by value
     #[prost(message, optional, tag = "8")]
-    pub order_value: ::core::option::Option<OrderedValue>,
+    pub order_value: ::core::option::Option<OrderValue>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4914,6 +4914,25 @@ pub struct UpdateResult {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrderedValue {
+    #[prost(oneof = "ordered_value::Variant", tags = "1, 2")]
+    pub variant: ::core::option::Option<ordered_value::Variant>,
+}
+/// Nested message and enum types in `OrderedValue`.
+pub mod ordered_value {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(int64, tag = "1")]
+        Int(i64),
+        #[prost(double, tag = "2")]
+        Float(f64),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScoredPoint {
     /// Point id
     #[prost(message, optional, tag = "1")]
@@ -4933,6 +4952,9 @@ pub struct ScoredPoint {
     /// Shard key
     #[prost(message, optional, tag = "7")]
     pub shard_key: ::core::option::Option<ShardKey>,
+    /// Order by value
+    #[prost(message, optional, tag = "8")]
+    pub order_value: ::core::option::Option<OrderedValue>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -100,6 +100,7 @@ impl From<segment::types::ScoredPoint> for ScoredPoint {
             payload: value.payload,
             vector: value.vector.map(From::from),
             shard_key: value.shard_key,
+            order_value: value.order_value.map(From::from),
         }
     }
 }
@@ -113,6 +114,7 @@ impl From<ScoredPoint> for segment::types::ScoredPoint {
             payload: value.payload,
             vector: value.vector.map(From::from),
             shard_key: value.shard_key,
+            order_value: value.order_value.map(From::from),
         }
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -89,6 +89,8 @@ pub struct ScoredPoint {
     /// Shard Key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<segment::types::ShardKey>,
+    /// Order-by value
+    pub order_value: Option<segment::data_types::order_by::OrderedValue>,
 }
 
 /// Point data

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -90,7 +90,7 @@ pub struct ScoredPoint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<segment::types::ShardKey>,
     /// Order-by value
-    pub order_value: Option<segment::data_types::order_by::OrderedValue>,
+    pub order_value: Option<segment::data_types::order_by::OrderValue>,
 }
 
 /// Point data

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -13,7 +13,6 @@ use tokio::time::Instant;
 use super::Collection;
 use crate::events::SlowQueryEvent;
 use crate::operations::consistency_params::ReadConsistency;
-use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::*;
 
@@ -247,16 +246,14 @@ impl Collection {
             .into_iter()
             .zip(request.searches.iter())
             .map(|(res, request)| {
-                let order = match &request.query {
-                    QueryEnum::Nearest(_) => collection_params
-                        .get_distance(request.query.get_vector_name())?
-                        .distance_order(),
-
+                let order = if request.query.has_custom_scoring() {
                     // Score comes from special handling of the distances in a way that it doesn't
                     // directly represent distance anymore, so the order is always `LargeBetter`
-                    QueryEnum::Discover(_)
-                    | QueryEnum::Context(_)
-                    | QueryEnum::RecommendBestScore(_) => Order::LargeBetter,
+                    Order::LargeBetter
+                } else {
+                    collection_params
+                        .get_distance(request.query.get_vector_name())?
+                        .distance_order()
                 };
 
                 let mut top_res = match order {

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -246,14 +246,14 @@ impl Collection {
             .into_iter()
             .zip(request.searches.iter())
             .map(|(res, request)| {
-                let order = if request.query.has_custom_scoring() {
-                    // Score comes from special handling of the distances in a way that it doesn't
-                    // directly represent distance anymore, so the order is always `LargeBetter`
-                    Order::LargeBetter
-                } else {
+                let order = if request.query.is_distance_scored() {
                     collection_params
                         .get_distance(request.query.get_vector_name())?
                         .distance_order()
+                } else {
+                    // Score comes from special handling of the distances in a way that it doesn't
+                    // directly represent distance anymore, so the order is always `LargeBetter`
+                    Order::LargeBetter
                 };
 
                 let mut top_res = match order {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -8,7 +8,7 @@ use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::order_by::OrderedValue;
+use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
 use segment::data_types::vectors::{QueryVector, Vector};
 use segment::entry::entry_point::SegmentEntry;
@@ -636,7 +636,7 @@ impl SegmentEntry for ProxySegment {
         limit: Option<usize>,
         filter: Option<&'a Filter>,
         order_by: &'a segment::data_types::order_by::OrderBy,
-    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderValue, PointIdType)>> {
         let deleted_points = self.deleted_points.read();
         let mut read_points = if deleted_points.is_empty() {
             self.wrapped_segment

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -8,7 +8,7 @@ use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::order_by::OrderingValue;
+use segment::data_types::order_by::OrderedValue;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
 use segment::data_types::vectors::{QueryVector, Vector};
 use segment::entry::entry_point::SegmentEntry;
@@ -636,7 +636,7 @@ impl SegmentEntry for ProxySegment {
         limit: Option<usize>,
         filter: Option<&'a Filter>,
         order_by: &'a segment::data_types::order_by::OrderBy,
-    ) -> OperationResult<Vec<(OrderingValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
         let deleted_points = self.deleted_points.read();
         let mut read_points = if deleted_points.is_empty() {
             self.wrapped_segment

--- a/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
+++ b/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
@@ -11,6 +11,7 @@ fn score_point(id: usize, score: ScoreType, version: SeqNumberType) -> ScoredPoi
         payload: None,
         vector: None,
         shard_key: None,
+        order_value: None,
     }
 }
 

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -202,6 +202,7 @@ mod unit_tests {
             payload: Some(Payload::from(serde_json::json!({ "docId": payloads }))),
             vector: None,
             shard_key: None,
+            order_value: None,
         }
     }
 
@@ -213,6 +214,7 @@ mod unit_tests {
             payload: None,
             vector: None,
             shard_key: None,
+            order_value: None,
         }
     }
 

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -232,13 +232,13 @@ pub async fn group_by(
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
 ) -> CollectionResult<Vec<PointGroup>> {
-    let score_ordering = if request.source.query.has_custom_scoring() {
-        Order::LargeBetter
-    } else {
+    let score_ordering = if request.source.query.is_distance_scored() {
         let vector_name = request.source.query.get_vector_name();
         let collection_params = collection.collection_config.read().await;
         let distance = collection_params.params.get_distance(vector_name)?;
         distance.distance_order()
+    } else {
+        Order::LargeBetter
     };
 
     let mut aggregator = GroupsAggregator::new(

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -6,7 +6,7 @@ use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
 use segment::json_path::{JsonPath, JsonPathInterface as _};
 use segment::types::{
-    AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
+    AnyVariants, Condition, FieldCondition, Filter, Match, Order, ScoredPoint, WithPayloadInterface,
 };
 use serde_json::Value;
 use tokio::sync::RwLockReadGuard;
@@ -232,7 +232,9 @@ pub async fn group_by(
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
 ) -> CollectionResult<Vec<PointGroup>> {
-    let score_ordering = {
+    let score_ordering = if request.source.query.has_custom_scoring() {
+        Order::LargeBetter
+    } else {
         let vector_name = request.source.query.get_vector_name();
         let collection_params = collection.collection_config.read().await;
         let distance = collection_params.params.get_distance(vector_name)?;
@@ -460,6 +462,18 @@ mod tests {
 
     use crate::grouping::types::Group;
 
+    fn make_scored_point(id: u64, score: f32, payload: Option<Payload>) -> ScoredPoint {
+        ScoredPoint {
+            id: id.into(),
+            version: 0,
+            score,
+            payload,
+            vector: None,
+            shard_key: None,
+            order_value: None,
+        }
+    }
+
     #[test]
     fn test_hydrated_from() {
         // arrange
@@ -468,43 +482,15 @@ mod tests {
             (
                 "a",
                 [
-                    ScoredPoint {
-                        id: 1.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
-                    ScoredPoint {
-                        id: 2.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
+                    make_scored_point(1, 1.0, None),
+                    make_scored_point(2, 1.0, None),
                 ],
             ),
             (
                 "b",
                 [
-                    ScoredPoint {
-                        id: 3.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
-                    ScoredPoint {
-                        id: 4.into(),
-                        version: 0,
-                        score: 1.0,
-                        payload: None,
-                        vector: None,
-                        shard_key: None,
-                    },
+                    make_scored_point(3, 1.0, None),
+                    make_scored_point(4, 1.0, None),
                 ],
             ),
         ]
@@ -521,38 +507,10 @@ mod tests {
         let payload_b = Payload::from(serde_json::json!({"some_key": "some value b"}));
 
         let hydrated = vec![
-            ScoredPoint {
-                id: 1.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_a.clone()),
-                vector: None,
-                shard_key: None,
-            },
-            ScoredPoint {
-                id: 2.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_a.clone()),
-                vector: None,
-                shard_key: None,
-            },
-            ScoredPoint {
-                id: 3.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_b.clone()),
-                vector: None,
-                shard_key: None,
-            },
-            ScoredPoint {
-                id: 4.into(),
-                version: 0,
-                score: 1.0,
-                payload: Some(payload_b.clone()),
-                vector: None,
-                shard_key: None,
-            },
+            make_scored_point(1, 1.0, Some(payload_a.clone())),
+            make_scored_point(2, 1.0, Some(payload_a.clone())),
+            make_scored_point(3, 1.0, Some(payload_b.clone())),
+            make_scored_point(4, 1.0, Some(payload_b.clone())),
         ];
 
         let set: HashMap<_, _> = hydrated.into_iter().map(|p| (p.id, p)).collect();

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -12,8 +12,8 @@ impl QueryEnum {
         }
     }
 
-    /// Only when the distance is the scoring, this will return false.
-    pub fn has_custom_scoring(&self) -> bool {
+    /// Only when the distance is the scoring, this will return true.
+    pub fn is_distance_scored(&self) -> bool {
         match self {
             QueryEnum::Nearest(_) => false,
             QueryEnum::RecommendBestScore(_) | QueryEnum::Discover(_) | QueryEnum::Context(_) => {

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -12,6 +12,16 @@ impl QueryEnum {
         }
     }
 
+    /// Only when the distance is the scoring, this will return false.
+    pub fn has_custom_scoring(&self) -> bool {
+        match self {
+            QueryEnum::Nearest(_) => false,
+            QueryEnum::RecommendBestScore(_) | QueryEnum::Discover(_) | QueryEnum::Context(_) => {
+                true
+            }
+        }
+    }
+
     pub fn iterate_sparse(&self, mut f: impl FnMut(&str, &SparseVector)) {
         match self {
             QueryEnum::Nearest(vector) => match vector {

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -15,9 +15,9 @@ impl QueryEnum {
     /// Only when the distance is the scoring, this will return true.
     pub fn is_distance_scored(&self) -> bool {
         match self {
-            QueryEnum::Nearest(_) => false,
+            QueryEnum::Nearest(_) => true,
             QueryEnum::RecommendBestScore(_) | QueryEnum::Discover(_) | QueryEnum::Context(_) => {
-                true
+                false
             }
         }
     }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -443,5 +443,6 @@ pub fn try_scored_point_from_grpc(
         payload,
         vector,
         shard_key: convert_shard_key_from_grpc_opt(point.shard_key),
+        order_value: point.order_value.map(TryFrom::try_from).transpose()?,
     })
 }

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -277,6 +277,7 @@ mod test {
             payload: None,
             vector: None,
             shard_key: None,
+            order_value: None,
         }
     }
 

--- a/lib/segment/src/common/reciprocal_rank_fusion.rs
+++ b/lib/segment/src/common/reciprocal_rank_fusion.rs
@@ -66,6 +66,7 @@ mod tests {
             payload: None,
             vector: None,
             shard_key: None,
+            order_value: None,
         }
     }
 

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -84,17 +84,17 @@ impl OrderBy {
         self.direction.unwrap_or_default()
     }
 
-    pub fn start_from(&self) -> OrderingValue {
+    pub fn start_from(&self) -> OrderedValue {
         self.start_from
             .as_ref()
             .map(|start_from| match start_from {
-                StartFrom::Integer(i) => OrderingValue::Int(*i),
-                StartFrom::Float(f) => OrderingValue::Float(*f),
-                StartFrom::Datetime(dt) => OrderingValue::Int(dt.timestamp()),
+                StartFrom::Integer(i) => OrderedValue::Int(*i),
+                StartFrom::Float(f) => OrderedValue::Float(*f),
+                StartFrom::Datetime(dt) => OrderedValue::Int(dt.timestamp()),
             })
             .unwrap_or_else(|| match self.direction() {
-                Direction::Asc => OrderingValue::MIN,
-                Direction::Desc => OrderingValue::MAX,
+                Direction::Asc => OrderedValue::MIN,
+                Direction::Desc => OrderedValue::MAX,
             })
     }
 
@@ -109,51 +109,52 @@ impl OrderBy {
         new_payload
     }
 
-    fn json_value_to_ordering_value(&self, value: Option<serde_json::Value>) -> OrderingValue {
+    fn json_value_to_ordering_value(&self, value: Option<serde_json::Value>) -> OrderedValue {
         value
-            .and_then(|v| OrderingValue::try_from(v).ok())
+            .and_then(|v| OrderedValue::try_from(v).ok())
             .unwrap_or_else(|| match self.direction() {
-                Direction::Asc => OrderingValue::MAX,
-                Direction::Desc => OrderingValue::MIN,
+                Direction::Asc => OrderedValue::MAX,
+                Direction::Desc => OrderedValue::MIN,
             })
     }
 
-    pub fn get_order_value_from_payload(&self, payload: Option<&Payload>) -> OrderingValue {
+    pub fn get_order_value_from_payload(&self, payload: Option<&Payload>) -> OrderedValue {
         self.json_value_to_ordering_value(
             payload.and_then(|payload| payload.0.get(INTERNAL_KEY_OF_ORDER_BY_VALUE).cloned()),
         )
     }
 
-    pub fn remove_order_value_from_payload(&self, payload: Option<&mut Payload>) -> OrderingValue {
+    pub fn remove_order_value_from_payload(&self, payload: Option<&mut Payload>) -> OrderedValue {
         self.json_value_to_ordering_value(
             payload.and_then(|payload| payload.0.remove(INTERNAL_KEY_OF_ORDER_BY_VALUE)),
         )
     }
 }
 
-#[derive(Debug)]
-pub enum OrderingValue {
-    Float(FloatPayloadType),
+#[derive(Debug, Clone, Copy, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum OrderedValue {
     Int(IntPayloadType),
+    Float(FloatPayloadType),
 }
 
-impl OrderingValue {
+impl OrderedValue {
     const MAX: Self = Self::Float(f64::NAN);
     const MIN: Self = Self::Float(f64::MIN);
 }
 
-impl From<OrderingValue> for serde_json::Value {
-    fn from(value: OrderingValue) -> Self {
+impl From<OrderedValue> for serde_json::Value {
+    fn from(value: OrderedValue) -> Self {
         match value {
-            OrderingValue::Float(value) => serde_json::Number::from_f64(value)
+            OrderedValue::Float(value) => serde_json::Number::from_f64(value)
                 .map(serde_json::Value::Number)
                 .unwrap_or(serde_json::Value::Null),
-            OrderingValue::Int(value) => serde_json::Value::Number(serde_json::Number::from(value)),
+            OrderedValue::Int(value) => serde_json::Value::Number(serde_json::Number::from(value)),
         }
     }
 }
 
-impl TryFrom<serde_json::Value> for OrderingValue {
+impl TryFrom<serde_json::Value> for OrderedValue {
     type Error = ();
 
     fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
@@ -165,52 +166,52 @@ impl TryFrom<serde_json::Value> for OrderingValue {
     }
 }
 
-impl From<FloatPayloadType> for OrderingValue {
+impl From<FloatPayloadType> for OrderedValue {
     fn from(value: FloatPayloadType) -> Self {
-        OrderingValue::Float(value)
+        OrderedValue::Float(value)
     }
 }
 
-impl From<IntPayloadType> for OrderingValue {
+impl From<IntPayloadType> for OrderedValue {
     fn from(value: IntPayloadType) -> Self {
-        OrderingValue::Int(value)
+        OrderedValue::Int(value)
     }
 }
 
-impl Eq for OrderingValue {}
+impl Eq for OrderedValue {}
 
-impl PartialEq for OrderingValue {
+impl PartialEq for OrderedValue {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (OrderingValue::Float(a), OrderingValue::Float(b)) => {
+            (OrderedValue::Float(a), OrderedValue::Float(b)) => {
                 OrderedFloat(*a) == OrderedFloat(*b)
             }
-            (OrderingValue::Int(a), OrderingValue::Int(b)) => a == b,
-            (OrderingValue::Float(a), OrderingValue::Int(b)) => a.num_eq(*b),
-            (OrderingValue::Int(a), OrderingValue::Float(b)) => a.num_eq(*b),
+            (OrderedValue::Int(a), OrderedValue::Int(b)) => a == b,
+            (OrderedValue::Float(a), OrderedValue::Int(b)) => a.num_eq(*b),
+            (OrderedValue::Int(a), OrderedValue::Float(b)) => a.num_eq(*b),
         }
     }
 }
 
-impl PartialOrd for OrderingValue {
+impl PartialOrd for OrderedValue {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for OrderingValue {
+impl Ord for OrderedValue {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (self, other) {
-            (OrderingValue::Float(a), OrderingValue::Float(b)) => {
+            (OrderedValue::Float(a), OrderedValue::Float(b)) => {
                 OrderedFloat(*a).cmp(&OrderedFloat(*b))
             }
-            (OrderingValue::Int(a), OrderingValue::Int(b)) => a.cmp(b),
-            (OrderingValue::Float(a), OrderingValue::Int(b)) => {
+            (OrderedValue::Int(a), OrderedValue::Int(b)) => a.cmp(b),
+            (OrderedValue::Float(a), OrderedValue::Int(b)) => {
                 // num_cmp() might return None only if the float value is NaN. We follow the
                 // OrderedFloat logic here: the NaN is always greater than any other value.
                 a.num_cmp(*b).unwrap_or(std::cmp::Ordering::Greater)
             }
-            (OrderingValue::Int(a), OrderingValue::Float(b)) => {
+            (OrderedValue::Int(a), OrderedValue::Float(b)) => {
                 // Ditto, but the NaN is on the right side of the comparison.
                 a.num_cmp(*b).unwrap_or(std::cmp::Ordering::Less)
             }
@@ -222,22 +223,22 @@ impl Ord for OrderingValue {
 mod tests {
     use proptest::proptest;
 
-    use crate::data_types::order_by::OrderingValue;
+    use crate::data_types::order_by::OrderedValue;
 
     proptest! {
 
         #[test]
         fn test_min_ordering_value(a in i64::MIN..0, b in f64::MIN..0.0) {
-            assert!(OrderingValue::MIN.cmp(&OrderingValue::from(a)).is_le());
-            assert!(OrderingValue::MIN.cmp(&OrderingValue::from(b)).is_le());
-            assert!(OrderingValue::MIN.cmp(&OrderingValue::from(f64::NAN)).is_le());
+            assert!(OrderedValue::MIN.cmp(&OrderedValue::from(a)).is_le());
+            assert!(OrderedValue::MIN.cmp(&OrderedValue::from(b)).is_le());
+            assert!(OrderedValue::MIN.cmp(&OrderedValue::from(f64::NAN)).is_le());
         }
 
         #[test]
         fn test_max_ordering_value(a in 0..i64::MAX, b in 0.0..f64::MAX) {
-            assert!(OrderingValue::MAX.cmp(&OrderingValue::from(a)).is_ge());
-            assert!(OrderingValue::MAX.cmp(&OrderingValue::from(b)).is_ge());
-            assert!(OrderingValue::MAX.cmp(&OrderingValue::from(f64::NAN)).is_ge());
+            assert!(OrderedValue::MAX.cmp(&OrderedValue::from(a)).is_ge());
+            assert!(OrderedValue::MAX.cmp(&OrderedValue::from(b)).is_ge());
+            assert!(OrderedValue::MAX.cmp(&OrderedValue::from(f64::NAN)).is_ge());
         }
     }
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -5,7 +5,7 @@ use common::types::TelemetryDetail;
 
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
 use crate::data_types::named_vectors::NamedVectors;
-use crate::data_types::order_by::{OrderBy, OrderedValue};
+use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{QueryVector, Vector};
 use crate::index::field_index::CardinalityEstimation;
@@ -124,7 +124,7 @@ pub trait SegmentEntry {
         limit: Option<usize>,
         filter: Option<&'a Filter>,
         order_by: &'a OrderBy,
-    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>>;
+    ) -> OperationResult<Vec<(OrderValue, PointIdType)>>;
 
     /// Read points in [from; to) range
     fn read_range(&self, from: Option<PointIdType>, to: Option<PointIdType>) -> Vec<PointIdType>;

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -5,7 +5,7 @@ use common::types::TelemetryDetail;
 
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
 use crate::data_types::named_vectors::NamedVectors;
-use crate::data_types::order_by::{OrderBy, OrderingValue};
+use crate::data_types::order_by::{OrderBy, OrderedValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{QueryVector, Vector};
 use crate::index::field_index::CardinalityEstimation;
@@ -124,7 +124,7 @@ pub trait SegmentEntry {
         limit: Option<usize>,
         filter: Option<&'a Filter>,
         order_by: &'a OrderBy,
-    ) -> OperationResult<Vec<(OrderingValue, PointIdType)>>;
+    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>>;
 
     /// Read points in [from; to) range
     fn read_range(&self, from: Option<PointIdType>, to: Option<PointIdType>) -> Vec<PointIdType>;

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -8,7 +8,7 @@ use super::map_index::MapIndex;
 use super::numeric_index::StreamRange;
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
-use crate::data_types::order_by::OrderedValue;
+use crate::data_types::order_by::OrderValue;
 use crate::index::field_index::binary_index::BinaryIndex;
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
@@ -357,21 +357,21 @@ pub enum NumericFieldIndex<'a> {
     FloatIndex(&'a NumericIndex<FloatPayloadType>),
 }
 
-impl<'a> StreamRange<OrderedValue> for NumericFieldIndex<'a> {
+impl<'a> StreamRange<OrderValue> for NumericFieldIndex<'a> {
     fn stream_range(
         &self,
         range: &RangeInterface,
-    ) -> Box<dyn DoubleEndedIterator<Item = (OrderedValue, PointOffsetType)> + 'a> {
+    ) -> Box<dyn DoubleEndedIterator<Item = (OrderValue, PointOffsetType)> + 'a> {
         match self {
             NumericFieldIndex::IntIndex(index) => Box::new(
                 index
                     .stream_range(range)
-                    .map(|(v, p)| (OrderedValue::from(v), p)),
+                    .map(|(v, p)| (OrderValue::from(v), p)),
             ),
             NumericFieldIndex::FloatIndex(index) => Box::new(
                 index
                     .stream_range(range)
-                    .map(|(v, p)| (OrderedValue::from(v), p)),
+                    .map(|(v, p)| (OrderValue::from(v), p)),
             ),
         }
     }
@@ -381,7 +381,7 @@ impl<'a> NumericFieldIndex<'a> {
     pub fn get_ordering_values(
         &self,
         idx: PointOffsetType,
-    ) -> Box<dyn Iterator<Item = OrderedValue> + 'a> {
+    ) -> Box<dyn Iterator<Item = OrderValue> + 'a> {
         match self {
             NumericFieldIndex::IntIndex(index) => Box::new(
                 index
@@ -389,7 +389,7 @@ impl<'a> NumericFieldIndex<'a> {
                     .into_iter()
                     .flatten()
                     .copied()
-                    .map(OrderedValue::Int),
+                    .map(OrderValue::Int),
             ),
             NumericFieldIndex::FloatIndex(index) => Box::new(
                 index
@@ -397,7 +397,7 @@ impl<'a> NumericFieldIndex<'a> {
                     .into_iter()
                     .flatten()
                     .copied()
-                    .map(OrderedValue::Float),
+                    .map(OrderValue::Float),
             ),
         }
     }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -8,7 +8,7 @@ use super::map_index::MapIndex;
 use super::numeric_index::StreamRange;
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
-use crate::data_types::order_by::OrderingValue;
+use crate::data_types::order_by::OrderedValue;
 use crate::index::field_index::binary_index::BinaryIndex;
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
@@ -357,21 +357,21 @@ pub enum NumericFieldIndex<'a> {
     FloatIndex(&'a NumericIndex<FloatPayloadType>),
 }
 
-impl<'a> StreamRange<OrderingValue> for NumericFieldIndex<'a> {
+impl<'a> StreamRange<OrderedValue> for NumericFieldIndex<'a> {
     fn stream_range(
         &self,
         range: &RangeInterface,
-    ) -> Box<dyn DoubleEndedIterator<Item = (OrderingValue, PointOffsetType)> + 'a> {
+    ) -> Box<dyn DoubleEndedIterator<Item = (OrderedValue, PointOffsetType)> + 'a> {
         match self {
             NumericFieldIndex::IntIndex(index) => Box::new(
                 index
                     .stream_range(range)
-                    .map(|(v, p)| (OrderingValue::from(v), p)),
+                    .map(|(v, p)| (OrderedValue::from(v), p)),
             ),
             NumericFieldIndex::FloatIndex(index) => Box::new(
                 index
                     .stream_range(range)
-                    .map(|(v, p)| (OrderingValue::from(v), p)),
+                    .map(|(v, p)| (OrderedValue::from(v), p)),
             ),
         }
     }
@@ -381,7 +381,7 @@ impl<'a> NumericFieldIndex<'a> {
     pub fn get_ordering_values(
         &self,
         idx: PointOffsetType,
-    ) -> Box<dyn Iterator<Item = OrderingValue> + 'a> {
+    ) -> Box<dyn Iterator<Item = OrderedValue> + 'a> {
         match self {
             NumericFieldIndex::IntIndex(index) => Box::new(
                 index
@@ -389,7 +389,7 @@ impl<'a> NumericFieldIndex<'a> {
                     .into_iter()
                     .flatten()
                     .copied()
-                    .map(OrderingValue::Int),
+                    .map(OrderedValue::Int),
             ),
             NumericFieldIndex::FloatIndex(index) => Box::new(
                 index
@@ -397,7 +397,7 @@ impl<'a> NumericFieldIndex<'a> {
                     .into_iter()
                     .flatten()
                     .copied()
-                    .map(OrderingValue::Float),
+                    .map(OrderedValue::Float),
             ),
         }
     }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -26,7 +26,7 @@ use crate::common::operation_error::{
 use crate::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
 use crate::data_types::named_vectors::NamedVectors;
-use crate::data_types::order_by::{Direction, OrderBy, OrderingValue};
+use crate::data_types::order_by::{Direction, OrderBy, OrderedValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{MultiDenseVector, QueryVector, Vector, VectorRef};
 use crate::entry::entry_point::SegmentEntry;
@@ -703,6 +703,7 @@ impl Segment {
                     payload,
                     vector,
                     shard_key: None,
+                    order_value: None,
                 })
             })
             .collect()
@@ -802,7 +803,7 @@ impl Segment {
         order_by: &OrderBy,
         limit: Option<usize>,
         condition: &Filter,
-    ) -> OperationResult<Vec<(OrderingValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
         let payload_index = self.payload_index.borrow();
         let id_tracker = self.id_tracker.borrow();
 
@@ -878,7 +879,7 @@ impl Segment {
         order_by: &OrderBy,
         limit: Option<usize>,
         filter: Option<&Filter>,
-    ) -> OperationResult<Vec<(OrderingValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
         let payload_index = self.payload_index.borrow();
 
         let numeric_index = payload_index
@@ -1304,7 +1305,7 @@ impl SegmentEntry for Segment {
         limit: Option<usize>,
         filter: Option<&'a Filter>,
         order_by: &'a OrderBy,
-    ) -> OperationResult<Vec<(OrderingValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
         match filter {
             None => self.filtered_read_by_value_stream(order_by, limit, None),
             Some(filter) => {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -26,7 +26,7 @@ use crate::common::operation_error::{
 use crate::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
 use crate::data_types::named_vectors::NamedVectors;
-use crate::data_types::order_by::{Direction, OrderBy, OrderedValue};
+use crate::data_types::order_by::{Direction, OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{MultiDenseVector, QueryVector, Vector, VectorRef};
 use crate::entry::entry_point::SegmentEntry;
@@ -803,7 +803,7 @@ impl Segment {
         order_by: &OrderBy,
         limit: Option<usize>,
         condition: &Filter,
-    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderValue, PointIdType)>> {
         let payload_index = self.payload_index.borrow();
         let id_tracker = self.id_tracker.borrow();
 
@@ -879,7 +879,7 @@ impl Segment {
         order_by: &OrderBy,
         limit: Option<usize>,
         filter: Option<&Filter>,
-    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderValue, PointIdType)>> {
         let payload_index = self.payload_index.borrow();
 
         let numeric_index = payload_index
@@ -1305,7 +1305,7 @@ impl SegmentEntry for Segment {
         limit: Option<usize>,
         filter: Option<&'a Filter>,
         order_by: &'a OrderBy,
-    ) -> OperationResult<Vec<(OrderedValue, PointIdType)>> {
+    ) -> OperationResult<Vec<(OrderValue, PointIdType)>> {
         match filter {
             None => self.filtered_read_by_value_stream(order_by, limit, None),
             Some(filter) => {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -219,8 +219,14 @@ pub struct ScoredPoint {
 impl Eq for ScoredPoint {}
 
 impl Ord for ScoredPoint {
+    /// Compare two scored points by score, unless they have `order_value`, in that case compare by `order_value`.
     fn cmp(&self, other: &Self) -> Ordering {
-        OrderedFloat(self.score).cmp(&OrderedFloat(other.score))
+        match (&self.order_value, &other.order_value) {
+            (None, None) => OrderedFloat(self.score).cmp(&OrderedFloat(other.score)),
+            (Some(_), None) => Ordering::Greater,
+            (None, Some(_)) => Ordering::Less,
+            (Some(self_order), Some(other_order)) => self_order.cmp(other_order),
+        }
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -25,7 +25,7 @@ use validator::{Validate, ValidationError, ValidationErrors};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::{self, MaybeOneOrMany, MultiValue};
 use crate::data_types::integer_index::IntegerIndexParams;
-use crate::data_types::order_by::OrderedValue;
+use crate::data_types::order_by::OrderValue;
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::{VectorElementType, VectorStruct};
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
@@ -213,7 +213,7 @@ pub struct ScoredPoint {
     /// Shard Key
     pub shard_key: Option<ShardKey>,
     /// Order-by value
-    pub order_value: Option<OrderedValue>,
+    pub order_value: Option<OrderValue>,
 }
 
 impl Eq for ScoredPoint {}

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -25,6 +25,7 @@ use validator::{Validate, ValidationError, ValidationErrors};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::{self, MaybeOneOrMany, MultiValue};
 use crate::data_types::integer_index::IntegerIndexParams;
+use crate::data_types::order_by::OrderedValue;
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::{VectorElementType, VectorStruct};
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
@@ -211,6 +212,8 @@ pub struct ScoredPoint {
     pub vector: Option<VectorStruct>,
     /// Shard Key
     pub shard_key: Option<ShardKey>,
+    /// Order-by value
+    pub order_value: Option<OrderedValue>,
 }
 
 impl Eq for ScoredPoint {}


### PR DESCRIPTION
Tracked in #4225 
Supersedes #4251 #4278 

- Fix ordering in group-by for custom scoring
- Rename `OrderingValue` -> `OrderedValue`
- Introduce `order_value` field in `ScoredPoint` (internal, grpc, and rest)
