### PR TITLE
Fix Versions persistence atomicity

### DIFF
--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -33,10 +33,11 @@ impl DatabaseColumnScheduledUpdateWrapper {
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
     {
+        // keep `insert_pending_persistence` lock for atomicity
+        let mut insert_guard = self.insert_pending_persistence.lock();
+        insert_guard.insert(key.as_ref().to_vec(), value.as_ref().to_vec());
         self.deleted_pending_persistence.lock().remove(key.as_ref());
-        self.insert_pending_persistence
-            .lock()
-            .insert(key.as_ref().to_vec(), value.as_ref().to_vec());
+        drop(insert_guard);
         Ok(())
     }
 
@@ -45,14 +46,21 @@ impl DatabaseColumnScheduledUpdateWrapper {
         K: AsRef<[u8]>,
     {
         let key = key.as_ref();
-        self.insert_pending_persistence.lock().remove(key);
+        // keep `insert_pending_persistence` lock for atomicity
+        let mut insert_guard = self.insert_pending_persistence.lock();
+        insert_guard.remove(key);
         self.deleted_pending_persistence.lock().insert(key.to_vec());
+        drop(insert_guard);
         Ok(())
     }
 
     pub fn flusher(&self) -> Flusher {
-        let ids_to_delete = mem::take(&mut *self.deleted_pending_persistence.lock());
         let ids_to_insert = mem::take(&mut *self.insert_pending_persistence.lock());
+        let ids_to_delete = mem::take(&mut *self.deleted_pending_persistence.lock());
+        debug_assert!(
+            ids_to_insert.keys().all(|key| !ids_to_delete.contains(key)),
+            "Key to marked for insertion is also marked for deletion!"
+        );
         let wrapper = self.db.clone();
         Box::new(move || {
             for id in ids_to_delete {


### PR DESCRIPTION
This PR fixes the atomicity of the `Versions` persistence (context https://github.com/qdrant/qdrant/issues/4318)

The operations on `Versions` are buffered with `DatabaseColumnScheduledUpdateWrapper` in order to flush all the changes at once on demand and not when the operations are requested.

To that end there are two methods for tracking deletions and insertion independently:

```rust
   pub fn put<K, V>(&self, key: K, value: V) -> OperationResult<()>
    where
        K: AsRef<[u8]>,
        V: AsRef<[u8]>,
    {
        self.deleted_pending_persistence.lock().remove(key.as_ref());
        self.insert_pending_persistence
            .lock()
            .insert(key.as_ref().to_vec(), value.as_ref().to_vec());
        Ok(())
    }

    pub fn remove<K>(&self, key: K) -> OperationResult<()>
    where
        K: AsRef<[u8]>,
    {
        let key = key.as_ref();
        self.insert_pending_persistence.lock().remove(key);
        self.deleted_pending_persistence.lock().insert(key.to_vec());
        Ok(())
    }
``` 

Although those functions used locks, they still allow an incorrect interleaved execution.

Given two threads `t1` & `t2` targeting the same key `k` with `put` and `remove` concurrently.

- t1: `delete_pending.remove(k)`
- t2: `insert_pending.remove(k)`
- t2: `delete_pending.insert(k)`
- t1: `insert_pending.insert(k)`

At the end, `k` is part of both the insertion set and the deletion set.

This is an issue because we do the following for flushing:

```rust
 pub fn flusher(&self) -> Flusher {
        let ids_to_delete = mem::take(&mut *self.deleted_pending_persistence.lock());
        let ids_to_insert = mem::take(&mut *self.insert_pending_persistence.lock());
        let wrapper = self.db.clone();
        Box::new(move || {
            for id in ids_to_delete {
                wrapper.remove(id)?;
            }
            for (id, value) in ids_to_insert {
                wrapper.put(id, value)?;
            }
            wrapper.flusher()()
        })
    }
```

In that case the version `k` is not deleted as we apply insertions last.

This behavior can explain why we have seen deleted vectors with `version` although the flushing sequence is supposed to prevent it.

By synchronizing those methods over the same lock, they become atomic and no `versions` are resurrected for deleted points.

p.s. It is interesting to note that we were able to repair the RocksDB state with `ldb repair` because the [remove operations were using the WAL](https://github.com/qdrant/qdrant/pull/4370) at that time, thus making them available for replay during repair.