### PR TITLE
Move build_index out of VectorIndex

### DIFF
--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -77,17 +77,17 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
         quantized_vectors.clone(),
         segment.payload_index.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-
-    hnsw_index.build_index(permit.clone(), &stopped).unwrap();
 
     // intent: bench `search` without filter
     group.bench_function("hnsw-multivec-search", |b| {

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -13,7 +13,7 @@ use segment::data_types::vectors::{only_default_multi_vector, DEFAULT_VECTOR_NAM
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_multi_vector;
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::VectorIndex;
 use segment::segment_constructor::build_segment;
@@ -77,16 +77,16 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        segment.payload_index.clone(),
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: segment.payload_index.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     // intent: bench `search` without filter

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -2,9 +2,7 @@
 mod prof;
 
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
-use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use dataset::Dataset;
@@ -13,8 +11,9 @@ use itertools::Itertools as _;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram_from_iter;
-use segment::index::hnsw_index::num_rayon_threads;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::{
+    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
+};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -75,14 +74,10 @@ fn sparse_vector_index_search_benchmark_impl(
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
 
     let sparse_vector_index = fixture_sparse_index_ram_from_iter(
-        progress("Indexing (1/3)", vectors_len).wrap_iter(vectors),
+        progress("Indexing (1/2)", vectors_len).wrap_iter(vectors),
         FULL_SCAN_THRESHOLD,
         data_dir.path(),
         &stopped,
-        || {
-            let pb = progress("Indexing (2/3)", vectors_len);
-            move || pb.inc(1)
-        },
     );
 
     // adding payload on field
@@ -104,14 +99,12 @@ fn sparse_vector_index_search_benchmark_impl(
 
     let mut query_vector_it = query_vectors.iter().cycle();
 
-    let permit_cpu_count = num_rayon_threads(0);
-    let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-
     // mmap inverted index
     let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
     let sparse_index_config =
         SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap, None);
-    let mut sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
+    let pb = progress("Indexing (2/2)", vectors_len);
+    let sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_index.id_tracker().clone(),
@@ -119,11 +112,8 @@ fn sparse_vector_index_search_benchmark_impl(
             payload_index: sparse_vector_index.payload_index().clone(),
             path: mmap_index_dir.path(),
             stopped: &stopped,
+            tick_progress: || pb.inc(1),
         })
-        .unwrap();
-    let pb = progress("Indexing (3/3)", vectors_len);
-    sparse_vector_index_mmap
-        .build_index_with_progress(permit, &stopped, || pb.inc(1))
         .unwrap();
     pb.finish_and_clear();
     assert_eq!(sparse_vector_index_mmap.indexed_vector_count(), vectors_len);

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -11,9 +11,7 @@ use itertools::Itertools as _;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram_from_iter;
-use segment::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -24,6 +22,7 @@ use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_positive_sparse_vector, random_sparse_vector};
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::loaders::Csr;
 use tempfile::Builder;
 
@@ -73,12 +72,14 @@ fn sparse_vector_index_search_benchmark_impl(
 
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
 
-    let sparse_vector_index = fixture_sparse_index_ram_from_iter(
+    let sparse_vector_index = fixture_sparse_index_ram_from_iter::<InvertedIndexRam>(
+        data_dir.path(),
         progress("Indexing (1/2)", vectors_len).wrap_iter(vectors),
         FULL_SCAN_THRESHOLD,
-        data_dir.path(),
+        SparseIndexType::MutableRam,
         &stopped,
-    );
+    )
+    .unwrap();
 
     // adding payload on field
     let field_name = "field";

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -10,7 +10,7 @@ use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use itertools::Itertools as _;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram_from_iter;
+use segment::fixtures::sparse_fixtures::fixture_sparse_index_from_iter;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
@@ -72,12 +72,11 @@ fn sparse_vector_index_search_benchmark_impl(
 
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
 
-    let sparse_vector_index = fixture_sparse_index_ram_from_iter::<InvertedIndexRam>(
+    let sparse_vector_index = fixture_sparse_index_from_iter::<InvertedIndexRam>(
         data_dir.path(),
         progress("Indexing (1/2)", vectors_len).wrap_iter(vectors),
         FULL_SCAN_THRESHOLD,
         SparseIndexType::MutableRam,
-        &stopped,
     )
     .unwrap();
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -78,18 +78,30 @@ struct HNSWSearchesTelemetry {
     exact_unfiltered: Arc<Mutex<OperationDurationsAggregator>>,
 }
 
+pub struct HnswIndexOpenArgs<'a> {
+    pub path: &'a Path,
+    pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+    pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+    pub quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+    pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    pub hnsw_config: HnswConfig,
+    pub permit: Option<Arc<CpuPermit>>,
+    pub stopped: &'a AtomicBool,
+}
+
 impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
-    #[allow(clippy::too_many_arguments)]
-    pub fn open(
-        path: &Path,
-        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-        quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
-        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-        hnsw_config: HnswConfig,
-        permit: Option<Arc<CpuPermit>>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Self> {
+    pub fn open(args: HnswIndexOpenArgs<'_>) -> OperationResult<Self> {
+        let HnswIndexOpenArgs {
+            path,
+            id_tracker,
+            vector_storage,
+            quantized_vectors,
+            payload_index,
+            hnsw_config,
+            permit,
+            stopped,
+        } = args;
+
         create_dir_all(path)?;
 
         let config_path = HnswGraphConfig::get_config_path(path);

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -13,7 +13,6 @@ use crate::fixtures::index_fixtures::random_vector;
 use crate::index::hnsw_index::graph_links::{GraphLinks, GraphLinksRam};
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::hnsw_index::num_rayon_threads;
-use crate::index::VectorIndex;
 use crate::segment_constructor::build_segment;
 use crate::types::{
     Distance, HnswConfig, Indexes, SegmentConfig, SeqNumberType, VectorDataConfig,

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -11,7 +11,7 @@ use crate::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use crate::entry::entry_point::SegmentEntry;
 use crate::fixtures::index_fixtures::random_vector;
 use crate::index::hnsw_index::graph_links::{GraphLinks, GraphLinksRam};
-use crate::index::hnsw_index::hnsw::HNSWIndex;
+use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use crate::index::hnsw_index::num_rayon_threads;
 use crate::segment_constructor::build_segment;
 use crate::types::{
@@ -76,18 +76,18 @@ fn test_graph_connectivity() {
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
 
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        segment.vector_data[DEFAULT_VECTOR_NAME]
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
-        Default::default(),
-        payload_index_ptr.clone(),
+        quantized_vectors: Default::default(),
+        payload_index: payload_index_ptr.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let mut reverse_links = vec![vec![]; num_vectors as usize];

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use parking_lot::Mutex;
 use schemars::_serde_json::Value;
@@ -320,15 +318,6 @@ impl VectorIndex for PlainIndex {
                     .collect()
             }
         }
-    }
-
-    fn build_index_with_progress(
-        &mut self,
-        _permit: Arc<CpuPermit>,
-        _stopped: &AtomicBool,
-        _tick_progress: impl FnMut(),
-    ) -> OperationResult<()> {
-        Ok(())
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -6,7 +6,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use io::storage_version::{StorageVersion as _, VERSION_FILE};
 use itertools::Itertools;
@@ -14,7 +13,6 @@ use semver::Version;
 use sparse::common::scores_memory_pool::ScoresMemoryPool;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::DimId;
-use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
 use sparse::index::inverted_index::{InvertedIndex, INDEX_FILE_NAME, OLD_INDEX_FILE_NAME};
 use sparse::index::search_context::SearchContext;
@@ -84,18 +82,19 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     }
 }
 
-pub struct SparseVectorIndexOpenArgs<'a> {
+pub struct SparseVectorIndexOpenArgs<'a, F: FnMut()> {
     pub config: SparseIndexConfig,
     pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
     pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     pub path: &'a Path,
     pub stopped: &'a AtomicBool,
+    pub tick_progress: F,
 }
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     /// Open a sparse vector index at a given path
-    pub fn open(args: SparseVectorIndexOpenArgs) -> OperationResult<Self> {
+    pub fn open<F: FnMut()>(args: SparseVectorIndexOpenArgs<F>) -> OperationResult<Self> {
         let SparseVectorIndexOpenArgs {
             config,
             id_tracker,
@@ -103,6 +102,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             payload_index,
             path,
             stopped,
+            tick_progress,
         } = args;
 
         // create directory if it does not exist
@@ -117,16 +117,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 vector_storage.clone(),
                 path,
                 stopped,
-                || (),
+                tick_progress,
             )?;
             (config, inverted_index, indices_tracker)
-        } else if path.read_dir()?.next().is_none() {
-            // Newly created directory - initialize empty inverted index
-            (
-                config,
-                TInvertedIndex::from_ram_index(Cow::Owned(InvertedIndexRam::empty()), path)?,
-                IndicesTracker::default(),
-            )
         } else {
             Self::try_load(path).or_else(|e| {
                 log::warn!("Failed to load, rebuilding: {}", e.to_string());
@@ -136,7 +129,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                     vector_storage.clone(),
                     path,
                     stopped,
-                    || (),
+                    tick_progress,
                 )?;
 
                 // Drop index completely.
@@ -547,35 +540,6 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
             results.push(search_results);
         }
         Ok(results)
-    }
-
-    fn build_index_with_progress(
-        &mut self,
-        _permit: Arc<CpuPermit>,
-        stopped: &AtomicBool,
-        tick_progress: impl FnMut(),
-    ) -> OperationResult<()> {
-        let (inverted_index, indices_tracker) = Self::build_inverted_index(
-            self.id_tracker.clone(),
-            self.vector_storage.clone(),
-            &self.path,
-            stopped,
-            tick_progress,
-        )?;
-
-        self.inverted_index = inverted_index;
-        self.indices_tracker = indices_tracker;
-
-        // save inverted index
-        if self.config.index_type.is_persisted() {
-            TInvertedIndex::Version::save(&self.path)?;
-            self.indices_tracker.save(&self.path)?;
-            self.inverted_index.save(&self.path)?;
-        }
-
-        // save config to mark successful build
-        self.save_config()?;
-        Ok(())
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -20,7 +20,7 @@ use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::{IdTracker, IdTrackerEnum};
 use crate::index::sparse_index::sparse_vector_index::SparseVectorIndexOpenArgs;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::{PayloadIndex, VectorIndexEnum};
+use crate::index::PayloadIndex;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::payload_storage::PayloadStorage;
 use crate::segment::{Segment, SegmentVersion};
@@ -313,24 +313,16 @@ impl SegmentBuilder {
                 let quantized_vectors = quantized_vectors.remove(vector_name);
                 let quantized_vectors_arc = Arc::new(AtomicRefCell::new(quantized_vectors));
 
-                let mut vector_index = create_vector_index(
+                create_vector_index(
                     vector_config,
                     &vector_index_path,
                     id_tracker_arc.clone(),
                     vector_storage_arc,
                     payload_index_arc.clone(),
                     quantized_vectors_arc,
+                    Some(permit.clone()),
+                    stopped,
                 )?;
-
-                match &mut vector_index {
-                    VectorIndexEnum::HnswRam(index) => {
-                        index.build_index(permit.clone(), stopped)?
-                    }
-                    VectorIndexEnum::HnswMmap(index) => {
-                        index.build_index(permit.clone(), stopped)?
-                    }
-                    _ => (),
-                }
             }
 
             for (vector_name, sparse_vector_config) in &segment_config.sparse_vector_data {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -336,13 +336,13 @@ pub(crate) fn create_vector_index(
 
 #[cfg(feature = "testing")]
 pub fn create_sparse_vector_index_test(
-    args: SparseVectorIndexOpenArgs,
+    args: SparseVectorIndexOpenArgs<impl FnMut()>,
 ) -> OperationResult<VectorIndexEnum> {
     create_sparse_vector_index(args)
 }
 
 pub(crate) fn create_sparse_vector_index(
-    args: SparseVectorIndexOpenArgs,
+    args: SparseVectorIndexOpenArgs<impl FnMut()>,
 ) -> OperationResult<VectorIndexEnum> {
     let vector_index = match (
         args.config.index_type,
@@ -498,6 +498,7 @@ fn create_segment(
             payload_index: payload_index.clone(),
             path: &vector_index_path,
             stopped,
+            tick_progress: || (),
         })?);
 
         check_process_stopped(stopped)?;

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -149,17 +149,17 @@ fn test_batch_and_single_request_equivalency() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
         quantized_vectors.clone(),
         payload_index_ptr,
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-
-    hnsw_index.build_index(permit, &stopped).unwrap();
 
     for _ in 0..10 {
         let query_vector_1 = random_vector(&mut rnd, dim).into();

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -10,7 +10,7 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::index_fixtures::random_vector;
 use segment::fixtures::payload_fixtures::random_int_payload;
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::VectorIndex;
 use segment::json_path::path;
@@ -149,16 +149,16 @@ fn test_batch_and_single_request_equivalency() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        payload_index_ptr,
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: payload_index_ptr,
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     for _ in 0..10 {

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -12,7 +12,7 @@ use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VEC
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_dense_byte_vector, random_int_payload};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::path;
 use segment::segment_constructor::build_segment;
@@ -211,20 +211,20 @@ fn test_byte_storage_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir_byte.path(),
-        segment_byte.id_tracker.clone(),
-        segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+    let hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir_byte.path(),
+        id_tracker: segment_byte.id_tracker.clone(),
+        vector_storage: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
-        segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+        quantized_vectors: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
             .quantized_vectors
             .clone(),
-        segment_byte.payload_index.clone(),
+        payload_index: segment_byte.payload_index.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -211,7 +211,7 @@ fn test_byte_storage_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let mut hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir_byte.path(),
         segment_byte.id_tracker.clone(),
         segment_byte.vector_data[DEFAULT_VECTOR_NAME]
@@ -222,10 +222,10 @@ fn test_byte_storage_hnsw(
             .clone(),
         segment_byte.payload_index.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-
-    hnsw_index_byte.build_index(permit, &stopped).unwrap();
 
     let top = 3;
     let mut hits = 0;

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -337,7 +337,7 @@ fn test_byte_storage_binary_quantization_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let mut hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir_byte.path(),
         segment_byte.id_tracker.clone(),
         segment_byte.vector_data[DEFAULT_VECTOR_NAME]
@@ -348,9 +348,10 @@ fn test_byte_storage_binary_quantization_hnsw(
             .clone(),
         segment_byte.payload_index.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-    hnsw_index_byte.build_index(permit, &stopped).unwrap();
 
     let top = 5;
     let mut sames = 0;

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -15,7 +15,7 @@ use segment::data_types::vectors::{
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_dense_byte_vector, random_int_payload};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::path;
@@ -337,20 +337,20 @@ fn test_byte_storage_binary_quantization_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir_byte.path(),
-        segment_byte.id_tracker.clone(),
-        segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+    let hnsw_index_byte = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir_byte.path(),
+        id_tracker: segment_byte.id_tracker.clone(),
+        vector_storage: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
-        segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+        quantized_vectors: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
             .quantized_vectors
             .clone(),
-        segment_byte.payload_index.clone(),
+        payload_index: segment_byte.payload_index.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 5;

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -10,7 +10,7 @@ use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::path;
@@ -128,20 +128,20 @@ fn exact_search_test() {
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        segment.vector_data[DEFAULT_VECTOR_NAME]
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
-        segment.vector_data[DEFAULT_VECTOR_NAME]
+        quantized_vectors: segment.vector_data[DEFAULT_VECTOR_NAME]
             .quantized_vectors
             .clone(),
-        payload_index_ptr.clone(),
+        payload_index: payload_index_ptr.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -149,22 +149,8 @@ fn _test_filterable_hnsw(
         payload_m: None,
     };
 
-    let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
-    let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        payload_index_ptr.clone(),
-        hnsw_config,
-    )
-    .unwrap();
-
-    hnsw_index.build_index(permit.clone(), &stopped).unwrap();
 
     payload_index_ptr
         .borrow_mut()
@@ -204,7 +190,19 @@ fn _test_filterable_hnsw(
         "not all points are covered by payload blocks"
     );
 
-    hnsw_index.build_index(permit, &stopped).unwrap();
+    let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
+    let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+        hnsw_dir.path(),
+        segment.id_tracker.clone(),
+        vector_storage.clone(),
+        quantized_vectors.clone(),
+        payload_index_ptr.clone(),
+        hnsw_config,
+        Some(permit),
+        &stopped,
+    )
+    .unwrap();
 
     let top = 3;
     let mut hits = 0;

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -12,7 +12,7 @@ use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VEC
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::path;
@@ -192,16 +192,16 @@ fn _test_filterable_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        payload_index_ptr.clone(),
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: payload_index_ptr.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -10,7 +10,7 @@ use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VEC
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::path;
@@ -110,16 +110,16 @@ fn hnsw_discover_precision() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        payload_index_ptr.clone(),
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: payload_index_ptr.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 3;
@@ -233,16 +233,16 @@ fn filtered_hnsw_discover_precision() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        payload_index_ptr.clone(),
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: payload_index_ptr.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -110,17 +110,17 @@ fn hnsw_discover_precision() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
         quantized_vectors.clone(),
         payload_index_ptr.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-
-    hnsw_index.build_index(permit, &stopped).unwrap();
 
     let top = 3;
     let mut discovery_hits = 0;
@@ -214,6 +214,10 @@ fn filtered_hnsw_discover_precision() {
     }
 
     let payload_index_ptr = segment.payload_index.clone();
+    payload_index_ptr
+        .borrow_mut()
+        .set_indexed(&path(keyword_key), PayloadSchemaType::Keyword.into())
+        .unwrap();
 
     let hnsw_config = HnswConfig {
         m,
@@ -229,22 +233,17 @@ fn filtered_hnsw_discover_precision() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
         quantized_vectors.clone(),
         payload_index_ptr.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-
-    payload_index_ptr
-        .borrow_mut()
-        .set_indexed(&path(keyword_key), PayloadSchemaType::Keyword.into())
-        .unwrap();
-
-    hnsw_index.build_index(permit, &stopped).unwrap();
 
     let top = 3;
     let mut discovery_hits = 0;

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -129,7 +129,7 @@ fn hnsw_quantized_search_test(
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
 
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         segment.vector_data[DEFAULT_VECTOR_NAME]
@@ -140,10 +140,10 @@ fn hnsw_quantized_search_test(
             .clone(),
         segment.payload_index.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-
-    hnsw_index.build_index(permit, &stopped).unwrap();
 
     let query_vectors = (0..attempts)
         .map(|_| random_vector(&mut rnd, dim).into())

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -12,7 +12,7 @@ use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VEC
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_vector, STR_KEY};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{VectorIndex, VectorIndexEnum};
 use segment::json_path::path;
@@ -129,20 +129,20 @@ fn hnsw_quantized_search_test(
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
 
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        segment.vector_data[DEFAULT_VECTOR_NAME]
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
-        segment.vector_data[DEFAULT_VECTOR_NAME]
+        quantized_vectors: segment.vector_data[DEFAULT_VECTOR_NAME]
             .quantized_vectors
             .clone(),
-        segment.payload_index.clone(),
+        payload_index: segment.payload_index.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let query_vectors = (0..attempts)

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -12,7 +12,7 @@ use segment::data_types::vectors::{only_default_multi_vector, QueryVector, DEFAU
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_multi_vector};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::path;
@@ -183,16 +183,16 @@ fn test_multi_filterable_hnsw(
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        payload_index_ptr.clone(),
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: payload_index_ptr.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -164,6 +164,10 @@ fn test_multi_filterable_hnsw(
     );
 
     let payload_index_ptr = segment.payload_index.clone();
+    payload_index_ptr
+        .borrow_mut()
+        .set_indexed(&path(int_key), PayloadSchemaType::Integer.into())
+        .unwrap();
 
     let hnsw_config = HnswConfig {
         m,
@@ -179,24 +183,17 @@ fn test_multi_filterable_hnsw(
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
         quantized_vectors.clone(),
         payload_index_ptr.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-
-    hnsw_index.build_index(permit.clone(), &stopped).unwrap();
-
-    payload_index_ptr
-        .borrow_mut()
-        .set_indexed(&path(int_key), PayloadSchemaType::Integer.into())
-        .unwrap();
-
-    hnsw_index.build_index(permit, &stopped).unwrap();
 
     let top = 3;
     let mut hits = 0;

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -15,7 +15,7 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::index_fixtures::random_vector;
 use segment::fixtures::payload_fixtures::random_int_payload;
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::VectorIndex;
 use segment::json_path::path;
 use segment::segment_constructor::build_segment;
@@ -138,30 +138,30 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index_dense = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        vector_storage.clone(),
-        quantized_vectors.clone(),
-        segment.payload_index.clone(),
-        hnsw_config.clone(),
-        Some(permit.clone()),
-        &stopped,
-    )
+    let hnsw_index_dense = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: vector_storage.clone(),
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: segment.payload_index.clone(),
+        hnsw_config: hnsw_config.clone(),
+        permit: Some(permit.clone()),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let multi_storage = Arc::new(AtomicRefCell::new(multi_storage));
 
-    let hnsw_index_multi = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        multi_storage,
-        quantized_vectors.clone(),
-        segment.payload_index.clone(),
+    let hnsw_index_multi = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: multi_storage,
+        quantized_vectors: quantized_vectors.clone(),
+        payload_index: segment.payload_index.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     for _ in 0..10 {

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -138,31 +138,31 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let mut hnsw_index_dense = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index_dense = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
         quantized_vectors.clone(),
         segment.payload_index.clone(),
         hnsw_config.clone(),
+        Some(permit.clone()),
+        &stopped,
     )
     .unwrap();
-    hnsw_index_dense
-        .build_index(permit.clone(), &stopped)
-        .unwrap();
 
     let multi_storage = Arc::new(AtomicRefCell::new(multi_storage));
 
-    let mut hnsw_index_multi = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index_multi = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         multi_storage,
         quantized_vectors.clone(),
         segment.payload_index.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-    hnsw_index_multi.build_index(permit, &stopped).unwrap();
 
     for _ in 0..10 {
         let random_vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -15,7 +15,7 @@ use segment::data_types::vectors::{
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_multi_vector};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
-use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::path;
@@ -308,20 +308,20 @@ fn test_multivector_quantization_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
-        hnsw_dir.path(),
-        segment.id_tracker.clone(),
-        segment.vector_data[DEFAULT_VECTOR_NAME]
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(HnswIndexOpenArgs {
+        path: hnsw_dir.path(),
+        id_tracker: segment.id_tracker.clone(),
+        vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
-        segment.vector_data[DEFAULT_VECTOR_NAME]
+        quantized_vectors: segment.vector_data[DEFAULT_VECTOR_NAME]
             .quantized_vectors
             .clone(),
-        segment.payload_index.clone(),
+        payload_index: segment.payload_index.clone(),
         hnsw_config,
-        Some(permit),
-        &stopped,
-    )
+        permit: Some(permit),
+        stopped: &stopped,
+    })
     .unwrap();
 
     let top = 5;

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -308,7 +308,7 @@ fn test_multivector_quantization_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+    let hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         segment.vector_data[DEFAULT_VECTOR_NAME]
@@ -319,9 +319,10 @@ fn test_multivector_quantization_hnsw(
             .clone(),
         segment.payload_index.clone(),
         hnsw_config,
+        Some(permit),
+        &stopped,
     )
     .unwrap();
-    hnsw_index.build_index(permit, &stopped).unwrap();
 
     let top = 5;
     let mut sames = 0;

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -75,6 +75,14 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedMmap<W> {
 
     fn save(&self, path: &Path) -> std::io::Result<()> {
         debug_assert_eq!(path, self.path);
+
+        // If Self instance exists, it's either constructed by using `open()` (which reads index
+        // files), or using `from_ram_index()` (which writes them). Both assume that the files
+        // exist. If any of the files are missing, then something went wrong.
+        for file in Self::files(path) {
+            debug_assert!(file.exists());
+        }
+
         Ok(())
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -45,6 +45,7 @@ pub struct InvertedIndexFileHeader {
 }
 
 /// Inverted flatten index from dimension id to posting list
+#[derive(Debug)]
 pub struct InvertedIndexCompressedMmap<W> {
     path: PathBuf,
     mmap: Arc<Mmap>,

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -40,6 +40,7 @@ pub struct InvertedIndexFileHeader {
 }
 
 /// Inverted flatten index from dimension id to posting list
+#[derive(Debug)]
 pub struct InvertedIndexMmap {
     path: PathBuf,
     mmap: Arc<Mmap>,

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -63,6 +63,14 @@ impl InvertedIndex for InvertedIndexMmap {
 
     fn save(&self, path: &Path) -> std::io::Result<()> {
         debug_assert_eq!(path, self.path);
+
+        // If Self instance exists, it's either constructed by using `open()` (which reads index
+        // files), or using `from_ram_index()` (which writes them). Both assume that the files
+        // exist. If any of the files are missing, then something went wrong.
+        for file in Self::files(path) {
+            debug_assert!(file.exists());
+        }
+
         Ok(())
     }
 

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
@@ -19,7 +20,7 @@ pub mod inverted_index_ram_builder;
 pub const OLD_INDEX_FILE_NAME: &str = "inverted_index.data";
 pub const INDEX_FILE_NAME: &str = "inverted_index.dat";
 
-pub trait InvertedIndex: Sized {
+pub trait InvertedIndex: Sized + Debug {
     type Iter<'a>: PostingListIter + Clone
     where
         Self: 'a;


### PR DESCRIPTION
Based on #4454.

This PR removes `build_index()` method from `VectorIndex` implementation. Instead, the index is getting built inside `open()`.

Reason:
- For sparse vectors, it's already weird to have a separate `build_index()` method (it's getting rebuilt in `open()` in case of migration/missing files). Related comment: https://github.com/qdrant/qdrant/pull/4453#discussion_r1637799716
- For plain index, `build_index()` is a no-op.
- The remaining one trait implementation is HNSW. We can remove it for consistency with other trait implementations; and to avoid initializing it in an inconsistent state (like, when the index is "loaded", but not actually valid).