### PR TITLE
Fix deadlock caused by concurrent snapshot and optimization

### DIFF
--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -207,8 +207,8 @@ pub fn build_test_holder(path: &Path) -> RwLock<SegmentHolder> {
 
     let mut holder = SegmentHolder::default();
 
-    let _sid1 = holder.add(segment1);
-    let _sid2 = holder.add(segment2);
+    let _sid1 = holder.add_new(segment1);
+    let _sid2 = holder.add_new(segment2);
 
     RwLock::new(holder)
 }
@@ -272,7 +272,7 @@ pub fn optimize_segment(segment: Segment) -> LockedSegment {
 
     let mut holder = SegmentHolder::default();
 
-    let segment_id = holder.add(segment);
+    let segment_id = holder.add_new(segment);
 
     let optimizer = get_indexing_optimizer(&segments_dir, dir.path(), dim);
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -239,7 +239,8 @@ impl<'s> SegmentHolder {
     ///
     /// Pair of (id of newly inserted segment, Vector of replaced segments)
     ///
-    pub fn swap<T>(
+    /// The inserted segment gets assigned a new unique ID.
+    pub fn swap_new<T>(
         &mut self,
         segment: T,
         remove_ids: &[SegmentId],
@@ -850,7 +851,7 @@ impl<'s> SegmentHolder {
                 log::error!("Failed to replicate proxy segment field indexes, ignoring: {err}");
             }
 
-            let (segment_id, segments) = write_segments.swap(proxy, &[segment_id]);
+            let (segment_id, segments) = write_segments.swap_new(proxy, &[original_segment_id]);
             debug_assert_eq!(segments.len(), 1);
             let locked_proxy_segment = write_segments
                 .get(segment_id)
@@ -908,7 +909,7 @@ impl<'s> SegmentHolder {
             }
             proxy_segment.wrapped_segment.clone()
         };
-        let (_, segments) = write_segments.swap(wrapped_segment, &[proxy_id]);
+        let (_, segments) = write_segments.swap_new(wrapped_segment, &[proxy_id]);
         debug_assert_eq!(segments.len(), 1);
 
         // Downgrade write lock to read and give it back
@@ -956,7 +957,7 @@ impl<'s> SegmentHolder {
                         }
                         proxy_segment.wrapped_segment.clone()
                     };
-                    let (_, segments) = write_segments.swap(wrapped_segment, &[proxy_id]);
+                    let (_, segments) = write_segments.swap_new(wrapped_segment, &[proxy_id]);
                     debug_assert_eq!(segments.len(), 1);
                 }
                 // If already unproxied, do nothing
@@ -1143,7 +1144,7 @@ mod tests {
 
         let segment3 = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
 
-        let (_sid3, replaced_segments) = holder.swap(segment3, &[sid1, sid2]);
+        let (_sid3, replaced_segments) = holder.swap_new(segment3, &[sid1, sid2]);
         replaced_segments
             .into_iter()
             .for_each(|s| s.drop_data().unwrap());

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -179,9 +179,7 @@ impl<'s> SegmentHolder {
 
     fn generate_new_key(&self) -> SegmentId {
         let key: SegmentId = self.id_source.fetch_add(1, Ordering::SeqCst);
-        if self.appendable_segments.contains_key(&key)
-            || self.non_appendable_segments.contains_key(&key)
-        {
+        if self.get(key).is_some() {
             debug_assert!(false, "generated new key that already exists");
             self.generate_new_key()
         } else {
@@ -196,21 +194,44 @@ impl<'s> SegmentHolder {
     where
         T: Into<LockedSegment>,
     {
-        let locked_segment = segment.into();
-        self.add_new_locked(locked_segment)
+        let segment_id = self.generate_new_key();
+        self.add_existing(segment_id, segment);
+        segment_id
     }
 
     /// Add new segment to storage which is already LockedSegment
     ///
     /// The segment gets assigned a new unique ID.
     pub fn add_new_locked(&mut self, segment: LockedSegment) -> SegmentId {
-        let key = self.generate_new_key();
+        let segment_id = self.generate_new_key();
+        self.add_existing_locked(segment_id, segment);
+        segment_id
+    }
+
+    /// Add an existing segment to storage
+    ///
+    /// The segment gets the provided ID, which must not be in the segment holder yet.
+    pub fn add_existing<T>(&mut self, segment_id: SegmentId, segment: T)
+    where
+        T: Into<LockedSegment>,
+    {
+        let locked_segment = segment.into();
+        self.add_existing_locked(segment_id, locked_segment);
+    }
+
+    /// Add an existing segment to storage which is already LockedSegment
+    ///
+    /// The segment gets the provided ID, which must not be in the segment holder yet.
+    pub fn add_existing_locked(&mut self, segment_id: SegmentId, segment: LockedSegment) {
+        debug_assert!(
+            self.get(segment_id).is_none(),
+            "cannot add segment with ID {segment_id}, it already exists",
+        );
         if segment.get().read().is_appendable() {
-            self.appendable_segments.insert(key, segment);
+            self.appendable_segments.insert(segment_id, segment);
         } else {
-            self.non_appendable_segments.insert(key, segment);
+            self.non_appendable_segments.insert(segment_id, segment);
         }
-        key
     }
 
     pub fn remove(&mut self, remove_ids: &[SegmentId]) -> Vec<LockedSegment> {
@@ -250,6 +271,31 @@ impl<'s> SegmentHolder {
     {
         let new_id = self.add_new(segment);
         (new_id, self.remove(remove_ids))
+    }
+
+    /// Replace old segments with a new one
+    ///
+    /// # Arguments
+    ///
+    /// * `segment` - segment to insert
+    /// * `remove_ids` - ids of segments to replace
+    ///
+    /// # Result
+    ///
+    /// Pair of (id of newly inserted segment, Vector of replaced segments)
+    ///
+    /// The inserted segment uses the provided segment ID, which must not be in the segment holder yet.
+    pub fn swap_existing<T>(
+        &mut self,
+        use_segment_id: SegmentId,
+        segment: T,
+        remove_ids: &[SegmentId],
+    ) -> Vec<LockedSegment>
+    where
+        T: Into<LockedSegment>,
+    {
+        self.add_existing(use_segment_id, segment);
+        self.remove(remove_ids)
     }
 
     pub fn get(&self, id: SegmentId) -> Option<&LockedSegment> {
@@ -685,7 +731,7 @@ impl<'s> SegmentHolder {
         log::trace!("Applying function on all proxied shard segments");
         let mut result = Ok(());
         let mut unproxied_segment_ids = Vec::with_capacity(proxies.len());
-        for (proxy_id, proxy_segment) in &proxies {
+        for (proxy_id, original_segment_id, proxy_segment) in &proxies {
             // Get segment to snapshot
             let segment = match proxy_segment {
                 LockedSegment::Proxy(proxy_segment) => {
@@ -708,7 +754,12 @@ impl<'s> SegmentHolder {
 
             // Try to unproxy/release this segment since we don't use it anymore
             // Unproxying now prevent unnecessary writes to the temporary segment
-            match Self::try_unproxy_segment(segments_lock, *proxy_id, proxy_segment.clone()) {
+            match Self::try_unproxy_segment(
+                segments_lock,
+                *proxy_id,
+                *original_segment_id,
+                proxy_segment.clone(),
+            ) {
                 Ok(lock) => {
                     segments_lock = lock;
                     unproxied_segment_ids.push(*proxy_id);
@@ -716,7 +767,7 @@ impl<'s> SegmentHolder {
                 Err(lock) => segments_lock = lock,
             }
         }
-        proxies.retain(|(id, _)| !unproxied_segment_ids.contains(id));
+        proxies.retain(|(id, _, _)| !unproxied_segment_ids.contains(id));
 
         // Unproxy all segments
         // Always do this to prevent leaving proxy segments behind
@@ -799,7 +850,7 @@ impl<'s> SegmentHolder {
         segments_path: &Path,
         collection_params: Option<&CollectionParams>,
     ) -> OperationResult<(
-        Vec<(SegmentId, LockedSegment)>,
+        Vec<(SegmentId, SegmentId, LockedSegment)>,
         LockedSegment,
         RwLockUpgradableReadGuard<'a, SegmentHolder>,
     )> {
@@ -842,7 +893,7 @@ impl<'s> SegmentHolder {
         // We cannot fail past this point to prevent only having some segments proxified
         let mut proxies = Vec::with_capacity(new_proxies.len());
         let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
-        for (segment_id, mut proxy) in new_proxies {
+        for (original_segment_id, mut proxy) in new_proxies {
             // Replicate field indexes the second time, because optimized segments could have
             // been changed. The probability is small, though, so we can afford this operation
             // under the full collection write lock
@@ -857,7 +908,7 @@ impl<'s> SegmentHolder {
                 .get(segment_id)
                 .cloned()
                 .expect("failed to get segment from segment holder we just swapped in");
-            proxies.push((segment_id, locked_proxy_segment));
+            proxies.push((segment_id, original_segment_id, locked_proxy_segment));
         }
         let segments_lock = RwLockWriteGuard::downgrade_to_upgradable(write_segments);
 
@@ -873,6 +924,7 @@ impl<'s> SegmentHolder {
     fn try_unproxy_segment(
         segments_lock: RwLockUpgradableReadGuard<SegmentHolder>,
         proxy_id: SegmentId,
+        original_segment_id: SegmentId,
         proxy_segment: LockedSegment,
     ) -> Result<RwLockUpgradableReadGuard<SegmentHolder>, RwLockUpgradableReadGuard<SegmentHolder>>
     {
@@ -902,6 +954,7 @@ impl<'s> SegmentHolder {
 
         // Batch 2: propagate changes to wrapped segment with segment holder write lock
         // Propagate proxied changes to wrapped segment, take it out and swap with proxy
+        // Important: put the wrapped segment back with its original segment ID
         let wrapped_segment = {
             let proxy_segment = proxy_segment.read();
             if let Err(err) = proxy_segment.propagate_to_wrapped() {
@@ -909,7 +962,8 @@ impl<'s> SegmentHolder {
             }
             proxy_segment.wrapped_segment.clone()
         };
-        let (_, segments) = write_segments.swap_new(wrapped_segment, &[proxy_id]);
+        let segments =
+            write_segments.swap_existing(original_segment_id, wrapped_segment, &[proxy_id]);
         debug_assert_eq!(segments.len(), 1);
 
         // Downgrade write lock to read and give it back
@@ -919,7 +973,7 @@ impl<'s> SegmentHolder {
     /// Unproxy all shard segments for [`proxy_all_segments_and_apply`]
     fn unproxy_all_segments(
         segments_lock: RwLockUpgradableReadGuard<SegmentHolder>,
-        proxies: Vec<(SegmentId, LockedSegment)>,
+        proxies: Vec<(SegmentId, SegmentId, LockedSegment)>,
         tmp_segment: LockedSegment,
     ) -> OperationResult<()> {
         // We must propagate all changes in the proxy into their wrapped segments, as we'll put the
@@ -934,7 +988,7 @@ impl<'s> SegmentHolder {
         // Batch 1: propagate changes to wrapped segment with segment holder read lock
         proxies
             .iter()
-            .filter_map(|(proxy_id, proxy_segment)| match proxy_segment {
+            .filter_map(|(proxy_id, _original_segment_id, proxy_segment)| match proxy_segment {
                 LockedSegment::Proxy(proxy_segment) => Some((proxy_id, proxy_segment)),
                 LockedSegment::Original(_) => None,
             }).for_each(|(proxy_id, proxy_segment)| {
@@ -946,9 +1000,10 @@ impl<'s> SegmentHolder {
         // Batch 2: propagate changes to wrapped segment with segment holder write lock
         // Swap out each proxy with wrapped segment once changes are propagated
         let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
-        for (proxy_id, proxy_segment) in proxies {
+        for (proxy_id, original_segment_id, proxy_segment) in proxies {
             match proxy_segment {
                 // Propagate proxied changes to wrapped segment, take it out and swap with proxy
+                // Important: put the wrapped segment back with its original segment ID
                 LockedSegment::Proxy(proxy_segment) => {
                     let wrapped_segment = {
                         let proxy_segment = proxy_segment.read();
@@ -957,7 +1012,11 @@ impl<'s> SegmentHolder {
                         }
                         proxy_segment.wrapped_segment.clone()
                     };
-                    let (_, segments) = write_segments.swap_new(wrapped_segment, &[proxy_id]);
+                    let segments = write_segments.swap_existing(
+                        original_segment_id,
+                        wrapped_segment,
+                        &[proxy_id],
+                    );
                     debug_assert_eq!(segments.len(), 1);
                 }
                 // If already unproxied, do nothing

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1420,17 +1420,34 @@ mod tests {
 
         let holder = Arc::new(RwLock::new(holder));
 
+        let before_ids = holder
+            .read()
+            .iter()
+            .map(|(id, _)| *id)
+            .collect::<HashSet<_>>();
+
         let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
         SegmentHolder::snapshot_all_segments(
-            holder,
+            holder.clone(),
             segments_dir.path(),
             None,
             temp_dir.path(),
             snapshot_dir.path(),
         )
         .unwrap();
+
+        let after_ids = holder
+            .read()
+            .iter()
+            .map(|(id, _)| *id)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(
+            before_ids, after_ids,
+            "segment holder IDs before and after snapshotting must be equal",
+        );
 
         let archive_count = read_dir(&snapshot_dir).unwrap().count();
         // one archive produced per concrete segment in the SegmentHolder

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -277,6 +277,7 @@ impl<'s> SegmentHolder {
     ///
     /// # Arguments
     ///
+    /// * `segment_id` - segment ID to use
     /// * `segment` - segment to insert
     /// * `remove_ids` - ids of segments to replace
     ///
@@ -287,14 +288,14 @@ impl<'s> SegmentHolder {
     /// The inserted segment uses the provided segment ID, which must not be in the segment holder yet.
     pub fn swap_existing<T>(
         &mut self,
-        use_segment_id: SegmentId,
+        segment_id: SegmentId,
         segment: T,
         remove_ids: &[SegmentId],
     ) -> Vec<LockedSegment>
     where
         T: Into<LockedSegment>,
     {
-        self.add_existing(use_segment_id, segment);
+        self.add_existing(segment_id, segment);
         self.remove(remove_ids)
     }
 

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -314,7 +314,7 @@ mod tests {
 
         let segment = random_segment(dir.path(), 100, point_count, dim as usize);
 
-        let segment_id = holder.add(segment);
+        let segment_id = holder.add_new(segment);
         let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
 
         let hnsw_config = HnswConfig {
@@ -469,7 +469,7 @@ mod tests {
             vector2_dim as usize,
         );
 
-        let segment_id = holder.add(segment);
+        let segment_id = holder.add_new(segment);
         let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
 
         let hnsw_config_collection = HnswConfig {
@@ -639,7 +639,7 @@ mod tests {
             vector2_dim as usize,
         );
 
-        let segment_id = holder.add(segment);
+        let segment_id = holder.add_new(segment);
         let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
 
         let quantization_config_collection =

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -334,7 +334,7 @@ mod tests {
 
         let segment_config = large_segment.segment_config.clone();
 
-        let large_segment_id = holder.add(large_segment);
+        let large_segment_id = holder.add_new(large_segment);
 
         let vectors_config: BTreeMap<String, VectorParams> = segment_config
             .vector_data
@@ -443,10 +443,10 @@ mod tests {
 
         let segment_config = small_segment.segment_config.clone();
 
-        let small_segment_id = holder.add(small_segment);
-        let middle_low_segment_id = holder.add(middle_low_segment);
-        let middle_segment_id = holder.add(middle_segment);
-        let large_segment_id = holder.add(large_segment);
+        let small_segment_id = holder.add_new(small_segment);
+        let middle_low_segment_id = holder.add_new(middle_low_segment);
+        let middle_segment_id = holder.add_new(middle_segment);
+        let large_segment_id = holder.add_new(large_segment);
 
         let mut index_optimizer = IndexingOptimizer::new(
             2,
@@ -736,7 +736,7 @@ mod tests {
 
         let _segment_ids: Vec<SegmentId> = segments
             .into_iter()
-            .map(|segment| holder.add(segment))
+            .map(|segment| holder.add_new(segment))
             .collect();
 
         let locked_holder: Arc<RwLock<_, _>> = Arc::new(RwLock::new(holder));
@@ -841,7 +841,7 @@ mod tests {
 
         let segment = random_segment(dir.path(), 100, point_count, dim as usize);
 
-        let segment_id = holder.add(segment);
+        let segment_id = holder.add_new(segment);
         let locked_holder: Arc<parking_lot::RwLock<_>> = Arc::new(RwLock::new(holder));
 
         let hnsw_config = HnswConfig {

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -171,9 +171,9 @@ mod tests {
         let dim = 256;
 
         let _segments_to_merge = [
-            holder.add(random_segment(dir.path(), 100, 40, dim)),
-            holder.add(random_segment(dir.path(), 100, 50, dim)),
-            holder.add(random_segment(dir.path(), 100, 60, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 40, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 50, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 60, dim)),
         ];
 
         let mut merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim);
@@ -205,16 +205,16 @@ mod tests {
         let dim = 256;
 
         let segments_to_merge = [
-            holder.add(random_segment(dir.path(), 100, 3, dim)),
-            holder.add(random_segment(dir.path(), 100, 3, dim)),
-            holder.add(random_segment(dir.path(), 100, 3, dim)),
-            holder.add(random_segment(dir.path(), 100, 10, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 10, dim)),
         ];
 
         let other_segment_ids = [
-            holder.add(random_segment(dir.path(), 100, 20, dim)),
-            holder.add(random_segment(dir.path(), 100, 20, dim)),
-            holder.add(random_segment(dir.path(), 100, 20, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 20, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 20, dim)),
+            holder.add_new(random_segment(dir.path(), 100, 20, dim)),
         ];
 
         let merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim);

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -581,6 +581,11 @@ pub trait SegmentOptimizer {
             optimized_segment.prefault_mmap_pages();
 
             let (_, proxies) = write_segments_guard.swap_new(optimized_segment, &proxy_ids);
+            debug_assert_eq!(
+                proxies.len(),
+                proxy_ids.len(),
+                "swapped different number of proxies on unwrap, missing or incorrect segment IDs?"
+            );
 
             let has_appendable_segments = write_segments_guard.has_appendable_segment();
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -279,7 +279,7 @@ pub trait SegmentOptimizer {
                     LockedSegment::Proxy(proxy_segment) => {
                         let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
                         let (restored_id, _proxies) =
-                            segments_lock.swap(wrapped_segment, &[proxy_id]);
+                            segments_lock.swap_new(wrapped_segment, &[proxy_id]);
                         restored_segment_ids.push(restored_id);
                     }
                 }
@@ -506,7 +506,7 @@ pub trait SegmentOptimizer {
                 // so we can afford this operation under the full collection write lock
                 let op_num = 0;
                 proxy.replicate_field_indexes(op_num)?; // Slow only in case the index is change in the gap between two calls
-                proxy_ids.push(write_segments.swap(proxy, &[idx]).0);
+                proxy_ids.push(write_segments.swap_new(proxy, &[idx]).0);
             }
             proxy_ids
         };
@@ -580,7 +580,7 @@ pub trait SegmentOptimizer {
 
             optimized_segment.prefault_mmap_pages();
 
-            let (_, proxies) = write_segments_guard.swap(optimized_segment, &proxy_ids);
+            let (_, proxies) = write_segments_guard.swap_new(optimized_segment, &proxy_ids);
 
             let has_appendable_segments = write_segments_guard.has_appendable_segment();
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -320,7 +320,7 @@ pub trait SegmentOptimizer {
         self.unwrap_proxy(segments, proxy_ids);
         if temp_segment.get().read().available_point_count() > 0 {
             let mut write_segments = segments.write();
-            write_segments.add_locked(temp_segment.clone());
+            write_segments.add_new_locked(temp_segment.clone());
         }
     }
 
@@ -589,7 +589,7 @@ pub trait SegmentOptimizer {
 
             // Append a temp segment to collection if it is not empty or there is no other appendable segment
             if tmp_segment.get().read().available_point_count() > 0 || !has_appendable_segments {
-                write_segments_guard.add_locked(tmp_segment);
+                write_segments_guard.add_new_locked(tmp_segment);
 
                 // unlock collection for search and updates
                 drop(write_segments_guard);

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -234,7 +234,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let mut holder = SegmentHolder::default();
-        let segment_id = holder.add(random_segment(dir.path(), 100, 200, 4));
+        let segment_id = holder.add_new(random_segment(dir.path(), 100, 200, 4));
 
         let segment = holder.get(segment_id).unwrap();
 
@@ -423,7 +423,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut segment_id = holder.add(segment);
+        let mut segment_id = holder.add_new(segment);
         let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
 
         let hnsw_config = HnswConfig {

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -711,8 +711,8 @@ mod tests {
 
         let mut holder = SegmentHolder::default();
 
-        let _sid1 = holder.add(segment1);
-        let _sid2 = holder.add(segment2);
+        let _sid1 = holder.add_new(segment1);
+        let _sid2 = holder.add_new(segment2);
 
         let segment_holder = Arc::new(RwLock::new(holder));
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -40,7 +40,7 @@ fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId, path: &Path) -> Seg
         proxy_deleted_indexes,
     );
 
-    let (new_id, _replaced_segments) = write_segments.swap(proxy, &[sid]);
+    let (new_id, _replaced_segments) = write_segments.swap_new(proxy, &[sid]);
     new_id
 }
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -53,8 +53,8 @@ fn test_update_proxy_segments() {
 
     let mut holder = SegmentHolder::default();
 
-    let sid1 = holder.add(segment1);
-    let _sid2 = holder.add(segment2);
+    let sid1 = holder.add_new(segment1);
+    let _sid2 = holder.add_new(segment2);
 
     let segments = Arc::new(RwLock::new(holder));
 
@@ -103,8 +103,8 @@ fn test_move_points_to_copy_on_write() {
 
     let mut holder = SegmentHolder::default();
 
-    let sid1 = holder.add(segment1);
-    let _sid2 = holder.add(segment2);
+    let sid1 = holder.add_new(segment1);
+    let _sid2 = holder.add_new(segment2);
 
     let segments = Arc::new(RwLock::new(holder));
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -291,7 +291,7 @@ impl LocalShard {
                 })
                 .unwrap_or(Ok(()))?;
 
-            segment_holder.add(segment);
+            segment_holder.add_new(segment);
         }
 
         let res = segment_holder.deduplicate_points()?;
@@ -474,7 +474,7 @@ impl LocalShard {
                 ))
             })??;
 
-            segment_holder.add(segment);
+            segment_holder.add_new(segment);
         }
 
         let wal: SerdeWal<OperationWithClockTag> =

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -34,16 +34,16 @@ async fn test_optimization_process() {
     let mut holder = SegmentHolder::default();
 
     let segments_to_merge = vec![
-        holder.add(random_segment(dir.path(), 100, 3, dim)),
-        holder.add(random_segment(dir.path(), 100, 3, dim)),
-        holder.add(random_segment(dir.path(), 100, 3, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 3, dim)),
     ];
 
-    let segment_to_index = holder.add(random_segment(dir.path(), 100, 110, dim));
+    let segment_to_index = holder.add_new(random_segment(dir.path(), 100, 110, dim));
 
     let _other_segment_ids: Vec<SegmentId> = vec![
-        holder.add(random_segment(dir.path(), 100, 20, dim)),
-        holder.add(random_segment(dir.path(), 100, 20, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 20, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 20, dim)),
     ];
 
     let merge_optimizer: Arc<Optimizer> =
@@ -138,7 +138,7 @@ async fn test_cancel_optimization() {
     let dim = 256;
 
     for _ in 0..5 {
-        holder.add(random_segment(dir.path(), 100, 1000, dim));
+        holder.add_new(random_segment(dir.path(), 100, 1000, dim));
     }
 
     let indexing_optimizer: Arc<Optimizer> =


### PR DESCRIPTION
Fix a deadlock that could occur when a snapshot happens during an active optimization.

With our non-blocking snapshot implementation, all segments are proxied for snapshotting. When unproxying, all segments get a new unique ID assigned. This causes the active optimization to loose track of the segments, because IDs don't match up anymore. If the optimizer unproxies, we get a broken state.

More specifically, when this happens we end up with both the proxy and the wrapped segment in the segment holder. The segment is effectively placed twice in the holder now. It causes a double read, causing a deadlock.

This PRs does a few things to mitigate the problem:
- when unproxing after a snapshot, put the segment back with their original ID
- change segment ID generation to be auto incrementing, prevent potential conflicts when putting back old IDs
- add a (debug) sanity check when unproxying in the optimizer, make sure we remove the expected number of proxies
- function names have been changed to clarify the segment ID behavior better
- extend a snapshot test to assert correct behavior

This also fixes the following message that popped up due to a double read (e.g. <https://github.com/qdrant/qdrant/issues/4199>):

> Trying to read-lock all collection segments is taking a long time. This could be a deadlock and may block new updates.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?