### PR TITLE
Log failed segment flush on drop

### DIFF
--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1923,7 +1923,9 @@ impl SegmentEntry for Segment {
 
 impl Drop for Segment {
     fn drop(&mut self) {
-        let _lock = self.lock_flushing();
+        if let Err(flushing_err) = self.lock_flushing() {
+            log::error!("Failed to flush segment during drop: {flushing_err}");
+        }
     }
 }
 


### PR DESCRIPTION
It is a good practice to not ignore silently persistence errors.

 This PR proposes to log at debug level failed segment flush on drop, this might help us one day.