### PR TITLE
universal-query: finish implementation of `query()` fn in collection

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -2,15 +2,17 @@ use std::sync::Arc;
 
 use futures::{future, TryFutureExt};
 use itertools::{Either, Itertools};
+use segment::common::reciprocal_rank_fusion::rrf_scoring;
 use segment::types::{Order, ScoredPoint};
 use segment::utils::scored_point_ties::ScoredPointTies;
+use tokio::time::Instant;
 
 use super::Collection;
 use crate::common::fetch_vectors::resolve_referenced_vectors_batch;
 use crate::common::transpose_iterator::transposed_iter;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
-use crate::operations::types::CollectionResult;
+use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::collection_query::CollectionQueryRequest;
 use crate::operations::universal_query::shard_query::{
     Fusion, ScoringQuery, ShardQueryRequest, ShardQueryResponse,
@@ -64,6 +66,8 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
     ) -> CollectionResult<Vec<ScoredPoint>> {
+        let instant = Instant::now();
+
         // Turn ids into vectors, if necessary
         let ids_to_vectors = resolve_referenced_vectors_batch(
             &[(&request, shard_selection.clone())],
@@ -73,10 +77,41 @@ impl Collection {
         )
         .await?;
 
-        let _shard_request = request.try_into_shard_request(&ids_to_vectors)?;
+        let request = Arc::new(request.try_into_shard_request(&ids_to_vectors)?);
 
-        // TODO(universal-query): Implement the rest of the user-facing query logic
-        todo!()
+        let all_shards_results = self
+            .query_shards_concurrently(request.clone(), read_consistency, shard_selection)
+            .await?;
+
+        let mut merged_intemediates = self
+            .merge_intermediate_results_from_shards(request.as_ref(), all_shards_results)
+            .await?;
+
+        let result = if let Some(ScoringQuery::Fusion(fusion)) = &request.query {
+            // If the root query is a Fusion, the returned results correspond to each the prefetches.
+            match fusion {
+                Fusion::Rrf => rrf_scoring(merged_intemediates, request.limit, request.offset),
+            }
+        } else {
+            // Otherwise, it will be a list with a single list of scored points.
+            debug_assert_eq!(merged_intemediates.len(), 1);
+            merged_intemediates
+                .pop()
+                .ok_or_else(|| {
+                    CollectionError::service_error(
+                        "Query response was expected to have one list of results.",
+                    )
+                })?
+                .into_iter()
+                .skip(request.offset)
+                .take(request.limit)
+                .collect()
+        };
+
+        let filter_refs = request.filter_refs();
+        self.post_process_if_slow_request(instant.elapsed(), filter_refs);
+
+        Ok(result)
     }
 
     /// To be called on the remote instance. Only used for the internal service.
@@ -97,7 +132,27 @@ impl Collection {
             .query_shards_concurrently(Arc::clone(&request), read_consistency, shard_selection)
             .await?;
 
-        let query_infos = intermediate_query_infos(&request);
+        let merged = self
+            .merge_intermediate_results_from_shards(request.as_ref(), all_shards_results)
+            .await?;
+
+        Ok(merged)
+    }
+
+    /// Merges the results in each shard for each intermediate query.
+    /// ```text
+    /// [ [shard1_result1, shard1_result2],
+    ///          ↓               ↓
+    ///   [shard2_result1, shard2_result2] ]
+    ///
+    /// = [merged_result1, merged_result2]
+    /// ```
+    async fn merge_intermediate_results_from_shards(
+        &self,
+        request: &ShardQueryRequest,
+        all_shards_results: Vec<ShardQueryResponse>,
+    ) -> CollectionResult<ShardQueryResponse> {
+        let query_infos = intermediate_query_infos(request);
         let results_len = query_infos.len();
         let mut results = ShardQueryResponse::with_capacity(results_len);
         debug_assert!(all_shards_results
@@ -105,15 +160,6 @@ impl Collection {
             .all(|shard_results| shard_results.len() == results_len));
 
         let collection_params = self.collection_config.read().await.params.clone();
-
-        // Time to merge the results in each shard for each intermediate query.
-        // In order to do this, we need to iterate over columns of the all_shards_results matrix.
-        //
-        // [ [shard1_result1, shard1_result2],
-        //          ↓               ↓
-        //   [shard2_result1, shard2_result2] ]
-        //
-        // = [merged_result1, merged_result2]
 
         // Shape: [num_internal_queries, num_shards, num_scored_points]
         let all_shards_result_by_transposed = transposed_iter(all_shards_results);
@@ -163,7 +209,13 @@ impl Collection {
 ///
 /// Example: `[info1, info2, info3]` corresponds to `[result1, result2, result3]` of each shard
 fn intermediate_query_infos(request: &ShardQueryRequest) -> Vec<IntermediateQueryInfo<'_>> {
-    if let Some(ScoringQuery::Fusion(Fusion::Rrf)) = request.query {
+    let has_intermediate_results = request
+        .query
+        .as_ref()
+        .map(|sq| sq.needs_intermediate_results())
+        .unwrap_or(false);
+
+    if has_intermediate_results {
         // In case of RRF, expect the propagated intermediate results
         request
             .prefetches

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -281,13 +281,13 @@ impl Collection {
         Ok(top_results)
     }
 
-    fn post_process_if_slow_request<'a>(
+    pub fn post_process_if_slow_request<'a>(
         &self,
         duration: Duration,
-        filters: impl Iterator<Item = Option<&'a Filter>>,
+        filters: impl IntoIterator<Item = Option<&'a Filter>>,
     ) {
         if duration > segment::problems::UnindexedField::slow_query_threshold() {
-            let filters = filters.flatten().cloned().collect::<Vec<_>>();
+            let filters = filters.into_iter().flatten().cloned().collect_vec();
 
             let schema = self.payload_index_schema.read().schema.clone();
 

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -109,6 +109,33 @@ pub struct ShardPrefetch {
     pub score_threshold: Option<ScoreType>,
 }
 
+impl ShardQueryRequest {
+    pub fn filter_refs(&self) -> Vec<Option<&Filter>> {
+        let mut filters = vec![];
+        filters.push(self.filter.as_ref());
+
+        for prefetch in &self.prefetches {
+            filters.extend(prefetch.filter_refs())
+        }
+
+        filters
+    }
+}
+
+impl ShardPrefetch {
+    fn filter_refs(&self) -> Vec<Option<&Filter>> {
+        let mut filters = vec![];
+
+        filters.push(self.filter.as_ref());
+
+        for prefetch in &self.prefetches {
+            filters.extend(prefetch.filter_refs())
+        }
+
+        filters
+    }
+}
+
 impl TryFrom<grpc::QueryShardPoints> for ShardQueryRequest {
     type Error = Status;
 

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -206,7 +206,8 @@ impl LocalShard {
     ) -> CollectionResult<Vec<ScoredPoint>> {
         match rescore_query {
             ScoringQuery::Fusion(Fusion::Rrf) => {
-                let top_rrf = rrf_scoring(sources.map(Cow::into_owned), limit, 0);
+                let mut top_rrf = rrf_scoring(sources.map(Cow::into_owned));
+                top_rrf.truncate(limit);
                 Ok(top_rrf)
             }
             ScoringQuery::OrderBy(order_by) => {

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -206,7 +206,7 @@ impl LocalShard {
     ) -> CollectionResult<Vec<ScoredPoint>> {
         match rescore_query {
             ScoringQuery::Fusion(Fusion::Rrf) => {
-                let top_rrf = rrf_scoring(sources.map(Cow::into_owned), limit);
+                let top_rrf = rrf_scoring(sources.map(Cow::into_owned), limit, 0);
                 Ok(top_rrf)
             }
             ScoringQuery::OrderBy(order_by) => {

--- a/lib/segment/src/common/reciprocal_rank_fusion.rs
+++ b/lib/segment/src/common/reciprocal_rank_fusion.rs
@@ -23,9 +23,7 @@ fn position_score(position: usize) -> f32 {
 /// The output is a single sorted list of ScoredPoint.
 /// Does not break ties.
 pub fn rrf_scoring(
-    responses: impl IntoIterator<Item = Vec<ScoredPoint>>,
-    take: usize,
-    skip: usize,
+    responses: impl IntoIterator<Item = Vec<ScoredPoint>>
 ) -> Vec<ScoredPoint> {
     // track scored points by id
     let mut points_by_id: HashMap<ExtendedPointId, ScoredPoint> = HashMap::new();
@@ -47,19 +45,13 @@ pub fn rrf_scoring(
         }
     }
 
-    let mut scores = points_by_id.into_iter().collect::<Vec<_>>();
+    let mut scores: Vec<_> = points_by_id.into_values().collect();
     scores.sort_unstable_by(|a, b| {
         // sort by score descending
-        OrderedFloat(b.1.score).cmp(&OrderedFloat(a.1.score))
+        OrderedFloat(b.score).cmp(&OrderedFloat(a.score))
     });
 
-    // materialized updated scored points
     scores
-        .into_iter()
-        .skip(skip)
-        .take(take)
-        .map(|(_, v)| v)
-        .collect()
 }
 
 #[cfg(test)]
@@ -82,14 +74,14 @@ mod tests {
     #[test]
     fn test_rrf_scoring_empty() {
         let responses = vec![];
-        let scored_points = rrf_scoring(responses, 10, 0);
+        let scored_points = rrf_scoring(responses);
         assert_eq!(scored_points.len(), 0);
     }
 
     #[test]
     fn test_rrf_scoring_one() {
         let responses = vec![vec![make_scored_point(1, 0.9)]];
-        let scored_points = rrf_scoring(responses, 10, 0);
+        let scored_points = rrf_scoring(responses);
         assert_eq!(scored_points.len(), 1);
         assert_eq!(scored_points[0].id, 1.into());
         assert_eq!(scored_points[0].score, 0.5); // 1 / (0 + 2)
@@ -112,40 +104,11 @@ mod tests {
         ];
 
         // top 10
-        let scored_points = rrf_scoring(responses.clone(), 10, 0);
+        let scored_points = rrf_scoring(responses.clone());
         assert_eq!(scored_points.len(), 4);
         // assert that the list is sorted
         assert!(scored_points.windows(2).all(|w| w[0].score >= w[1].score));
 
-        // top 1
-        let scored_points = rrf_scoring(responses.clone(), 1, 0);
-        assert_eq!(scored_points.len(), 1);
-        assert_eq!(scored_points[0].id, 1.into());
-        assert_eq!(scored_points[0].score, 1.0833334);
-
-        // top 2
-        let scored_points = rrf_scoring(responses.clone(), 2, 0);
-        assert_eq!(scored_points.len(), 2);
-        assert_eq!(scored_points[0].id, 1.into());
-        assert_eq!(scored_points[0].score, 1.0833334);
-
-        assert_eq!(scored_points[1].id, 2.into());
-        assert_eq!(scored_points[1].score, 0.8333334);
-
-        // top 3
-        let scored_points = rrf_scoring(responses.clone(), 3, 0);
-        assert_eq!(scored_points.len(), 3);
-        assert_eq!(scored_points[0].id, 1.into());
-        assert_eq!(scored_points[0].score, 1.0833334);
-
-        assert_eq!(scored_points[1].id, 2.into());
-        assert_eq!(scored_points[1].score, 0.8333334);
-
-        assert_eq!(scored_points[2].id, 3.into());
-        assert_eq!(scored_points[2].score, 0.5833334);
-
-        // top 4
-        let scored_points = rrf_scoring(responses, 4, 0);
         assert_eq!(scored_points.len(), 4);
         assert_eq!(scored_points[0].id, 1.into());
         assert_eq!(scored_points[0].score, 1.0833334);

--- a/lib/segment/src/common/reciprocal_rank_fusion.rs
+++ b/lib/segment/src/common/reciprocal_rank_fusion.rs
@@ -22,9 +22,7 @@ fn position_score(position: usize) -> f32 {
 ///
 /// The output is a single sorted list of ScoredPoint.
 /// Does not break ties.
-pub fn rrf_scoring(
-    responses: impl IntoIterator<Item = Vec<ScoredPoint>>
-) -> Vec<ScoredPoint> {
+pub fn rrf_scoring(responses: impl IntoIterator<Item = Vec<ScoredPoint>>) -> Vec<ScoredPoint> {
     // track scored points by id
     let mut points_by_id: HashMap<ExtendedPointId, ScoredPoint> = HashMap::new();
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -298,21 +298,18 @@ impl TableOfContent {
         &self,
         collection_name: &str,
         mut request: CollectionQueryRequest,
-        _read_consistency: Option<ReadConsistency>, // TODO(universal-query): pass this to collection
-        _shard_selection: ShardSelectorInternal, // TODO(universal-query): pass this to collection
+        read_consistency: Option<ReadConsistency>,
+        shard_selection: ShardSelectorInternal,
         access: Access,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
-        let _collection = self.get_collection(&collection_pass).await?;
+        let collection = self.get_collection(&collection_pass).await?;
 
-        //TODO(universal-query): implement query in collection
-        // collection
-        //     .query(request, read_consistency, &shard_selection)
-        //     .await
-        //     .map_err(|err| err.into())
-
-        todo!()
+        collection
+            .query(request, read_consistency, &shard_selection)
+            .await
+            .map_err(|err| err.into())
     }
 
     /// # Cancel safety


### PR DESCRIPTION
Needs #4360

- reuse merging from shards in both `query()` and `query_internal()`
- check filters for issues if it was a slow request

