### PR TITLE
Re-enable Windows CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,9 +31,7 @@ jobs:
       run: cargo build --tests --workspace
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
-      # Allow failures on Windows until the issue #4419 is solved.
-      run: cargo nextest run --workspace --profile ci || [ "$RUNNER_OS" = "Windows" ]
-      shell: bash
+      run: cargo nextest run --workspace --profile ci
     - name: Upload test report
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/4419>

According to various sources, the Windows CI image has been fixed. Hopefully that will no longer break our CI tests on Windows.

This PR enables our testing again, reverting <https://github.com/qdrant/qdrant/pull/4421>.

Let's run the Windows test two or three times to confirm the above.