### PR TITLE
universal-query: Fix query order_by tests

### DIFF
--- a/tests/consensus_tests/test_points_query.py
+++ b/tests/consensus_tests/test_points_query.py
@@ -262,49 +262,56 @@ def test_points_query(tmp_path: pathlib.Path):
                 "score_threshold": 0.5
             })
         ),
-        # TODO(universal-query) uncomment when order_by aggregation is fixed
-        # (
-        #     # scroll
-        #     ("scroll", "points.id", {
-        #         "filter": filter,
-        #         "limit": 5,
-        #     }),
-        #     ("query", "id", {
-        #         "filter": filter,
-        #         "limit": 5,
-        #         "with_payload": True,
-        #     }),
-        # ),
-        # (
-        #     # scroll order by `asc`
-        #     ("scroll", "points.id", {
-        #         "filter": filter,
-        #         "limit": 5,
-        #         "order_by": "count",
-        #         "direction": "asc",
-        #     }),
-        #     ("query", "id", {
-        #         "filter": filter,
-        #         "limit": 5,
-        #         "order_by": "count",
-        #         "direction": "asc",
-        #     }),
-        # ),
-        # (
-        #     # scroll order by `desc`
-        #     ("scroll", "points.id", {
-        #         "filter": filter,
-        #         "limit": 5,
-        #         "order_by": "count",
-        #         "direction": "desc",
-        #     }),
-        #     ("query", "id", {
-        #         "filter": filter,
-        #         "limit": 5,
-        #         "order_by": "count",
-        #         "direction": "desc",
-        #     }),
-        # )
+        (
+            # scroll
+            ("scroll", "points.id", {
+                "filter": filter,
+                "limit": 5,
+            }),
+            ("query", "id", {
+                "filter": filter,
+                "limit": 5,
+                "with_payload": True,
+            }),
+        ),
+        (
+            # scroll order by `asc`
+            ("scroll", "points.id", {
+                "filter": filter,
+                "limit": 5,
+                "order_by": "count",
+                "direction": "asc",
+            }),
+            ("query", "id", {
+                "filter": filter,
+                "limit": 5,
+                "query": {
+                    "order_by": {
+                        "key": "count",
+                        "direction": "asc",
+                    }
+                }
+            }),
+        ),
+        (
+            # scroll order by `desc`
+            ("scroll", "points.id", {
+                "filter": filter,
+                "limit": 5,
+                "order_by": "count",
+                "direction": "desc",
+            }),
+            ("query", "id", {
+                "filter": filter,
+                "limit": 5,
+                "query": {
+                    "order_by": {
+                        "key": "count",
+                        "direction": "desc",
+                    }
+                }
+            }),
+        )
     ]
 
     # Verify that the results are the same across all peers


### PR DESCRIPTION
This PR enables tests for the query API using `order_by` that were broken.

Actually, there was no bug on the server side but the tests were not using the query API properly :face_with_head_bandage: 