### PR TITLE
Recreate sparse vector index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5074,6 +5074,7 @@ dependencies = [
  "schemars",
  "seahash",
  "segment",
+ "semver",
  "serde",
  "serde-untagged",
  "serde-value",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -60,6 +60,7 @@ num-cmp = "0.1.0"
 rand = "0.8"
 bitvec = "1.0.1"
 seahash = "4.1.0"
+semver = { workspace = true }
 tar = { workspace = true }
 fs_extra = "1.3.0"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -16,16 +16,9 @@ pub struct IndicesTracker {
 }
 
 impl IndicesTracker {
-    pub fn open(path: &Path, max_index_fn: impl Fn() -> DimOffset) -> std::io::Result<Self> {
+    pub fn open(path: &Path) -> std::io::Result<Self> {
         let path = Self::file_path(path);
-        if !path.exists() {
-            let max_index = max_index_fn();
-            Ok(IndicesTracker {
-                map: (0..max_index).map(|i| (i, i)).collect(),
-            })
-        } else {
-            Ok(read_json(&path)?)
-        }
+        Ok(read_json(&path)?)
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -14,6 +14,7 @@ use memory::mmap_ops::{
 use serde::{Deserialize, Serialize};
 
 use super::inverted_index_compressed_immutable_ram::InvertedIndexImmutableRam;
+use super::INDEX_FILE_NAME;
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::{DimId, DimOffset};
 use crate::index::compressed_posting_list::{
@@ -24,7 +25,6 @@ use crate::index::inverted_index::InvertedIndex;
 use crate::index::posting_list_common::PostingElement;
 
 const POSTING_HEADER_SIZE: usize = size_of::<PostingListFileHeader>();
-const INDEX_FILE_NAME: &str = "inverted_index.data";
 const INDEX_CONFIG_FILE_NAME: &str = "inverted_index_config.json";
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
-use io::storage_version::{StorageVersion as _, VERSION_FILE};
 use memmap2::{Mmap, MmapMut};
 use memory::madvise;
 use memory::mmap_ops::{
@@ -17,7 +16,6 @@ use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::{DimId, DimOffset};
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::inverted_index::InvertedIndex;
-use crate::index::migrate::SparseVectorIndexVersion;
 use crate::index::posting_list::PostingListIterator;
 use crate::index::posting_list_common::PostingElementEx;
 
@@ -69,12 +67,10 @@ impl InvertedIndex for InvertedIndexMmap {
     }
 
     fn files(path: &Path) -> Vec<PathBuf> {
-        let mut files = vec![path.join(VERSION_FILE), Self::index_file_path(path)];
-        files.retain(|f| f.exists());
-
-        files.push(Self::index_config_file_path(path));
-
-        files
+        vec![
+            Self::index_file_path(path),
+            Self::index_config_file_path(path),
+        ]
     }
 
     fn upsert(&mut self, _id: PointOffsetType, _vector: RemappedSparseVector) {
@@ -147,9 +143,6 @@ impl InvertedIndexMmap {
         // save header properties
         let posting_count = inverted_index_ram.postings.len();
         let vector_count = inverted_index_ram.vector_count();
-
-        // save version
-        SparseVectorIndexVersion::save(path.as_ref())?;
 
         // finalize data with index file.
         let file_header = InvertedIndexFileHeader {

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -12,6 +12,7 @@ use memory::mmap_ops::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::INDEX_FILE_NAME;
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::{DimId, DimOffset};
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
@@ -20,7 +21,6 @@ use crate::index::posting_list::PostingListIterator;
 use crate::index::posting_list_common::PostingElementEx;
 
 const POSTING_HEADER_SIZE: usize = size_of::<PostingListFileHeader>();
-const INDEX_FILE_NAME: &str = "inverted_index.data";
 const INDEX_CONFIG_FILE_NAME: &str = "inverted_index_config.json";
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -14,6 +14,9 @@ pub mod inverted_index_mmap;
 pub mod inverted_index_ram;
 pub mod inverted_index_ram_builder;
 
+pub const OLD_INDEX_FILE_NAME: &str = "inverted_index.data";
+pub const INDEX_FILE_NAME: &str = "inverted_index.dat";
+
 pub trait InvertedIndex: Sized {
     type Iter<'a>: PostingListIter + Clone
     where

--- a/lib/sparse/src/index/migrate.rs
+++ b/lib/sparse/src/index/migrate.rs
@@ -1,6 +1,3 @@
-use std::path::Path;
-
-use io::file_operations::{FileOperationResult, FileStorageError};
 use io::storage_version::StorageVersion;
 
 pub struct SparseVectorIndexVersion;
@@ -9,42 +6,4 @@ impl StorageVersion for SparseVectorIndexVersion {
     fn current_raw() -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
-}
-
-pub fn migrate(path: &Path) -> FileOperationResult<()> {
-    let app_version = SparseVectorIndexVersion::current();
-    match SparseVectorIndexVersion::load(path)? {
-        Some(version) if version == app_version => (),
-        Some(version) => {
-            return Err(FileStorageError::generic(format!(
-                "Version mismatch: expected {app_version}, found {version}"
-            )))
-        }
-        None => migrate_from_v1(path)?,
-    }
-    Ok(())
-}
-
-fn migrate_from_v1(path: &Path) -> FileOperationResult<()> {
-    // Disable migration for now.
-    SparseVectorIndexVersion::save(path)?;
-
-    /*
-    log::info!("Migrating {path:?}");
-
-    let index_v1 = InvertedIndexMmap::index_file_path_v1(path);
-    let index_v2 = InvertedIndexMmap::index_file_path(path);
-
-    // 1. Migrate index to a new file.
-    AtomicFile::new(index_v2, OverwriteBehavior::AllowOverwrite)
-        .write(|f| std::io::copy(&mut File::open(&index_v1)?, f))?;
-
-    // 2. Save version info. Having this file signals that migration is complete.
-    SparseVectorIndexVersion::save(path)?;
-
-    // 3. Remove old index file.
-    std::fs::remove_file(&index_v1)?;
-    */
-
-    Ok(())
 }


### PR DESCRIPTION
Instead of implementing index migration, we could just drop and re-create the index from scratch when it is not compatible or fails to load. This PR implements this approach.

Pros of this approach over hand-written migration:
- Simpler and more robust.
- We can implement arbitrary changes in the index format as many times as we want without fear of losing/corrupting the data.
- It allows rolling back to the previous index version for free.

Cons:
- It takes 25 seconds of CPU time on my machine to rebuild an index in a single segment with 1.3M of points.
- Increased memory consumption during the first startup. Might significantly increase loading time if the system is swapping.