### PR TITLE
Improve performance of compressed posting list

### DIFF
--- a/lib/sparse/src/index/posting_list_common.rs
+++ b/lib/sparse/src/index/posting_list_common.rs
@@ -1,5 +1,3 @@
-use std::ops::ControlFlow;
-
 use common::types::PointOffsetType;
 
 use crate::common::types::DimWeight;
@@ -58,9 +56,13 @@ pub trait PostingListIter {
 
     fn current_index(&self) -> usize;
 
-    fn try_for_each<F, R>(&mut self, f: F) -> ControlFlow<R>
-    where
-        F: FnMut(PostingElement) -> ControlFlow<R>;
+    /// Iterate over the posting list until `id` is reached (inclusive).
+    fn for_each_till_id<Ctx: ?Sized>(
+        &mut self,
+        id: PointOffsetType,
+        ctx: &mut Ctx,
+        f: impl FnMut(&mut Ctx, PointOffsetType, DimWeight),
+    );
 
     /// Whether the max_next_weight is reliable.
     fn reliable_max_next_weight() -> bool;


### PR DESCRIPTION
This PR optimizes implementation of the compressed posting list.
#4143

# Benchmark results

Previous results: #4253.

## Basic
task | ram | ramc | diff | mmap | mmapc | diff
| - | - | - | - | - | - | -
random-50k | 0.75844 | 0.95927 | +26% | 0.75591 | 0.99954 | +32%
random-500k | 7.0467 | 8.5863 | +21% | 7.1477 | 8.7218 | +22%
neurips2023-1M | 11.628 | 13.191 | +13% | 11.591 | 13.650 | +17%
neurips2023-full-25pct | 27.021 | 30.671 | +13% | 26.939 | 30.986 | +15%
movies | 3.2623 | 4.0095 | +22% | 3.2435 | 4.0141 | +23%

## Hottest
task | ram | ramc | diff | mmap | mmapc | diff
| - | - | - | - | - | - | -
random-50k | 0.18326 | 0.18706 | +2% | 0.18369 | 0.18878 | +2%
random-500k | 1.5832 | 1.6346 | +3% | 1.5791 | 1.6348 | +3%
neurips2023-1M | 8.4410 | 8.9399 | +5% | 8.3978 | 8.9317 | +6%
neurips2023-full-25pct | 18.646 | 20.068 | +7% | 18.713 | 20.065 | +7%
movies | 0.18189 | 0.1956 | +7% | 0.18151 | 0.19476 | +7%
