### PR TITLE
Allow failures on Windows CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,9 @@ jobs:
       run: cargo build --tests --workspace
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
-      run: cargo nextest run --workspace --profile ci
+      # Allow failures on Windows until the issue #4419 is solved.
+      run: cargo nextest run --workspace --profile ci || [ "$RUNNER_OS" = "Windows" ]
+      shell: bash
     - name: Upload test report
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Allow failures on Windows until the issue #4419 is solved.