### PR TITLE
Simplify resharding stages, add method to describe current stage for humans

### DIFF
--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -27,9 +27,11 @@ pub enum ClusterOperations {
     /// Restart transfer
     RestartTransfer(RestartTransferOperation),
     /// Start resharding
+    // TODO(resharding): expose when releasing resharding
     #[schemars(skip)]
     StartResharding(StartReshardingOperation),
     /// Abort resharding
+    // TODO(resharding): expose when releasing resharding
     #[schemars(skip)]
     AbortResharding(AbortReshardingOperation),
 }

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -129,6 +129,10 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
     pub fn save_to(&self, path: impl Into<PathBuf>) -> Result<(), Error> {
         Self::save_data_to(path, &self.data.read())
     }
+
+    pub async fn delete(self) -> std::io::Result<()> {
+        tokio::fs::remove_file(self.path).await
+    }
 }
 
 impl<T> Deref for SaveOnDisk<T> {

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -547,6 +547,7 @@ async fn has_enough_replicas(
 /// Stage 3: replicate to match replication factor
 ///
 /// Do replicate replicate to match replication factor.
+#[allow(clippy::too_many_arguments)]
 async fn stage_replicate(
     reshard_key: &ReshardKey,
     state: &PersistedState,

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -261,6 +261,7 @@ pub async fn drive_resharding(
     stage_finalize(&state)?;
 
     // Remove the state file after successful resharding
+    drop(state);
     if let Err(err) = tokio::fs::remove_file(resharding_state_path).await {
         log::error!(
             "Failed to remove resharding state file after successful resharding, ignoring: {err}"

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -105,7 +105,8 @@ impl DriverState {
     }
 
     /// Describe the current stage and state in a human readable string.
-    pub fn describe(&self) -> String {
+    // TODO(resharding): connect this to cluster info
+    pub fn _describe(&self) -> String {
         let Some(lowest_stage) = self.peers.values().min() else {
             return "unknown: no known peers".into();
         };
@@ -164,7 +165,7 @@ impl Stage {
             Self::S4_CommitHashring => Self::S5_PropagateDeletes,
             Self::S5_PropagateDeletes => Self::S6_Finalize,
             Self::S6_Finalize => Self::Finished,
-            Self::Finished => unreachable!()
+            Self::Finished => unreachable!(),
         }
     }
 }

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -261,9 +261,8 @@ pub async fn drive_resharding(
     log::debug!("Resharding {collection_id}:{to_shard_id} stage: finalize");
     stage_finalize(&state)?;
 
-    // Remove the state file after successful resharding
-    drop(state);
-    if let Err(err) = tokio::fs::remove_file(resharding_state_path).await {
+    // Delete the state file after successful resharding
+    if let Err(err) = state.delete().await {
         log::error!(
             "Failed to remove resharding state file after successful resharding, ignoring: {err}"
         );

--- a/lib/collection/src/shards/resharding/tasks_pool.rs
+++ b/lib/collection/src/shards/resharding/tasks_pool.rs
@@ -37,9 +37,7 @@ pub struct ReshardTaskStatus {
 impl ReshardTaskProgress {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        Self {
-            description: None,
-        }
+        Self { description: None }
     }
 }
 

--- a/lib/collection/src/shards/resharding/tasks_pool.rs
+++ b/lib/collection/src/shards/resharding/tasks_pool.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
-use std::fmt::Write as _;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::common::eta_calculator::EtaCalculator;
 use crate::common::stoppable_task_async::CancellableAsyncTaskHandle;
 use crate::shards::resharding::ReshardKey;
 use crate::shards::CollectionId;
@@ -21,10 +19,7 @@ pub struct ReshardTaskItem {
 }
 
 pub struct ReshardTaskProgress {
-    // TODO(resharding): find a different metric, this might not make sense here
-    pub points_transferred: usize,
-    pub points_total: usize,
-    pub eta: EtaCalculator,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -43,9 +38,7 @@ impl ReshardTaskProgress {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
-            points_transferred: 0,
-            points_total: 0,
-            eta: EtaCalculator::new(),
+            description: None,
         }
     }
 }
@@ -69,19 +62,17 @@ impl ReshardTasksPool {
         };
 
         let progress = task.progress.lock();
-        let mut comment = format!(
-            "Transferring records ({}/{}), started {}s ago, ETA: ",
-            progress.points_transferred,
-            progress.points_total,
+        let mut parts = vec![];
+        if let Some(description) = &progress.description {
+            parts.push(description.clone());
+        }
+        parts.push(format!(
+            "started {}s ago",
             chrono::Utc::now()
                 .signed_duration_since(task.started_at)
                 .num_seconds(),
-        );
-        if let Some(eta) = progress.eta.estimate(progress.points_total) {
-            write!(comment, "{:.2}s", eta.as_secs_f64()).unwrap();
-        } else {
-            comment.push('-');
-        }
+        ));
+        let comment = parts.join(", ");
 
         Some(ReshardTaskStatus { result, comment })
     }


### PR DESCRIPTION
Tracked in: #4213 

This simplifies the resharding stages we have. We now don't have start/end variants anymore, but a single variant for each stage.

It also adds a method to describe the current stage in human readable format. This will be connected to the cluster info later to show the current progress to users.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?