### PR TITLE
Integrate compressed posting list (attempt 2)

### DIFF
--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -15,7 +15,9 @@ use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use segment::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
+use segment::index::sparse_index::sparse_vector_index::{
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
+};
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::VectorIndex;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
@@ -73,7 +75,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     let vector_storage = Arc::new(AtomicRefCell::new(vector_storage));
 
     let mut sparse_vector_index: SparseVectorIndex<InvertedIndexRam> =
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: index_config,
             id_tracker: id_tracker.clone(),
             vector_storage: vector_storage.clone(),
@@ -95,7 +97,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
 
     // build once to reuse in mmap conversion benchmark
     let mut sparse_vector_index: SparseVectorIndex<InvertedIndexRam> =
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: index_config,
             id_tracker,
             vector_storage,

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -15,7 +15,9 @@ use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram_from_iter;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use segment::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
+use segment::index::sparse_index::sparse_vector_index::{
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
+};
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{Condition, FieldCondition, Filter, Payload};
@@ -110,7 +112,7 @@ fn sparse_vector_index_search_benchmark_impl(
     let sparse_index_config =
         SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap);
     let mut sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_index.id_tracker().clone(),
             vector_storage: sparse_vector_index.vector_storage().clone(),

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -15,7 +15,7 @@ use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram_from_iter;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
+use segment::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{Condition, FieldCondition, Filter, Payload};
@@ -110,14 +110,14 @@ fn sparse_vector_index_search_benchmark_impl(
     let sparse_index_config =
         SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap);
     let mut sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
-        SparseVectorIndex::open(
-            sparse_index_config,
-            sparse_vector_index.id_tracker().clone(),
-            sparse_vector_index.vector_storage().clone(),
-            sparse_vector_index.payload_index().clone(),
-            mmap_index_dir.path(),
-            &stopped,
-        )
+        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+            config: sparse_index_config,
+            id_tracker: sparse_vector_index.id_tracker().clone(),
+            vector_storage: sparse_vector_index.vector_storage().clone(),
+            payload_index: sparse_vector_index.payload_index().clone(),
+            path: mmap_index_dir.path(),
+            stopped: &stopped,
+        })
         .unwrap();
     let pb = progress("Indexing (3/3)", vectors_len);
     sparse_vector_index_mmap

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -16,7 +16,9 @@ use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::index::hnsw_index::num_rayon_threads;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use crate::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
+use crate::index::sparse_index::sparse_vector_index::{
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
+};
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndex;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
@@ -73,7 +75,7 @@ pub fn fixture_open_sparse_index<I: InvertedIndex>(
 
     let sparse_index_config = SparseIndexConfig::new(Some(full_scan_threshold), index_type);
     let sparse_vector_index: SparseVectorIndex<I> =
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker,
             vector_storage: vector_storage.clone(),

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -16,7 +16,7 @@ use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::index::hnsw_index::num_rayon_threads;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use crate::index::sparse_index::sparse_vector_index::SparseVectorIndex;
+use crate::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndex;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
@@ -72,14 +72,15 @@ pub fn fixture_open_sparse_index<I: InvertedIndex>(
     );
 
     let sparse_index_config = SparseIndexConfig::new(Some(full_scan_threshold), index_type);
-    let sparse_vector_index: SparseVectorIndex<I> = SparseVectorIndex::open(
-        sparse_index_config,
-        id_tracker,
-        vector_storage.clone(),
-        wrapped_payload_index,
-        index_dir,
-        stopped,
-    )?;
+    let sparse_vector_index: SparseVectorIndex<I> =
+        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+            config: sparse_index_config,
+            id_tracker,
+            vector_storage: vector_storage.clone(),
+            payload_index: wrapped_payload_index,
+            path: index_dir,
+            stopped,
+        })?;
 
     Ok(sparse_vector_index)
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -78,16 +78,27 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     }
 }
 
+pub struct OpenArgs<'a> {
+    pub config: SparseIndexConfig,
+    pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+    pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+    pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    pub path: &'a Path,
+    pub stopped: &'a AtomicBool,
+}
+
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     /// Open a sparse vector index at a given path
-    pub fn open(
-        config: SparseIndexConfig,
-        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-        path: &Path,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Self> {
+    pub fn open(args: OpenArgs) -> OperationResult<Self> {
+        let OpenArgs {
+            config,
+            id_tracker,
+            vector_storage,
+            payload_index,
+            path,
+            stopped,
+        } = args;
+
         // create directory if it does not exist
         create_dir_all(path)?;
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -79,7 +79,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     }
 }
 
-pub struct OpenArgs<'a> {
+pub struct SparseVectorIndexOpenArgs<'a> {
     pub config: SparseIndexConfig,
     pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
@@ -90,8 +90,8 @@ pub struct OpenArgs<'a> {
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     /// Open a sparse vector index at a given path
-    pub fn open(args: OpenArgs) -> OperationResult<Self> {
-        let OpenArgs {
+    pub fn open(args: SparseVectorIndexOpenArgs) -> OperationResult<Self> {
+        let SparseVectorIndexOpenArgs {
             config,
             id_tracker,
             vector_storage,

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -64,12 +64,12 @@ pub enum VectorIndexEnum {
     HnswRam(HNSWIndex<GraphLinksRam>),
     HnswMmap(HNSWIndex<GraphLinksMmap>),
     SparseRam(SparseVectorIndex<InvertedIndexRam>),
-    SparseImmRam(SparseVectorIndex<InvertedIndexImmutableRam>),
+    SparseImmutableRam(SparseVectorIndex<InvertedIndexImmutableRam>),
     SparseMmap(SparseVectorIndex<InvertedIndexMmap>),
-    SparseCompImmRamF32(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f32>>),
-    SparseCompImmRamF16(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f16>>),
-    SparseCompMmapF32(SparseVectorIndex<InvertedIndexCompressedMmap<f32>>),
-    SparseCompMmapF16(SparseVectorIndex<InvertedIndexCompressedMmap<f16>>),
+    SparseCompressedImmutableRamF32(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f32>>),
+    SparseCompressedImmutableRamF16(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f16>>),
+    SparseCompressedMmapF32(SparseVectorIndex<InvertedIndexCompressedMmap<f32>>),
+    SparseCompressedMmapF16(SparseVectorIndex<InvertedIndexCompressedMmap<f16>>),
 }
 
 impl VectorIndexEnum {
@@ -79,12 +79,12 @@ impl VectorIndexEnum {
             Self::HnswRam(_) => true,
             Self::HnswMmap(_) => true,
             Self::SparseRam(_) => true,
-            Self::SparseImmRam(_) => true,
+            Self::SparseImmutableRam(_) => true,
             Self::SparseMmap(_) => true,
-            Self::SparseCompImmRamF32(_) => true,
-            Self::SparseCompImmRamF16(_) => true,
-            Self::SparseCompMmapF32(_) => true,
-            Self::SparseCompMmapF16(_) => true,
+            Self::SparseCompressedImmutableRamF32(_) => true,
+            Self::SparseCompressedImmutableRamF16(_) => true,
+            Self::SparseCompressedMmapF32(_) => true,
+            Self::SparseCompressedMmapF16(_) => true,
         }
     }
 
@@ -92,12 +92,12 @@ impl VectorIndexEnum {
         match self {
             Self::Plain(_) | Self::HnswRam(_) | Self::HnswMmap(_) => (),
             Self::SparseRam(index) => index.fill_idf_statistics(idf),
-            Self::SparseImmRam(index) => index.fill_idf_statistics(idf),
+            Self::SparseImmutableRam(index) => index.fill_idf_statistics(idf),
             Self::SparseMmap(index) => index.fill_idf_statistics(idf),
-            Self::SparseCompImmRamF32(index) => index.fill_idf_statistics(idf),
-            Self::SparseCompImmRamF16(index) => index.fill_idf_statistics(idf),
-            Self::SparseCompMmapF32(index) => index.fill_idf_statistics(idf),
-            Self::SparseCompMmapF16(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompressedImmutableRamF32(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompressedImmutableRamF16(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf),
         }
     }
 }
@@ -124,22 +124,22 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::SparseRam(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
-            VectorIndexEnum::SparseImmRam(index) => {
+            VectorIndexEnum::SparseImmutableRam(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
             VectorIndexEnum::SparseMmap(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
-            VectorIndexEnum::SparseCompImmRamF32(index) => {
+            VectorIndexEnum::SparseCompressedImmutableRamF32(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
-            VectorIndexEnum::SparseCompImmRamF16(index) => {
+            VectorIndexEnum::SparseCompressedImmutableRamF16(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
-            VectorIndexEnum::SparseCompMmapF32(index) => {
+            VectorIndexEnum::SparseCompressedMmapF32(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
-            VectorIndexEnum::SparseCompMmapF16(index) => {
+            VectorIndexEnum::SparseCompressedMmapF16(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
         }
@@ -164,22 +164,22 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::SparseRam(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
-            VectorIndexEnum::SparseImmRam(index) => {
+            VectorIndexEnum::SparseImmutableRam(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
             VectorIndexEnum::SparseMmap(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
-            VectorIndexEnum::SparseCompImmRamF32(index) => {
+            VectorIndexEnum::SparseCompressedImmutableRamF32(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
-            VectorIndexEnum::SparseCompImmRamF16(index) => {
+            VectorIndexEnum::SparseCompressedImmutableRamF16(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
-            VectorIndexEnum::SparseCompMmapF32(index) => {
+            VectorIndexEnum::SparseCompressedMmapF32(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
-            VectorIndexEnum::SparseCompMmapF16(index) => {
+            VectorIndexEnum::SparseCompressedMmapF16(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
         }
@@ -191,12 +191,16 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::HnswRam(index) => index.get_telemetry_data(detail),
             VectorIndexEnum::HnswMmap(index) => index.get_telemetry_data(detail),
             VectorIndexEnum::SparseRam(index) => index.get_telemetry_data(detail),
-            VectorIndexEnum::SparseImmRam(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseImmutableRam(index) => index.get_telemetry_data(detail),
             VectorIndexEnum::SparseMmap(index) => index.get_telemetry_data(detail),
-            VectorIndexEnum::SparseCompImmRamF32(index) => index.get_telemetry_data(detail),
-            VectorIndexEnum::SparseCompImmRamF16(index) => index.get_telemetry_data(detail),
-            VectorIndexEnum::SparseCompMmapF32(index) => index.get_telemetry_data(detail),
-            VectorIndexEnum::SparseCompMmapF16(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseCompressedImmutableRamF32(index) => {
+                index.get_telemetry_data(detail)
+            }
+            VectorIndexEnum::SparseCompressedImmutableRamF16(index) => {
+                index.get_telemetry_data(detail)
+            }
+            VectorIndexEnum::SparseCompressedMmapF32(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseCompressedMmapF16(index) => index.get_telemetry_data(detail),
         }
     }
 
@@ -206,12 +210,12 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::HnswRam(index) => index.files(),
             VectorIndexEnum::HnswMmap(index) => index.files(),
             VectorIndexEnum::SparseRam(index) => index.files(),
-            VectorIndexEnum::SparseImmRam(index) => index.files(),
+            VectorIndexEnum::SparseImmutableRam(index) => index.files(),
             VectorIndexEnum::SparseMmap(index) => index.files(),
-            VectorIndexEnum::SparseCompImmRamF32(index) => index.files(),
-            VectorIndexEnum::SparseCompImmRamF16(index) => index.files(),
-            VectorIndexEnum::SparseCompMmapF32(index) => index.files(),
-            VectorIndexEnum::SparseCompMmapF16(index) => index.files(),
+            VectorIndexEnum::SparseCompressedImmutableRamF32(index) => index.files(),
+            VectorIndexEnum::SparseCompressedImmutableRamF16(index) => index.files(),
+            VectorIndexEnum::SparseCompressedMmapF32(index) => index.files(),
+            VectorIndexEnum::SparseCompressedMmapF16(index) => index.files(),
         }
     }
 
@@ -221,12 +225,12 @@ impl VectorIndex for VectorIndexEnum {
             Self::HnswRam(index) => index.indexed_vector_count(),
             Self::HnswMmap(index) => index.indexed_vector_count(),
             Self::SparseRam(index) => index.indexed_vector_count(),
-            Self::SparseImmRam(index) => index.indexed_vector_count(),
+            Self::SparseImmutableRam(index) => index.indexed_vector_count(),
             Self::SparseMmap(index) => index.indexed_vector_count(),
-            Self::SparseCompImmRamF32(index) => index.indexed_vector_count(),
-            Self::SparseCompImmRamF16(index) => index.indexed_vector_count(),
-            Self::SparseCompMmapF32(index) => index.indexed_vector_count(),
-            Self::SparseCompMmapF16(index) => index.indexed_vector_count(),
+            Self::SparseCompressedImmutableRamF32(index) => index.indexed_vector_count(),
+            Self::SparseCompressedImmutableRamF16(index) => index.indexed_vector_count(),
+            Self::SparseCompressedMmapF32(index) => index.indexed_vector_count(),
+            Self::SparseCompressedMmapF16(index) => index.indexed_vector_count(),
         }
     }
 
@@ -236,12 +240,12 @@ impl VectorIndex for VectorIndexEnum {
             Self::HnswRam(index) => index.update_vector(id, vector),
             Self::HnswMmap(index) => index.update_vector(id, vector),
             Self::SparseRam(index) => index.update_vector(id, vector),
-            Self::SparseImmRam(index) => index.update_vector(id, vector),
+            Self::SparseImmutableRam(index) => index.update_vector(id, vector),
             Self::SparseMmap(index) => index.update_vector(id, vector),
-            Self::SparseCompImmRamF32(index) => index.update_vector(id, vector),
-            Self::SparseCompImmRamF16(index) => index.update_vector(id, vector),
-            Self::SparseCompMmapF32(index) => index.update_vector(id, vector),
-            Self::SparseCompMmapF16(index) => index.update_vector(id, vector),
+            Self::SparseCompressedImmutableRamF32(index) => index.update_vector(id, vector),
+            Self::SparseCompressedImmutableRamF16(index) => index.update_vector(id, vector),
+            Self::SparseCompressedMmapF32(index) => index.update_vector(id, vector),
+            Self::SparseCompressedMmapF16(index) => index.update_vector(id, vector),
         }
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use half::f16;
 use sparse::common::types::DimId;
+use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
@@ -61,8 +64,12 @@ pub enum VectorIndexEnum {
     HnswRam(HNSWIndex<GraphLinksRam>),
     HnswMmap(HNSWIndex<GraphLinksMmap>),
     SparseRam(SparseVectorIndex<InvertedIndexRam>),
-    SparseImmutableRam(SparseVectorIndex<InvertedIndexImmutableRam>),
+    SparseImmRam(SparseVectorIndex<InvertedIndexImmutableRam>),
     SparseMmap(SparseVectorIndex<InvertedIndexMmap>),
+    SparseCompImmRamF32(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f32>>),
+    SparseCompImmRamF16(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f16>>),
+    SparseCompMmapF32(SparseVectorIndex<InvertedIndexCompressedMmap<f32>>),
+    SparseCompMmapF16(SparseVectorIndex<InvertedIndexCompressedMmap<f16>>),
 }
 
 impl VectorIndexEnum {
@@ -72,8 +79,12 @@ impl VectorIndexEnum {
             Self::HnswRam(_) => true,
             Self::HnswMmap(_) => true,
             Self::SparseRam(_) => true,
-            Self::SparseImmutableRam(_) => true,
+            Self::SparseImmRam(_) => true,
             Self::SparseMmap(_) => true,
+            Self::SparseCompImmRamF32(_) => true,
+            Self::SparseCompImmRamF16(_) => true,
+            Self::SparseCompMmapF32(_) => true,
+            Self::SparseCompMmapF16(_) => true,
         }
     }
 
@@ -81,8 +92,12 @@ impl VectorIndexEnum {
         match self {
             Self::Plain(_) | Self::HnswRam(_) | Self::HnswMmap(_) => (),
             Self::SparseRam(index) => index.fill_idf_statistics(idf),
-            Self::SparseImmutableRam(index) => index.fill_idf_statistics(idf),
+            Self::SparseImmRam(index) => index.fill_idf_statistics(idf),
             Self::SparseMmap(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompImmRamF32(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompImmRamF16(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompMmapF32(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompMmapF16(index) => index.fill_idf_statistics(idf),
         }
     }
 }
@@ -109,10 +124,22 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::SparseRam(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
-            VectorIndexEnum::SparseImmutableRam(index) => {
+            VectorIndexEnum::SparseImmRam(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
             VectorIndexEnum::SparseMmap(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            VectorIndexEnum::SparseCompImmRamF32(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            VectorIndexEnum::SparseCompImmRamF16(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            VectorIndexEnum::SparseCompMmapF32(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            VectorIndexEnum::SparseCompMmapF16(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
         }
@@ -137,10 +164,22 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::SparseRam(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
-            VectorIndexEnum::SparseImmutableRam(index) => {
+            VectorIndexEnum::SparseImmRam(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
             VectorIndexEnum::SparseMmap(index) => {
+                index.build_index_with_progress(permit, stopped, tick_progress)
+            }
+            VectorIndexEnum::SparseCompImmRamF32(index) => {
+                index.build_index_with_progress(permit, stopped, tick_progress)
+            }
+            VectorIndexEnum::SparseCompImmRamF16(index) => {
+                index.build_index_with_progress(permit, stopped, tick_progress)
+            }
+            VectorIndexEnum::SparseCompMmapF32(index) => {
+                index.build_index_with_progress(permit, stopped, tick_progress)
+            }
+            VectorIndexEnum::SparseCompMmapF16(index) => {
                 index.build_index_with_progress(permit, stopped, tick_progress)
             }
         }
@@ -152,8 +191,12 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::HnswRam(index) => index.get_telemetry_data(detail),
             VectorIndexEnum::HnswMmap(index) => index.get_telemetry_data(detail),
             VectorIndexEnum::SparseRam(index) => index.get_telemetry_data(detail),
-            VectorIndexEnum::SparseImmutableRam(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseImmRam(index) => index.get_telemetry_data(detail),
             VectorIndexEnum::SparseMmap(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseCompImmRamF32(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseCompImmRamF16(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseCompMmapF32(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseCompMmapF16(index) => index.get_telemetry_data(detail),
         }
     }
 
@@ -163,8 +206,12 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::HnswRam(index) => index.files(),
             VectorIndexEnum::HnswMmap(index) => index.files(),
             VectorIndexEnum::SparseRam(index) => index.files(),
-            VectorIndexEnum::SparseImmutableRam(index) => index.files(),
+            VectorIndexEnum::SparseImmRam(index) => index.files(),
             VectorIndexEnum::SparseMmap(index) => index.files(),
+            VectorIndexEnum::SparseCompImmRamF32(index) => index.files(),
+            VectorIndexEnum::SparseCompImmRamF16(index) => index.files(),
+            VectorIndexEnum::SparseCompMmapF32(index) => index.files(),
+            VectorIndexEnum::SparseCompMmapF16(index) => index.files(),
         }
     }
 
@@ -174,8 +221,12 @@ impl VectorIndex for VectorIndexEnum {
             Self::HnswRam(index) => index.indexed_vector_count(),
             Self::HnswMmap(index) => index.indexed_vector_count(),
             Self::SparseRam(index) => index.indexed_vector_count(),
-            Self::SparseImmutableRam(index) => index.indexed_vector_count(),
+            Self::SparseImmRam(index) => index.indexed_vector_count(),
             Self::SparseMmap(index) => index.indexed_vector_count(),
+            Self::SparseCompImmRamF32(index) => index.indexed_vector_count(),
+            Self::SparseCompImmRamF16(index) => index.indexed_vector_count(),
+            Self::SparseCompMmapF32(index) => index.indexed_vector_count(),
+            Self::SparseCompMmapF16(index) => index.indexed_vector_count(),
         }
     }
 
@@ -185,8 +236,12 @@ impl VectorIndex for VectorIndexEnum {
             Self::HnswRam(index) => index.update_vector(id, vector),
             Self::HnswMmap(index) => index.update_vector(id, vector),
             Self::SparseRam(index) => index.update_vector(id, vector),
-            Self::SparseImmutableRam(index) => index.update_vector(id, vector),
+            Self::SparseImmRam(index) => index.update_vector(id, vector),
             Self::SparseMmap(index) => index.update_vector(id, vector),
+            Self::SparseCompImmRamF32(index) => index.update_vector(id, vector),
+            Self::SparseCompImmRamF16(index) => index.update_vector(id, vector),
+            Self::SparseCompMmapF32(index) => index.update_vector(id, vector),
+            Self::SparseCompMmapF16(index) => index.update_vector(id, vector),
         }
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use sparse::common::types::DimId;
 use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
@@ -72,6 +74,15 @@ impl VectorIndexEnum {
             Self::SparseRam(_) => true,
             Self::SparseImmutableRam(_) => true,
             Self::SparseMmap(_) => true,
+        }
+    }
+
+    pub fn fill_idf_statistics(&self, idf: &mut HashMap<DimId, usize>) {
+        match self {
+            Self::Plain(_) | Self::HnswRam(_) | Self::HnswMmap(_) => (),
+            Self::SparseRam(index) => index.fill_idf_statistics(idf),
+            Self::SparseImmutableRam(index) => index.fill_idf_statistics(idf),
+            Self::SparseMmap(index) => index.fill_idf_statistics(idf),
         }
     }
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,7 +1,6 @@
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -1901,21 +1900,7 @@ impl SegmentEntry for Segment {
 
         for (vector_name, idf) in query_context.mut_idf().iter_mut() {
             if let Some(vector_data) = self.vector_data.get(vector_name) {
-                let vector_index = vector_data.vector_index.borrow();
-                match vector_index.deref() {
-                    VectorIndexEnum::SparseRam(sparse_index) => {
-                        sparse_index.fill_idf_statistics(idf);
-                    }
-                    VectorIndexEnum::SparseImmutableRam(sparse_index) => {
-                        sparse_index.fill_idf_statistics(idf);
-                    }
-                    VectorIndexEnum::SparseMmap(sparse_index) => {
-                        sparse_index.fill_idf_statistics(idf);
-                    }
-                    VectorIndexEnum::Plain(_)
-                    | VectorIndexEnum::HnswRam(_)
-                    | VectorIndexEnum::HnswMmap(_) => {}
-                }
+                vector_data.vector_index.borrow().fill_idf_statistics(idf);
             }
         }
     }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -18,6 +18,7 @@ use crate::common::error_logging::LogError;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::{IdTracker, IdTrackerEnum};
+use crate::index::sparse_index::sparse_vector_index;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
@@ -337,14 +338,14 @@ impl SegmentBuilder {
 
                 let vector_storage_arc = Arc::new(AtomicRefCell::new(vector_storage));
 
-                let mut vector_index = create_sparse_vector_index(
-                    sparse_vector_config.clone(),
-                    &vector_index_path,
-                    id_tracker_arc.clone(),
-                    vector_storage_arc,
-                    payload_index_arc.clone(),
+                let mut vector_index = create_sparse_vector_index(sparse_vector_index::OpenArgs {
+                    config: sparse_vector_config.index,
+                    id_tracker: id_tracker_arc.clone(),
+                    vector_storage: vector_storage_arc.clone(),
+                    payload_index: payload_index_arc.clone(),
+                    path: &vector_index_path,
                     stopped,
-                )?;
+                })?;
 
                 vector_index.build_index(permit.clone(), stopped)?;
             }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -18,7 +18,7 @@ use crate::common::error_logging::LogError;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::{IdTracker, IdTrackerEnum};
-use crate::index::sparse_index::sparse_vector_index;
+use crate::index::sparse_index::sparse_vector_index::SparseVectorIndexOpenArgs;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
@@ -338,7 +338,7 @@ impl SegmentBuilder {
 
                 let vector_storage_arc = Arc::new(AtomicRefCell::new(vector_storage));
 
-                let mut vector_index = create_sparse_vector_index(sparse_vector_index::OpenArgs {
+                let mut vector_index = create_sparse_vector_index(SparseVectorIndexOpenArgs {
                     config: sparse_vector_config.index,
                     id_tracker: id_tracker_arc.clone(),
                     vector_storage: vector_storage_arc.clone(),

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -349,16 +349,14 @@ pub(crate) fn create_sparse_vector_index(
             vector_index_path,
             stopped,
         )?),
-        SparseIndexType::ImmutableRam => {
-            VectorIndexEnum::SparseImmutableRam(SparseVectorIndex::open(
-                sparse_vector_config.index,
-                id_tracker.clone(),
-                vector_storage.clone(),
-                payload_index.clone(),
-                vector_index_path,
-                stopped,
-            )?)
-        }
+        SparseIndexType::ImmutableRam => VectorIndexEnum::SparseImmRam(SparseVectorIndex::open(
+            sparse_vector_config.index,
+            id_tracker.clone(),
+            vector_storage.clone(),
+            payload_index.clone(),
+            vector_index_path,
+            stopped,
+        )?),
         SparseIndexType::Mmap => VectorIndexEnum::SparseMmap(SparseVectorIndex::open(
             sparse_vector_config.index,
             id_tracker.clone(),

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -22,7 +22,9 @@ use crate::index::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::PlainIndex;
 use crate::index::sparse_index::sparse_index_config::SparseIndexType;
-use crate::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
+use crate::index::sparse_index::sparse_vector_index::{
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
+};
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndexEnum;
 use crate::payload_storage::on_disk_payload_storage::OnDiskPayloadStorage;
@@ -333,12 +335,12 @@ pub(crate) fn create_vector_index(
 }
 
 pub(crate) fn create_sparse_vector_index(
-    args: sparse_vector_index::OpenArgs,
+    args: SparseVectorIndexOpenArgs,
 ) -> OperationResult<VectorIndexEnum> {
     let vector_index = match args.config.index_type {
         SparseIndexType::MutableRam => VectorIndexEnum::SparseRam(SparseVectorIndex::open(args)?),
         SparseIndexType::ImmutableRam => {
-            VectorIndexEnum::SparseImmRam(SparseVectorIndex::open(args)?)
+            VectorIndexEnum::SparseImmutableRam(SparseVectorIndex::open(args)?)
         }
         SparseIndexType::Mmap => VectorIndexEnum::SparseMmap(SparseVectorIndex::open(args)?),
     };
@@ -454,7 +456,7 @@ fn create_segment(
             );
         }
 
-        let vector_index = sp(create_sparse_vector_index(sparse_vector_index::OpenArgs {
+        let vector_index = sp(create_sparse_vector_index(SparseVectorIndexOpenArgs {
             config: sparse_vector_config.index,
             id_tracker: id_tracker.clone(),
             vector_storage: vector_storage.clone(),

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -13,7 +13,9 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use segment::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
+use segment::index::sparse_index::sparse_vector_index::{
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
+};
 use segment::index::VectorIndex;
 use segment::segment_constructor::build_segment;
 use segment::types::{
@@ -167,7 +169,7 @@ fn sparse_index_discover_test() {
 
     let vector_storage = &sparse_segment.vector_data[SPARSE_VECTOR_NAME].vector_storage;
     let mut sparse_index =
-        SparseVectorIndex::<InvertedIndexImmutableRam>::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::<InvertedIndexImmutableRam>::open(SparseVectorIndexOpenArgs {
             config: SparseIndexConfig {
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::ImmutableRam,

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -13,7 +13,7 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
+use segment::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
 use segment::index::VectorIndex;
 use segment::segment_constructor::build_segment;
 use segment::types::{
@@ -166,18 +166,19 @@ fn sparse_index_discover_test() {
     let payload_index_ptr = sparse_segment.payload_index.clone();
 
     let vector_storage = &sparse_segment.vector_data[SPARSE_VECTOR_NAME].vector_storage;
-    let mut sparse_index = SparseVectorIndex::<InvertedIndexImmutableRam>::open(
-        SparseIndexConfig {
-            full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
-            index_type: SparseIndexType::ImmutableRam,
-        },
-        sparse_segment.id_tracker.clone(),
-        vector_storage.clone(),
-        payload_index_ptr.clone(),
-        index_dir.path(),
-        &stopped,
-    )
-    .unwrap();
+    let mut sparse_index =
+        SparseVectorIndex::<InvertedIndexImmutableRam>::open(sparse_vector_index::OpenArgs {
+            config: SparseIndexConfig {
+                full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
+                index_type: SparseIndexType::ImmutableRam,
+            },
+            id_tracker: sparse_segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            payload_index: payload_index_ptr.clone(),
+            path: index_dir.path(),
+            stopped: &stopped,
+        })
+        .unwrap();
 
     sparse_index.build_index(permit, &stopped).unwrap();
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -18,7 +18,7 @@ use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::fixtures::sparse_fixtures::{fixture_open_sparse_index, fixture_sparse_index_ram};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
+use segment::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
 use segment::index::{PayloadIndex, VectorIndex, VectorIndexEnum};
 use segment::json_path::path;
 use segment::segment::Segment;
@@ -216,14 +216,14 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let mut sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
-        SparseVectorIndex::open(
-            sparse_index_config,
-            sparse_vector_ram_index.id_tracker().clone(),
-            sparse_vector_ram_index.vector_storage().clone(),
-            sparse_vector_ram_index.payload_index().clone(),
-            mmap_index_dir.path(),
-            &stopped,
-        )
+        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+            config: sparse_index_config,
+            id_tracker: sparse_vector_ram_index.id_tracker().clone(),
+            vector_storage: sparse_vector_ram_index.vector_storage().clone(),
+            payload_index: sparse_vector_ram_index.payload_index().clone(),
+            path: mmap_index_dir.path(),
+            stopped: &stopped,
+        })
         .unwrap();
 
     // build index
@@ -245,15 +245,16 @@ fn sparse_vector_index_consistent_with_storage() {
     // load index from memmap file
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
-    let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> = SparseVectorIndex::open(
-        sparse_index_config,
-        sparse_vector_ram_index.id_tracker().clone(),
-        sparse_vector_ram_index.vector_storage().clone(),
-        sparse_vector_ram_index.payload_index().clone(),
-        mmap_index_dir.path(),
-        &stopped,
-    )
-    .unwrap();
+    let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
+        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+            config: sparse_index_config,
+            id_tracker: sparse_vector_ram_index.id_tracker().clone(),
+            vector_storage: sparse_vector_ram_index.vector_storage().clone(),
+            payload_index: sparse_vector_ram_index.payload_index().clone(),
+            path: mmap_index_dir.path(),
+            stopped: &stopped,
+        })
+        .unwrap();
 
     assert_eq!(
         sparse_vector_mmap_index.indexed_vector_count(),
@@ -705,19 +706,19 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
         .unwrap();
 
     let open_index = || -> SparseVectorIndex<TInvertedIndex> {
-        SparseVectorIndex::open(
-            SparseIndexConfig {
+        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+            config: SparseIndexConfig {
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::Mmap,
             },
-            segment.id_tracker.clone(),
-            segment.vector_data[SPARSE_VECTOR_NAME]
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
                 .vector_storage
                 .clone(),
-            segment.payload_index.clone(),
-            inverted_index_dir.path(),
-            &stopped,
-        )
+            payload_index: segment.payload_index.clone(),
+            path: inverted_index_dir.path(),
+            stopped: &stopped,
+        })
         .unwrap()
     };
 
@@ -786,14 +787,14 @@ fn sparse_vector_index_files() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let mut sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
-        SparseVectorIndex::open(
-            sparse_index_config,
-            sparse_vector_ram_index.id_tracker().clone(),
-            sparse_vector_ram_index.vector_storage().clone(),
-            sparse_vector_ram_index.payload_index().clone(),
-            mmap_index_dir.path(),
-            &stopped,
-        )
+        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+            config: sparse_index_config,
+            id_tracker: sparse_vector_ram_index.id_tracker().clone(),
+            vector_storage: sparse_vector_ram_index.vector_storage().clone(),
+            payload_index: sparse_vector_ram_index.payload_index().clone(),
+            path: mmap_index_dir.path(),
+            stopped: &stopped,
+        })
         .unwrap();
 
     // build index

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -18,7 +18,9 @@ use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::fixtures::sparse_fixtures::{fixture_open_sparse_index, fixture_sparse_index_ram};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use segment::index::sparse_index::sparse_vector_index::{self, SparseVectorIndex};
+use segment::index::sparse_index::sparse_vector_index::{
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
+};
 use segment::index::{PayloadIndex, VectorIndex, VectorIndexEnum};
 use segment::json_path::path;
 use segment::segment::Segment;
@@ -216,7 +218,7 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let mut sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_ram_index.id_tracker().clone(),
             vector_storage: sparse_vector_ram_index.vector_storage().clone(),
@@ -246,7 +248,7 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_ram_index.id_tracker().clone(),
             vector_storage: sparse_vector_ram_index.vector_storage().clone(),
@@ -706,7 +708,7 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
         .unwrap();
 
     let open_index = || -> SparseVectorIndex<TInvertedIndex> {
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: SparseIndexConfig {
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::Mmap,
@@ -787,7 +789,7 @@ fn sparse_vector_index_files() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let mut sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
-        SparseVectorIndex::open(sparse_vector_index::OpenArgs {
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_ram_index.id_tracker().clone(),
             vector_storage: sparse_vector_ram_index.vector_storage().clone(),

--- a/lib/sparse/benches/search.rs
+++ b/lib/sparse/benches/search.rs
@@ -14,8 +14,8 @@ use rand::SeedableRng as _;
 use sparse::common::scores_memory_pool::ScoresMemoryPool;
 use sparse::common::sparse_vector::{RemappedSparseVector, SparseVector};
 use sparse::common::sparse_vector_fixture::{random_positive_sparse_vector, random_sparse_vector};
-use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexImmutableRam;
-use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexMmap as InvertedIndexCompressedMmap;
+use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
@@ -137,7 +137,7 @@ pub fn run_bench(
 
     run_bench2(
         c.benchmark_group(format!("search/ram_c32/{name}")),
-        &InvertedIndexImmutableRam::<f32>::from_ram_index(
+        &InvertedIndexCompressedImmutableRam::<f32>::from_ram_index(
             Cow::Borrowed(&index),
             "nonexistent/path",
         )
@@ -148,7 +148,7 @@ pub fn run_bench(
 
     run_bench2(
         c.benchmark_group(format!("search/ram_c16/{name}")),
-        &InvertedIndexImmutableRam::<half::f16>::from_ram_index(
+        &InvertedIndexCompressedImmutableRam::<half::f16>::from_ram_index(
             Cow::Borrowed(&index),
             "nonexistent/path",
         )

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -28,6 +28,8 @@ impl<W: Weight> InvertedIndexCompressedImmutableRam<W> {
 impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
     type Iter<'a> = CompressedPostingListIterator<'a, W>;
 
+    type Version = <InvertedIndexCompressedMmap<W> as InvertedIndex>::Version;
+
     fn open(path: &Path) -> std::io::Result<Self> {
         let mmap_inverted_index = InvertedIndexCompressedMmap::load(path)?;
         let mut inverted_index = InvertedIndexCompressedImmutableRam {

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
+use io::storage_version::StorageVersion;
 use memmap2::Mmap;
 use memory::madvise;
 use memory::mmap_ops::{
@@ -28,6 +29,14 @@ use crate::index::posting_list_common::GenericPostingElement;
 
 const POSTING_HEADER_SIZE: usize = size_of::<PostingListFileHeader>();
 const INDEX_CONFIG_FILE_NAME: &str = "inverted_index_config.json";
+
+pub struct Version;
+
+impl StorageVersion for Version {
+    fn current_raw() -> &'static str {
+        "0.2.0"
+    }
+}
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct InvertedIndexFileHeader {
@@ -57,6 +66,8 @@ struct PostingListFileHeader {
 
 impl<W: Weight> InvertedIndex for InvertedIndexCompressedMmap<W> {
     type Iter<'a> = CompressedPostingListIterator<'a, W>;
+
+    type Version = Version;
 
     fn open(path: &Path) -> std::io::Result<Self> {
         Self::load(path)

--- a/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
@@ -20,6 +20,8 @@ pub struct InvertedIndexImmutableRam {
 impl InvertedIndex for InvertedIndexImmutableRam {
     type Iter<'a> = PostingListIterator<'a>;
 
+    type Version = <InvertedIndexMmap as InvertedIndex>::Version;
+
     fn open(path: &Path) -> std::io::Result<Self> {
         let mmap_inverted_index = InvertedIndexMmap::load(path)?;
         let mut inverted_index = InvertedIndexRam {

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
+use io::storage_version::StorageVersion;
 use memmap2::{Mmap, MmapMut};
 use memory::madvise;
 use memory::mmap_ops::{
@@ -23,6 +24,14 @@ use crate::index::posting_list_common::PostingElementEx;
 
 const POSTING_HEADER_SIZE: usize = size_of::<PostingListFileHeader>();
 const INDEX_CONFIG_FILE_NAME: &str = "inverted_index_config.json";
+
+pub struct Version;
+
+impl StorageVersion for Version {
+    fn current_raw() -> &'static str {
+        "0.1.0"
+    }
+}
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct InvertedIndexFileHeader {
@@ -45,6 +54,8 @@ struct PostingListFileHeader {
 
 impl InvertedIndex for InvertedIndexMmap {
     type Iter<'a> = PostingListIterator<'a>;
+
+    type Version = Version;
 
     fn open(path: &Path) -> std::io::Result<Self> {
         Self::load(path)

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -3,12 +3,21 @@ use std::cmp::max;
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
+use io::storage_version::StorageVersion;
 
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::DimId;
 use crate::index::inverted_index::InvertedIndex;
 use crate::index::posting_list::{PostingList, PostingListIterator};
 use crate::index::posting_list_common::PostingElementEx;
+
+pub struct Version;
+
+impl StorageVersion for Version {
+    fn current_raw() -> &'static str {
+        panic!("InvertedIndexRam is not supposed to be versioned");
+    }
+}
 
 /// Inverted flatten index from dimension id to posting list
 #[derive(Debug, Clone, PartialEq)]
@@ -23,6 +32,8 @@ pub struct InvertedIndexRam {
 
 impl InvertedIndex for InvertedIndexRam {
     type Iter<'a> = PostingListIterator<'a>;
+
+    type Version = Version;
 
     fn open(_path: &Path) -> std::io::Result<Self> {
         panic!("InvertedIndexRam is not supposed to be loaded");

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
+use io::storage_version::StorageVersion;
 
 use super::posting_list_common::PostingListIter;
 use crate::common::sparse_vector::RemappedSparseVector;
@@ -22,6 +23,8 @@ pub trait InvertedIndex: Sized {
     type Iter<'a>: PostingListIter + Clone
     where
         Self: 'a;
+
+    type Version: StorageVersion;
 
     /// Open existing index based on path
     fn open(path: &Path) -> std::io::Result<Self>;

--- a/lib/sparse/src/index/migrate.rs
+++ b/lib/sparse/src/index/migrate.rs
@@ -1,9 +1,0 @@
-use io::storage_version::StorageVersion;
-
-pub struct SparseVectorIndexVersion;
-
-impl StorageVersion for SparseVectorIndexVersion {
-    fn current_raw() -> &'static str {
-        env!("CARGO_PKG_VERSION")
-    }
-}

--- a/lib/sparse/src/index/mod.rs
+++ b/lib/sparse/src/index/mod.rs
@@ -3,7 +3,6 @@
 pub mod compressed_posting_list;
 pub mod inverted_index;
 pub mod loaders;
-pub mod migrate;
 pub mod posting_list;
 pub mod posting_list_common;
 pub mod search_context;

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -391,34 +391,34 @@ mod tests {
     use crate::common::scores_memory_pool::ScoresMemoryPool;
     use crate::common::sparse_vector::SparseVector;
     use crate::common::sparse_vector_fixture::random_sparse_vector;
+    use crate::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
+    use crate::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
+    use crate::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
+    use crate::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
     use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
     use crate::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
-    use crate::index::inverted_index::{
-        inverted_index_compressed_immutable_ram, inverted_index_compressed_mmap,
-        inverted_index_immutable_ram, inverted_index_mmap,
-    };
 
     // ---- Test instantiations ----
 
     #[instantiate_tests(<InvertedIndexRam>)]
     mod ram {}
 
-    #[instantiate_tests(<inverted_index_mmap::InvertedIndexMmap>)]
+    #[instantiate_tests(<InvertedIndexMmap>)]
     mod mmap {}
 
-    #[instantiate_tests(<inverted_index_immutable_ram::InvertedIndexImmutableRam>)]
+    #[instantiate_tests(<InvertedIndexImmutableRam>)]
     mod iram {}
 
-    #[instantiate_tests(<inverted_index_compressed_immutable_ram::InvertedIndexImmutableRam<f32>>)]
+    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<f32>>)]
     mod iram_f32 {}
 
-    #[instantiate_tests(<inverted_index_compressed_immutable_ram::InvertedIndexImmutableRam<half::f16>>)]
+    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<half::f16>>)]
     mod iram_f16 {}
 
-    #[instantiate_tests(<inverted_index_compressed_mmap::InvertedIndexMmap<f32>>)]
+    #[instantiate_tests(<InvertedIndexCompressedMmap<f32>>)]
     mod mmap_f32 {}
 
-    #[instantiate_tests(<inverted_index_compressed_mmap::InvertedIndexMmap<half::f16>>)]
+    #[instantiate_tests(<InvertedIndexCompressedMmap<half::f16>>)]
     mod mmap_f16 {}
 
     // --- End of test instantiations ---


### PR DESCRIPTION
This PR integrates new compressed posting lists into `VectorIndexEnum`.
It doesn't affect the actual behavior (non-compressed index is still used non-conditionally), so it should be safe to include this into a patch release.