### PR TITLE
universal-query: Add `CollectionQueryRequest`

### DIFF
--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -1,0 +1,56 @@
+use common::types::ScoreType;
+use segment::data_types::vectors::Vector;
+use segment::types::{Filter, PointIdType, SearchParams, WithPayloadInterface, WithVector};
+use segment::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery};
+
+use super::shard_query::Fusion;
+use crate::operations::types::OrderByInterface;
+
+/// Internal representation of a query request, used to converge from REST and gRPC. This can have IDs referencing vectors.
+pub struct CollectionQueryRequest {
+    pub prefetches: Vec<CollectionPrefetch>,
+    pub query: Query,
+    pub using: String,
+    pub filter: Option<Filter>,
+    pub score_threshold: Option<ScoreType>,
+    pub limit: usize,
+    pub offset: usize,
+    /// Search params for when there is no prefetch
+    pub params: Option<SearchParams>,
+    pub with_vector: WithVector,
+    pub with_payload: WithPayloadInterface,
+}
+
+pub enum Query {
+    /// Score points against some vector(s)
+    Vector(VectorQuery),
+
+    /// Reciprocal rank fusion
+    Fusion(Fusion),
+
+    /// Order by a payload field
+    OrderBy(OrderByInterface),
+}
+
+pub enum VectorInput {
+    Id(PointIdType),
+    Vector(Vector),
+}
+
+pub enum VectorQuery {
+    Nearest(VectorInput),
+    RecommendBestScore(RecoQuery<VectorInput>),
+    Discover(DiscoveryQuery<VectorInput>),
+    Context(ContextQuery<VectorInput>),
+}
+
+pub struct CollectionPrefetch {
+    pub prefetch: Vec<CollectionPrefetch>,
+    pub query: Query,
+    pub using: String,
+    pub filter: Option<Filter>,
+    pub score_threshold: Option<ScoreType>,
+    pub limit: usize,
+    /// Search params for when there is no prefetch
+    pub params: Option<SearchParams>,
+}

--- a/lib/collection/src/operations/universal_query/mod.rs
+++ b/lib/collection/src/operations/universal_query/mod.rs
@@ -10,7 +10,6 @@
 //! 4. `QueryShardPoints`: to be used in the internal service. Created for RemoteShard, converts to and from ShardQueryRequest
 //! 5. `PlannedQuery`: an easier-to-execute representation. Created in LocalShard
 
+pub mod collection_query;
 pub mod planned_query;
 pub mod shard_query;
-
-// TODO(universal-query): Create `CollectionQueryRequest` struct


### PR DESCRIPTION
Adds the bare types for `CollectionQueryRequest`. The type into which REST and gRPC will converge.