### PR TITLE
universal-query: batch in internal service

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -23,6 +23,7 @@ service PointsInternal {
   rpc Recommend (RecommendPointsInternal) returns (RecommendResponse) {}
   rpc Get (GetPointsInternal) returns (GetResponse) {}
   rpc Query (QueryPointsInternal) returns (QueryResponse) {}
+  rpc QueryBatch (QueryBatchPointsInternal) returns (QueryBatchResponse) {}
 }
 
 
@@ -244,7 +245,7 @@ message QueryShardPoints {
       OrderBy order_by = 3; // Order by a field
     }
   }
-  
+
   message Prefetch {
     repeated Prefetch prefetch = 1;
     Query query = 2;
@@ -254,7 +255,7 @@ message QueryShardPoints {
     SearchParams params = 6;
     optional float score_threshold = 7;
   }
-  
+
   repeated Prefetch prefetch = 1;
   Query query = 2;
   optional string using = 3;
@@ -274,11 +275,27 @@ message QueryPointsInternal {
   optional uint64 timeout = 4;
 }
 
+message QueryBatchPointsInternal {
+  string collection_name = 1;
+  repeated QueryShardPoints query_points = 2;
+  optional uint32 shard_id = 3;
+  optional uint64 timeout = 4;
+}
+
 message IntermediateResult {
   repeated ScoredPoint result = 1;
 }
 
 message QueryResponse {
   repeated IntermediateResult result = 1;
+  double time = 2; // Time spent to process
+}
+
+message QueryResult {
+    repeated IntermediateResult result = 1;
+}
+
+message QueryBatchResponse {
+  repeated QueryResult batch_results = 1;
   double time = 2; // Time spent to process
 }

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -3,13 +3,14 @@
 use std::time::Duration;
 
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
-use collection::operations::universal_query::shard_query::ShardQueryRequest;
+use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use segment::types::ScoredPoint;
 
 use super::TableOfContent;
 use crate::content_manager::errors::StorageError;
 
 impl TableOfContent {
+    // TODO(universal-query): remove in favor of batch version
     pub async fn query_internal(
         &self,
         collection_name: &str,
@@ -21,6 +22,22 @@ impl TableOfContent {
 
         let res = collection
             .query_internal(request, &shard_selection, timeout)
+            .await?;
+
+        Ok(res)
+    }
+
+    pub async fn query_batch_internal(
+        &self,
+        collection_name: &str,
+        requests: Vec<ShardQueryRequest>,
+        shard_selection: ShardSelectorInternal,
+        timeout: Option<Duration>,
+    ) -> Result<Vec<ShardQueryResponse>, StorageError> {
+        let collection = self.get_collection_unchecked(collection_name).await?;
+
+        let res = collection
+            .query_batch_internal(requests, &shard_selection, timeout)
             .await?;
 
         Ok(res)

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -91,7 +91,7 @@ pub async fn query_batch_internal(
 ) -> Result<Response<QueryBatchResponse>, Status> {
     let batch_requests: Vec<_> = query_points
         .into_iter()
-        .map(|query_points| ShardQueryRequest::try_from(query_points))
+        .map(ShardQueryRequest::try_from)
         .try_collect()?;
 
     let timing = Instant::now();

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -6,14 +6,16 @@ use api::grpc::qdrant::{
     ClearPayloadPointsInternal, CoreSearchBatchPointsInternal, CountPointsInternal, CountResponse,
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
     DeletePayloadPointsInternal, DeletePointsInternal, DeleteVectorsInternal, GetPointsInternal,
-    GetResponse, IntermediateResult, PointsOperationResponseInternal, QueryPointsInternal,
-    QueryResponse, QueryShardPoints, RecommendPointsInternal, RecommendResponse,
-    ScrollPointsInternal, ScrollResponse, SearchBatchResponse, SetPayloadPointsInternal,
-    SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
+    GetResponse, IntermediateResult, PointsOperationResponseInternal, QueryBatchPointsInternal,
+    QueryBatchResponse, QueryPointsInternal, QueryResponse, QueryResult, QueryShardPoints,
+    RecommendPointsInternal, RecommendResponse, ScrollPointsInternal, ScrollResponse,
+    SearchBatchResponse, SetPayloadPointsInternal, SyncPointsInternal, UpdateVectorsInternal,
+    UpsertPointsInternal,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use collection::shards::shard::ShardId;
+use itertools::Itertools;
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
 use storage::rbac::Access;
@@ -40,7 +42,8 @@ impl PointsInternalService {
     }
 }
 
-pub async fn query(
+// TODO(universal-query): remove in favor of batch version
+pub async fn query_internal(
     toc: &TableOfContent,
     collection_name: String,
     query_points: QueryShardPoints,
@@ -71,6 +74,53 @@ pub async fn query(
             .into_iter()
             .map(|points| IntermediateResult {
                 result: points.into_iter().map(From::from).collect::<Vec<_>>(),
+            })
+            .collect(),
+        time: timing.elapsed().as_secs_f64(),
+    };
+
+    Ok(Response::new(response))
+}
+
+pub async fn query_batch_internal(
+    toc: &TableOfContent,
+    collection_name: String,
+    query_points: Vec<QueryShardPoints>,
+    shard_selection: Option<ShardId>,
+    timeout: Option<Duration>,
+) -> Result<Response<QueryBatchResponse>, Status> {
+    let batch_requests: Vec<_> = query_points
+        .into_iter()
+        .map(|query_points| ShardQueryRequest::try_from(query_points))
+        .try_collect()?;
+
+    let timing = Instant::now();
+
+    // As this function is handling an internal request,
+    // we can assume that shard_key is already resolved
+    let shard_selection = match shard_selection {
+        None => {
+            debug_assert!(false, "Shard selection is expected for internal request");
+            ShardSelectorInternal::All
+        }
+        Some(shard_id) => ShardSelectorInternal::ShardId(shard_id),
+    };
+
+    let batch_response = toc
+        .query_batch_internal(&collection_name, batch_requests, shard_selection, timeout)
+        .await
+        .map_err(error_to_status)?;
+
+    let response = QueryBatchResponse {
+        batch_results: batch_response
+            .into_iter()
+            .map(|response| QueryResult {
+                result: response
+                    .into_iter()
+                    .map(|intermediate| IntermediateResult {
+                        result: intermediate.into_iter().map(From::from).collect_vec(),
+                    })
+                    .collect_vec(),
             })
             .collect(),
         time: timing.elapsed().as_secs_f64(),
@@ -493,7 +543,33 @@ impl PointsInternal for PointsInternalService {
 
         // Individual `read_consistency` values are ignored
 
-        query(
+        query_internal(
+            self.toc.as_ref(),
+            collection_name,
+            query_points,
+            shard_id,
+            timeout,
+        )
+        .await
+    }
+
+    async fn query_batch(
+        &self,
+        request: Request<QueryBatchPointsInternal>,
+    ) -> Result<Response<QueryBatchResponse>, Status> {
+        // TODO(universal-query): validate
+        // validate_and_log(request.get_ref());
+
+        let QueryBatchPointsInternal {
+            collection_name,
+            shard_id,
+            query_points,
+            timeout,
+        } = request.into_inner();
+
+        let timeout = timeout.map(Duration::from_secs);
+
+        query_batch_internal(
             self.toc.as_ref(),
             collection_name,
             query_points,


### PR DESCRIPTION
To make it easy to review I've created separate methods to handle the batch queries. The single request version will be removed shortly.
