### PR TITLE
Add `ReshardingOperations::CommitHashRing` consensus message

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -84,6 +84,10 @@ impl Collection {
         Ok(())
     }
 
+    pub async fn commit_hashring(&self, reshard: ReshardKey) -> CollectionResult<()> {
+        self.shards_holder.write().await.commit_hashring(reshard)
+    }
+
     pub async fn abort_resharding(&self, reshard_key: ReshardKey) -> CollectionResult<()> {
         self.shards_holder
             .write()

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -76,6 +76,16 @@ impl<T: Hash + Copy + PartialEq> HashRing<T> {
         new.add(shard);
     }
 
+    pub fn commit(&mut self) -> bool {
+        let Self::Resharding { new, .. } = self else {
+            log::warn!("committing resharding hashring, but hashring is not in resharding mode");
+            return false;
+        };
+
+        *self = Self::Single(new.clone());
+        true
+    }
+
     pub fn remove_resharding(&mut self, shard: T) -> bool
     where
         T: fmt::Display,

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -295,6 +295,7 @@ pub struct DeleteCollectionOperation(pub String);
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub enum ReshardingOperation {
     Start(ReshardKey),
+    CommitHashRing(ReshardKey),
     Abort(ReshardKey),
 }
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -328,6 +328,10 @@ impl TableOfContent {
                     .await?;
             }
 
+            ReshardingOperation::CommitHashRing(key) => {
+                collection.commit_hashring(key).await?;
+            }
+
             ReshardingOperation::Abort(key) => {
                 collection.abort_resharding(key).await?;
             }


### PR DESCRIPTION
Tracked in #4213. Based on #4351.

This PR adds `CommitHashRing` consensus operation.

We *might* still redesign this (e.g., to use multiple hashring commit steps or something), but I'd expect most of the code in this PR to be reused anyway.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
