### PR TITLE
Skip serializing null fields in `Record` and `ScoredPoint` (REST)

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -97,13 +97,16 @@ pub struct ScoredPoint {
     /// Points vector distance to the query vector
     pub score: common::types::ScoreType,
     /// Payload - values assigned to the point
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<segment::types::Payload>,
     /// Vector of the point
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vector: Option<VectorStruct>,
     /// Shard Key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<segment::types::ShardKey>,
     /// Order-by value
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order_value: Option<segment::data_types::order_by::OrderValue>,
 }
 
@@ -114,8 +117,10 @@ pub struct Record {
     /// Id of the point
     pub id: segment::types::PointIdType,
     /// Payload - values assigned to the point
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<segment::types::Payload>,
     /// Vector of the point
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vector: Option<VectorStruct>,
     /// Shard Key
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/consensus_tests/test_order_by.py
+++ b/tests/consensus_tests/test_order_by.py
@@ -141,7 +141,7 @@ def test_order_by_from_remote_shard(tmp_path, every_test):
     assert_http_ok(res)
 
     for point in res.json()["result"]["points"]:
-        assert point["payload"] is not None
+        assert point.get("payload") is not None
 
     values = [point["payload"]["index"] for point in res.json()["result"]["points"]]
 
@@ -160,4 +160,4 @@ def test_order_by_from_remote_shard(tmp_path, every_test):
     assert ids == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     for point in res.json()["result"]["points"]:
-        assert point["payload"] is None
+        assert point.get("payload") is None

--- a/tests/openapi/openapi_integration/test_batch_update.py
+++ b/tests/openapi/openapi_integration/test_batch_update.py
@@ -1,9 +1,9 @@
+from operator import itemgetter
+
 import pytest
 
-from .helpers.helpers import request_with_validation
 from .helpers.collection_setup import basic_collection_setup, drop_collection
-
-from operator import itemgetter
+from .helpers.helpers import request_with_validation
 
 collection_name = 'test_collection_batch_update'
 
@@ -32,9 +32,13 @@ def assert_points(points, nonexisting_ids=None, with_vectors=False):
     )
     assert response.ok
 
-    assert sorted(response.json()['result'], key=itemgetter('id')) == sorted(
-        points, key=itemgetter('id')
-    )
+    for point, expected in zip(
+        sorted(response.json()['result'], key=itemgetter('id')), 
+        sorted(points, key=itemgetter('id'))
+    ):
+        assert point.get('id') == expected.get('id')
+        assert point.get('payload') == expected.get('payload')
+        assert point.get('vector') == expected.get('vector')
 
 
 def test_batch_update():

--- a/tests/openapi/openapi_integration/test_group.py
+++ b/tests/openapi/openapi_integration/test_group.py
@@ -332,7 +332,7 @@ def assert_group_with_default_lookup(group, group_size=3):
 
     lookup = group["lookup"]
     assert lookup["payload"]
-    assert not lookup["vector"]
+    assert not lookup.get("vector")
 
 
 @pytest.mark.parametrize("with_lookup", lookup_params)
@@ -434,8 +434,8 @@ def test_search_groups_with_lookup_without_payload_nor_vectors(with_lookup):
         assert group["id"] == group["lookup"]["id"]
 
         lookup = group["lookup"]
-        assert not lookup["payload"]
-        assert not lookup["vector"]
+        assert not lookup.get("payload")
+        assert not lookup.get("vector")
 
 
 def test_search_groups_lookup_with_non_existing_collection():

--- a/tests/openapi/openapi_integration/test_payload_selector.py
+++ b/tests/openapi/openapi_integration/test_payload_selector.py
@@ -44,7 +44,7 @@ def test_payload_selectors():
     )
     assert response.ok
     assert len(response.json()['result']['points']) == 1
-    assert response.json()['result']['points'][0]['payload'] is None
+    assert response.json()['result']['points'][0].get('payload') is None
 
     # Search with payload selector ALL
     response = request_with_validation(


### PR DESCRIPTION
With the intention of making the interface simpler, I propose to skip serializing the optional fields in `Record` and `ScoredPoint`.

From my POV, this has two advantages:
- Less noise in the response when `with_payload` and `with_vector` are not requested.
- Less confusion from users thinking their points don't have payload/vector ("It says payload is null!")

Python client will keep deserializing them into their classes as `None` fields, though, so the advantages only apply when doing plain REST requests.
