### PR TITLE
universal-query: Fix order in `LocalShard` vector rescoring

### DIFF
--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -148,12 +148,11 @@ impl LocalShard {
             }
             ScoringQuery::Vector(query_enum) => {
                 // create single search request for rescoring query
-                let point_ids = sources.into_iter().fold(HashSet::new(), |mut acc, source| {
-                    for scored_point in source {
-                        acc.insert(scored_point.id);
-                    }
-                    acc
-                });
+                let point_ids = sources
+                    .into_iter()
+                    .flatten()
+                    .map(|point| point.id)
+                    .collect::<HashSet<_>>();
 
                 // create filter for target point ids
                 let filter = Filter::new_must(segment::types::Condition::HasId(

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -182,7 +182,7 @@ impl LocalShard {
             limit,
             offset: 0,
             with_payload: None, // the payload is fetched separately
-            with_vector: None,  // the vector is fetched separetely
+            with_vector: None,  // the vector is fetched separately
             score_threshold: None,
         };
 

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -12,7 +11,6 @@ use tokio::runtime::Handle;
 
 use super::LocalShard;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
-use crate::operations::query_enum::QueryEnum;
 use crate::operations::types::{CollectionResult, CoreSearchRequest, CoreSearchRequestBatch};
 use crate::operations::universal_query::planned_query::{
     MergePlan, PlannedQuery, PrefetchSource, ResultsMerge,
@@ -27,19 +25,19 @@ impl LocalShard {
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<ShardQueryResponse> {
-        let mut core_results = self
+        let core_results = self
             .do_search(request.searches, search_runtime_handle, timeout)
             .await?;
 
-        let mut scrolls = self
+        let scrolls = self
             .query_scroll_batch(request.scrolls, search_runtime_handle)
             .await?;
 
         let mut scored_points = self
             .recurse_prefetch(
                 request.merge_plan,
-                &mut core_results,
-                &mut scrolls,
+                &core_results,
+                &scrolls,
                 search_runtime_handle,
                 timeout,
                 0, // initial depth
@@ -78,8 +76,8 @@ impl LocalShard {
     fn recurse_prefetch<'shard, 'query>(
         &'shard self,
         prefetch: MergePlan,
-        core_results: &'query mut Vec<Vec<ScoredPoint>>,
-        scrolls: &'query mut Vec<Vec<ScoredPoint>>,
+        core_results: &'query Vec<Vec<ScoredPoint>>,
+        scrolls: &'query Vec<Vec<ScoredPoint>>,
         search_runtime_handle: &'shard Handle,
         timeout: Option<Duration>,
         depth: usize,
@@ -91,16 +89,18 @@ impl LocalShard {
             let mut sources: Vec<Vec<ScoredPoint>> = Vec::with_capacity(prefetch.sources.len());
 
             for source in prefetch.sources.into_iter() {
-                match source {
+                let vec: Vec<Vec<ScoredPoint>> = match source {
                     PrefetchSource::SearchesIdx(idx) => {
-                        debug_assert!(idx < core_results.len());
-                        sources.push(mem::take(&mut core_results[idx]));
+                        // TODO(universal-query): don't clone, by using something like a hashmap instead of a vec
+                        let scored_searches = core_results.get(idx).cloned().unwrap_or_default();
+                        vec![scored_searches]
                     }
                     PrefetchSource::ScrollsIdx(idx) => {
-                        debug_assert!(idx < scrolls.len());
-                        sources.push(mem::take(&mut scrolls[idx]));
+                        // TODO(universal-query): don't clone, by using something like a hashmap instead of a vec
+                        let scrolled = scrolls.get(idx).cloned().unwrap_or_default();
+                        vec![scrolled]
                     }
-                    PrefetchSource::Prefetch(prefetch) => sources.extend(
+                    PrefetchSource::Prefetch(prefetch) => {
                         self.recurse_prefetch(
                             prefetch,
                             core_results,
@@ -109,9 +109,10 @@ impl LocalShard {
                             timeout,
                             depth + 1,
                         )
-                        .await?,
-                    ),
+                        .await?
+                    }
                 };
+                sources.extend(vec);
             }
 
             if depth == 0 && prefetch.merge.rescore == Some(ScoringQuery::Fusion(Fusion::Rrf)) {
@@ -146,62 +147,48 @@ impl LocalShard {
                 todo!("order by not implemented yet for {:?}", o)
             }
             ScoringQuery::Vector(query_enum) => {
-                self.vector_rescore(sources, query_enum, limit, search_runtime_handle, timeout)
-                    .await
-            }
-        }
-    }
-
-    async fn vector_rescore(
-        &self,
-        sources: Vec<Vec<ScoredPoint>>,
-        query_enum: QueryEnum,
-        limit: usize,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> Result<Vec<ScoredPoint>, crate::operations::types::CollectionError> {
-        // create single search request for rescoring query
-        let point_ids =
-            sources
-                .into_iter()
-                .flatten()
-                .fold(HashSet::new(), |mut acc, scored_point| {
-                    acc.insert(scored_point.id);
+                // create single search request for rescoring query
+                let point_ids = sources.into_iter().fold(HashSet::new(), |mut acc, source| {
+                    for scored_point in source {
+                        acc.insert(scored_point.id);
+                    }
                     acc
                 });
 
-        // create filter for target point ids
-        let filter = Filter::new_must(segment::types::Condition::HasId(HasIdCondition::from(
-            point_ids,
-        )));
+                // create filter for target point ids
+                let filter = Filter::new_must(segment::types::Condition::HasId(
+                    HasIdCondition::from(point_ids),
+                ));
 
-        let search_request = CoreSearchRequest {
-            query: query_enum,
-            filter: Some(filter),
-            params: None,
-            limit,
-            offset: 0,
-            with_payload: None, // the payload is fetched separately
-            with_vector: None,  // the vector is fetched separately
-            score_threshold: None,
-        };
+                let search_request = CoreSearchRequest {
+                    query: query_enum,
+                    filter: Some(filter),
+                    params: None,
+                    limit,
+                    offset: 0,
+                    with_payload: None, // the payload is fetched separately
+                    with_vector: None,  // the vector is fetched separately
+                    score_threshold: None,
+                };
 
-        let rescoring_core_search_request = CoreSearchRequestBatch {
-            searches: vec![search_request],
-        };
+                let rescoring_core_search_request = CoreSearchRequestBatch {
+                    searches: vec![search_request],
+                };
 
-        let top = self
-            .do_search(
-                Arc::new(rescoring_core_search_request),
-                search_runtime_handle,
-                timeout,
-            )
-            .await?
-            // One search request is sent. We expect only one result
-            .pop()
-            .unwrap_or_default();
+                let top = self
+                    .do_search(
+                        Arc::new(rescoring_core_search_request),
+                        search_runtime_handle,
+                        timeout,
+                    )
+                    .await?
+                    // One search request is sent. We expect only one result
+                    .pop()
+                    .unwrap_or_default();
 
-        Ok(top)
+                Ok(top)
+            }
+        }
     }
 
     /// Merge multiple prefetches into a single result up to the limit.


### PR DESCRIPTION
Tracked in #4225 

- create a single core search request for all ids to rescore. Correct ordering is already handled within `do_search`
~- optimize taking from sources so that no extra cloning is made~
