### PR TITLE
Move resharding state into shard holder

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -670,17 +670,7 @@ impl Collection {
             .create_replica_set(shard_id, &[peer_id], Some(ReplicaState::Resharding))
             .await?;
 
-        shard_holder.start_resharding(shard_id, replica_set, shard_key.clone())?;
-
-        shard_holder.resharding_state.write(|state| {
-            debug_assert!(
-                state.is_none(),
-                "resharding of collection {} is already in progress: {state:?}",
-                self.id
-            );
-
-            *state = Some(ReshardingState::new(peer_id, shard_id, shard_key));
-        })?;
+        shard_holder.start_resharding(peer_id, shard_id, replica_set, shard_key.clone())?;
 
         Ok(())
     }
@@ -726,13 +716,8 @@ impl Collection {
 
         // TODO(resharding): Contextualize errors? 🤔
         shard_holder
-            .abort_resharding(shard_id, peer_id, shard_key.clone(), is_in_progress)
+            .abort_resharding(peer_id, shard_id, shard_key.clone(), is_in_progress)
             .await?;
-
-        // TODO(resharding): Contextualize errors? 🤔
-        shard_holder.resharding_state.write(|state| {
-            *state = None;
-        })?;
 
         Ok(())
     }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -1,6 +1,7 @@
 use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
 
+use crate::shards::resharding::ReshardingKey;
 use crate::shards::shard::{PeerId, ShardId};
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -17,6 +18,14 @@ impl ReshardingState {
             peer_id,
             shard_id,
             shard_key,
+        }
+    }
+
+    pub fn key(&self) -> ReshardingKey {
+        ReshardingKey {
+            peer_id: self.peer_id,
+            shard_id: self.shard_id,
+            shard_key: self.shard_key.clone(),
         }
     }
 }

--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -8,6 +8,7 @@ pub mod proxy_shard;
 pub mod queue_proxy_shard;
 pub mod remote_shard;
 pub mod replica_set;
+pub mod resharding;
 pub mod resolve;
 pub mod shard;
 pub mod shard_config;

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -1,0 +1,13 @@
+use schemars::JsonSchema;
+use segment::types::ShardKey;
+use serde::{Deserialize, Serialize};
+
+use super::shard::{PeerId, ShardId};
+
+/// Unique identifier of a resharding operation
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReshardingKey {
+    pub peer_id: PeerId,
+    pub shard_id: ShardId,
+    pub shard_key: Option<ShardKey>,
+}

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -13,6 +13,7 @@ use tokio::sync::RwLock;
 
 use super::replica_set::AbortShardTransfer;
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
+use crate::collection::resharding::ReshardingState;
 use crate::common::validate_snapshot_archive::validate_open_snapshot_archive;
 use crate::config::{CollectionConfig, ShardingMethod};
 use crate::hash_ring::HashRing;
@@ -32,6 +33,7 @@ use crate::shards::transfer::{ShardTransfer, ShardTransferKey};
 use crate::shards::CollectionId;
 
 const SHARD_TRANSFERS_FILE: &str = "shard_transfers";
+const RESHARDING_STATE_FILE: &str = "resharding_state.json";
 pub const SHARD_KEY_MAPPING_FILE: &str = "shard_key_mapping.json";
 
 pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
@@ -39,8 +41,8 @@ pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
 pub struct ShardHolder {
     shards: HashMap<ShardId, ShardReplicaSet>,
     pub(crate) shard_transfers: SaveOnDisk<HashSet<ShardTransfer>>,
+    pub(crate) resharding_state: SaveOnDisk<Option<ReshardingState>>,
     pub(crate) rings: HashMap<Option<ShardKey>, HashRing>,
-    resharding: Option<ShardId>,
     key_mapping: SaveOnDisk<ShardKeyMapping>,
     // Duplicates the information from `key_mapping` for faster access
     // Do not require locking
@@ -50,8 +52,10 @@ pub struct ShardHolder {
 pub type LockedShardHolder = RwLock<ShardHolder>;
 
 impl ShardHolder {
-    pub fn new(collection_path: &Path, resharding: Option<ShardId>) -> CollectionResult<Self> {
+    pub fn new(collection_path: &Path) -> CollectionResult<Self> {
         let shard_transfers = SaveOnDisk::load_or_init(collection_path.join(SHARD_TRANSFERS_FILE))?;
+        let resharding_state: SaveOnDisk<Option<ReshardingState>> =
+            SaveOnDisk::load_or_init(collection_path.join(RESHARDING_STATE_FILE))?;
 
         let key_mapping: SaveOnDisk<ShardKeyMapping> =
             SaveOnDisk::load_or_init(collection_path.join(SHARD_KEY_MAPPING_FILE))?;
@@ -66,7 +70,7 @@ impl ShardHolder {
 
         let mut rings = HashMap::from([(None, HashRing::single())]);
 
-        if let Some(shard_id) = resharding {
+        if let Some(shard_id) = resharding_state.read().clone().map(|state| state.shard_id) {
             rings.insert(
                 shard_id_to_key_mapping.get(&shard_id).cloned(),
                 HashRing::resharding(shard_id),
@@ -76,8 +80,8 @@ impl ShardHolder {
         Ok(Self {
             shards: HashMap::new(),
             shard_transfers,
+            resharding_state,
             rings,
-            resharding,
             key_mapping,
             shard_id_to_key_mapping,
         })
@@ -134,9 +138,9 @@ impl ShardHolder {
 
         if ring.is_resharding() {
             debug_assert!(
-                self.resharding.is_some(),
+                self.resharding_state.read().is_some(),
                 "shard holder contains resharding hashring, but resharding field is {:?}",
-                self.resharding
+                self.resharding_state.read().clone(),
             );
 
             // TODO(resharding): `CollectionError::service_error`? 🤔
@@ -146,9 +150,9 @@ impl ShardHolder {
         }
 
         debug_assert!(
-            self.resharding.is_none(),
+            self.resharding_state.read().is_none(),
             "shard holder does not contain resharding hashring, but resharding field is {:?}",
-            self.resharding
+            self.resharding_state.read().clone(),
         );
 
         if self.shards.contains_key(&shard_id) {
@@ -159,7 +163,6 @@ impl ShardHolder {
         }
 
         ring.add_resharding(shard_id);
-        self.resharding = Some(shard_id);
         self.add_shard(shard_id, shard, shard_key)?;
 
         Ok(())
@@ -484,7 +487,12 @@ impl ShardHolder {
             }
             ShardSelectorInternal::All => {
                 for (&shard_id, shard) in self.shards.iter() {
-                    if self.resharding == Some(shard_id) {
+                    let is_resharding = self
+                        .resharding_state
+                        .read()
+                        .clone()
+                        .map_or(false, |state| state.shard_id == shard_id);
+                    if is_resharding {
                         continue;
                     }
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -12,6 +12,7 @@ use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
 use super::replica_set::AbortShardTransfer;
+use super::resharding::ReshardingKey;
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
 use crate::collection::resharding::ReshardingState;
 use crate::common::validate_snapshot_archive::validate_open_snapshot_archive;
@@ -112,11 +113,15 @@ impl ShardHolder {
 
     pub fn start_resharding(
         &mut self,
-        peer_id: PeerId,
-        shard_id: ShardId,
+        resharding_key: ReshardingKey,
         shard: ShardReplicaSet,
-        shard_key: Option<ShardKey>,
     ) -> Result<(), CollectionError> {
+        let ReshardingKey {
+            shard_id,
+            shard_key,
+            peer_id,
+        } = resharding_key;
+
         // TODO(resharding):
         //
         // `CollectionError::service_error` seems more fitting here... but if `start_resharding`
@@ -179,11 +184,14 @@ impl ShardHolder {
 
     pub async fn abort_resharding(
         &mut self,
-        peer_id: PeerId,
-        shard_id: ShardId,
-        shard_key: Option<ShardKey>,
+        resharding_key: ReshardingKey,
         is_in_progress: bool,
     ) -> Result<(), CollectionError> {
+        let ReshardingKey {
+            shard_id,
+            shard_key,
+            peer_id,
+        } = resharding_key;
         let mut removed_resharding = false;
 
         if let Some(ring) = self.rings.get_mut(&shard_key) {

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -6,6 +6,7 @@ use collection::config::ShardingMethod;
 use collection::events::{CollectionDeletedEvent, IndexCreatedEvent};
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::ReplicaState;
+use collection::shards::resharding::ReshardingKey;
 use collection::shards::transfer::ShardTransfer;
 use collection::shards::{transfer, CollectionId};
 use uuid::Uuid;
@@ -279,9 +280,12 @@ impl TableOfContent {
                 shard_id,
                 shard_key,
             } => {
-                collection
-                    .start_resharding(peer_id, shard_id, shard_key)
-                    .await?;
+                let reshard = ReshardingKey {
+                    peer_id,
+                    shard_id,
+                    shard_key,
+                };
+                collection.start_resharding(reshard).await?;
             }
 
             ReshardingOperation::Abort {
@@ -289,9 +293,12 @@ impl TableOfContent {
                 shard_id,
                 shard_key,
             } => {
-                collection
-                    .abort_resharding(peer_id, shard_id, shard_key)
-                    .await?;
+                let reshard = ReshardingKey {
+                    peer_id,
+                    shard_id,
+                    shard_key,
+                };
+                collection.abort_resharding(reshard).await?;
             }
         }
 

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -578,7 +578,7 @@ pub async fn do_update_collection_cluster(
                 .await
         }
         ClusterOperations::AbortResharding(_) => {
-            let Some(state) = collection.resharding_state() else {
+            let Some(state) = collection.resharding_state().await else {
                 return Err(StorageError::bad_request(format!(
                     "resharding is not in progress for collection {collection_name}"
                 )));


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>

Move the resharding state from the collection struct into the shard holder. It now lives next to the shard transfers state.

I've also added a `ReshardingKey` which holds the peer ID, shard ID and resharding key because we commonly use these together. This matches with the shard transfer key.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?