### PR TITLE
Sparse: misc fixes

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 multiling-chinese = ["charabia/chinese"]
 multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
-testing = ["common/testing"]
+testing = ["common/testing", "sparse/testing"]
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_os = "windows"))]
 mod prof;
 
+use std::borrow::Cow;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -108,8 +109,8 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     group.bench_function("convert-mmap-index", |b| {
         b.iter(|| {
             let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
-            let mmap_inverted_index = InvertedIndexMmap::convert_and_save(
-                sparse_vector_index.inverted_index(),
+            let mmap_inverted_index = InvertedIndexMmap::from_ram_index(
+                Cow::Borrowed(sparse_vector_index.inverted_index()),
                 &mmap_index_dir,
             )
             .unwrap();

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::{create_dir_all, remove_dir_all, rename};
 use std::path::{Path, PathBuf};
@@ -231,7 +232,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             tick_progress();
         }
         Ok((
-            TInvertedIndex::from_ram_index(ram_index_builder.build(), path)?,
+            TInvertedIndex::from_ram_index(Cow::Owned(ram_index_builder.build()), path)?,
             indices_tracker,
         ))
     }

--- a/lib/sparse/benches/search.rs
+++ b/lib/sparse/benches/search.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
@@ -136,7 +137,8 @@ pub fn run_bench(
 
     run_bench2(
         c.benchmark_group(format!("search/ram_c/{name}")),
-        &InvertedIndexImmutableRam::from_ram_index(index.clone(), "nonexistent/path").unwrap(),
+        &InvertedIndexImmutableRam::from_ram_index(Cow::Borrowed(&index), "nonexistent/path")
+            .unwrap(),
         query_vectors,
         &hottest_query_vectors,
     );
@@ -147,7 +149,7 @@ pub fn run_bench(
         .unwrap();
     run_bench2(
         c.benchmark_group(format!("search/mmap/{name}")),
-        &InvertedIndexMmap::from_ram_index(index.clone(), tmp_dir_path.path()).unwrap(),
+        &InvertedIndexMmap::from_ram_index(Cow::Borrowed(&index), tmp_dir_path.path()).unwrap(),
         query_vectors,
         &hottest_query_vectors,
     );
@@ -158,7 +160,8 @@ pub fn run_bench(
         .unwrap();
     run_bench2(
         c.benchmark_group(format!("search/mmap_c/{name}")),
-        &InvertedIndexCompressedMmap::from_ram_index(index, tmp_dir_path.path()).unwrap(),
+        &InvertedIndexCompressedMmap::from_ram_index(Cow::Borrowed(&index), tmp_dir_path.path())
+            .unwrap(),
         query_vectors,
         &hottest_query_vectors,
     );

--- a/lib/sparse/src/common/mod.rs
+++ b/lib/sparse/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod scores_memory_pool;
 pub mod sparse_vector;
+#[cfg(feature = "testing")]
 pub mod sparse_vector_fixture;
 pub mod types;

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io::{BufWriter, Write as _};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
@@ -85,7 +86,7 @@ impl InvertedIndex for InvertedIndexMmap {
     }
 
     fn from_ram_index<P: AsRef<Path>>(
-        ram_index: InvertedIndexRam,
+        ram_index: Cow<InvertedIndexRam>,
         path: P,
     ) -> std::io::Result<Self> {
         let index = InvertedIndexImmutableRam::from_ram_index(ram_index, &path)?;
@@ -271,8 +272,11 @@ mod tests {
         builder.add(9, [(1, 6.0)].into());
         let inverted_index_ram = builder.build();
         let tmp_dir_path = Builder::new().prefix("test_index_dir1").tempdir().unwrap();
-        let inverted_index_ram =
-            InvertedIndexImmutableRam::from_ram_index(inverted_index_ram, &tmp_dir_path).unwrap();
+        let inverted_index_ram = InvertedIndexImmutableRam::from_ram_index(
+            Cow::Borrowed(&inverted_index_ram),
+            &tmp_dir_path,
+        )
+        .unwrap();
 
         let tmp_dir_path = Builder::new().prefix("test_index_dir2").tempdir().unwrap();
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::Path;
 
 use common::types::PointOffsetType;
@@ -69,10 +70,12 @@ impl InvertedIndex for InvertedIndexImmutableRam {
     }
 
     fn from_ram_index<P: AsRef<Path>>(
-        ram_index: InvertedIndexRam,
+        ram_index: Cow<InvertedIndexRam>,
         _path: P,
     ) -> std::io::Result<Self> {
-        Ok(InvertedIndexImmutableRam { inner: ram_index })
+        Ok(InvertedIndexImmutableRam {
+            inner: ram_index.into_owned(),
+        })
     }
 
     fn vector_count(&self) -> usize {
@@ -100,9 +103,11 @@ mod tests {
         let inverted_index_ram = builder.build();
 
         let tmp_dir_path = Builder::new().prefix("test_index_dir").tempdir().unwrap();
-        let inverted_index_immutable_ram =
-            InvertedIndexImmutableRam::from_ram_index(inverted_index_ram, tmp_dir_path.path())
-                .unwrap();
+        let inverted_index_immutable_ram = InvertedIndexImmutableRam::from_ram_index(
+            Cow::Borrowed(&inverted_index_ram),
+            tmp_dir_path.path(),
+        )
+        .unwrap();
         inverted_index_immutable_ram
             .save(tmp_dir_path.path())
             .unwrap();

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -78,7 +79,7 @@ impl InvertedIndex for InvertedIndexMmap {
     }
 
     fn from_ram_index<P: AsRef<Path>>(
-        ram_index: InvertedIndexRam,
+        ram_index: Cow<InvertedIndexRam>,
         path: P,
     ) -> std::io::Result<Self> {
         Self::convert_and_save(&ram_index, path)

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::max;
 use std::path::{Path, PathBuf};
 
@@ -52,10 +53,10 @@ impl InvertedIndex for InvertedIndexRam {
     }
 
     fn from_ram_index<P: AsRef<Path>>(
-        ram_index: InvertedIndexRam,
+        ram_index: Cow<InvertedIndexRam>,
         _path: P,
     ) -> std::io::Result<Self> {
-        Ok(ram_index)
+        Ok(ram_index.into_owned())
     }
 
     fn vector_count(&self) -> usize {

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
@@ -50,7 +51,7 @@ pub trait InvertedIndex: Sized {
 
     /// Create inverted index from ram index
     fn from_ram_index<P: AsRef<Path>>(
-        ram_index: InvertedIndexRam,
+        ram_index: Cow<InvertedIndexRam>,
         path: P,
     ) -> std::io::Result<Self>;
 

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -379,6 +379,7 @@ impl<'a, 'b, T: PostingListIter> SearchContext<'a, 'b, T> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::sync::OnceLock;
 
     use rand::Rng;
@@ -467,7 +468,8 @@ mod tests {
             .tempdir()
             .unwrap();
         let inverted_index_mmap =
-            InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
+            InvertedIndexMmap::from_ram_index(Cow::Borrowed(&inverted_index_ram), &tmp_dir_path)
+                .unwrap();
         _search_test(&inverted_index_mmap);
     }
 
@@ -636,7 +638,8 @@ mod tests {
             .tempdir()
             .unwrap();
         let inverted_index_mmap =
-            InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
+            InvertedIndexMmap::from_ram_index(Cow::Borrowed(&inverted_index_ram), &tmp_dir_path)
+                .unwrap();
         _search_with_hot_key_test(&inverted_index_mmap);
     }
 


### PR DESCRIPTION
Two small fixes in the `sparse` crate:
- `InvertedIndexRam` → `Cow<InvertedIndexRam>`.
- Hide module `sparse_vector_fixture` under `#[cfg(feature="testing")]`.