### PR TITLE
universal-query: API testing with multi named vectors

### DIFF
--- a/tests/openapi/openapi_integration/helpers/collection_setup.py
+++ b/tests/openapi/openapi_integration/helpers/collection_setup.py
@@ -438,3 +438,181 @@ def multivec_collection_setup(
         }
     )
     assert response.ok
+
+
+def full_collection_setup(
+        collection_name='test_collection',
+        on_disk_payload=False,
+        on_disk_vectors=False,
+        distance=None,
+):
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "dense-image": {
+                    "size": 4,
+                    "distance": distance or "Dot",
+                    "on_disk": on_disk_vectors,
+                },
+                "dense-text": {
+                    "size": 8,
+                    "distance": distance or "Cosine",
+                    "on_disk": on_disk_vectors,
+                },
+                "dense-multi": {
+                    "size": 4,
+                    "distance": distance or "Dot",
+                    "on_disk": on_disk_vectors,
+                    "multivec_config": {
+                        "comparator": "max_sim"
+                    }
+                },
+            },
+            "sparse_vectors": {
+                "sparse-image": {},
+                "sparse-text": {},
+            },
+            "on_disk_payload": on_disk_payload,
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "dense-image": [0.05, 0.61, 0.76, 0.74],
+                        "dense-text": [0.05, 0.61, 0.76, 0.74, 0.05, 0.61, 0.76, 0.74],
+                        "dense-multi": [
+                            [1.05, 1.61, 1.76, 1.74],
+                            [2.05, 2.61, 2.76, 2.74],
+                            [3.05, 3.61, 3.76, 3.74]
+                        ],
+                        "sparse-image": {
+                            "indices": [1, 2, 4, 8],
+                            "values": [1.5, 1.5, 1.5, 1.5]
+                        },
+                        "sparse-text": {
+                            "indices": [66, 12],
+                            "values": [1.5, 1.5]
+                        }
+                    },
+                    "payload": {"city": "Berlin"}
+                },
+                {
+                    "id": 2,
+                    "vector": {
+                        "dense-image": [0.19, 0.81, 0.75, 0.11],
+                        "dense-text": [0.19, 0.81, 0.75, 0.11, 0.19, 0.81, 0.75, 0.11],
+                        "dense-multi": [
+                            [2.05, 2.61, 2.76, 2.74],
+                            [3.05, 3.61, 3.76, 3.74],
+                            [4.05, 4.61, 4.76, 4.74]
+                        ],
+                        "sparse-image": {
+                            "indices": [1, 2, 4, 8],
+                            "values": [2.5, 2.5, 2.5, 2.5]
+                        },
+                        "sparse-text": {
+                            "indices": [66, 12],
+                            "values": [2.5, 2.5]
+                        }
+                    },
+                    "payload": {"city": ["Berlin", "London"]}
+                },
+                {
+                    "id": 3,
+                    "vector": {
+                        "dense-image": [0.36, 0.55, 0.47, 0.94],
+                        "dense-text": [0.36, 0.55, 0.47, 0.94, 0.36, 0.55, 0.47, 0.94],
+                        "sparse-image": {
+                            "indices": [1, 2, 4, 8],
+                            "values": [3.5, 3.5, 3.5, 3.5]
+                        },
+                        "sparse-text": {
+                            "indices": [66, 12],
+                            "values": [3.5, 3.5]
+                        }
+                    },
+                    "payload": {"city": ["Berlin", "Moscow"]}
+                },
+                {
+                    "id": 4,
+                    "vector": {
+                        "dense-image": [0.18, 0.01, 0.85, 0.80],
+                        "dense-text": [0.18, 0.01, 0.85, 0.80, 0.18, 0.01, 0.85, 0.80],
+                    },
+                    "payload": {"city": ["London", "Moscow"]}
+                },
+                {
+                    "id": 5,
+                    "vector": {
+                        "dense-image": [0.24, 0.18, 0.22, 0.44],
+                        "dense-text": [0.24, 0.18, 0.22, 0.44, 0.24, 0.18, 0.22, 0.44],
+                        "dense-multi": [
+                            [5.05, 5.61, 5.76, 5.74],
+                            [6.05, 6.61, 6.76, 6.74],
+                            [7.05, 7.61, 7.76, 7.74]
+                        ],
+                    },
+                    "payload": {"count": 0}
+                },
+                {
+                    "id": 6,
+                    "vector": {
+                        "dense-image": [0.35, 0.08, 0.11, 0.44],
+                        "dense-text": [0.35, 0.08, 0.11, 0.44, 0.35, 0.08, 0.11, 0.44],
+                    },
+                    "payload": {"count": 1}
+                },
+                {
+                    "id": 7,
+                    "vector": {
+                        "sparse-image": {
+                            "indices": [1, 2, 4, 8],
+                            "values": [7.5, 7.5, 7.5, 7.5]
+                        },
+                        "sparse-text": {
+                            "indices": [66, 12],
+                            "values": [7.5, 7.5]
+                        }
+                    }
+                },
+                {
+                    "id": 8,
+                    "vector": {
+                        "dense-multi": [
+                            [8.05, 8.61, 8.76, 8.74],
+                            [9.05, 9.61, 9.76, 9.74],
+                            [3.05, 3.61, 3.76, 3.74]
+                        ],
+                    },
+                    "payload": {"count": 2}
+                }
+            ]
+        }
+    )
+    assert response.ok

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -324,10 +324,8 @@ def test_order_by():
         path_params={"collection_name": collection_name},
         body={
             "order_by": "count",
-            "using": "dense-image",
         },
     )
-    print(response.json())
     assert response.ok
     scroll_result = response.json()["result"]["points"]
 
@@ -339,6 +337,16 @@ def test_order_by():
 
 
 def test_rrf():
+    filter = {
+        "must": [
+            {
+                "key": "city",
+                "match": {
+                    "value": "Berlin"
+                }
+            }
+        ]
+    }
     response = request_with_validation(
         api="/collections/{collection_name}/points/search",
         method="POST",
@@ -348,6 +356,7 @@ def test_rrf():
                 "name": "dense-image",
                 "vector": [0.1, 0.2, 0.3, 0.4]
             },
+            "filter": filter,
             "limit": 10,
         },
     )
@@ -363,6 +372,7 @@ def test_rrf():
                 "name": "dense-text",
                 "vector": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
             },
+            "filter": filter,
             "limit": 10,
         },
     )
@@ -381,6 +391,7 @@ def test_rrf():
                     "values": [1, 2.2, 3.3],
                 }
             },
+            "filter": filter,
             "limit": 10,
         },
     )
@@ -396,6 +407,7 @@ def test_rrf():
                 "name": "dense-multi",
                 "vector": [3.05, 3.61, 3.76, 3.74], # legacy API expands single vector to multiple vectors
             },
+            "filter": filter,
             "limit": 10,
         },
     )
@@ -430,6 +442,8 @@ def test_rrf():
                     "using": "dense-multi"
                 },
             ],
+            "filter": filter,
+            "limit": 10,
             "query": {"fusion": "rrf"}
         },
     )

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -1,0 +1,372 @@
+from math import isclose
+
+import pytest
+
+from .helpers.collection_setup import drop_collection, full_collection_setup
+from .helpers.helpers import reciprocal_rank_fusion, request_with_validation
+
+collection_name = "test_query"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(on_disk_vectors):
+    full_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
+
+    # keyword index on `city`
+    response = request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        query_params={'wait': 'true'},
+        path_params={"collection_name": collection_name},
+        body={"field_name": "city", "field_schema": "keyword"},
+    )
+    assert response.ok
+
+    # integer index on count
+    response = request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        query_params={'wait': 'true'},
+        path_params={"collection_name": collection_name},
+        body={"field_name": "count", "field_schema": "integer"},
+    )
+    assert response.ok
+
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def root_and_rescored_query(query, using, limit=None, with_payload=None):
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": query,
+            "limit": limit,
+            "with_payload": with_payload,
+            "using": using,
+        },
+    )
+    assert response.ok
+    root_query_result = response.json()["result"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": {
+                "limit": 1000,
+            },
+            "query": query,
+            "with_payload": with_payload,
+            "using": using,
+        },
+    )
+    assert response.ok
+    nested_query_result = response.json()["result"]
+
+    assert root_query_result == nested_query_result
+    return root_query_result
+
+
+def test_search():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": {
+                "name": "dense-image",
+                "vector": [0.1, 0.2, 0.3, 0.4],
+            },
+            "limit": 10,
+        },
+    )
+    assert response.ok
+    search_result = response.json()["result"]
+
+    default_query_result = root_and_rescored_query([0.1, 0.2, 0.3, 0.4], "dense-image")
+
+    nearest_query_result = root_and_rescored_query({"nearest": [0.1, 0.2, 0.3, 0.4]}, "dense-image")
+
+    assert search_result == default_query_result
+    assert search_result == nearest_query_result
+
+
+def test_scroll():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/scroll",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={},
+    )
+    assert response.ok
+    scroll_result = response.json()["result"]["points"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "with_payload": True,
+        },
+    )
+    assert response.ok
+    query_result = response.json()["result"]
+
+    for record, scored_point in zip(scroll_result, query_result):
+        assert record.get("id") == scored_point.get("id")
+        assert record.get("payload") == scored_point.get("payload")
+
+
+def test_recommend_avg():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [1, 2, 3, 4],  # ids
+            "negative": [3],  # ids
+            "limit": 10,
+            "using": "dense-image",
+        },
+    )
+    assert response.ok
+    recommend_result = response.json()["result"]
+
+    query_result = root_and_rescored_query(
+        {
+            "recommend": {"positive": [1, 2, 3, 4], "negative": [3]},  # ids
+        },
+        "dense-image",
+    )
+
+    assert recommend_result == query_result
+
+
+def test_recommend_best_score():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [1, 2, 3, 4],  # ids
+            "negative": [3],  # ids
+            "limit": 10,
+            "strategy": "best_score",
+            "using": "dense-image",
+        },
+    )
+    assert response.ok
+    recommend_result = response.json()["result"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": {
+                "recommend": {
+                    "positive": [1, 2, 3, 4],  # ids
+                    "negative": [3],  # ids
+                    "strategy": "best_score",
+                },
+            },
+            "using": "dense-image",
+        },
+    )
+    assert response.ok
+    query_result = response.json()["result"]
+
+    assert recommend_result == query_result
+
+
+def test_discover():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/discover",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "target": 2,  # ids
+            "context": [{"positive": 3, "negative": 4}],  # ids
+            "limit": 10,
+            "using": "dense-image",
+        },
+    )
+    assert response.ok
+    discover_result = response.json()["result"]
+
+    query_result = root_and_rescored_query(
+        {
+            "discover": {
+                "target": 2,
+                "context": [{"positive": 3, "negative": 4}],
+            }
+        },
+        "dense-image"
+    )
+
+    assert discover_result == query_result
+
+
+def test_context():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/discover",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "context": [{"positive": 2, "negative": 4}],
+            "limit": 100,
+            "using": "dense-image",
+        },
+    )
+    assert response.ok
+    context_result = response.json()["result"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": {
+                "context": [{"positive": 2, "negative": 4}],
+            },
+            "limit": 100,
+            "using": "dense-image",
+        },
+    )
+    assert response.ok
+    query_result = response.json()["result"]
+
+    assert set([p["id"] for p in context_result]) == set([p["id"] for p in query_result])
+
+
+def test_order_by():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/scroll",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "order_by": "count",
+            "using": "dense-image",
+        },
+    )
+    print(response.json())
+    assert response.ok
+    scroll_result = response.json()["result"]["points"]
+
+    query_result = root_and_rescored_query({"order_by": "count"}, "dense-image", with_payload=True)
+
+    for record, scored_point in zip(scroll_result, query_result):
+        assert record.get("id") == scored_point.get("id")
+        assert record.get("payload") == scored_point.get("payload")
+
+
+def test_rrf():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": {
+                "name": "dense-image",
+                "vector": [0.1, 0.2, 0.3, 0.4]
+            },
+            "limit": 10,
+        },
+    )
+    assert response.ok
+    search_result_1 = response.json()["result"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": {
+                "name": "dense-text",
+                "vector": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+            },
+            "limit": 10,
+        },
+    )
+    assert response.ok
+    search_result_2 = response.json()["result"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": {
+                "name": "sparse-text",
+                "vector": {
+                    "indices": [63, 65, 66],
+                    "values": [1, 2.2, 3.3],
+                }
+            },
+            "limit": 10,
+        },
+    )
+    assert response.ok
+    search_result_3 = response.json()["result"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": {
+                "name": "dense-multi",
+                "vector": [3.05, 3.61, 3.76, 3.74], # legacy API expands single vector to multiple vectors
+            },
+            "limit": 10,
+        },
+    )
+    assert response.ok
+    search_result_4 = response.json()["result"]
+
+    rrf_expected = reciprocal_rank_fusion([search_result_1, search_result_2, search_result_3, search_result_4], limit=10)
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": [
+                {
+                    "query": [0.1, 0.2, 0.3, 0.4],
+                    "using": "dense-image"
+                },
+                {
+                    "query": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+                    "using": "dense-text"
+                },
+                {
+                    "query": {
+                        "indices": [63, 65, 66],
+                        "values": [1, 2.2, 3.3],
+                    },
+                    "using": "sparse-text",
+                },
+                {
+                    "query": [[3.05, 3.61, 3.76, 3.74]],
+                    "using": "dense-multi"
+                },
+            ],
+            "query": {"fusion": "rrf"}
+        },
+    )
+    assert response.ok, response.json()
+    rrf_result = response.json()["result"]
+
+    def get_id(x):
+        return x["id"]
+
+    # rrf order is not deterministic with same scores, so we need to sort by id
+    for expected, result in zip(sorted(rrf_expected, key=get_id), sorted(rrf_result, key=get_id)):
+        assert expected["id"] == result["id"]
+        assert expected["payload"] == result["payload"]
+        assert isclose(expected["score"], result["score"], rel_tol=1e-5)


### PR DESCRIPTION
This PR introduces test for the new query API using several named vectors of different types:
- dense
- sparse
- multivector

The goal is to provide a larger safety net as we start to change the internals significantly.