### PR TITLE
Switch back to upstream hashring crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,8 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "hashring"
-version = "0.3.3"
-source = "git+https://github.com/qdrant/hashring-rs?branch=hashring-clone#41146f4bc135e01a27e2c4435213c2906c5149df"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381cb8ad0bbf2c0038bfb29522e494454ae7d2722bd72287c44ab7c248b74433"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,5 +194,3 @@ opt-level = 3
 [patch.crates-io]
 # Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
 tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }
-# Temporary patch until <https://github.com/jeromefroe/hashring-rs/pull/25> is merged
-hashring = { git = 'https://github.com/qdrant/hashring-rs', branch = "hashring-clone" }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { workspace = true }
 rmp-serde = "~1.3"
 wal = { workspace = true }
 ordered-float = "4.2"
-hashring = "0.3.3"
+hashring = "0.3.4"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 bitvec = "1.0.1"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>

<https://github.com/jeromefroe/hashring-rs/pull/25> got merged, so we can switch back to the upstream crate.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?