### PR TITLE
Query fetches payload and vector if necessary

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -335,6 +335,12 @@ impl SegmentsSearcher {
         Ok(top_scores)
     }
 
+    /// Retrieve records for the given points ids from the segments
+    /// - if payload is enabled, payload will be fetched
+    /// - if vector is enabled, vector will be fetched
+    ///
+    /// The points ids can contain duplicates, the records will be fetched only once
+    /// and returned in the same order as the input points.
     pub fn retrieve(
         segments: &RwLock<SegmentHolder>,
         points: &[PointIdType],

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -55,7 +55,7 @@ impl LocalShard {
 
             // it might make sense to change this approach to fetch payload and vector at the collection level
             // after the shard results merge, but it requires careful benchmarking
-            let records = SegmentsSearcher::retrieve(
+            let mut records = SegmentsSearcher::retrieve(
                 self.segments(),
                 &point_ids,
                 &WithPayload::from(&request.with_payload),
@@ -63,9 +63,10 @@ impl LocalShard {
             )?;
 
             // update scored points in place
-            for (scored_point, record) in scored_points.iter_mut().flatten().zip(records.iter()) {
-                scored_point.payload.clone_from(&record.payload);
-                scored_point.vector.clone_from(&record.vector);
+            for (scored_point, record) in scored_points.iter_mut().flatten().zip(records.iter_mut())
+            {
+                scored_point.payload = record.payload.take();
+                scored_point.vector = record.vector.take();
             }
         }
 

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -49,13 +49,11 @@ impl LocalShard {
         // fetch payload and/or vector for scored points if necessary
         if request.with_payload.is_required() || request.with_vector.is_enabled() {
             // ids to retrieve
-            let mut point_ids = Vec::new();
+            let mut point_ids_set = HashSet::new();
             for scored_point in scored_points.iter().flatten() {
-                point_ids.push(scored_point.id);
+                point_ids_set.insert(scored_point.id);
             }
-            // remove duplicates
-            point_ids.sort_unstable();
-            point_ids.dedup();
+            let point_ids: Vec<_> = point_ids_set.into_iter().collect();
 
             // it might make sense to change this approach to fetch payload and vector at the collection level
             // after the shard results merge, but it requires careful benchmarking

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -99,6 +99,12 @@ async fn test_shard_query_rrf_rescoring() {
     // so the number of results is not limited by the outer limit at the shard level
     // the first source returned all its inner results
     assert_eq!(sources_scores[0].len(), inner_limit);
+    // no payload/vector were requests
+    sources_scores[0].iter().all(|scored_point| {
+        assert_eq!(scored_point.vector, None);
+        assert_eq!(scored_point.payload, None);
+        true
+    });
 
     // RRF query with two prefetches
     let inner_limit = 3;
@@ -258,4 +264,66 @@ async fn test_shard_query_vector_rescoring() {
     // merging taking place
     // number of results is limited by the outer limit for vector rescoring
     assert_eq!(sources_scores[0].len(), outer_limit);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shard_query_payload_vector() {
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let config = create_collection_config();
+
+    let collection_name = "test".to_string();
+
+    let current_runtime: Handle = Handle::current();
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        current_runtime.clone(),
+        CpuBudget::default(),
+    )
+    .await
+    .unwrap();
+
+    let upsert_ops = upsert_operation();
+
+    shard.update(upsert_ops.into(), true).await.unwrap();
+
+    let nearest_query = QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+        Vector::Dense(vec![1.0, 2.0, 3.0, 4.0]),
+        DEFAULT_VECTOR_NAME,
+    ));
+
+    // rescoring against a vector without prefetches
+    let outer_limit = 2;
+    let query = ShardQueryRequest {
+        prefetches: vec![],
+        query: ScoringQuery::Vector(nearest_query),
+        filter: None,
+        score_threshold: None,
+        limit: outer_limit,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(true), // requesting vector
+        with_payload: WithPayloadInterface::Bool(true), // requesting payload
+    };
+
+    let sources_scores = shard
+        .query(Arc::new(query), &current_runtime)
+        .await
+        .unwrap();
+
+    // only one inner result in absence of prefetches
+    assert_eq!(sources_scores.len(), 1);
+    // number of results is limited by the outer limit for rescoring
+    assert_eq!(sources_scores[0].len(), outer_limit);
+    // payload/vector were requests
+    sources_scores[0].iter().all(|scored_point| {
+        assert!(scored_point.vector.is_some());
+        assert!(scored_point.payload.is_some());
+        true
+    });
 }

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -100,10 +100,9 @@ async fn test_shard_query_rrf_rescoring() {
     // the first source returned all its inner results
     assert_eq!(sources_scores[0].len(), inner_limit);
     // no payload/vector were requests
-    sources_scores[0].iter().all(|scored_point| {
+    sources_scores[0].iter().for_each(|scored_point| {
         assert_eq!(scored_point.vector, None);
         assert_eq!(scored_point.payload, None);
-        true
     });
 
     // RRF query with two prefetches
@@ -321,9 +320,8 @@ async fn test_shard_query_payload_vector() {
     // number of results is limited by the outer limit for rescoring
     assert_eq!(sources_scores[0].len(), outer_limit);
     // payload/vector were requests
-    sources_scores[0].iter().all(|scored_point| {
+    sources_scores[0].iter().for_each(|scored_point| {
         assert!(scored_point.vector.is_some());
         assert!(scored_point.payload.is_some());
-        true
     });
 }

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -99,7 +99,7 @@ async fn test_shard_query_rrf_rescoring() {
     // so the number of results is not limited by the outer limit at the shard level
     // the first source returned all its inner results
     assert_eq!(sources_scores[0].len(), inner_limit);
-    // no payload/vector were requests
+    // no payload/vector were requested
     sources_scores[0].iter().for_each(|scored_point| {
         assert_eq!(scored_point.vector, None);
         assert_eq!(scored_point.payload, None);
@@ -319,7 +319,7 @@ async fn test_shard_query_payload_vector() {
     assert_eq!(sources_scores.len(), 1);
     // number of results is limited by the outer limit for rescoring
     assert_eq!(sources_scores[0].len(), outer_limit);
-    // payload/vector were requests
+    // payload/vector were requested
     sources_scores[0].iter().for_each(|scored_point| {
         assert!(scored_point.vector.is_some());
         assert!(scored_point.payload.is_some());


### PR DESCRIPTION
Hydrate query scores with `payload` and `vector` if necessary.