### PR TITLE
universal-query: Fix lost offset in planned query conversion

### DIFF
--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -649,7 +649,7 @@ mod tests {
                 ),),
                 filter: dummy_filter,
                 params: dummy_params,
-                limit: 37,
+                limit: 37 + 49, // limit + offset
                 offset: 0,
                 with_payload: Some(WithPayloadInterface::Bool(false)),
                 with_vector: Some(WithVector::Bool(false)),

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -169,7 +169,10 @@ impl TryFrom<ShardQueryRequest> for PlannedQuery {
             with_payload = WithPayloadInterface::Bool(false);
 
             // Root-level query without prefetches is the only case where merge is `None`
-            MergePlan { sources, merge: None }
+            MergePlan {
+                sources,
+                merge: None,
+            }
         };
 
         Ok(Self {

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -136,7 +136,7 @@ impl TryFrom<ShardQueryRequest> for PlannedQuery {
                         filter: req_filter,
                         with_vector: req_with_vector,
                         with_payload: Some(req_with_payload),
-                        limit: Some(limit),
+                        limit: Some(limit + req_offset),
                         offset: None,
                     };
 
@@ -153,7 +153,7 @@ impl TryFrom<ShardQueryRequest> for PlannedQuery {
                         filter: req_filter,
                         with_vector: req_with_vector,
                         with_payload: Some(req_with_payload),
-                        limit: Some(limit),
+                        limit: Some(limit + req_offset),
                         offset: None,
                     };
 


### PR DESCRIPTION
I realized we were sometimes ignoring `offset` when crafting the `PlannedQuery`, specifically in the case of root-level scroll-like requests. This PR fixes this and propagates the root level offset into all the limits in prefetches