### PR TITLE
Rocksdb remove should use the same options as put

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -166,9 +166,10 @@ impl DatabaseColumnWrapper {
     {
         let db = self.database.read();
         let cf_handle = self.get_column_family(&db)?;
-        db.delete_cf(cf_handle, key).map_err(|err| {
-            OperationError::service_error(format!("RocksDB delete_cf error: {err}"))
-        })?;
+        db.delete_cf_opt(cf_handle, key, &Self::get_write_options())
+            .map_err(|err| {
+                OperationError::service_error(format!("RocksDB delete_cf error: {err}"))
+            })?;
         Ok(())
     }
 


### PR DESCRIPTION
For the sake of consistency, we should apply the same options to `remove` and `put` operations against RocksDB.

```rust
fn get_write_options() -> WriteOptions {
        let mut write_options = WriteOptions::default();
        write_options.set_sync(false); // default to false
        write_options.disable_wal(true); // default to false
        write_options
    }
```

The current setup might cause some storage inconsistencies which are difficult to debug given that we control precisely the exact moment of the flushing. 