### PR TITLE
Reset update buffers for simple storages

### DIFF
--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -175,6 +175,9 @@ impl<T: PrimitiveVectorElement> SimpleDenseVectorStorage<T> {
         record.deleted = deleted;
         if let Some(vector) = vector {
             record.vector.copy_from_slice(vector);
+        } else {
+            // reset buffer record
+            record.vector.iter_mut().for_each(|v| *v = T::default());
         }
 
         // Store updated record

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -209,6 +209,9 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
                 .vector
                 .flattened_vectors
                 .extend_from_slice(vector.flattened_vectors);
+        } else {
+            // reset buffer record
+            record.vector.flattened_vectors.clear();
         }
 
         // Store updated record

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -211,7 +211,7 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
                 .extend_from_slice(vector.flattened_vectors);
         } else {
             // reset buffer record
-            record.vector.flattened_vectors.clear();
+            record.vector = TypedMultiDenseVector::placeholder(self.dim);
         }
 
         // Store updated record

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -114,6 +114,10 @@ impl SimpleSparseVectorStorage {
                 self.total_sparse_size += vector.values.len();
             }
             record.vector = vector.clone();
+        } else {
+            // reset buffer record
+            record.vector.values.clear();
+            record.vector.indices.clear();
         }
 
         // Store updated record


### PR DESCRIPTION
This PR makes sure we are not re-using the data of the previously inserted vector when inserting a new deleted vector in a rocksdb simple storage.