### PR TITLE
universal-query: convert `CollectionQueryRequest` into `ShardQueryRequest` (resolve ids into vectors)

### DIFF
--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -27,7 +27,7 @@ fn discovery_into_core_search(
 ) -> CollectionResult<CoreSearchRequest> {
     let lookup_collection_name = request.lookup_from.as_ref().map(|x| &x.collection);
 
-    let lookup_vector_name = request.get_search_vector_name();
+    let lookup_vector_name = request.get_lookup_vector_name();
 
     // Check we actually fetched all referenced vectors in this request
     let referenced_ids = request.get_referenced_point_ids();

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -1,11 +1,21 @@
+use std::iter;
+
 use api::rest::RecommendStrategy;
 use common::types::ScoreType;
+use itertools::Itertools;
 use segment::data_types::order_by::OrderBy;
-use segment::data_types::vectors::{MultiDenseVector, Vector, DEFAULT_VECTOR_NAME};
+use segment::data_types::vectors::{
+    MultiDenseVector, NamedQuery, NamedVectorStruct, Vector, VectorRef, DEFAULT_VECTOR_NAME,
+};
 use segment::types::{Filter, PointIdType, SearchParams, WithPayloadInterface, WithVector};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 
-use super::shard_query::Fusion;
+use super::shard_query::{Fusion, ScoringQuery, ShardPrefetch, ShardQueryRequest};
+use crate::common::fetch_vectors::ReferencedVectors;
+use crate::common::retrieve_request_trait::RetrieveRequest;
+use crate::operations::query_enum::QueryEnum;
+use crate::operations::types::{CollectionError, CollectionResult};
+use crate::recommendations::avg_vector_for_recommendation;
 
 /// Internal representation of a query request, used to converge from REST and gRPC. This can have IDs referencing vectors.
 pub struct CollectionQueryRequest {
@@ -34,7 +44,7 @@ impl CollectionQueryRequest {
 
 pub enum Query {
     /// Score points against some vector(s)
-    Vector(VectorQuery),
+    Vector(VectorQuery<VectorInput>),
 
     /// Reciprocal rank fusion
     Fusion(Fusion),
@@ -43,17 +53,206 @@ pub enum Query {
     OrderBy(OrderBy),
 }
 
+impl Query {
+    pub fn try_into_scoring_query(
+        self,
+        ids_to_vectors: &ReferencedVectors,
+        lookup_vector_name: &str,
+        lookup_collection: Option<&String>,
+        using: String,
+    ) -> CollectionResult<ScoringQuery> {
+        let scoring_query = match self {
+            Query::Vector(vector_query) => {
+                let query_enum = vector_query
+                    // Homogenize the input into raw vectors
+                    .ids_into_vectors(ids_to_vectors, lookup_vector_name, lookup_collection)
+                    // Turn into QueryEnum
+                    .into_query_enum(using)?;
+
+                ScoringQuery::Vector(query_enum)
+            }
+            Query::Fusion(fusion) => ScoringQuery::Fusion(fusion),
+            Query::OrderBy(order_by) => ScoringQuery::OrderBy(order_by),
+        };
+
+        Ok(scoring_query)
+    }
+}
 pub enum VectorInput {
     Id(PointIdType),
     Vector(Vector),
 }
 
-pub enum VectorQuery {
-    Nearest(VectorInput),
-    RecommendAverageVector(RecoQuery<VectorInput>),
-    RecommendBestScore(RecoQuery<VectorInput>),
-    Discover(DiscoveryQuery<VectorInput>),
-    Context(ContextQuery<VectorInput>),
+impl VectorInput {
+    pub fn as_id(&self) -> Option<&PointIdType> {
+        match self {
+            VectorInput::Id(id) => Some(id),
+            VectorInput::Vector(_) => None,
+        }
+    }
+}
+
+pub enum VectorQuery<T> {
+    Nearest(T),
+    RecommendAverageVector(RecoQuery<T>),
+    RecommendBestScore(RecoQuery<T>),
+    Discover(DiscoveryQuery<T>),
+    Context(ContextQuery<T>),
+}
+
+impl<T> VectorQuery<T> {
+    /// Iterate through all items, without any kind of structure
+    pub fn flat_iter(&self) -> Box<dyn Iterator<Item = &T> + '_> {
+        match self {
+            VectorQuery::Nearest(input) => Box::new(std::iter::once(input)),
+            VectorQuery::RecommendAverageVector(query) => Box::new(query.flat_iter()),
+            VectorQuery::RecommendBestScore(query) => Box::new(query.flat_iter()),
+            VectorQuery::Discover(query) => Box::new(query.flat_iter()),
+            VectorQuery::Context(query) => Box::new(query.flat_iter()),
+        }
+    }
+}
+
+impl VectorQuery<VectorInput> {
+    /// Turns all [VectorInput]s into [Vector]s, using the provided [ReferencedVectors] to look up the vectors.
+    ///
+    /// Will panic if the ids are not found in the [ReferencedVectors].
+    fn ids_into_vectors(
+        self,
+        ids_to_vectors: &ReferencedVectors,
+        lookup_vector_name: &str,
+        lookup_collection: Option<&String>,
+    ) -> VectorQuery<Vector> {
+        match self {
+            VectorQuery::Nearest(vector_input) => {
+                let vector = ids_to_vectors
+                    .convert_to_vectors_owned(
+                        iter::once(vector_input),
+                        lookup_vector_name,
+                        lookup_collection,
+                    )
+                    .next()
+                    .unwrap();
+
+                VectorQuery::Nearest(vector)
+            }
+            VectorQuery::RecommendAverageVector(reco) => {
+                let positives = ids_to_vectors
+                    .convert_to_vectors_owned(
+                        reco.positives.into_iter(),
+                        lookup_vector_name,
+                        lookup_collection,
+                    )
+                    .collect();
+                let negatives = ids_to_vectors
+                    .convert_to_vectors_owned(
+                        reco.negatives.into_iter(),
+                        lookup_vector_name,
+                        lookup_collection,
+                    )
+                    .collect();
+
+                VectorQuery::RecommendAverageVector(RecoQuery::new(positives, negatives))
+            }
+            VectorQuery::RecommendBestScore(reco) => {
+                // TODO(universal-query): This is a copy-paste from `RecommendAverageVector` branch, remove duplicated code
+                let positives = ids_to_vectors
+                    .convert_to_vectors_owned(
+                        reco.positives.into_iter(),
+                        lookup_vector_name,
+                        lookup_collection,
+                    )
+                    .collect();
+                let negatives = ids_to_vectors
+                    .convert_to_vectors_owned(
+                        reco.negatives.into_iter(),
+                        lookup_vector_name,
+                        lookup_collection,
+                    )
+                    .collect();
+
+                VectorQuery::RecommendBestScore(RecoQuery::new(positives, negatives))
+            }
+            VectorQuery::Discover(discover) => {
+                let target = ids_to_vectors
+                    .convert_to_vectors_owned(
+                        iter::once(discover.target),
+                        lookup_vector_name,
+                        lookup_collection,
+                    )
+                    .next()
+                    .unwrap();
+                let pairs = discover
+                    .pairs
+                    .into_iter()
+                    .map(|pair| {
+                        let mut vector_pair = ids_to_vectors.convert_to_vectors_owned(
+                            pair.into_iter(),
+                            lookup_vector_name,
+                            lookup_collection,
+                        );
+                        ContextPair {
+                            positive: vector_pair.next().unwrap(),
+                            negative: vector_pair.next().unwrap(),
+                        }
+                    })
+                    .collect();
+
+                VectorQuery::Discover(DiscoveryQuery { target, pairs })
+            }
+            VectorQuery::Context(context) => {
+                let pairs = context
+                    .pairs
+                    .into_iter()
+                    .map(|pair| {
+                        let mut vector_pair = ids_to_vectors.convert_to_vectors_owned(
+                            pair.into_iter(),
+                            lookup_vector_name,
+                            lookup_collection,
+                        );
+                        ContextPair {
+                            positive: vector_pair.next().unwrap(),
+                            negative: vector_pair.next().unwrap(),
+                        }
+                    })
+                    .collect();
+
+                VectorQuery::Context(ContextQuery { pairs })
+            }
+        }
+    }
+}
+
+impl VectorQuery<Vector> {
+    fn into_query_enum(self, using: String) -> CollectionResult<QueryEnum> {
+        let query_enum = match self {
+            VectorQuery::Nearest(vector) => {
+                QueryEnum::Nearest(NamedVectorStruct::new_from_vector(vector, using))
+            }
+            VectorQuery::RecommendAverageVector(reco) => {
+                // Get average vector
+                let search_vector = avg_vector_for_recommendation(
+                    reco.positives.iter().map(VectorRef::from),
+                    reco.negatives.iter().map(VectorRef::from).peekable(),
+                )?;
+                QueryEnum::Nearest(NamedVectorStruct::new_from_vector(search_vector, using))
+            }
+            VectorQuery::RecommendBestScore(reco) => QueryEnum::RecommendBestScore(NamedQuery {
+                query: reco,
+                using: Some(using),
+            }),
+            VectorQuery::Discover(discover) => QueryEnum::Discover(NamedQuery {
+                query: discover,
+                using: Some(using),
+            }),
+            VectorQuery::Context(context) => QueryEnum::Context(NamedQuery {
+                query: context,
+                using: Some(using),
+            }),
+        };
+
+        Ok(query_enum)
+    }
 }
 
 pub struct CollectionPrefetch {
@@ -65,6 +264,104 @@ pub struct CollectionPrefetch {
     pub limit: usize,
     /// Search params for when there is no prefetch
     pub params: Option<SearchParams>,
+}
+
+impl CollectionPrefetch {
+    fn try_into_shard_prefetch(
+        self,
+        ids_to_vectors: &ReferencedVectors,
+        lookup_vector_name: &str,
+        lookup_collection: Option<&String>,
+    ) -> CollectionResult<ShardPrefetch> {
+        let query = self
+            .query
+            .map(|query| {
+                query.try_into_scoring_query(
+                    ids_to_vectors,
+                    lookup_vector_name,
+                    lookup_collection,
+                    self.using,
+                )
+            })
+            .transpose()?;
+
+        let prefetches = self
+            .prefetch
+            .into_iter()
+            .map(|prefetch| {
+                prefetch.try_into_shard_prefetch(
+                    ids_to_vectors,
+                    lookup_vector_name,
+                    lookup_collection,
+                )
+            })
+            .try_collect()?;
+
+        Ok(ShardPrefetch {
+            prefetches,
+            query,
+            filter: self.filter,
+            score_threshold: self.score_threshold,
+            limit: self.limit,
+            params: self.params,
+        })
+    }
+}
+
+impl CollectionQueryRequest {
+    pub fn try_into_shard_request(
+        self,
+        ids_to_vectors: &ReferencedVectors,
+    ) -> CollectionResult<ShardQueryRequest> {
+        // Check we actually fetched all referenced vectors in this request (and nested prefetches)
+        for &point_id in &(&self).get_referenced_point_ids() {
+            if ids_to_vectors.get(&None, point_id).is_none() {
+                return Err(CollectionError::PointNotFound {
+                    missed_point_id: point_id,
+                });
+            }
+        }
+
+        let lookup_vector_name = (&self).get_lookup_vector_name();
+        let lookup_collection = (&self).get_lookup_collection().cloned();
+        let using = self.using.clone();
+
+        let query = self
+            .query
+            .map(|query| {
+                query.try_into_scoring_query(
+                    ids_to_vectors,
+                    &lookup_vector_name,
+                    lookup_collection.as_ref(),
+                    using,
+                )
+            })
+            .transpose()?;
+
+        let prefetches = self
+            .prefetch
+            .into_iter()
+            .map(|prefetch| {
+                prefetch.try_into_shard_prefetch(
+                    ids_to_vectors,
+                    &lookup_vector_name,
+                    lookup_collection.as_ref(),
+                )
+            })
+            .try_collect()?;
+
+        Ok(ShardQueryRequest {
+            prefetches,
+            query,
+            filter: self.filter,
+            score_threshold: self.score_threshold,
+            limit: self.limit,
+            offset: self.offset,
+            params: self.params,
+            with_vector: self.with_vector,
+            with_payload: self.with_payload,
+        })
+    }
 }
 
 mod from_rest {
@@ -147,7 +444,7 @@ mod from_rest {
         }
     }
 
-    impl From<rest::RecommendInput> for VectorQuery {
+    impl From<rest::RecommendInput> for VectorQuery<VectorInput> {
         fn from(value: rest::RecommendInput) -> Self {
             let rest::RecommendInput {
                 positives,
@@ -167,7 +464,7 @@ mod from_rest {
         }
     }
 
-    impl From<rest::DiscoverInput> for VectorQuery {
+    impl From<rest::DiscoverInput> for VectorQuery<VectorInput> {
         fn from(value: rest::DiscoverInput) -> Self {
             let rest::DiscoverInput {
                 target,
@@ -185,7 +482,7 @@ mod from_rest {
         }
     }
 
-    impl From<rest::ContextInput> for VectorQuery {
+    impl From<rest::ContextInput> for VectorQuery<VectorInput> {
         fn from(value: rest::ContextInput) -> Self {
             let rest::ContextInput { pairs } = value;
 
@@ -367,7 +664,7 @@ mod from_grpc {
         }
     }
 
-    impl TryFrom<grpc::RecommendInput> for VectorQuery {
+    impl TryFrom<grpc::RecommendInput> for VectorQuery<VectorInput> {
         type Error = Status;
 
         fn try_from(value: grpc::RecommendInput) -> Result<Self, Self::Error> {
@@ -402,7 +699,7 @@ mod from_grpc {
         }
     }
 
-    impl TryFrom<grpc::DiscoverInput> for VectorQuery {
+    impl TryFrom<grpc::DiscoverInput> for VectorQuery<VectorInput> {
         type Error = Status;
 
         fn try_from(value: grpc::DiscoverInput) -> Result<Self, Self::Error> {
@@ -425,7 +722,7 @@ mod from_grpc {
         }
     }
 
-    impl TryFrom<grpc::ContextInput> for VectorQuery {
+    impl TryFrom<grpc::ContextInput> for VectorQuery<VectorInput> {
         type Error = Status;
 
         fn try_from(value: grpc::ContextInput) -> Result<Self, Self::Error> {

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -38,6 +38,7 @@ pub enum Fusion {
     Rrf,
 }
 
+/// Same as `Query`, but with the resolved vector references.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScoringQuery {
     /// Score points against some vector(s)

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::iter::{self, Chain, Once};
 
 use common::math::fast_sigmoid;
 use common::types::ScoreType;
@@ -57,6 +57,16 @@ impl<T> ContextPair<T> {
         let difference = positive - negative - MARGIN;
 
         fast_sigmoid(ScoreType::min(difference, 0.0))
+    }
+}
+
+impl<T> IntoIterator for ContextPair<T> {
+    type Item = T;
+
+    type IntoIter = Chain<Once<T>, Once<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self.positive).chain(iter::once(self.negative))
     }
 }
 

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -125,7 +125,10 @@ impl<'a> CollectionAccessView<'a> {
         }
     }
 
-    fn check_vector_query(&self, vector_query: &VectorQuery) -> Result<(), StorageError> {
+    fn check_vector_query(
+        &self,
+        vector_query: &VectorQuery<VectorInput>,
+    ) -> Result<(), StorageError> {
         match vector_query {
             VectorQuery::Nearest(nearest) => self.check_vector_input(nearest)?,
             VectorQuery::RecommendBestScore(reco) | VectorQuery::RecommendAverageVector(reco) => {


### PR DESCRIPTION
Needs #4331 

- make `VectorQuery` generic
- retrieve ids from `CollectionQueryRequest` and convert into vectors
- implement `RetrieveRequest` trait for it
- calculate avg vector with logic from `recommendations.rs`
- convert `CollectionQueryRequest` into `ShardQueryRequest`
- begin implementing `query()` fn in collection

