### PR TITLE
universal-query: Reject having prefetches without a rescoring query

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -896,8 +896,10 @@ impl CollectionError {
         CollectionError::NotFound { what: what.into() }
     }
 
-    pub fn bad_request(description: String) -> CollectionError {
-        CollectionError::BadRequest { description }
+    pub fn bad_request(description: impl Into<String>) -> CollectionError {
+        CollectionError::BadRequest {
+            description: description.into(),
+        }
     }
 
     pub fn bad_shard_selection(description: String) -> CollectionError {

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -296,6 +296,13 @@ impl CollectionPrefetch {
         lookup_vector_name: &str,
         lookup_collection: Option<&String>,
     ) -> CollectionResult<ShardPrefetch> {
+        // Check no prefetches without a query
+        if !self.prefetch.is_empty() && self.query.is_none() {
+            return Err(CollectionError::bad_request(
+                "A query is needed to merge the prefetches. Can't have prefetches without defining a query.",
+            ));
+        }
+
         let filter = exclude_referenced_ids(&self.query, self.filter);
 
         let query = self
@@ -339,6 +346,13 @@ impl CollectionQueryRequest {
         self,
         ids_to_vectors: &ReferencedVectors,
     ) -> CollectionResult<ShardQueryRequest> {
+        // Check no prefetches without a query
+        if !self.prefetch.is_empty() && self.query.is_none() {
+            return Err(CollectionError::bad_request(
+                "A query is needed to merge the prefetches. Can't have prefetches without defining a query.",
+            ));
+        }
+
         // Check we actually fetched all referenced vectors in this request (and nested prefetches)
         for &point_id in &(&self).get_referenced_point_ids() {
             if ids_to_vectors.get(&None, point_id).is_none() {

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -212,7 +212,7 @@ impl ShardHolder {
 
                 None => {
                     return Err(CollectionError::bad_request(
-                        "resharding is not in progress".into(),
+                        "resharding is not in progress",
                     ))
                 }
             }

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -130,7 +130,7 @@ pub fn validate_transfer(
     if transfer.method == Some(ShardTransferMethod::ReshardingStreamRecords) {
         let Some(to_shard_id) = transfer.to_shard_id else {
             return Err(CollectionError::bad_request(
-                "Target shard is not set for resharding transfer".into(),
+                "Target shard is not set for resharding transfer",
             ));
         };
 


### PR DESCRIPTION
Needs #4406 

Defining `prefetch`es without defining a rescoring `query` does not make much sense, and makes handling ambiguous. So we rather reject this combination.