### PR TITLE
universal-query: add `query_batch` to `ShardOperations`

### DIFF
--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -110,4 +110,13 @@ impl ShardOperation for DummyShard {
     ) -> CollectionResult<ShardQueryResponse> {
         self.dummy()
     }
+
+    async fn query_batch(
+        &self,
+        _request: Arc<Vec<ShardQueryRequest>>,
+        _search_runtime_handle: &Handle,
+        _timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ShardQueryResponse>> {
+        self.dummy()
+    }
 }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -294,4 +294,16 @@ impl ShardOperation for ForwardProxyShard {
             .query(request, search_runtime_handle, timeout)
             .await
     }
+
+    async fn query_batch(
+        &self,
+        request: Arc<Vec<ShardQueryRequest>>,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ShardQueryResponse>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard
+            .query_batch(request, search_runtime_handle, timeout)
+            .await
+    }
 }

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -258,4 +258,16 @@ impl ShardOperation for ProxyShard {
             .query(request, search_runtime_handle, timeout)
             .await
     }
+
+    async fn query_batch(
+        &self,
+        request: Arc<Vec<ShardQueryRequest>>,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ShardQueryResponse>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard
+            .query_batch(request, search_runtime_handle, timeout)
+            .await
+    }
 }

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -306,6 +306,20 @@ impl ShardOperation for QueueProxyShard {
             .query(request, search_runtime_handle, timeout)
             .await
     }
+
+    async fn query_batch(
+        &self,
+        request: Arc<Vec<ShardQueryRequest>>,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ShardQueryResponse>> {
+        self.inner
+            .as_ref()
+            .expect("Queue proxy has been finalized")
+            .wrapped_shard
+            .query_batch(request, search_runtime_handle, timeout)
+            .await
+    }
 }
 
 // Safe guard in debug mode to ensure that `finalize()` is called before dropping
@@ -588,6 +602,18 @@ impl ShardOperation for Inner {
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.wrapped_shard
             .query(request, search_runtime_handle, timeout)
+            .await
+    }
+
+    async fn query_batch(
+        &self,
+        request: Arc<Vec<ShardQueryRequest>>,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ShardQueryResponse>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard
+            .query_batch(request, search_runtime_handle, timeout)
             .await
     }
 }

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -880,4 +880,14 @@ impl ShardOperation for RemoteShard {
 
         result.map_err(CollectionError::from)
     }
+
+    async fn query_batch(
+        &self,
+        _request: Arc<Vec<ShardQueryRequest>>,
+        _search_runtime_handle: &Handle,
+        _timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ShardQueryResponse>> {
+        // TODO(universal-query): implement remote query batch
+        todo!()
+    }
 }

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -54,6 +54,13 @@ pub trait ShardOperation {
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<ShardQueryResponse>;
+
+    async fn query_batch(
+        &self,
+        request: Arc<Vec<ShardQueryRequest>>,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ShardQueryResponse>>;
 }
 
 pub type ShardOperationSS = dyn ShardOperation + Send + Sync;


### PR DESCRIPTION
simply adds a new `query_batch` fn to the `ShardOperations` trait.

The remote shard implementation is not yet here because we will add the required types and conversions in a subsequent PR
