### PR TITLE
universal-query: Exclude referenced ids

### DIFF
--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api::rest::RecommendStrategy;
 use common::types::ScoreType;
 use itertools::Itertools;
@@ -5,7 +7,9 @@ use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{
     MultiDenseVector, NamedQuery, NamedVectorStruct, Vector, VectorRef, DEFAULT_VECTOR_NAME,
 };
-use segment::types::{Filter, PointIdType, SearchParams, WithPayloadInterface, WithVector};
+use segment::types::{
+    Condition, Filter, HasIdCondition, PointIdType, SearchParams, WithPayloadInterface, WithVector,
+};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 
 use super::shard_query::{Fusion, ScoringQuery, ShardPrefetch, ShardQueryRequest};
@@ -264,6 +268,22 @@ pub struct CollectionPrefetch {
     pub params: Option<SearchParams>,
 }
 
+/// Exclude the referenced ids by editing the filter.
+fn exclude_referenced_ids(query: &Option<Query>, filter: Option<Filter>) -> Option<Filter> {
+    match query {
+        Some(Query::Vector(vector_query)) => {
+            let ids: HashSet<_> = vector_query
+                .get_referenced_ids()
+                .into_iter()
+                .cloned()
+                .collect();
+            let id_filter = Filter::new_must_not(Condition::HasId(HasIdCondition::from(ids)));
+            Some(id_filter.merge_owned(filter.unwrap_or_default()))
+        }
+        _ => filter,
+    }
+}
+
 impl CollectionPrefetch {
     fn try_into_shard_prefetch(
         self,
@@ -271,6 +291,8 @@ impl CollectionPrefetch {
         lookup_vector_name: &str,
         lookup_collection: Option<&String>,
     ) -> CollectionResult<ShardPrefetch> {
+        let filter = exclude_referenced_ids(&self.query, self.filter);
+
         let query = self
             .query
             .map(|query| {
@@ -298,7 +320,7 @@ impl CollectionPrefetch {
         Ok(ShardPrefetch {
             prefetches,
             query,
-            filter: self.filter,
+            filter,
             score_threshold: self.score_threshold,
             limit: self.limit,
             params: self.params,
@@ -307,6 +329,7 @@ impl CollectionPrefetch {
 }
 
 impl CollectionQueryRequest {
+    /// Substitutes all the point ids in the request with the actual vectors, as well as editing filters so that ids are not included in the response.
     pub fn try_into_shard_request(
         self,
         ids_to_vectors: &ReferencedVectors,
@@ -323,6 +346,8 @@ impl CollectionQueryRequest {
         let lookup_vector_name = (&self).get_lookup_vector_name();
         let lookup_collection = (&self).get_lookup_collection().cloned();
         let using = self.using.clone();
+
+        let filter = exclude_referenced_ids(&self.query, self.filter);
 
         let query = self
             .query
@@ -351,7 +376,7 @@ impl CollectionQueryRequest {
         Ok(ShardQueryRequest {
             prefetches,
             query,
-            filter: self.filter,
+            filter,
             score_threshold: self.score_threshold,
             limit: self.limit,
             offset: self.offset,

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -275,8 +275,13 @@ fn exclude_referenced_ids(query: &Option<Query>, filter: Option<Filter>) -> Opti
             let ids: HashSet<_> = vector_query
                 .get_referenced_ids()
                 .into_iter()
-                .cloned()
+                .copied()
                 .collect();
+
+            if ids.is_empty() {
+                return filter;
+            }
+
             let id_filter = Filter::new_must_not(Condition::HasId(HasIdCondition::from(ids)));
             Some(id_filter.merge_owned(filter.unwrap_or_default()))
         }

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -19,7 +19,7 @@ pub type ShardQueryResponse = Vec<Vec<ScoredPoint>>;
 /// Internal representation of a universal query request.
 ///
 /// Direct translation of the user-facing request, but with all point ids substituted with their corresponding vectors.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ShardQueryRequest {
     pub prefetches: Vec<ShardPrefetch>,
     pub query: Option<ScoringQuery>,
@@ -99,7 +99,7 @@ impl ScoringQuery {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ShardPrefetch {
     pub prefetches: Vec<ShardPrefetch>,
     pub query: Option<ScoringQuery>,


### PR DESCRIPTION
Needs #4404 

In the Query API, all vector inputs can be ids, for convenience, but we were missing to exclude those ids from the response.
