### PR TITLE
Rework `CommitHashRing` consensus message into `CommitRead`/`CommitWrite`/`Finish`

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -962,7 +962,11 @@ fn conditions_helper_to_grpc(conditions: Option<Vec<segment::types::Condition>>)
             if conditions.is_empty() {
                 vec![]
             } else {
-                conditions.into_iter().map(|c| c.into()).collect()
+                conditions
+                    .into_iter()
+                    .filter(|c| !matches!(c, segment::types::Condition::Resharding(_))) // TODO(resharding)!?
+                    .map(|c| c.into())
+                    .collect()
             }
         }
     }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1060,6 +1060,10 @@ impl From<segment::types::Condition> for Condition {
             segment::types::Condition::Nested(nested) => {
                 ConditionOneOf::Nested(nested.nested.into())
             }
+
+            segment::types::Condition::Resharding(_) => {
+                unimplemented!()
+            }
         };
 
         Self {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -964,7 +964,7 @@ fn conditions_helper_to_grpc(conditions: Option<Vec<segment::types::Condition>>)
             } else {
                 conditions
                     .into_iter()
-                    .filter(|c| !matches!(c, segment::types::Condition::Resharding(_))) // TODO(resharding)!?
+                    .filter(|c| !c.is_local_only()) // TODO(resharding)!?
                     .map(|c| c.into())
                     .collect()
             }

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -385,7 +385,7 @@ impl Collection {
         let with_payload = WithPayload::from(with_payload_interface);
         let request = Arc::new(request);
 
-        #[allow(unused_assignments)] // 🤦‍♀️
+        #[allow(unused_assignments)]
         let mut resharding_filter = None;
 
         let all_shard_collection_results = {

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -5,7 +5,7 @@ use futures::stream::FuturesUnordered;
 use futures::{future, StreamExt as _, TryFutureExt, TryStreamExt as _};
 use itertools::Itertools;
 use segment::data_types::order_by::{Direction, OrderBy};
-use segment::types::{ShardKey, WithPayload, WithPayloadInterface};
+use segment::types::{Filter, ShardKey, WithPayload, WithPayloadInterface};
 use validator::Validate as _;
 
 use super::Collection;
@@ -207,10 +207,15 @@ impl Collection {
 
     pub async fn scroll_by(
         &self,
-        request: ScrollRequestInternal,
+        mut request: ScrollRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
     ) -> CollectionResult<ScrollResult> {
+        merge_filters(
+            &mut request.filter,
+            self.shards_holder.read().await.resharding_filter(),
+        );
+
         let default_request = ScrollRequestInternal::default();
 
         let id_offset = request.offset;
@@ -333,10 +338,15 @@ impl Collection {
 
     pub async fn count(
         &self,
-        request: CountRequestInternal,
+        mut request: CountRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
     ) -> CollectionResult<CountResult> {
+        merge_filters(
+            &mut request.filter,
+            self.shards_holder.read().await.resharding_filter(),
+        );
+
         let shards_holder = self.shards_holder.read().await;
         let shards = shards_holder.select_shards(shard_selection)?;
 
@@ -374,8 +384,16 @@ impl Collection {
             .unwrap_or(&WithPayloadInterface::Bool(false));
         let with_payload = WithPayload::from(with_payload_interface);
         let request = Arc::new(request);
+
+        #[allow(unused_assignments)] // 🤦‍♀️
+        let mut resharding_filter = None;
+
         let all_shard_collection_results = {
             let shard_holder = self.shards_holder.read().await;
+
+            // Get resharding filter, while we hold the lock to shard holder
+            resharding_filter = shard_holder.resharding_filter_impl();
+
             let target_shards = shard_holder.select_shards(shard_selection)?;
             let retrieve_futures = target_shards.into_iter().map(|(shard, shard_key)| {
                 let shard_key = shard_key.cloned();
@@ -397,15 +415,32 @@ impl Collection {
                         Ok(records)
                     })
             });
+
             future::try_join_all(retrieve_futures).await?
         };
+
         let mut covered_point_ids = HashSet::new();
         let points = all_shard_collection_results
             .into_iter()
             .flatten()
+            // If resharding is in progress, and *read* hash-ring is committed, filter-out "resharded" points
+            .filter(|point| match &resharding_filter {
+                Some(filter) => filter.check(point.id),
+                None => true,
+            })
             // Add each point only once, deduplicate point IDs
             .filter(|point| covered_point_ids.insert(point.id))
             .collect();
+
         Ok(points)
+    }
+}
+
+fn merge_filters(filter: &mut Option<Filter>, resharding_filter: Option<Filter>) {
+    if let Some(resharding_filter) = resharding_filter {
+        *filter = Some(match filter.take() {
+            Some(filter) => filter.merge_owned(resharding_filter),
+            None => resharding_filter,
+        });
     }
 }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -87,8 +87,25 @@ impl Collection {
         Ok(())
     }
 
-    pub async fn commit_hashring(&self, reshard: ReshardKey) -> CollectionResult<()> {
-        self.shards_holder.write().await.commit_hashring(reshard)
+    pub async fn commit_read_hashring(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
+        self.shards_holder
+            .write()
+            .await
+            .commit_read_hashring(resharding_key)
+    }
+
+    pub async fn commit_write_hashring(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
+        self.shards_holder
+            .write()
+            .await
+            .commit_write_hashring(resharding_key)
+    }
+
+    pub async fn finish_resharding(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
+        self.shards_holder
+            .write()
+            .await
+            .finish_resharding(resharding_key)
     }
 
     pub async fn abort_resharding(&self, reshard_key: ReshardKey) -> CollectionResult<()> {

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -76,7 +76,7 @@ impl<T: Hash + Copy + PartialEq> HashRing<T> {
         new.add(shard);
     }
 
-    pub fn commit(&mut self) -> bool {
+    pub fn commit_resharding(&mut self) -> bool {
         let Self::Resharding { new, .. } = self else {
             log::warn!("committing resharding hashring, but hashring is not in resharding mode");
             return false;

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,7 +1,9 @@
-use std::fmt;
 use std::hash::Hash;
+use std::{any, fmt};
 
 use itertools::Itertools as _;
+use segment::index::field_index::CardinalityEstimation;
+use segment::types::{PointIdType, ReshardingCondition};
 use smallvec::SmallVec;
 
 use crate::shards::shard::ShardId;
@@ -245,6 +247,61 @@ impl<T: Hash + Copy> Inner<T> {
             Inner::Raw(ring) => ring.is_empty(),
             Inner::Fair { ring, .. } => ring.is_empty(),
         }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Inner::Raw(ring) => ring.len(),
+            Inner::Fair { ring, scale } => ring.len() / *scale as usize,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Filter<T = ShardId> {
+    ring: Inner<T>,
+    filter: T,
+}
+
+impl<T> Filter<T> {
+    pub fn new(ring: Inner<T>, filter: T) -> Self {
+        Self { ring, filter }
+    }
+
+    pub fn check(&self, point_id: PointIdType) -> bool
+    where
+        T: Hash + PartialEq + Copy,
+    {
+        self.ring.get(&point_id) == Some(&self.filter)
+    }
+}
+
+impl<T> ReshardingCondition for Filter<T>
+where
+    T: fmt::Debug + Hash + PartialEq + Copy + 'static,
+{
+    fn check(&self, point_id: PointIdType) -> bool {
+        self.check(point_id)
+    }
+
+    fn estimate_cardinality(&self, points: usize) -> CardinalityEstimation {
+        CardinalityEstimation {
+            primary_clauses: vec![],
+            min: 0,
+            exp: points / self.ring.len(),
+            max: points,
+        }
+    }
+
+    fn eq(&self, other: &dyn ReshardingCondition) -> bool {
+        match other.as_any().downcast_ref::<Self>() {
+            Some(other) => self == other,
+            None => false,
+        }
+    }
+
+    fn as_any(&self) -> &dyn any::Any {
+        self
     }
 }
 

--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -62,6 +62,7 @@ impl ShardReplicaSet {
 
         let remotes_count = remotes.len();
 
+        // TODO(resharding): Handle resharded shard?
         let active_remotes_count = remotes
             .iter()
             .filter(|remote| self.peer_is_active(&remote.peer_id))
@@ -179,6 +180,7 @@ impl ShardReplicaSet {
             None
         };
 
+        // TODO(resharding): Handle resharded shard?
         let mut active_remotes: Vec<_> = remotes
             .iter()
             .filter(|remote| self.peer_is_active(&remote.peer_id))

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -34,6 +34,7 @@ pub struct ReshardState {
     pub peer_id: PeerId,
     pub shard_id: ShardId,
     pub shard_key: Option<ShardKey>,
+    pub filter_read_operations: bool, // TODO(resharding): Add proper resharding state!
 }
 
 impl ReshardState {
@@ -42,6 +43,7 @@ impl ReshardState {
             peer_id,
             shard_id,
             shard_key,
+            filter_read_operations: false,
         }
     }
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -197,13 +197,13 @@ impl ShardHolder {
             ..
         } = resharding_key;
 
-        let ring = get_ring(&mut self.rings, &shard_key)?;
+        let ring = get_ring(&mut self.rings, shard_key)?;
 
         let state = self.resharding_state.read();
         assert_resharding_state_consistency(&state, ring, &resharding_key.shard_key);
 
         match state.deref() {
-            Some(state) if state.matches(&resharding_key) => {
+            Some(state) if state.matches(resharding_key) => {
                 check_state(state)?;
             }
 
@@ -221,7 +221,7 @@ impl ShardHolder {
         }
 
         debug_assert!(
-            self.shards.contains_key(&shard_id),
+            self.shards.contains_key(shard_id),
             "shard holder does not contain shard {shard_id} replica set"
         );
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -186,35 +186,37 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn commit_hashring(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
+    pub fn check_resharding(
+        &mut self,
+        resharding_key: &ReshardKey,
+        check_state: impl Fn(&ReshardState) -> CollectionResult<()>,
+    ) -> CollectionResult<()> {
         let ReshardKey {
             shard_id,
-            ref shard_key,
+            shard_key,
             ..
         } = resharding_key;
 
-        let ring = get_ring(&mut self.rings, shard_key)?;
+        let ring = get_ring(&mut self.rings, &shard_key)?;
 
-        {
-            let state = self.resharding_state.read();
-            assert_resharding_state_consistency(&state, ring, shard_key);
+        let state = self.resharding_state.read();
+        assert_resharding_state_consistency(&state, ring, &resharding_key.shard_key);
 
-            match state.deref() {
-                Some(state) if state.matches(&resharding_key) => {
-                    // TODO(resharding): Check resharding is in the correct state to commit hashring!
-                }
+        match state.deref() {
+            Some(state) if state.matches(&resharding_key) => {
+                check_state(state)?;
+            }
 
-                Some(state) => {
-                    return Err(CollectionError::bad_request(format!(
-                        "another resharding is in progress:\n{state:#?}"
-                    )))
-                }
+            Some(state) => {
+                return Err(CollectionError::bad_request(format!(
+                    "another resharding is in progress:\n{state:#?}"
+                )));
+            }
 
-                None => {
-                    return Err(CollectionError::bad_request(
-                        "resharding is not in progress",
-                    ))
-                }
+            None => {
+                return Err(CollectionError::bad_request(
+                    "resharding is not in progress",
+                ));
             }
         }
 
@@ -225,9 +227,37 @@ impl ShardHolder {
 
         // TODO(resharding): Assert that peer exists!?
 
-        ring.commit();
+        Ok(())
+    }
+
+    pub fn commit_read_hashring(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
+        self.check_resharding(&resharding_key, |_| {
+            // TODO(resharding): Check resharding is in the correct state to commit read hashring!
+            Ok(())
+        })?;
+
+        todo!()
+    }
+
+    pub fn commit_write_hashring(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
+        self.check_resharding(&resharding_key, |_| {
+            // TODO(resharding): Check resharding is in the correct state to commit write hashring!
+            Ok(())
+        })?;
+
+        let ring = get_ring(&mut self.rings, &resharding_key.shard_key)?;
+        ring.commit_resharding();
 
         Ok(())
+    }
+
+    pub fn finish_resharding(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
+        self.check_resharding(&resharding_key, |_| {
+            // TODO(resharding): Check resharding is in the correct state to finish resharding!
+            Ok(())
+        })?;
+
+        todo!()
     }
 
     pub async fn abort_resharding(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
@@ -638,6 +668,8 @@ impl ShardHolder {
             }
             ShardSelectorInternal::All => {
                 for (&shard_id, shard) in self.shards.iter() {
+                    // TODO(resharding): Handle resharded shard!?
+
                     let is_resharding = self
                         .resharding_state
                         .read()
@@ -1249,10 +1281,13 @@ pub(crate) fn shard_not_found_error(shard_id: ShardId) -> CollectionError {
 
 fn get_ring<'a>(
     rings: &'a mut HashMap<Option<ShardKey>, HashRing>,
-    key: &'_ Option<ShardKey>,
+    shard_key: &'_ Option<ShardKey>,
 ) -> CollectionResult<&'a mut HashRing> {
-    rings.get_mut(key).ok_or_else(|| {
-        CollectionError::bad_request(format!("{} hashring does not exist", shard_key_fmt(key)))
+    rings.get_mut(shard_key).ok_or_else(|| {
+        CollectionError::bad_request(format!(
+            "{} hashring does not exist",
+            shard_key_fmt(shard_key)
+        ))
     })
 }
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -380,11 +380,11 @@ impl ShardHolder {
         }
 
         let Some(ring) = self.rings.get(&state.shard_key) else {
-            return None; // TODO(resharding)!?
+            return None; // TODO(resharding): Return error?
         };
 
         let HashRing::Resharding { new, .. } = ring else {
-            return None; // TODO(resharding)!?
+            return None; // TODO(resharding): Return error?
         };
 
         Some(hash_ring::Filter::new(new.clone(), state.shard_id))

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -361,6 +361,7 @@ impl ShardHolder {
         Ok(())
     }
 
+    /// A filter that excludes points migrated to a different shard, as part of resharding.
     pub fn resharding_filter(&self) -> Option<Filter> {
         let filter = self.resharding_filter_impl()?;
         let filter = Filter::new_must_not(Condition::Resharding(Arc::new(filter)));

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -349,6 +349,7 @@ mod tests {
                 exp: TOTAL / 2,
                 max: TOTAL,
             },
+            Condition::Resharding(_) => todo!(),
         }
     }
 

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -304,6 +304,7 @@ mod tests {
         match condition {
             Condition::Filter(_) => panic!("unexpected Filter"),
             Condition::Nested(_) => panic!("unexpected Nested"),
+            Condition::Resharding(_) => panic!("unexpected Resharding"),
             Condition::Field(field) => match field.key.to_string().as_str() {
                 "color" => CardinalityEstimation {
                     primary_clauses: vec![PrimaryCondition::Condition(field.clone())],
@@ -349,7 +350,6 @@ mod tests {
                 exp: TOTAL / 2,
                 max: TOTAL,
             },
-            Condition::Resharding(_) => todo!(),
         }
     }
 

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -121,6 +121,15 @@ pub fn condition_converter<'a>(
                 })
             })
         }
+        Condition::Resharding(cond) => {
+            let segment_ids: HashSet<_> = id_tracker
+                .iter_external()
+                .filter(|&point_id| cond.check(point_id))
+                .filter_map(|external_id| id_tracker.internal_id(external_id))
+                .collect();
+
+            Box::new(move |internal_id| segment_ids.contains(&internal_id))
+        }
         Condition::Filter(_) => unreachable!(),
     }
 }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -305,9 +305,14 @@ impl StructPayloadIndex {
                     max: num_ids,
                 }
             }
+
             Condition::Field(field_condition) => self
                 .estimate_field_condition(field_condition, nested_path)
                 .unwrap_or_else(|| CardinalityEstimation::unknown(self.available_point_count())),
+
+            Condition::Resharding(cond) => {
+                cond.estimate_cardinality(self.id_tracker.borrow().available_point_count())
+            }
         }
     }
 

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -147,6 +147,11 @@ where
                     )
                 })
         }
+
+        Condition::Resharding(cond) => id_tracker
+            .and_then(|id_tracker| id_tracker.external_id(point_id))
+            .map_or(false, |point_id| cond.check(point_id)),
+
         Condition::Filter(_) => unreachable!(),
     };
 

--- a/lib/segment/src/problems/unindexed_field.rs
+++ b/lib/segment/src/problems/unindexed_field.rs
@@ -323,6 +323,7 @@ impl<'a> Extractor<'a> {
             }
             // No index needed
             Condition::HasId(_) => return,
+            Condition::Resharding(_) => return,
         };
 
         let full_key = JsonPathV2::extend_or_new(nested_prefix, key);

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1976,6 +1976,13 @@ impl Condition {
             nested: Nested { key, filter },
         })
     }
+
+    pub fn is_local_only(&self) -> bool {
+        match self {
+            Condition::Resharding(_) => true,
+            _ => false,
+        }
+    }
 }
 
 // The validator crate does not support deriving for enums.

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,10 +1,12 @@
+use std::any;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::hash::Hash;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use common::types::ScoreType;
 use fnv::FnvBuildHasher;
@@ -27,6 +29,7 @@ use crate::data_types::integer_index::IntegerIndexParams;
 use crate::data_types::order_by::OrderValue;
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::VectorStructInternal;
+use crate::index::field_index::CardinalityEstimation;
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
 use crate::json_path::{JsonPath, JsonPathInterface};
 use crate::spaces::metric::MetricPostProcessing;
@@ -1931,7 +1934,7 @@ impl NestedCondition {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum Condition {
@@ -1947,6 +1950,24 @@ pub enum Condition {
     Nested(NestedCondition),
     /// Nested filter
     Filter(Filter),
+
+    #[serde(skip)]
+    Resharding(Arc<dyn ReshardingCondition + Send + Sync + 'static>),
+}
+
+impl PartialEq for Condition {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Field(this), Self::Field(other)) => this == other,
+            (Self::IsEmpty(this), Self::IsEmpty(other)) => this == other,
+            (Self::IsNull(this), Self::IsNull(other)) => this == other,
+            (Self::HasId(this), Self::HasId(other)) => this == other,
+            (Self::Nested(this), Self::Nested(other)) => this == other,
+            (Self::Filter(this), Self::Filter(other)) => this == other,
+            (Self::Resharding(this), Self::Resharding(other)) => this.eq(other.deref()),
+            _ => false,
+        }
+    }
 }
 
 impl Condition {
@@ -1965,8 +1986,17 @@ impl Validate for Condition {
             Condition::Field(field_condition) => field_condition.validate(),
             Condition::Nested(nested_condition) => nested_condition.validate(),
             Condition::Filter(filter) => filter.validate(),
+            Condition::Resharding(_) => Ok(()),
         }
     }
+}
+
+pub trait ReshardingCondition: fmt::Debug {
+    fn estimate_cardinality(&self, points: usize) -> CardinalityEstimation;
+    fn check(&self, point_id: ExtendedPointId) -> bool;
+
+    fn eq(&self, other: &dyn ReshardingCondition) -> bool;
+    fn as_any(&self) -> &dyn any::Any;
 }
 
 /// Options for specifying which payload to include or not

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1978,10 +1978,7 @@ impl Condition {
     }
 
     pub fn is_local_only(&self) -> bool {
-        match self {
-            Condition::Resharding(_) => true,
-            _ => false,
-        }
+        matches!(self, Condition::Resharding(_))
     }
 }
 

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -295,7 +295,9 @@ pub struct DeleteCollectionOperation(pub String);
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub enum ReshardingOperation {
     Start(ReshardKey),
-    CommitHashRing(ReshardKey),
+    CommitRead(ReshardKey),
+    CommitWrite(ReshardKey),
+    Finish(ReshardKey),
     Abort(ReshardKey),
 }
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -328,8 +328,16 @@ impl TableOfContent {
                     .await?;
             }
 
-            ReshardingOperation::CommitHashRing(key) => {
-                collection.commit_hashring(key).await?;
+            ReshardingOperation::CommitRead(key) => {
+                collection.commit_read_hashring(key).await?;
+            }
+
+            ReshardingOperation::CommitWrite(key) => {
+                collection.commit_write_hashring(key).await?;
+            }
+
+            ReshardingOperation::Finish(key) => {
+                collection.finish_resharding(key).await?;
             }
 
             ReshardingOperation::Abort(key) => {


### PR DESCRIPTION
Tracked in #4213.

This PR reworks `CommitHashRing` into three separate operations: `CommitRead`, `CommitWrite` and `Finish`.
We need all three to make resharding process seem "transparent" to the user.

We don't (yet) properly track resharding state, so this PR adds some "stubs" and `TODO`s in places where we will introduce state later.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
