### PR TITLE
When selecting a segment for writing, select the smallest one

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -457,7 +457,7 @@ impl<'s> SegmentHolder {
             ));
         }
 
-        let mut entries: Vec<_> = Default::default();
+        let mut entries: Vec<_> = Vec::with_capacity(segment_ids.len());
 
         // Try to access each segment first without any timeout (fast)
         for segment_id in segment_ids {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -354,7 +354,7 @@ impl<'s> SegmentHolder {
 
     /// Get the smallest appendable segment
     ///
-    /// The returned segment likley has the most capacity for new points, which will help balance
+    /// The returned segment likely has the most capacity for new points, which will help balance
     /// new incoming data over all segments we have.
     ///
     /// This attempts a non-blocking read-lock on all segments to find the smallest one. Segments

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -329,7 +329,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),
@@ -487,7 +487,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),
@@ -654,7 +654,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -857,7 +857,7 @@ mod tests {
             // Optimizers used in test
             let index_optimizer = IndexingOptimizer::new(
                 2,
-                thresholds_config.clone(),
+                thresholds_config,
                 dir.path().to_owned(),
                 temp_dir.path().to_owned(),
                 collection_params.clone(),
@@ -865,7 +865,7 @@ mod tests {
                 Default::default(),
             );
             let config_mismatch_optimizer = ConfigMismatchOptimizer::new(
-                thresholds_config.clone(),
+                thresholds_config,
                 dir.path().to_owned(),
                 temp_dir.path().to_owned(),
                 collection_params.clone(),
@@ -919,7 +919,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -31,7 +31,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 
 const BYTES_IN_KB: usize = 1024;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct OptimizerThresholds {
     pub max_segment_size_kb: usize,
     pub memmap_threshold_kb: usize,

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -441,7 +441,7 @@ mod tests {
         // Optimizers used in test
         let index_optimizer = IndexingOptimizer::new(
             2,
-            thresholds_config.clone(),
+            thresholds_config,
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             collection_params.clone(),

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -420,7 +420,7 @@ where
     {
         let default_write_segment =
             segments
-                .random_appendable_segment()
+                .smallest_appendable_segment()
                 .ok_or(CollectionError::service_error(
                     "No appendable segments exists, expected at least one",
                 ))?;

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -161,7 +161,7 @@ pub fn build_optimizers(
     Arc::new(vec![
         Arc::new(MergeOptimizer::new(
             optimizers_config.get_number_segments(),
-            threshold_config.clone(),
+            threshold_config,
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),
@@ -170,7 +170,7 @@ pub fn build_optimizers(
         )),
         Arc::new(IndexingOptimizer::new(
             optimizers_config.get_number_segments(),
-            threshold_config.clone(),
+            threshold_config,
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),
@@ -180,7 +180,7 @@ pub fn build_optimizers(
         Arc::new(VacuumOptimizer::new(
             optimizers_config.deleted_threshold,
             optimizers_config.vacuum_min_vector_number,
-            threshold_config.clone(),
+            threshold_config,
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),


### PR DESCRIPTION
Builds on top of: <https://github.com/qdrant/qdrant/pull/4416>
Alternative to: <https://github.com/qdrant/qdrant/pull/4420>

Direct new writes to the smallest segment.

This attempts a non-blocking read lock on all segments and returns the smallest one. Segments that cannot be read locked at this time are skipped. If no segment accepted a read lock, a random one is returned.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
