### PR TITLE
Fix flusher+propagate deadlock in proxy segment while snapshotting

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -234,13 +234,14 @@ impl ProxySegment {
         {
             let deleted_points = self.deleted_points.upgradable_read();
             if !deleted_points.is_empty() {
+                let mut deleted_points = RwLockUpgradableReadGuard::upgrade(deleted_points);
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for point_id in deleted_points.iter() {
                         wrapped_segment.delete_point(op_num, *point_id)?;
                     }
                     OperationResult::Ok(())
                 })?;
-                RwLockUpgradableReadGuard::upgrade(deleted_points).clear();
+                deleted_points.clear();
 
                 // Note: We do not clear the deleted mask here, as it provides
                 // no performance advantage and does not affect the correctness of search.
@@ -253,13 +254,14 @@ impl ProxySegment {
         {
             let deleted_indexes = self.deleted_indexes.upgradable_read();
             if !deleted_indexes.is_empty() {
+                let mut deleted_indexes = RwLockUpgradableReadGuard::upgrade(deleted_indexes);
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for key in deleted_indexes.iter() {
                         wrapped_segment.delete_field_index(op_num, key)?;
                     }
                     OperationResult::Ok(())
                 })?;
-                RwLockUpgradableReadGuard::upgrade(deleted_indexes).clear();
+                deleted_indexes.clear();
             }
         }
 
@@ -268,13 +270,14 @@ impl ProxySegment {
         {
             let created_indexes = self.created_indexes.upgradable_read();
             if !created_indexes.is_empty() {
+                let mut created_indexes = RwLockUpgradableReadGuard::upgrade(created_indexes);
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for (key, field_schema) in created_indexes.iter() {
                         wrapped_segment.create_field_index(op_num, key, Some(field_schema))?;
                     }
                     OperationResult::Ok(())
                 })?;
-                RwLockUpgradableReadGuard::upgrade(created_indexes).clear();
+                created_indexes.clear();
             }
         }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -896,7 +896,8 @@ impl<'s> SegmentHolder {
         let wrapped_segment = {
             let proxy_segment = proxy_segment.read();
             if let Err(err) = proxy_segment.propagate_to_wrapped() {
-                log::error!("Propagating proxy segment {proxy_id} changes to wrapped segment failed, ignoring: {err}");
+                log::error!("Propagating proxy segment {proxy_id} changes to wrapped segment failed, retrying later: {err}");
+                return Err(RwLockWriteGuard::downgrade_to_upgradable(write_segments));
             }
             proxy_segment.wrapped_segment.clone()
         };


### PR DESCRIPTION
I have the suspicion the following has been causing deadlocks in our snapshotting logic.

When flushing a proxy segment, we read lock deleted points first and then read lock the wrapped segment. When propagating changes to the wrapped segment we write lock the wrapped segment first, then we write lock the deleted points.

Ordering in both is reversed, which I believe can cause a deadlock.

Problematic scenario:
1. flusher [read locks](https://github.com/qdrant/qdrant/blob/5844d23dea02f8d477f238a58f3546b3e18b1bd0/lib/collection/src/collection_manager/holders/proxy_segment.rs#L821) deleted points
2. propagation [write locks](https://github.com/qdrant/qdrant/blob/5844d23dea02f8d477f238a58f3546b3e18b1bd0/lib/collection/src/collection_manager/holders/proxy_segment.rs#L237-L242) wrapped segment
3. flusher tries to get wrapped segment [read lock](https://github.com/qdrant/qdrant/blob/5844d23dea02f8d477f238a58f3546b3e18b1bd0/lib/collection/src/collection_manager/holders/proxy_segment.rs#L825), but gets stuck (held by 2)
4. propagation tries to get deleted points [write lock](https://github.com/qdrant/qdrant/blob/5844d23dea02f8d477f238a58f3546b3e18b1bd0/lib/collection/src/collection_manager/holders/proxy_segment.rs#L243), but gets stuck (held by 1)
5. profit (3 and 4 blocking each other)

In this PR I changed the ordering in the propagation logic to match that of the flusher. We now always lock the deleted points first, after which we lock the wrapped segment.

I've not been able to catch this deadlock yet on my own machine. So I hope my thinking is correct. Those upgradable reads are breaking my brain.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?