### PR TITLE
Fix inplace updates for sparse index

### DIFF
--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -352,14 +352,6 @@ impl<'a> VectorRef<'a> {
             VectorRef::MultiDense(v) => Vector::MultiDense(v.to_owned()),
         }
     }
-
-    pub fn is_sparse(&self) -> bool {
-        match self {
-            VectorRef::Dense(_) => false,
-            VectorRef::Sparse(_) => true,
-            VectorRef::MultiDense(_) => false,
-        }
-    }
 }
 
 impl<'a> TryInto<&'a [VectorElementType]> for &'a Vector {

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -352,6 +352,14 @@ impl<'a> VectorRef<'a> {
             VectorRef::MultiDense(v) => Vector::MultiDense(v.to_owned()),
         }
     }
+
+    pub fn is_sparse(&self) -> bool {
+        match self {
+            VectorRef::Dense(_) => false,
+            VectorRef::Sparse(_) => true,
+            VectorRef::MultiDense(_) => false,
+        }
+    }
 }
 
 impl<'a> TryInto<&'a [VectorElementType]> for &'a Vector {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -909,8 +909,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
     fn update_vector(
         &mut self,
         _id: PointOffsetType,
-        _vector: VectorRef,
-        _old_vector: Option<Vector>,
+        _vector: Option<VectorRef>,
     ) -> OperationResult<()> {
         Err(OperationError::service_error("Cannot update HNSW index"))
     }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -906,7 +906,12 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             .unwrap_or(0)
     }
 
-    fn update_vector(&mut self, _id: PointOffsetType, _vector: VectorRef) -> OperationResult<()> {
+    fn update_vector(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: VectorRef,
+        _old_vector: Option<Vector>,
+    ) -> OperationResult<()> {
         Err(OperationError::service_error("Cannot update HNSW index"))
     }
 }

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -371,6 +371,7 @@ impl VectorIndex for PlainIndex {
             vector_storage.insert_vector(id, vector)?;
         } else {
             if id as usize >= vector_storage.total_vector_count() {
+                debug_assert!(id as usize == vector_storage.total_vector_count());
                 // Vector doesn't exist in the storage
                 // Insert default vector to keep the sequence
                 let default_vector = vector_storage.default_vector();

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -16,7 +16,7 @@ use crate::common::operation_time_statistics::{
 };
 use crate::common::{Flusher, BYTES_IN_KB};
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
@@ -360,7 +360,12 @@ impl VectorIndex for PlainIndex {
         0
     }
 
-    fn update_vector(&mut self, _id: PointOffsetType, _vector: VectorRef) -> OperationResult<()> {
+    fn update_vector(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: VectorRef,
+        _old_vector: Option<Vector>,
+    ) -> OperationResult<()> {
         Ok(())
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -606,6 +606,14 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
             let vector = self.indices_tracker.remap_vector(vector.to_owned());
             let old_vector = old_vector.map(|v| self.indices_tracker.remap_vector(v.to_owned()));
             self.inverted_index.upsert(id, vector, old_vector);
+        } else {
+            if let Some(old_vector) = old_vector {
+                // Make sure empty vectors do not interfere with the index
+                if !old_vector.is_empty() {
+                    let old_vector = self.indices_tracker.remap_vector(old_vector);
+                    self.inverted_index.remove(id, old_vector);
+                }
+            }
         }
         Ok(())
     }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -606,13 +606,11 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
             let vector = self.indices_tracker.remap_vector(vector.to_owned());
             let old_vector = old_vector.map(|v| self.indices_tracker.remap_vector(v.to_owned()));
             self.inverted_index.upsert(id, vector, old_vector);
-        } else {
-            if let Some(old_vector) = old_vector {
-                // Make sure empty vectors do not interfere with the index
-                if !old_vector.is_empty() {
-                    let old_vector = self.indices_tracker.remap_vector(old_vector);
-                    self.inverted_index.remove(id, old_vector);
-                }
+        } else if let Some(old_vector) = old_vector {
+            // Make sure empty vectors do not interfere with the index
+            if !old_vector.is_empty() {
+                let old_vector = self.indices_tracker.remap_vector(old_vector);
+                self.inverted_index.remove(id, old_vector);
             }
         }
         Ok(())

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -14,7 +14,7 @@ use super::plain_payload_index::PlainIndex;
 use super::sparse_index::sparse_vector_index::SparseVectorIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 
@@ -51,7 +51,12 @@ pub trait VectorIndex {
     fn indexed_vector_count(&self) -> usize;
 
     /// Update index for a single vector
-    fn update_vector(&mut self, id: PointOffsetType, vector: VectorRef) -> OperationResult<()>;
+    fn update_vector(
+        &mut self,
+        id: PointOffsetType,
+        vector: VectorRef,
+        _old_vector: Option<Vector>,
+    ) -> OperationResult<()>;
 }
 
 pub enum VectorIndexEnum {
@@ -168,14 +173,19 @@ impl VectorIndex for VectorIndexEnum {
         }
     }
 
-    fn update_vector(&mut self, id: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
+    fn update_vector(
+        &mut self,
+        id: PointOffsetType,
+        vector: VectorRef,
+        old_vector: Option<Vector>,
+    ) -> OperationResult<()> {
         match self {
-            Self::Plain(index) => index.update_vector(id, vector),
-            Self::HnswRam(index) => index.update_vector(id, vector),
-            Self::HnswMmap(index) => index.update_vector(id, vector),
-            Self::SparseRam(index) => index.update_vector(id, vector),
-            Self::SparseImmutableRam(index) => index.update_vector(id, vector),
-            Self::SparseMmap(index) => index.update_vector(id, vector),
+            Self::Plain(index) => index.update_vector(id, vector, old_vector),
+            Self::HnswRam(index) => index.update_vector(id, vector, old_vector),
+            Self::HnswMmap(index) => index.update_vector(id, vector, old_vector),
+            Self::SparseRam(index) => index.update_vector(id, vector, old_vector),
+            Self::SparseImmutableRam(index) => index.update_vector(id, vector, old_vector),
+            Self::SparseMmap(index) => index.update_vector(id, vector, old_vector),
         }
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -51,6 +51,14 @@ pub trait VectorIndex {
     fn indexed_vector_count(&self) -> usize;
 
     /// Update index for a single vector
+    ///
+    /// # Arguments
+    /// - `id` - sequential vector id, offset in the vector storage
+    /// - `vector` - new vector value,
+    ///        if None - vector will be removed from the index marked as deleted in storage.
+    ///        Note: inserting None vector is not equal to removing vector from the storage.
+    ///              Unlike removing, it will always result in storage growth.
+    ///              Proper removing should be performed by the optimizer.
     fn update_vector(
         &mut self,
         id: PointOffsetType,

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -14,7 +14,7 @@ use super::plain_payload_index::PlainIndex;
 use super::sparse_index::sparse_vector_index::SparseVectorIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
+use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 
@@ -54,8 +54,7 @@ pub trait VectorIndex {
     fn update_vector(
         &mut self,
         id: PointOffsetType,
-        vector: VectorRef,
-        _old_vector: Option<Vector>,
+        vector: Option<VectorRef>,
     ) -> OperationResult<()>;
 }
 
@@ -176,16 +175,15 @@ impl VectorIndex for VectorIndexEnum {
     fn update_vector(
         &mut self,
         id: PointOffsetType,
-        vector: VectorRef,
-        old_vector: Option<Vector>,
+        vector: Option<VectorRef>,
     ) -> OperationResult<()> {
         match self {
-            Self::Plain(index) => index.update_vector(id, vector, old_vector),
-            Self::HnswRam(index) => index.update_vector(id, vector, old_vector),
-            Self::HnswMmap(index) => index.update_vector(id, vector, old_vector),
-            Self::SparseRam(index) => index.update_vector(id, vector, old_vector),
-            Self::SparseImmutableRam(index) => index.update_vector(id, vector, old_vector),
-            Self::SparseMmap(index) => index.update_vector(id, vector, old_vector),
+            Self::Plain(index) => index.update_vector(id, vector),
+            Self::HnswRam(index) => index.update_vector(id, vector),
+            Self::HnswMmap(index) => index.update_vector(id, vector),
+            Self::SparseRam(index) => index.update_vector(id, vector),
+            Self::SparseImmutableRam(index) => index.update_vector(id, vector),
+            Self::SparseMmap(index) => index.update_vector(id, vector),
         }
     }
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -194,14 +194,13 @@ impl Segment {
         check_named_vectors(&vectors, &self.segment_config)?;
         for (vector_name, new_vector) in vectors {
             let vector_data = &self.vector_data[vector_name.as_ref()];
+            let mut vector_storage = vector_data.vector_storage.borrow_mut();
             let old_vector = if new_vector.as_vec_ref().is_sparse() {
                 // Sparse vector index requires an old vector to be passed
                 // to update operation, so it can clean up old index entries properly
                 //
                 // So we retrieve it here.
-                vector_data
-                    .vector_storage
-                    .borrow()
+                vector_storage
                     .get_vector_opt(internal_id)
                     .map(CowVector::to_owned)
             } else {
@@ -211,10 +210,7 @@ impl Segment {
             };
 
             let new_vector = new_vector.as_vec_ref();
-            vector_data
-                .vector_storage
-                .borrow_mut()
-                .insert_vector(internal_id, new_vector)?;
+            vector_storage.insert_vector(internal_id, new_vector)?;
             vector_data.vector_index.borrow_mut().update_vector(
                 internal_id,
                 new_vector,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -15,8 +15,8 @@ use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
-    TypedMultiDenseVectorRef, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
-    VectorRef,
+    MultiDenseVector, TypedMultiDenseVectorRef, Vector, VectorElementType, VectorElementTypeByte,
+    VectorElementTypeHalf, VectorRef,
 };
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::dense::appendable_mmap_dense_vector_storage::AppendableMmapDenseVectorStorage;
@@ -160,6 +160,43 @@ impl VectorStorageEnum {
             VectorStorageEnum::MultiDenseAppendableMemmap(s) => Some(s.multi_vector_config()),
             VectorStorageEnum::MultiDenseAppendableMemmapByte(s) => Some(s.multi_vector_config()),
             VectorStorageEnum::MultiDenseAppendableMemmapHalf(s) => Some(s.multi_vector_config()),
+        }
+    }
+
+    pub(crate) fn default_vector(&self) -> Vector {
+        match self {
+            VectorStorageEnum::DenseSimple(v) => Vector::from(vec![1.0; v.vector_dim()]),
+            VectorStorageEnum::DenseSimpleByte(v) => Vector::from(vec![1.0; v.vector_dim()]),
+            VectorStorageEnum::DenseSimpleHalf(v) => Vector::from(vec![1.0; v.vector_dim()]),
+            VectorStorageEnum::DenseMemmap(v) => Vector::from(vec![1.0; v.vector_dim()]),
+            VectorStorageEnum::DenseMemmapByte(v) => Vector::from(vec![1.0; v.vector_dim()]),
+            VectorStorageEnum::DenseMemmapHalf(v) => Vector::from(vec![1.0; v.vector_dim()]),
+            VectorStorageEnum::DenseAppendableMemmap(v) => Vector::from(vec![1.0; v.vector_dim()]),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                Vector::from(vec![1.0; v.vector_dim()])
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                Vector::from(vec![1.0; v.vector_dim()])
+            }
+            VectorStorageEnum::SparseSimple(_) => Vector::from(SparseVector::default()),
+            VectorStorageEnum::MultiDenseSimple(v) => {
+                Vector::from(MultiDenseVector::placeholder(v.vector_dim()))
+            }
+            VectorStorageEnum::MultiDenseSimpleByte(v) => {
+                Vector::from(MultiDenseVector::placeholder(v.vector_dim()))
+            }
+            VectorStorageEnum::MultiDenseSimpleHalf(v) => {
+                Vector::from(MultiDenseVector::placeholder(v.vector_dim()))
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                Vector::from(MultiDenseVector::placeholder(v.vector_dim()))
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                Vector::from(MultiDenseVector::placeholder(v.vector_dim()))
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                Vector::from(MultiDenseVector::placeholder(v.vector_dim()))
+            }
         }
     }
 }

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -71,7 +71,12 @@ impl<W: Weight> InvertedIndex for InvertedIndexImmutableRam<W> {
         InvertedIndexMmap::<W>::files(path)
     }
 
-    fn upsert(&mut self, _id: PointOffsetType, _vector: RemappedSparseVector) {
+    fn upsert(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: RemappedSparseVector,
+        _old_vector: Option<RemappedSparseVector>,
+    ) {
         panic!("Cannot upsert into a read-only RAM inverted index")
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -71,6 +71,10 @@ impl<W: Weight> InvertedIndex for InvertedIndexImmutableRam<W> {
         InvertedIndexMmap::<W>::files(path)
     }
 
+    fn remove(&mut self, _id: PointOffsetType, _old_vector: RemappedSparseVector) {
+        panic!("Cannot remove from a read-only RAM inverted index")
+    }
+
     fn upsert(
         &mut self,
         _id: PointOffsetType,

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -86,6 +86,10 @@ impl<W: Weight> InvertedIndex for InvertedIndexMmap<W> {
         ]
     }
 
+    fn remove(&mut self, _id: PointOffsetType, _old_vector: RemappedSparseVector) {
+        panic!("Cannot remove from a read-only Mmap inverted index")
+    }
+
     fn upsert(
         &mut self,
         _id: PointOffsetType,

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -86,7 +86,12 @@ impl<W: Weight> InvertedIndex for InvertedIndexMmap<W> {
         ]
     }
 
-    fn upsert(&mut self, _id: PointOffsetType, _vector: RemappedSparseVector) {
+    fn upsert(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: RemappedSparseVector,
+        _old_vector: Option<RemappedSparseVector>,
+    ) {
         panic!("Cannot upsert into a read-only Mmap inverted index")
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
@@ -65,7 +65,12 @@ impl InvertedIndex for InvertedIndexImmutableRam {
         InvertedIndexMmap::files(path)
     }
 
-    fn upsert(&mut self, _id: PointOffsetType, _vector: RemappedSparseVector) {
+    fn upsert(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: RemappedSparseVector,
+        _old_vector: Option<RemappedSparseVector>,
+    ) {
         panic!("Cannot upsert into a read-only RAM inverted index")
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
@@ -65,6 +65,10 @@ impl InvertedIndex for InvertedIndexImmutableRam {
         InvertedIndexMmap::files(path)
     }
 
+    fn remove(&mut self, _id: PointOffsetType, _old_vector: RemappedSparseVector) {
+        panic!("Cannot remove from a read-only RAM inverted index")
+    }
+
     fn upsert(
         &mut self,
         _id: PointOffsetType,

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -74,7 +74,12 @@ impl InvertedIndex for InvertedIndexMmap {
         ]
     }
 
-    fn upsert(&mut self, _id: PointOffsetType, _vector: RemappedSparseVector) {
+    fn upsert(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: RemappedSparseVector,
+        _old_vector: Option<RemappedSparseVector>,
+    ) {
         panic!("Cannot upsert into a read-only Mmap inverted index")
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -74,6 +74,10 @@ impl InvertedIndex for InvertedIndexMmap {
         ]
     }
 
+    fn remove(&mut self, _id: PointOffsetType, _old_vector: RemappedSparseVector) {
+        panic!("Cannot remove from a read-only Mmap inverted index")
+    }
+
     fn upsert(
         &mut self,
         _id: PointOffsetType,

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::cmp::max;
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
@@ -106,7 +105,7 @@ impl InvertedIndexRam {
         old_vector: Option<RemappedSparseVector>,
     ) {
         // Find elements of the old vector that are not in the new vector
-        if let Some(old_vector) = old_vector {
+        if let Some(old_vector) = &old_vector {
             let elements_to_delete = old_vector
                 .indices
                 .iter()

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -48,6 +48,14 @@ impl InvertedIndex for InvertedIndexRam {
         Vec::new()
     }
 
+    fn remove(&mut self, id: PointOffsetType, old_vector: RemappedSparseVector) {
+        for dim_id in old_vector.indices {
+            self.postings[dim_id as usize].delete(id);
+        }
+
+        self.vector_count = self.vector_count.saturating_sub(1);
+    }
+
     fn upsert(
         &mut self,
         id: PointOffsetType,

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -125,9 +125,9 @@ impl InvertedIndexRam {
                 }
             }
         }
-        // given that there are no holes in the internal ids and that we are not deleting from the index
-        // we can just use the id as a proxy the count
-        self.vector_count = max(self.vector_count, id as usize + 1);
+        if old_vector.is_none() {
+            self.vector_count += 1;
+        }
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -47,7 +47,12 @@ pub trait InvertedIndex: Sized {
     fn files(path: &Path) -> Vec<PathBuf>;
 
     /// Upsert a vector into the inverted index.
-    fn upsert(&mut self, id: PointOffsetType, vector: RemappedSparseVector);
+    fn upsert(
+        &mut self,
+        id: PointOffsetType,
+        vector: RemappedSparseVector,
+        old_vector: Option<RemappedSparseVector>,
+    );
 
     /// Create inverted index from ram index
     fn from_ram_index<P: AsRef<Path>>(

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -46,6 +46,8 @@ pub trait InvertedIndex: Sized {
     /// Files used by this index
     fn files(path: &Path) -> Vec<PathBuf>;
 
+    fn remove(&mut self, id: PointOffsetType, old_vector: RemappedSparseVector);
+
     /// Upsert a vector into the inverted index.
     fn upsert(
         &mut self,

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -29,6 +29,18 @@ impl PostingList {
         }
     }
 
+    pub fn delete(&mut self, record_id: PointOffsetType) {
+        let index = self
+            .elements
+            .binary_search_by_key(&record_id, |e| e.record_id);
+        if let Ok(found_index) = index {
+            self.elements.remove(found_index);
+            if found_index < self.elements.len() {
+                self.propagate_max_next_weight_to_the_left(found_index);
+            }
+        }
+    }
+
     /// Upsert a posting element into the posting list.
     ///
     /// Worst case is adding a new element at the end of the list with a very large weight.

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -3,7 +3,9 @@ use std::cmp::max;
 use common::types::PointOffsetType;
 use ordered_float::OrderedFloat;
 
-use super::posting_list_common::{PostingElement, PostingElementEx, PostingListIter};
+use super::posting_list_common::{
+    PostingElement, PostingElementEx, PostingListIter, DEFAULT_MAX_NEXT_WEIGHT,
+};
 use crate::common::types::DimWeight;
 
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -35,8 +37,13 @@ impl PostingList {
             .binary_search_by_key(&record_id, |e| e.record_id);
         if let Ok(found_index) = index {
             self.elements.remove(found_index);
+            if let Some(last) = self.elements.last_mut() {
+                last.max_next_weight = DEFAULT_MAX_NEXT_WEIGHT;
+            }
             if found_index < self.elements.len() {
                 self.propagate_max_next_weight_to_the_left(found_index);
+            } else if !self.elements.is_empty() {
+                self.propagate_max_next_weight_to_the_left(self.elements.len() - 1);
             }
         }
     }
@@ -98,13 +105,7 @@ impl PostingList {
         for element in self.elements[..up_to_index].iter_mut().rev() {
             // update max_next_weight for element
             element.max_next_weight = max_next_weight;
-            if element.weight >= max_next_weight {
-                // no need to propagate further because the current element is larger
-                break;
-            } else {
-                // update max_next_weight based on current element
-                max_next_weight = max_next_weight.max(element.weight);
-            }
+            max_next_weight = max_next_weight.max(element.weight);
         }
     }
 
@@ -296,6 +297,8 @@ impl<'a> PostingListIterator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
+
     use super::*;
     use crate::index::posting_list_common::DEFAULT_MAX_NEXT_WEIGHT;
 
@@ -469,5 +472,82 @@ mod tests {
             posting_list.elements[2].max_next_weight,
             DEFAULT_MAX_NEXT_WEIGHT
         );
+    }
+
+    #[test]
+    fn test_random_delete() {
+        use rand::seq::SliceRandom;
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let mut ids = Vec::new();
+            let mut cur_id = 0;
+            for _ in 0..32 {
+                cur_id += rng.gen_range(1..10);
+                ids.push(cur_id);
+            }
+            ids.shuffle(&mut rng);
+            let random_id = ids[rng.gen_range(0..ids.len())];
+
+            let mut builder1 = PostingBuilder::new();
+            let mut builder2 = PostingBuilder::new();
+            for id in ids {
+                let val = rng.gen_range(0..100) as f32 / 10.0;
+                builder1.add(id, val);
+                if id != random_id {
+                    builder2.add(id, val);
+                }
+            }
+
+            let mut posting_list1 = builder1.build();
+            posting_list1.delete(random_id);
+            let posting_list2 = builder2.build();
+
+            // Ok
+            assert_eq!(
+                posting_list1
+                    .elements
+                    .iter()
+                    .map(|e| e.record_id)
+                    .collect_vec(),
+                posting_list2
+                    .elements
+                    .iter()
+                    .map(|e| e.record_id)
+                    .collect_vec(),
+            );
+            assert_eq!(
+                posting_list1
+                    .elements
+                    .iter()
+                    .map(|e| e.weight)
+                    .collect_vec(),
+                posting_list2
+                    .elements
+                    .iter()
+                    .map(|e| e.weight)
+                    .collect_vec(),
+            );
+
+            // Fail
+            assert_eq!(
+                posting_list1
+                    .elements
+                    .iter()
+                    .map(|e| e.max_next_weight)
+                    .collect_vec(),
+                posting_list2
+                    .elements
+                    .iter()
+                    .map(|e| e.max_next_weight)
+                    .collect_vec(),
+            );
+
+            // Ok (at least they won't break pruning logic)
+            assert!(
+                std::iter::zip(&posting_list1.elements, &posting_list2.elements,)
+                    .all(|(e1, e2)| e1.max_next_weight >= e2.max_next_weight),
+            );
+        }
     }
 }

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -564,6 +564,7 @@ mod tests {
                 indices: vec![1, 2, 3],
                 values: vec![40.0, 40.0, 40.0],
             },
+            None,
         );
         let mut search_context = SearchContext::new(
             RemappedSparseVector {
@@ -801,7 +802,7 @@ mod tests {
             let SparseVector { indices, values } =
                 random_sparse_vector(rnd_gen, max_sparse_dimension);
             let vector = RemappedSparseVector::new(indices, values).unwrap();
-            inverted_index_ram.upsert(i, vector);
+            inverted_index_ram.upsert(i, vector, None);
         }
         inverted_index_ram
     }

--- a/tests/openapi/openapi_integration/test_sparse_update.py
+++ b/tests/openapi/openapi_integration/test_sparse_update.py
@@ -1,0 +1,153 @@
+import pytest
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = 'test_sparse_dense_collection_setup'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    sparse_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def sparse_collection_setup(
+        collection_name='test_collection',
+):
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "sparse_vectors": {
+                "text": {}
+            },
+        }
+    )
+    assert response.ok
+
+
+def test_sparse_dense_updates():
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "text": {
+                            "indices": [100, 500, 10], "values": [0.9, 0.8, 0.5]
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "limit": 10,
+            "vector": {
+                "name": "text",
+                "vector": {
+                    "indices": [100],
+                    "values": [0.9]
+                }
+            }
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 1
+
+    # Overwrite existing vector with new indices
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "text": {
+                            "indices": [600, 700, 10], "values": [0.9, 0.8, 0.5]
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "limit": 10,
+            "vector": {
+                "name": "text",
+                "vector": {
+                    "indices": [100],
+                    "values": [0.9]
+                }
+            }
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 0
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "limit": 10,
+            "vector": {
+                "name": "text",
+                "vector": {
+                    "indices": [700],
+                    "values": [0.9]
+                }
+            }
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 1
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "limit": 10,
+            "vector": {
+                "name": "text",
+                "vector": {
+                    "indices": [10],
+                    "values": [0.9]
+                }
+            }
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 1
+


### PR DESCRIPTION
In the current dev version, the procedure of updating mutable sparse index didn't take into account, that there might be existing vectors with non-overlapping elements.
Those elements were not removed from the posting lists on insertion.


This PR fixes the insertion by introducing an additional optional parameter `old_vector`, which is used to properly cleaned the storage.
Dense index doesn't require old vector to do proper updates, so it is only retrieved when we are updating sparse index in-place.