### PR TITLE
macos lints: allow missing_safety_doc and dead_code

### DIFF
--- a/lib/segment/src/spaces/metric_f16/neon/dot.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/dot.rs
@@ -10,6 +10,7 @@ extern "C" {
     fn dotProduct_half_4x4(v1: *const f16, v2: *const f16, n: i32) -> f32;
 }
 
+#[allow(clippy::missing_safety_doc)]
 #[cfg(target_feature = "neon")]
 pub unsafe fn neon_dot_similarity_half(
     v1: &[VectorElementTypeHalf],

--- a/lib/segment/src/spaces/metric_f16/neon/euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/euclid.rs
@@ -10,6 +10,7 @@ extern "C" {
     fn euclideanDist_half_4x4(v1: *const f16, v2: *const f16, n: i32) -> f32;
 }
 
+#[allow(clippy::missing_safety_doc)]
 #[cfg(target_feature = "neon")]
 pub unsafe fn neon_euclid_similarity_half(
     v1: &[VectorElementTypeHalf],

--- a/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
@@ -10,6 +10,7 @@ extern "C" {
     fn manhattanDist_half_4x4(v1: *const f16, v2: *const f16, n: i32) -> f32;
 }
 
+#[allow(clippy::missing_safety_doc)]
 #[cfg(target_feature = "neon")]
 pub unsafe fn neon_manhattan_similarity_half(
     v1: &[VectorElementTypeHalf],

--- a/src/common/debugger.rs
+++ b/src/common/debugger.rs
@@ -28,6 +28,7 @@ pub enum DebugConfigPatch {
 }
 
 pub struct DebuggerState {
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub pyroscope: Arc<Mutex<Option<PyroscopeState>>>,
 }
 


### PR DESCRIPTION
On mac, these lints appeared with the latest rust version