### PR TITLE
Build perf with up to 256 codegen units to make building fast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,7 @@ codegen-units = 256 # restore default value for faster compilation
 inherits = "release"
 lto = false
 opt-level = 3
+codegen-units = 256 # restore default value for faster compilation
 
 [patch.crates-io]
 # Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged


### PR DESCRIPTION
The `perf` profile is supposed to build fast. However, since it now inherits 1 codegen unit from the release profile this is not the case anymore.

This sets the number of codegen units on the profile back to the default, making builds significantly faster.

On my machine:
- without this patch, building takes 412 seconds
- with this patch, building takes 187 seconds

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?