### PR TITLE
Bump version to 1.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "api"
-version = "1.9.4"
+version = "1.9.5"
 dependencies = [
  "chrono",
  "common",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.9.4"
+version = "1.9.5"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.9.4"
+version = "1.9.5"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.9.4"
+version = "1.9.5"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.9.4";
+pub const QDRANT_VERSION_STRING: &str = "1.9.5";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=ccf7f1d24f37dcfe82dad85fa66fb91352bd7a21
+IGNORE_UPTO=15de581d15530ba1b07988dcc6767a5039979e63
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Release Qdrant 1.9.5.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/4343>.