### PR TITLE
Ensure we have any segment within capacity, otherwise add new one

### DIFF
--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -222,9 +222,9 @@ pub(crate) fn get_merge_optimizer(
     MergeOptimizer::new(
         5,
         optimizer_thresholds.unwrap_or(OptimizerThresholds {
-            max_segment_size: 100_000,
-            memmap_threshold: 1_000_000,
-            indexing_threshold: 1_000_000,
+            max_segment_size_kb: 100_000,
+            memmap_threshold_kb: 1_000_000,
+            indexing_threshold_kb: 1_000_000,
         }),
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),
@@ -247,9 +247,9 @@ pub(crate) fn get_indexing_optimizer(
     IndexingOptimizer::new(
         2,
         OptimizerThresholds {
-            max_segment_size: 100_000,
-            memmap_threshold: 100,
-            indexing_threshold: 100,
+            max_segment_size_kb: 100_000,
+            memmap_threshold_kb: 100,
+            indexing_threshold_kb: 100,
         },
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -35,7 +35,7 @@ pub fn empty_segment(path: &Path) -> Segment {
 
 /// A generator for random point IDs
 #[derive(Default)]
-struct PointIdGenerator {
+pub(crate) struct PointIdGenerator {
     thread_rng: ThreadRng,
     used: HashSet<u64>,
 }
@@ -217,14 +217,15 @@ pub(crate) fn get_merge_optimizer(
     segment_path: &Path,
     collection_temp_dir: &Path,
     dim: usize,
+    optimizer_thresholds: Option<OptimizerThresholds>,
 ) -> MergeOptimizer {
     MergeOptimizer::new(
         5,
-        OptimizerThresholds {
+        optimizer_thresholds.unwrap_or(OptimizerThresholds {
             max_segment_size: 100_000,
-            memmap_threshold: 1000000,
-            indexing_threshold: 1000000,
-        },
+            memmap_threshold: 1_000_000,
+            indexing_threshold: 1_000_000,
+        }),
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),
         CollectionParams {

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -296,9 +296,9 @@ mod tests {
         // Collection configuration
         let (point_count, dim) = (1000, 10);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: usize::MAX,
-            memmap_threshold: usize::MAX,
-            indexing_threshold: 10,
+            max_segment_size_kb: usize::MAX,
+            memmap_threshold_kb: usize::MAX,
+            indexing_threshold_kb: 10,
         };
         let collection_params = CollectionParams {
             vectors: VectorsConfig::Single(
@@ -430,9 +430,9 @@ mod tests {
         // Collection configuration
         let (point_count, vector1_dim, vector2_dim) = (1000, 10, 20);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: usize::MAX,
-            memmap_threshold: usize::MAX,
-            indexing_threshold: 10,
+            max_segment_size_kb: usize::MAX,
+            memmap_threshold_kb: usize::MAX,
+            indexing_threshold_kb: 10,
         };
         let hnsw_config_vector1 = HnswConfigDiff {
             m: Some(10),
@@ -598,9 +598,9 @@ mod tests {
         // Collection configuration
         let (point_count, vector1_dim, vector2_dim) = (1000, 10, 20);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: usize::MAX,
-            memmap_threshold: usize::MAX,
-            indexing_threshold: 10,
+            max_segment_size_kb: usize::MAX,
+            memmap_threshold_kb: usize::MAX,
+            indexing_threshold_kb: 10,
         };
         let quantization_config_vector1 =
             QuantizationConfig::Scalar(segment::types::ScalarQuantization {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -112,11 +112,11 @@ impl IndexingOptimizer {
 
                 let indexing_threshold_bytes = self
                     .thresholds_config
-                    .indexing_threshold
+                    .indexing_threshold_kb
                     .saturating_mul(BYTES_IN_KB);
                 let mmap_threshold_bytes = self
                     .thresholds_config
-                    .memmap_threshold
+                    .memmap_threshold_kb
                     .saturating_mul(BYTES_IN_KB);
                 let mut require_optimization = false;
 
@@ -210,7 +210,7 @@ impl IndexingOptimizer {
                 && selected_segment_size + size
                     < self
                         .thresholds_config
-                        .max_segment_size
+                        .max_segment_size_kb
                         .saturating_mul(BYTES_IN_KB)
             {
                 return vec![selected_segment_id, *idx];
@@ -224,7 +224,7 @@ impl IndexingOptimizer {
                 && selected_segment_size + size
                     < self
                         .thresholds_config
-                        .max_segment_size
+                        .max_segment_size_kb
                         .saturating_mul(BYTES_IN_KB)
             {
                 return vec![selected_segment_id, idx];
@@ -350,9 +350,9 @@ mod tests {
         let mut index_optimizer = IndexingOptimizer::new(
             2,
             OptimizerThresholds {
-                max_segment_size: 300,
-                memmap_threshold: 1000,
-                indexing_threshold: 1000,
+                max_segment_size_kb: 300,
+                memmap_threshold_kb: 1000,
+                indexing_threshold_kb: 1000,
             },
             segments_dir.path().to_owned(),
             segments_temp_dir.path().to_owned(),
@@ -371,8 +371,8 @@ mod tests {
             index_optimizer.check_condition(locked_holder.clone(), &excluded_ids);
         assert!(suggested_to_optimize.is_empty());
 
-        index_optimizer.thresholds_config.memmap_threshold = 1000;
-        index_optimizer.thresholds_config.indexing_threshold = 50;
+        index_optimizer.thresholds_config.memmap_threshold_kb = 1000;
+        index_optimizer.thresholds_config.indexing_threshold_kb = 50;
 
         let suggested_to_optimize =
             index_optimizer.check_condition(locked_holder.clone(), &excluded_ids);
@@ -451,9 +451,9 @@ mod tests {
         let mut index_optimizer = IndexingOptimizer::new(
             2,
             OptimizerThresholds {
-                max_segment_size: 300,
-                memmap_threshold: 1000,
-                indexing_threshold: 1000,
+                max_segment_size_kb: 300,
+                memmap_threshold_kb: 1000,
+                indexing_threshold_kb: 1000,
             },
             segments_dir.path().to_owned(),
             segments_temp_dir.path().to_owned(),
@@ -480,30 +480,30 @@ mod tests {
             index_optimizer.check_condition(locked_holder.clone(), &excluded_ids);
         assert!(suggested_to_optimize.is_empty());
 
-        index_optimizer.thresholds_config.memmap_threshold = 1000;
-        index_optimizer.thresholds_config.indexing_threshold = 50;
+        index_optimizer.thresholds_config.memmap_threshold_kb = 1000;
+        index_optimizer.thresholds_config.indexing_threshold_kb = 50;
 
         let suggested_to_optimize =
             index_optimizer.check_condition(locked_holder.clone(), &excluded_ids);
         assert!(suggested_to_optimize.contains(&large_segment_id));
         assert!(suggested_to_optimize.contains(&middle_low_segment_id));
 
-        index_optimizer.thresholds_config.memmap_threshold = 1000;
-        index_optimizer.thresholds_config.indexing_threshold = 1000;
+        index_optimizer.thresholds_config.memmap_threshold_kb = 1000;
+        index_optimizer.thresholds_config.indexing_threshold_kb = 1000;
 
         let suggested_to_optimize =
             index_optimizer.check_condition(locked_holder.clone(), &excluded_ids);
         assert!(suggested_to_optimize.is_empty());
 
-        index_optimizer.thresholds_config.memmap_threshold = 50;
-        index_optimizer.thresholds_config.indexing_threshold = 1000;
+        index_optimizer.thresholds_config.memmap_threshold_kb = 50;
+        index_optimizer.thresholds_config.indexing_threshold_kb = 1000;
 
         let suggested_to_optimize =
             index_optimizer.check_condition(locked_holder.clone(), &excluded_ids);
         assert!(suggested_to_optimize.contains(&large_segment_id));
 
-        index_optimizer.thresholds_config.memmap_threshold = 150;
-        index_optimizer.thresholds_config.indexing_threshold = 50;
+        index_optimizer.thresholds_config.memmap_threshold_kb = 150;
+        index_optimizer.thresholds_config.indexing_threshold_kb = 50;
 
         // ----- CREATE AN INDEXED FIELD ------
         process_field_index_operation(
@@ -658,7 +658,7 @@ mod tests {
 
         // Index even the smallest segment
         let permit = CpuPermit::dummy(permit_cpu_count as u32);
-        index_optimizer.thresholds_config.indexing_threshold = 20;
+        index_optimizer.thresholds_config.indexing_threshold_kb = 20;
         let suggested_to_optimize =
             index_optimizer.check_condition(locked_holder.clone(), &Default::default());
         assert!(suggested_to_optimize.contains(&small_segment_id));
@@ -744,9 +744,9 @@ mod tests {
         let index_optimizer = IndexingOptimizer::new(
             number_of_segments, // Keep the same number of segments
             OptimizerThresholds {
-                max_segment_size: 1000,
-                memmap_threshold: 1000,
-                indexing_threshold: 10, // Always optimize
+                max_segment_size_kb: 1000,
+                memmap_threshold_kb: 1000,
+                indexing_threshold_kb: 10, // Always optimize
             },
             segments_dir.path().to_owned(),
             segments_temp_dir.path().to_owned(),
@@ -821,9 +821,9 @@ mod tests {
         // Collection configuration
         let (point_count, dim) = (1000, 10);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: usize::MAX,
-            memmap_threshold: 10,
-            indexing_threshold: usize::MAX,
+            max_segment_size_kb: usize::MAX,
+            memmap_threshold_kb: 10,
+            indexing_threshold_kb: usize::MAX,
         };
         let mut collection_params = CollectionParams {
             vectors: VectorsConfig::Single(

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -176,7 +176,7 @@ mod tests {
             holder.add_new(random_segment(dir.path(), 100, 60, dim)),
         ];
 
-        let mut merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim);
+        let mut merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim, None);
 
         let locked_holder = Arc::new(RwLock::new(holder));
 
@@ -217,7 +217,7 @@ mod tests {
             holder.add_new(random_segment(dir.path(), 100, 20, dim)),
         ];
 
-        let merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim);
+        let merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim, None);
 
         let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -129,7 +129,7 @@ impl SegmentOptimizer for MergeOptimizer {
                 *size
                     < self
                         .thresholds_config
-                        .max_segment_size
+                        .max_segment_size_kb
                         .saturating_mul(BYTES_IN_KB)
             })
             .take(max_candidates)
@@ -182,14 +182,14 @@ mod tests {
 
         merge_optimizer.default_segments_number = 1;
 
-        merge_optimizer.thresholds_config.max_segment_size = 100;
+        merge_optimizer.thresholds_config.max_segment_size_kb = 100;
 
         let check_result_empty =
             merge_optimizer.check_condition(locked_holder.clone(), &Default::default());
 
         assert!(check_result_empty.is_empty());
 
-        merge_optimizer.thresholds_config.max_segment_size = 200;
+        merge_optimizer.thresholds_config.max_segment_size_kb = 200;
 
         let check_result = merge_optimizer.check_condition(locked_holder, &Default::default());
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -33,9 +33,9 @@ const BYTES_IN_KB: usize = 1024;
 
 #[derive(Debug, Clone)]
 pub struct OptimizerThresholds {
-    pub max_segment_size: usize,
-    pub memmap_threshold: usize,
-    pub indexing_threshold: usize,
+    pub max_segment_size_kb: usize,
+    pub memmap_threshold_kb: usize,
+    pub indexing_threshold_kb: usize,
 }
 
 /// SegmentOptimizer - trait implementing common functionality of the optimizers
@@ -147,10 +147,10 @@ pub trait SegmentOptimizer {
         let collection_params = self.collection_params();
 
         let threshold_is_indexed = maximal_vector_store_size_bytes
-            >= thresholds.indexing_threshold.saturating_mul(BYTES_IN_KB);
+            >= thresholds.indexing_threshold_kb.saturating_mul(BYTES_IN_KB);
 
         let threshold_is_on_disk = maximal_vector_store_size_bytes
-            >= thresholds.memmap_threshold.saturating_mul(BYTES_IN_KB);
+            >= thresholds.memmap_threshold_kb.saturating_mul(BYTES_IN_KB);
 
         let mut vector_data = collection_params.to_base_vector_data()?;
         let mut sparse_vector_data = collection_params.to_sparse_vector_data()?;

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -293,9 +293,9 @@ mod tests {
             0.2,
             50,
             OptimizerThresholds {
-                max_segment_size: 1000000,
-                memmap_threshold: 1000000,
-                indexing_threshold: 1000000,
+                max_segment_size_kb: 1000000,
+                memmap_threshold_kb: 1000000,
+                indexing_threshold_kb: 1000000,
             },
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
@@ -384,9 +384,9 @@ mod tests {
         // Collection configuration
         let (point_count, vector1_dim, vector2_dim) = (1000, 10, 20);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: usize::MAX,
-            memmap_threshold: usize::MAX,
-            indexing_threshold: 10,
+            max_segment_size_kb: usize::MAX,
+            memmap_threshold_kb: usize::MAX,
+            indexing_threshold_kb: 10,
         };
         let collection_params = CollectionParams {
             vectors: VectorsConfig::Multi(BTreeMap::from([

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -105,25 +105,25 @@ impl OptimizersConfig {
     }
 
     pub fn optimizer_thresholds(&self) -> OptimizerThresholds {
-        let indexing_threshold = match self.indexing_threshold {
+        let indexing_threshold_kb = match self.indexing_threshold {
             None => DEFAULT_INDEXING_THRESHOLD_KB, // default value
             Some(0) => usize::MAX,                 // disable vector index
             Some(custom) => custom,
         };
 
-        let memmap_threshold = match self.memmap_threshold {
+        let memmap_threshold_kb = match self.memmap_threshold {
             None | Some(0) => usize::MAX, // default | disable memmap
             Some(custom) => custom,
         };
 
         OptimizerThresholds {
-            memmap_threshold,
-            indexing_threshold,
-            max_segment_size: self.get_max_segment_size(),
+            memmap_threshold_kb,
+            indexing_threshold_kb,
+            max_segment_size_kb: self.get_max_segment_size_in_kilobytes(),
         }
     }
 
-    pub fn get_max_segment_size(&self) -> usize {
+    pub fn get_max_segment_size_in_kilobytes(&self) -> usize {
         if let Some(max_segment_size) = self.max_segment_size {
             max_segment_size
         } else {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -158,6 +158,8 @@ impl LocalShard {
 
         let mut update_handler = UpdateHandler::new(
             shared_storage_config.clone(),
+            config.params.clone(),
+            config.optimizer_config.optimizer_thresholds(),
             optimizers.clone(),
             optimizers_log.clone(),
             optimizer_cpu_budget.clone(),
@@ -681,6 +683,8 @@ impl LocalShard {
             &config.quantization_config,
         );
         update_handler.optimizers = new_optimizers;
+        update_handler.collection_params = config.params.clone();
+        update_handler.thresholds_config = config.optimizer_config.optimizer_thresholds();
         update_handler.flush_interval_sec = config.optimizer_config.flush_interval_sec;
         update_handler.max_optimization_threads = config.optimizer_config.max_optimization_threads;
         update_handler.run_workers(update_receiver);

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -158,8 +158,6 @@ impl LocalShard {
 
         let mut update_handler = UpdateHandler::new(
             shared_storage_config.clone(),
-            config.params.clone(),
-            config.optimizer_config.optimizer_thresholds(),
             optimizers.clone(),
             optimizers_log.clone(),
             optimizer_cpu_budget.clone(),
@@ -683,8 +681,6 @@ impl LocalShard {
             &config.quantization_config,
         );
         update_handler.optimizers = new_optimizers;
-        update_handler.collection_params = config.params.clone();
-        update_handler.thresholds_config = config.optimizer_config.optimizer_thresholds();
         update_handler.flush_interval_sec = config.optimizer_config.flush_interval_sec;
         update_handler.max_optimization_threads = config.optimizer_config.max_optimization_threads;
         update_handler.run_workers(update_receiver);

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -220,9 +220,9 @@ async fn test_new_segment_when_all_over_capacity() {
     holder.add_new(random_segment(dir.path(), 100, 3, dim));
 
     let optimizer_thresholds = OptimizerThresholds {
-        max_segment_size: 1,
-        memmap_threshold: 1_000_000,
-        indexing_threshold: 1_000_000,
+        max_segment_size_kb: 1,
+        memmap_threshold_kb: 1_000_000,
+        indexing_threshold_kb: 1_000_000,
     };
     let merge_optimizer: Arc<Optimizer> = Arc::new(get_merge_optimizer(
         dir.path(),

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -348,7 +348,7 @@ impl UpdateHandler {
                                 // Handle and report errors
                                 Err(error) => match error {
                                     CollectionError::Cancelled { description } => {
-                                        debug!("Optimization cancelled - {}", description);
+                                        debug!("Optimization cancelled - {description}");
                                         tracker_handle
                                             .update(TrackerStatus::Cancelled(description));
                                         false
@@ -360,7 +360,7 @@ impl UpdateHandler {
                                         // It is only possible to fix after full restart,
                                         // so the best available action here is to stop whole
                                         // optimization thread and log the error
-                                        log::error!("Optimization error: {}", error);
+                                        log::error!("Optimization error: {error}");
 
                                         tracker_handle
                                             .update(TrackerStatus::Error(error.to_string()));

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -420,7 +420,7 @@ impl UpdateHandler {
                         .max_available_vectors_size_in_bytes()
                         .unwrap_or_default();
                     let max_segment_size_bytes = thresholds_config
-                        .max_segment_size
+                        .max_segment_size_kb
                         .saturating_add(segment::common::BYTES_IN_KB);
 
                     max_vector_size_bytes >= max_segment_size_bytes

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -406,7 +406,7 @@ impl UpdateHandler {
                         .unwrap_or_default();
                     let max_segment_size_bytes = thresholds_config
                         .max_segment_size_kb
-                        .saturating_add(segment::common::BYTES_IN_KB);
+                        .saturating_mul(segment::common::BYTES_IN_KB);
 
                     max_vector_size_bytes >= max_segment_size_bytes
                 })

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -66,8 +66,10 @@ def test_triple_replication(tmp_path: pathlib.Path):
         all_active = True
         points_counts = set()
         for peer_api_uri in peer_api_uris:
+            count = get_collection_point_count(peer_api_uri, "test_collection", exact=True)
+            points_counts.add(count)
+
             res = check_collection_cluster(peer_api_uri, "test_collection")
-            points_counts.add(res['points_count'])
             if res['state'] != 'Active':
                 all_active = False
 
@@ -83,8 +85,8 @@ def test_triple_replication(tmp_path: pathlib.Path):
                         f.write(f"{peer_api_uri} {res.json()['result']}\n")
 
                 for peer_api_uri in peer_api_uris:
-                    res = requests.post(f"{peer_api_uri}/collections/test_collection/points/count", json={"exact": True})
-                    print(res.json())
+                    count = get_collection_point_count(peer_api_uri, "test_collection", exact=True)
+                    print(count)
 
                 assert False, f"Points count is not equal on all peers: {points_counts}"
             break

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -253,6 +253,13 @@ def get_collection_info(peer_api_uri: str, collection_name: str) -> dict:
     return res
 
 
+def get_collection_point_count(peer_api_uri: str, collection_name: str, exact: bool = False) -> int:
+    r = requests.post(f"{peer_api_uri}/collections/test_collection/points/count", json={"exact": exact})
+    assert_http_ok(r)
+    res = r.json()["result"]["count"]
+    return res
+
+
 def print_collection_cluster_info(peer_api_uri: str, collection_name: str, headers={}):
     print(json.dumps(get_collection_cluster_info(peer_api_uri, collection_name, headers=headers), indent=4))
 


### PR DESCRIPTION
Extend our optimizer loop to add a new empty segment if all segments are over capacity. The capacity check is based off `max_segment_size_kb` as configured by the user.

Routing writes to segments with capacity is done in the next PR: <https://github.com/qdrant/qdrant/pull/4420>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
