### PR TITLE
When selecting a segment for writing, select one that has capacity

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -229,10 +229,11 @@ impl Collection {
     /// Partially blocking. Stopping existing optimizers is blocking. Starting new optimizers is
     /// not blocking.
     pub async fn recreate_optimizers_blocking(&self) -> CollectionResult<()> {
+        let effective_config = self.effective_optimizers_config().await?;
         let shard_holder = self.shards_holder.read().await;
         let updates = shard_holder
             .all_shards()
-            .map(|replica_set| replica_set.on_optimizer_config_update());
+            .map(|replica_set| replica_set.on_optimizer_config_update(effective_config.clone()));
         future::try_join_all(updates).await?;
         Ok(())
     }

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -33,6 +33,22 @@ pub fn empty_segment(path: &Path) -> Segment {
     build_simple_segment(path, 4, Distance::Dot).unwrap()
 }
 
+impl SegmentHolder {
+    pub fn fixture() -> Self {
+        Self::new(OptimizerThresholds::fixture())
+    }
+}
+
+impl OptimizerThresholds {
+    pub fn fixture() -> Self {
+        Self {
+            max_segment_size_kb: 100_000,
+            memmap_threshold_kb: 1_000_000,
+            indexing_threshold_kb: 1_000_000,
+        }
+    }
+}
+
 /// A generator for random point IDs
 #[derive(Default)]
 pub(crate) struct PointIdGenerator {
@@ -205,7 +221,7 @@ pub fn build_test_holder(path: &Path) -> RwLock<SegmentHolder> {
     let segment1 = build_segment_1(path);
     let segment2 = build_segment_2(path);
 
-    let mut holder = SegmentHolder::default();
+    let mut holder = SegmentHolder::fixture();
 
     let _sid1 = holder.add_new(segment1);
     let _sid2 = holder.add_new(segment2);
@@ -221,11 +237,7 @@ pub(crate) fn get_merge_optimizer(
 ) -> MergeOptimizer {
     MergeOptimizer::new(
         5,
-        optimizer_thresholds.unwrap_or(OptimizerThresholds {
-            max_segment_size_kb: 100_000,
-            memmap_threshold_kb: 1_000_000,
-            indexing_threshold_kb: 1_000_000,
-        }),
+        optimizer_thresholds.unwrap_or_else(OptimizerThresholds::fixture),
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),
         CollectionParams {
@@ -271,7 +283,7 @@ pub fn optimize_segment(segment: Segment) -> LockedSegment {
 
     let dim = segment.segment_config.vector_data.get("").unwrap().size;
 
-    let mut holder = SegmentHolder::default();
+    let mut holder = SegmentHolder::fixture();
 
     let segment_id = holder.add_new(segment);
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -457,7 +457,7 @@ impl<'s> SegmentHolder {
             ));
         }
 
-        let mut entries: Vec<_> = Default::default();
+        let mut entries: Vec<_> = Vec::with_capacity(segment_ids.len());
 
         // Try to access each segment first without any timeout (fast)
         for segment_id in segment_ids {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -154,7 +154,7 @@ pub struct SegmentHolder {
     pub optimizer_errors: Option<CollectionError>,
 
     /// Thresholds config, needed for capacity based segment selection.
-    thresholds_config: OptimizerThresholds,
+    pub(crate) thresholds_config: OptimizerThresholds,
 }
 
 pub type LockedSegmentHolder = Arc<RwLock<SegmentHolder>>;

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -310,7 +310,7 @@ mod tests {
         // Base segment
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let segment = random_segment(dir.path(), 100, point_count, dim as usize);
 
@@ -459,7 +459,7 @@ mod tests {
         // Base segment
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let segment = random_multi_vec_segment(
             dir.path(),
@@ -629,7 +629,7 @@ mod tests {
         // Base segment
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let segment = random_multi_vec_segment(
             dir.path(),

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -329,7 +329,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),
@@ -487,7 +487,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),
@@ -654,7 +654,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -857,7 +857,7 @@ mod tests {
             // Optimizers used in test
             let index_optimizer = IndexingOptimizer::new(
                 2,
-                thresholds_config.clone(),
+                thresholds_config,
                 dir.path().to_owned(),
                 temp_dir.path().to_owned(),
                 collection_params.clone(),
@@ -865,7 +865,7 @@ mod tests {
                 Default::default(),
             );
             let config_mismatch_optimizer = ConfigMismatchOptimizer::new(
-                thresholds_config.clone(),
+                thresholds_config,
                 dir.path().to_owned(),
                 temp_dir.path().to_owned(),
                 collection_params.clone(),
@@ -919,7 +919,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     fn test_multi_vector_optimization() {
         init();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let stopped = AtomicBool::new(false);
         let dim1 = 128;
@@ -421,7 +421,7 @@ mod tests {
         init();
 
         let mut rng = thread_rng();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let payload_field: JsonPath = "number".parse().unwrap();
 
@@ -712,7 +712,7 @@ mod tests {
     fn test_indexing_optimizer_with_number_of_segments() {
         init();
 
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let stopped = AtomicBool::new(false);
         let dim = 256;
@@ -837,7 +837,7 @@ mod tests {
         // Base segment
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let segment = random_segment(dir.path(), 100, point_count, dim as usize);
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -167,7 +167,7 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
         let dim = 256;
 
         let _segments_to_merge = [
@@ -201,7 +201,7 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
         let dim = 256;
 
         let segments_to_merge = [

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -31,7 +31,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 
 const BYTES_IN_KB: usize = 1024;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct OptimizerThresholds {
     pub max_segment_size_kb: usize,
     pub memmap_threshold_kb: usize,

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -233,7 +233,7 @@ mod tests {
     fn test_vacuum_conditions() {
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
         let segment_id = holder.add_new(random_segment(dir.path(), 100, 200, 4));
 
         let segment = holder.get(segment_id).unwrap();
@@ -405,7 +405,7 @@ mod tests {
         // Base segment
         let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let mut segment = random_multi_vec_segment(
             dir.path(),

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -441,7 +441,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -709,7 +709,7 @@ mod tests {
         let segment1 = random_segment(dir.path(), 10, 2000, 4);
         let segment2 = random_segment(dir.path(), 10, 4000, 4);
 
-        let mut holder = SegmentHolder::default();
+        let mut holder = SegmentHolder::fixture();
 
         let _sid1 = holder.add_new(segment1);
         let _sid2 = holder.add_new(segment2);

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -418,12 +418,9 @@ where
         .filter(|x| !(updated_points.contains(x)));
 
     {
-        let default_write_segment =
-            segments
-                .random_appendable_segment()
-                .ok_or(CollectionError::service_error(
-                    "No appendable segments exists, expected at least one",
-                ))?;
+        let default_write_segment = segments.random_appendable_segment_with_capacity().ok_or(
+            CollectionError::service_error("No appendable segments exists, expected at least one"),
+        )?;
 
         let segment_arc = default_write_segment.get();
         let mut write_segment = segment_arc.write();

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -16,6 +16,7 @@ use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
 };
+use crate::collection_manager::optimizers::segment_optimizer::OptimizerThresholds;
 use crate::collection_manager::segments_updater::upsert_points;
 use crate::operations::point_ops::PointStruct;
 
@@ -175,5 +176,66 @@ fn test_move_points_to_copy_on_write() {
     for idx in internal_ids {
         let external = id_mapper.borrow().external_id(idx).unwrap();
         eprintln!("{idx} -> {external}");
+    }
+}
+
+#[test]
+fn test_upsert_points_in_segment_with_capacity() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut segment1 = build_segment_1(dir.path());
+    let mut segment2 = build_segment_2(dir.path());
+    let segment3 = empty_segment(dir.path());
+
+    // Fill segment 1 and 2 to the capacity
+    for point_id in 0..100 {
+        segment1
+            .upsert_point(
+                20,
+                point_id.into(),
+                only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            )
+            .unwrap();
+        segment2
+            .upsert_point(
+                20,
+                (100 + point_id).into(),
+                only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            )
+            .unwrap();
+    }
+
+    let optimizer_thresholds = OptimizerThresholds {
+        max_segment_size_kb: 1,
+        memmap_threshold_kb: 100_000,
+        indexing_threshold_kb: 100_000,
+    };
+    let mut holder = SegmentHolder::new(optimizer_thresholds);
+
+    let _sid1 = holder.add_new(segment1);
+    let _sid2 = holder.add_new(segment2);
+    let sid3 = holder.add_new(segment3);
+
+    let segments = Arc::new(RwLock::new(holder));
+
+    let points: Vec<_> = (1000..1010)
+        .map(|id| PointStruct {
+            id: id.into(),
+            vector: VectorStruct::from(vec![0.0, 0.0, 0.0, 0.0]).into(),
+            payload: None,
+        })
+        .collect();
+    upsert_points(&segments.read(), 1000, &points).unwrap();
+
+    // Segment 1 and 2 are over capacity, we expect to have the new points in segment 3
+    {
+        let segment3 = segments.read().get(sid3).unwrap().get();
+        let segment3_read = segment3.read();
+        for point_id in 1000..1010 {
+            assert!(segment3_read.has_point(point_id.into()));
+        }
+        for point_id in 0..10 {
+            assert!(!segment3_read.has_point(point_id.into()));
+        }
     }
 }

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -51,7 +51,7 @@ fn test_update_proxy_segments() {
     let segment1 = build_segment_1(dir.path());
     let segment2 = build_segment_2(dir.path());
 
-    let mut holder = SegmentHolder::default();
+    let mut holder = SegmentHolder::fixture();
 
     let sid1 = holder.add_new(segment1);
     let _sid2 = holder.add_new(segment2);
@@ -101,7 +101,7 @@ fn test_move_points_to_copy_on_write() {
     let segment1 = build_segment_1(dir.path());
     let segment2 = build_segment_2(dir.path());
 
-    let mut holder = SegmentHolder::default();
+    let mut holder = SegmentHolder::fixture();
 
     let sid1 = holder.add_new(segment1);
     let _sid2 = holder.add_new(segment2);

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -161,7 +161,7 @@ pub fn build_optimizers(
     Arc::new(vec![
         Arc::new(MergeOptimizer::new(
             optimizers_config.get_number_segments(),
-            threshold_config.clone(),
+            threshold_config,
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),
@@ -170,7 +170,7 @@ pub fn build_optimizers(
         )),
         Arc::new(IndexingOptimizer::new(
             optimizers_config.get_number_segments(),
-            threshold_config.clone(),
+            threshold_config,
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),
@@ -180,7 +180,7 @@ pub fn build_optimizers(
         Arc::new(VacuumOptimizer::new(
             optimizers_config.deleted_threshold,
             optimizers_config.vacuum_min_vector_number,
-            threshold_config.clone(),
+            threshold_config,
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -23,6 +23,7 @@ use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQu
 use crate::operations::{
     CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
+use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard_trait::ShardOperation;
@@ -163,8 +164,13 @@ impl ForwardProxyShard {
             .await
     }
 
-    pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
-        self.wrapped_shard.on_optimizer_config_update().await
+    pub async fn on_optimizer_config_update(
+        &self,
+        optimizer_config: OptimizersConfig,
+    ) -> CollectionResult<()> {
+        self.wrapped_shard
+            .on_optimizer_config_update(optimizer_config)
+            .await
     }
 
     pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -260,7 +260,8 @@ impl LocalShard {
             );
         }
 
-        let mut segment_holder = SegmentHolder::default();
+        let mut segment_holder =
+            SegmentHolder::new(effective_optimizers_config.optimizer_thresholds());
 
         for handler in load_handlers {
             let segment = handler.join().map_err(|err| {
@@ -434,7 +435,8 @@ impl LocalShard {
             ))
         })?;
 
-        let mut segment_holder = SegmentHolder::default();
+        let mut segment_holder =
+            SegmentHolder::new(effective_optimizers_config.optimizer_thresholds());
         let mut build_handlers = vec![];
 
         let vector_params = config.params.to_base_vector_data()?;

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -25,6 +25,7 @@ use crate::operations::types::{
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::OperationWithClockTag;
+use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
@@ -77,8 +78,13 @@ impl ProxyShard {
             .await
     }
 
-    pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
-        self.wrapped_shard.on_optimizer_config_update().await
+    pub async fn on_optimizer_config_update(
+        &self,
+        optimizer_config: OptimizersConfig,
+    ) -> CollectionResult<()> {
+        self.wrapped_shard
+            .on_optimizer_config_update(optimizer_config)
+            .await
     }
 
     pub async fn reinit_changelog(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -24,6 +24,7 @@ use crate::operations::types::{
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::OperationWithClockTag;
+use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
@@ -147,12 +148,15 @@ impl QueueProxyShard {
             .await
     }
 
-    pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
+    pub async fn on_optimizer_config_update(
+        &self,
+        optimizer_config: OptimizersConfig,
+    ) -> CollectionResult<()> {
         self.inner
             .as_ref()
             .expect("Queue proxy has been finalized")
             .wrapped_shard
-            .on_optimizer_config_update()
+            .on_optimizer_config_update(optimizer_config)
             .await
     }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -680,10 +680,13 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub(crate) async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
+    pub(crate) async fn on_optimizer_config_update(
+        &self,
+        optimizer_config: OptimizersConfig,
+    ) -> CollectionResult<()> {
         let read_local = self.local.read().await;
         if let Some(shard) = &*read_local {
-            shard.on_optimizer_config_update().await
+            shard.on_optimizer_config_update(optimizer_config).await
         } else {
             Ok(())
         }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -7,6 +7,7 @@ use common::types::TelemetryDetail;
 use super::local_shard::clock_map::RecoveryPoint;
 use super::update_tracker::UpdateTracker;
 use crate::operations::types::{CollectionError, CollectionResult};
+use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::dummy_shard::DummyShard;
 use crate::shards::forward_proxy_shard::ForwardProxyShard;
 use crate::shards::local_shard::LocalShard;
@@ -110,12 +111,31 @@ impl Shard {
         }
     }
 
-    pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
+    pub async fn on_optimizer_config_update(
+        &self,
+        optimizer_config: OptimizersConfig,
+    ) -> CollectionResult<()> {
         match self {
-            Shard::Local(local_shard) => local_shard.on_optimizer_config_update().await,
-            Shard::Proxy(proxy_shard) => proxy_shard.on_optimizer_config_update().await,
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.on_optimizer_config_update().await,
-            Shard::QueueProxy(proxy_shard) => proxy_shard.on_optimizer_config_update().await,
+            Shard::Local(local_shard) => {
+                local_shard
+                    .on_optimizer_config_update(optimizer_config)
+                    .await
+            }
+            Shard::Proxy(proxy_shard) => {
+                proxy_shard
+                    .on_optimizer_config_update(optimizer_config)
+                    .await
+            }
+            Shard::ForwardProxy(proxy_shard) => {
+                proxy_shard
+                    .on_optimizer_config_update(optimizer_config)
+                    .await
+            }
+            Shard::QueueProxy(proxy_shard) => {
+                proxy_shard
+                    .on_optimizer_config_update(optimizer_config)
+                    .await
+            }
             Shard::Dummy(dummy_shard) => dummy_shard.on_optimizer_config_update().await,
         }
     }

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -38,7 +38,7 @@ async fn test_optimization_process() {
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
     let dim = 256;
-    let mut holder = SegmentHolder::default();
+    let mut holder = SegmentHolder::fixture();
 
     let segments_to_merge = vec![
         holder.add_new(random_segment(dir.path(), 100, 3, dim)),
@@ -141,7 +141,7 @@ async fn test_cancel_optimization() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
-    let mut holder = SegmentHolder::default();
+    let mut holder = SegmentHolder::fixture();
     let dim = 256;
 
     for _ in 0..5 {
@@ -222,7 +222,7 @@ async fn test_new_segment_when_all_over_capacity() {
         memmap_threshold_kb: 1_000_000,
         indexing_threshold_kb: 1_000_000,
     };
-    let mut holder = SegmentHolder::default();
+    let mut holder = SegmentHolder::new(optimizer_thresholds.clone());
 
     holder.add_new(random_segment(dir.path(), 100, 3, dim));
     holder.add_new(random_segment(dir.path(), 100, 3, dim));

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -222,7 +222,7 @@ async fn test_new_segment_when_all_over_capacity() {
         memmap_threshold_kb: 1_000_000,
         indexing_threshold_kb: 1_000_000,
     };
-    let mut holder = SegmentHolder::new(optimizer_thresholds.clone());
+    let mut holder = SegmentHolder::new(optimizer_thresholds);
 
     holder.add_new(random_segment(dir.path(), 100, 3, dim));
     holder.add_new(random_segment(dir.path(), 100, 3, dim));


### PR DESCRIPTION
Builds on top of: <https://github.com/qdrant/qdrant/pull/4416>

Direct writes to segments with capacity.

When selecting an appendable segment for writing, consider the capacity and prefer segments that still have capacity.

Checking capacity requires us to read lock segments. In this implementation I tried to find the right balance between correctness and performance. For example, when selecting an appendable segment for writing it may be over capacity if the segments having capacity currently could not be read-locked. Nor do we always return the segment with minimum capacity because that would require us to read lock every segment all the time. I tried to keep our existing structures mostly intact.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
