### PR TITLE
Fix Rust 1.79 warnings

### DIFF
--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -570,6 +570,7 @@ mod from_grpc {
     use crate::operations::consistency_params::ReadConsistency;
     use crate::operations::shard_selector_internal::ShardSelectorInternal;
 
+    #[allow(dead_code)]
     pub struct IntoCollectionQueryRequest {
         pub request: CollectionQueryRequest,
         pub collection_name: String,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,6 +15,7 @@ use crate::tracing;
 const DEFAULT_CONFIG: &str = include_str!("../config/config.yaml");
 
 #[derive(Debug, Deserialize, Validate, Clone)]
+#[allow(dead_code)] // necessary because some field are only used in main.rs
 pub struct ServiceConfig {
     #[validate(length(min = 1))]
     pub host: String,
@@ -65,6 +66,7 @@ pub struct ClusterConfig {
 }
 
 #[derive(Debug, Deserialize, Clone, Validate)]
+#[allow(dead_code)] // necessary because some field are only used in main.rs
 pub struct P2pConfig {
     #[serde(default)]
     pub port: Option<u16>,
@@ -122,6 +124,7 @@ pub struct TlsConfig {
 }
 
 #[derive(Debug, Deserialize, Clone, Validate)]
+#[allow(dead_code)] // necessary because some field are only used in main.rs
 pub struct Settings {
     #[serde(default)]
     pub log_level: Option<String>,


### PR DESCRIPTION
We are getting new warnings for fields which are used only in `main.rs` :shrug: 

```
warning: fields `grpc_port` and `slow_query_secs` are never read
  --> src/settings.rs:22:9
   |
18 | pub struct ServiceConfig {
   |            ------------- fields in this struct
...
22 |     pub grpc_port: Option<u16>, // None means that gRPC is disabled
   |         ^^^^^^^^^
...
47 |     pub slow_query_secs: Option<f32>,
   |         ^^^^^^^^^^^^^^^
   |
   = note: `ServiceConfig` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default

warning: field `port` is never read
  --> src/settings.rs:70:9
   |
68 | pub struct P2pConfig {
   |            --------- field in this struct
69 |     #[serde(default)]
70 |     pub port: Option<u16>,
   |         ^^^^
   |
   = note: `P2pConfig` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis

warning: fields `log_level`, `logger`, and `telemetry_disabled` are never read
   --> src/settings.rs:127:9
    |
125 | pub struct Settings {
    |            -------- fields in this struct
126 |     #[serde(default)]
127 |     pub log_level: Option<String>,
    |         ^^^^^^^^^
128 |     #[serde(default)]
129 |     pub logger: tracing::LoggerConfig,
    |         ^^^^^^
...
138 |     pub telemetry_disabled: bool,
    |         ^^^^^^^^^^^^^^^^^^
    |
    = note: `Settings` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
```