### PR TITLE
order_by: don't check for index eagerly, improve error message

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -226,10 +226,8 @@ impl Collection {
         let order_by = request.order_by.map(OrderBy::from);
 
         // Validate user did not try to use an id offset with order_by
-        if order_by.is_some() {
-            if id_offset.is_some() {
-                return Err(CollectionError::bad_input("Cannot use an `offset` when using `order_by`. The alternative for paging is to use `order_by.start_from` and a filter to exclude the IDs that you've already seen for the `order_by.start_from` value".to_string()));
-            }
+        if order_by.is_some() && id_offset.is_some() {
+            return Err(CollectionError::bad_input("Cannot use an `offset` when using `order_by`. The alternative for paging is to use `order_by.start_from` and a filter to exclude the IDs that you've already seen for the `order_by.start_from` value".to_string()));
         };
 
         if limit == 0 {

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -225,24 +225,8 @@ impl Collection {
 
         let order_by = request.order_by.map(OrderBy::from);
 
-        // Handle case of order_by
-        if let Some(order_by) = &order_by {
-            // Validate we have a range index for the order_by key
-            let has_range_index_for_order_by_field = self
-                .payload_index_schema
-                .read()
-                .schema
-                .get(&order_by.key)
-                .is_some_and(|field| field.has_range_index());
-
-            if !has_range_index_for_order_by_field {
-                return Err(CollectionError::bad_request(format!(
-                    "No range index for `order_by` key: {}. Please create one to use `order_by`. Integer, float, and datetime payloads can have range indexes, see https://qdrant.tech/documentation/concepts/indexing/#payload-index.",
-                    &order_by.key
-                )));
-            }
-
-            // Validate user did not try to use an id offset with order_by
+        // Validate user did not try to use an id offset with order_by
+        if order_by.is_some() {
             if id_offset.is_some() {
                 return Err(CollectionError::bad_input("Cannot use an `offset` when using `order_by`. The alternative for paging is to use `order_by.start_from` and a filter to exclude the IDs that you've already seen for the `order_by.start_from` value".to_string()));
             }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1026,6 +1026,7 @@ impl From<OperationError> for CollectionError {
                 description: "Conversion between multi and regular vectors failed".to_string(),
             },
             OperationError::WrongPayloadKey { description } => Self::BadInput { description },
+            OperationError::MissingRangeIndexForOrderBy { .. } => Self::bad_input(format!("{err}")),
         }
     }
 }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -56,6 +56,8 @@ pub enum OperationError {
     WrongMulti,
     #[error("Wrong key of payload")]
     WrongPayloadKey { description: String },
+    #[error("No range index for `order_by` key: `{key}`. Please create one to use `order_by`. Check https://qdrant.tech/documentation/concepts/indexing/#payload-index to see which payload schemas support Range conditions")]
+    MissingRangeIndexForOrderBy { key: String },
 }
 
 impl OperationError {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -839,7 +839,9 @@ impl Segment {
             .field_indexes
             .get(&order_by.key)
             .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
-            .ok_or_else(|| OperationError::ValidationError { description: "There is no range index for the `order_by` key, please create one to use `order_by`".to_string() })?;
+            .ok_or_else(|| OperationError::MissingRangeIndexForOrderBy {
+                key: order_by.key.to_string(),
+            })?;
 
         let start_from = order_by.start_from();
 
@@ -914,7 +916,9 @@ impl Segment {
             .field_indexes
             .get(&order_by.key)
             .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
-            .ok_or_else(|| OperationError::ValidationError { description: "There is no range index for the `order_by` key, please create one to use `order_by`".to_string() })?;
+            .ok_or_else(|| OperationError::MissingRangeIndexForOrderBy {
+                key: order_by.key.to_string(),
+            })?;
 
         let range_iter = numeric_index.stream_range(&order_by.as_range());
 


### PR DESCRIPTION
- delegates checking for a range index until segment, to unify the error to return.
- creates a new `OperationError::MissingRangeIndexForOrderBy` and improves error message

New error message:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/CN31nys0KXeRmF0Pailo/b1bfa09c-24d6-4879-badb-e68b918d773b.png)

