### PR TITLE
Deduplicate points for shard reads

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use futures::stream::FuturesUnordered;
@@ -414,7 +415,13 @@ impl Collection {
             });
             future::try_join_all(retrieve_futures).await?
         };
-        let points = all_shard_collection_results.into_iter().flatten().collect();
+        let mut covered_point_ids = HashSet::new();
+        let points = all_shard_collection_results
+            .into_iter()
+            .flatten()
+            // Add each point only once, deduplicate point IDs
+            .filter(|point| covered_point_ids.insert(point.id))
+            .collect();
         Ok(points)
     }
 }

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -325,6 +325,8 @@ impl Collection {
                         Direction::Asc => value_a <= value_b,
                         Direction::Desc => value_a >= value_b,
                     })
+                    // Add each point only once, deduplicate point IDs
+                    .dedup_by(|(_, record_a), (_, record_b)| record_a.id == record_b.id)
                     .map(|(_, record)| api::rest::Record::from(record))
                     .take(limit)
                     .collect_vec()

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -298,6 +298,8 @@ impl Collection {
             None => retrieved_iter
                 .flatten()
                 .sorted_unstable_by_key(|point| point.id)
+                // Add each point only once, deduplicate point IDs
+                .dedup_by(|a, b| a.id == b.id)
                 .take(limit)
                 .map(api::rest::Record::from)
                 .collect_vec(),

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -6,7 +7,7 @@ use futures::{future, TryFutureExt};
 use segment::data_types::vectors::VectorStruct;
 use segment::spaces::tools;
 use segment::types::{
-    ExtendedPointId, Filter, Order, PointIdType, ScoredPoint, WithPayloadInterface, WithVector,
+    ExtendedPointId, Filter, Order, ScoredPoint, WithPayloadInterface, WithVector,
 };
 use tokio::time::Instant;
 
@@ -228,25 +229,27 @@ impl Collection {
 
     async fn merge_from_shards(
         &self,
-        all_searches_res: Vec<Vec<Vec<ScoredPoint>>>,
+        mut all_searches_res: Vec<Vec<Vec<ScoredPoint>>>,
         request: Arc<CoreSearchRequestBatch>,
         is_client_request: bool,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let batch_size = request.searches.len();
 
-        // merge results from shards in order
-        let mut merged_results: Vec<Vec<ScoredPoint>> = vec![vec![]; batch_size];
-        let mut merged_point_ids: Vec<HashSet<PointIdType>> = vec![HashSet::new(); batch_size];
-        for shard_searches_results in all_searches_res.into_iter() {
-            for (index, shard_searches_result) in shard_searches_results.into_iter().enumerate() {
-                let point_ids = &mut merged_point_ids[index];
-                merged_results[index].extend(
-                    shard_searches_result
-                        .into_iter()
-                        // Add each point only once, deduplicate point IDs
-                        .filter(|result| point_ids.insert(result.id)),
-                );
-            }
+        // Merge results from shards in order and deduplicate based on point ID
+        let batch_count = all_searches_res.first().map_or(0, Vec::len);
+        debug_assert!(all_searches_res.iter().all(|x| batch_count == x.len()));
+        let mut merged_results: Vec<Vec<ScoredPoint>> = Vec::with_capacity(batch_size);
+        let mut covered_point_ids = HashSet::new();
+        for batch_index in 0..batch_count {
+            let results_from_shards = all_searches_res
+                .iter_mut()
+                .flat_map(|res| mem::take(&mut res[batch_index]));
+            let results = results_from_shards
+                // Add each point only once, deduplicate point IDs
+                .filter(|result| covered_point_ids.insert(result.id))
+                .collect();
+            merged_results.push(results);
+            covered_point_ids.clear();
         }
 
         let collection_params = self.collection_config.read().await.params.clone();

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod fixtures;
+mod points_dedup;
 mod sha_256_test;
 mod shard_query;
 mod snapshot_test;

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -1,0 +1,154 @@
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use api::rest::VectorStruct;
+use common::cpu::CpuBudget;
+use segment::types::Distance;
+use tempfile::Builder;
+
+use crate::collection::{Collection, RequestShardTransfer};
+use crate::config::{CollectionConfig, CollectionParams, WalConfig};
+use crate::operations::point_ops::{PointInsertOperationsInternal, PointOperations, PointStruct};
+use crate::operations::shard_selector_internal::ShardSelectorInternal;
+use crate::operations::shared_storage_config::SharedStorageConfig;
+use crate::operations::types::{ScrollRequestInternal, VectorsConfig};
+use crate::operations::vector_params_builder::VectorParamsBuilder;
+use crate::operations::{CollectionUpdateOperations, OperationWithClockTag};
+use crate::optimizers_builder::OptimizersConfig;
+use crate::shards::channel_service::ChannelService;
+use crate::shards::collection_shard_distribution::CollectionShardDistribution;
+use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState, ReplicaState};
+use crate::shards::shard::{PeerId, ShardId};
+
+const PEER_ID: u64 = 1;
+const SHARD_COUNT: u32 = 4;
+
+/// Create the collection used for deduplication tests.
+async fn fixture() -> Collection {
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+    };
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
+        shard_number: NonZeroU32::new(4).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        ..CollectionParams::empty()
+    };
+
+    let config = CollectionConfig {
+        params: collection_params,
+        optimizer_config: OptimizersConfig::fixture(),
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+    };
+
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
+
+    let collection_name = "test".to_string();
+    let shards: HashMap<ShardId, HashSet<PeerId>> = (0..SHARD_COUNT)
+        .map(|i| (i, HashSet::from([PEER_ID])))
+        .collect();
+
+    let storage_config: SharedStorageConfig = SharedStorageConfig::default();
+    let storage_config = Arc::new(storage_config);
+
+    let collection = Collection::new(
+        collection_name.clone(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_path.path(),
+        &config,
+        storage_config.clone(),
+        CollectionShardDistribution { shards },
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        CpuBudget::default(),
+    )
+    .await
+    .unwrap();
+
+    // Insert two points into all shards directly, a point matching the shard ID, and point 100
+    // We insert into all shards directly to prevent spreading points by the hashring
+    // We insert the same point into multiple shards on purpose
+    for (shard_id, shard) in collection.shards_holder().write().await.get_shards() {
+        let op = OperationWithClockTag::from(CollectionUpdateOperations::PointOperation(
+            PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(vec![
+                PointStruct {
+                    id: (*shard_id as u64).into(),
+                    vector: VectorStruct::Multi(HashMap::new()),
+                    payload: None,
+                },
+                PointStruct {
+                    id: 100.into(),
+                    vector: VectorStruct::Multi(HashMap::new()),
+                    payload: None,
+                },
+            ])),
+        ));
+        shard
+            .update_local(op, true)
+            .await
+            .expect("failed to insert points");
+    }
+
+    // Activate all shards
+    for shard_id in 0..SHARD_COUNT {
+        collection
+            .set_shard_replica_state(shard_id as ShardId, PEER_ID, ReplicaState::Active, None)
+            .await
+            .expect("failed to active shard");
+    }
+
+    collection
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scroll_dedup() {
+    let collection = fixture().await;
+
+    // Scroll all points, we must get each point ID once
+    let result = collection
+        .scroll_by(
+            ScrollRequestInternal {
+                offset: None,
+                limit: Some(usize::MAX),
+                filter: None,
+                with_payload: Some(false.into()),
+                with_vector: false.into(),
+                order_by: None,
+            },
+            None,
+            &ShardSelectorInternal::All,
+        )
+        .await
+        .expect("failed to search");
+    let mut seen = HashSet::new();
+    for point_id in result.points.iter().map(|point| point.id) {
+        assert!(
+            seen.insert(point_id),
+            "got point id {point_id} more than once, they should be deduplicated",
+        );
+    }
+}
+
+pub fn dummy_on_replica_failure() -> ChangePeerState {
+    Arc::new(move |_peer_id, _shard_id| {})
+}
+
+pub fn dummy_request_shard_transfer() -> RequestShardTransfer {
+    Arc::new(move |_transfer| {})
+}
+
+pub fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+    Arc::new(|_transfer, _reason| {})
+}

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -24,6 +24,7 @@ use crate::shards::collection_shard_distribution::CollectionShardDistribution;
 use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState, ReplicaState};
 use crate::shards::shard::{PeerId, ShardId};
 
+const DIM: u64 = 4;
 const PEER_ID: u64 = 1;
 const SHARD_COUNT: u32 = 4;
 const DUPLICATE_POINT_ID: ExtendedPointId = ExtendedPointId::NumId(100);
@@ -36,8 +37,8 @@ async fn fixture() -> Collection {
     };
 
     let collection_params = CollectionParams {
-        vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
-        shard_number: NonZeroU32::new(4).unwrap(),
+        vectors: VectorsConfig::Single(VectorParamsBuilder::new(DIM, Distance::Dot).build()),
+        shard_number: NonZeroU32::new(SHARD_COUNT).unwrap(),
         replication_factor: NonZeroU32::new(1).unwrap(),
         write_consistency_factor: NonZeroU32::new(1).unwrap(),
         ..CollectionParams::empty()
@@ -151,6 +152,7 @@ async fn test_scroll_dedup() {
         )
         .await
         .expect("failed to search");
+    assert!(!result.points.is_empty(), "expected some points");
 
     let mut seen = HashSet::new();
     for point_id in result.points.iter().map(|point| point.id) {
@@ -176,6 +178,7 @@ async fn test_scroll_dedup() {
         )
         .await
         .expect("failed to search");
+    assert!(!result.points.is_empty(), "expected some points");
 
     let mut seen = HashSet::new();
     for point_id in result.points.iter().map(|point| point.id) {
@@ -205,6 +208,7 @@ async fn test_retrieve_dedup() {
         )
         .await
         .expect("failed to search");
+    assert!(!records.is_empty(), "expected some records");
 
     let mut seen = HashSet::new();
     for point_id in records.iter().map(|record| record.id) {


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>

Deduplicate points based on their point ID in all reads from shards.

This is necessary for resharding, where multiple shards may have a single point ID.

The idea was to only deduplicate this while resharding is active, but after a discussion with @generall we decided to enable it at all times. We might benefit from this in other cases too, such as when we have the same point ID across multiple shard keys. At this time it is unclear yet what performance impact that might have, so that's yet to be tested.

### Tasks
- [x] Add tests for every deduplication scenario

### Open questions
- Do we need to handle read errors in any special way?
  - e.g., *ignore* read errors from new shard?

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
