### PR TITLE
universal-query: Add layer of response structure specific to query

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5235,10 +5235,7 @@
                       "type": "string"
                     },
                     "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ScoredPoint"
-                      }
+                      "$ref": "#/components/schemas/QueryResponse"
                     }
                   }
                 }
@@ -5335,10 +5332,7 @@
                     "result": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/components/schemas/ScoredPoint"
-                        }
+                        "$ref": "#/components/schemas/QueryResponse"
                       }
                     }
                   }
@@ -11949,6 +11943,20 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/QueryRequest"
+            }
+          }
+        }
+      },
+      "QueryResponse": {
+        "type": "object",
+        "required": [
+          "points"
+        ],
+        "properties": {
+          "points": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScoredPoint"
             }
           }
         }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -209,6 +209,11 @@ pub struct QueryRequestBatch {
     pub searches: Vec<QueryRequest>,
 }
 
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct QueryResponse {
+    pub points: Vec<ScoredPoint>,
+}
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum QueryInterface {

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -636,7 +636,7 @@ paths:
             type: integer
             minimum: 1
 
-      responses: #@ response(array(reference("ScoredPoint")))
+      responses: #@ response(reference("QueryResponse"))
   
   /collections/{collection_name}/points/query/batch:
     post:
@@ -674,7 +674,7 @@ paths:
             type: integer
             minimum: 1
 
-      responses: #@ response(array(array(reference("ScoredPoint"))))
+      responses: #@ response(array(reference("QueryResponse")))
 
 components:
   securitySchemes:

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -1,6 +1,6 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use api::rest::{QueryRequest, QueryRequestBatch};
+use api::rest::{QueryRequest, QueryRequestBatch, QueryResponse};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::collection_query::CollectionQueryRequest;
 use itertools::Itertools;
@@ -31,7 +31,7 @@ async fn query_points(
             Some(shard_keys) => shard_keys.into(),
         };
 
-        let res = dispatcher
+        let points = dispatcher
             .toc(&access)
             .query_batch(
                 &collection.name,
@@ -49,7 +49,7 @@ async fn query_points(
             .map(api::rest::ScoredPoint::from)
             .collect_vec();
 
-        Ok(res)
+        Ok(QueryResponse { points })
     })
     .await
 }
@@ -94,11 +94,11 @@ async fn query_points_batch(
             )
             .await?
             .into_iter()
-            .map(|response| {
-                response
+            .map(|response| QueryResponse {
+                points: response
                     .into_iter()
                     .map(api::rest::ScoredPoint::from)
-                    .collect_vec()
+                    .collect_vec(),
             })
             .collect_vec();
 

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,5 +1,5 @@
 use api::grpc::models::{CollectionsResponse, VersionInfo};
-use api::rest::{QueryRequest, QueryRequestBatch, Record, ScoredPoint};
+use api::rest::{QueryRequest, QueryRequestBatch, QueryResponse, Record, ScoredPoint};
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
@@ -83,6 +83,7 @@ struct AllDefinitions {
     bd: CollectionExistence,
     be: QueryRequest,
     bf: QueryRequestBatch,
+    bg: QueryResponse,
 }
 
 fn save_schema<T: JsonSchema>() {

--- a/tests/consensus_tests/auth_tests/test_jwt_validation.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_validation.py
@@ -192,7 +192,7 @@ def test_payload_filters_query(berlin_token, prefetch):
     )
 
     cities_in_payload = set(
-        point["payload"].get("city") for point in res.json()["result"]
+        point["payload"].get("city") for point in res.json()["result"]["points"]
     )
 
     assert len(cities_in_payload) > 1
@@ -210,7 +210,7 @@ def test_payload_filters_query(berlin_token, prefetch):
     )
 
     cities_in_payload = set(
-        point["payload"].get("city") for point in res.json()["result"]
+        point["payload"].get("city") for point in res.json()["result"]["points"]
     )
 
     assert cities_in_payload == {"Berlin"}

--- a/tests/consensus_tests/test_points_query.py
+++ b/tests/consensus_tests/test_points_query.py
@@ -316,7 +316,7 @@ def test_points_query(tmp_path: pathlib.Path):
             json=body1
         )
         assert_http_ok(r_init_one)
-        r_init_one = r_init_one.json()["result"]
+        r_init_one = get_results(action1, r_init_one.json())
         if extract1:
             r_init_one = apply_json_path(r_init_one, extract1)
 
@@ -329,7 +329,7 @@ def test_points_query(tmp_path: pathlib.Path):
                 json=body1
             )
             assert_http_ok(r_one)
-            r_one = r_one.json()["result"]
+            r_one = get_results(action1, r_one.json())
             if extract1:
                 r_one = apply_json_path(r_one, extract1)
 
@@ -340,7 +340,7 @@ def test_points_query(tmp_path: pathlib.Path):
                 json=body2
             )
             assert_http_ok(r_two)
-            r_two = r_two.json()["result"]
+            r_two = get_results(action2, r_two.json())
             if extract2:
                 r_two = apply_json_path(r_two, extract2)
 
@@ -350,6 +350,13 @@ def test_points_query(tmp_path: pathlib.Path):
             assert set(str(d) for d in r_one) == set(str(d) for d in r_two), f"Different results for {action1} and {action2}"
             # assert stable across peers
             assert set(str(d) for d in r_one) == set(str(d) for d in r_init_one), f"Different results for {action1} and {action2}"
+
+
+def get_results(action_name, res_json):
+    if action_name == "query":
+        return res_json["result"]["points"]
+    return res_json["result"]
+
 
 def apply_json_path(json_obj, json_path):
     if json_path is None:

--- a/tests/openapi/openapi_integration/test_query.py
+++ b/tests/openapi/openapi_integration/test_query.py
@@ -34,7 +34,7 @@ def root_and_rescored_query(query, limit=None, with_payload=None):
         },
     )
     assert response.ok
-    root_query_result = response.json()["result"]
+    root_query_result = response.json()["result"]["points"]
 
     response = request_with_validation(
         api="/collections/{collection_name}/points/query",
@@ -49,7 +49,7 @@ def root_and_rescored_query(query, limit=None, with_payload=None):
         },
     )
     assert response.ok
-    nested_query_result = response.json()["result"]
+    nested_query_result = response.json()["result"]["points"]
 
     assert root_query_result == nested_query_result
     return root_query_result
@@ -95,7 +95,7 @@ def test_basic_scroll():
         },
     )
     assert response.ok
-    query_result = response.json()["result"]
+    query_result = response.json()["result"]["points"]
 
     for record, scored_point in zip(scroll_result, query_result):
         assert record.get("id") == scored_point.get("id")
@@ -155,7 +155,7 @@ def test_basic_recommend_best_score():
         },
     )
     assert response.ok
-    query_result = response.json()["result"]
+    query_result = response.json()["result"]["points"]
 
     assert recommend_result == query_result
 
@@ -211,7 +211,7 @@ def test_basic_context():
         },
     )
     assert response.ok
-    query_result = response.json()["result"]
+    query_result = response.json()["result"]["points"]
 
     assert set([p["id"] for p in context_result]) == set([p["id"] for p in query_result])
 
@@ -275,7 +275,7 @@ def test_basic_rrf():
         },
     )
     assert response.ok, response.json()
-    rrf_result = response.json()["result"]
+    rrf_result = response.json()["result"]["points"]
     
     def get_id(x):
         return x["id"]

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -50,7 +50,7 @@ def root_and_rescored_query(query, using, filter=None, limit=None, with_payload=
         },
     )
     assert response.ok
-    root_query_result = response.json()["result"]
+    root_query_result = response.json()["result"]["points"]
 
     response = request_with_validation(
         api="/collections/{collection_name}/points/query",
@@ -67,7 +67,7 @@ def root_and_rescored_query(query, using, filter=None, limit=None, with_payload=
         },
     )
     assert response.ok
-    nested_query_result = response.json()["result"]
+    nested_query_result = response.json()["result"]["points"]
 
     assert root_query_result == nested_query_result
     return root_query_result
@@ -107,7 +107,7 @@ def test_search_by_id():
         },
     )
     assert response.ok
-    by_id_query_result = response.json()["result"]
+    by_id_query_result = response.json()["result"]["points"]
 
     top = by_id_query_result[0]
     assert top["id"] != 2 # id 2 is excluded from the results
@@ -166,7 +166,7 @@ def test_scroll():
         },
     )
     assert response.ok
-    query_result = response.json()["result"]
+    query_result = response.json()["result"]["points"]
 
     for record, scored_point in zip(scroll_result, query_result):
         assert record.get("id") == scored_point.get("id")
@@ -204,7 +204,7 @@ def test_filtered_scroll():
         },
     )
     assert response.ok
-    query_result = response.json()["result"]
+    query_result = response.json()["result"]["points"]
 
     for record, scored_point in zip(scroll_result, query_result):
         assert record.get("id") == scored_point.get("id")
@@ -268,7 +268,7 @@ def test_recommend_best_score():
         },
     )
     assert response.ok
-    query_result = response.json()["result"]
+    query_result = response.json()["result"]["points"]
 
     assert recommend_result == query_result
 
@@ -328,7 +328,7 @@ def test_context():
         },
     )
     assert response.ok
-    query_result = response.json()["result"]
+    query_result = response.json()["result"]["points"]
 
     assert set([p["id"] for p in context_result]) == set([p["id"] for p in query_result])
 
@@ -464,7 +464,7 @@ def test_rrf():
         },
     )
     assert response.ok, response.json()
-    rrf_result = response.json()["result"]
+    rrf_result = response.json()["result"]["points"]
 
     def get_id(x):
         return x["id"]
@@ -511,7 +511,7 @@ def test_rrf():
         },
     )
     assert response.ok, response.json()
-    rrf_inner_filter_result = response.json()["result"]
+    rrf_inner_filter_result = response.json()["result"]["points"]
 
     for expected, result in zip(sorted(rrf_expected, key=get_id), sorted(rrf_inner_filter_result, key=get_id)):
         assert expected["id"] == result["id"]
@@ -543,7 +543,7 @@ def test_sparse_dense_rerank_colbert():
         },
     )
     assert response.ok, response.json()
-    rerank_result = response.json()["result"]
+    rerank_result = response.json()["result"]["points"]
     assert len(rerank_result) == 3
     # record current result to detect change
     assert rerank_result[0]["id"] == 5


### PR DESCRIPTION
Introduces `QueryResponse` in rest api response, which allows our futures selves to extend it with other fields like `explain`, `total`, etc