### PR TITLE
universal-query: some interface renaming/edits

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3207,8 +3207,8 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| positives | [VectorInput](#qdrant-VectorInput) | repeated | Look for vectors closest to the vectors from these points |
-| negatives | [VectorInput](#qdrant-VectorInput) | repeated | Try to avoid vectors like the vector from these points |
+| positive | [VectorInput](#qdrant-VectorInput) | repeated | Look for vectors closest to the vectors from these points |
+| negative | [VectorInput](#qdrant-VectorInput) | repeated | Try to avoid vectors like the vector from these points |
 | strategy | [RecommendStrategy](#qdrant-RecommendStrategy) | optional | How to use the provided vectors to find the results |
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -115,7 +115,8 @@
     - [Condition](#qdrant-Condition)
     - [ContextExamplePair](#qdrant-ContextExamplePair)
     - [ContextInput](#qdrant-ContextInput)
-    - [ContextPairInput](#qdrant-ContextPairInput)
+    - [ContextInputElement](#qdrant-ContextInputElement)
+    - [ContextInputPair](#qdrant-ContextInputPair)
     - [CountPoints](#qdrant-CountPoints)
     - [CountResponse](#qdrant-CountResponse)
     - [CountResult](#qdrant-CountResult)
@@ -1981,16 +1982,31 @@ The JSON representation for `Value` is a JSON value.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| context_pairs | [ContextPairInput](#qdrant-ContextPairInput) | repeated | Search space will be constrained by these pairs of vectors |
+| context | [ContextInputElement](#qdrant-ContextInputElement) | repeated | Search space will be constrained by these pairs of vectors |
 
 
 
 
 
 
-<a name="qdrant-ContextPairInput"></a>
+<a name="qdrant-ContextInputElement"></a>
 
-### ContextPairInput
+### ContextInputElement
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pair | [ContextInputPair](#qdrant-ContextInputPair) |  | leaving extensibility for unstructured context |
+
+
+
+
+
+
+<a name="qdrant-ContextInputPair"></a>
+
+### ContextInputPair
 
 
 
@@ -2227,7 +2243,7 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | target | [VectorInput](#qdrant-VectorInput) |  | Use this as the primary search objective |
-| context_pairs | [ContextPairInput](#qdrant-ContextPairInput) | repeated | Search space will be constrained by these pairs of vectors |
+| context | [ContextInputElement](#qdrant-ContextInputElement) | repeated | Search space will be constrained by these pairs of vectors |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -115,7 +115,6 @@
     - [Condition](#qdrant-Condition)
     - [ContextExamplePair](#qdrant-ContextExamplePair)
     - [ContextInput](#qdrant-ContextInput)
-    - [ContextInputElement](#qdrant-ContextInputElement)
     - [ContextInputPair](#qdrant-ContextInputPair)
     - [CountPoints](#qdrant-CountPoints)
     - [CountResponse](#qdrant-CountResponse)
@@ -1982,22 +1981,7 @@ The JSON representation for `Value` is a JSON value.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| context | [ContextInputElement](#qdrant-ContextInputElement) | repeated | Search space will be constrained by these pairs of vectors |
-
-
-
-
-
-
-<a name="qdrant-ContextInputElement"></a>
-
-### ContextInputElement
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| pair | [ContextInputPair](#qdrant-ContextInputPair) |  | leaving extensibility for unstructured context |
+| pairs | [ContextInputPair](#qdrant-ContextInputPair) | repeated | Search space will be constrained by these pairs of vectors |
 
 
 
@@ -2243,7 +2227,7 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | target | [VectorInput](#qdrant-VectorInput) |  | Use this as the primary search objective |
-| context | [ContextInputElement](#qdrant-ContextInputElement) | repeated | Search space will be constrained by these pairs of vectors |
+| context | [ContextInput](#qdrant-ContextInput) |  | Search space will be constrained by these pairs of vectors |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11338,7 +11338,7 @@
             ]
           },
           "query": {
-            "description": "Query to perform. If missing, returns points ordered by their IDs.",
+            "description": "Query to perform. If missing without prefetches, returns points ordered by their IDs.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/QueryInterface"
@@ -11441,7 +11441,7 @@
             ]
           },
           "query": {
-            "description": "Query to perform. If missing, returns points ordered by their IDs.",
+            "description": "Query to perform. If missing without prefetches, returns points ordered by their IDs.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/QueryInterface"
@@ -11705,10 +11705,13 @@
         ]
       },
       "Fusion": {
-        "anyOf": [
+        "oneOf": [
           {
             "description": "Reciprocal rank fusion",
-            "nullable": true
+            "type": "string",
+            "enum": [
+              "rrf"
+            ]
           }
         ]
       }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11615,7 +11615,7 @@
       "RecommendInput": {
         "type": "object",
         "properties": {
-          "positives": {
+          "positive": {
             "description": "Look for vectors closest to the vectors from these points",
             "type": "array",
             "items": {
@@ -11623,7 +11623,7 @@
             },
             "nullable": true
           },
-          "negatives": {
+          "negative": {
             "description": "Try to avoid vectors like the vector from these points",
             "type": "array",
             "items": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11647,14 +11647,14 @@
       "DiscoverInput": {
         "type": "object",
         "required": [
-          "context_pairs",
+          "context",
           "target"
         ],
         "properties": {
           "target": {
             "$ref": "#/components/schemas/VectorInput"
           },
-          "context_pairs": {
+          "context": {
             "description": "Search space will be constrained by these pairs of vectors",
             "anyOf": [
               {
@@ -11689,29 +11689,20 @@
         }
       },
       "ContextInput": {
-        "type": "object",
-        "required": [
-          "pairs"
-        ],
-        "properties": {
-          "pairs": {
-            "description": "Search space will be constrained by these pairs of vectors",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ContextPair"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/ContextPair"
-                }
-              },
-              {
-                "nullable": true
-              }
-            ]
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ContextPair"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContextPair"
+            }
+          },
+          {
+            "nullable": true
           }
-        }
+        ]
       },
       "Fusion": {
         "anyOf": [

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -483,8 +483,8 @@ message CountPoints {
 }
 
 message RecommendInput {
-  repeated VectorInput positives = 1; // Look for vectors closest to the vectors from these points
-  repeated VectorInput negatives = 2; // Try to avoid vectors like the vector from these points
+  repeated VectorInput positive = 1; // Look for vectors closest to the vectors from these points
+  repeated VectorInput negative = 2; // Try to avoid vectors like the vector from these points
   optional RecommendStrategy strategy = 3; // How to use the provided vectors to find the results
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -488,13 +488,6 @@ message RecommendInput {
   optional RecommendStrategy strategy = 3; // How to use the provided vectors to find the results
 }
 
-message ContextInputElement {
-  oneof variant {
-    ContextInputPair pair = 1;
-    // leaving extensibility for unstructured context
-  }
-}
-
 message ContextInputPair {
   VectorInput positive = 1; // A positive vector
   VectorInput negative = 2; // Repel from this vector
@@ -502,11 +495,11 @@ message ContextInputPair {
 
 message DiscoverInput {
   VectorInput target = 1; // Use this as the primary search objective
-  repeated ContextInputElement context = 2; // Search space will be constrained by these pairs of vectors
+  ContextInput context = 2; // Search space will be constrained by these pairs of vectors
 }
 
 message ContextInput {
-  repeated ContextInputElement context = 1; // Search space will be constrained by these pairs of vectors
+    repeated ContextInputPair pairs = 1; // Search space will be constrained by these pairs of vectors
 }
 
 enum Fusion {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -488,18 +488,25 @@ message RecommendInput {
   optional RecommendStrategy strategy = 3; // How to use the provided vectors to find the results
 }
 
-message ContextPairInput {
+message ContextInputElement {
+  oneof variant {
+    ContextInputPair pair = 1;
+    // leaving extensibility for unstructured context
+  }
+}
+
+message ContextInputPair {
   VectorInput positive = 1; // A positive vector
   VectorInput negative = 2; // Repel from this vector
 }
 
 message DiscoverInput {
   VectorInput target = 1; // Use this as the primary search objective
-  repeated ContextPairInput context_pairs = 2; // Search space will be constrained by these pairs of vectors
+  repeated ContextInputElement context = 2; // Search space will be constrained by these pairs of vectors
 }
 
 message ContextInput {
-  repeated ContextPairInput context_pairs = 1; // Search space will be constrained by these pairs of vectors
+  repeated ContextInputElement context = 1; // Search space will be constrained by these pairs of vectors
 }
 
 enum Fusion {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4741,7 +4741,25 @@ pub struct RecommendInput {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ContextPairInput {
+pub struct ContextInputElement {
+    #[prost(oneof = "context_input_element::Variant", tags = "1")]
+    pub variant: ::core::option::Option<context_input_element::Variant>,
+}
+/// Nested message and enum types in `ContextInputElement`.
+pub mod context_input_element {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        /// leaving extensibility for unstructured context
+        #[prost(message, tag = "1")]
+        Pair(super::ContextInputPair),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContextInputPair {
     /// A positive vector
     #[prost(message, optional, tag = "1")]
     pub positive: ::core::option::Option<VectorInput>,
@@ -4758,7 +4776,7 @@ pub struct DiscoverInput {
     pub target: ::core::option::Option<VectorInput>,
     /// Search space will be constrained by these pairs of vectors
     #[prost(message, repeated, tag = "2")]
-    pub context_pairs: ::prost::alloc::vec::Vec<ContextPairInput>,
+    pub context: ::prost::alloc::vec::Vec<ContextInputElement>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -4766,7 +4784,7 @@ pub struct DiscoverInput {
 pub struct ContextInput {
     /// Search space will be constrained by these pairs of vectors
     #[prost(message, repeated, tag = "1")]
-    pub context_pairs: ::prost::alloc::vec::Vec<ContextPairInput>,
+    pub context: ::prost::alloc::vec::Vec<ContextInputElement>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4741,24 +4741,6 @@ pub struct RecommendInput {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ContextInputElement {
-    #[prost(oneof = "context_input_element::Variant", tags = "1")]
-    pub variant: ::core::option::Option<context_input_element::Variant>,
-}
-/// Nested message and enum types in `ContextInputElement`.
-pub mod context_input_element {
-    #[derive(serde::Serialize)]
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Variant {
-        /// leaving extensibility for unstructured context
-        #[prost(message, tag = "1")]
-        Pair(super::ContextInputPair),
-    }
-}
-#[derive(serde::Serialize)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContextInputPair {
     /// A positive vector
     #[prost(message, optional, tag = "1")]
@@ -4775,8 +4757,8 @@ pub struct DiscoverInput {
     #[prost(message, optional, tag = "1")]
     pub target: ::core::option::Option<VectorInput>,
     /// Search space will be constrained by these pairs of vectors
-    #[prost(message, repeated, tag = "2")]
-    pub context: ::prost::alloc::vec::Vec<ContextInputElement>,
+    #[prost(message, optional, tag = "2")]
+    pub context: ::core::option::Option<ContextInput>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -4784,7 +4766,7 @@ pub struct DiscoverInput {
 pub struct ContextInput {
     /// Search space will be constrained by these pairs of vectors
     #[prost(message, repeated, tag = "1")]
-    pub context: ::prost::alloc::vec::Vec<ContextInputElement>,
+    pub pairs: ::prost::alloc::vec::Vec<ContextInputPair>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4730,10 +4730,10 @@ pub struct CountPoints {
 pub struct RecommendInput {
     /// Look for vectors closest to the vectors from these points
     #[prost(message, repeated, tag = "1")]
-    pub positives: ::prost::alloc::vec::Vec<VectorInput>,
+    pub positive: ::prost::alloc::vec::Vec<VectorInput>,
     /// Try to avoid vectors like the vector from these points
     #[prost(message, repeated, tag = "2")]
-    pub negatives: ::prost::alloc::vec::Vec<VectorInput>,
+    pub negative: ::prost::alloc::vec::Vec<VectorInput>,
     /// How to use the provided vectors to find the results
     #[prost(enumeration = "RecommendStrategy", optional, tag = "3")]
     pub strategy: ::core::option::Option<i32>,

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -156,7 +156,7 @@ pub enum OrderByInterface {
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Fusion {
     /// Reciprocal rank fusion
     Rrf,

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -295,10 +295,10 @@ pub enum RecommendStrategy {
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct RecommendInput {
     /// Look for vectors closest to the vectors from these points
-    pub positives: Option<Vec<VectorInput>>,
+    pub positive: Option<Vec<VectorInput>>,
 
     /// Try to avoid vectors like the vector from these points
-    pub negatives: Option<Vec<VectorInput>>,
+    pub negative: Option<Vec<VectorInput>>,
 
     /// How to use the provided vectors to find the results
     pub strategy: Option<RecommendStrategy>,
@@ -306,10 +306,10 @@ pub struct RecommendInput {
 
 impl RecommendInput {
     pub fn iter(&self) -> impl Iterator<Item = &VectorInput> {
-        self.positives
+        self.positive
             .iter()
             .flatten()
-            .chain(self.negatives.iter().flatten())
+            .chain(self.negative.iter().flatten())
     }
 }
 

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -323,17 +323,16 @@ pub struct DiscoverInput {
     #[validate]
     #[serde(with = "MaybeOneOrMany")]
     #[schemars(with = "MaybeOneOrMany<ContextPair>")]
-    pub context_pairs: Option<Vec<ContextPair>>,
+    pub context: Option<Vec<ContextPair>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
-pub struct ContextInput {
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ContextInput(
     /// Search space will be constrained by these pairs of vectors
-    #[validate]
     #[serde(with = "MaybeOneOrMany")]
     #[schemars(with = "MaybeOneOrMany<ContextPair>")]
-    pub pairs: Option<Vec<ContextPair>>,
-}
+    pub Option<Vec<ContextPair>>,
+);
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
 pub struct ContextPair {
@@ -344,4 +343,10 @@ pub struct ContextPair {
     /// Repel from this vector
     #[validate]
     pub negative: VectorInput,
+}
+
+impl ContextPair {
+    pub fn iter(&self) -> impl Iterator<Item = &VectorInput> {
+        std::iter::once(&self.positive).chain(std::iter::once(&self.negative))
+    }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -179,7 +179,7 @@ pub struct QueryRequestInternal {
     #[schemars(with = "MaybeOneOrMany<Prefetch>")]
     pub prefetch: Option<Vec<Prefetch>>,
 
-    /// Query to perform. If missing, returns points ordered by their IDs.
+    /// Query to perform. If missing without prefetches, returns points ordered by their IDs.
     #[validate]
     pub query: Option<QueryInterface>,
 
@@ -254,7 +254,7 @@ pub struct Prefetch {
     #[schemars(with = "MaybeOneOrMany<Prefetch>")]
     pub prefetch: Option<Vec<Prefetch>>,
 
-    /// Query to perform. If missing, returns points ordered by their IDs.
+    /// Query to perform. If missing without prefetches, returns points ordered by their IDs.
     #[validate]
     pub query: Option<QueryInterface>,
 

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -2,7 +2,9 @@ use common::validation::validate_multi_vector;
 use validator::{Validate, ValidationError};
 
 use super::schema::{BatchVectorStruct, Vector, VectorStruct};
-use super::{Fusion, OrderByInterface, Query, QueryInterface, RecommendInput, VectorInput};
+use super::{
+    ContextInput, Fusion, OrderByInterface, Query, QueryInterface, RecommendInput, VectorInput,
+};
 use crate::rest::NamedVectorStruct;
 
 impl Validate for VectorStruct {
@@ -103,6 +105,16 @@ impl Validate for RecommendInput {
         }
 
         for item in self.iter() {
+            item.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Validate for ContextInput {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        for item in self.0.iter().flatten().flat_map(|item| item.iter()) {
             item.validate()?;
         }
 

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -82,16 +82,8 @@ impl Validate for VectorInput {
 
 impl Validate for RecommendInput {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        let no_positives = self
-            .positives
-            .as_ref()
-            .map(|p| p.is_empty())
-            .unwrap_or(true);
-        let no_negatives = self
-            .positives
-            .as_ref()
-            .map(|n| n.is_empty())
-            .unwrap_or(true);
+        let no_positives = self.positive.as_ref().map(|p| p.is_empty()).unwrap_or(true);
+        let no_negatives = self.negative.as_ref().map(|n| n.is_empty()).unwrap_or(true);
 
         if no_positives && no_negatives {
             let mut errors = validator::ValidationErrors::new();

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -475,13 +475,13 @@ mod from_rest {
     impl From<rest::RecommendInput> for VectorQuery<VectorInput> {
         fn from(value: rest::RecommendInput) -> Self {
             let rest::RecommendInput {
-                positives,
-                negatives,
+                positive,
+                negative,
                 strategy,
             } = value;
 
-            let positives = positives.into_iter().flatten().map(From::from).collect();
-            let negatives = negatives.into_iter().flatten().map(From::from).collect();
+            let positives = positive.into_iter().flatten().map(From::from).collect();
+            let negatives = negative.into_iter().flatten().map(From::from).collect();
 
             let reco_query = RecoQuery::new(positives, negatives);
 
@@ -694,16 +694,16 @@ mod from_grpc {
 
         fn try_from(value: grpc::RecommendInput) -> Result<Self, Self::Error> {
             let grpc::RecommendInput {
-                positives,
-                negatives,
+                positive,
+                negative,
                 strategy,
             } = value;
 
-            let positives = positives
+            let positives = positive
                 .into_iter()
                 .map(TryFrom::try_from)
                 .collect::<Result<Vec<_>, _>>()?;
-            let negatives = negatives
+            let negatives = negative
                 .into_iter()
                 .map(TryFrom::try_from)
                 .collect::<Result<Vec<_>, _>>()?;

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -494,13 +494,10 @@ mod from_rest {
 
     impl From<rest::DiscoverInput> for VectorQuery<VectorInput> {
         fn from(value: rest::DiscoverInput) -> Self {
-            let rest::DiscoverInput {
-                target,
-                context_pairs,
-            } = value;
+            let rest::DiscoverInput { target, context } = value;
 
             let target = From::from(target);
-            let context = context_pairs
+            let context = context
                 .into_iter()
                 .flatten()
                 .map(context_pair_from_rest)
@@ -512,7 +509,7 @@ mod from_rest {
 
     impl From<rest::ContextInput> for VectorQuery<VectorInput> {
         fn from(value: rest::ContextInput) -> Self {
-            let rest::ContextInput { pairs } = value;
+            let rest::ContextInput(pairs) = value;
 
             let context = pairs
                 .into_iter()
@@ -731,17 +728,14 @@ mod from_grpc {
         type Error = Status;
 
         fn try_from(value: grpc::DiscoverInput) -> Result<Self, Self::Error> {
-            let grpc::DiscoverInput {
-                target,
-                context_pairs,
-            } = value;
+            let grpc::DiscoverInput { target, context } = value;
 
             let target = VectorInput::try_from(
                 target
                     .ok_or_else(|| Status::invalid_argument("DiscoverInput target is missing"))?,
             )?;
 
-            let context = context_pairs
+            let context = context
                 .into_iter()
                 .map(context_pair_from_grpc)
                 .collect::<Result<_, _>>()?;
@@ -754,10 +748,10 @@ mod from_grpc {
         type Error = Status;
 
         fn try_from(value: grpc::ContextInput) -> Result<Self, Self::Error> {
-            let grpc::ContextInput { context_pairs } = value;
+            let grpc::ContextInput { context } = value;
 
             Ok(VectorQuery::Context(ContextQuery {
-                pairs: context_pairs
+                pairs: context
                     .into_iter()
                     .map(context_pair_from_grpc)
                     .collect::<Result<_, _>>()?,
@@ -791,9 +785,15 @@ mod from_grpc {
 
     /// Circular dependencies prevents us from implementing `TryFrom` directly
     fn context_pair_from_grpc(
-        value: grpc::ContextPairInput,
+        value: grpc::ContextInputElement,
     ) -> Result<ContextPair<VectorInput>, Status> {
-        let grpc::ContextPairInput { positive, negative } = value;
+        let variant = value
+            .variant
+            .ok_or_else(|| Status::invalid_argument("ContextInputElement variant is missing"))?;
+
+        let grpc::context_input_element::Variant::Pair(value) = variant;
+
+        let grpc::ContextInputPair { positive, negative } = value;
 
         let positive =
             positive.ok_or_else(|| Status::invalid_argument("ContextPair positive is missing"))?;


### PR DESCRIPTION
Needs #4405 

in grpc:
- restructure `ContextInput`, so that it becomes easy to handle both pairs and positive/negative lists in the future

in rest: 
- restructure context queries so that they don't repeat the label in order to be used . E.g. turn `{ query: { context: { context: [ ... ] } } }` into `{ query: { context: [ ... ] } }` 
- fixes fusion so that `{query: { fusion: "rrf" } }` actually works

both:
- renames `RecommendInput` positives and negatives to singular (same as in reco api)