### PR TITLE
universal-query: Fix local shard ordering

### DIFF
--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -279,8 +279,7 @@ mod tests {
 
     use segment::data_types::vectors::{MultiDenseVector, NamedVectorStruct, Vector};
     use segment::types::{
-        Condition, FieldCondition, Filter, Match, SearchParams, WithPayloadInterface,
-        WithVector,
+        Condition, FieldCondition, Filter, Match, SearchParams, WithPayloadInterface, WithVector,
     };
     use sparse::common::sparse_vector::SparseVector;
 

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -322,6 +322,8 @@ mod tests {
             ("byte".to_string(), cosine_params.clone()),
             ("full".to_string(), cosine_params.clone()),
             ("multi".to_string(), cosine_params.clone()),
+            // this is incorrect, but we don't care for this test
+            ("sparse".to_string(), cosine_params.clone()),
         ]);
 
         CollectionParams {

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -190,10 +190,8 @@ impl ShardOperation for LocalShard {
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let collection_params = self.collection_config.read().await.params.clone();
-
         self.do_planned_query(
-            PlannedQuery::from_shard_request(request.as_ref().to_owned(), &collection_params)?,
+            PlannedQuery::try_from(request.as_ref().to_owned())?,
             search_runtime_handle,
             None,
         )

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -190,8 +190,10 @@ impl ShardOperation for LocalShard {
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        let collection_params = self.collection_config.read().await.params.clone();
+
         self.do_planned_query(
-            PlannedQuery::try_from(request.as_ref().to_owned())?,
+            PlannedQuery::from_shard_request(request.as_ref().to_owned(), &collection_params)?,
             search_runtime_handle,
             None,
         )

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -189,6 +189,7 @@ impl Distance {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub enum Order {
     LargeBetter,
     SmallBetter,


### PR DESCRIPTION
Needs #4380 

- adds an `order` field in `planned_query::ResultsMerge` to indicate the desired direction of merging, and merges accordingly
  - converting from `ShardQueryRequest` to `PlannedQuery` now needs the collection params to determine the required order depending on the vector config
- handles previously unhandled `filter` and `score_threshold` in `LocalShard::merge_prefetches()`, either by passing it to the core_search/scroll rescoring or during regular merging