### PR TITLE
Huge limit now does not crash

### DIFF
--- a/lib/common/common/src/fixed_length_priority_queue.rs
+++ b/lib/common/common/src/fixed_length_priority_queue.rs
@@ -7,6 +7,13 @@ use std::vec::IntoIter as VecIntoIter;
 
 use serde::{Deserialize, Serialize};
 
+/// To avoid excessive memory allocation, FixedLengthPriorityQueue
+/// imposes a reasonable limit on the allocation size. If the limit
+/// is extremely large, we treat it as if no limit was set and
+/// delay allocation, assuming that the results will fit within a
+/// predefined threshold.
+const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
+
 /// A container that forgets all but the top N elements
 ///
 /// This is a MinHeap by default - it will keep the largest elements, pop smallest
@@ -26,8 +33,8 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
     /// Creates a new queue with the given length
     /// Panics if length is 0
     pub fn new(length: usize) -> Self {
-        let heap = BinaryHeap::with_capacity(length + 1);
-        let length = NonZeroUsize::new(length).expect("length must be > 0");
+        let heap = BinaryHeap::with_capacity((length + 1).min(LARGEST_REASONABLE_ALLOCATION_SIZE));
+        let length = NonZeroUsize::new(length).expect("length must be greater than zero");
         FixedLengthPriorityQueue::<T> { heap, length }
     }
 

--- a/lib/common/common/src/fixed_length_priority_queue.rs
+++ b/lib/common/common/src/fixed_length_priority_queue.rs
@@ -7,6 +7,8 @@ use std::vec::IntoIter as VecIntoIter;
 
 use serde::{Deserialize, Serialize};
 
+/// A container that forgets all but the top N elements
+///
 /// This is a MinHeap by default - it will keep the largest elements, pop smallest
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct FixedLengthPriorityQueue<T: Ord> {
@@ -29,6 +31,9 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
         FixedLengthPriorityQueue::<T> { heap, length }
     }
 
+    /// Pushes a value into the priority queue.
+    ///
+    /// If the queue if full, replaces the smallest value and returns it.
     pub fn push(&mut self, value: T) -> Option<T> {
         if self.heap.len() < self.length.into() {
             self.heap.push(Reverse(value));
@@ -43,6 +48,7 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
         Some(value.0)
     }
 
+    /// Returns the top N elements sorted ascending.
     pub fn into_vec(self) -> Vec<T> {
         self.heap
             .into_sorted_vec()
@@ -51,12 +57,15 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
             .collect()
     }
 
+    /// Returns an iterator over the elements in the queue.
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             it: self.heap.iter().rev(),
         }
     }
 
+    /// Returns the smallest element of the queue,
+    /// if there is any.
     pub fn top(&self) -> Option<&T> {
         self.heap.peek().map(|x| &x.0)
     }

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -23,8 +23,8 @@ where
         return vec![];
     }
 
-    // If small values is better - PQ should pop-out big values first.
-    // Hence is should be min-heap
+    // If the caller is interested in smallest
+    // values coming first, the priority queue should be a min-heap
     let mut pq = FixedLengthPriorityQueue::new(top);
     for element in elements {
         pq.push(Reverse(element));
@@ -40,8 +40,8 @@ where
         return vec![];
     }
 
-    // If big values is better - PQ should pop-out small values first.
-    // Hence it should be min-heap
+    // If the caller is interested in greatest
+    // values coming first, the priority queue should be a max-heap
     let mut pq = FixedLengthPriorityQueue::new(top);
     for element in elements {
         pq.push(element);


### PR DESCRIPTION
/claim #4321

After these changes, `FixedLengthPriorityQueue` will reallocate its underlying Binary Heap in case it's too large to be preallocated in one go.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
