### PR TITLE
Remove unused chaos-test feature

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -19,8 +19,6 @@ use prost::Message as _;
 use raft::eraftpb::Message as RaftMessage;
 use raft::prelude::*;
 use raft::{SoftState, StateRole, INVALID_ID};
-#[cfg(feature = "chaos-test")]
-use rand::Rng;
 use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::content_manager::consensus_ops::{ConsensusOperations, SnapshotStatus};
 use storage::content_manager::toc::TableOfContent;


### PR DESCRIPTION
It seems like the trace of a previous experimentation before using `chaos-testing`.