### PR TITLE
universal-query: add `query()` in toc and handle `Access` token

### DIFF
--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -9,7 +9,7 @@ use super::shard_query::Fusion;
 /// Internal representation of a query request, used to converge from REST and gRPC. This can have IDs referencing vectors.
 pub struct CollectionQueryRequest {
     pub prefetches: Vec<CollectionPrefetch>,
-    pub query: Query,
+    pub query: Option<Query>,
     pub using: String,
     pub filter: Option<Filter>,
     pub score_threshold: Option<ScoreType>,
@@ -46,7 +46,7 @@ pub enum VectorQuery {
 
 pub struct CollectionPrefetch {
     pub prefetch: Vec<CollectionPrefetch>,
-    pub query: Query,
+    pub query: Option<Query>,
     pub using: String,
     pub filter: Option<Filter>,
     pub score_threshold: Option<ScoreType>,

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -4,6 +4,7 @@ mod collection_meta_ops;
 mod create_collection;
 mod locks;
 mod point_ops;
+mod point_ops_internal;
 mod snapshots;
 mod temp_directories;
 pub mod transfer;

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -7,6 +7,7 @@ use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::point_ops::WriteOrdering;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::*;
+use collection::operations::universal_query::collection_query::CollectionQueryRequest;
 use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use collection::{discovery, recommendations};
 use futures::stream::FuturesUnordered;
@@ -291,6 +292,27 @@ impl TableOfContent {
             .scroll_by(request, read_consistency, &shard_selection)
             .await
             .map_err(|err| err.into())
+    }
+
+    pub async fn query(
+        &self,
+        collection_name: &str,
+        mut request: CollectionQueryRequest,
+        _read_consistency: Option<ReadConsistency>, // TODO(universal-query): pass this to collection
+        _shard_selection: ShardSelectorInternal, // TODO(universal-query): pass this to collection
+        access: Access,
+    ) -> Result<Vec<ScoredPoint>, StorageError> {
+        let collection_pass = access.check_point_op(collection_name, &mut request)?;
+        
+        let _collection = self.get_collection(&collection_pass).await?;
+        
+        //TODO(universal-query): implement query in collection
+        // collection
+        //     .query(request, read_consistency, &shard_selection)
+        //     .await
+        //     .map_err(|err| err.into())
+        
+        todo!()
     }
 
     /// # Cancel safety

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -303,15 +303,15 @@ impl TableOfContent {
         access: Access,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
-        
+
         let _collection = self.get_collection(&collection_pass).await?;
-        
+
         //TODO(universal-query): implement query in collection
         // collection
         //     .query(request, read_consistency, &shard_selection)
         //     .await
         //     .map_err(|err| err.into())
-        
+
         todo!()
     }
 

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -1,11 +1,11 @@
 //! Methods here are for distributed internal use only.
 
-use collection::operations::{shard_selector_internal::ShardSelectorInternal, universal_query::shard_query::ShardQueryRequest};
+use collection::operations::shard_selector_internal::ShardSelectorInternal;
+use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use segment::types::ScoredPoint;
 
-use crate::content_manager::errors::StorageError;
-
 use super::TableOfContent;
+use crate::content_manager::errors::StorageError;
 
 impl TableOfContent {
     pub async fn query_internal(
@@ -15,13 +15,13 @@ impl TableOfContent {
         _shard_selection: ShardSelectorInternal, // TODO(universal-query): pass this to collection
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
         let _collection = self.get_collection_unchecked(collection_name).await?;
-        
-        //TODO(universal-query): implement query_internal in collection
+
+        // TODO(universal-query): implement query_internal in collection
         // collection
         //     .query(request, read_consistency, &shard_selection)
         //     .await
         //     .map_err(|err| err.into())
-        
+
         todo!()
     }
 }

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -1,0 +1,27 @@
+//! Methods here are for distributed internal use only.
+
+use collection::operations::{shard_selector_internal::ShardSelectorInternal, universal_query::shard_query::ShardQueryRequest};
+use segment::types::ScoredPoint;
+
+use crate::content_manager::errors::StorageError;
+
+use super::TableOfContent;
+
+impl TableOfContent {
+    pub async fn query_internal(
+        &self,
+        collection_name: &str,
+        _request: ShardQueryRequest,
+        _shard_selection: ShardSelectorInternal, // TODO(universal-query): pass this to collection
+    ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
+        let _collection = self.get_collection_unchecked(collection_name).await?;
+        
+        //TODO(universal-query): implement query_internal in collection
+        // collection
+        //     .query(request, read_consistency, &shard_selection)
+        //     .await
+        //     .map_err(|err| err.into())
+        
+        todo!()
+    }
+}


### PR DESCRIPTION
Tracked in #4225 

- Add `query()` to ToC, for user requests
  - Implement handling of `Access` token
- Add `query_internal()`to ToC, for shard queries.
- Solve remaining TODOs in `points_internal_api::query()`