### PR TITLE
Fix overflow panic if scroll limit is usize::MAX

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -256,7 +256,7 @@ impl Collection {
         // `order_by` does not support offset
         if order_by.is_none() {
             // Needed to return next page offset.
-            limit += 1;
+            limit = limit.saturating_add(1);
         };
 
         let local_only = shard_selection.is_shard_id();


### PR DESCRIPTION
The scroll limit might overflow if providing `usize::MAX` because we add one to it if no ordering is used:

```rust
thread 'tests::snapshot_test::test_shard_dedup' panicked at lib/collection/src/collection/point_ops.rs:260:13:
attempt to add with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I've changed this to `saturating_add(1)`. It means we won't add one if the limit is `usize::MAX`, but I think it's unreasonable to reach that limit anyway. Better be safe than panic.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?