### PR TITLE
Properly integrate replica set state switching in resharding transfers

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -285,6 +285,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | shard_id | [uint32](#uint32) |  | Local shard id |
+| to_shard_id | [uint32](#uint32) | optional |  |
 | from_peer_id | [uint64](#uint64) |  |  |
 | to_peer_id | [uint64](#uint64) |  |  |
 
@@ -908,6 +909,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | shard_id | [uint32](#uint32) |  | Local shard id |
+| to_shard_id | [uint32](#uint32) | optional |  |
 | from_peer_id | [uint64](#uint64) |  |  |
 | to_peer_id | [uint64](#uint64) |  |  |
 | method | [ShardTransferMethod](#qdrant-ShardTransferMethod) | optional |  |
@@ -1131,6 +1133,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | shard_id | [uint32](#uint32) |  | Local shard id |
+| to_shard_id | [uint32](#uint32) | optional |  |
 | from_peer_id | [uint64](#uint64) |  |  |
 | to_peer_id | [uint64](#uint64) |  |  |
 | method | [ShardTransferMethod](#qdrant-ShardTransferMethod) | optional |  |
@@ -1149,6 +1152,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | shard_id | [uint32](#uint32) |  | Local shard id |
+| to_shard_id | [uint32](#uint32) | optional |  |
 | from_peer_id | [uint64](#uint64) |  |  |
 | to_peer_id | [uint64](#uint64) |  |  |
 | method | [ShardTransferMethod](#qdrant-ShardTransferMethod) |  |  |
@@ -1200,6 +1204,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | shard_id | [uint32](#uint32) |  | Local shard id |
+| to_shard_id | [uint32](#uint32) | optional |  |
 | from | [uint64](#uint64) |  |  |
 | to | [uint64](#uint64) |  |  |
 | sync | [bool](#bool) |  | If `true` transfer is a synchronization of a replicas; If `false` transfer is a moving of a shard from one peer to another |
@@ -1640,6 +1645,7 @@ Note: 1kB = 1 vector of size 256. |
 | StreamRecords | 0 | Stream shard records in batches |
 | Snapshot | 1 | Snapshot the shard and recover it on the target peer |
 | WalDelta | 2 | Resolve WAL delta between peers and transfer the difference |
+| ReshardingStreamRecords | 3 | Stream shard records in batches for resharding |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8900,6 +8900,12 @@
             "format": "uint32",
             "minimum": 0
           },
+          "to_shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "nullable": true
+          },
           "from": {
             "description": "Source peer id",
             "type": "integer",
@@ -10108,6 +10114,12 @@
             "format": "uint32",
             "minimum": 0
           },
+          "to_shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "nullable": true
+          },
           "to_peer_id": {
             "type": "integer",
             "format": "uint64",
@@ -10155,6 +10167,12 @@
             "format": "uint32",
             "minimum": 0
           },
+          "to_shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "nullable": true
+          },
           "to_peer_id": {
             "type": "integer",
             "format": "uint64",
@@ -10201,6 +10219,12 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 0
+          },
+          "to_shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "nullable": true
           },
           "to_peer_id": {
             "type": "integer",
@@ -10336,6 +10360,12 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 0
+          },
+          "to_shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "nullable": true
           },
           "from_peer_id": {
             "type": "integer",

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -501,10 +501,10 @@ message RemoteShardInfo {
 
 message ShardTransferInfo {
   uint32 shard_id = 1; // Local shard id
+  optional uint32 to_shard_id = 5;
   uint64 from = 2;
   uint64 to = 3;
   bool sync = 4; // If `true` transfer is a synchronization of a replicas; If `false` transfer is a moving of a shard from one peer to another
-  optional uint32 to_shard_id = 5;
 }
 
 message CollectionClusterInfoResponse {
@@ -517,33 +517,33 @@ message CollectionClusterInfoResponse {
 
 message MoveShard {
   uint32 shard_id = 1; // Local shard id
+  optional uint32 to_shard_id = 5;
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
   optional ShardTransferMethod method = 4;
-  optional uint32 to_shard_id = 5;
 }
 
 message ReplicateShard {
   uint32 shard_id = 1; // Local shard id
+  optional uint32 to_shard_id = 5;
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
   optional ShardTransferMethod method = 4;
-  optional uint32 to_shard_id = 5;
 }
 
 message AbortShardTransfer {
   uint32 shard_id = 1; // Local shard id
+  optional uint32 to_shard_id = 5;
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
-  optional uint32 to_shard_id = 5;
 }
 
 message RestartTransfer {
   uint32 shard_id = 1; // Local shard id
+  optional uint32 to_shard_id = 5;
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
   ShardTransferMethod method = 4;
-  optional uint32 to_shard_id = 5;
 }
 
 enum ShardTransferMethod {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -504,6 +504,7 @@ message ShardTransferInfo {
   uint64 from = 2;
   uint64 to = 3;
   bool sync = 4; // If `true` transfer is a synchronization of a replicas; If `false` transfer is a moving of a shard from one peer to another
+  optional uint32 to_shard_id = 5;
 }
 
 message CollectionClusterInfoResponse {
@@ -519,6 +520,7 @@ message MoveShard {
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
   optional ShardTransferMethod method = 4;
+  optional uint32 to_shard_id = 5;
 }
 
 message ReplicateShard {
@@ -526,12 +528,14 @@ message ReplicateShard {
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
   optional ShardTransferMethod method = 4;
+  optional uint32 to_shard_id = 5;
 }
 
 message AbortShardTransfer {
   uint32 shard_id = 1; // Local shard id
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
+  optional uint32 to_shard_id = 5;
 }
 
 message RestartTransfer {
@@ -539,12 +543,14 @@ message RestartTransfer {
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
   ShardTransferMethod method = 4;
+  optional uint32 to_shard_id = 5;
 }
 
 enum ShardTransferMethod {
   StreamRecords = 0; // Stream shard records in batches
   Snapshot = 1; // Snapshot the shard and recover it on the target peer
   WalDelta = 2; // Resolve WAL delta between peers and transfer the difference
+  ReshardingStreamRecords = 3; // Stream shard records in batches for resharding
 }
 
 message Replica {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -904,6 +904,8 @@ pub struct ShardTransferInfo {
     /// If `true` transfer is a synchronization of a replicas; If `false` transfer is a moving of a shard from one peer to another
     #[prost(bool, tag = "4")]
     pub sync: bool,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -938,6 +940,8 @@ pub struct MoveShard {
     pub to_peer_id: u64,
     #[prost(enumeration = "ShardTransferMethod", optional, tag = "4")]
     pub method: ::core::option::Option<i32>,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -952,6 +956,8 @@ pub struct ReplicateShard {
     pub to_peer_id: u64,
     #[prost(enumeration = "ShardTransferMethod", optional, tag = "4")]
     pub method: ::core::option::Option<i32>,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -964,6 +970,8 @@ pub struct AbortShardTransfer {
     pub from_peer_id: u64,
     #[prost(uint64, tag = "3")]
     pub to_peer_id: u64,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -978,6 +986,8 @@ pub struct RestartTransfer {
     pub to_peer_id: u64,
     #[prost(enumeration = "ShardTransferMethod", tag = "4")]
     pub method: i32,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -1503,6 +1513,8 @@ pub enum ShardTransferMethod {
     Snapshot = 1,
     /// Resolve WAL delta between peers and transfer the difference
     WalDelta = 2,
+    /// Stream shard records in batches for resharding
+    ReshardingStreamRecords = 3,
 }
 impl ShardTransferMethod {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1514,6 +1526,7 @@ impl ShardTransferMethod {
             ShardTransferMethod::StreamRecords => "StreamRecords",
             ShardTransferMethod::Snapshot => "Snapshot",
             ShardTransferMethod::WalDelta => "WalDelta",
+            ShardTransferMethod::ReshardingStreamRecords => "ReshardingStreamRecords",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1522,6 +1535,7 @@ impl ShardTransferMethod {
             "StreamRecords" => Some(Self::StreamRecords),
             "Snapshot" => Some(Self::Snapshot),
             "WalDelta" => Some(Self::WalDelta),
+            "ReshardingStreamRecords" => Some(Self::ReshardingStreamRecords),
             _ => None,
         }
     }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -897,6 +897,8 @@ pub struct ShardTransferInfo {
     /// Local shard id
     #[prost(uint32, tag = "1")]
     pub shard_id: u32,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
     #[prost(uint64, tag = "2")]
     pub from: u64,
     #[prost(uint64, tag = "3")]
@@ -904,8 +906,6 @@ pub struct ShardTransferInfo {
     /// If `true` transfer is a synchronization of a replicas; If `false` transfer is a moving of a shard from one peer to another
     #[prost(bool, tag = "4")]
     pub sync: bool,
-    #[prost(uint32, optional, tag = "5")]
-    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -934,14 +934,14 @@ pub struct MoveShard {
     /// Local shard id
     #[prost(uint32, tag = "1")]
     pub shard_id: u32,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
     #[prost(uint64, tag = "2")]
     pub from_peer_id: u64,
     #[prost(uint64, tag = "3")]
     pub to_peer_id: u64,
     #[prost(enumeration = "ShardTransferMethod", optional, tag = "4")]
     pub method: ::core::option::Option<i32>,
-    #[prost(uint32, optional, tag = "5")]
-    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -950,14 +950,14 @@ pub struct ReplicateShard {
     /// Local shard id
     #[prost(uint32, tag = "1")]
     pub shard_id: u32,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
     #[prost(uint64, tag = "2")]
     pub from_peer_id: u64,
     #[prost(uint64, tag = "3")]
     pub to_peer_id: u64,
     #[prost(enumeration = "ShardTransferMethod", optional, tag = "4")]
     pub method: ::core::option::Option<i32>,
-    #[prost(uint32, optional, tag = "5")]
-    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -966,12 +966,12 @@ pub struct AbortShardTransfer {
     /// Local shard id
     #[prost(uint32, tag = "1")]
     pub shard_id: u32,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
     #[prost(uint64, tag = "2")]
     pub from_peer_id: u64,
     #[prost(uint64, tag = "3")]
     pub to_peer_id: u64,
-    #[prost(uint32, optional, tag = "5")]
-    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -980,14 +980,14 @@ pub struct RestartTransfer {
     /// Local shard id
     #[prost(uint32, tag = "1")]
     pub shard_id: u32,
+    #[prost(uint32, optional, tag = "5")]
+    pub to_shard_id: ::core::option::Option<u32>,
     #[prost(uint64, tag = "2")]
     pub from_peer_id: u64,
     #[prost(uint64, tag = "3")]
     pub to_peer_id: u64,
     #[prost(enumeration = "ShardTransferMethod", tag = "4")]
     pub method: i32,
-    #[prost(uint32, optional, tag = "5")]
-    pub to_shard_id: ::core::option::Option<u32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -543,7 +543,7 @@ impl Collection {
                 None => {
                     log::debug!(
                         "Transfer {:?} does not exist, but not reported as cancelled. Reporting now.",
-                        transfer.key()
+                        transfer.key(),
                     );
                     on_transfer_failure(transfer, self.name(), "transfer task does not exist");
                 }
@@ -551,14 +551,14 @@ impl Collection {
                 Some(TaskResult::Finished) => {
                     log::debug!(
                         "Transfer {:?} is finished successfully, but not reported. Reporting now.",
-                        transfer.key()
+                        transfer.key(),
                     );
                     on_transfer_success(transfer, self.name());
                 }
                 Some(TaskResult::Failed) => {
                     log::debug!(
                         "Transfer {:?} is failed, but not reported as failed. Reporting now.",
-                        transfer.key()
+                        transfer.key(),
                     );
                     on_transfer_failure(transfer, self.name(), "transfer failed");
                 }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -67,6 +67,7 @@ impl Collection {
                 collection_id,
                 self.path.clone(),
                 collection_config,
+                self.shared_storage_config.clone(),
                 channel_service,
                 temp_dir,
                 on_finish,

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -369,7 +369,9 @@ impl Collection {
                 let shard_transfer_registered = shards_holder.shard_transfers.wait_for(
                     |shard_transfers| {
                         shard_transfers.iter().any(|shard_transfer| {
-                            shard_transfer.shard_id == shard_id && shard_transfer.to == this_peer_id
+                            (shard_transfer.shard_id == shard_id
+                                || shard_transfer.to_shard_id == Some(shard_id))
+                                && shard_transfer.to == this_peer_id
                         })
                     },
                     Duration::from_secs(60),

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -273,7 +273,7 @@ impl Collection {
         let Some(replica_set) = shard_holder.get_shard(&transfer_key.shard_id) else {
             return Err(CollectionError::bad_request(format!(
                 "Shard {} doesn't exist",
-                transfer_key.shard_id
+                transfer_key.shard_id,
             )));
         };
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -57,8 +57,10 @@ impl Collection {
             shard_transfer.method.replace(method);
         }
 
-        let shard_id = shard_transfer.shard_id;
         let do_transfer = {
+            // Set state of target shard, in the case of resharding this will be a different shard
+            let shard_id = shard_transfer.to_shard_id.unwrap_or(shard_transfer.shard_id);
+
             let shards_holder = self.shards_holder.read().await;
             let _was_not_transferred =
                 shards_holder.register_start_shard_transfer(shard_transfer.clone())?;

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -58,8 +58,18 @@ impl Collection {
         }
 
         let do_transfer = {
+            let this_peer_id = consensus.this_peer_id();
+            let is_receiver = this_peer_id == shard_transfer.to;
+            let is_sender = this_peer_id == shard_transfer.from;
+
             // Set state of target shard, in the case of resharding this will be a different shard
-            let shard_id = shard_transfer.to_shard_id.unwrap_or(shard_transfer.shard_id);
+            let shard_id = if is_receiver {
+                shard_transfer
+                    .to_shard_id
+                    .unwrap_or(shard_transfer.shard_id)
+            } else {
+                shard_transfer.shard_id
+            };
 
             let shards_holder = self.shards_holder.read().await;
             let _was_not_transferred =
@@ -78,8 +88,6 @@ impl Collection {
             };
 
             let is_local = replica_set.is_local().await;
-            let is_receiver = replica_set.this_peer_id() == shard_transfer.to;
-            let is_sender = replica_set.this_peer_id() == shard_transfer.from;
 
             let initial_state = match shard_transfer.method.unwrap_or_default() {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -107,7 +107,8 @@ impl Collection {
                 )
                 .await?;
 
-                to_replica_set.set_local(shard, Some(initial_state)).await?;
+                let old_shard = to_replica_set.set_local(shard, Some(initial_state)).await?;
+                debug_assert!(old_shard.is_none(), "We should not have a local shard yet");
             } else {
                 to_replica_set
                     .ensure_replica_with_state(&shard_transfer.to, initial_state)

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -202,6 +202,9 @@ impl Collection {
         // Unwrap forward proxy into local shard, or replace it with remote shard
         // depending on the `sync` flag.
         if self.this_peer_id == transfer.from {
+            // Normally we promote the shard to become active, in case of resharding we do not.
+            // For resharding we have multiple transfers in sequence, during which the shard should
+            // remain in the resharding state. Once all are done, the shard is manually promoted to active.
             let activate_shard = transfer
                 .method
                 .map_or(true, |method| !method.is_resharding());
@@ -218,6 +221,7 @@ impl Collection {
 
         // Should happen on receiving side
         // Promote partial shard to active shard
+        // In case of resharding we manually promote the shard, and there are no partial shards
         if self.this_peer_id == transfer.to
             && !transfer
                 .method
@@ -235,6 +239,9 @@ impl Collection {
         // Should happen on a third-party side
         // Change direction of the remote shards or add a new remote shard
         if self.this_peer_id != transfer.from {
+            // Normally we promote the shard to become active, in case of resharding we do not.
+            // For resharding we have multiple transfers in sequence, during which the shard should
+            // remain in the resharding state. Once all are done, the shard is manually promoted to active.
             let state = if transfer
                 .method
                 .map_or(false, |method| method.is_resharding())

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -369,9 +369,10 @@ impl Collection {
                 let shard_transfer_registered = shards_holder.shard_transfers.wait_for(
                     |shard_transfers| {
                         shard_transfers.iter().any(|shard_transfer| {
-                            (shard_transfer.shard_id == shard_id
-                                || shard_transfer.to_shard_id == Some(shard_id))
-                                && shard_transfer.to == this_peer_id
+                            let to_shard_id = shard_transfer
+                                .to_shard_id
+                                .unwrap_or(shard_transfer.shard_id);
+                            to_shard_id == shard_id && shard_transfer.to == this_peer_id
                         })
                     },
                     Duration::from_secs(60),

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -29,7 +29,7 @@ pub enum ClusterOperations {
     /// Start resharding
     #[schemars(skip)]
     StartResharding(StartReshardingOperation),
-    // Abort resharding
+    /// Abort resharding
     #[schemars(skip)]
     AbortResharding(AbortReshardingOperation),
 }

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -96,6 +96,8 @@ pub struct RestartTransfer {
     pub from_peer_id: PeerId,
     pub to_peer_id: PeerId,
     pub method: ShardTransferMethod,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
 }
 
 impl Validate for ClusterOperations {
@@ -164,6 +166,8 @@ pub struct ReplicateShard {
     pub from_peer_id: PeerId,
     /// Method for transferring the shard from one node to another
     pub method: Option<ShardTransferMethod>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
 }
 
 impl Validate for ReplicateShard {
@@ -180,6 +184,8 @@ pub struct MoveShard {
     pub from_peer_id: PeerId,
     /// Method for transferring the shard from one node to another
     pub method: Option<ShardTransferMethod>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
 }
 
 impl Validate for MoveShard {
@@ -207,6 +213,8 @@ pub struct AbortShardTransfer {
     pub shard_id: ShardId,
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -143,12 +143,16 @@ pub struct AbortTransferOperation {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
 pub struct StartReshardingOperation {
+    #[validate]
     pub start_resharding: StartResharding,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
 pub struct AbortReshardingOperation {
+    #[validate]
     pub abort_resharding: AbortResharding,
 }
 
@@ -206,10 +210,12 @@ pub struct AbortShardTransfer {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
 pub struct StartResharding {
     pub peer_id: Option<PeerId>,
     pub shard_key: Option<ShardKey>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
 pub struct AbortResharding {}

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -93,11 +93,11 @@ pub struct DropShardingKey {
 #[serde(rename_all = "snake_case")]
 pub struct RestartTransfer {
     pub shard_id: ShardId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
     pub from_peer_id: PeerId,
     pub to_peer_id: PeerId,
     pub method: ShardTransferMethod,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to_shard_id: Option<ShardId>,
 }
 
 impl Validate for ClusterOperations {
@@ -162,12 +162,12 @@ pub struct AbortReshardingOperation {
 #[serde(rename_all = "snake_case")]
 pub struct ReplicateShard {
     pub shard_id: ShardId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,
     /// Method for transferring the shard from one node to another
     pub method: Option<ShardTransferMethod>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to_shard_id: Option<ShardId>,
 }
 
 impl Validate for ReplicateShard {
@@ -180,12 +180,12 @@ impl Validate for ReplicateShard {
 #[serde(rename_all = "snake_case")]
 pub struct MoveShard {
     pub shard_id: ShardId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,
     /// Method for transferring the shard from one node to another
     pub method: Option<ShardTransferMethod>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to_shard_id: Option<ShardId>,
 }
 
 impl Validate for MoveShard {
@@ -211,10 +211,10 @@ pub struct Replica {
 #[serde(rename_all = "snake_case")]
 pub struct AbortShardTransfer {
     pub shard_id: ShardId,
-    pub to_peer_id: PeerId,
-    pub from_peer_id: PeerId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to_shard_id: Option<ShardId>,
+    pub to_peer_id: PeerId,
+    pub from_peer_id: PeerId,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1694,10 +1694,10 @@ impl From<ShardTransferInfo> for api::grpc::qdrant::ShardTransferInfo {
     fn from(value: ShardTransferInfo) -> Self {
         Self {
             shard_id: value.shard_id,
+            to_shard_id: value.to_shard_id,
             from: value.from,
             to: value.to,
             sync: value.sync,
-            to_shard_id: value.to_shard_id,
         }
     }
 }
@@ -1733,10 +1733,10 @@ impl TryFrom<api::grpc::qdrant::ReplicateShard> for ReplicateShard {
         let method = value.method.map(TryInto::try_into).transpose()?;
         Ok(Self {
             shard_id: value.shard_id,
+            to_shard_id: value.to_shard_id,
             from_peer_id: value.from_peer_id,
             to_peer_id: value.to_peer_id,
             method,
-            to_shard_id: value.to_shard_id,
         })
     }
 }
@@ -1748,10 +1748,10 @@ impl TryFrom<api::grpc::qdrant::MoveShard> for MoveShard {
         let method = value.method.map(TryInto::try_into).transpose()?;
         Ok(Self {
             shard_id: value.shard_id,
+            to_shard_id: value.to_shard_id,
             from_peer_id: value.from_peer_id,
             to_peer_id: value.to_peer_id,
             method,
-            to_shard_id: value.to_shard_id,
         })
     }
 }
@@ -1762,9 +1762,9 @@ impl TryFrom<api::grpc::qdrant::AbortShardTransfer> for AbortShardTransfer {
     fn try_from(value: api::grpc::qdrant::AbortShardTransfer) -> Result<Self, Self::Error> {
         Ok(Self {
             shard_id: value.shard_id,
+            to_shard_id: value.to_shard_id,
             from_peer_id: value.from_peer_id,
             to_peer_id: value.to_peer_id,
-            to_shard_id: value.to_shard_id,
         })
     }
 }
@@ -1884,10 +1884,10 @@ impl TryFrom<ClusterOperationsPb> for ClusterOperations {
                 ClusterOperations::RestartTransfer(RestartTransferOperation {
                     restart_transfer: RestartTransfer {
                         shard_id: op.shard_id,
+                        to_shard_id: op.to_shard_id,
                         from_peer_id: op.from_peer_id,
                         to_peer_id: op.to_peer_id,
                         method: op.method.try_into()?,
-                        to_shard_id: op.to_shard_id,
                     },
                 })
             }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1697,6 +1697,7 @@ impl From<ShardTransferInfo> for api::grpc::qdrant::ShardTransferInfo {
             from: value.from,
             to: value.to,
             sync: value.sync,
+            to_shard_id: value.to_shard_id,
         }
     }
 }
@@ -1735,6 +1736,7 @@ impl TryFrom<api::grpc::qdrant::ReplicateShard> for ReplicateShard {
             from_peer_id: value.from_peer_id,
             to_peer_id: value.to_peer_id,
             method,
+            to_shard_id: value.to_shard_id,
         })
     }
 }
@@ -1749,6 +1751,7 @@ impl TryFrom<api::grpc::qdrant::MoveShard> for MoveShard {
             from_peer_id: value.from_peer_id,
             to_peer_id: value.to_peer_id,
             method,
+            to_shard_id: value.to_shard_id,
         })
     }
 }
@@ -1761,6 +1764,7 @@ impl TryFrom<api::grpc::qdrant::AbortShardTransfer> for AbortShardTransfer {
             shard_id: value.shard_id,
             from_peer_id: value.from_peer_id,
             to_peer_id: value.to_peer_id,
+            to_shard_id: value.to_shard_id,
         })
     }
 }
@@ -1785,6 +1789,9 @@ impl From<api::grpc::qdrant::ShardTransferMethod> for ShardTransferMethod {
             }
             api::grpc::qdrant::ShardTransferMethod::Snapshot => ShardTransferMethod::Snapshot,
             api::grpc::qdrant::ShardTransferMethod::WalDelta => ShardTransferMethod::WalDelta,
+            api::grpc::qdrant::ShardTransferMethod::ReshardingStreamRecords => {
+                ShardTransferMethod::ReshardingStreamRecords
+            }
         }
     }
 }
@@ -1880,6 +1887,7 @@ impl TryFrom<ClusterOperationsPb> for ClusterOperations {
                         from_peer_id: op.from_peer_id,
                         to_peer_id: op.to_peer_id,
                         method: op.method.try_into()?,
+                        to_shard_id: op.to_shard_id,
                     },
                 })
             }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -218,6 +218,9 @@ pub struct ShardTransferInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<ShardTransferMethod>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
+
     /// A human-readable report of the transfer progress. Available only on the source peer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -205,6 +205,9 @@ pub struct CollectionClusterInfo {
 pub struct ShardTransferInfo {
     pub shard_id: ShardId,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
+
     /// Source peer id
     pub from: PeerId,
 
@@ -217,9 +220,6 @@ pub struct ShardTransferInfo {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<ShardTransferMethod>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to_shard_id: Option<ShardId>,
 
     /// A human-readable report of the transfer progress. Available only on the source peer.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -14,7 +14,9 @@ use tokio::sync::Mutex;
 
 use super::update_tracker::UpdateTracker;
 use crate::hash_ring::HashRing;
-use crate::operations::point_ops::{PointOperations, PointStruct, PointSyncOperation};
+use crate::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStruct, PointSyncOperation,
+};
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
@@ -87,6 +89,7 @@ impl ForwardProxyShard {
         offset: Option<PointIdType>,
         batch_size: usize,
         hashring_filter: Option<&HashRing>,
+        merge_points: bool,
         runtime_handle: &Handle,
     ) -> CollectionResult<Option<PointIdType>> {
         debug_assert!(batch_size > 0);
@@ -127,13 +130,15 @@ impl ForwardProxyShard {
 
         // Use sync API to leverage potentially existing points
         let insert_points_operation = {
-            CollectionUpdateOperations::PointOperation(PointOperations::SyncPoints(
-                PointSyncOperation {
+            CollectionUpdateOperations::PointOperation(if !merge_points {
+                PointOperations::SyncPoints(PointSyncOperation {
                     from_id: offset,
                     to_id: next_page_offset,
                     points,
-                },
-            ))
+                })
+            } else {
+                PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(points))
+            })
         };
 
         // We only need to wait for the last batch.

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -333,6 +333,7 @@ impl ShardReplicaSet {
         offset: Option<PointIdType>,
         batch_size: usize,
         hashring_filter: Option<&HashRing>,
+        merge_points: bool,
     ) -> CollectionResult<Option<PointIdType>> {
         let local = self.local.read().await;
 
@@ -344,7 +345,13 @@ impl ShardReplicaSet {
         };
 
         proxy
-            .transfer_batch(offset, batch_size, hashring_filter, &self.search_runtime)
+            .transfer_batch(
+                offset,
+                batch_size,
+                hashring_filter,
+                merge_points,
+                &self.search_runtime,
+            )
             .await
     }
 

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -311,7 +311,7 @@ async fn stage_migrate_points(
         .map_err(|err| {
             CollectionError::service_error(format!(
                 "Failed to migrate points from shard {source_shard_id} to {} for resharding: {err}",
-                reshard_key.shard_id
+                reshard_key.shard_id,
             ))
         })?;
         log::debug!(

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -145,6 +145,7 @@ pub async fn drive_resharding(
         DriverState::new(reshard_key.clone())
     })?;
 
+    // TODO(resharding): sync list of peers more often throughout resharding in case peers change
     state.write(|data| {
         data.sync_peers(&consensus.peers());
     })?;
@@ -219,10 +220,13 @@ fn completed_init(state: &PersistedState) -> bool {
 fn stage_init(state: &PersistedState) -> CollectionResult<()> {
     log::debug!("Resharding stage: init");
 
+    // TODO(reshard): do any necessary initialisation here
+
     state.write(|data| {
         data.bump_all_peers_to(Stage::S1_InitEnd);
     })?;
-    todo!();
+
+    Ok(())
 }
 
 /// Stage 2: migrate points

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -200,6 +200,8 @@ fn completed_init(state: &PersistedState) -> bool {
 ///
 /// Do initialize the resharding process.
 fn stage_init(state: &PersistedState) -> CollectionResult<()> {
+    log::debug!("Resharding stage: init");
+
     state.write(|data| {
         data.bump_all_peers_to(Stage::S1_InitEnd);
     })?;
@@ -227,6 +229,8 @@ async fn stage_migrate_points(
     consensus: &dyn ShardTransferConsensus,
     collection_id: &CollectionId,
 ) -> CollectionResult<()> {
+    log::debug!("Resharding stage: migrate points");
+
     state.write(|data| {
         data.bump_all_peers_to(Stage::S2_MigratePointsStart);
     })?;
@@ -377,6 +381,8 @@ async fn stage_replicate(
     collection_id: &CollectionId,
     collection_config: Arc<RwLock<CollectionConfig>>,
 ) -> CollectionResult<()> {
+    log::debug!("Resharding stage: replicate");
+
     state.write(|data| {
         data.bump_all_peers_to(Stage::S3_ReplicateStart);
     })?;
@@ -464,6 +470,7 @@ fn completed_commit_hashring() -> bool {
 ///
 /// Do commit the new hashring.
 fn stage_commit_hashring() -> CollectionResult<()> {
+    log::debug!("Resharding stage: commit hashring");
     todo!()
 }
 
@@ -478,6 +485,7 @@ fn completed_propagate_deletes() -> bool {
 ///
 /// Do delete migrated points from their old shards.
 fn stage_propagate_deletes() -> CollectionResult<()> {
+    log::debug!("Resharding stage: propagate deletes");
     todo!()
 }
 
@@ -485,6 +493,7 @@ fn stage_propagate_deletes() -> CollectionResult<()> {
 ///
 /// Finalize the resharding operation.
 fn stage_finalize() -> CollectionResult<()> {
+    log::debug!("Resharding stage: finalize");
     todo!()
 }
 

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -275,11 +275,11 @@ async fn stage_migrate_points(
 
                 let transfer = ShardTransfer {
                     shard_id: source_shard_id,
+                    to_shard_id: Some(reshard_key.shard_id),
                     from: source_peer_id,
                     to: consensus.this_peer_id(),
                     sync: true,
                     method: Some(ShardTransferMethod::ReshardingStreamRecords),
-                    to_shard_id: Some(reshard_key.shard_id),
                 };
                 (transfer, true)
             }
@@ -411,12 +411,12 @@ async fn stage_replicate(
 
         let transfer = ShardTransfer {
             shard_id: reshard_key.shard_id,
+            to_shard_id: None,
             from: consensus.this_peer_id(),
             to: target_peer,
             sync: true,
             // TODO(resharding): define preferred shard transfer method here!
             method: Some(ShardTransferMethod::default()),
-            to_shard_id: None,
         };
 
         // Create listener for transfer end before proposing to start the transfer

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -21,6 +21,7 @@ use super::shard::{PeerId, ShardId};
 use super::transfer::ShardTransferConsensus;
 use crate::common::stoppable_task_async::{spawn_async_cancellable, CancellableAsyncTaskHandle};
 use crate::config::CollectionConfig;
+use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::shard_holder::LockedShardHolder;
 use crate::shards::CollectionId;
@@ -83,6 +84,7 @@ pub fn spawn_resharding_task<T, F>(
     collection_id: CollectionId,
     collection_path: PathBuf,
     collection_config: Arc<RwLock<CollectionConfig>>,
+    shared_storage_config: Arc<SharedStorageConfig>,
     channel_service: ChannelService,
     temp_dir: PathBuf,
     on_finish: T,
@@ -114,6 +116,7 @@ where
                     collection_id.clone(),
                     collection_path.clone(),
                     collection_config.clone(),
+                    &shared_storage_config,
                     channel_service.clone(),
                     &temp_dir,
                 )

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -587,6 +587,7 @@ impl ShardHolder {
         let mut shard_transfers = vec![];
         for shard_transfer in self.shard_transfers.read().iter() {
             let shard_id = shard_transfer.shard_id;
+            let to_shard_id = shard_transfer.to_shard_id;
             let to = shard_transfer.to;
             let from = shard_transfer.from;
             let sync = shard_transfer.sync;
@@ -594,6 +595,7 @@ impl ShardHolder {
             let status = tasks_pool.get_task_status(&shard_transfer.key());
             shard_transfers.push(ShardTransferInfo {
                 shard_id,
+                to_shard_id,
                 from,
                 to,
                 sync,

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -30,6 +30,10 @@ const CONSENSUS_CONFIRM_TIMEOUT: Duration = defaults::CONSENSUS_META_OP_WAIT;
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransfer {
     pub shard_id: ShardId,
+    /// For resharding, a different target shard ID may be configured
+    /// By default the shard ID on the target peer is the same.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
     pub from: PeerId,
     pub to: PeerId,
     /// If this flag is true, this is a replication related transfer of shard from 1 peer to another
@@ -38,10 +42,6 @@ pub struct ShardTransfer {
     /// Method to transfer shard with. `None` to choose automatically.
     #[serde(default)]
     pub method: Option<ShardTransferMethod>,
-    /// For resharding, a different target shard ID may be configured
-    /// By default the shard ID on the target peer is the same.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to_shard_id: Option<ShardId>,
 }
 
 impl ShardTransfer {
@@ -58,11 +58,11 @@ impl ShardTransfer {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransferRestart {
     pub shard_id: ShardId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
     pub from: PeerId,
     pub to: PeerId,
     pub method: ShardTransferMethod,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to_shard_id: Option<ShardId>,
 }
 
 impl ShardTransferRestart {
@@ -80,10 +80,10 @@ impl From<ShardTransfer> for ShardTransferRestart {
     fn from(transfer: ShardTransfer) -> Self {
         Self {
             shard_id: transfer.shard_id,
+            to_shard_id: transfer.to_shard_id,
             from: transfer.from,
             to: transfer.to,
             method: transfer.method.unwrap_or_default(),
-            to_shard_id: transfer.to_shard_id,
         }
     }
 }

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -388,6 +388,65 @@ pub trait ShardTransferConsensus: Send + Sync {
         })
     }
 
+    /// Set the shard replica state on this peer through consensus
+    ///
+    /// # Warning
+    ///
+    /// This only submits a proposal to consensus. Calling this does not guarantee that consensus
+    /// will actually apply the operation across the cluster.
+    async fn set_shard_replica_set_state(
+        &self,
+        collection_id: CollectionId,
+        shard_id: ShardId,
+        state: ReplicaState,
+        from_state: Option<ReplicaState>,
+    ) -> CollectionResult<()>;
+
+    /// Propose to set the shard replica state on this peer through consensus
+    ///
+    /// This internally confirms and retries a few times if needed to ensure consensus picks up the
+    /// operation.
+    async fn set_shard_replica_set_state_confirm_and_retry(
+        &self,
+        collection_id: &CollectionId,
+        shard_id: ShardId,
+        state: ReplicaState,
+        from_state: Option<ReplicaState>,
+    ) -> CollectionResult<()> {
+        let mut result = Err(CollectionError::service_error(
+            "`set_shard_replica_set_state_confirm_and_retry` exit without attempting any work, \
+             this is a programming error",
+        ));
+
+        for attempt in 0..CONSENSUS_CONFIRM_RETRIES {
+            if attempt > 0 {
+                sleep(CONSENSUS_CONFIRM_RETRY_DELAY).await;
+            }
+
+            log::trace!("Propose and confirm set shard replica set state");
+            result = self
+                .set_shard_replica_set_state(collection_id.clone(), shard_id, state, from_state)
+                .await;
+
+            match &result {
+                Ok(()) => break,
+                Err(err) => {
+                    log::error!(
+                        "Failed to confirm set shard replica set state operation on consensus: {err}"
+                    );
+                    continue;
+                }
+            }
+        }
+
+        result.map_err(|err| {
+            CollectionError::service_error(format!(
+                "Failed to set shard replica set state through consensus \
+                 after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
+            ))
+        })
+    }
+
     /// Wait for all other peers to reach the current consensus
     ///
     /// This will take the current consensus state of this node. It then explicitly awaits on all

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -230,7 +230,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     async fn start_shard_transfer(
         &self,
         transfer_config: ShardTransfer,
-        collection_name: CollectionId,
+        collection_id: CollectionId,
     ) -> CollectionResult<()>;
 
     /// Propose to start a shard transfer
@@ -240,7 +240,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     async fn start_shard_transfer_confirm_and_retry(
         &self,
         transfer_config: &ShardTransfer,
-        collection_name: &str,
+        collection_id: &str,
     ) -> CollectionResult<()> {
         let mut result = Err(CollectionError::service_error(
             "`start_shard_transfer_confirm_and_retry` exit without attempting any work, \
@@ -254,7 +254,7 @@ pub trait ShardTransferConsensus: Send + Sync {
 
             log::trace!("Propose and confirm shard transfer start operation");
             result = self
-                .start_shard_transfer(transfer_config.clone(), collection_name.into())
+                .start_shard_transfer(transfer_config.clone(), collection_id.into())
                 .await;
 
             match &result {

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -122,6 +122,12 @@ pub enum ShardTransferMethod {
     ReshardingStreamRecords,
 }
 
+impl ShardTransferMethod {
+    pub fn is_resharding(&self) -> bool {
+        matches!(self, Self::ReshardingStreamRecords)
+    }
+}
+
 /// Interface to consensus for shard transfer operations.
 #[async_trait]
 pub trait ShardTransferConsensus: Send + Sync {

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -48,6 +48,7 @@ impl ShardTransfer {
     pub fn key(&self) -> ShardTransferKey {
         ShardTransferKey {
             shard_id: self.shard_id,
+            to_shard_id: self.to_shard_id,
             from: self.from,
             to: self.to,
         }
@@ -60,12 +61,15 @@ pub struct ShardTransferRestart {
     pub from: PeerId,
     pub to: PeerId,
     pub method: ShardTransferMethod,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
 }
 
 impl ShardTransferRestart {
     pub fn key(&self) -> ShardTransferKey {
         ShardTransferKey {
             shard_id: self.shard_id,
+            to_shard_id: self.to_shard_id,
             from: self.from,
             to: self.to,
         }
@@ -79,6 +83,7 @@ impl From<ShardTransfer> for ShardTransferRestart {
             from: transfer.from,
             to: transfer.to,
             method: transfer.method.unwrap_or_default(),
+            to_shard_id: transfer.to_shard_id,
         }
     }
 }
@@ -87,6 +92,8 @@ impl From<ShardTransfer> for ShardTransferRestart {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransferKey {
     pub shard_id: ShardId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_shard_id: Option<ShardId>,
     pub from: PeerId,
     pub to: PeerId,
 }

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -122,7 +122,7 @@ pub(super) async fn transfer_resharding_stream_records(
 
         let cutoff = replica_set.shard_recovery_point().await?;
         let result = remote_shard
-            .update_shard_cutoff_point(collection_id, shard_id, &cutoff)
+            .update_shard_cutoff_point(collection_id, remote_shard.id, &cutoff)
             .await;
 
         // Warn and ignore if remote shard is running an older version, error otherwise

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -92,7 +92,7 @@ pub(super) async fn transfer_resharding_stream_records(
         };
 
         offset = replica_set
-            .transfer_batch(offset, TRANSFER_BATCH_SIZE, Some(&hashring))
+            .transfer_batch(offset, TRANSFER_BATCH_SIZE, Some(&hashring), true)
             .await?;
 
         {

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -108,7 +108,7 @@ pub(super) async fn transfer_stream_records(
 
         let cutoff = replica_set.shard_recovery_point().await?;
         let result = remote_shard
-            .update_shard_cutoff_point(collection_id, shard_id, &cutoff)
+            .update_shard_cutoff_point(collection_id, remote_shard.id, &cutoff)
             .await;
 
         // Warn and ignore if remote shard is running an older version, error otherwise

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -78,7 +78,7 @@ pub(super) async fn transfer_stream_records(
         };
 
         offset = replica_set
-            .transfer_batch(offset, TRANSFER_BATCH_SIZE, None)
+            .transfer_batch(offset, TRANSFER_BATCH_SIZE, None, false)
             .await?;
 
         {

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -473,11 +473,11 @@ impl TableOfContent {
 
                 let new_transfer = ShardTransfer {
                     shard_id: transfer_restart.shard_id,
+                    to_shard_id: None,
                     from: transfer_restart.from,
                     to: transfer_restart.to,
                     sync: old_transfer.sync, // Preserve sync flag from the old transfer
                     method: Some(transfer_restart.method),
-                    to_shard_id: None,
                 };
 
                 Box::pin(

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -80,11 +80,11 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
     async fn start_shard_transfer(
         &self,
         transfer_config: ShardTransfer,
-        collection_name: CollectionId,
+        collection_id: CollectionId,
     ) -> CollectionResult<()> {
         let operation =
             ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::TransferShard(
-                collection_name,
+                collection_id,
                 ShardTransferOperations::Start(transfer_config),
             )));
         self

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -89,7 +89,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
             )));
         self
             .consensus_state
-            .propose_consensus_op_with_await(operation.clone(), None)
+            .propose_consensus_op_with_await(operation, None)
             .await
             .map(|_| ())
             .map_err(|err| {
@@ -109,7 +109,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
             )));
         self
             .consensus_state
-            .propose_consensus_op_with_await(operation.clone(), None)
+            .propose_consensus_op_with_await(operation, None)
             .await
             .map(|_| ())
             .map_err(|err| {
@@ -133,7 +133,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
             )));
         self
             .consensus_state
-            .propose_consensus_op_with_await(operation.clone(), None)
+            .propose_consensus_op_with_await(operation, None)
             .await
             .map(|_| ())
             .map_err(|err| {

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -260,7 +260,7 @@ pub async fn do_update_collection_cluster(
                         collection_name,
                         Start(ShardTransfer {
                             shard_id: move_shard.shard_id,
-                            to_shard_id: None,
+                            to_shard_id: move_shard.to_shard_id,
                             to: move_shard.to_peer_id,
                             from: move_shard.from_peer_id,
                             sync: false,
@@ -296,7 +296,7 @@ pub async fn do_update_collection_cluster(
                         collection_name,
                         Start(ShardTransfer {
                             shard_id: replicate_shard.shard_id,
-                            to_shard_id: None,
+                            to_shard_id: replicate_shard.to_shard_id,
                             to: replicate_shard.to_peer_id,
                             from: replicate_shard.from_peer_id,
                             sync: true,
@@ -311,6 +311,7 @@ pub async fn do_update_collection_cluster(
         ClusterOperations::AbortTransfer(AbortTransferOperation { abort_transfer }) => {
             let transfer = ShardTransferKey {
                 shard_id: abort_transfer.shard_id,
+                to_shard_id: abort_transfer.to_shard_id,
                 to: abort_transfer.to_peer_id,
                 from: abort_transfer.from_peer_id,
             };
@@ -482,10 +483,12 @@ pub async fn do_update_collection_cluster(
                 from_peer_id,
                 to_peer_id,
                 method,
+                to_shard_id,
             } = restart_transfer;
 
             let transfer_key = ShardTransferKey {
                 shard_id,
+                to_shard_id,
                 to: to_peer_id,
                 from: from_peer_id,
             };
@@ -508,6 +511,7 @@ pub async fn do_update_collection_cluster(
                             to: to_peer_id,
                             from: from_peer_id,
                             method,
+                            to_shard_id,
                         }),
                     ),
                     access,

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -480,10 +480,10 @@ pub async fn do_update_collection_cluster(
         ClusterOperations::RestartTransfer(RestartTransferOperation { restart_transfer }) => {
             let RestartTransfer {
                 shard_id,
+                to_shard_id,
                 from_peer_id,
                 to_peer_id,
                 method,
-                to_shard_id,
             } = restart_transfer;
 
             let transfer_key = ShardTransferKey {
@@ -508,10 +508,10 @@ pub async fn do_update_collection_cluster(
                         collection_name,
                         ShardTransferOperations::Restart(ShardTransferRestart {
                             shard_id,
+                            to_shard_id,
                             to: to_peer_id,
                             from: from_peer_id,
                             method,
-                            to_shard_id,
                         }),
                     ),
                     access,


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>

In <https://github.com/qdrant/qdrant/pull/4373> I implemented a first iteration of point migration. In practice, transferring still appeared to be broken because a lot more had to be done for replica set state switching and shard routing.

This PR does all that needs to be done in terms of shard transfers to make resharding work. Specifically, to actually migrate points from all shards to the new target shard, and to replicate the new shard matching the configured replication factor.

Most importantly, this does:
- support transfers with a different source/target shard (for resharding)
- extend the unique shard key with a target shard field (for resharding)
- resharding transfer must merge points in target shard, it should not replace them
- the resharding driver state must be aware of the peers we know about
- use correct replica set state switching for staring and finishing resharding transfers

What doesn't work yet and will be resolved in a separate PR:
- migrate points within the same node

I've extensively tested this locally with various different scenarios, such as different shard numbers, replication factors and target nodes. All works well.

We cannot (automatically) test this yet, because the consensus operation for finalizing resharding is missing. Once that's there, I'll add an integration test to assert correct behavior.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?