### PR TITLE
Replicate new shard to match replication factor in resharding driver

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -56,6 +56,7 @@ impl Collection {
 
             let shard_holder = self.shards_holder.clone();
             let collection_id = self.id.clone();
+            let collection_config = Arc::clone(&self.collection_config);
             let channel_service = self.channel_service.clone();
             let progress = Arc::new(Mutex::new(ReshardTaskProgress::new()));
             let spawned_task = resharding::spawn_resharding_task(
@@ -65,6 +66,7 @@ impl Collection {
                 consensus,
                 collection_id,
                 self.path.clone(),
+                collection_config,
                 channel_service,
                 temp_dir,
                 on_finish,

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -488,16 +488,16 @@ fn stage_finalize() -> CollectionResult<()> {
     todo!()
 }
 
-/// Await for a resharding shard trnasfer to succeed.
+/// Await for a resharding shard transfer to succeed.
 ///
-/// Yields on a successfull transfer.
+/// Yields on a successful transfer.
 ///
 /// Returns an error if:
 /// - the transfer failed or got aborted
 /// - the transfer timed out
 /// - no matching transfer is ongoing; it never started or went missing without a notification
 ///
-/// Yields on a succesful transfer. Returns an error if an error occurred or if the global timeout
+/// Yields on a successful transfer. Returns an error if an error occurred or if the global timeout
 /// is reached.
 async fn await_transfer_success(
     reshard_key: &ReshardKey,

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -399,12 +399,12 @@ async fn stage_replicate(
                     reshard_key.shard_id,
                 )));
             };
-            replica_set.peers().into_keys().collect::<HashSet<_>>()
+            replica_set.peers().into_keys().collect()
         };
         let all_peers = consensus.peers().into_iter().collect::<HashSet<_>>();
-        let peer_candidates: Vec<_> = all_peers.difference(&occupied_peers).cloned().collect();
+        let candidate_peers: Vec<_> = all_peers.difference(&occupied_peers).cloned().collect();
         // TODO(resharding): do not just pick random source, consider shard distribution
-        let Some(target_peer) = peer_candidates.choose(&mut rand::thread_rng()).cloned() else {
+        let Some(target_peer) = candidate_peers.choose(&mut rand::thread_rng()).cloned() else {
             log::warn!("Resharding could not match desired replication factors as all peers are occupied, continuing with lower replication factor");
             break;
         };

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -14,11 +14,13 @@ use schemars::JsonSchema;
 use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
 use tasks_pool::ReshardTaskProgress;
+use tokio::sync::RwLock;
 use tokio::time::sleep;
 
 use super::shard::{PeerId, ShardId};
 use super::transfer::ShardTransferConsensus;
 use crate::common::stoppable_task_async::{spawn_async_cancellable, CancellableAsyncTaskHandle};
+use crate::config::CollectionConfig;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::shard_holder::LockedShardHolder;
 use crate::shards::CollectionId;
@@ -80,6 +82,7 @@ pub fn spawn_resharding_task<T, F>(
     consensus: Box<dyn ShardTransferConsensus>,
     collection_id: CollectionId,
     collection_path: PathBuf,
+    collection_config: Arc<RwLock<CollectionConfig>>,
     channel_service: ChannelService,
     temp_dir: PathBuf,
     on_finish: T,
@@ -110,6 +113,7 @@ where
                     consensus.as_ref(),
                     collection_id.clone(),
                     collection_path.clone(),
+                    collection_config.clone(),
                     channel_service.clone(),
                     &temp_dir,
                 )

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -119,7 +119,10 @@ pub enum ShardTransferMethod {
 #[async_trait]
 pub trait ShardTransferConsensus: Send + Sync {
     /// Get the peer ID for the current node.
-    fn this_peer_id(&self) -> CollectionResult<PeerId>;
+    fn this_peer_id(&self) -> PeerId;
+
+    /// Get all peer IDs, including that of the current node.
+    fn peers(&self) -> Vec<PeerId>;
 
     /// Get the current consensus commit and term state.
     ///

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -184,6 +184,15 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         self.persistent.read().this_peer_id
     }
 
+    pub fn peers(&self) -> Vec<PeerId> {
+        self.persistent
+            .read()
+            .peer_address_by_id()
+            .keys()
+            .copied()
+            .collect()
+    }
+
     pub fn first_voter(&self) -> PeerId {
         match self.first_voter.read().as_ref() {
             Some(id) => *id,

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -35,13 +35,12 @@ impl ShardTransferDispatcher {
 
 #[async_trait]
 impl ShardTransferConsensus for ShardTransferDispatcher {
-    fn this_peer_id(&self) -> CollectionResult<PeerId> {
-        let Some(toc) = self.toc.upgrade() else {
-            return Err(CollectionError::service_error(
-                "Failed to get this peer ID, table of contents is dropped",
-            ));
-        };
-        Ok(toc.this_peer_id())
+    fn this_peer_id(&self) -> PeerId {
+        self.consensus_state.this_peer_id()
+    }
+
+    fn peers(&self) -> Vec<PeerId> {
+        self.consensus_state.peers()
     }
 
     fn consensus_commit_term(&self) -> (u64, u64) {


### PR DESCRIPTION
Tracked in: #4213 
Depends on: <https://github.com/qdrant/qdrant/pull/4379>

Implements the third stage in the resharding driver. It keeps replicating our new shard until we match the desired replication factor. This is dynamic and will follow the latest configured replication factor, even while it changes during this process. If we don't have enough peers to allow that number of replicas it continues early.

This does not implement the following yet, marked as TODOs:
- using the preferred shard transfer method, as configured by the user
- balance the shard distribution across the peers

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?