### PR TITLE
Fix missing segments, use correct path for new segment created during snapshot

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -658,7 +658,7 @@ impl<'s> SegmentHolder {
     /// sourced from it.
     pub fn proxy_all_segments_and_apply<F>(
         segments: LockedSegmentHolder,
-        collection_path: &Path,
+        shard_path: &Path,
         collection_params: Option<&CollectionParams>,
         f: F,
     ) -> OperationResult<()>
@@ -670,7 +670,7 @@ impl<'s> SegmentHolder {
         // Proxy all segments
         log::trace!("Proxying all shard segments to apply function");
         let (mut proxies, tmp_segment, mut segments_lock) =
-            Self::proxy_all_segments(segments_lock, collection_path, collection_params)?;
+            Self::proxy_all_segments(segments_lock, shard_path, collection_params)?;
 
         // Apply provided function
         log::trace!("Applying function on all proxied shard segments");
@@ -721,7 +721,7 @@ impl<'s> SegmentHolder {
     #[allow(clippy::type_complexity)]
     fn proxy_all_segments<'a>(
         segments_lock: RwLockUpgradableReadGuard<'a, SegmentHolder>,
-        collection_path: &Path,
+        shard_path: &Path,
         collection_params: Option<&CollectionParams>,
     ) -> OperationResult<(
         Vec<(SegmentId, LockedSegment)>,
@@ -753,7 +753,7 @@ impl<'s> SegmentHolder {
         };
 
         // Create temporary appendable segment to direct all proxy writes into
-        let tmp_segment = LockedSegment::new(build_segment(collection_path, &config, false)?);
+        let tmp_segment = LockedSegment::new(build_segment(shard_path, &config, false)?);
 
         // List all segments we want to snapshot
         let segment_ids = segments_lock.segment_ids();
@@ -936,23 +936,18 @@ impl<'s> SegmentHolder {
     /// Shortcuts at the first failing segment snapshot.
     pub fn snapshot_all_segments(
         segments: LockedSegmentHolder,
-        collection_path: &Path,
+        shard_path: &Path,
         collection_params: Option<&CollectionParams>,
         temp_dir: &Path,
         snapshot_dir_path: &Path,
     ) -> OperationResult<()> {
         // Snapshotting may take long-running read locks on segments blocking incoming writes, do
         // this through proxied segments to allow writes to continue.
-        Self::proxy_all_segments_and_apply(
-            segments,
-            collection_path,
-            collection_params,
-            |segment| {
-                let read_segment = segment.read();
-                read_segment.take_snapshot(temp_dir, snapshot_dir_path)?;
-                Ok(())
-            },
-        )
+        Self::proxy_all_segments_and_apply(segments, shard_path, collection_params, |segment| {
+            let read_segment = segment.read();
+            read_segment.take_snapshot(temp_dir, snapshot_dir_path)?;
+            Ok(())
+        })
     }
 
     pub fn report_optimizer_error<E: Into<CollectionError>>(&mut self, error: E) {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1308,12 +1308,12 @@ mod tests {
 
         let holder = Arc::new(RwLock::new(holder));
 
-        let collection_dir = Builder::new().prefix("collection_dir").tempdir().unwrap();
+        let shard_dir = Builder::new().prefix("shard_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
         SegmentHolder::snapshot_all_segments(
             holder,
-            collection_dir.path(),
+            shard_dir.path(),
             None,
             temp_dir.path(),
             snapshot_dir.path(),

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1308,12 +1308,12 @@ mod tests {
 
         let holder = Arc::new(RwLock::new(holder));
 
-        let shard_dir = Builder::new().prefix("shard_dir").tempdir().unwrap();
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
         SegmentHolder::snapshot_all_segments(
             holder,
-            shard_dir.path(),
+            segments_dir.path(),
             None,
             temp_dir.path(),
             snapshot_dir.path(),

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -223,7 +223,7 @@ impl SegmentOptimizer for ConfigMismatchOptimizer {
         "config mismatch"
     }
 
-    fn collection_path(&self) -> &Path {
+    fn segments_path(&self) -> &Path {
         self.segments_path.as_path()
     }
 

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -252,7 +252,7 @@ impl SegmentOptimizer for IndexingOptimizer {
         "indexing"
     }
 
-    fn collection_path(&self) -> &Path {
+    fn segments_path(&self) -> &Path {
         self.segments_path.as_path()
     }
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -61,7 +61,7 @@ impl SegmentOptimizer for MergeOptimizer {
         "merge"
     }
 
-    fn collection_path(&self) -> &Path {
+    fn segments_path(&self) -> &Path {
         self.segments_path.as_path()
     }
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -50,8 +50,8 @@ pub trait SegmentOptimizer {
     /// Get name describing this optimizer
     fn name(&self) -> &str;
 
-    /// Get path of the whole collection
-    fn collection_path(&self) -> &Path;
+    /// Get path of the the shard
+    fn segments_path(&self) -> &Path;
 
     /// Get temp path, where optimized segments could be temporary stored
     fn temp_path(&self) -> &Path;
@@ -90,7 +90,7 @@ pub trait SegmentOptimizer {
             },
         };
         Ok(LockedSegment::new(build_segment(
-            self.collection_path(),
+            self.segments_path(),
             &config,
             save_version,
         )?))
@@ -245,7 +245,7 @@ pub trait SegmentOptimizer {
         };
 
         Ok(SegmentBuilder::new(
-            self.collection_path(),
+            self.segments_path(),
             self.temp_path(),
             &optimized_config,
         )?)

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -167,7 +167,7 @@ impl SegmentOptimizer for VacuumOptimizer {
         "vacuum"
     }
 
-    fn collection_path(&self) -> &Path {
+    fn segments_path(&self) -> &Path {
         self.segments_path.as_path()
     }
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -699,7 +699,7 @@ impl LocalShard {
             rx.await?;
         }
 
-        let shard_path = self.path.clone();
+        let segments_path = Self::segments_path(&self.path);
         let collection_params = self.collection_config.read().await.params.clone();
         let temp_path = temp_path.to_owned();
 
@@ -707,7 +707,7 @@ impl LocalShard {
             // Do not change segments while snapshotting
             SegmentHolder::snapshot_all_segments(
                 segments.clone(),
-                &shard_path,
+                &segments_path,
                 Some(&collection_params),
                 &temp_path,
                 &snapshot_segments_shard_path,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -699,9 +699,7 @@ impl LocalShard {
             rx.await?;
         }
 
-        let collection_path = self.path.parent().map(Path::to_path_buf).ok_or_else(|| {
-            CollectionError::service_error("Failed to determine collection path for shard")
-        })?;
+        let shard_path = self.path.clone();
         let collection_params = self.collection_config.read().await.params.clone();
         let temp_path = temp_path.to_owned();
 
@@ -709,7 +707,7 @@ impl LocalShard {
             // Do not change segments while snapshotting
             SegmentHolder::snapshot_all_segments(
                 segments.clone(),
-                &collection_path,
+                &shard_path,
                 Some(&collection_params),
                 &temp_path,
                 &snapshot_segments_shard_path,

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -505,7 +505,7 @@ pub fn load_segment(path: &Path, stopped: &AtomicBool) -> OperationResult<Option
 ///
 /// # Arguments
 ///
-/// * `shard_path` - Path to the collection shard. Segment folder will be created in this directory
+/// * `segments_path` - Path to the segments directory. Segment folder will be created in this directory
 /// * `config` - Segment configuration
 /// * `ready` - Whether the segment is ready after building; will save segment version
 ///
@@ -513,11 +513,11 @@ pub fn load_segment(path: &Path, stopped: &AtomicBool) -> OperationResult<Option
 /// will not be stored. Then the segment is skipped on restart when trying to load it again. In
 /// that case, the segment version must be stored manually to make it ready.
 pub fn build_segment(
-    shard_path: &Path,
+    segments_path: &Path,
     config: &SegmentConfig,
     ready: bool,
 ) -> OperationResult<Segment> {
-    let segment_path = shard_path.join(Uuid::new_v4().to_string());
+    let segment_path = segments_path.join(Uuid::new_v4().to_string());
 
     std::fs::create_dir_all(&segment_path)?;
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -505,15 +505,19 @@ pub fn load_segment(path: &Path, stopped: &AtomicBool) -> OperationResult<Option
 ///
 /// # Arguments
 ///
-/// * `path` - A path to collection. Segment folder will be created in this directory
+/// * `shard_path` - Path to the collection shard. Segment folder will be created in this directory
 /// * `config` - Segment configuration
 /// * `ready` - Whether the segment is ready after building; will save segment version
 ///
 /// To load a segment, saving the segment version is required. If `ready` is false, the version
 /// will not be stored. Then the segment is skipped on restart when trying to load it again. In
 /// that case, the segment version must be stored manually to make it ready.
-pub fn build_segment(path: &Path, config: &SegmentConfig, ready: bool) -> OperationResult<Segment> {
-    let segment_path = path.join(Uuid::new_v4().to_string());
+pub fn build_segment(
+    shard_path: &Path,
+    config: &SegmentConfig,
+    ready: bool,
+) -> OperationResult<Segment> {
+    let segment_path = shard_path.join(Uuid::new_v4().to_string());
 
     std::fs::create_dir_all(&segment_path)?;
 


### PR DESCRIPTION
Fix issue where segments did go missing.

We created a new segments in the wrong directory, which means they would not be loaded on restart.

This also refactors some parameters, function names and documentation to remove a lot of confusion around what type of paths are used where.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?