### PR TITLE
Max size of multivector to fix chunk in storage

### DIFF
--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -3,6 +3,9 @@ use std::borrow::Cow;
 use serde::Serialize;
 use validator::{Validate, ValidationError, ValidationErrors};
 
+// Multivector sholud be small enough to fir the chunk of vector storage
+pub const MAX_MULTIVECTOR_FLATTENED_LEN: usize = 1_000_000;
+
 #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
 pub fn validate_iter<T: Validate>(iter: impl Iterator<Item = T>) -> Result<(), ValidationErrors> {
     let errors = iter
@@ -161,6 +164,16 @@ pub fn validate_multi_vector<T>(multivec: &[Vec<T>]) -> Result<(), ValidationErr
         return Err(errors);
     }
 
+    // total size of all vectors must be less than MAX_MULTIVECTOR_FLATTENED_LEN
+    let flattened_len = multivec.iter().map(|v| v.len()).sum::<usize>();
+    if flattened_len >= MAX_MULTIVECTOR_FLATTENED_LEN {
+        let mut errors = ValidationErrors::default();
+        let mut err = ValidationError::new("multi_vector_too_large");
+        err.add_param(Cow::from("message"), &format!("Total size of all vectors ({flattened_len}) must be less than {MAX_MULTIVECTOR_FLATTENED_LEN}"));
+        errors.add("data", err);
+        return Err(errors);
+    }
+
     // all vectors must have the same length
     let dim = multivec[0].len();
     if let Some(bad_vec) = multivec.iter().find(|v| v.len() != dim) {
@@ -194,7 +207,17 @@ pub fn validate_multi_vector_len(
         errors.add("data", err);
         return Err(errors);
     }
+
     let dense_vector_len = flatten_dense_vector.len();
+    if dense_vector_len >= MAX_MULTIVECTOR_FLATTENED_LEN {
+        let mut errors = ValidationErrors::default();
+        let mut err = ValidationError::new("Vector size is too large");
+        err.add_param(Cow::from("vector_len"), &dense_vector_len);
+        err.add_param(Cow::from("vectors_count"), &vectors_count);
+        errors.add("data", err);
+        return Err(errors);
+    }
+
     if dense_vector_len % vectors_count as usize != 0 {
         let mut errors = ValidationErrors::default();
         let mut err = ValidationError::new("invalid dense vector length for vectors count");

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -130,6 +130,10 @@ impl<T: Sized + Copy + 'static> ChunkedMmapVectors<T> {
         chunk_vector_idx * self.config.dim
     }
 
+    pub fn get_chunk_size_in_bytes(&self) -> usize {
+        self.config.chunk_size_bytes
+    }
+
     pub fn len(&self) -> usize {
         self.status.len
     }

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -10,7 +10,7 @@ use common::types::PointOffsetType;
 use crate::common::vector_utils::{TrySetCapacity, TrySetCapacityExact};
 
 // chunk size in bytes
-const CHUNK_SIZE: usize = 32 * 1024 * 1024;
+pub const CHUNK_SIZE: usize = 32 * 1024 * 1024;
 
 // if dimension is too high, use this capacity
 const MIN_CHUNK_CAPACITY: usize = 16;


### PR DESCRIPTION
This PR adds max size limit for multivector.

Problem: we cannot use unlimited size of multivector because vector storage is divided into chunks and multivector may be larger that vector storage shunk.

Solution: add validation to multivector, add additional checks in vector storages, and cover it by test.