### PR TITLE
universal-query: use batch implementation everywhere

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -278,11 +278,11 @@ message IntermediateResult {
   repeated ScoredPoint result = 1;
 }
 
-message QueryResult {
-    repeated IntermediateResult result = 1;
+message QueryResultInternal {
+    repeated IntermediateResult intermediate_results = 1;
 }
 
 message QueryBatchResponse {
-  repeated QueryResult batch_results = 1;
+  repeated QueryResultInternal results = 1;
   double time = 2; // Time spent to process
 }

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -22,7 +22,6 @@ service PointsInternal {
   rpc Count (CountPointsInternal) returns (CountResponse) {}
   rpc Recommend (RecommendPointsInternal) returns (RecommendResponse) {}
   rpc Get (GetPointsInternal) returns (GetResponse) {}
-  rpc Query (QueryPointsInternal) returns (QueryResponse) {}
   rpc QueryBatch (QueryBatchPointsInternal) returns (QueryBatchResponse) {}
 }
 
@@ -268,13 +267,6 @@ message QueryShardPoints {
   WithVectorsSelector with_vectors = 10;
 }
 
-message QueryPointsInternal {
-  string collection_name = 1;
-  QueryShardPoints query_points = 2;
-  optional uint32 shard_id = 3;
-  optional uint64 timeout = 4;
-}
-
 message QueryBatchPointsInternal {
   string collection_name = 1;
   repeated QueryShardPoints query_points = 2;
@@ -284,11 +276,6 @@ message QueryBatchPointsInternal {
 
 message IntermediateResult {
   repeated ScoredPoint result = 1;
-}
-
-message QueryResponse {
-  repeated IntermediateResult result = 1;
-  double time = 2; // Time spent to process
 }
 
 message QueryResult {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -8368,19 +8368,6 @@ pub mod query_shard_points {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryPointsInternal {
-    #[prost(string, tag = "1")]
-    pub collection_name: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
-    pub query_points: ::core::option::Option<QueryShardPoints>,
-    #[prost(uint32, optional, tag = "3")]
-    pub shard_id: ::core::option::Option<u32>,
-    #[prost(uint64, optional, tag = "4")]
-    pub timeout: ::core::option::Option<u64>,
-}
-#[derive(serde::Serialize)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryBatchPointsInternal {
     #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
@@ -8397,16 +8384,6 @@ pub struct QueryBatchPointsInternal {
 pub struct IntermediateResult {
     #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
-}
-#[derive(serde::Serialize)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryResponse {
-    #[prost(message, repeated, tag = "1")]
-    pub result: ::prost::alloc::vec::Vec<IntermediateResult>,
-    /// Time spent to process
-    #[prost(double, tag = "2")]
-    pub time: f64,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -8900,28 +8877,6 @@ pub mod points_internal_client {
             req.extensions_mut().insert(GrpcMethod::new("qdrant.PointsInternal", "Get"));
             self.inner.unary(req, path, codec).await
         }
-        pub async fn query(
-            &mut self,
-            request: impl tonic::IntoRequest<super::QueryPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::QueryResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Query",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.PointsInternal", "Query"));
-            self.inner.unary(req, path, codec).await
-        }
         pub async fn query_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryBatchPointsInternal>,
@@ -9059,10 +9014,6 @@ pub mod points_internal_server {
             &self,
             request: tonic::Request<super::GetPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
-        async fn query(
-            &self,
-            request: tonic::Request<super::QueryPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::QueryResponse>, tonic::Status>;
         async fn query_batch(
             &self,
             request: tonic::Request<super::QueryBatchPointsInternal>,
@@ -9881,52 +9832,6 @@ pub mod points_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/qdrant.PointsInternal/Query" => {
-                    #[allow(non_camel_case_types)]
-                    struct QuerySvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::QueryPointsInternal>
-                    for QuerySvc<T> {
-                        type Response = super::QueryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::QueryPointsInternal>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as PointsInternal>::query(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = QuerySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -8388,16 +8388,16 @@ pub struct IntermediateResult {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryResult {
+pub struct QueryResultInternal {
     #[prost(message, repeated, tag = "1")]
-    pub result: ::prost::alloc::vec::Vec<IntermediateResult>,
+    pub intermediate_results: ::prost::alloc::vec::Vec<IntermediateResult>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryBatchResponse {
     #[prost(message, repeated, tag = "1")]
-    pub batch_results: ::prost::alloc::vec::Vec<QueryResult>,
+    pub results: ::prost::alloc::vec::Vec<QueryResultInternal>,
     /// Time spent to process
     #[prost(double, tag = "2")]
     pub time: f64,

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -64,7 +64,7 @@ impl Collection {
     }
 
     /// This function is used to query the collection. It will return a list of scored points.
-    pub async fn do_query_batch(
+    async fn do_query_batch(
         &self,
         requests_batch: Vec<ShardQueryRequest>,
         read_consistency: Option<ReadConsistency>,

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -9,6 +9,7 @@ use segment::utils::scored_point_ties::ScoredPointTies;
 use tokio::time::Instant;
 
 use super::Collection;
+use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::resolve_referenced_vectors_batch;
 use crate::common::transpose_iterator::transposed_iter;
 use crate::operations::consistency_params::ReadConsistency;
@@ -26,42 +27,6 @@ struct IntermediateQueryInfo<'a> {
 }
 
 impl Collection {
-    /// Returns a vector of shard responses for the given query.
-    // TODO(universal-query): remove in favor of batch version
-    async fn query_shards_concurrently(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        read_consistency: Option<ReadConsistency>,
-        shard_selection: &ShardSelectorInternal,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<ShardQueryResponse>> {
-        // query all shards concurrently
-        let shard_holder = self.shards_holder.read().await;
-        let target_shards = shard_holder.select_shards(shard_selection)?;
-        let all_searches = target_shards.iter().map(|(shard, shard_key)| {
-            let shard_key = shard_key.cloned();
-            shard
-                .query(
-                    Arc::clone(&request),
-                    read_consistency,
-                    shard_selection.is_shard_id(),
-                    timeout,
-                )
-                .and_then(move |mut records| async move {
-                    if shard_key.is_none() {
-                        return Ok(records);
-                    }
-                    for batch in &mut records {
-                        for point in batch {
-                            point.shard_key.clone_from(&shard_key);
-                        }
-                    }
-                    Ok(records)
-                })
-        });
-        future::try_join_all(all_searches).await
-    }
-
     /// Returns a shape of [shard_id, batch_id, intermediate_response, points]
     async fn batch_query_shards_concurrently(
         &self,
@@ -98,88 +63,121 @@ impl Collection {
         future::try_join_all(all_searches).await
     }
 
+    /// This function is used to query the collection. It will return a list of scored points.
+    pub async fn do_query_batch(
+        &self,
+        requests_batch: Vec<ShardQueryRequest>,
+        read_consistency: Option<ReadConsistency>,
+        shard_selection: ShardSelectorInternal,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        let instant = Instant::now();
+
+        let requests_batch = Arc::new(requests_batch);
+
+        let all_shards_results = self
+            .batch_query_shards_concurrently(
+                requests_batch.clone(),
+                read_consistency,
+                &shard_selection,
+                timeout,
+            )
+            .await?;
+
+        let results_f = transposed_iter(all_shards_results)
+            .zip(requests_batch.iter())
+            .map(|(shards_results, request)| async {
+                // shards_results shape: [num_shards, num_intermediate_results, num_points]
+                let mut merged_intermediates = self
+                    .merge_intermediate_results_from_shards(request, shards_results)
+                    .await?;
+
+                let result = if let Some(ScoringQuery::Fusion(fusion)) = &request.query {
+                    // If the root query is a Fusion, the returned results correspond to each the prefetches.
+                    match fusion {
+                        Fusion::Rrf => rrf_scoring(merged_intermediates),
+                    }
+                } else {
+                    // Otherwise, it will be a list with a single list of scored points.
+                    debug_assert_eq!(merged_intermediates.len(), 1);
+                    merged_intermediates.pop().ok_or_else(|| {
+                        CollectionError::service_error(
+                            "Query response was expected to have one list of results.",
+                        )
+                    })?
+                };
+
+                let result: Vec<ScoredPoint> = result
+                    .into_iter()
+                    .skip(request.offset)
+                    .take(request.limit)
+                    .collect();
+
+                let filter_refs = request.filter_refs();
+                self.post_process_if_slow_request(instant.elapsed(), filter_refs);
+
+                Ok::<_, CollectionError>(result)
+            });
+        let results = future::try_join_all(results_f).await?;
+
+        Ok(results)
+    }
+
     /// To be called on the user-responding instance. Resolves ids into vectors, and merges the results from local and remote shards.
     ///
     /// This function is used to query the collection. It will return a list of scored points.
-    pub async fn query(
+    pub async fn query_batch(
         &self,
-        request: CollectionQueryRequest,
+        requests_batch: Vec<(CollectionQueryRequest, ShardSelectorInternal)>,
         read_consistency: Option<ReadConsistency>,
-        shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
-        let instant = Instant::now();
-
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         // Turn ids into vectors, if necessary
         let ids_to_vectors = resolve_referenced_vectors_batch(
-            &[(&request, shard_selection.clone())],
+            &requests_batch,
             self,
             |_| async { unimplemented!("lookup_from is not implemented yet") },
             read_consistency,
         )
         .await?;
 
-        let request = Arc::new(request.try_into_shard_request(&ids_to_vectors)?);
+        let futures = batch_requests::<
+            (CollectionQueryRequest, ShardSelectorInternal),
+            ShardSelectorInternal,
+            Vec<ShardQueryRequest>,
+            Vec<_>,
+        >(
+            requests_batch,
+            |(_req, shard)| shard,
+            |(req, _), acc| {
+                req.try_into_shard_request(&ids_to_vectors)
+                    .map(|shard_req| {
+                        acc.push(shard_req);
+                    })
+            },
+            |shard_selection, shard_requests, futures| {
+                if shard_requests.is_empty() {
+                    return Ok(());
+                }
 
-        let all_shards_results = self
-            .query_shards_concurrently(request.clone(), read_consistency, shard_selection, timeout)
-            .await?;
+                futures.push(self.do_query_batch(
+                    shard_requests,
+                    read_consistency,
+                    shard_selection,
+                    timeout,
+                ));
 
-        let mut merged_intermediates = self
-            .merge_intermediate_results_from_shards(request.as_ref(), all_shards_results)
-            .await?;
+                Ok(())
+            },
+        )?;
 
-        let result = if let Some(ScoringQuery::Fusion(fusion)) = &request.query {
-            // If the root query is a Fusion, the returned results correspond to each the prefetches.
-            match fusion {
-                Fusion::Rrf => rrf_scoring(merged_intermediates),
-            }
-        } else {
-            // Otherwise, it will be a list with a single list of scored points.
-            debug_assert_eq!(merged_intermediates.len(), 1);
-            merged_intermediates.pop().ok_or_else(|| {
-                CollectionError::service_error(
-                    "Query response was expected to have one list of results.",
-                )
-            })?
-        };
-
-        let result: Vec<_> = result
+        let results = future::try_join_all(futures)
+            .await?
             .into_iter()
-            .skip(request.offset)
-            .take(request.limit)
+            .flatten()
             .collect();
 
-        let filter_refs = request.filter_refs();
-        self.post_process_if_slow_request(instant.elapsed(), filter_refs);
-
-        Ok(result)
-    }
-
-    /// To be called on the remote instance. Only used for the internal service.
-    ///
-    /// If the root query is a Fusion, the returned results correspond to each the prefetches.
-    /// Otherwise, it will be a list with a single list of scored points.
-    // TODO(universal-query): Remove in favor of batch version
-    pub async fn query_internal(
-        &self,
-        request: ShardQueryRequest,
-        shard_selection: &ShardSelectorInternal,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<ShardQueryResponse> {
-        let request = Arc::new(request);
-
-        // Results from all shards
-        // Shape: [num_shards, num_intermediate_results, num_points]
-        let all_shards_results = self
-            .query_shards_concurrently(Arc::clone(&request), None, shard_selection, timeout)
-            .await?;
-
-        let merged = self
-            .merge_intermediate_results_from_shards(request.as_ref(), all_shards_results)
-            .await?;
-
-        Ok(merged)
+        Ok(results)
     }
 
     /// To be called on the remote instance. Only used for the internal service.
@@ -213,7 +211,6 @@ impl Collection {
                     .await
             });
         let merged = futures::future::try_join_all(merged_f).await?;
-
         Ok(merged)
     }
 

--- a/lib/collection/src/common/retrieve_request_trait.rs
+++ b/lib/collection/src/common/retrieve_request_trait.rs
@@ -105,7 +105,7 @@ impl RetrieveRequest for DiscoverRequestInternal {
     }
 }
 
-impl RetrieveRequest for &CollectionQueryRequest {
+impl RetrieveRequest for CollectionQueryRequest {
     fn get_lookup_collection(&self) -> Option<&String> {
         None // TODO(universal-query): Change this when we add lookup_from to CollectionQueryRequest
     }

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -346,7 +346,7 @@ impl CollectionQueryRequest {
         }
 
         // Check we actually fetched all referenced vectors in this request (and nested prefetches)
-        for &point_id in &(&self).get_referenced_point_ids() {
+        for &point_id in &self.get_referenced_point_ids() {
             if ids_to_vectors.get(&None, point_id).is_none() {
                 return Err(CollectionError::PointNotFound {
                     missed_point_id: point_id,
@@ -354,12 +354,12 @@ impl CollectionQueryRequest {
             }
         }
 
-        let lookup_vector_name = (&self).get_lookup_vector_name();
-        let lookup_collection = (&self).get_lookup_collection().cloned();
+        let lookup_vector_name = self.get_lookup_vector_name();
+        let lookup_collection = self.get_lookup_collection().cloned();
         let using = self.using.clone();
 
         // Edit filter to exclude all referenced point ids (root and nested)
-        let filter = exclude_referenced_ids((&self).get_referenced_point_ids(), self.filter);
+        let filter = exclude_referenced_ids(self.get_referenced_point_ids(), self.filter);
 
         let query = self
             .query

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -102,18 +102,9 @@ impl ShardOperation for DummyShard {
         self.dummy()
     }
 
-    async fn query(
-        &self,
-        _: Arc<ShardQueryRequest>,
-        _: &Handle,
-        _: Option<Duration>,
-    ) -> CollectionResult<ShardQueryResponse> {
-        self.dummy()
-    }
-
     async fn query_batch(
         &self,
-        _request: Arc<Vec<ShardQueryRequest>>,
+        _requests: Arc<Vec<ShardQueryRequest>>,
         _search_runtime_handle: &Handle,
         _timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -283,27 +283,15 @@ impl ShardOperation for ForwardProxyShard {
             .await
     }
 
-    async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<ShardQueryResponse> {
-        let local_shard = &self.wrapped_shard;
-        local_shard
-            .query(request, search_runtime_handle, timeout)
-            .await
-    }
-
     async fn query_batch(
         &self,
-        request: Arc<Vec<ShardQueryRequest>>,
+        requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .query_batch(request, search_runtime_handle, timeout)
+            .query_batch(requests, search_runtime_handle, timeout)
             .await
     }
 }

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -185,32 +185,13 @@ impl ShardOperation for LocalShard {
         SegmentsSearcher::retrieve(self.segments(), &request.ids, with_payload, with_vector)
     }
 
-    async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let planned_query = PlannedQuery::try_from(vec![request.as_ref().to_owned()])?;
-
-        let mut batch_result = self
-            .do_planned_query(planned_query, search_runtime_handle, timeout)
-            .await?;
-
-        debug_assert_eq!(batch_result.len(), 1);
-
-        batch_result
-            .pop()
-            .ok_or_else(|| CollectionError::service_error("Query result is empty".to_string()))
-    }
-
     async fn query_batch(
         &self,
-        request: Arc<Vec<ShardQueryRequest>>,
+        requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
-        let planned_query = PlannedQuery::try_from(request.as_ref().to_owned())?;
+        let planned_query = PlannedQuery::try_from(requests.as_ref().to_owned())?;
 
         self.do_planned_query(planned_query, search_runtime_handle, timeout)
             .await

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -248,17 +248,6 @@ impl ShardOperation for ProxyShard {
     }
 
     /// Forward read-only `query` to `wrapped_shard`
-    async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<ShardQueryResponse> {
-        self.wrapped_shard
-            .query(request, search_runtime_handle, timeout)
-            .await
-    }
-
     async fn query_batch(
         &self,
         request: Arc<Vec<ShardQueryRequest>>,

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -293,23 +293,9 @@ impl ShardOperation for QueueProxyShard {
     }
 
     /// Forward read-only `query` to `wrapped_shard`
-    async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<ShardQueryResponse> {
-        self.inner
-            .as_ref()
-            .expect("Queue proxy has been finalized")
-            .wrapped_shard
-            .query(request, search_runtime_handle, timeout)
-            .await
-    }
-
     async fn query_batch(
         &self,
-        request: Arc<Vec<ShardQueryRequest>>,
+        requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
@@ -317,7 +303,7 @@ impl ShardOperation for QueueProxyShard {
             .as_ref()
             .expect("Queue proxy has been finalized")
             .wrapped_shard
-            .query_batch(request, search_runtime_handle, timeout)
+            .query_batch(requests, search_runtime_handle, timeout)
             .await
     }
 }
@@ -594,17 +580,6 @@ impl ShardOperation for Inner {
     }
 
     /// Forward read-only `query` to `wrapped_shard`
-    async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        self.wrapped_shard
-            .query(request, search_runtime_handle, timeout)
-            .await
-    }
-
     async fn query_batch(
         &self,
         request: Arc<Vec<ShardQueryRequest>>,

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -849,7 +849,7 @@ impl ShardOperation for RemoteShard {
 
         let requests = requests.as_ref();
 
-        let search_batch_response = self
+        let batch_response = self
             .with_points_client(|mut client| async move {
                 let query_points = requests
                     .iter()
@@ -874,15 +874,15 @@ impl ShardOperation for RemoteShard {
             .await?
             .into_inner();
 
-        let result = search_batch_response
-            .batch_results
+        let result = batch_response
+            .results
             .into_iter()
             .zip(requests.iter())
             .map(|(query_result, request)| {
                 let is_payload_required = request.with_payload.is_required();
 
                 query_result
-                    .result
+                    .intermediate_results
                     .into_iter()
                     .map(|intermediate| {
                         intermediate

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -12,7 +12,7 @@ use api::grpc::qdrant::{
     CollectionOperationResponse, CoreSearchBatchPointsInternal, CountPoints, CountPointsInternal,
     GetCollectionInfoRequest, GetCollectionInfoRequestInternal, GetPoints, GetPointsInternal,
     GetShardRecoveryPointRequest, HealthCheckRequest, InitiateShardTransferRequest,
-    QueryBatchPointsInternal, QueryPointsInternal, QueryShardPoints, RecoverShardSnapshotRequest,
+    QueryBatchPointsInternal, QueryShardPoints, RecoverShardSnapshotRequest,
     RecoverSnapshotResponse, ScrollPoints, ScrollPointsInternal, ShardSnapshotLocation,
     UpdateShardCutoffPointRequest, WaitForShardStateRequest,
 };
@@ -838,67 +838,20 @@ impl ShardOperation for RemoteShard {
         result.map_err(|e| e.into())
     }
 
-    // TODO(universal-query): remove in favor of batch version
-    async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        _search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<ShardQueryResponse> {
-        let is_payload_required = request.with_payload.is_required();
-
-        let request = request.as_ref();
-
-        let query_response = self
-            .with_points_client(|mut client| async move {
-                let query_points = Some(QueryShardPoints::from(request.to_owned()));
-
-                let request = QueryPointsInternal {
-                    collection_name: self.collection_id.clone(),
-                    query_points,
-                    shard_id: Some(self.id),
-                    timeout: timeout.map(|t| t.as_secs()),
-                };
-
-                let mut request = tonic::Request::new(request);
-
-                if let Some(timeout) = timeout {
-                    request.set_timeout(timeout);
-                }
-                client.query(request).await
-            })
-            .await?
-            .into_inner();
-
-        let result: Result<ShardQueryResponse, Status> = query_response
-            .result
-            .into_iter()
-            .map(|intermediate| {
-                intermediate
-                    .result
-                    .into_iter()
-                    .map(|point| try_scored_point_from_grpc(point, is_payload_required))
-                    .collect()
-            })
-            .collect();
-
-        result.map_err(CollectionError::from)
-    }
-
     async fn query_batch(
         &self,
-        batch_request: Arc<Vec<ShardQueryRequest>>,
+        requests: Arc<Vec<ShardQueryRequest>>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);
         timer.set_success(false);
 
-        let batch_request = batch_request.as_ref();
+        let requests = requests.as_ref();
 
         let search_batch_response = self
             .with_points_client(|mut client| async move {
-                let query_points = batch_request
+                let query_points = requests
                     .iter()
                     .map(|request| QueryShardPoints::from(request.clone()))
                     .collect();
@@ -924,7 +877,7 @@ impl ShardOperation for RemoteShard {
         let result = search_batch_response
             .batch_results
             .into_iter()
-            .zip(batch_request.iter())
+            .zip(requests.iter())
             .map(|(query_result, request)| {
                 let is_payload_required = request.with_payload.is_required();
 

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -138,40 +138,19 @@ impl ShardReplicaSet {
         }
     }
 
-    // TODO(universal-query): Remove in favor of batch version
-    pub async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        read_consistency: Option<ReadConsistency>,
-        local_only: bool,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        self.execute_and_resolve_read_operation(
-            |shard| {
-                let request = Arc::clone(&request);
-                let search_runtime = self.search_runtime.clone();
-
-                async move { shard.query(request, &search_runtime, timeout).await }.boxed()
-            },
-            read_consistency,
-            local_only,
-        )
-        .await
-    }
-
     pub async fn query_batch(
         &self,
-        request: Arc<Vec<ShardQueryRequest>>,
+        requests: Arc<Vec<ShardQueryRequest>>,
         read_consistency: Option<ReadConsistency>,
         local_only: bool,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         self.execute_and_resolve_read_operation(
             |shard| {
-                let request = Arc::clone(&request);
+                let requests = Arc::clone(&requests);
                 let search_runtime = self.search_runtime.clone();
 
-                async move { shard.query_batch(request, &search_runtime, timeout).await }.boxed()
+                async move { shard.query_batch(requests, &search_runtime, timeout).await }.boxed()
             },
             read_consistency,
             local_only,

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -48,16 +48,9 @@ pub trait ShardOperation {
         with_vector: &WithVector,
     ) -> CollectionResult<Vec<Record>>;
 
-    async fn query(
-        &self,
-        request: Arc<ShardQueryRequest>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<ShardQueryResponse>;
-
     async fn query_batch(
         &self,
-        request: Arc<Vec<ShardQueryRequest>>,
+        requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<ShardQueryResponse>>;

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -56,7 +56,9 @@ async fn test_shard_query_rrf_rescoring() {
         with_payload: WithPayloadInterface::Bool(false),
     };
 
-    let sources_scores = shard.query(Arc::new(query), &current_runtime, None).await;
+    let sources_scores = shard
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .await;
     let expected_error =
         CollectionError::bad_request("cannot apply Fusion without prefetches".to_string());
     assert!(matches!(sources_scores, Err(err) if err == expected_error));
@@ -89,8 +91,10 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime, None)
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
         .await
+        .unwrap()
+        .pop()
         .unwrap();
 
     // one score per prefetch
@@ -133,8 +137,10 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime, None)
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
         .await
+        .unwrap()
+        .pop()
         .unwrap();
 
     // one score per prefetch
@@ -174,8 +180,10 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime, None)
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
         .await
+        .unwrap()
+        .pop()
         .unwrap();
 
     // one score per prefetch
@@ -243,8 +251,10 @@ async fn test_shard_query_vector_rescoring() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime, None)
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
         .await
+        .unwrap()
+        .pop()
         .unwrap();
 
     // only one inner result in absence of prefetches
@@ -267,8 +277,10 @@ async fn test_shard_query_vector_rescoring() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime, None)
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
         .await
+        .unwrap()
+        .pop()
         .unwrap();
 
     // only one inner result in absence of prefetches
@@ -294,8 +306,10 @@ async fn test_shard_query_vector_rescoring() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime, None)
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
         .await
+        .unwrap()
+        .pop()
         .unwrap();
 
     // only one inner result in absence of fusion
@@ -352,8 +366,10 @@ async fn test_shard_query_payload_vector() {
     };
 
     let sources_scores = shard
-        .query(Arc::new(query), &current_runtime, None)
+        .query_batch(Arc::new(vec![query]), &current_runtime, None)
         .await
+        .unwrap()
+        .pop()
         .unwrap();
 
     // only one inner result in absence of prefetches

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -4,29 +4,11 @@ use std::time::Duration;
 
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
-use segment::types::ScoredPoint;
 
 use super::TableOfContent;
 use crate::content_manager::errors::StorageError;
 
 impl TableOfContent {
-    // TODO(universal-query): remove in favor of batch version
-    pub async fn query_internal(
-        &self,
-        collection_name: &str,
-        request: ShardQueryRequest,
-        shard_selection: ShardSelectorInternal,
-        timeout: Option<Duration>,
-    ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
-        let collection = self.get_collection_unchecked(collection_name).await?;
-
-        let res = collection
-            .query_internal(request, &shard_selection, timeout)
-            .await?;
-
-        Ok(res)
-    }
-
     pub async fn query_batch_internal(
         &self,
         collection_name: &str,

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -7,9 +7,9 @@ use api::grpc::qdrant::{
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
     DeletePayloadPointsInternal, DeletePointsInternal, DeleteVectorsInternal, GetPointsInternal,
     GetResponse, IntermediateResult, PointsOperationResponseInternal, QueryBatchPointsInternal,
-    QueryBatchResponse, QueryResult, QueryShardPoints, RecommendPointsInternal, RecommendResponse,
-    ScrollPointsInternal, ScrollResponse, SearchBatchResponse, SetPayloadPointsInternal,
-    SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
+    QueryBatchResponse, QueryResultInternal, QueryShardPoints, RecommendPointsInternal,
+    RecommendResponse, ScrollPointsInternal, ScrollResponse, SearchBatchResponse,
+    SetPayloadPointsInternal, SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
@@ -71,10 +71,10 @@ pub async fn query_batch_internal(
         .map_err(error_to_status)?;
 
     let response = QueryBatchResponse {
-        batch_results: batch_response
+        results: batch_response
             .into_iter()
-            .map(|response| QueryResult {
-                result: response
+            .map(|response| QueryResultInternal {
+                intermediate_results: response
                     .into_iter()
                     .map(|intermediate| IntermediateResult {
                         result: intermediate.into_iter().map(From::from).collect_vec(),

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -7,10 +7,9 @@ use api::grpc::qdrant::{
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
     DeletePayloadPointsInternal, DeletePointsInternal, DeleteVectorsInternal, GetPointsInternal,
     GetResponse, IntermediateResult, PointsOperationResponseInternal, QueryBatchPointsInternal,
-    QueryBatchResponse, QueryPointsInternal, QueryResponse, QueryResult, QueryShardPoints,
-    RecommendPointsInternal, RecommendResponse, ScrollPointsInternal, ScrollResponse,
-    SearchBatchResponse, SetPayloadPointsInternal, SyncPointsInternal, UpdateVectorsInternal,
-    UpsertPointsInternal,
+    QueryBatchResponse, QueryResult, QueryShardPoints, RecommendPointsInternal, RecommendResponse,
+    ScrollPointsInternal, ScrollResponse, SearchBatchResponse, SetPayloadPointsInternal,
+    SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
@@ -40,46 +39,6 @@ impl PointsInternalService {
     pub fn new(toc: Arc<TableOfContent>) -> Self {
         Self { toc }
     }
-}
-
-// TODO(universal-query): remove in favor of batch version
-pub async fn query_internal(
-    toc: &TableOfContent,
-    collection_name: String,
-    query_points: QueryShardPoints,
-    shard_selection: Option<ShardId>,
-    timeout: Option<Duration>,
-) -> Result<Response<QueryResponse>, Status> {
-    let request = ShardQueryRequest::try_from(query_points)?;
-
-    let timing = Instant::now();
-
-    // As this function is handling an internal request,
-    // we can assume that shard_key is already resolved
-    let shard_selection = match shard_selection {
-        None => {
-            debug_assert!(false, "Shard selection is expected for internal request");
-            ShardSelectorInternal::All
-        }
-        Some(shard_id) => ShardSelectorInternal::ShardId(shard_id),
-    };
-
-    let scored_points = toc
-        .query_internal(&collection_name, request, shard_selection, timeout)
-        .await
-        .map_err(error_to_status)?;
-
-    let response = QueryResponse {
-        result: scored_points
-            .into_iter()
-            .map(|points| IntermediateResult {
-                result: points.into_iter().map(From::from).collect::<Vec<_>>(),
-            })
-            .collect(),
-        time: timing.elapsed().as_secs_f64(),
-    };
-
-    Ok(Response::new(response))
 }
 
 pub async fn query_batch_internal(
@@ -518,37 +477,6 @@ impl PointsInternal for PointsInternalService {
             clock_tag.map(Into::into),
             shard_id,
             FULL_ACCESS.clone(),
-        )
-        .await
-    }
-
-    async fn query(
-        &self,
-        request: Request<QueryPointsInternal>,
-    ) -> Result<Response<QueryResponse>, Status> {
-        // TODO(universal-query): validate
-        // validate_and_log(request.get_ref());
-
-        let QueryPointsInternal {
-            collection_name,
-            shard_id,
-            query_points,
-            timeout,
-        } = request.into_inner();
-
-        let query_points =
-            query_points.ok_or_else(|| Status::invalid_argument("QueryPoints is missing"))?;
-
-        let timeout = timeout.map(Duration::from_secs);
-
-        // Individual `read_consistency` values are ignored
-
-        query_internal(
-            self.toc.as_ref(),
-            collection_name,
-            query_points,
-            shard_id,
-            timeout,
         )
         .await
     }


### PR DESCRIPTION
Uses the batch implementation everywhere, and gets rid of the single implementation. 

For single endpoints, it is a batch of 1 request.