### PR TITLE
While resharding, respect configured shard transfer limits

### DIFF
--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -333,6 +333,7 @@ fn completed_migrate_points(state: &PersistedState) -> bool {
 /// Keeps checking what shards are still pending point migrations. For each of them it starts a
 /// shard transfer if needed, waiting for them to finish. Once this returns, all points are
 /// migrated to the target shard.
+#[allow(clippy::too_many_arguments)]
 async fn stage_migrate_points(
     reshard_key: &ReshardKey,
     state: &PersistedState,

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -1008,6 +1008,13 @@ impl ShardHolder {
         })
     }
 
+    /// Count how many shard replicas are on the given peer.
+    pub fn count_peer_shards(&self, peer_id: PeerId) -> usize {
+        self.get_shards()
+            .filter(|(_, replica_set)| replica_set.peer_state(&peer_id).is_some())
+            .count()
+    }
+
     pub fn check_transfer_exists(&self, transfer_key: &ShardTransferKey) -> bool {
         self.shard_transfers
             .read()


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>
Depends on: <https://github.com/qdrant/qdrant/pull/4491>

A user may configure incoming and outgoing shard transfer limits. This PR makes sure to respect these limits during resharding.

This also selects peers with the lowest number of shards while replicating to balance the shard distribution.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/4491>
- [x] Rebase on `dev`
- [x] Undraft PR

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?