### PR TITLE
On shard load, ensure we have any appendable segments

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -717,6 +717,19 @@ impl<'s> SegmentHolder {
         result
     }
 
+    /// Create a new appendable segment and add it to the segment holder.
+    ///
+    /// The segment configuration is sourced from the given collection parameters.
+    pub fn create_appendable_segment(
+        &mut self,
+        segments_path: &Path,
+        collection_params: &CollectionParams,
+    ) -> OperationResult<LockedSegment> {
+        let segment = self.build_tmp_segment(segments_path, Some(collection_params), true)?;
+        self.add_locked(segment.clone());
+        Ok(segment)
+    }
+
     /// Build a temporary appendable segment, usually for proxying writes into.
     ///
     /// The segment configuration is sourced from the given collection parameters. If none is

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -787,7 +787,7 @@ impl<'s> SegmentHolder {
     #[allow(clippy::type_complexity)]
     fn proxy_all_segments<'a>(
         segments_lock: RwLockUpgradableReadGuard<'a, SegmentHolder>,
-        collection_path: &Path,
+        segments_path: &Path,
         collection_params: Option<&CollectionParams>,
     ) -> OperationResult<(
         Vec<(SegmentId, LockedSegment)>,
@@ -796,7 +796,7 @@ impl<'s> SegmentHolder {
     )> {
         // Create temporary appendable segment to direct all proxy writes into
         let tmp_segment =
-            segments_lock.build_tmp_segment(collection_path, collection_params, false)?;
+            segments_lock.build_tmp_segment(segments_path, collection_params, false)?;
 
         // List all segments we want to snapshot
         let segment_ids = segments_lock.segment_ids();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -717,17 +717,29 @@ impl<'s> SegmentHolder {
         result
     }
 
-    /// Proxy all shard segments for [`proxy_all_segments_and_apply`]
-    #[allow(clippy::type_complexity)]
-    fn proxy_all_segments<'a>(
-        segments_lock: RwLockUpgradableReadGuard<'a, SegmentHolder>,
+    /// Build a temporary appendable segment, usually for proxying writes into.
+    ///
+    /// The segment configuration is sourced from the given collection parameters. If none is
+    /// specified this will fall back and clone the configuration of any existing appendable
+    /// segment in the segment holder.
+    ///
+    /// # Errors
+    ///
+    /// Errors if:
+    /// - building the segment fails
+    /// - no segment configuration is provided, and no appendable segment is in the segment holder
+    ///
+    /// # Warning
+    ///
+    /// This builds a segment on disk, but does NOT add it to the current segment holder. That must
+    /// be done explicitly. `save_version` must be true for the segment to be loaded when Qdrant
+    /// restarts.
+    fn build_tmp_segment(
+        &self,
         segments_path: &Path,
         collection_params: Option<&CollectionParams>,
-    ) -> OperationResult<(
-        Vec<(SegmentId, LockedSegment)>,
-        LockedSegment,
-        RwLockUpgradableReadGuard<'a, SegmentHolder>,
-    )> {
+        save_version: bool,
+    ) -> OperationResult<LockedSegment> {
         // Source config for temporary segment which we target all writes to
         let config = match collection_params {
             // Base config on collection params
@@ -742,7 +754,7 @@ impl<'s> SegmentHolder {
             },
             // Base config on existing appendable or non-appendable segment
             None => {
-                segments_lock
+                self
                     .random_appendable_segment()
                     .ok_or_else(|| OperationError::service_error("No existing segment to source temporary segment configuration from"))?
                     .get()
@@ -753,7 +765,27 @@ impl<'s> SegmentHolder {
         };
 
         // Create temporary appendable segment to direct all proxy writes into
-        let tmp_segment = LockedSegment::new(build_segment(segments_path, &config, false)?);
+        Ok(LockedSegment::new(build_segment(
+            segments_path,
+            &config,
+            save_version,
+        )?))
+    }
+
+    /// Proxy all shard segments for [`proxy_all_segments_and_apply`]
+    #[allow(clippy::type_complexity)]
+    fn proxy_all_segments<'a>(
+        segments_lock: RwLockUpgradableReadGuard<'a, SegmentHolder>,
+        collection_path: &Path,
+        collection_params: Option<&CollectionParams>,
+    ) -> OperationResult<(
+        Vec<(SegmentId, LockedSegment)>,
+        LockedSegment,
+        RwLockUpgradableReadGuard<'a, SegmentHolder>,
+    )> {
+        // Create temporary appendable segment to direct all proxy writes into
+        let tmp_segment =
+            segments_lock.build_tmp_segment(collection_path, collection_params, false)?;
 
         // List all segments we want to snapshot
         let segment_ids = segments_lock.segment_ids();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -740,7 +740,6 @@ impl<'s> SegmentHolder {
         collection_params: Option<&CollectionParams>,
         save_version: bool,
     ) -> OperationResult<LockedSegment> {
-        // Source config for temporary segment which we target all writes to
         let config = match collection_params {
             // Base config on collection params
             Some(collection_params) => SegmentConfig {
@@ -752,7 +751,7 @@ impl<'s> SegmentHolder {
                     .map_err(|err| OperationError::service_error(format!("Failed to source sparse vector configuration from collection parameters: {err:?}")))?,
                 payload_storage_type: collection_params.payload_storage_type(),
             },
-            // Base config on existing appendable or non-appendable segment
+            // Fall back: base config on existing appendable segment
             None => {
                 self
                     .random_appendable_segment()
@@ -764,7 +763,6 @@ impl<'s> SegmentHolder {
             }
         };
 
-        // Create temporary appendable segment to direct all proxy writes into
         Ok(LockedSegment::new(build_segment(
             segments_path,
             &config,

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -586,8 +586,7 @@ pub trait SegmentOptimizer {
 
             let (_, proxies) = write_segments_guard.swap(optimized_segment, &proxy_ids);
 
-            let has_appendable_segments =
-                write_segments_guard.random_appendable_segment().is_some();
+            let has_appendable_segments = write_segments_guard.has_appendable_segment();
 
             // Release reference counter of the optimized segments
             drop(optimizing_segments);

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -50,7 +50,7 @@ pub trait SegmentOptimizer {
     /// Get name describing this optimizer
     fn name(&self) -> &str;
 
-    /// Get path of the the shard
+    /// Get the path of the segments directory
     fn segments_path(&self) -> &Path;
 
     /// Get temp path, where optimized segments could be temporary stored

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -418,9 +418,12 @@ where
         .filter(|x| !(updated_points.contains(x)));
 
     {
-        let default_write_segment = segments.random_appendable_segment().ok_or_else(|| {
-            CollectionError::service_error("No segments exists, expected at least one".to_string())
-        })?;
+        let default_write_segment =
+            segments
+                .random_appendable_segment()
+                .ok_or(CollectionError::service_error(
+                    "No appendable segments exists, expected at least one",
+                ))?;
 
         let segment_arc = default_write_segment.get();
         let mut write_segment = segment_arc.write();

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -312,6 +312,10 @@ impl LocalShard {
 
         // Always make sure we have any appendable segments, needed for update operations
         if !segment_holder.has_appendable_segment() {
+            debug_assert!(
+                false,
+                "Shard has no appendable segments, this should never happen",
+            );
             log::warn!("Shard has no appendable segments, this should never happen. Creating new appendable segment now");
             let segments_path = LocalShard::segments_path(shard_path);
             let collection_params = collection_config.read().await.params.clone();

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -310,6 +310,14 @@ impl LocalShard {
 
         let clocks = LocalShardClocks::load(shard_path)?;
 
+        // Always make sure we have any appendable segments, needed for update operations
+        if !segment_holder.has_appendable_segment() {
+            log::warn!("Shard has no appendable segments, this should never happen. Creating new appendable segment now");
+            let segments_path = LocalShard::segments_path(shard_path);
+            let collection_params = collection_config.read().await.params.clone();
+            segment_holder.create_appendable_segment(&segments_path, &collection_params)?;
+        }
+
         let local_shard = LocalShard::new(
             segment_holder,
             collection_config,


### PR DESCRIPTION
Related to: <https://github.com/qdrant/qdrant/pull/4332>

When loading a shard, ensure that we have at least one appendable segment. If we don't, create one.

Normally, we never expect this scenario. This just helps being on the safe side by preventing an unrecoverable crash loop if this somehow does occur.

However, a recent bug - fixed in <https://github.com/qdrant/qdrant/pull/4332> - did allow this situation to occur by misplacing the appendable shard in the wrong directory. We need to improvement to prevent accidental crash loops as described above.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?