### PR TITLE
Log Service Error as error in actix processing

### DIFF
--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -37,7 +37,7 @@ pub fn process_response_error(err: StorageError, timing: Instant) -> HttpRespons
         backtrace,
     } = &err
     {
-        log::warn!("error processing request: {}", description);
+        log::error!("error processing request: {}", description);
         if let Some(backtrace) = backtrace {
             log::trace!("backtrace: {}", backtrace);
         }


### PR DESCRIPTION
Storage service error should be logged with the level ERROR when processing a REST request.

Example of output after this PR:

``` 
2024-05-29T14:25:52.118957Z ERROR qdrant::actix::helpers: error processing request: 1 of 1 read operations failed:
  Service internal error: Inconsistent storage: Vector storage 'sparse-vector' is inconsistent, total_vector_count: 3401, point_offset: 3865
```  