### PR TITLE
While resharding, support migrating points on a node locally

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -351,6 +351,17 @@ impl ShardReplicaSet {
         self.replica_state.read().get_peer_state(peer_id).copied()
     }
 
+    /// List the peer IDs on which this shard is active, both the local and remote peers.
+    pub async fn active_shards(&self) -> Vec<PeerId> {
+        let replica_state = self.replica_state.read();
+        replica_state
+            .active_peers()
+            .into_iter()
+            .filter(|peer_id| !self.is_locally_disabled(peer_id))
+            .collect()
+    }
+
+    /// List the remote peer IDs on which this shard is active, excludes the local peer ID.
     pub async fn active_remote_shards(&self) -> Vec<PeerId> {
         let replica_state = self.replica_state.read();
         let this_peer_id = replica_state.this_peer_id;

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -135,7 +135,6 @@ pub async fn drive_resharding(
     reshard_key: ReshardKey,
     _progress: Arc<Mutex<ReshardTaskProgress>>,
     shard_holder: Arc<LockedShardHolder>,
-    // TODO(resharding): we might want to separate this type into shard transfer and resharding
     consensus: &dyn ShardTransferConsensus,
     collection_id: CollectionId,
     collection_path: PathBuf,
@@ -150,7 +149,6 @@ pub async fn drive_resharding(
         DriverState::new(reshard_key.clone(), &consensus.peers())
     })?;
 
-    // TODO(resharding): sync list of peers more often throughout resharding in case peers change
     state.write(|data| {
         data.sync_peers(&consensus.peers());
     })?;
@@ -231,8 +229,6 @@ fn completed_init(state: &PersistedState) -> bool {
 ///
 /// Do initialize the resharding process.
 fn stage_init(state: &PersistedState) -> CollectionResult<()> {
-    // TODO(reshard): do any necessary initialisation here
-
     state.write(|data| {
         data.bump_all_peers_to(Stage::S1_InitEnd);
     })?;

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -47,10 +47,10 @@ struct DriverState {
 }
 
 impl DriverState {
-    pub fn new(key: ReshardKey) -> Self {
+    pub fn new(key: ReshardKey, peers: &[PeerId]) -> Self {
         Self {
             key,
-            peers: HashMap::new(),
+            peers: HashMap::from_iter(peers.iter().map(|peer_id| (*peer_id, Stage::default()))),
             migrated_shards: vec![],
         }
     }
@@ -147,7 +147,7 @@ pub async fn drive_resharding(
     let to_shard_id = reshard_key.shard_id;
     let resharding_state_path = resharding_state_path(&reshard_key, &collection_path);
     let state: PersistedState = SaveOnDisk::load_or_init(&resharding_state_path, || {
-        DriverState::new(reshard_key.clone())
+        DriverState::new(reshard_key.clone(), &consensus.peers())
     })?;
 
     // TODO(resharding): sync list of peers more often throughout resharding in case peers change

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -22,7 +22,7 @@ use crate::shards::CollectionId;
 /// # Cancel safety
 ///
 /// This function is cancel safe.
-pub(super) async fn transfer_resharding_stream_records(
+pub(crate) async fn transfer_resharding_stream_records(
     shard_holder: Arc<LockedShardHolder>,
     progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>
Depends on: <https://github.com/qdrant/qdrant/pull/4480>

Allow resharding migration transfers within the same node. It's a special case where the source and target shard are on the same machine, while our shard transfer mechanism doesn't support this.

This scenario must be supported if there's only one shard replica, exclusively on the node having the new target shard.

It's an initial approach, still relying on some building blocks of shard transfers and remote shards. It still talks over gRPC channels, but to itself. Eventually I'd like to improve upon this to migrate points from one shard replica to another directly instead of relying on transfers. But that requires significant refactoring as various components, such as our proxy shards, don't support this. I propose to attempt that later.

Note that this PR also refactors the point migration function overall. The idea is that it better shows the possible code paths.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/4480>
- [x] Rebase on `dev`
- [x] Undraft PR

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?