### PR TITLE
Add optional post WAL data consistency check

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install clang
       - name: Build
-        run: cargo build --features service_debug
+        run: cargo build --features service_debug data-consistency-check
       - name: Run integration tests
         run: ./tests/integration-tests.sh
         shell: bash
@@ -52,7 +52,7 @@ jobs:
       - name: Install python deps
         run: pip install -r ./tests/consensus_tests/requirements.txt
       - name: Build
-        run: cargo build --features service_debug
+        run: cargo build --features service_debug data-consistency-check
       - name: Run integration tests - 1 peer
         run: ./tests/integration-tests.sh distributed
         shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install clang
       - name: Build
-        run: cargo build --features service_debug data-consistency-check
+        run: cargo build --features "service_debug data-consistency-check"
       - name: Run integration tests
         run: ./tests/integration-tests.sh
         shell: bash
@@ -52,7 +52,7 @@ jobs:
       - name: Install python deps
         run: pip install -r ./tests/consensus_tests/requirements.txt
       - name: Build
-        run: cargo build --features service_debug data-consistency-check
+        run: cargo build --features "service_debug data-consistency-check"
       - name: Run integration tests - 1 peer
         run: ./tests/integration-tests.sh distributed
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tracing-tracy = ["tracing", "dep:tracing-tracy"]
 tokio-tracing = ["tokio/tracing"]
 stacktrace = ["rstack-self"]
 chaos-testing = []
+data-consistency-check = ["collection/data-consistency-check"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [features]
 testing = []
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
+data-consistency-check = []
 
 [dev-dependencies]
 criterion = "0.5"

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -116,7 +116,7 @@ function test_version() {
 }
 
 # Build
-cargo build
+cargo build --features data-consistency-check
 
 # Test previous patch version
 test_version $PREV_PATCH_QDRANT_VERSION


### PR DESCRIPTION
This PR adds a new post WAL application data consistency check.

The core assumption is that there must be no data consistency issue **after** the outstanding operations from the WAL have been applied.

The data consistency check looks for:
- dangling internal ids
- dangling external ids
- internal ids without version
- internal ids without stored vector

The proposal is to perform this new check behind a new feature flag in order for us to test internally our storage without impacting users.

I have added the feature flag in our CI pipelines where I believe it makes sense.

When an inconsistency is detected, the impacted shard cannot be loaded properly.

The server is still up but without the shards with corrupted segments.