### PR TITLE
Improve tools/*.sh

### DIFF
--- a/tools/generate_grpc_docs.sh
+++ b/tools/generate_grpc_docs.sh
@@ -6,28 +6,27 @@ set -e
 cd "$(dirname "$0")/../"
 
 # Create a temporary directory and store its name in a variable.
-TEMPD=$(mktemp -d)
+TEMPD=$(mktemp -d -t qdrant_docs.XXXXXXXXXX)
+trap 'rm -rf -- "$TEMPD"' EXIT
 
-cp -r $(pwd)/lib/api/src/grpc/proto/* ${TEMPD}
+cp -r "$PWD"/lib/api/src/grpc/proto/* "$TEMPD"
 
 # Do not generate docs for internal services
-rm ${TEMPD}/'collections_internal_service.proto'
-rm ${TEMPD}/'points_internal_service.proto'
-rm ${TEMPD}/'shard_snapshots_service.proto'
-rm ${TEMPD}/'raft_service.proto'
+rm "$TEMPD/collections_internal_service.proto"
+rm "$TEMPD/points_internal_service.proto"
+rm "$TEMPD/shard_snapshots_service.proto"
+rm "$TEMPD/raft_service.proto"
 
-cat ${TEMPD}/qdrant.proto \
+cat "$TEMPD/qdrant.proto" \
   | grep -v 'collections_internal_service.proto' \
   | grep -v 'points_internal_service.proto' \
   | grep -v 'shard_snapshots_service.proto' \
   | grep -v 'raft_service.proto'\
-   > ${TEMPD}/qdrant.proto.tmp
-mv ${TEMPD}/qdrant.proto.tmp ${TEMPD}/qdrant.proto
+   > "$TEMPD/qdrant.proto.tmp"
+mv "$TEMPD/qdrant.proto.tmp" "$TEMPD/qdrant.proto"
 
 docker run --rm \
-  -v $(pwd)/docs/grpc:/out \
-  -v ${TEMPD}:/protos \
+  -u "$(id -u):$(id -g)" \
+  -v "$PWD/docs/grpc":/out \
+  -v "$TEMPD":/protos \
   pseudomuto/protoc-gen-doc --doc_opt=markdown,docs.md
-
-# <https://github.com/pseudomuto/protoc-gen-doc/issues/383>
-sudo chown -R "$USER:$(id -g -n)" $(pwd)/docs/grpc

--- a/tools/generate_openapi_models.sh
+++ b/tools/generate_openapi_models.sh
@@ -6,40 +6,45 @@ set -e
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
+# Fallback to dockerized utilities if they are not installed locally
+
+if command -v ytt &>/dev/null; then
+    sh_with_ytt() { sh -c "$1"; }
+else
+    sh_with_ytt() { docker run --rm -v "${PWD}":/workspace --entrypoint sh gerritk/ytt -c "$1"; }
+fi
+
+if ! yq --version 2>&1 | grep -q mikefarah; then
+    yq() { docker run --rm -v "${PWD}":/workdir mikefarah/yq "$@"; }
+fi
+
 # Apply `ytt` template engine to obtain OpenAPI definitions for REST endpoints
 
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-shards.ytt.yaml > ./openapi/openapi-shards.yaml
-
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-service.ytt.yaml > ./openapi/openapi-service.yaml
-
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-cluster.ytt.yaml > ./openapi/openapi-cluster.yaml
-
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-collections.ytt.yaml > ./openapi/openapi-collections.yaml
-
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-snapshots.ytt.yaml > ./openapi/openapi-snapshots.yaml
-
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-shard-snapshots.ytt.yaml > ./openapi/openapi-shard-snapshots.yaml
-
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-points.ytt.yaml > ./openapi/openapi-points.yaml
-
-docker run --rm -v "${PWD}":/workspace gerritk/ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-main.ytt.yaml > ./openapi/openapi-main.yaml
+sh_with_ytt '
+    set -e
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-shards.ytt.yaml > ./openapi/openapi-shards.yaml
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-service.ytt.yaml > ./openapi/openapi-service.yaml
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-cluster.ytt.yaml > ./openapi/openapi-cluster.yaml
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-collections.ytt.yaml > ./openapi/openapi-collections.yaml
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-snapshots.ytt.yaml > ./openapi/openapi-snapshots.yaml
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-shard-snapshots.ytt.yaml > ./openapi/openapi-shard-snapshots.yaml
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-points.ytt.yaml > ./openapi/openapi-points.yaml
+    ytt -f ./openapi/openapi.lib.yml -f ./openapi/openapi-main.ytt.yaml > ./openapi/openapi-main.yaml
+'
 
 # Generates models from internal service structures
 cargo run --package qdrant --bin schema_generator > ./openapi/schemas/AllDefinitions.json
 
-(
-    cd tools/schema2openapi/
-    docker build . --tag schema2openapi
-)
+docker build tools/schema2openapi --tag schema2openapi
 
 docker run --rm \
-    -v "$(pwd)/openapi/schemas/AllDefinitions.json:/app/schema.json" \
+    -v "$PWD/openapi/schemas/AllDefinitions.json:/app/schema.json" \
     schema2openapi | sed -e 's%#/definitions/%#/components/schemas/%g' >./openapi/models.json
 
-docker run --rm -i mikefarah/yq eval -P - <./openapi/models.json > ./openapi/models.yaml
+yq eval -o yaml -P ./openapi/models.json > ./openapi/models.yaml
 
 # Merge all *.yaml files together into a single-file OpenAPI definition
-docker run --rm -v "${PWD}":/workdir mikefarah/yq eval-all '. as $item ireduce ({}; . *+ $item)' \
+yq eval-all '. as $item ireduce ({}; . *+ $item)' \
   ./openapi/openapi-shards.yaml \
   ./openapi/openapi-service.yaml \
   ./openapi/openapi-cluster.yaml \
@@ -52,6 +57,6 @@ docker run --rm -v "${PWD}":/workdir mikefarah/yq eval-all '. as $item ireduce (
 
 docker run --rm -v "${PWD}"/openapi:/spec redocly/openapi-cli:v1.0.0-beta.88 lint openapi-merged.yaml
 
-docker run --rm -i mikefarah/yq eval -o=json - <./openapi/openapi-merged.yaml | jq > ./openapi/openapi-merged.json
+yq eval -o=json ./openapi/openapi-merged.yaml | jq > ./openapi/openapi-merged.json
 
 cp ./openapi/openapi-merged.json ./docs/redoc/master/openapi.json


### PR DESCRIPTION
1. Speedup `tools/generate_openapi_models.sh` by reducing the amount of `docker run` invocations.
    - On my machine, it's now faster by 5 seconds.
    - When `ytt` and `yq` are installed locally, it's faster by 7 seconds.
2. Clean up temp files in `tools/generate_grpc_docs.sh`. No need to pollute `/tmp`. Also, use a meaningful temporary directory name.
3. Do not call `sudo chmod` in `tools/generate_grpc_docs.sh`. [The causing issue](https://www.github.com/pseudomuto/protoc-gen-doc/issues/383) is solved.
4. Use proper shell quoting in `tools/generate_grpc_docs.sh`.