### PR TITLE
Commit read/write hashrings while resharding

### DIFF
--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -24,7 +24,11 @@ mod test;
 
 use std::path::{Path, PathBuf};
 
-use shard::ShardId;
+use channel_service::ChannelService;
+use common::defaults;
+use shard::{PeerId, ShardId};
+use tokio::time::{sleep_until, timeout_at};
+use transfer::ShardTransferConsensus;
 
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::shard_versioning::versioned_shard_path;
@@ -49,6 +53,45 @@ pub async fn create_shard_dir(
             } else {
                 Err(CollectionError::from(e))
             }
+        }
+    }
+}
+
+/// Await for consensus to synchronize across all peers
+///
+/// This will take the current consensus state of this node. It then explicitly waits on all other
+/// nodes to reach the same (or later) consensus.
+///
+/// If awaiting on other nodes fails for any reason, this simply continues after the consensus
+/// timeout.
+///
+/// # Cancel safety
+///
+/// This function is cancel safe.
+async fn await_consensus_sync(
+    consensus: &dyn ShardTransferConsensus,
+    channel_service: &ChannelService,
+    this_peer_id: PeerId,
+) {
+    let wait_until = tokio::time::Instant::now() + defaults::CONSENSUS_META_OP_WAIT;
+    let sync_consensus = timeout_at(
+        wait_until,
+        consensus.await_consensus_sync(this_peer_id, channel_service),
+    )
+    .await;
+
+    match sync_consensus {
+        Ok(Ok(_)) => log::trace!("All peers reached consensus"),
+        // Failed to sync explicitly, waiting until timeout to assume synchronization
+        Ok(Err(err)) => {
+            log::warn!("All peers failed to synchronize consensus, waiting until timeout: {err}");
+            sleep_until(wait_until).await;
+        }
+        // Reached timeout, assume consensus is synchronized
+        Err(err) => {
+            log::warn!(
+                "All peers failed to synchronize consensus, continuing after timeout: {err}"
+            );
         }
     }
 }

--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -71,14 +71,10 @@ pub async fn create_shard_dir(
 async fn await_consensus_sync(
     consensus: &dyn ShardTransferConsensus,
     channel_service: &ChannelService,
-    this_peer_id: PeerId,
 ) {
     let wait_until = tokio::time::Instant::now() + defaults::CONSENSUS_META_OP_WAIT;
-    let sync_consensus = timeout_at(
-        wait_until,
-        consensus.await_consensus_sync(this_peer_id, channel_service),
-    )
-    .await;
+    let sync_consensus =
+        timeout_at(wait_until, consensus.await_consensus_sync(channel_service)).await;
 
     match sync_consensus {
         Ok(Ok(_)) => log::trace!("All peers reached consensus"),

--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 
 use channel_service::ChannelService;
 use common::defaults;
-use shard::{PeerId, ShardId};
+use shard::ShardId;
 use tokio::time::{sleep_until, timeout_at};
 use transfer::ShardTransferConsensus;
 

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -126,8 +126,10 @@ enum Stage {
     S3_ReplicateStart,
     #[serde(rename = "replicate_end")]
     S3_ReplicateEnd,
-    #[serde(rename = "commit_hash_ring")]
-    S4_CommitHashring,
+    #[serde(rename = "commit_hash_ring_start")]
+    S4_CommitHashringStart,
+    #[serde(rename = "commit_hash_ring_end")]
+    S4_CommitHashringEnd,
     #[serde(rename = "propagate_deletes_start")]
     S5_PropagateDeletesStart,
     #[serde(rename = "propagate_deletes_end")]
@@ -205,9 +207,15 @@ pub async fn drive_resharding(
     }
 
     // Stage 4: commit new hashring
-    if !completed_commit_hashring() {
+    if !completed_commit_hashring(&state) {
         log::debug!("Resharding {collection_id}:{to_shard_id} stage: commit hashring");
-        stage_commit_hashring()?;
+        stage_commit_hashring(
+            &reshard_key,
+            &state,
+            consensus,
+            &channel_service,
+            &collection_id,
+        ).await?;
     }
 
     // Stage 5: propagate deletes
@@ -575,15 +583,41 @@ async fn stage_replicate(
 /// Stage 4: commit new hashring
 ///
 /// Check whether the new hashring still needs to be committed.
-fn completed_commit_hashring() -> bool {
-    todo!()
+fn completed_commit_hashring(
+    state: &PersistedState,
+) -> bool {
+    state.read().all_peers_reached(Stage::S4_CommitHashringEnd)
 }
 
 /// Stage 4: commit new hashring
 ///
 /// Do commit the new hashring.
-fn stage_commit_hashring() -> CollectionResult<()> {
-    todo!()
+async fn stage_commit_hashring(
+    reshard_key: &ReshardKey,
+    state: &PersistedState,
+    consensus: &dyn ShardTransferConsensus,
+    channel_service: &ChannelService,
+    collection_id: &CollectionId,
+) -> CollectionResult<()> {
+    let this_peer_id = consensus.this_peer_id();
+
+    state.write(|data| {
+        data.bump_all_peers_to(Stage::S4_CommitHashringStart);
+    })?;
+
+    // Commit read hashring and sync cluster
+    consensus.commit_read_hashring_confirm_and_retry(collection_id, reshard_key).await?;
+    consensus.await_consensus_sync(this_peer_id, channel_service).await;
+
+    // Commit write hashring and sync cluster
+    consensus.commit_write_hashring_confirm_and_retry(collection_id, reshard_key).await?;
+    consensus.await_consensus_sync(this_peer_id, channel_service).await;
+
+    state.write(|data| {
+        data.bump_all_peers_to(Stage::S4_CommitHashringEnd);
+    })?;
+
+    Ok(())
 }
 
 /// Stage 5: propagate deletes

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -3,14 +3,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use common::defaults;
 use futures::Future;
 use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio::task::block_in_place;
-use tokio::time::{sleep_until, timeout_at};
 
 use super::tasks_pool::ReshardTaskProgress;
 use super::ReshardKey;

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -600,8 +600,6 @@ async fn stage_commit_hashring(
     channel_service: &ChannelService,
     collection_id: &CollectionId,
 ) -> CollectionResult<()> {
-    let this_peer_id = consensus.this_peer_id();
-
     state.write(|data| {
         data.bump_all_peers_to(Stage::S4_CommitHashringStart);
     })?;
@@ -610,13 +608,13 @@ async fn stage_commit_hashring(
     consensus
         .commit_read_hashring_confirm_and_retry(collection_id, reshard_key)
         .await?;
-    await_consensus_sync(consensus, channel_service, this_peer_id).await;
+    await_consensus_sync(consensus, channel_service).await;
 
     // Commit write hashring and sync cluster
     consensus
         .commit_write_hashring_confirm_and_retry(collection_id, reshard_key)
         .await?;
-    await_consensus_sync(consensus, channel_service, this_peer_id).await;
+    await_consensus_sync(consensus, channel_service).await;
 
     state.write(|data| {
         data.bump_all_peers_to(Stage::S4_CommitHashringEnd);

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use common::defaults::{self, CONSENSUS_CONFIRM_RETRIES};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tokio::time::{sleep, sleep_until, timeout_at};
+use tokio::time::sleep;
 
 use super::channel_service::ChannelService;
 use super::remote_shard::RemoteShard;
@@ -597,44 +597,5 @@ pub trait ShardTransferConsensus: Send + Sync {
         channel_service
             .await_commit_on_all_peers(this_peer_id, commit, term, defaults::CONSENSUS_META_OP_WAIT)
             .await
-    }
-}
-
-/// Await for consensus to synchronize across all peers
-///
-/// This will take the current consensus state of this node. It then explicitly waits on all other
-/// nodes to reach the same (or later) consensus.
-///
-/// If awaiting on other nodes fails for any reason, this simply continues after the consensus
-/// timeout.
-///
-/// # Cancel safety
-///
-/// This function is cancel safe.
-async fn await_consensus_sync(
-    consensus: &dyn ShardTransferConsensus,
-    channel_service: &ChannelService,
-    this_peer_id: PeerId,
-) {
-    let wait_until = tokio::time::Instant::now() + defaults::CONSENSUS_META_OP_WAIT;
-    let sync_consensus = timeout_at(
-        wait_until,
-        consensus.await_consensus_sync(this_peer_id, channel_service),
-    )
-    .await;
-
-    match sync_consensus {
-        Ok(Ok(_)) => log::trace!("All peers reached consensus"),
-        // Failed to sync explicitly, waiting until timeout to assume synchronization
-        Ok(Err(err)) => {
-            log::warn!("All peers failed to synchronize consensus, waiting until timeout: {err}");
-            sleep_until(wait_until).await;
-        }
-        // Reached timeout, assume consensus is synchronized
-        Err(err) => {
-            log::warn!(
-                "All peers failed to synchronize consensus, continuing after timeout: {err}"
-            );
-        }
     }
 }

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -579,11 +579,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     /// # Cancel safety
     ///
     /// This method is cancel safe.
-    async fn await_consensus_sync(
-        &self,
-        this_peer_id: PeerId,
-        channel_service: &ChannelService,
-    ) -> CollectionResult<()> {
+    async fn await_consensus_sync(&self, channel_service: &ChannelService) -> CollectionResult<()> {
         let other_peer_count = channel_service.id_to_address.read().len().saturating_sub(1);
         if other_peer_count == 0 {
             log::warn!("There are no other peers, skipped synchronizing consensus");
@@ -595,7 +591,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             "Waiting on {other_peer_count} peer(s) to reach consensus (commit: {commit}, term: {term}) before finalizing shard transfer"
         );
         channel_service
-            .await_commit_on_all_peers(this_peer_id, commit, term, defaults::CONSENSUS_META_OP_WAIT)
+            .await_commit_on_all_peers(
+                self.this_peer_id(),
+                commit,
+                term,
+                defaults::CONSENSUS_META_OP_WAIT,
+            )
             .await
     }
 }

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -276,7 +276,7 @@ pub(super) async fn transfer_snapshot(
         })?;
 
     // Synchronize all nodes
-    await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
+    await_consensus_sync(consensus, &channel_service).await;
 
     log::debug!(
         "Ending shard {shard_id} transfer to peer {remote_peer_id} using snapshot transfer"

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -14,7 +14,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
-use crate::shards::CollectionId;
+use crate::shards::{await_consensus_sync, CollectionId};
 
 /// Orchestrate shard snapshot transfer
 ///
@@ -276,7 +276,7 @@ pub(super) async fn transfer_snapshot(
         })?;
 
     // Synchronize all nodes
-    super::await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
+    await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
 
     log::debug!(
         "Ending shard {shard_id} transfer to peer {remote_peer_id} using snapshot transfer"

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -11,7 +11,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
-use crate::shards::CollectionId;
+use crate::shards::{await_consensus_sync, CollectionId};
 
 /// Orchestrate shard diff transfer
 ///
@@ -168,7 +168,7 @@ pub(super) async fn transfer_wal_delta(
         })?;
 
     // Synchronize all nodes
-    super::await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
+    await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
 
     log::debug!("Ending shard {shard_id} transfer to peer {remote_peer_id} using diff transfer");
 

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -168,7 +168,7 @@ pub(super) async fn transfer_wal_delta(
         })?;
 
     // Synchronize all nodes
-    await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
+    await_consensus_sync(consensus, &channel_service).await;
 
     log::debug!("Ending shard {shard_id} transfer to peer {remote_peer_id} using diff transfer");
 

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -3,13 +3,14 @@ use std::sync::Weak;
 use async_trait::async_trait;
 use collection::operations::types::{CollectionError, CollectionResult};
 use collection::shards::replica_set::ReplicaState;
+use collection::shards::resharding::ReshardKey;
 use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::transfer::{ShardTransfer, ShardTransferConsensus, ShardTransferKey};
 use collection::shards::CollectionId;
 
 use super::TableOfContent;
 use crate::content_manager::collection_meta_ops::{
-    CollectionMetaOperations, ShardTransferOperations,
+    CollectionMetaOperations, ReshardingOperation, ShardTransferOperations
 };
 use crate::content_manager::consensus_manager::ConsensusStateRef;
 use crate::content_manager::consensus_ops::ConsensusOperations;
@@ -163,6 +164,46 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
             .map(|_| ())
             .map_err(|err| {
                 CollectionError::service_error(format!("Failed to propose and confirm set replica set state operation through consensus: {err}"))
+            })
+    }
+
+    async fn commit_read_hashring(
+        &self,
+        collection_id: CollectionId,
+        reshard_key: ReshardKey,
+    ) -> CollectionResult<()> {
+        let operation =
+            ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::Resharding(
+                collection_id,
+                ReshardingOperation::CommitRead(reshard_key),
+            )));
+        self
+            .consensus_state
+            .propose_consensus_op_with_await(operation, None)
+            .await
+            .map(|_| ())
+            .map_err(|err| {
+                CollectionError::service_error(format!("Failed to propose and confirm commit read hashring operation through consensus: {err}"))
+            })
+    }
+
+    async fn commit_write_hashring(
+        &self,
+        collection_id: CollectionId,
+        reshard_key: ReshardKey,
+    ) -> CollectionResult<()> {
+        let operation =
+            ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::Resharding(
+                collection_id,
+                ReshardingOperation::CommitWrite(reshard_key),
+            )));
+        self
+            .consensus_state
+            .propose_consensus_op_with_await(operation, None)
+            .await
+            .map(|_| ())
+            .map_err(|err| {
+                CollectionError::service_error(format!("Failed to propose and confirm commit write hasrhing operation through consensus: {err}"))
             })
     }
 }

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -10,7 +10,7 @@ use collection::shards::CollectionId;
 
 use super::TableOfContent;
 use crate::content_manager::collection_meta_ops::{
-    CollectionMetaOperations, ReshardingOperation, ShardTransferOperations
+    CollectionMetaOperations, ReshardingOperation, ShardTransferOperations,
 };
 use crate::content_manager::consensus_manager::ConsensusStateRef;
 use crate::content_manager::consensus_ops::ConsensusOperations;


### PR DESCRIPTION
Tracked in: #4213 

Implement the hashring commit stage in the resharding driver.

Commit the read and write hashrings separately and sync the cluster in both cases after doing so.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?