### PR TITLE
Hnsw update entry point after linking

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -308,7 +308,7 @@ impl GraphLayersBuilder {
         let entry_point_opt = self
             .entry_points
             .lock()
-            .new_point(point_id, level, |point_id| {
+            .get_entry_point(|point_id| {
                 points_scorer.check_vector(point_id)
             });
         match entry_point_opt {
@@ -450,6 +450,12 @@ impl GraphLayersBuilder {
             }
         }
         self.ready_list.write().set(point_id as usize, true);
+        self
+            .entry_points
+            .lock()
+            .new_point(point_id, level, |point_id| {
+                points_scorer.check_vector(point_id)
+            });
     }
 
     /// This function returns average number of links per node in HNSW graph

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -308,9 +308,7 @@ impl GraphLayersBuilder {
         let entry_point_opt = self
             .entry_points
             .lock()
-            .get_entry_point(|point_id| {
-                points_scorer.check_vector(point_id)
-            });
+            .get_entry_point(|point_id| points_scorer.check_vector(point_id));
         match entry_point_opt {
             // New point is a new empty entry (for this filter, at least)
             // We can't do much here, so just quit
@@ -450,8 +448,7 @@ impl GraphLayersBuilder {
             }
         }
         self.ready_list.write().set(point_id as usize, true);
-        self
-            .entry_points
+        self.entry_points
             .lock()
             .new_point(point_id, level, |point_id| {
                 points_scorer.check_vector(point_id)


### PR DESCRIPTION
This PR is a subset of changes from https://github.com/qdrant/qdrant/pull/4412.

It's a minimal change to fix flacky `test_graph_connectivity`.

There is a bug while HNSW construction. We change entry points before linking. In multithreaded environment is cause such problem: point may take entry with no links.

The solution is updating entry points after linking.