### PR TITLE
Shortcut HNSW build on empty storages

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -679,13 +679,17 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         stopped: &AtomicBool,
         _tick_progress: impl FnMut(),
     ) -> OperationResult<()> {
+        let vector_storage = self.vector_storage.borrow();
+        let total_vector_count = vector_storage.total_vector_count();
+        if total_vector_count == 0 {
+            return Ok(());
+        }
+
         // Build main index graph
         let id_tracker = self.id_tracker.borrow();
-        let vector_storage = self.vector_storage.borrow();
+
         let quantized_vectors = self.quantized_vectors.borrow();
         let mut rng = thread_rng();
-
-        let total_vector_count = vector_storage.total_vector_count();
         let deleted_bitslice = vector_storage.deleted_vector_bitslice();
 
         debug!(


### PR DESCRIPTION
While running my tests I often see large logs like this

```
2024-06-11T07:47:46.191447Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.191954Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.192067Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.198172Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.219346Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.219883Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.220135Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.225815Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.251805Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.252331Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.252416Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.258160Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.288593Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.289280Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.289377Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.296411Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.325360Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.325901Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.325982Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.331456Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.363376Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.363816Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.363891Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.369211Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.399810Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.400387Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.400472Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.407409Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.437240Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.437704Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.437779Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.443896Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.473937Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.474789Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.474876Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.481993Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.510470Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.511064Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.511194Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.516654Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.539283Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.539778Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.539969Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.547052Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.568789Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.569303Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.569413Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.574854Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.601320Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.601794Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.601876Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.608949Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.631036Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.631543Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.631626Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.637115Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.658171Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.658679Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.658760Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.665714Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.687958Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.688658Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.688830Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.694564Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.717298Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.717784Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.717859Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.724608Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.746267Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.746734Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.746817Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.752177Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.774058Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.774516Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.774625Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.780761Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.802389Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.802903Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.802994Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.808683Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.832367Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.832847Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.832926Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.841497Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.864324Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.864968Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.865153Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.871169Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.893212Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.893685Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.894049Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.903675Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.927965Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.928541Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.928624Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.934139Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.955866Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.956401Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.956533Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.963466Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:46.991105Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:46.991602Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:46.991697Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:46.996767Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:47.028171Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:47.028656Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:47.028739Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:47.034815Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
2024-06-11T07:47:47.066930Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 0 vectors with 7 CPUs
2024-06-11T07:47:47.067484Z DEBUG segment::index::hnsw_index::hnsw: finish main graph
2024-06-11T07:47:47.067570Z DEBUG segment::index::hnsw_index::hnsw: building additional index for field crasher-payload-keyword
2024-06-11T07:47:47.078222Z DEBUG segment::index::hnsw_index::hnsw: finish additional payload field indexing
```

This PR shortcuts the whole HNSW build if the storage is empty, this avoids noisy debug logs and more interestingly decrease unused allocations for the `GraphLayersBuilder` and `RayonPool`.