### PR TITLE
universal-query: Propagate filters to leaf queries

### DIFF
--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -83,8 +83,13 @@ impl TryFrom<ShardQueryRequest> for PlannedQuery {
 
         let merge_plan = if !prefetches.is_empty() {
             offset = req_offset;
-            let sources =
-                recurse_prefetches(&mut core_searches, &mut scrolls, prefetches, offset, req_filter)?;
+            let sources = recurse_prefetches(
+                &mut core_searches,
+                &mut scrolls,
+                prefetches,
+                offset,
+                req_filter,
+            )?;
             let rescore = query.ok_or_else(|| {
                 CollectionError::bad_request("cannot have prefetches without a query".to_string())
             })?;
@@ -268,7 +273,8 @@ fn recurse_prefetches(
             }
         } else {
             // This has nested prefetches. Recurse into them
-            let inner_sources = recurse_prefetches(core_searches, scrolls, prefetches, offset, filter)?;
+            let inner_sources =
+                recurse_prefetches(core_searches, scrolls, prefetches, offset, filter)?;
 
             let rescore = query.ok_or_else(|| {
                 CollectionError::bad_request("cannot have prefetches without a query".to_string())
@@ -354,7 +360,7 @@ mod tests {
                     Vector::Dense(dummy_vector.clone()),
                     "byte",
                 )),
-                filter: None,
+                filter: Some(Filter::default()),
                 params: None,
                 limit: 1000,
                 offset: 0,
@@ -505,7 +511,7 @@ mod tests {
                         Vector::Dense(dummy_vector.clone()),
                         "dense",
                     )),
-                    filter: None,
+                    filter: Some(Filter::default()),
                     params: None,
                     limit: 100,
                     offset: 0,
@@ -518,7 +524,7 @@ mod tests {
                         Vector::Sparse(dummy_sparse.clone()),
                         "sparse",
                     )),
-                    filter: None,
+                    filter: Some(Filter::default()),
                     params: None,
                     limit: 100,
                     offset: 0,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2261,6 +2261,15 @@ impl Filter {
             must_not: merge_component(self.must_not, other.must_not),
         }
     }
+
+    pub fn merge_opts(this: Option<Self>, other: Option<Self>) -> Option<Self> {
+        match (this, other) {
+            (None, None) => None,
+            (Some(this), None) => Some(this),
+            (None, Some(other)) => Some(other),
+            (Some(this), Some(other)) => Some(this.merge_owned(other)),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR changes the planned query conversion to propagate every filter from the root of the query to each of the subqueries.

The motivation is so that every condition is already satisfied when merging multiple prefetches, and prevent post-filtering behavior.