### PR TITLE
Persist state in resharding driver

### DIFF
--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -26,7 +26,8 @@ impl Collection {
         collection_path: &Path,
     ) -> CollectionResult<SaveOnDisk<PayloadIndexSchema>> {
         let payload_index_file = Self::payload_index_file(collection_path);
-        let schema: SaveOnDisk<PayloadIndexSchema> = SaveOnDisk::load_or_init(payload_index_file)?;
+        let schema: SaveOnDisk<PayloadIndexSchema> =
+            SaveOnDisk::load_or_init_default(payload_index_file)?;
         Ok(schema)
     }
 

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -64,6 +64,7 @@ impl Collection {
                 reshard_key.clone(),
                 consensus,
                 collection_id,
+                self.path.clone(),
                 channel_service,
                 temp_dir,
                 on_finish,

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -149,7 +149,7 @@ impl ShardReplicaSet {
             None
         };
         let replica_state: SaveOnDisk<ReplicaSetState> =
-            SaveOnDisk::load_or_init(shard_path.join(REPLICA_STATE_FILE))?;
+            SaveOnDisk::load_or_init_default(shard_path.join(REPLICA_STATE_FILE))?;
 
         let init_replica_state = init_state.unwrap_or(ReplicaState::Initializing);
         replica_state.write(|rs| {
@@ -219,7 +219,7 @@ impl ShardReplicaSet {
         optimizer_cpu_budget: CpuBudget,
     ) -> Self {
         let replica_state: SaveOnDisk<ReplicaSetState> =
-            SaveOnDisk::load_or_init(shard_path.join(REPLICA_STATE_FILE)).unwrap();
+            SaveOnDisk::load_or_init_default(shard_path.join(REPLICA_STATE_FILE)).unwrap();
 
         if replica_state.read().this_peer_id != this_peer_id {
             replica_state

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -38,7 +38,7 @@ impl ShardReplicaSet {
         is_distributed: bool,
     ) -> CollectionResult<()> {
         let replica_state: SaveOnDisk<ReplicaSetState> =
-            SaveOnDisk::load_or_init(snapshot_path.join(REPLICA_STATE_FILE))?;
+            SaveOnDisk::load_or_init_default(snapshot_path.join(REPLICA_STATE_FILE))?;
 
         // If this shard have local data
         let is_snapshot_local = replica_state.read().is_local;

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -79,6 +79,7 @@ pub fn spawn_resharding_task<T, F>(
     reshard_key: ReshardKey,
     consensus: Box<dyn ShardTransferConsensus>,
     collection_id: CollectionId,
+    collection_path: PathBuf,
     channel_service: ChannelService,
     temp_dir: PathBuf,
     on_finish: T,
@@ -108,6 +109,7 @@ where
                     shards_holder.clone(),
                     consensus.as_ref(),
                     collection_id.clone(),
+                    collection_path.clone(),
                     channel_service.clone(),
                     &temp_dir,
                 )

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -57,12 +57,13 @@ pub type LockedShardHolder = RwLock<ShardHolder>;
 
 impl ShardHolder {
     pub fn new(collection_path: &Path) -> CollectionResult<Self> {
-        let shard_transfers = SaveOnDisk::load_or_init(collection_path.join(SHARD_TRANSFERS_FILE))?;
+        let shard_transfers =
+            SaveOnDisk::load_or_init_default(collection_path.join(SHARD_TRANSFERS_FILE))?;
         let resharding_state: SaveOnDisk<Option<ReshardState>> =
-            SaveOnDisk::load_or_init(collection_path.join(RESHARDING_STATE_FILE))?;
+            SaveOnDisk::load_or_init_default(collection_path.join(RESHARDING_STATE_FILE))?;
 
         let key_mapping: SaveOnDisk<ShardKeyMapping> =
-            SaveOnDisk::load_or_init(collection_path.join(SHARD_KEY_MAPPING_FILE))?;
+            SaveOnDisk::load_or_init_default(collection_path.join(SHARD_KEY_MAPPING_FILE))?;
 
         let mut shard_id_to_key_mapping = HashMap::new();
 


### PR DESCRIPTION
Tracked in: #4213 
Depends on: <https://github.com/qdrant/qdrant/pull/4373>

Persist the resharding driver state on disk, so we can resume it on restart.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?