### PR TITLE
universal-query: Fix intermediate response order

### DIFF
--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -41,7 +41,7 @@ impl PrefetchHolder {
         }
     }
 
-    fn get<'a>(&'a self, element: FetchedSource) -> CollectionResult<Cow<'a, Vec<ScoredPoint>>> {
+    fn get(&self, element: FetchedSource) -> CollectionResult<Cow<'_, Vec<ScoredPoint>>> {
         match element {
             FetchedSource::Core(idx) => self.core_results.get(idx).map(Cow::Borrowed),
             FetchedSource::Scroll(idx) => self.scrolls.get(idx).map(Cow::Borrowed),
@@ -144,7 +144,7 @@ impl LocalShard {
                             )
                             .await?
                             .into_iter()
-                            .map(|v| Cow::Owned(v));
+                            .map(Cow::Owned);
                         cow_sources.extend(merged);
                     }
                 }

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -1,5 +1,9 @@
+use std::collections::HashSet;
+
 use segment::data_types::vectors::VectorStruct;
-use segment::types::{Distance, PayloadFieldSchema, PayloadSchemaType};
+use segment::types::{
+    Condition, Distance, Filter, PayloadFieldSchema, PayloadSchemaType, PointIdType,
+};
 
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::point_ops::{PointOperations, PointStruct};
@@ -101,4 +105,8 @@ pub fn delete_point_operation(idx: u64) -> CollectionUpdateOperations {
     CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
         ids: vec![idx.into()],
     })
+}
+
+pub fn filter_single_id(id: impl Into<PointIdType>) -> Filter {
+    Filter::new_must(Condition::HasId(HashSet::from([id.into()]).into()))
 }

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -174,7 +174,7 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime)
+        .query(Arc::new(query), &current_runtime, None)
         .await
         .unwrap();
 


### PR DESCRIPTION
Fix and tests the order of the intermediate responses.

This important for some fusion requests, where the order of the prefetches in the request matters.