### PR TITLE
fix pyroscope warning on non-linux platforms

### DIFF
--- a/src/common/pyroscope_state.rs
+++ b/src/common/pyroscope_state.rs
@@ -86,7 +86,7 @@ pub mod pyro {
     pub struct PyroscopeState {}
 
     impl PyroscopeState {
-        pub fn from_config(config: Option<PyroscopeConfig>) -> Option<Self> {
+        pub fn from_config(_config: Option<PyroscopeConfig>) -> Option<Self> {
             None
         }
     }


### PR DESCRIPTION
Unused argument in non-linux platforms