### PR TITLE
Add get optional vector for all storages

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -73,7 +73,11 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
-        self.get_dense(key).into()
+        self.get_vector_opt(key).expect("vector not found")
+    }
+
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        self.vectors.get_opt(key).map(|v| v.into())
     }
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -58,6 +58,25 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
         &chunk_data[idx..idx + self.dim]
     }
 
+    /// Duplicate of `get` with explicit bound check.
+    pub fn get_opt<TKey>(&self, key: TKey) -> Option<&[T]>
+    where
+        TKey: num_traits::cast::AsPrimitive<usize>,
+    {
+        if self.chunks.is_empty() {
+            return None;
+        }
+        let key: usize = key.as_();
+        let chunk_data = &self.chunks[key / self.chunk_capacity];
+        let idx = (key % self.chunk_capacity) * self.dim;
+        let range = idx..idx + self.dim;
+        if range.start < chunk_data.len() && range.end <= chunk_data.len() {
+            Some(&chunk_data[range])
+        } else {
+            None
+        }
+    }
+
     pub fn get_many<TKey>(&self, key: TKey, count: usize) -> &[T]
     where
         TKey: num_traits::cast::AsPrimitive<usize>,
@@ -263,12 +282,16 @@ mod tests {
     #[test]
     fn test_chunked_vectors_with_skipped_chunks() {
         let mut vectors = ChunkedVectors::new(3);
+        assert_eq!(vectors.get_opt(0), None);
+
         vectors.insert(0, &[1, 2, 3]).unwrap();
         vectors.insert(10_000_000, &[4, 5, 6]).unwrap();
         assert!(vectors.chunks.len() > 3);
 
         assert_eq!(vectors.get(0), &[1, 2, 3]);
         assert_eq!(vectors.get(10_000_000), &[4, 5, 6]);
+
+        assert_eq!(vectors.get_opt(10_000_001), None);
 
         // check if first chunk is fully allocated
         assert_eq!(vectors.get(100), &[0, 0, 0]);

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -67,14 +67,13 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
             return None;
         }
         let key: usize = key.as_();
-        let chunk_data = &self.chunks[key / self.chunk_capacity];
-        let idx = (key % self.chunk_capacity) * self.dim;
-        let range = idx..idx + self.dim;
-        if range.start < chunk_data.len() && range.end <= chunk_data.len() {
-            Some(&chunk_data[range])
-        } else {
-            None
-        }
+        self.chunks
+            .get(key / self.chunk_capacity)
+            .and_then(|chunk_data| {
+                let idx = (key % self.chunk_capacity) * self.dim;
+                let range = idx..idx + self.dim;
+                chunk_data.get(range)
+            })
     }
 
     pub fn get_many<TKey>(&self, key: TKey, count: usize) -> &[T]

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -52,13 +52,9 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
     where
         TKey: num_traits::cast::AsPrimitive<usize>,
     {
-        let key: usize = key.as_();
-        let chunk_data = &self.chunks[key / self.chunk_capacity];
-        let idx = (key % self.chunk_capacity) * self.dim;
-        &chunk_data[idx..idx + self.dim]
+        self.get_opt(key).expect("vector not found")
     }
 
-    /// Duplicate of `get` with explicit bound check.
     pub fn get_opt<TKey>(&self, key: TKey) -> Option<&[T]>
     where
         TKey: num_traits::cast::AsPrimitive<usize>,

--- a/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
@@ -138,7 +138,13 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStora
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
-        CowVector::from(T::slice_to_float_cow(self.get_dense(key).into()))
+        self.get_vector_opt(key).expect("vector not found")
+    }
+
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        self.vectors
+            .get(key)
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
     }
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -157,9 +157,15 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
-        CowVector::from(T::slice_to_float_cow(
-            self.mmap_store.as_ref().unwrap().get_vector(key).into(),
-        ))
+        self.get_vector_opt(key).expect("vector not found")
+    }
+
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        self.mmap_store
+            .as_ref()
+            .unwrap()
+            .get_vector_opt(key)
+            .map(|vector| T::slice_to_float_cow(vector.into()).into())
     }
 
     fn insert_vector(&mut self, _key: PointOffsetType, _vector: VectorRef) -> OperationResult<()> {

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -119,8 +119,14 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
 
     /// Returns reference to vector data by key
     pub fn get_vector(&self, key: PointOffsetType) -> &[T] {
-        let offset = self.data_offset(key).unwrap();
+        let offset = self.data_offset(key).expect("offset not found");
         self.raw_vector_offset(offset)
+    }
+
+    /// Returns an optional reference to vector data by key
+    pub fn get_vector_opt(&self, key: PointOffsetType) -> Option<&[T]> {
+        self.data_offset(key)
+            .map(|offset| self.raw_vector_offset(offset))
     }
 
     pub fn delete(&mut self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -119,8 +119,7 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
 
     /// Returns reference to vector data by key
     pub fn get_vector(&self, key: PointOffsetType) -> &[T] {
-        let offset = self.data_offset(key).expect("offset not found");
-        self.raw_vector_offset(offset)
+        self.get_vector_opt(key).expect("vector not found")
     }
 
     /// Returns an optional reference to vector data by key

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -215,6 +215,13 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         CowVector::from(T::slice_to_float_cow(self.vectors.get(key).into()))
     }
 
+    /// Get vector by key, if it exists.
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        self.vectors
+            .get_opt(key)
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
+    }
+
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
         let vector: &[VectorElementType] = vector.try_into()?;
         let vector = T::slice_from_float_cow(Cow::from(vector));

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -212,7 +212,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
-        CowVector::from(T::slice_to_float_cow(self.vectors.get(key).into()))
+        self.get_vector_opt(key).expect("vector not found")
     }
 
     /// Get vector by key, if it exists.

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -266,7 +266,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
 
     /// Panics if key is out of bounds
     fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T> {
-        self.get_multi_opt(key).expect("Vector not found")
+        self.get_multi_opt(key).expect("vector not found")
     }
 
     /// None if key is out of bounds

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -162,8 +162,10 @@ impl VectorStorage for SimpleSparseVectorStorage {
         vector.unwrap_or_else(CowVector::default_sparse)
     }
 
+    /// Get vector by key, if it exists.
+    ///
+    /// ignore any error
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
-        // ignore any error
         self.get_sparse(key).ok().map(CowVector::from)
     }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -55,10 +55,7 @@ pub trait VectorStorage {
     fn get_vector(&self, key: PointOffsetType) -> CowVector;
 
     /// Get the vector by the given key if it exists
-    /// Blanket implementation - override if necessary
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
-        Some(self.get_vector(key))
-    }
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector>;
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()>;
 
@@ -116,6 +113,7 @@ pub trait SparseVectorStorage: VectorStorage {
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     fn vector_dim(&self) -> usize;
     fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T>;
+    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<T>>;
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send;
     fn multi_vector_config(&self) -> &MultiVectorConfig;
 }


### PR DESCRIPTION
The newly introduced [data consistency check](https://github.com/qdrant/qdrant/pull/4359) relies on the `get_vector_opt` from storages.

In order to detect the absence of vector, the implementation must not crash in that case.

This PR adds dedicated function to retrieve a dense vector optional on `chunked_vector` which is the in-memory representation for dense simple storage.

Before this patch the consistency check fails with:

`2024-05-31T08:22:53.090417Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/vector_storage/chunked_vectors.rs at line 58: range end index 3048448 out of range for slice of length 3047424`


After it can leverage the None:

`2024-05-31T10:07:20.229041Z ERROR segment::segment: Vector storage 'dense-vector-rocksdb' is missing point Some(NumId(1461)) point_offset: 2618 version: Some(4223)`