### PR TITLE
Rocksdb atomic flush

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -49,6 +49,7 @@ pub fn db_options() -> Options {
     options.set_delete_obsolete_files_period_micros(DB_DELETE_OBSOLETE_FILES_PERIOD);
     options.create_missing_column_families(true);
     options.set_max_open_files(DB_MAX_OPEN_FILES as i32);
+    options.set_atomic_flush(true);
 
     // Qdrant relies on it's own WAL for durability
     options.set_wal_recovery_mode(DBRecoveryMode::TolerateCorruptedTailRecords);


### PR DESCRIPTION
RocksDB documentation about atomic flush:
https://github.com/facebook/rocksdb/wiki/Atomic-flush

Possible solution of https://github.com/qdrant/qdrant/issues/4318

RocksDB has an internal background flush which is a black box. Maybe bug was appeared because background flush did IDTracker flush first (because of small size of changes or something else) and background flush of Storage didn't finish because of killing machine.

If so, rocksdb has an option `atomic_flush` wich guarantee consistency between column families in background flush.