### PR TITLE
Deduplicate collection ID in shard transfers/resharding

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -65,7 +65,6 @@ impl Collection {
                 consensus,
                 collection_id,
                 channel_service,
-                self.name(),
                 temp_dir,
                 on_finish,
                 on_error,

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -156,7 +156,6 @@ impl Collection {
             collection_id,
             channel_service,
             self.snapshots_path.clone(),
-            self.name(),
             temp_dir,
             on_finish,
             on_error,

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -28,7 +28,6 @@ pub async fn drive_resharding(
     _shard_holder: Arc<LockedShardHolder>,
     _consensus: &dyn ShardTransferConsensus,
     _collection_id: CollectionId,
-    _collection_name: &str,
     _channel_service: ChannelService,
     _temp_dir: &Path,
 ) -> CollectionResult<bool> {

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -80,7 +80,6 @@ pub fn spawn_resharding_task<T, F>(
     consensus: Box<dyn ShardTransferConsensus>,
     collection_id: CollectionId,
     channel_service: ChannelService,
-    collection_name: String,
     temp_dir: PathBuf,
     on_finish: T,
     on_error: F,
@@ -109,7 +108,6 @@ where
                     shards_holder.clone(),
                     consensus.as_ref(),
                     collection_id.clone(),
-                    &collection_name,
                     channel_service.clone(),
                     &temp_dir,
                 )

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -39,7 +39,6 @@ pub async fn transfer_shard(
     shard_holder: Arc<LockedShardHolder>,
     consensus: &dyn ShardTransferConsensus,
     collection_id: CollectionId,
-    collection_name: &str,
     channel_service: ChannelService,
     snapshots_path: &Path,
     temp_dir: &Path,
@@ -67,7 +66,7 @@ pub async fn transfer_shard(
                 progress,
                 local_shard_id,
                 remote_shard,
-                collection_name,
+                &collection_id,
             )
             .await?;
         }
@@ -79,7 +78,7 @@ pub async fn transfer_shard(
                 progress,
                 local_shard_id,
                 remote_shard,
-                collection_name,
+                &collection_id,
             )
             .await?;
         }
@@ -95,7 +94,7 @@ pub async fn transfer_shard(
                 channel_service,
                 consensus,
                 snapshots_path,
-                collection_name,
+                &collection_id,
                 temp_dir,
             )
             .await?;
@@ -111,7 +110,7 @@ pub async fn transfer_shard(
                 remote_shard,
                 channel_service,
                 consensus,
-                collection_name,
+                &collection_id,
             )
             .await;
 
@@ -122,7 +121,7 @@ pub async fn transfer_shard(
                 let did_fall_back = transfer_shard_fallback_default(
                     transfer_config,
                     consensus,
-                    collection_name,
+                    &collection_id,
                     fallback_shard_transfer_method,
                 )
                 .await?;
@@ -140,7 +139,7 @@ pub async fn transfer_shard(
 pub async fn transfer_shard_fallback_default(
     mut transfer_config: ShardTransfer,
     consensus: &dyn ShardTransferConsensus,
-    collection_name: &str,
+    collection_id: &CollectionId,
     fallback_method: ShardTransferMethod,
 ) -> CollectionResult<bool> {
     // Do not attempt to fall back to the same method
@@ -153,7 +152,7 @@ pub async fn transfer_shard_fallback_default(
     // Propose to restart transfer with a different method
     transfer_config.method.replace(fallback_method);
     consensus
-        .restart_shard_transfer_confirm_and_retry(&transfer_config, collection_name)
+        .restart_shard_transfer_confirm_and_retry(&transfer_config, collection_id)
         .await?;
 
     Ok(false)
@@ -267,7 +266,6 @@ pub fn spawn_transfer_task<T, F>(
     collection_id: CollectionId,
     channel_service: ChannelService,
     snapshots_path: PathBuf,
-    collection_name: String,
     temp_dir: PathBuf,
     on_finish: T,
     on_error: F,
@@ -297,7 +295,6 @@ where
                     shards_holder.clone(),
                     consensus.as_ref(),
                     collection_id.clone(),
-                    &collection_name,
                     channel_service.clone(),
                     &snapshots_path,
                     &temp_dir,

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -135,7 +135,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     fn snapshot_recovered_switch_to_partial(
         &self,
         transfer_config: &ShardTransfer,
-        collection_name: CollectionId,
+        collection_id: CollectionId,
     ) -> CollectionResult<()>;
 
     /// After snapshot recovery, propose to switch shard to `Partial` and confirm on remote shard
@@ -155,7 +155,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     async fn snapshot_recovered_switch_to_partial_confirm_remote(
         &self,
         transfer_config: &ShardTransfer,
-        collection_name: &str,
+        collection_id: &CollectionId,
         remote_shard: &RemoteShard,
     ) -> CollectionResult<()> {
         let mut result = Err(CollectionError::service_error(
@@ -169,7 +169,7 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
 
             result = self
-                .snapshot_recovered_switch_to_partial(transfer_config, collection_name.to_string());
+                .snapshot_recovered_switch_to_partial(transfer_config, collection_id.to_string());
 
             if let Err(err) = &result {
                 log::error!("Failed to propose snapshot recovered operation to consensus: {err}");
@@ -180,7 +180,7 @@ pub trait ShardTransferConsensus: Send + Sync {
 
             result = remote_shard
                 .wait_for_shard_state(
-                    collection_name,
+                    collection_id,
                     transfer_config.shard_id,
                     ReplicaState::Partial,
                     CONSENSUS_CONFIRM_TIMEOUT,
@@ -217,7 +217,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     async fn restart_shard_transfer(
         &self,
         transfer_config: ShardTransfer,
-        collection_name: CollectionId,
+        collection_id: CollectionId,
     ) -> CollectionResult<()>;
 
     /// Propose to restart a shard transfer with a different given configuration
@@ -227,7 +227,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     async fn restart_shard_transfer_confirm_and_retry(
         &self,
         transfer_config: &ShardTransfer,
-        collection_name: &str,
+        collection_id: &CollectionId,
     ) -> CollectionResult<()> {
         let mut result = Err(CollectionError::service_error(
             "`restart_shard_transfer_confirm_and_retry` exit without attempting any work, \
@@ -241,7 +241,7 @@ pub trait ShardTransferConsensus: Send + Sync {
 
             log::trace!("Propose and confirm shard transfer restart operation");
             result = self
-                .restart_shard_transfer(transfer_config.clone(), collection_name.into())
+                .restart_shard_transfer(transfer_config.clone(), collection_id.into())
                 .await;
 
             match &result {

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -8,6 +8,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
 use crate::shards::transfer::stream_records::TRANSFER_BATCH_SIZE;
+use crate::shards::CollectionId;
 
 /// Orchestrate shard transfer by streaming records, but only the points that fall into the new
 /// shard.
@@ -26,7 +27,7 @@ pub(super) async fn transfer_resharding_stream_records(
     progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,
-    collection_name: &str,
+    collection_id: &CollectionId,
 ) -> CollectionResult<()> {
     let remote_peer_id = remote_shard.peer_id;
     let hashring;
@@ -121,7 +122,7 @@ pub(super) async fn transfer_resharding_stream_records(
 
         let cutoff = replica_set.shard_recovery_point().await?;
         let result = remote_shard
-            .update_shard_cutoff_point(collection_name, shard_id, &cutoff)
+            .update_shard_cutoff_point(collection_id, shard_id, &cutoff)
             .await;
 
         // Warn and ignore if remote shard is running an older version, error otherwise

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -7,6 +7,7 @@ use crate::operations::types::{CollectionError, CollectionResult, CountRequestIn
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
+use crate::shards::CollectionId;
 
 pub(super) const TRANSFER_BATCH_SIZE: usize = 100;
 
@@ -26,7 +27,7 @@ pub(super) async fn transfer_stream_records(
     progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,
-    collection_name: &str,
+    collection_id: &CollectionId,
 ) -> CollectionResult<()> {
     let remote_peer_id = remote_shard.peer_id;
 
@@ -107,7 +108,7 @@ pub(super) async fn transfer_stream_records(
 
         let cutoff = replica_set.shard_recovery_point().await?;
         let result = remote_shard
-            .update_shard_cutoff_point(collection_name, shard_id, &cutoff)
+            .update_shard_cutoff_point(collection_id, shard_id, &cutoff)
             .await;
 
         // Warn and ignore if remote shard is running an older version, error otherwise

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -11,6 +11,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
+use crate::shards::CollectionId;
 
 /// Orchestrate shard diff transfer
 ///
@@ -79,7 +80,7 @@ pub(super) async fn transfer_wal_delta(
     remote_shard: RemoteShard,
     channel_service: ChannelService,
     consensus: &dyn ShardTransferConsensus,
-    collection_name: &str,
+    collection_id: &CollectionId,
 ) -> CollectionResult<()> {
     let remote_peer_id = remote_shard.peer_id;
 
@@ -87,7 +88,7 @@ pub(super) async fn transfer_wal_delta(
 
     // Ask remote shard on failed node for recovery point
     let recovery_point = remote_shard
-        .shard_recovery_point(collection_name, shard_id)
+        .shard_recovery_point(collection_id, shard_id)
         .await
         .map_err(|err| {
             CollectionError::service_error(format!(
@@ -135,7 +136,7 @@ pub(super) async fn transfer_wal_delta(
         // Note: once we migrate from partial snapshot to recovery, we give this method a proper name
         .snapshot_recovered_switch_to_partial_confirm_remote(
             &transfer_config,
-            collection_name,
+            collection_id,
             &remote_shard,
         )
         .await

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -42,7 +42,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
     fn snapshot_recovered_switch_to_partial(
         &self,
         transfer_config: &ShardTransfer,
-        collection_name: CollectionId,
+        collection_id: CollectionId,
     ) -> CollectionResult<()> {
         let Some(toc) = self.toc.upgrade() else {
             return Err(CollectionError::service_error(
@@ -58,7 +58,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
         // Propose operation to progress transfer, setting shard state to partial
         let operation =
             ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::TransferShard(
-                collection_name,
+                collection_id,
                 ShardTransferOperations::RecoveryToPartial(transfer_config.key()),
             )));
         proposal_sender.send(operation).map_err(|err| {
@@ -71,11 +71,11 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
     async fn restart_shard_transfer(
         &self,
         transfer_config: ShardTransfer,
-        collection_name: CollectionId,
+        collection_id: CollectionId,
     ) -> CollectionResult<()> {
         let operation =
             ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::TransferShard(
-                collection_name,
+                collection_id,
                 ShardTransferOperations::Restart(transfer_config.into()),
             )));
         self


### PR DESCRIPTION
For shard transfer and resharding, we passed in a `collection_id` and `collection_name`.

They are equal. This removes the `collection_name`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?