### PR TITLE
Fix: Ignore non-existing postings when deleting old vector

### DIFF
--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -112,7 +112,9 @@ impl InvertedIndexRam {
                 .filter(|&dim_id| !vector.indices.contains(dim_id))
                 .map(|&dim_id| dim_id as usize);
             for dim_id in elements_to_delete {
-                self.postings[dim_id].delete(id);
+                if let Some(posting) = self.postings.get_mut(dim_id) {
+                    posting.delete(id);
+                }
             }
         }
 


### PR DESCRIPTION
Fixup for #4375.

When restoring after a crash from WAL, it's possible to have a vector in the storage, but not in the index. The crash happen when `update()` tries to delete old vector remains from a non-existing posting. The obvious fix is to just ignore such postings.