### PR TITLE
Add datatype option for sparse vector index

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1219,6 +1219,7 @@ Note: 1kB = 1 vector of size 256. |
 | ----- | ---- | ----- | ----------- |
 | full_scan_threshold | [uint64](#uint64) | optional | Prefer a full scan search upto (excluding) this number of vectors. Note: this is number of vectors, not KiloBytes. |
 | on_disk | [bool](#bool) | optional | Store inverted index on disk. If set to false, the index will be stored in RAM. |
+| datatype | [Datatype](#qdrant-Datatype) | optional | Datatype used to store weights in the index. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5879,6 +5879,17 @@
             "description": "Store index on disk. If set to false, the index will be stored in RAM. Default: false",
             "type": "boolean",
             "nullable": true
+          },
+          "datatype": {
+            "description": "Datatype used to store weights in the index.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Datatype"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -9537,6 +9548,17 @@
           },
           "index_type": {
             "$ref": "#/components/schemas/SparseIndexType"
+          },
+          "datatype": {
+            "description": "Datatype used to store weights in the index.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SparseVectorIndexDatatype"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -9564,6 +9586,14 @@
               "Mmap"
             ]
           }
+        ]
+      },
+      "SparseVectorIndexDatatype": {
+        "description": "Storage types for vectors",
+        "type": "string",
+        "enum": [
+          "float32",
+          "float16"
         ]
       },
       "PayloadStorageType": {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -192,6 +192,10 @@ message SparseIndexConfig {
   Store inverted index on disk. If set to false, the index will be stored in RAM.
    */
   optional bool on_disk = 2;
+  /*
+  Datatype used to store weights in the index.
+  */
+  optional Datatype datatype = 3;
 }
 
 message WalConfigDiff {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -265,6 +265,10 @@ pub struct SparseIndexConfig {
     /// Store inverted index on disk. If set to false, the index will be stored in RAM.
     #[prost(bool, optional, tag = "2")]
     pub on_disk: ::core::option::Option<bool>,
+    ///
+    /// Datatype used to store weights in the index.
+    #[prost(enumeration = "Datatype", optional, tag = "3")]
+    pub datatype: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -9,7 +9,9 @@ use atomicwrites::OverwriteBehavior::AllowOverwrite;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use segment::types::{
     default_replication_factor_const, default_shard_number_const,
     default_write_consistency_factor_const, Distance, HnswConfig, Indexes, PayloadStorageType,
@@ -389,8 +391,8 @@ impl CollectionParams {
                                 datatype: params
                                     .index
                                     .and_then(|index| index.datatype)
-                                    .unwrap_or_default()
-                                    .try_into()?,
+                                    .map(SparseVectorIndexDatatype::try_from)
+                                    .transpose()?,
                             },
                         },
                     ))

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -375,10 +375,10 @@ impl CollectionParams {
         &self,
     ) -> CollectionResult<HashMap<String, SparseVectorDataConfig>> {
         if let Some(sparse_vectors) = &self.sparse_vectors {
-            Ok(sparse_vectors
+            sparse_vectors
                 .iter()
                 .map(|(name, params)| {
-                    (
+                    Ok((
                         name.into(),
                         SparseVectorDataConfig {
                             index: SparseIndexConfig {
@@ -386,11 +386,16 @@ impl CollectionParams {
                                     .index
                                     .and_then(|index| index.full_scan_threshold),
                                 index_type: SparseIndexType::MutableRam,
+                                datatype: params
+                                    .index
+                                    .and_then(|index| index.datatype)
+                                    .unwrap_or_default()
+                                    .try_into()?,
                             },
                         },
-                    )
+                    ))
                 })
-                .collect())
+                .collect()
         } else {
             Ok(Default::default())
         }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1324,7 +1324,6 @@ pub struct SparseIndexParams {
     pub on_disk: Option<bool>,
     /// Datatype used to store weights in the index.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(skip) /* TODO(1.10): remove this in the next minor release to expose the compressed sparse index */]
     pub datatype: Option<Datatype>,
 }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -24,6 +24,7 @@ use segment::data_types::groups::GroupId;
 use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStruct, DEFAULT_VECTOR_NAME,
 };
+use segment::index::sparse_index::sparse_index_config::SparseVectorIndexDatatype;
 use segment::types::{
     Distance, Filter, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType,
     QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
@@ -1207,6 +1208,20 @@ impl From<Datatype> for VectorStorageDatatype {
     }
 }
 
+impl TryFrom<Datatype> for SparseVectorIndexDatatype {
+    type Error = CollectionError;
+
+    fn try_from(value: Datatype) -> Result<Self, Self::Error> {
+        match value {
+            Datatype::Float32 => Ok(Self::Float32),
+            Datatype::Float16 => Ok(Self::Float16),
+            Datatype::Uint8 => Err(CollectionError::BadInput {
+                description: "Uint8 datatype is not supported for sparse vectors".to_string(),
+            }),
+        }
+    }
+}
+
 /// Params of single vector data storage
 #[derive(Debug, Hash, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1307,6 +1322,10 @@ pub struct SparseIndexParams {
     /// Store index on disk. If set to false, the index will be stored in RAM. Default: false
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on_disk: Option<bool>,
+    /// Datatype used to store weights in the index.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(compressed_sparse_index): remove this once feature is released
+    pub datatype: Option<Datatype>,
 }
 
 impl Anonymize for SparseIndexParams {
@@ -1314,6 +1333,7 @@ impl Anonymize for SparseIndexParams {
         SparseIndexParams {
             full_scan_threshold: self.full_scan_threshold,
             on_disk: self.on_disk,
+            datatype: self.datatype,
         }
     }
 }
@@ -1323,16 +1343,22 @@ impl SparseIndexParams {
         SparseIndexParams {
             full_scan_threshold,
             on_disk,
+            datatype: None, // TODO
         }
     }
 
     pub fn update_from_other(&mut self, other: &SparseIndexParams) {
-        if let Some(full_scan_threshold) = other.full_scan_threshold {
-            self.full_scan_threshold = Some(full_scan_threshold);
-        }
-        if let Some(on_disk) = other.on_disk {
-            self.on_disk = Some(on_disk);
-        }
+        let SparseIndexParams {
+            full_scan_threshold,
+            on_disk,
+            datatype,
+        } = other;
+
+        *self = SparseIndexParams {
+            full_scan_threshold: full_scan_threshold.or(self.full_scan_threshold),
+            on_disk: on_disk.or(self.on_disk),
+            datatype: datatype.or(self.datatype),
+        };
     }
 }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1324,7 +1324,7 @@ pub struct SparseIndexParams {
     pub on_disk: Option<bool>,
     /// Datatype used to store weights in the index.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(skip)] // TODO(compressed_sparse_index): remove this once feature is released
+    #[schemars(skip) /* TODO(1.10): remove this in the next minor release to expose the compressed sparse index */]
     pub datatype: Option<Datatype>,
 }
 
@@ -1339,14 +1339,6 @@ impl Anonymize for SparseIndexParams {
 }
 
 impl SparseIndexParams {
-    pub fn new(full_scan_threshold: Option<usize>, on_disk: Option<bool>) -> Self {
-        SparseIndexParams {
-            full_scan_threshold,
-            on_disk,
-            datatype: None, // TODO
-        }
-    }
-
     pub fn update_from_other(&mut self, other: &SparseIndexParams) {
         let SparseIndexParams {
             full_scan_threshold,

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -9,6 +9,7 @@ use atomic_refcell::AtomicRefCell;
 use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use criterion::{criterion_group, criterion_main, Criterion};
+use half::f16;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
@@ -26,6 +27,7 @@ use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use segment::vector_storage::VectorStorage;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::InvertedIndex;
@@ -120,6 +122,30 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
             let mmap_inverted_index = InvertedIndexMmap::from_ram_index(
+                Cow::Borrowed(sparse_vector_index.inverted_index()),
+                &mmap_index_dir,
+            )
+            .unwrap();
+            assert_eq!(mmap_inverted_index.vector_count(), NUM_VECTORS);
+        })
+    });
+
+    group.bench_function("convert-mmap-index-f32", |b| {
+        b.iter(|| {
+            let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
+            let mmap_inverted_index = InvertedIndexCompressedMmap::<f32>::from_ram_index(
+                Cow::Borrowed(sparse_vector_index.inverted_index()),
+                &mmap_index_dir,
+            )
+            .unwrap();
+            assert_eq!(mmap_inverted_index.vector_count(), NUM_VECTORS);
+        })
+    });
+
+    group.bench_function("convert-mmap-index-f16", |b| {
+        b.iter(|| {
+            let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
+            let mmap_inverted_index = InvertedIndexCompressedMmap::<f16>::from_ram_index(
                 Cow::Borrowed(sparse_vector_index.inverted_index()),
                 &mmap_index_dir,
             )

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -14,7 +14,9 @@ use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::index::hnsw_index::num_rayon_threads;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -67,7 +69,11 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     }
 
     // save index config to disk
-    let index_config = SparseIndexConfig::new(Some(10_000), SparseIndexType::ImmutableRam);
+    let index_config = SparseIndexConfig::new(
+        Some(10_000),
+        SparseIndexType::ImmutableRam,
+        SparseVectorIndexDatatype::Float32,
+    );
 
     let permit_cpu_count = num_rayon_threads(0);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -74,7 +74,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     let index_config = SparseIndexConfig::new(
         Some(10_000),
         SparseIndexType::ImmutableRam,
-        SparseVectorIndexDatatype::Float32,
+        Some(SparseVectorIndexDatatype::Float32),
     );
 
     let permit_cpu_count = num_rayon_threads(0);

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -14,7 +14,9 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram_from_iter;
 use segment::index::hnsw_index::num_rayon_threads;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -109,8 +111,11 @@ fn sparse_vector_index_search_benchmark_impl(
 
     // mmap inverted index
     let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
-    let sparse_index_config =
-        SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap);
+    let sparse_index_config = SparseIndexConfig::new(
+        Some(FULL_SCAN_THRESHOLD),
+        SparseIndexType::Mmap,
+        SparseVectorIndexDatatype::Float32,
+    );
     let mut sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -14,9 +14,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram_from_iter;
 use segment::index::hnsw_index::num_rayon_threads;
-use segment::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -111,11 +109,8 @@ fn sparse_vector_index_search_benchmark_impl(
 
     // mmap inverted index
     let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
-    let sparse_index_config = SparseIndexConfig::new(
-        Some(FULL_SCAN_THRESHOLD),
-        SparseIndexType::Mmap,
-        SparseVectorIndexDatatype::Float32,
-    );
+    let sparse_index_config =
+        SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap, None);
     let mut sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -15,9 +15,7 @@ use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::index::hnsw_index::num_rayon_threads;
-use crate::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use crate::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -75,11 +73,7 @@ pub fn fixture_open_sparse_index<I: InvertedIndex>(
         num_vectors,
     );
 
-    let sparse_index_config = SparseIndexConfig::new(
-        Some(full_scan_threshold),
-        index_type,
-        SparseVectorIndexDatatype::Float32,
-    );
+    let sparse_index_config = SparseIndexConfig::new(Some(full_scan_threshold), index_type, None);
     let sparse_vector_index: SparseVectorIndex<I> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -15,7 +15,9 @@ use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::index::hnsw_index::num_rayon_threads;
-use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use crate::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use crate::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -73,7 +75,11 @@ pub fn fixture_open_sparse_index<I: InvertedIndex>(
         num_vectors,
     );
 
-    let sparse_index_config = SparseIndexConfig::new(Some(full_scan_threshold), index_type);
+    let sparse_index_config = SparseIndexConfig::new(
+        Some(full_scan_threshold),
+        index_type,
+        SparseVectorIndexDatatype::Float32,
+    );
     let sparse_vector_index: SparseVectorIndex<I> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,

--- a/lib/segment/src/index/sparse_index/sparse_index_config.rs
+++ b/lib/segment/src/index/sparse_index/sparse_index_config.rs
@@ -4,6 +4,7 @@ use io::file_operations::{atomic_save_json, read_json};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::sparse_vector_index::USE_COMPRESSED;
 use crate::common::anonymize::Anonymize;
 use crate::common::operation_error::OperationResult;
 
@@ -39,8 +40,25 @@ impl SparseIndexType {
     }
 }
 
+/// Storage types for vectors
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Default)]
+pub enum SparseVectorIndexDatatype {
+    // Single-precision floating point
+    #[default]
+    Float32,
+    // Half-precision floating point
+    Float16,
+}
+
+impl SparseVectorIndexDatatype {
+    fn should_hide(&self) -> bool {
+        // Hide default value until the feature is released
+        !USE_COMPRESSED && *self == Self::Float32
+    }
+}
+
 /// Configuration for sparse inverted index.
-#[derive(Debug, Hash, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct SparseIndexConfig {
     /// We prefer a full scan search upto (excluding) this number of vectors.
@@ -49,6 +67,11 @@ pub struct SparseIndexConfig {
     pub full_scan_threshold: Option<usize>,
     /// Type of sparse index
     pub index_type: SparseIndexType,
+    /// Datatype used to store weights in the index.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "SparseVectorIndexDatatype::should_hide")]
+    #[schemars(skip)] // TODO(compressed_sparse_index): remove this once feature is released
+    pub datatype: SparseVectorIndexDatatype,
 }
 
 impl Anonymize for SparseIndexConfig {
@@ -56,15 +79,21 @@ impl Anonymize for SparseIndexConfig {
         SparseIndexConfig {
             full_scan_threshold: self.full_scan_threshold,
             index_type: self.index_type,
+            datatype: self.datatype,
         }
     }
 }
 
 impl SparseIndexConfig {
-    pub fn new(full_scan_threshold: Option<usize>, index_type: SparseIndexType) -> Self {
+    pub fn new(
+        full_scan_threshold: Option<usize>,
+        index_type: SparseIndexType,
+        datatype: SparseVectorIndexDatatype,
+    ) -> Self {
         SparseIndexConfig {
             full_scan_threshold,
             index_type,
+            datatype,
         }
     }
 

--- a/lib/segment/src/index/sparse_index/sparse_index_config.rs
+++ b/lib/segment/src/index/sparse_index/sparse_index_config.rs
@@ -42,6 +42,7 @@ impl SparseIndexType {
 
 /// Storage types for vectors
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
 pub enum SparseVectorIndexDatatype {
     // Single-precision floating point
     #[default]
@@ -70,7 +71,7 @@ pub struct SparseIndexConfig {
     /// Datatype used to store weights in the index.
     #[serde(default)]
     #[serde(skip_serializing_if = "SparseVectorIndexDatatype::should_hide")]
-    #[schemars(skip)] // TODO(compressed_sparse_index): remove this once feature is released
+    #[schemars(skip) /* TODO(1.10): remove this in the next minor release to expose the compressed sparse index */]
     pub datatype: SparseVectorIndexDatatype,
 }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -40,7 +40,7 @@ use crate::vector_storage::{
     check_deleted_condition, new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum,
 };
 
-// TODO(compressed_sparse_index): remove this once feature is released
+// TODO(1.10): remove this in the next minor release to expose the compressed sparse index
 /// Whether to use the new compressed format.
 pub const USE_COMPRESSED: bool = false;
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -40,6 +40,10 @@ use crate::vector_storage::{
     check_deleted_condition, new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum,
 };
 
+// TODO(compressed_sparse_index): remove this once feature is released
+/// Whether to use the new compressed format.
+pub const USE_COMPRESSED: bool = false;
+
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     config: SparseIndexConfig,
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -346,7 +346,7 @@ pub(crate) fn create_sparse_vector_index(
 ) -> OperationResult<VectorIndexEnum> {
     let vector_index = match (
         args.config.index_type,
-        args.config.datatype,
+        args.config.datatype.unwrap_or_default(),
         sparse_vector_index::USE_COMPRESSED,
     ) {
         (_, SparseVectorIndexDatatype::Float16, false) => Err(OperationError::ValidationError {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -21,9 +21,9 @@ use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
 use crate::index::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::PlainIndex;
-use crate::index::sparse_index::sparse_index_config::SparseIndexType;
+use crate::index::sparse_index::sparse_index_config::{SparseIndexType, SparseVectorIndexDatatype};
 use crate::index::sparse_index::sparse_vector_index::{
-    SparseVectorIndex, SparseVectorIndexOpenArgs,
+    self, SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndexEnum;
@@ -337,12 +337,40 @@ pub(crate) fn create_vector_index(
 pub(crate) fn create_sparse_vector_index(
     args: SparseVectorIndexOpenArgs,
 ) -> OperationResult<VectorIndexEnum> {
-    let vector_index = match args.config.index_type {
-        SparseIndexType::MutableRam => VectorIndexEnum::SparseRam(SparseVectorIndex::open(args)?),
-        SparseIndexType::ImmutableRam => {
+    let vector_index = match (
+        args.config.index_type,
+        args.config.datatype,
+        sparse_vector_index::USE_COMPRESSED,
+    ) {
+        (_, SparseVectorIndexDatatype::Float16, false) => Err(OperationError::ValidationError {
+            description: "Float16 datatype is not supported".to_string(),
+        })?,
+
+        (SparseIndexType::MutableRam, _, _) => {
+            VectorIndexEnum::SparseRam(SparseVectorIndex::open(args)?)
+        }
+
+        // Non-compressed
+        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Float32, false) => {
             VectorIndexEnum::SparseImmutableRam(SparseVectorIndex::open(args)?)
         }
-        SparseIndexType::Mmap => VectorIndexEnum::SparseMmap(SparseVectorIndex::open(args)?),
+        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Float32, false) => {
+            VectorIndexEnum::SparseMmap(SparseVectorIndex::open(args)?)
+        }
+
+        // Compressed
+        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Float32, true) => {
+            VectorIndexEnum::SparseCompressedImmutableRamF32(SparseVectorIndex::open(args)?)
+        }
+        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Float32, true) => {
+            VectorIndexEnum::SparseCompressedMmapF32(SparseVectorIndex::open(args)?)
+        }
+        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Float16, true) => {
+            VectorIndexEnum::SparseCompressedImmutableRamF16(SparseVectorIndex::open(args)?)
+        }
+        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Float16, true) => {
+            VectorIndexEnum::SparseCompressedMmapF16(SparseVectorIndex::open(args)?)
+        }
     };
 
     Ok(vector_index)

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -334,6 +334,13 @@ pub(crate) fn create_vector_index(
     Ok(vector_index)
 }
 
+#[cfg(feature = "testing")]
+pub fn create_sparse_vector_index_test(
+    args: SparseVectorIndexOpenArgs,
+) -> OperationResult<VectorIndexEnum> {
+    create_sparse_vector_index(args)
+}
+
 pub(crate) fn create_sparse_vector_index(
     args: SparseVectorIndexOpenArgs,
 ) -> OperationResult<VectorIndexEnum> {

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{only_default_vector, DenseVector, VectorRef};
 use segment::entry::entry_point::SegmentEntry;
-use segment::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
@@ -256,11 +254,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
             sparse_vector_data: HashMap::from([(
                 "sparse".to_owned(),
                 SparseVectorDataConfig {
-                    index: SparseIndexConfig::new(
-                        None,
-                        SparseIndexType::MutableRam,
-                        SparseVectorIndexDatatype::Float32,
-                    ),
+                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
                 },
             )]),
             payload_storage_type: Default::default(),
@@ -345,11 +339,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             sparse_vector_data: HashMap::from([(
                 "sparse".to_owned(),
                 SparseVectorDataConfig {
-                    index: SparseIndexConfig::new(
-                        None,
-                        SparseIndexType::MutableRam,
-                        SparseVectorIndexDatatype::Float32,
-                    ),
+                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
                 },
             )]),
             payload_storage_type: Default::default(),

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{only_default_vector, DenseVector, VectorRef};
 use segment::entry::entry_point::SegmentEntry;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
@@ -254,7 +256,11 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
             sparse_vector_data: HashMap::from([(
                 "sparse".to_owned(),
                 SparseVectorDataConfig {
-                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam),
+                    index: SparseIndexConfig::new(
+                        None,
+                        SparseIndexType::MutableRam,
+                        SparseVectorIndexDatatype::Float32,
+                    ),
                 },
             )]),
             payload_storage_type: Default::default(),
@@ -339,7 +345,11 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             sparse_vector_data: HashMap::from([(
                 "sparse".to_owned(),
                 SparseVectorDataConfig {
-                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam),
+                    index: SparseIndexConfig::new(
+                        None,
+                        SparseIndexType::MutableRam,
+                        SparseVectorIndexDatatype::Float32,
+                    ),
                 },
             )]),
             payload_storage_type: Default::default(),

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -15,18 +15,15 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{
     SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
 };
-use segment::index::sparse_index::sparse_vector_index::{
-    SparseVectorIndex, SparseVectorIndexOpenArgs,
-};
+use segment::index::sparse_index::sparse_vector_index::SparseVectorIndexOpenArgs;
 use segment::index::VectorIndex;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, create_sparse_vector_index_test};
 use segment::types::{
     Distance, Indexes, SegmentConfig, SeqNumberType, SparseVectorDataConfig, VectorDataConfig,
     VectorStorageType, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use sparse::common::sparse_vector::SparseVector;
-use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 3;
@@ -171,20 +168,19 @@ fn sparse_index_discover_test() {
     let payload_index_ptr = sparse_segment.payload_index.clone();
 
     let vector_storage = &sparse_segment.vector_data[SPARSE_VECTOR_NAME].vector_storage;
-    let mut sparse_index =
-        SparseVectorIndex::<InvertedIndexImmutableRam>::open(SparseVectorIndexOpenArgs {
-            config: SparseIndexConfig {
-                full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
-                index_type: SparseIndexType::ImmutableRam,
-                datatype: SparseVectorIndexDatatype::Float32,
-            },
-            id_tracker: sparse_segment.id_tracker.clone(),
-            vector_storage: vector_storage.clone(),
-            payload_index: payload_index_ptr.clone(),
-            path: index_dir.path(),
-            stopped: &stopped,
-        })
-        .unwrap();
+    let mut sparse_index = create_sparse_vector_index_test(SparseVectorIndexOpenArgs {
+        config: SparseIndexConfig {
+            full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
+            index_type: SparseIndexType::ImmutableRam,
+            datatype: SparseVectorIndexDatatype::Float32,
+        },
+        id_tracker: sparse_segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        payload_index: payload_index_ptr.clone(),
+        path: index_dir.path(),
+        stopped: &stopped,
+    })
+    .unwrap();
 
     sparse_index.build_index(permit, &stopped).unwrap();
 

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -12,7 +12,9 @@ use segment::data_types::vectors::{QueryVector, VectorElementType};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
 use segment::index::hnsw_index::num_rayon_threads;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -125,6 +127,7 @@ fn sparse_index_discover_test() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
+                    datatype: SparseVectorIndexDatatype::Float32,
                 },
             },
         )]),
@@ -173,6 +176,7 @@ fn sparse_index_discover_test() {
             config: SparseIndexConfig {
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::ImmutableRam,
+                datatype: SparseVectorIndexDatatype::Float32,
             },
             id_tracker: sparse_segment.id_tracker.clone(),
             vector_storage: vector_storage.clone(),

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -124,7 +124,7 @@ fn sparse_index_discover_test() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
-                    datatype: SparseVectorIndexDatatype::Float32,
+                    datatype: Some(SparseVectorIndexDatatype::Float32),
                 },
             },
         )]),
@@ -172,7 +172,7 @@ fn sparse_index_discover_test() {
         config: SparseIndexConfig {
             full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
             index_type: SparseIndexType::ImmutableRam,
-            datatype: SparseVectorIndexDatatype::Float32,
+            datatype: Some(SparseVectorIndexDatatype::Float32),
         },
         id_tracker: sparse_segment.id_tracker.clone(),
         vector_storage: vector_storage.clone(),

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -17,7 +17,9 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::fixtures::sparse_fixtures::{fixture_open_sparse_index, fixture_sparse_index_ram};
 use segment::index::hnsw_index::num_rayon_threads;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -624,6 +626,7 @@ fn sparse_vector_index_persistence_test() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
+                    datatype: SparseVectorIndexDatatype::Float32,
                 },
             },
         )]),
@@ -712,6 +715,7 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
             config: SparseIndexConfig {
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::Mmap,
+                datatype: SparseVectorIndexDatatype::Float32,
             },
             id_tracker: segment.id_tracker.clone(),
             vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
@@ -826,6 +830,7 @@ fn sparse_vector_test_large_index() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
+                    datatype: SparseVectorIndexDatatype::Float32,
                 },
             },
         )]),

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -626,7 +626,7 @@ fn sparse_vector_index_persistence_test() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
-                    datatype: SparseVectorIndexDatatype::Float32,
+                    datatype: Some(SparseVectorIndexDatatype::Float32),
                 },
             },
         )]),
@@ -715,7 +715,7 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
             config: SparseIndexConfig {
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::Mmap,
-                datatype: SparseVectorIndexDatatype::Float32,
+                datatype: Some(SparseVectorIndexDatatype::Float32),
             },
             id_tracker: segment.id_tracker.clone(),
             vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
@@ -830,7 +830,7 @@ fn sparse_vector_test_large_index() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
-                    datatype: SparseVectorIndexDatatype::Float32,
+                    datatype: Some(SparseVectorIndexDatatype::Float32),
                 },
             },
         )]),

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -40,7 +40,8 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
                 },
                 sparse_vectors: value
                     .sparse_vectors_config
-                    .map(|config| config.map.into_iter().map(|(k, v)| (k, v.into())).collect()),
+                    .map(|v| SparseVectorsConfig::try_from(v).map(|SparseVectorsConfig(x)| x))
+                    .transpose()?,
                 hnsw_config: value.hnsw_config.map(|v| v.into()),
                 wal_config: value.wal_config.map(|v| v.into()),
                 optimizers_config: value.optimizers_config.map(|v| v.into()),
@@ -83,11 +84,10 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                     .quantization_config
                     .map(TryInto::try_into)
                     .transpose()?,
-                sparse_vectors: value.sparse_vectors_config.map(|config| {
-                    SparseVectorsConfig(
-                        config.map.into_iter().map(|(k, v)| (k, v.into())).collect(),
-                    )
-                }),
+                sparse_vectors: value
+                    .sparse_vectors_config
+                    .map(TryInto::try_into)
+                    .transpose()?,
             },
         )))
     }


### PR DESCRIPTION
Depends on #4453.

This PR adds an option `datatype` with possible values of `float16` and `float32`.
It's hidden in the OpenAPI docs for now, and is not usable until `USE_COMPRESSED` is false (see below).

The switch `pub const USE_COMPRESSED: bool = false;` is added as a feature gate until the v1.10 release. When it's false, the old index format is used.