### PR TITLE
Fix wrong consistency results ordering

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -293,7 +293,7 @@ impl Collection {
             Some(order_by) => {
                 retrieved_iter
                     // Extract and remove order value from payload
-                    .map(|records| {
+                    .flat_map(|records| {
                         records.into_iter().map(|mut record| {
                             let value;
                             if local_only {
@@ -310,7 +310,6 @@ impl Collection {
                             (value, record)
                         })
                     })
-                    .flatten()
                     .sorted_unstable_by(|(value_a, record_a), (value_b, record_b)| {
                         match order_by.direction() {
                             Direction::Asc => (value_a, &record_a.id).cmp(&(value_b, &record_b.id)),

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -318,10 +318,8 @@ impl Collection {
                             }
                         }
                     })
-                    // Add each point-value only once
-                    .dedup_by(|(value_a, record_a), (value_b, record_b)| {
-                        value_a == value_b && record_a.id == record_b.id
-                    })
+                    // Add each point only once, dedup by point ID
+                    .dedup_by(|(_, record_a), (_, record_b)| record_a.id == record_b.id)
                     .map(|(_, record)| api::rest::Record::from(record))
                     .take(limit)
                     .collect_vec()

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -245,28 +245,27 @@ impl Collection {
             // `shards_results` shape: [num_shards, num_scored_points]
             let order = ScoringQuery::order(query_info.scoring_query, &collection_params)?;
 
+            let shards_results_iter = shards_results.into_iter().flatten();
+
             // Equivalent to:
             //
             // shards_results
             //     .into_iter()
-            //     .kmerge_by(match order {
-            //         Order::LargeBetter => |a, b| ScoredPointTies(a) > ScoredPointTies(b),
-            //         Order::SmallBetter => |a, b| ScoredPointTies(a) < ScoredPointTies(b),
+            //     .sorted_unstable_by(match order {
+            //         Order::LargeBetter => |a, b| ScoredPointTies(b).cmp(ScoredPointTies(a)),
+            //         Order::SmallBetter => |a, b| ScoredPointTies(a).cmp(ScoredPointTies(b)),
             //     })
             //
-            // if the `kmerge_by` function were able to work with reference predicates.
             // Either::Left and Either::Right are used to allow type inference to work.
             //
             let intermediate_result = match order {
                 Order::LargeBetter => Either::Left(
-                    shards_results
-                        .into_iter()
-                        .kmerge_by(|a, b| ScoredPointTies(a) > ScoredPointTies(b)),
+                    shards_results_iter
+                        .sorted_unstable_by(|a, b| ScoredPointTies(b).cmp(&ScoredPointTies(a))),
                 ),
                 Order::SmallBetter => Either::Right(
-                    shards_results
-                        .into_iter()
-                        .kmerge_by(|a, b| ScoredPointTies(a) < ScoredPointTies(b)),
+                    shards_results_iter
+                        .sorted_unstable_by(|a, b| ScoredPointTies(a).cmp(&ScoredPointTies(b))),
                 ),
             }
             .dedup()

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -268,11 +268,16 @@ impl Collection {
 
             let results_from_shards = all_searches_res
                 .iter_mut()
-                .map(|res| mem::take(&mut res[batch_index]));
+                .map(|res| mem::take(&mut res[batch_index]))
+                .flatten();
 
             let merged_iter = match order {
-                Order::LargeBetter => Either::Left(results_from_shards.kmerge_by(|a, b| a > b)),
-                Order::SmallBetter => Either::Right(results_from_shards.kmerge_by(|a, b| a < b)),
+                Order::LargeBetter => {
+                    Either::Left(results_from_shards.sorted_unstable_by(|a, b| b.cmp(a)))
+                }
+                Order::SmallBetter => {
+                    Either::Right(results_from_shards.sorted_unstable_by(|a, b| a.cmp(b)))
+                }
             }
             .filter(|point| seen_ids.insert(point.id));
 

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -268,8 +268,7 @@ impl Collection {
 
             let results_from_shards = all_searches_res
                 .iter_mut()
-                .map(|res| mem::take(&mut res[batch_index]))
-                .flatten();
+                .flat_map(|res| mem::take(&mut res[batch_index]));
 
             let merged_iter = match order {
                 Order::LargeBetter => {

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -198,9 +198,10 @@ impl LocalShard {
 
         let (values, point_ids): (Vec<_>, Vec<_>) = all_reads
             .into_iter()
-            .kmerge_by(|a, b| match order_by.direction() {
-                Direction::Asc => a <= b,
-                Direction::Desc => a >= b,
+            .flatten()
+            .sorted_unstable_by(|a, b| match order_by.direction() {
+                Direction::Asc => a.cmp(b),
+                Direction::Desc => b.cmp(a),
             })
             .dedup()
             .take(limit)

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -45,9 +45,7 @@ impl Resolve for CountResult {
 
 impl Resolve for Vec<Record> {
     fn resolve(records: Vec<Self>, condition: ResolveCondition) -> Self {
-        let mut resolved = Resolver::resolve(records, |record| record.id, record_eq, condition);
-        resolved.sort_unstable_by_key(|record| record.id);
-        resolved
+        Resolver::resolve(records, |record| record.id, record_eq, condition)
     }
 }
 
@@ -59,13 +57,7 @@ impl Resolve for Vec<Vec<ScoredPoint>> {
         let batches = transposed_iter(batches);
 
         batches
-            .map(|points| {
-                let mut resolved =
-                    Resolver::resolve(points, |point| point.id, scored_point_eq, condition);
-
-                resolved.sort_unstable();
-                resolved
-            })
+            .map(|points| Resolver::resolve(points, |point| point.id, scored_point_eq, condition))
             .collect()
     }
 }


### PR DESCRIPTION
One assumption we were making when using `kmerge`, is that the results provided by each resolved shard were already ordered appropriately. But it turns out this is not the case for when we actually resolve consistency for a replica set. 

A mistake we were making is to sort the resolved consistency results always in ascending order, without considering if the order should be descending.

To fix this, in this PR I have:
- stopped sorting when resolving replica results
- replaced usages of `kmerge` with `sorted_unstable_by`

This will most likely have a slight perf hit, but at least results will be correct.

An additional thing this also fixes is that, at collection, we were deduping `order_by` results by id only, while multivalue payloads can make the same id appear as many times as the amount of values it has.

### Future work
In a later PR I want to introduce changes so that we communicate the desired order to the replica resolver, so that we can keep using `kmerge` or similar in the subsequent layers.