### PR TITLE
universal-query: lookup_from implementation

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -6,11 +7,15 @@ use itertools::{Either, Itertools};
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
 use segment::types::{Order, ScoredPoint};
 use segment::utils::scored_point_ties::ScoredPointTies;
+use tokio::sync::RwLockReadGuard;
 use tokio::time::Instant;
 
 use super::Collection;
 use crate::common::batching::batch_requests;
-use crate::common::fetch_vectors::resolve_referenced_vectors_batch;
+use crate::common::fetch_vectors::{
+    build_vector_resolver_queries, resolve_referenced_vectors_batch,
+};
+use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::common::transpose_iterator::transposed_iter;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
@@ -126,20 +131,40 @@ impl Collection {
     /// To be called on the user-responding instance. Resolves ids into vectors, and merges the results from local and remote shards.
     ///
     /// This function is used to query the collection. It will return a list of scored points.
-    pub async fn query_batch(
+    pub async fn query_batch<'a, F, Fut>(
         &self,
         requests_batch: Vec<(CollectionQueryRequest, ShardSelectorInternal)>,
+        collection_by_name: F,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        // Turn ids into vectors, if necessary
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
+    where
+        F: Fn(String) -> Fut,
+        Fut: Future<Output = Option<RwLockReadGuard<'a, Collection>>>,
+    {
+        // Lift nested prefetches to root queries for vector resolution
+        let resolver_requests = build_vector_resolver_queries(&requests_batch);
+
+        // Build referenced vectors
         let ids_to_vectors = resolve_referenced_vectors_batch(
-            &requests_batch,
+            &resolver_requests,
             self,
-            |_| async { unimplemented!("lookup_from is not implemented yet") },
+            collection_by_name,
             read_consistency,
         )
         .await?;
+
+        // Check we actually fetched all referenced vectors from the resolver requests
+        for (resolver_req, _) in &resolver_requests {
+            for point_id in resolver_req.get_referenced_point_ids() {
+                let lookup_collection = resolver_req.get_lookup_collection();
+                if ids_to_vectors.get(&lookup_collection, point_id).is_none() {
+                    return Err(CollectionError::PointNotFound {
+                        missed_point_id: point_id,
+                    });
+                }
+            }
+        }
 
         let futures = batch_requests::<
             (CollectionQueryRequest, ShardSelectorInternal),

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -175,7 +175,7 @@ impl Collection {
             requests_batch,
             |(_req, shard)| shard,
             |(req, _), acc| {
-                req.try_into_shard_request(&ids_to_vectors)
+                req.try_into_shard_request(&self.id, &ids_to_vectors)
                     .map(|shard_req| {
                         acc.push(shard_req);
                     })

--- a/lib/collection/src/common/fetch_vectors.rs
+++ b/lib/collection/src/common/fetch_vectors.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
 
 use api::rest::ShardKeySelector;
 use futures::future::try_join_all;
@@ -15,7 +16,10 @@ use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{
     CollectionError, CollectionResult, PointRequestInternal, RecommendExample, Record,
 };
-use crate::operations::universal_query::collection_query::VectorInput;
+use crate::operations::universal_query::collection_query;
+use crate::operations::universal_query::collection_query::{
+    CollectionQueryRequest, CollectionQueryResolveRequest, VectorInput,
+};
 
 pub async fn retrieve_points(
     collection: &Collection,
@@ -94,7 +98,7 @@ pub type CollectionName = String;
 ///
 /// This is a temporary structure, which holds resolved references to vectors,
 /// mentioned in the query.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ReferencedVectors {
     collection_mapping: HashMap<CollectionName, HashMap<PointIdType, Record>>,
     default_mapping: HashMap<PointIdType, Record>,
@@ -150,14 +154,15 @@ impl ReferencedVectors {
         match vector_input {
             VectorInput::Vector(vector) => Some(vector),
             VectorInput::Id(vid) => {
-                let rec = self.get(&collection_name, vid).unwrap();
+                // TODO(universal-search) we should properly error out if the collection does not exist
+                let rec = self.get(&collection_name, vid)?;
                 rec.get_vector_by_name(vector_name).map(|v| v.to_owned())
             }
         }
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ReferencedPoints<'coll_name> {
     ids_per_collection: HashMap<Option<&'coll_name String>, HashSet<PointIdType>>,
     vector_names_per_collection: HashMap<Option<&'coll_name String>, HashSet<String>>,
@@ -360,4 +365,32 @@ where
     }
 
     Ok(all_vectors_records_map)
+}
+
+/// This function is used to build a list of queries to resolve vectors for the given batch of query requests.
+/// For each request, one query is issue for the root request and one query for each nested prefetch.
+/// The resolver queries have no prefetches.
+pub fn build_vector_resolver_queries(
+    requests_batch: &Vec<(CollectionQueryRequest, ShardSelectorInternal)>,
+) -> Vec<(CollectionQueryResolveRequest, ShardSelectorInternal)> {
+    let mut resolve_prefetches = vec![];
+    for (request, shard_selector) in requests_batch {
+        // resolve query for root query
+        if let Some(collection_query::Query::Vector(vector_query)) = request.query.clone() {
+            let resolve_root = CollectionQueryResolveRequest {
+                vector_query,
+                lookup_from: request.lookup_from.clone(),
+                using: request.using.clone(),
+            };
+            resolve_prefetches.push((resolve_root, shard_selector.clone()));
+        }
+
+        // flatten prefetches
+        for prefetch in &request.prefetch {
+            for flatten in prefetch.flatten_resolver_requests() {
+                resolve_prefetches.push((flatten, shard_selector.clone()));
+            }
+        }
+    }
+    resolve_prefetches
 }

--- a/lib/collection/src/common/fetch_vectors.rs
+++ b/lib/collection/src/common/fetch_vectors.rs
@@ -376,7 +376,7 @@ pub fn build_vector_resolver_queries(
     let mut resolve_prefetches = vec![];
     for (request, shard_selector) in requests_batch {
         // resolve query for root query
-        if let Some(collection_query::Query::Vector(vector_query)) = request.query.clone() {
+        if let Some(collection_query::Query::Vector(vector_query)) = &request.query {
             let resolve_root = CollectionQueryResolveRequest {
                 vector_query,
                 lookup_from: request.lookup_from.clone(),

--- a/lib/collection/src/common/fetch_vectors.rs
+++ b/lib/collection/src/common/fetch_vectors.rs
@@ -154,7 +154,6 @@ impl ReferencedVectors {
         match vector_input {
             VectorInput::Vector(vector) => Some(vector),
             VectorInput::Id(vid) => {
-                // TODO(universal-search) we should properly error out if the collection does not exist
                 let rec = self.get(&collection_name, vid)?;
                 rec.get_vector_by_name(vector_name).map(|v| v.to_owned())
             }

--- a/lib/collection/src/common/retrieve_request_trait.rs
+++ b/lib/collection/src/common/retrieve_request_trait.rs
@@ -105,7 +105,7 @@ impl RetrieveRequest for DiscoverRequestInternal {
     }
 }
 
-impl RetrieveRequest for CollectionQueryResolveRequest {
+impl<'a> RetrieveRequest for CollectionQueryResolveRequest<'a> {
     fn get_lookup_collection(&self) -> Option<&String> {
         self.lookup_from.as_ref().map(|x| &x.collection)
     }

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -54,7 +54,7 @@ pub struct CollectionQueryResolveRequest<'a> {
     pub using: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Query {
     /// Score points against some vector(s)
     Vector(VectorQuery<VectorInput>),
@@ -90,7 +90,7 @@ impl Query {
         Ok(scoring_query)
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum VectorInput {
     Id(PointIdType),
     Vector(Vector),
@@ -105,7 +105,7 @@ impl VectorInput {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum VectorQuery<T> {
     Nearest(T),
     RecommendAverageVector(RecoQuery<T>),

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -297,13 +297,11 @@ impl CollectionPrefetch {
     }
 
     fn get_lookup_vector_name(&self) -> String {
-        match &self.lookup_from {
-            None => self.using.to_owned(),
-            Some(lookup_from) => match &lookup_from.vector {
-                None => self.using.to_owned(),
-                Some(vector_name) => vector_name.clone(),
-            },
-        }
+        self.lookup_from
+            .as_ref()
+            .and_then(|lookup_from| lookup_from.vector.as_ref())
+            .unwrap_or(&self.using)
+            .to_owned()
     }
 
     pub fn get_referenced_point_ids_on_collection(&self, collection: &str) -> Vec<PointIdType> {
@@ -401,13 +399,11 @@ impl CollectionQueryRequest {
     }
 
     fn get_lookup_vector_name(&self) -> String {
-        match &self.lookup_from {
-            None => self.using.to_owned(),
-            Some(lookup_from) => match &lookup_from.vector {
-                None => self.using.to_owned(),
-                Some(vector_name) => vector_name.clone(),
-            },
-        }
+        self.lookup_from
+            .as_ref()
+            .and_then(|lookup_from| lookup_from.vector.as_ref())
+            .unwrap_or(&self.using)
+            .to_owned()
     }
 
     fn get_referenced_point_ids_on_collection(&self, collection: &str) -> Vec<PointIdType> {
@@ -522,7 +518,7 @@ impl CollectionQueryRequest {
         if let Some(Query::Fusion(_)) = query {
             if using != DEFAULT_VECTOR_NAME {
                 return Err(CollectionError::bad_request(
-                    "Fusion queries can only be used with the default vector name.",
+                    "Fusion queries cannot be combined with the 'using' field.",
                 ));
             }
         }

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -48,8 +48,8 @@ impl CollectionQueryRequest {
 
 /// Lightweight representation of a query request to implement the [RetrieveRequest] trait.
 #[derive(Debug)]
-pub struct CollectionQueryResolveRequest {
-    pub vector_query: VectorQuery<VectorInput>,
+pub struct CollectionQueryResolveRequest<'a> {
+    pub vector_query: &'a VectorQuery<VectorInput>,
     pub lookup_from: Option<LookupLocation>,
     pub using: String,
 }
@@ -376,7 +376,7 @@ impl CollectionPrefetch {
     pub fn flatten_resolver_requests(&self) -> Vec<CollectionQueryResolveRequest> {
         let mut inner_queries = vec![];
         // resolve query for root query
-        if let Some(Query::Vector(vector_query)) = self.query.clone() {
+        if let Some(Query::Vector(vector_query)) = &self.query {
             let resolve_root = CollectionQueryResolveRequest {
                 vector_query,
                 lookup_from: self.lookup_from.clone(),

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -313,7 +313,12 @@ impl TableOfContent {
         let collection = self.get_collection(&collection_pass).await?;
 
         collection
-            .query_batch(requests, read_consistency, timeout)
+            .query_batch(
+                requests,
+                |name| self.get_collection_opt(name),
+                read_consistency,
+                timeout,
+            )
             .await
             .map_err(|err| err.into())
     }

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -333,7 +333,7 @@ impl CheckableCollectionOperation for CollectionQueryRequest {
             view.check_vector_query(vector_query)?
         }
 
-        // TODO(universal-query): implement lookup_from
+        access.check_lookup_from(&self.lookup_from)?;
 
         for prefetch_query in self.prefetch.iter_mut() {
             check_access_for_prefetch(prefetch_query, &view, access)?;
@@ -346,7 +346,7 @@ impl CheckableCollectionOperation for CollectionQueryRequest {
 fn check_access_for_prefetch(
     prefetch: &mut CollectionPrefetch,
     view: &CollectionAccessView<'_>,
-    _access: &CollectionAccessList, // TODO(universal_query): implement lookup_from
+    access: &CollectionAccessList,
 ) -> Result<(), StorageError> {
     view.apply_filter(&mut prefetch.filter);
 
@@ -354,11 +354,11 @@ fn check_access_for_prefetch(
         view.check_vector_query(vector_query)?
     }
 
-    // TODO(universal-query): implement lookup_from
+    access.check_lookup_from(&prefetch.lookup_from)?;
 
     // Recurse inner prefetches
     for prefetch_query in prefetch.prefetch.iter_mut() {
-        check_access_for_prefetch(prefetch_query, view, _access)?;
+        check_access_for_prefetch(prefetch_query, view, access)?;
     }
 
     Ok(())

--- a/tests/openapi/openapi_integration/test_query.py
+++ b/tests/openapi/openapi_integration/test_query.py
@@ -73,7 +73,7 @@ def test_query_validation():
     assert response.json()["status"]["error"] == ("Bad request: Can't use score_threshold with an order_by query.")
 
 
-# raw query to bypass local validation
+    # raw query to bypass local validation
     response = requests.post(f"http://{QDRANT_HOST}/collections/{collection_name}/points/query",
         json={
             "query": {

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -6,6 +6,7 @@ from .helpers.collection_setup import drop_collection, full_collection_setup
 from .helpers.helpers import reciprocal_rank_fusion, request_with_validation
 
 collection_name = "test_query"
+lookup_collection_name = "test_collection_lookup"
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -20,7 +21,7 @@ def setup(on_disk_vectors):
         path_params={"collection_name": collection_name},
         body={"field_name": "city", "field_schema": "keyword"},
     )
-    assert response.ok
+    assert response.ok, response.text
 
     # integer index on count
     response = request_with_validation(
@@ -30,7 +31,7 @@ def setup(on_disk_vectors):
         path_params={"collection_name": collection_name},
         body={"field_name": "count", "field_schema": "integer"},
     )
-    assert response.ok
+    assert response.ok, response.text
 
     yield
     drop_collection(collection_name=collection_name)
@@ -49,7 +50,7 @@ def root_and_rescored_query(query, using, filter=None, limit=None, with_payload=
             "using": using,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     root_query_result = response.json()["result"]["points"]
 
     response = request_with_validation(
@@ -66,7 +67,7 @@ def root_and_rescored_query(query, using, filter=None, limit=None, with_payload=
             "using": using,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     nested_query_result = response.json()["result"]["points"]
 
     assert root_query_result == nested_query_result
@@ -86,7 +87,7 @@ def test_search_by_vector():
             "limit": 10,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     search_result = response.json()["result"]
 
     default_query_result = root_and_rescored_query([0.1, 0.2, 0.3, 0.4], "dense-image")
@@ -106,11 +107,12 @@ def test_search_by_id():
             "using": "dense-image",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     by_id_query_result = response.json()["result"]["points"]
 
     top = by_id_query_result[0]
-    assert top["id"] != 2 # id 2 is excluded from the results
+    assert top["id"] != 2  # id 2 is excluded from the results
+
 
 def test_filtered_search():
     filter = {
@@ -136,7 +138,7 @@ def test_filtered_search():
             "limit": 10,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     search_result = response.json()["result"]
 
     default_query_result = root_and_rescored_query([0.1, 0.2, 0.3, 0.4], "dense-image", filter)
@@ -154,7 +156,7 @@ def test_scroll():
         path_params={"collection_name": collection_name},
         body={},
     )
-    assert response.ok
+    assert response.ok, response.text
     scroll_result = response.json()["result"]["points"]
 
     response = request_with_validation(
@@ -165,12 +167,13 @@ def test_scroll():
             "with_payload": True,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     query_result = response.json()["result"]["points"]
 
     for record, scored_point in zip(scroll_result, query_result):
         assert record.get("id") == scored_point.get("id")
         assert record.get("payload") == scored_point.get("payload")
+
 
 def test_filtered_scroll():
     filter = {
@@ -191,7 +194,7 @@ def test_filtered_scroll():
             "filter": filter
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     scroll_result = response.json()["result"]["points"]
 
     response = request_with_validation(
@@ -203,7 +206,7 @@ def test_filtered_scroll():
             "filter": filter
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     query_result = response.json()["result"]["points"]
 
     for record, scored_point in zip(scroll_result, query_result):
@@ -217,23 +220,351 @@ def test_recommend_avg():
         method="POST",
         path_params={"collection_name": collection_name},
         body={
-            "positive": [1, 2, 3, 4],  # ids
-            "negative": [3],  # ids
+            "positive": [1, 2, 3, 4],
+            "negative": [3],
             "limit": 10,
             "using": "dense-image",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     recommend_result = response.json()["result"]
 
     query_result = root_and_rescored_query(
         {
-            "recommend": {"positive": [1, 2, 3, 4], "negative": [3]},  # ids
+            "recommend": {"positive": [1, 2, 3, 4], "negative": [3]},
         },
         "dense-image",
     )
 
     assert recommend_result == query_result
+
+
+def test_recommend_lookup_validations():
+    # delete lookup collection if exists
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': lookup_collection_name},
+    )
+    assert response.ok, response.text
+
+    # re-create lookup collection
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': lookup_collection_name},
+        body={
+            "vectors": {
+                "other": {
+                    "size": 4,
+                    "distance": "Dot",
+                }
+            }
+        }
+    )
+    assert response.ok, response.text
+
+    # insert vectors to lookup collection
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': lookup_collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {"other": [1.0, 0.0, 0.0, 0.0]},
+                },
+                {
+                    "id": 2,
+                    "vector": {"other": [0.0, 0.0, 0.0, 2.0]},
+                },
+            ]
+        }
+    )
+    assert response.ok, response.text
+
+    # check query + lookup_from non-existing id
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": {
+                "recommend": {
+                    "positive": [1],
+                    "negative": [2, 3],
+                },
+            },
+            "limit": 10,
+            "using": "dense-image",
+            "lookup_from": {
+                "collection": lookup_collection_name,
+                "vector": "other"
+            }
+        },
+    )
+    assert not response.ok, response.text
+    assert response.json()["status"]["error"] == "Not found: No point with id 3 found"
+
+    # check query + lookup_from non-existing collection
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": {
+                "recommend": {
+                    "positive": [1],
+                    "negative": [2],
+                },
+            },
+            "limit": 10,
+            "using": "dense-image",
+            "lookup_from": {
+                "collection": "non-existing-collection",
+                "vector": "other"
+            }
+        },
+    )
+    assert not response.ok, response.text
+    assert response.json()["status"]["error"] == "Not found: Collection non-existing-collection not found"
+
+    # check query + lookup_from non-existing vector
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": {
+                "recommend": {
+                    "positive": [1],
+                    "negative": [2],
+                },
+            },
+            "limit": 10,
+            "using": "dense-image",
+            "lookup_from": {
+                "collection": lookup_collection_name,
+                "vector": "non-existing-vector"
+            }
+        },
+    )
+    assert not response.ok, response.text
+    assert response.json()["status"]["error"] == "Wrong input: Not existing vector name error: non-existing-vector"
+
+    # check nested query + lookup_from non-existing id
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": [
+                {
+                    "query": {
+                        "recommend": {
+                            "positive": [1],
+                            "negative": [2, 3],
+                        },
+                    },
+                    "using": "dense-image",
+                    "lookup_from": {
+                        "collection": lookup_collection_name,
+                        "vector": "other"
+                    }
+                }
+            ],
+            "limit": 10,
+            "using": "dense-image",
+            "query": {"fusion": "rrf"}
+        },
+    )
+    assert not response.ok, response.text
+    assert response.json()["status"]["error"] == "Not found: No point with id 3 found"
+
+    # check nested query + lookup_from non-existing collection
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": [
+                {
+                    "query": {
+                        "recommend": {
+                            "positive": [1],
+                            "negative": [2],
+                        },
+                    },
+                    "using": "dense-image",
+                    "lookup_from": {
+                        "collection": "non-existing-collection",
+                        "vector": "other"
+                    }
+                }
+            ],
+            "limit": 10,
+            "using": "dense-image",
+            "query": {"fusion": "rrf"}
+        },
+    )
+    assert not response.ok, response.text
+    assert response.json()["status"]["error"] == "Not found: Collection non-existing-collection not found"
+
+    # check nested query + lookup_from non-existing vector
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": [
+                {
+                    "query": {
+                        "recommend": {
+                            "positive": [1],
+                            "negative": [2],
+                        },
+                    },
+                    "using": "dense-image",
+                    "lookup_from": {
+                        "collection": lookup_collection_name,
+                        "vector": "non-existing-vector"
+                    }
+                }
+            ],
+            "limit": 10,
+            "using": "dense-image",
+            "query": {"fusion": "rrf"}
+        },
+    )
+    assert not response.ok, response.text
+    assert response.json()["status"]["error"] == "Wrong input: Not existing vector name error: non-existing-vector"
+
+
+def test_recommend_lookup():
+    # delete lookup collection if exists
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': lookup_collection_name},
+    )
+    assert response.ok, response.text
+
+    # re-create lookup collection
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': lookup_collection_name},
+        body={
+            "vectors": {
+                "other": {
+                    "size": 4,
+                    "distance": "Dot",
+                }
+            }
+        }
+    )
+    assert response.ok, response.text
+
+    # insert vectors to lookup collection
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': lookup_collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {"other": [1.0, 0.0, 0.0, 0.0]},
+                },
+                {
+                    "id": 2,
+                    "vector": {"other": [0.0, 0.0, 0.0, 2.0]},
+                },
+            ]
+        }
+    )
+    assert response.ok, response.text
+
+    # check recommend + lookup_from
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [1],
+            "negative": [2],
+            "limit": 10,
+            "using": "dense-image",
+            "lookup_from": {
+                "collection": lookup_collection_name,
+                "vector": "other"
+            }
+        },
+    )
+    assert response.ok, response.text
+    recommend_result = response.json()["result"]
+
+    # check query + lookup_from
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": {
+                "recommend": {
+                    "positive": [1],
+                    "negative": [2],
+                },
+            },
+            "limit": 10,
+            "using": "dense-image",
+            "lookup_from": {
+                "collection": lookup_collection_name,
+                "vector": "other"
+            }
+        },
+    )
+    assert response.ok, response.text
+    query_result = response.json()["result"]["points"]
+
+    # check equivalence recommend vs query
+    assert recommend_result == query_result
+
+    # check nested query + lookup_from
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": [
+                {
+                    "query": {
+                        "recommend": {
+                            "positive": [1],
+                            "negative": [2],
+                        },
+                    },
+                    "using": "dense-image",
+                    "lookup_from": {
+                        "collection": lookup_collection_name,
+                        "vector": "other"
+                    }
+                }
+            ],
+            "limit": 10,
+            "using": "dense-image",
+            "query": {"fusion": "rrf"}
+        },
+    )
+    assert response.ok, response.text
+    nested_query_result = response.json()["result"]["points"]
+    # no equivalence to rely on, just check the response is valid
+    assert nested_query_result[0]["id"] == 6
+    assert nested_query_result[1]["id"] == 5
+    assert nested_query_result[2]["id"] == 3
 
 
 def test_recommend_best_score():
@@ -242,14 +573,14 @@ def test_recommend_best_score():
         method="POST",
         path_params={"collection_name": collection_name},
         body={
-            "positive": [1, 2, 3, 4],  # ids
-            "negative": [3],  # ids
+            "positive": [1, 2, 3, 4],
+            "negative": [3],
             "limit": 10,
             "strategy": "best_score",
             "using": "dense-image",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     recommend_result = response.json()["result"]
 
     response = request_with_validation(
@@ -259,15 +590,15 @@ def test_recommend_best_score():
         body={
             "query": {
                 "recommend": {
-                    "positive": [1, 2, 3, 4],  # ids
-                    "negative": [3],  # ids
+                    "positive": [1, 2, 3, 4],
+                    "negative": [3],
                     "strategy": "best_score",
                 },
             },
             "using": "dense-image",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     query_result = response.json()["result"]["points"]
 
     assert recommend_result == query_result
@@ -279,13 +610,13 @@ def test_discover():
         method="POST",
         path_params={"collection_name": collection_name},
         body={
-            "target": 2,  # ids
-            "context": [{"positive": 3, "negative": 4}],  # ids
+            "target": 2,
+            "context": [{"positive": 3, "negative": 4}],
             "limit": 10,
             "using": "dense-image",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     discover_result = response.json()["result"]
 
     query_result = root_and_rescored_query(
@@ -312,7 +643,7 @@ def test_context():
             "using": "dense-image",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     context_result = response.json()["result"]
 
     response = request_with_validation(
@@ -327,7 +658,7 @@ def test_context():
             "using": "dense-image",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     query_result = response.json()["result"]["points"]
 
     assert set([p["id"] for p in context_result]) == set([p["id"] for p in query_result])
@@ -342,7 +673,7 @@ def test_order_by():
             "order_by": "count",
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     scroll_result = response.json()["result"]["points"]
 
     query_result = root_and_rescored_query({"order_by": "count"}, "dense-image", with_payload=True)
@@ -376,7 +707,7 @@ def test_rrf():
             "limit": 10,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     search_result_1 = response.json()["result"]
 
     response = request_with_validation(
@@ -392,7 +723,7 @@ def test_rrf():
             "limit": 10,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     search_result_2 = response.json()["result"]
 
     response = request_with_validation(
@@ -411,7 +742,7 @@ def test_rrf():
             "limit": 10,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     search_result_3 = response.json()["result"]
 
     response = request_with_validation(
@@ -427,7 +758,7 @@ def test_rrf():
             "limit": 10,
         },
     )
-    assert response.ok
+    assert response.ok, response.text
     search_result_4 = response.json()["result"]
 
     rrf_expected = reciprocal_rank_fusion([search_result_1, search_result_2, search_result_3, search_result_4], limit=10)
@@ -517,6 +848,7 @@ def test_rrf():
         assert expected["id"] == result["id"]
         assert expected.get("payload") == result.get("payload")
         assert isclose(expected["score"], result["score"], rel_tol=1e-5)
+
 
 def test_sparse_dense_rerank_colbert():
     response = request_with_validation(

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -532,7 +532,7 @@ def test_recommend_lookup():
     query_result = response.json()["result"]["points"]
 
     # check equivalence recommend vs query
-    assert recommend_result == query_result
+    assert recommend_result == query_result, f"{recommend_result} != {query_result}"
 
     # check nested query id + lookup_from
     response = request_with_validation(
@@ -585,13 +585,6 @@ def test_recommend_lookup():
     )
     assert response.ok, response.text
     nested_query_result_vector = response.json()["result"]["points"]
-
-    # remove vectors used for lookup in previous call for equivalence check
-    predicate = lambda x: x["id"] == 1 or x["id"] == 2
-    nested_query_result_vector = [x for x in nested_query_result_vector if not predicate(x)]
-
-    print(nested_query_result_id)
-    print(nested_query_result_vector)
 
     # check equivalence nested query id vs nested query vector
     assert nested_query_result_id == nested_query_result_vector, f"{nested_query_result_id} != {nested_query_result_vector}"

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -90,7 +90,7 @@ def test_query_validation():
         },
     )
     assert not response.ok, response.text
-    assert response.json()["status"]["error"] == "Bad request: Fusion queries can only be used with the default vector name."
+    assert response.json()["status"]["error"] == "Bad request: Fusion queries cannot be combined with the 'using' field."
 
 
 def test_search_by_vector():

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -74,6 +74,25 @@ def root_and_rescored_query(query, using, filter=None, limit=None, with_payload=
     return root_query_result
 
 
+def test_query_validation():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": {
+                "name": "dense-image",
+                "vector": [0.1, 0.2, 0.3, 0.4],
+            },
+            "using": "dense-image",
+            "query": {"fusion": "rrf"},
+            "limit": 10,
+        },
+    )
+    assert not response.ok, response.text
+    assert response.json()["status"]["error"] == "Bad request: Fusion queries can only be used with the default vector name."
+
+
 def test_search_by_vector():
     response = request_with_validation(
         api="/collections/{collection_name}/points/search",
@@ -555,7 +574,6 @@ def test_recommend_lookup():
                     }
                 }
             ],
-            "using": "dense-image",
             "query": {"fusion": "rrf"}
         },
     )
@@ -579,7 +597,6 @@ def test_recommend_lookup():
                     "using": "dense-image",
                 }
             ],
-            "using": "dense-image",
             "query": {"fusion": "rrf"}
         },
     )


### PR DESCRIPTION
This PR implements the logic for the `lookup_from` field on the query API.

Most of the complexity comes from resolving ids from different collections.

This change also makes sure `lookup_from` behave according to the user token.