### PR TITLE
universal-query: add lookups to query API definition

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3093,6 +3093,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) | optional | Options for specifying which payload to include or not. |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees. |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Specify in which shards to look for the points, if not specified - look in all shards. |
+| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3025,6 +3025,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | search_params | [SearchParams](#qdrant-SearchParams) | optional | Search params for when there is no prefetch. |
 | score_threshold | [float](#float) | optional | Return points with scores better than this threshold. |
 | limit | [uint64](#uint64) | optional | Max number of points. Default is 10 |
+| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use current collection |
 
 
 
@@ -3093,7 +3094,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) | optional | Options for specifying which payload to include or not. |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees. |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Specify in which shards to look for the points, if not specified - look in all shards. |
-| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
+| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use current collection |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3025,7 +3025,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | search_params | [SearchParams](#qdrant-SearchParams) | optional | Search params for when there is no prefetch. |
 | score_threshold | [float](#float) | optional | Return points with scores better than this threshold. |
 | limit | [uint64](#uint64) | optional | Max number of points. Default is 10 |
-| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use current collection |
+| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use collection from &#39;using&#39; field |
 
 
 
@@ -3094,7 +3094,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) | optional | Options for specifying which payload to include or not. |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees. |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Specify in which shards to look for the points, if not specified - look in all shards. |
-| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use current collection |
+| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use collection from &#39;using&#39; field. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3025,7 +3025,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | search_params | [SearchParams](#qdrant-SearchParams) | optional | Search params for when there is no prefetch. |
 | score_threshold | [float](#float) | optional | Return points with scores better than this threshold. |
 | limit | [uint64](#uint64) | optional | Max number of points. Default is 10 |
-| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use collection from &#39;using&#39; field |
+| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | The location to use for IDs lookup, if not specified - use the current collection and the &#39;using&#39; vector |
 
 
 
@@ -3094,7 +3094,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) | optional | Options for specifying which payload to include or not. |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees. |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Specify in which shards to look for the points, if not specified - look in all shards. |
-| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use collection from &#39;using&#39; field. |
+| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | The location to use for IDs lookup, if not specified - use the current collection and the &#39;using&#39; vector |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11417,11 +11417,12 @@
               }
             ]
           },
-          "with_lookup": {
-            "description": "Options for specifying where to lookup vector ids from during recommendation",
+          "lookup_from": {
+            "description": "The location used to lookup vectors. If not specified - use current collection. Note: the other collection should have the same vector size as the current collection",
+            "default": null,
             "anyOf": [
               {
-                "$ref": "#/components/schemas/WithLookupInterface"
+                "$ref": "#/components/schemas/LookupLocation"
               },
               {
                 "nullable": true
@@ -11501,6 +11502,18 @@
             "format": "uint",
             "minimum": 0,
             "nullable": true
+          },
+          "lookup_from": {
+            "description": "The location used to lookup vectors. If not specified - use current collection. Note: the other collection should have the same vector size as the current collection",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LookupLocation"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11418,7 +11418,7 @@
             ]
           },
           "lookup_from": {
-            "description": "The location used to lookup vectors. If not specified - use current collection. Note: the other collection should have the same vector size as the current collection",
+            "description": "The location used to lookup vectors. If not specified - use collection from 'using' field. Note: the other collection should have the same vector size as the 'using' collection",
             "default": null,
             "anyOf": [
               {
@@ -11504,7 +11504,7 @@
             "nullable": true
           },
           "lookup_from": {
-            "description": "The location used to lookup vectors. If not specified - use current collection. Note: the other collection should have the same vector size as the current collection",
+            "description": "The location used to lookup vectors. If not specified - use collection from 'using' field. Note: the other collection should have the same vector size as the 'using' collection",
             "default": null,
             "anyOf": [
               {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11416,6 +11416,17 @@
                 "nullable": true
               }
             ]
+          },
+          "with_lookup": {
+            "description": "Options for specifying where to lookup vector ids from during recommendation",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WithLookupInterface"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11418,7 +11418,7 @@
             ]
           },
           "lookup_from": {
-            "description": "The location used to lookup vectors. If not specified - use collection from 'using' field. Note: the other collection should have the same vector size as the 'using' collection",
+            "description": "The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector Note: the other collection vectors should have the same vector size as the 'using' vector in the current collection",
             "default": null,
             "anyOf": [
               {
@@ -11504,7 +11504,7 @@
             "nullable": true
           },
           "lookup_from": {
-            "description": "The location used to lookup vectors. If not specified - use collection from 'using' field. Note: the other collection should have the same vector size as the 'using' collection",
+            "description": "The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector Note: the other collection vectors should have the same vector size as the 'using' vector in the current collection",
             "default": null,
             "anyOf": [
               {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -17,9 +17,9 @@ use uuid::Uuid;
 use super::qdrant::raw_query::RawContextPair;
 use super::qdrant::{
     raw_query, start_from, BinaryQuantization, CompressionRatio, DatetimeRange, Direction,
-    GeoLineString, GroupId, MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range,
-    RawVector, RecommendStrategy, SearchPointGroups, SearchPoints, ShardKeySelector, SparseIndices,
-    StartFrom, WithLookup,
+    GeoLineString, GroupId, LookupLocation, MultiVectorComparator, MultiVectorConfig, OrderBy,
+    OrderValue, Range, RawVector, RecommendStrategy, SearchPointGroups, SearchPoints,
+    ShardKeySelector, SparseIndices, StartFrom, WithLookup,
 };
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
@@ -1999,5 +1999,15 @@ impl TryFrom<WithLookup> for rest::WithLookup {
                 .or_else(with_default_payload),
             with_vectors: value.with_vectors.map(|wv| wv.into()),
         })
+    }
+}
+
+impl From<LookupLocation> for rest::LookupLocation {
+    fn from(value: LookupLocation) -> Self {
+        Self {
+            collection: value.collection_name,
+            vector: value.vector_name,
+            shard_key: value.shard_key_selector.map(rest::ShardKeySelector::from),
+        }
     }
 }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -10,6 +10,7 @@ use segment::data_types::vectors as segment_vectors;
 use segment::json_path::JsonPath;
 use segment::types::{default_quantization_ignore_value, DateTimePayloadType, FloatPayloadType};
 use segment::vector_storage::query as segment_query;
+use sparse::common::sparse_vector::validate_sparse_vector_impl;
 use tonic::Status;
 use uuid::Uuid;
 
@@ -17,7 +18,8 @@ use super::qdrant::raw_query::RawContextPair;
 use super::qdrant::{
     raw_query, start_from, BinaryQuantization, CompressionRatio, DatetimeRange, Direction,
     GeoLineString, GroupId, MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range,
-    RawVector, RecommendStrategy, ShardKeySelector, SparseIndices, StartFrom,
+    RawVector, RecommendStrategy, SearchPointGroups, SearchPoints, ShardKeySelector, SparseIndices,
+    StartFrom, WithLookup,
 };
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
@@ -1881,6 +1883,121 @@ impl TryFrom<raw_query::Discovery> for segment_query::DiscoveryQuery<segment_vec
                 .into_iter()
                 .map(segment_query::ContextPair::try_from)
                 .try_collect()?,
+        })
+    }
+}
+
+impl TryFrom<SearchPoints> for rest::SearchRequestInternal {
+    type Error = Status;
+
+    fn try_from(value: SearchPoints) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vector: crate::grpc::conversions::into_named_vector_struct(
+                value.vector_name,
+                value.vector,
+                value.sparse_indices,
+            )?
+            .into(),
+            filter: value.filter.map(|f| f.try_into()).transpose()?,
+            params: value.params.map(|p| p.into()),
+            limit: value.limit as usize,
+            offset: value.offset.map(|x| x as usize),
+            with_payload: value.with_payload.map(|wp| wp.try_into()).transpose()?,
+            with_vector: Some(
+                value
+                    .with_vectors
+                    .map(|with_vectors| with_vectors.into())
+                    .unwrap_or_default(),
+            ),
+            score_threshold: value.score_threshold,
+        })
+    }
+}
+
+impl TryFrom<SearchPointGroups> for rest::SearchGroupsRequestInternal {
+    type Error = Status;
+
+    fn try_from(value: SearchPointGroups) -> Result<Self, Self::Error> {
+        let search_points = SearchPoints {
+            vector: value.vector,
+            filter: value.filter,
+            params: value.params,
+            with_payload: value.with_payload,
+            with_vectors: value.with_vectors,
+            score_threshold: value.score_threshold,
+            vector_name: value.vector_name,
+            limit: 0,
+            offset: None,
+            collection_name: String::new(),
+            read_consistency: None,
+            timeout: None,
+            shard_key_selector: None,
+            sparse_indices: value.sparse_indices,
+        };
+
+        if let Some(sparse_indices) = &search_points.sparse_indices {
+            validate_sparse_vector_impl(&sparse_indices.data, &search_points.vector).map_err(
+                |_| {
+                    Status::invalid_argument(
+                        "Sparse indices does not match sparse vector conditions",
+                    )
+                },
+            )?;
+        }
+
+        let rest::SearchRequestInternal {
+            vector,
+            filter,
+            params,
+            limit: _,
+            offset: _,
+            with_payload,
+            with_vector,
+            score_threshold,
+        } = search_points.try_into()?;
+
+        Ok(Self {
+            vector,
+            filter,
+            params,
+            with_payload,
+            with_vector,
+            score_threshold,
+            group_request: rest::BaseGroupRequest {
+                group_by: json_path_from_proto(&value.group_by)?,
+                limit: value.limit,
+                group_size: value.group_size,
+                with_lookup: value
+                    .with_lookup
+                    .map(rest::WithLookupInterface::try_from)
+                    .transpose()?,
+            },
+        })
+    }
+}
+
+impl TryFrom<WithLookup> for rest::WithLookupInterface {
+    type Error = Status;
+
+    fn try_from(value: WithLookup) -> Result<Self, Self::Error> {
+        Ok(Self::WithLookup(value.try_into()?))
+    }
+}
+
+impl TryFrom<WithLookup> for rest::WithLookup {
+    type Error = Status;
+
+    fn try_from(value: WithLookup) -> Result<Self, Self::Error> {
+        let with_default_payload = || Some(segment::types::WithPayloadInterface::Bool(true));
+
+        Ok(Self {
+            collection_name: value.collection,
+            with_payload: value
+                .with_payload
+                .map(|wp| wp.try_into())
+                .transpose()?
+                .or_else(with_default_payload),
+            with_vectors: value.with_vectors.map(|wv| wv.into()),
         })
     }
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -541,6 +541,7 @@ message QueryPoints {
   optional WithPayloadSelector with_payload = 11; // Options for specifying which payload to include or not.
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees.
   optional ShardKeySelector shard_key_selector = 13; // Specify in which shards to look for the points, if not specified - look in all shards.
+  optional WithLookup with_lookup = 14; // Options for specifying how to use the group id to lookup points in another collection
 }
 
 message PointsUpdateOperation {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -525,7 +525,7 @@ message PrefetchQuery {
   optional SearchParams search_params = 5; // Search params for when there is no prefetch.
   optional float score_threshold = 6; // Return points with scores better than this threshold.
   optional uint64 limit = 7; // Max number of points. Default is 10
-  optional LookupLocation lookup_from = 8; // Name of the collection to use for points lookup, if not specified - use current collection
+  optional LookupLocation lookup_from = 8; // Name of the collection to use for points lookup, if not specified - use collection from 'using' field
 }
 
 message QueryPoints {
@@ -542,7 +542,7 @@ message QueryPoints {
   optional WithPayloadSelector with_payload = 11; // Options for specifying which payload to include or not.
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees.
   optional ShardKeySelector shard_key_selector = 13; // Specify in which shards to look for the points, if not specified - look in all shards.
-  optional LookupLocation lookup_from = 14; // Name of the collection to use for points lookup, if not specified - use current collection
+  optional LookupLocation lookup_from = 14; // Name of the collection to use for points lookup, if not specified - use collection from 'using' field.
 }
 
 message PointsUpdateOperation {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -525,6 +525,7 @@ message PrefetchQuery {
   optional SearchParams search_params = 5; // Search params for when there is no prefetch.
   optional float score_threshold = 6; // Return points with scores better than this threshold.
   optional uint64 limit = 7; // Max number of points. Default is 10
+  optional LookupLocation lookup_from = 8; // Name of the collection to use for points lookup, if not specified - use current collection
 }
 
 message QueryPoints {
@@ -541,7 +542,7 @@ message QueryPoints {
   optional WithPayloadSelector with_payload = 11; // Options for specifying which payload to include or not.
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees.
   optional ShardKeySelector shard_key_selector = 13; // Specify in which shards to look for the points, if not specified - look in all shards.
-  optional WithLookup with_lookup = 14; // Options for specifying how to use the group id to lookup points in another collection
+  optional LookupLocation lookup_from = 14; // Name of the collection to use for points lookup, if not specified - use current collection
 }
 
 message PointsUpdateOperation {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -525,7 +525,7 @@ message PrefetchQuery {
   optional SearchParams search_params = 5; // Search params for when there is no prefetch.
   optional float score_threshold = 6; // Return points with scores better than this threshold.
   optional uint64 limit = 7; // Max number of points. Default is 10
-  optional LookupLocation lookup_from = 8; // Name of the collection to use for points lookup, if not specified - use collection from 'using' field
+  optional LookupLocation lookup_from = 8; // The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
 }
 
 message QueryPoints {
@@ -542,7 +542,7 @@ message QueryPoints {
   optional WithPayloadSelector with_payload = 11; // Options for specifying which payload to include or not.
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees.
   optional ShardKeySelector shard_key_selector = 13; // Specify in which shards to look for the points, if not specified - look in all shards.
-  optional LookupLocation lookup_from = 14; // Name of the collection to use for points lookup, if not specified - use collection from 'using' field.
+  optional LookupLocation lookup_from = 14; // The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
 }
 
 message PointsUpdateOperation {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4826,7 +4826,7 @@ pub struct PrefetchQuery {
     /// Max number of points. Default is 10
     #[prost(uint64, optional, tag = "7")]
     pub limit: ::core::option::Option<u64>,
-    /// Name of the collection to use for points lookup, if not specified - use collection from 'using' field
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
     #[prost(message, optional, tag = "8")]
     pub lookup_from: ::core::option::Option<LookupLocation>,
 }
@@ -4873,7 +4873,7 @@ pub struct QueryPoints {
     /// Specify in which shards to look for the points, if not specified - look in all shards.
     #[prost(message, optional, tag = "13")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
-    /// Name of the collection to use for points lookup, if not specified - use collection from 'using' field.
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
     #[prost(message, optional, tag = "14")]
     pub lookup_from: ::core::option::Option<LookupLocation>,
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4826,6 +4826,9 @@ pub struct PrefetchQuery {
     /// Max number of points. Default is 10
     #[prost(uint64, optional, tag = "7")]
     pub limit: ::core::option::Option<u64>,
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    #[prost(message, optional, tag = "8")]
+    pub lookup_from: ::core::option::Option<LookupLocation>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -4870,9 +4873,9 @@ pub struct QueryPoints {
     /// Specify in which shards to look for the points, if not specified - look in all shards.
     #[prost(message, optional, tag = "13")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
-    /// Options for specifying how to use the group id to lookup points in another collection
+    /// Name of the collection to use for points lookup, if not specified - use current collection
     #[prost(message, optional, tag = "14")]
-    pub with_lookup: ::core::option::Option<WithLookup>,
+    pub lookup_from: ::core::option::Option<LookupLocation>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4826,7 +4826,7 @@ pub struct PrefetchQuery {
     /// Max number of points. Default is 10
     #[prost(uint64, optional, tag = "7")]
     pub limit: ::core::option::Option<u64>,
-    /// Name of the collection to use for points lookup, if not specified - use current collection
+    /// Name of the collection to use for points lookup, if not specified - use collection from 'using' field
     #[prost(message, optional, tag = "8")]
     pub lookup_from: ::core::option::Option<LookupLocation>,
 }
@@ -4873,7 +4873,7 @@ pub struct QueryPoints {
     /// Specify in which shards to look for the points, if not specified - look in all shards.
     #[prost(message, optional, tag = "13")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
-    /// Name of the collection to use for points lookup, if not specified - use current collection
+    /// Name of the collection to use for points lookup, if not specified - use collection from 'using' field.
     #[prost(message, optional, tag = "14")]
     pub lookup_from: ::core::option::Option<LookupLocation>,
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4870,6 +4870,9 @@ pub struct QueryPoints {
     /// Specify in which shards to look for the points, if not specified - look in all shards.
     #[prost(message, optional, tag = "13")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+    /// Options for specifying how to use the group id to lookup points in another collection
+    #[prost(message, optional, tag = "14")]
+    pub with_lookup: ::core::option::Option<WithLookup>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -208,8 +208,8 @@ pub struct QueryRequestInternal {
     /// Options for specifying which payload to include or not. Default is false.
     pub with_payload: Option<WithPayloadInterface>,
 
-    /// The location used to lookup vectors. If not specified - use current collection.
-    /// Note: the other collection should have the same vector size as the current collection
+    /// The location used to lookup vectors. If not specified - use collection from 'using' field.
+    /// Note: the other collection should have the same vector size as the 'using' collection
     #[serde(default)]
     pub lookup_from: Option<LookupLocation>,
 }
@@ -279,8 +279,8 @@ pub struct Prefetch {
     /// Max number of points to return. Default is 10.
     pub limit: Option<usize>,
 
-    /// The location used to lookup vectors. If not specified - use current collection.
-    /// Note: the other collection should have the same vector size as the current collection
+    /// The location used to lookup vectors. If not specified - use collection from 'using' field.
+    /// Note: the other collection should have the same vector size as the 'using' collection
     #[serde(default)]
     pub lookup_from: Option<LookupLocation>,
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -4,7 +4,7 @@ use common::types::ScoreType;
 use schemars::JsonSchema;
 use segment::common::utils::MaybeOneOrMany;
 use segment::data_types::order_by::OrderBy;
-use segment::json_path::JsonPath;
+use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{Filter, SearchParams, ShardKey, WithPayloadInterface, WithVector};
 use serde::{Deserialize, Serialize};
 use sparse::common::sparse_vector::SparseVector;
@@ -207,6 +207,9 @@ pub struct QueryRequestInternal {
 
     /// Options for specifying which payload to include or not. Default is false.
     pub with_payload: Option<WithPayloadInterface>,
+
+    /// Options for specifying where to lookup vector ids from during recommendation
+    pub with_lookup: Option<WithLookupInterface>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
@@ -349,4 +352,119 @@ impl ContextPair {
     pub fn iter(&self) -> impl Iterator<Item = &VectorInput> {
         std::iter::once(&self.positive).chain(std::iter::once(&self.negative))
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct WithLookup {
+    /// Name of the collection to use for points lookup
+    #[serde(rename = "collection")]
+    pub collection_name: String,
+
+    /// Options for specifying which payload to include (or not)
+    #[serde(default = "default_with_payload")]
+    pub with_payload: Option<WithPayloadInterface>,
+
+    /// Options for specifying which vectors to include (or not)
+    #[serde(alias = "with_vector")]
+    #[serde(default)]
+    pub with_vectors: Option<WithVector>,
+}
+
+const fn default_with_payload() -> Option<WithPayloadInterface> {
+    Some(WithPayloadInterface::Bool(true))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum WithLookupInterface {
+    Collection(String),
+    WithLookup(WithLookup),
+}
+
+#[derive(Validate, Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+pub struct BaseGroupRequest {
+    /// Payload field to group by, must be a string or number field.
+    /// If the field contains more than 1 value, all values will be used for grouping.
+    /// One point can be in multiple groups.
+    #[schemars(length(min = 1))]
+    #[validate(custom = "JsonPath::validate_not_empty")]
+    pub group_by: JsonPath,
+
+    /// Maximum amount of points to return per group
+    #[validate(range(min = 1))]
+    pub group_size: u32,
+
+    /// Maximum amount of groups to return
+    #[validate(range(min = 1))]
+    pub limit: u32,
+
+    /// Look for points in another collection using the group ids
+    pub with_lookup: Option<WithLookupInterface>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+pub struct SearchGroupsRequestInternal {
+    /// Look for vectors closest to this
+    #[validate]
+    pub vector: NamedVectorStruct,
+
+    /// Look only for points which satisfies this conditions
+    #[validate]
+    pub filter: Option<Filter>,
+
+    /// Additional search params
+    #[validate]
+    pub params: Option<SearchParams>,
+
+    /// Select which payload to return with the response. Default: None
+    pub with_payload: Option<WithPayloadInterface>,
+
+    /// Whether to return the point vector with the result?
+    #[serde(default, alias = "with_vectors")]
+    pub with_vector: Option<WithVector>,
+
+    /// Define a minimal score threshold for the result.
+    /// If defined, less similar results will not be returned.
+    /// Score of the returned result might be higher or smaller than the threshold depending on the
+    /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
+    pub score_threshold: Option<ScoreType>,
+
+    #[serde(flatten)]
+    #[validate]
+    pub group_request: BaseGroupRequest,
+}
+
+/// Search request.
+/// Holds all conditions and parameters for the search of most similar points by vector similarity
+/// given the filtering restrictions.
+#[derive(Deserialize, Serialize, JsonSchema, Validate, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct SearchRequestInternal {
+    /// Look for vectors closest to this
+    #[validate]
+    pub vector: NamedVectorStruct,
+    /// Look only for points which satisfies this conditions
+    #[validate]
+    pub filter: Option<Filter>,
+    /// Additional search params
+    #[validate]
+    pub params: Option<SearchParams>,
+    /// Max number of result to return
+    #[serde(alias = "top")]
+    #[validate(range(min = 1))]
+    pub limit: usize,
+    /// Offset of the first result to return.
+    /// May be used to paginate results.
+    /// Note: large offset values may cause performance issues.
+    pub offset: Option<usize>,
+    /// Select which payload to return with the response. Default: None
+    pub with_payload: Option<WithPayloadInterface>,
+    /// Whether to return the point vector with the result?
+    #[serde(default, alias = "with_vectors")]
+    pub with_vector: Option<WithVector>,
+    /// Define a minimal score threshold for the result.
+    /// If defined, less similar results will not be returned.
+    /// Score of the returned result might be higher or smaller than the threshold depending on the
+    /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
+    pub score_threshold: Option<ScoreType>,
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -208,8 +208,8 @@ pub struct QueryRequestInternal {
     /// Options for specifying which payload to include or not. Default is false.
     pub with_payload: Option<WithPayloadInterface>,
 
-    /// The location used to lookup vectors. If not specified - use collection from 'using' field.
-    /// Note: the other collection should have the same vector size as the 'using' collection
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    /// Note: the other collection vectors should have the same vector size as the 'using' vector in the current collection
     #[serde(default)]
     pub lookup_from: Option<LookupLocation>,
 }
@@ -279,8 +279,8 @@ pub struct Prefetch {
     /// Max number of points to return. Default is 10.
     pub limit: Option<usize>,
 
-    /// The location used to lookup vectors. If not specified - use collection from 'using' field.
-    /// Note: the other collection should have the same vector size as the 'using' collection
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    /// Note: the other collection vectors should have the same vector size as the 'using' vector in the current collection
     #[serde(default)]
     pub lookup_from: Option<LookupLocation>,
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -208,8 +208,10 @@ pub struct QueryRequestInternal {
     /// Options for specifying which payload to include or not. Default is false.
     pub with_payload: Option<WithPayloadInterface>,
 
-    /// Options for specifying where to lookup vector ids from during recommendation
-    pub with_lookup: Option<WithLookupInterface>,
+    /// The location used to lookup vectors. If not specified - use current collection.
+    /// Note: the other collection should have the same vector size as the current collection
+    #[serde(default)]
+    pub lookup_from: Option<LookupLocation>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
@@ -276,6 +278,11 @@ pub struct Prefetch {
 
     /// Max number of points to return. Default is 10.
     pub limit: Option<usize>,
+
+    /// The location used to lookup vectors. If not specified - use current collection.
+    /// Note: the other collection should have the same vector size as the current collection
+    #[serde(default)]
+    pub lookup_from: Option<LookupLocation>,
 }
 
 /// How to use positive and negative examples to find the results, default is `average_vector`:
@@ -379,6 +386,23 @@ const fn default_with_payload() -> Option<WithPayloadInterface> {
 pub enum WithLookupInterface {
     Collection(String),
     WithLookup(WithLookup),
+}
+
+/// Defines a location to use for looking up the vector.
+/// Specifies collection and vector field name.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct LookupLocation {
+    /// Name of the collection used for lookup
+    pub collection: String,
+    /// Optional name of the vector field within the collection.
+    /// If not provided, the default vector field will be used.
+    #[serde(default)]
+    pub vector: Option<String>,
+
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard_key: Option<ShardKeySelector>,
 }
 
 #[derive(Validate, Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
+use api::rest::SearchRequestInternal;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStruct,
 };
-use collection::operations::types::{CoreSearchRequestBatch, SearchRequestInternal};
+use collection::operations::types::CoreSearchRequestBatch;
 use collection::operations::vector_params_builder::VectorParamsBuilder;
 use collection::operations::CollectionUpdateOperations;
 use collection::optimizers_builder::OptimizersConfig;

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -621,6 +621,7 @@ fn get_hnsw_ef_construct(config: &SegmentConfig, vector_name: &str) -> Option<us
 mod tests {
     use std::collections::HashSet;
 
+    use api::rest::SearchRequestInternal;
     use segment::fixtures::index_fixtures::random_vector;
     use segment::index::VectorIndexEnum;
     use segment::types::{Condition, HasIdCondition};
@@ -628,7 +629,7 @@ mod tests {
 
     use super::*;
     use crate::collection_manager::fixtures::{build_test_holder, random_segment};
-    use crate::operations::types::{CoreSearchRequest, SearchRequestInternal};
+    use crate::operations::types::CoreSearchRequest;
     use crate::optimizers_builder::DEFAULT_INDEXING_THRESHOLD_KB;
 
     #[test]

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::time::Duration;
 
+use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
 use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
 use segment::json_path::{JsonPath, JsonPathInterface as _};
@@ -19,8 +20,7 @@ use crate::lookup::WithLookup;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{
-    BaseGroupRequest, CollectionResult, PointGroup, RecommendGroupsRequestInternal,
-    RecommendRequestInternal, SearchGroupsRequestInternal, SearchRequestInternal,
+    CollectionResult, PointGroup, RecommendGroupsRequestInternal, RecommendRequestInternal,
 };
 use crate::recommendations::recommend_into_core_search;
 

--- a/lib/collection/src/lookup/mod.rs
+++ b/lib/collection/src/lookup/mod.rs
@@ -4,9 +4,7 @@ use std::collections::HashMap;
 
 use futures::Future;
 use itertools::Itertools;
-use schemars::JsonSchema;
 use segment::types::{PointIdType, WithPayloadInterface, WithVector};
-use serde::{Deserialize, Serialize};
 use tokio::sync::RwLockReadGuard;
 use types::PseudoId;
 
@@ -15,24 +13,16 @@ use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{CollectionError, CollectionResult, PointRequestInternal, Record};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WithLookup {
     /// Name of the collection to use for points lookup
-    #[serde(rename = "collection")]
     pub collection_name: String,
 
     /// Options for specifying which payload to include (or not)
-    #[serde(default = "default_with_payload")]
     pub with_payload: Option<WithPayloadInterface>,
 
     /// Options for specifying which vectors to include (or not)
-    #[serde(alias = "with_vector")]
-    #[serde(default)]
     pub with_vectors: Option<WithVector>,
-}
-
-const fn default_with_payload() -> Option<WithPayloadInterface> {
-    Some(WithPayloadInterface::Bool(true))
 }
 
 pub async fn lookup_ids<'a, F, Fut>(

--- a/lib/collection/src/lookup/types.rs
+++ b/lib/collection/src/lookup/types.rs
@@ -1,29 +1,51 @@
 use std::fmt::Display;
 
-use schemars::JsonSchema;
 use segment::data_types::groups::GroupId;
 use segment::types::PointIdType;
-use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::WithLookup;
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
-#[serde(untagged)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum WithLookupInterface {
     Collection(String),
     WithLookup(WithLookup),
 }
 
-impl From<WithLookupInterface> for WithLookup {
-    fn from(with_lookup: WithLookupInterface) -> Self {
+impl From<api::rest::WithLookupInterface> for WithLookupInterface {
+    fn from(with_lookup: api::rest::WithLookupInterface) -> Self {
         match with_lookup {
-            WithLookupInterface::Collection(collection_name) => Self {
+            api::rest::WithLookupInterface::Collection(collection_name) => {
+                Self::Collection(collection_name)
+            }
+            api::rest::WithLookupInterface::WithLookup(with_lookup) => {
+                Self::WithLookup(WithLookup::from(with_lookup))
+            }
+        }
+    }
+}
+
+impl From<api::rest::WithLookupInterface> for WithLookup {
+    fn from(with_lookup: api::rest::WithLookupInterface) -> Self {
+        match with_lookup {
+            api::rest::WithLookupInterface::Collection(collection_name) => Self {
                 collection_name,
                 with_payload: Some(true.into()),
                 with_vectors: Some(false.into()),
             },
-            WithLookupInterface::WithLookup(with_lookup) => with_lookup,
+            api::rest::WithLookupInterface::WithLookup(with_lookup) => {
+                WithLookup::from(with_lookup)
+            }
+        }
+    }
+}
+
+impl From<api::rest::WithLookup> for WithLookup {
+    fn from(with_lookup: api::rest::WithLookup) -> Self {
+        WithLookup {
+            collection_name: with_lookup.collection_name,
+            with_payload: with_lookup.with_payload.map(Into::into),
+            with_vectors: with_lookup.with_vectors.map(Into::into),
         }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -54,8 +54,8 @@ use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{
     AliasDescription, CollectionClusterInfo, CollectionInfo, CollectionStatus, CountResult,
-    LocalShardInfo, LookupLocation, OptimizersStatus, RecommendRequestInternal, Record,
-    RemoteShardInfo, ShardTransferInfo, UpdateResult, UpdateStatus, VectorParams, VectorsConfig,
+    LocalShardInfo, OptimizersStatus, RecommendRequestInternal, Record, RemoteShardInfo,
+    ShardTransferInfo, UpdateResult, UpdateStatus, VectorParams, VectorsConfig,
 };
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::remote_shard::{CollectionCoreSearchRequest, CollectionSearchRequest};
@@ -1304,16 +1304,6 @@ impl From<PointGroup> for api::grpc::qdrant::PointGroup {
             lookup: group
                 .lookup
                 .map(|record| api::grpc::qdrant::RetrievedPoint::from(Record::from(record))),
-        }
-    }
-}
-
-impl From<api::grpc::qdrant::LookupLocation> for LookupLocation {
-    fn from(value: api::grpc::qdrant::LookupLocation) -> Self {
-        Self {
-            collection: value.collection_name,
-            vector: value.vector_name,
-            shard_key: value.shard_key_selector.map(ShardKeySelector::from),
         }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -12,6 +12,7 @@ use api::grpc::qdrant::update_collection_cluster_setup_request::{
 };
 use api::grpc::qdrant::CreateShardKey;
 use api::rest::schema::ShardKeySelector;
+use api::rest::BaseGroupRequest;
 use common::types::ScoreType;
 use itertools::Itertools;
 use segment::data_types::vectors::{
@@ -25,10 +26,9 @@ use tonic::Status;
 
 use super::consistency_params::ReadConsistency;
 use super::types::{
-    BaseGroupRequest, ContextExamplePair, CoreSearchRequest, Datatype, DiscoverRequestInternal,
-    GroupsResult, Modifier, PointGroup, RecommendExample, RecommendGroupsRequestInternal,
-    SearchGroupsRequestInternal, SparseIndexParams, SparseVectorParams, VectorParamsDiff,
-    VectorsConfigDiff,
+    ContextExamplePair, CoreSearchRequest, Datatype, DiscoverRequestInternal, GroupsResult,
+    Modifier, PointGroup, RecommendExample, RecommendGroupsRequestInternal, SparseIndexParams,
+    SparseVectorParams, VectorParamsDiff, VectorsConfigDiff,
 };
 use crate::config::{
     default_replication_factor, default_write_consistency_factor, CollectionConfig,
@@ -55,8 +55,7 @@ use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{
     AliasDescription, CollectionClusterInfo, CollectionInfo, CollectionStatus, CountResult,
     LocalShardInfo, LookupLocation, OptimizersStatus, RecommendRequestInternal, Record,
-    RemoteShardInfo, SearchRequestInternal, ShardTransferInfo, UpdateResult, UpdateStatus,
-    VectorParams, VectorsConfig,
+    RemoteShardInfo, ShardTransferInfo, UpdateResult, UpdateStatus, VectorParams, VectorsConfig,
 };
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::remote_shard::{CollectionCoreSearchRequest, CollectionSearchRequest};
@@ -1288,92 +1287,6 @@ impl TryFrom<api::grpc::qdrant::CoreSearchPoints> for CoreSearchRequest {
                     .unwrap_or_default(),
             ),
             score_threshold: value.score_threshold,
-        })
-    }
-}
-
-impl TryFrom<api::grpc::qdrant::SearchPoints> for SearchRequestInternal {
-    type Error = Status;
-
-    fn try_from(value: api::grpc::qdrant::SearchPoints) -> Result<Self, Self::Error> {
-        Ok(SearchRequestInternal {
-            vector: api::grpc::conversions::into_named_vector_struct(
-                value.vector_name,
-                value.vector,
-                value.sparse_indices,
-            )?
-            .into(),
-            filter: value.filter.map(|f| f.try_into()).transpose()?,
-            params: value.params.map(|p| p.into()),
-            limit: value.limit as usize,
-            offset: value.offset.map(|x| x as usize),
-            with_payload: value.with_payload.map(|wp| wp.try_into()).transpose()?,
-            with_vector: Some(
-                value
-                    .with_vectors
-                    .map(|with_vectors| with_vectors.into())
-                    .unwrap_or_default(),
-            ),
-            score_threshold: value.score_threshold,
-        })
-    }
-}
-
-impl TryFrom<api::grpc::qdrant::SearchPointGroups> for SearchGroupsRequestInternal {
-    type Error = Status;
-
-    fn try_from(value: api::grpc::qdrant::SearchPointGroups) -> Result<Self, Self::Error> {
-        let search_points = api::grpc::qdrant::SearchPoints {
-            vector: value.vector,
-            filter: value.filter,
-            params: value.params,
-            with_payload: value.with_payload,
-            with_vectors: value.with_vectors,
-            score_threshold: value.score_threshold,
-            vector_name: value.vector_name,
-            limit: 0,
-            offset: None,
-            collection_name: String::new(),
-            read_consistency: None,
-            timeout: None,
-            shard_key_selector: None,
-            sparse_indices: value.sparse_indices,
-        };
-
-        if let Some(sparse_indices) = &search_points.sparse_indices {
-            validate_sparse_vector_impl(&sparse_indices.data, &search_points.vector).map_err(
-                |_| {
-                    Status::invalid_argument(
-                        "Sparse indices does not match sparse vector conditions",
-                    )
-                },
-            )?;
-        }
-
-        let SearchRequestInternal {
-            vector,
-            filter,
-            params,
-            limit: _,
-            offset: _,
-            with_payload,
-            with_vector,
-            score_threshold,
-        } = search_points.try_into()?;
-
-        Ok(SearchGroupsRequestInternal {
-            vector,
-            filter,
-            params,
-            with_payload,
-            with_vector,
-            score_threshold,
-            group_request: BaseGroupRequest {
-                group_by: json_path_from_proto(&value.group_by)?,
-                limit: value.limit,
-                group_size: value.group_size,
-                with_lookup: value.with_lookup.map(|l| l.try_into()).transpose()?,
-            },
         })
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -7,7 +7,10 @@ use std::num::NonZeroU64;
 use std::time::SystemTimeError;
 
 use api::grpc::transport_channel_pool::RequestError;
-use api::rest::{OrderByInterface, RecommendStrategy, ShardKeySelector};
+use api::rest::{
+    BaseGroupRequest, OrderByInterface, RecommendStrategy, SearchGroupsRequestInternal,
+    SearchRequestInternal, ShardKeySelector,
+};
 use common::defaults;
 use common::types::ScoreType;
 use common::validation::validate_range_generic;
@@ -21,7 +24,6 @@ use segment::data_types::groups::GroupId;
 use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStruct, DEFAULT_VECTOR_NAME,
 };
-use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{
     Distance, Filter, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType,
     QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
@@ -42,7 +44,6 @@ use validator::{Validate, ValidationError, ValidationErrors};
 use super::config_diff::{self};
 use super::ClockTag;
 use crate::config::{CollectionConfig, CollectionParams};
-use crate::lookup::types::WithLookupInterface;
 use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
 use crate::operations::query_enum::QueryEnum;
 use crate::save_on_disk;
@@ -350,41 +351,6 @@ pub struct SearchRequest {
     pub shard_key: Option<ShardKeySelector>,
 }
 
-/// Search request.
-/// Holds all conditions and parameters for the search of most similar points by vector similarity
-/// given the filtering restrictions.
-#[derive(Deserialize, Serialize, JsonSchema, Validate, Clone, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub struct SearchRequestInternal {
-    /// Look for vectors closest to this
-    #[validate]
-    pub vector: api::rest::NamedVectorStruct,
-    /// Look only for points which satisfies this conditions
-    #[validate]
-    pub filter: Option<Filter>,
-    /// Additional search params
-    #[validate]
-    pub params: Option<SearchParams>,
-    /// Max number of result to return
-    #[serde(alias = "top")]
-    #[validate(range(min = 1))]
-    pub limit: usize,
-    /// Offset of the first result to return.
-    /// May be used to paginate results.
-    /// Note: large offset values may cause performance issues.
-    pub offset: Option<usize>,
-    /// Select which payload to return with the response. Default: None
-    pub with_payload: Option<WithPayloadInterface>,
-    /// Whether to return the point vector with the result?
-    #[serde(default, alias = "with_vectors")]
-    pub with_vector: Option<WithVector>,
-    /// Define a minimal score threshold for the result.
-    /// If defined, less similar results will not be returned.
-    /// Score of the returned result might be higher or smaller than the threshold depending on the
-    /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
-    pub score_threshold: Option<ScoreType>,
-}
-
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct SearchRequestBatch {
@@ -426,38 +392,6 @@ pub struct SearchGroupsRequest {
     /// Specify in which shards to look for the points, if not specified - look in all shards
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
-}
-
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
-pub struct SearchGroupsRequestInternal {
-    /// Look for vectors closest to this
-    #[validate]
-    pub vector: api::rest::NamedVectorStruct,
-
-    /// Look only for points which satisfies this conditions
-    #[validate]
-    pub filter: Option<Filter>,
-
-    /// Additional search params
-    #[validate]
-    pub params: Option<SearchParams>,
-
-    /// Select which payload to return with the response. Default: None
-    pub with_payload: Option<WithPayloadInterface>,
-
-    /// Whether to return the point vector with the result?
-    #[serde(default, alias = "with_vectors")]
-    pub with_vector: Option<WithVector>,
-
-    /// Define a minimal score threshold for the result.
-    /// If defined, less similar results will not be returned.
-    /// Score of the returned result might be higher or smaller than the threshold depending on the
-    /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
-    pub score_threshold: Option<ScoreType>,
-
-    #[serde(flatten)]
-    #[validate]
-    pub group_request: BaseGroupRequest,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
@@ -1741,27 +1675,6 @@ pub enum NodeType {
     /// This is useful for nodes that are only used for writing data
     /// and backup purposes
     Listener,
-}
-
-#[derive(Validate, Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
-pub struct BaseGroupRequest {
-    /// Payload field to group by, must be a string or number field.
-    /// If the field contains more than 1 value, all values will be used for grouping.
-    /// One point can be in multiple groups.
-    #[schemars(length(min = 1))]
-    #[validate(custom = "JsonPath::validate_not_empty")]
-    pub group_by: JsonPath,
-
-    /// Maximum amount of points to return per group
-    #[validate(range(min = 1))]
-    pub group_size: u32,
-
-    /// Maximum amount of groups to return
-    #[validate(range(min = 1))]
-    pub limit: u32,
-
-    /// Look for points in another collection using the group ids
-    pub with_lookup: Option<WithLookupInterface>,
 }
 
 impl From<SearchRequestInternal> for CoreSearchRequest {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -8,8 +8,8 @@ use std::time::SystemTimeError;
 
 use api::grpc::transport_channel_pool::RequestError;
 use api::rest::{
-    BaseGroupRequest, OrderByInterface, RecommendStrategy, SearchGroupsRequestInternal,
-    SearchRequestInternal, ShardKeySelector,
+    BaseGroupRequest, LookupLocation, OrderByInterface, RecommendStrategy,
+    SearchGroupsRequestInternal, SearchRequestInternal, ShardKeySelector,
 };
 use common::defaults;
 use common::types::ScoreType;
@@ -459,23 +459,6 @@ impl From<String> for UsingVector {
     fn from(name: String) -> Self {
         UsingVector::Name(name)
     }
-}
-
-/// Defines a location to use for looking up the vector.
-/// Specifies collection and vector field name.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub struct LookupLocation {
-    /// Name of the collection used for lookup
-    pub collection: String,
-    /// Optional name of the vector field within the collection.
-    /// If not provided, the default vector field will be used.
-    #[serde(default)]
-    pub vector: Option<String>,
-
-    /// Specify in which shards to look for the points, if not specified - look in all shards
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub shard_key: Option<ShardKeySelector>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Default, Clone)]

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -16,6 +16,7 @@ use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, 
 use super::shard_query::{Fusion, ScoringQuery, ShardPrefetch, ShardQueryRequest};
 use crate::common::fetch_vectors::ReferencedVectors;
 use crate::common::retrieve_request_trait::RetrieveRequest;
+use crate::lookup::types::WithLookupInterface;
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::recommendations::avg_vector_for_recommendation;
@@ -33,6 +34,7 @@ pub struct CollectionQueryRequest {
     pub params: Option<SearchParams>,
     pub with_vector: WithVector,
     pub with_payload: WithPayloadInterface,
+    pub with_lookup: Option<WithLookupInterface>,
 }
 
 impl CollectionQueryRequest {
@@ -415,6 +417,7 @@ mod from_rest {
                 offset,
                 with_vector,
                 with_payload,
+                with_lookup,
             } = value;
 
             Self {
@@ -428,6 +431,7 @@ mod from_rest {
                 params,
                 with_vector: with_vector.unwrap_or(Self::DEFAULT_WITH_VECTOR),
                 with_payload: with_payload.unwrap_or(Self::DEFAULT_WITH_PAYLOAD),
+                with_lookup: with_lookup.map(WithLookupInterface::from),
             }
         }
     }
@@ -596,6 +600,7 @@ mod from_grpc {
                 with_vectors,
                 read_consistency,
                 shard_key_selector,
+                with_lookup,
             } = value;
 
             let request = CollectionQueryRequest {
@@ -621,6 +626,7 @@ mod from_grpc {
                     .map(TryFrom::try_from)
                     .transpose()?
                     .unwrap_or(CollectionQueryRequest::DEFAULT_WITH_PAYLOAD),
+                with_lookup: with_lookup.map(TryFrom::try_from).transpose()?,
             };
 
             let shard_key =

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -400,7 +400,7 @@ impl CollectionQueryRequest {
 }
 
 mod from_rest {
-    use api::rest::{schema as rest, LookupLocation};
+    use api::rest::schema as rest;
 
     use super::*;
 

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -17,6 +17,7 @@ use api::grpc::qdrant::{
     UpdateShardCutoffPointRequest, WaitForShardStateRequest,
 };
 use api::grpc::transport_channel_pool::{AddTimeout, MAX_GRPC_CHANNEL_TIMEOUT};
+use api::rest::SearchRequestInternal;
 use async_trait::async_trait;
 use common::types::TelemetryDetail;
 use itertools::Itertools;
@@ -45,8 +46,7 @@ use crate::operations::point_ops::{PointOperations, WriteOrdering};
 use crate::operations::snapshot_ops::SnapshotPriority;
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch,
-    CountRequestInternal, CountResult, PointRequestInternal, Record, SearchRequestInternal,
-    UpdateResult,
+    CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::vector_ops::VectorOperations;

--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
+use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
 use segment::data_types::vectors::{NamedSparseVector, NamedVectorStruct, Vector, VectorStruct};
 use sparse::common::sparse_vector::SparseVector;
 use validator::Validate;
 
 use crate::operations::point_ops::{Batch, PointStruct, PointsBatch, PointsList};
 use crate::operations::types::{
-    BaseGroupRequest, ContextExamplePair, DiscoverRequestInternal, RecommendExample,
-    RecommendRequestInternal, SearchGroupsRequestInternal, SearchRequestInternal,
+    ContextExamplePair, DiscoverRequestInternal, RecommendExample, RecommendRequestInternal,
 };
 use crate::operations::vector_ops::PointVectors;
 

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -1,13 +1,13 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
-use api::rest::OrderByInterface;
+use api::rest::{OrderByInterface, SearchRequestInternal};
 use collection::operations::payload_ops::{PayloadOps, SetPayloadOp};
 use collection::operations::point_ops::{Batch, PointOperations, PointStruct, WriteOrdering};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CountRequestInternal, PointRequestInternal, RecommendRequestInternal, ScrollRequestInternal,
-    SearchRequestInternal, UpdateStatus,
+    UpdateStatus,
 };
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -1,9 +1,7 @@
 use collection::collection::Collection;
 use collection::grouping::group_by::{GroupRequest, SourceRequest};
 use collection::operations::point_ops::{Batch, WriteOrdering};
-use collection::operations::types::{
-    RecommendRequestInternal, SearchRequestInternal, UpdateStatus,
-};
+use collection::operations::types::{RecommendRequestInternal, UpdateStatus};
 use collection::operations::CollectionUpdateOperations;
 use itertools::Itertools;
 use rand::distributions::Uniform;
@@ -21,6 +19,7 @@ fn rand_dense_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
 }
 
 mod group_by {
+    use api::rest::SearchRequestInternal;
     use collection::grouping::GroupBy;
     use segment::data_types::vectors::BatchVectorStruct;
 
@@ -435,6 +434,7 @@ mod group_by {
 /// Tests out the different features working together. The individual features are already tested in other places.
 mod group_by_builder {
 
+    use api::rest::SearchRequestInternal;
     use collection::grouping::GroupBy;
     use collection::lookup::types::PseudoId;
     use collection::lookup::WithLookup;

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::num::NonZeroU32;
 use std::path::Path;
 
+use api::rest::SearchRequestInternal;
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
@@ -9,8 +10,7 @@ use collection::operations::point_ops::{
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
-    CollectionError, PointRequestInternal, RecommendRequestInternal, SearchRequestInternal,
-    VectorsConfig,
+    CollectionError, PointRequestInternal, RecommendRequestInternal, VectorsConfig,
 };
 use collection::operations::vector_params_builder::VectorParamsBuilder;
 use collection::operations::CollectionUpdateOperations;

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -1,8 +1,8 @@
+use api::rest::SearchRequestInternal;
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
-use collection::operations::types::SearchRequestInternal;
 use collection::operations::CollectionUpdateOperations;
 use segment::data_types::vectors::VectorStruct;
 use segment::types::WithPayloadInterface;

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use api::rest::SearchRequestInternal;
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
@@ -7,7 +8,7 @@ use collection::operations::point_ops::{
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::shared_storage_config::SharedStorageConfig;
-use collection::operations::types::{NodeType, SearchRequestInternal, VectorsConfig};
+use collection::operations::types::{NodeType, VectorsConfig};
 use collection::operations::vector_params_builder::VectorParamsBuilder;
 use collection::operations::CollectionUpdateOperations;
 use collection::shards::channel_service::ChannelService;

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -612,14 +612,16 @@ mod tests {
 mod tests_ops {
     use std::fmt::Debug;
 
-    use api::rest::{BatchVectorStruct, OrderByInterface, RecommendStrategy, VectorStruct};
+    use api::rest::{
+        BatchVectorStruct, OrderByInterface, RecommendStrategy, SearchRequestInternal, VectorStruct,
+    };
     use collection::operations::payload_ops::PayloadOpsDiscriminants;
     use collection::operations::point_ops::{
         Batch, PointInsertOperationsInternal, PointInsertOperationsInternalDiscriminants,
         PointOperationsDiscriminants, PointStruct, PointSyncOperation,
     };
     use collection::operations::query_enum::QueryEnum;
-    use collection::operations::types::{SearchRequestInternal, UsingVector};
+    use collection::operations::types::UsingVector;
     use collection::operations::vector_ops::{
         PointVectors, UpdateVectorsOp, VectorOperationsDiscriminants,
     };

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -2,14 +2,14 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::mem::take;
 
+use api::rest::LookupLocation;
 use collection::grouping::group_by::{GroupRequest, SourceRequest};
 use collection::lookup::WithLookup;
 use collection::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
 use collection::operations::point_ops::{PointIdsList, PointOperations};
 use collection::operations::types::{
     ContextExamplePair, CoreSearchRequest, CountRequestInternal, DiscoverRequestInternal,
-    LookupLocation, PointRequestInternal, RecommendExample, RecommendRequestInternal,
-    ScrollRequestInternal,
+    PointRequestInternal, RecommendExample, RecommendRequestInternal, ScrollRequestInternal,
 };
 use collection::operations::universal_query::collection_query::{
     CollectionPrefetch, CollectionQueryRequest, Query, VectorInput, VectorQuery,
@@ -613,7 +613,8 @@ mod tests_ops {
     use std::fmt::Debug;
 
     use api::rest::{
-        BatchVectorStruct, OrderByInterface, RecommendStrategy, SearchRequestInternal, VectorStruct,
+        BatchVectorStruct, LookupLocation, OrderByInterface, RecommendStrategy,
+        SearchRequestInternal, VectorStruct,
     };
     use collection::operations::payload_ops::PayloadOpsDiscriminants;
     use collection::operations::point_ops::{

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use api::rest::ShardKeySelector;
+use api::rest::{SearchGroupsRequestInternal, ShardKeySelector};
 use collection::common::batching::batch_requests;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{
@@ -15,8 +15,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CoreSearchRequest, CoreSearchRequestBatch, CountRequestInternal, CountResult,
     DiscoverRequestBatch, DiscoverRequestInternal, GroupsResult, PointRequestInternal,
-    RecommendGroupsRequestInternal, Record, ScrollRequestInternal, ScrollResult,
-    SearchGroupsRequestInternal, UpdateResult,
+    RecommendGroupsRequestInternal, Record, ScrollRequestInternal, ScrollResult, UpdateResult,
 };
 use collection::operations::vector_ops::{
     DeleteVectors, UpdateVectors, UpdateVectorsOp, VectorOperations,


### PR DESCRIPTION
This PR adds the `lookup_from` field on the query API both at the root and prefetch level.

To that end, a number of types have been lifted up from the `collection` crate into the `api` crate.
It is necessary because the query definition lives in the `api` crate which does not have access to the lookup types in `collection`.

I also lifted the types for grouping which will be required later.

A future PR will add the actual implementation for `lookup_from` for queries.