### PR TITLE
fix: Communicate ordering to replica resolver

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -293,7 +293,7 @@ impl Collection {
             Some(order_by) => {
                 retrieved_iter
                     // Extract and remove order value from payload
-                    .map(|records| {
+                    .flat_map(|records| {
                         // TODO(1.11): read value only from record.order_value, remove & cleanup this part
                         records.into_iter().map(|mut record| {
                             let value;
@@ -318,8 +318,7 @@ impl Collection {
                             (value, record)
                         })
                     })
-                    // Get top results
-                    .kmerge_by(|(value_a, record_a), (value_b, record_b)| {
+                    .sorted_unstable_by(|(value_a, record_a), (value_b, record_b)| {
                         match order_by.direction() {
                             Direction::Asc => (value_a, record_a.id) < (value_b, record_b.id),
                             Direction::Desc => (value_a, record_a.id) > (value_b, record_b.id),

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -269,9 +269,11 @@ impl Collection {
                         if shard_key.is_none() {
                             return Ok(records);
                         }
-                        for point in &mut records {
+                        
+                        records.0.iter_mut().for_each(|point| {
                             point.shard_key.clone_from(&shard_key);
-                        }
+                        });
+                        
                         Ok(records)
                     })
             });
@@ -279,7 +281,7 @@ impl Collection {
             future::try_join_all(scroll_futures).await?
         };
 
-        let retrieved_iter = retrieved_points.into_iter();
+        let retrieved_iter = retrieved_points.into_iter().map(|(records, _)| records);
 
         let mut points = match &order_by {
             None => retrieved_iter

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -269,11 +269,11 @@ impl Collection {
                         if shard_key.is_none() {
                             return Ok(records);
                         }
-                        
+
                         records.0.iter_mut().for_each(|point| {
                             point.shard_key.clone_from(&shard_key);
                         });
-                        
+
                         Ok(records)
                     })
             });

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use futures::stream::FuturesUnordered;
 use futures::{future, StreamExt as _, TryFutureExt, TryStreamExt as _};
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use segment::data_types::order_by::{Direction, OrderBy};
 use segment::types::{Filter, ShardKey, WithPayload, WithPayloadInterface};
 use validator::Validate as _;
@@ -293,9 +293,9 @@ impl Collection {
                 .map(api::rest::Record::from)
                 .collect_vec(),
             Some(order_by) => {
-                retrieved_iter
+                let retrieved_iter = retrieved_iter
                     // Extract and remove order value from payload
-                    .flat_map(|records| {
+                    .map(|records| {
                         // TODO(1.11): read value only from record.order_value, remove & cleanup this part
                         records.into_iter().map(|mut record| {
                             let value;
@@ -319,18 +319,25 @@ impl Collection {
                             };
                             (value, record)
                         })
-                    })
-                    .sorted_unstable_by(|(value_a, record_a), (value_b, record_b)| {
-                        match order_by.direction() {
-                            Direction::Asc => (value_a, record_a.id) < (value_b, record_b.id),
-                            Direction::Desc => (value_a, record_a.id) > (value_b, record_b.id),
-                        }
-                    })
-                    // Only keep the point with the most "valuable" order value
-                    .dedup_by(|(_, record_a), (_, record_b)| record_a.id == record_b.id)
-                    .map(|(_, record)| api::rest::Record::from(record))
-                    .take(limit)
-                    .collect_vec()
+                    });
+
+                match order_by.direction() {
+                    Direction::Asc => Either::Left(retrieved_iter.kmerge_by(
+                        |(value_a, record_a), (value_b, record_b)| {
+                            (value_a, &record_a.id) < (value_b, &record_b.id)
+                        },
+                    )),
+                    Direction::Desc => Either::Right(retrieved_iter.kmerge_by(
+                        |(value_a, record_a), (value_b, record_b)| {
+                            (value_a, &record_a.id) > (value_b, &record_b.id)
+                        },
+                    )),
+                }
+                // Only keep the point with the most "valuable" order value
+                .dedup_by(|(_, record_a), (_, record_b)| record_a.id == record_b.id)
+                .map(|(_, record)| api::rest::Record::from(record))
+                .take(limit)
+                .collect_vec()
             }
         };
 

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -53,7 +53,7 @@ impl Collection {
                     shard_responses
                         .iter_mut()
                         .flatten()
-                        .flat_map(|(points, _)| points.iter_mut())
+                        .flat_map(|(points, _)| points)
                         .for_each(|point| point.shard_key.clone_from(&shard_key));
 
                     Ok(shard_responses)
@@ -291,7 +291,7 @@ impl Collection {
                     shards_results.kmerge_by(|a, b| ScoredPointTies(a) < ScoredPointTies(b)),
                 ),
             }
-            .dedup()
+            .unique_by(|point| point.id)
             .take(take)
             .collect();
 

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -268,11 +268,16 @@ impl Collection {
 
             let results_from_shards = all_searches_res
                 .iter_mut()
-                .map(|res| mem::take(&mut res[batch_index]));
+                .map(|res| mem::take(&mut res[batch_index]))
+                .flatten();
 
             let merged_iter = match order {
-                Order::LargeBetter => Either::Left(results_from_shards.kmerge_by(|a, b| a > b)),
-                Order::SmallBetter => Either::Right(results_from_shards.kmerge_by(|a, b| a < b)),
+                Order::LargeBetter => {
+                    Either::Left(results_from_shards.sorted_unstable_by(|a, b| b.cmp(a)))
+                }
+                Order::SmallBetter => {
+                    Either::Right(results_from_shards.sorted_unstable_by(|a, b| a.cmp(b)))
+                }
             }
             .filter(|point| seen_ids.insert(point.id));
 

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -266,11 +266,11 @@ impl Collection {
                 .map(|(_, order)| *order)
                 .unwrap_or(Order::SmallBetter);
 
-            let results = results_from_shards.into_iter().flat_map(|(res, _)| res);
+            let results = results_from_shards.into_iter().map(|(res, _)| res);
 
             let merged_iter = match order {
-                Order::LargeBetter => Either::Left(results.sorted_unstable_by(|a, b| b.cmp(a))),
-                Order::SmallBetter => Either::Right(results.sorted_unstable_by(|a, b| a.cmp(b))),
+                Order::LargeBetter => Either::Left(results.kmerge_by(|a, b| a > b)),
+                Order::SmallBetter => Either::Right(results.kmerge_by(|a, b| a > b)),
             }
             .filter(|point| seen_ids.insert(point.id));
 

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -268,8 +268,7 @@ impl Collection {
 
             let results_from_shards = all_searches_res
                 .iter_mut()
-                .map(|res| mem::take(&mut res[batch_index]))
-                .flatten();
+                .flat_map(|res| mem::take(&mut res[batch_index]));
 
             let merged_iter = match order {
                 Order::LargeBetter => {

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -89,8 +89,6 @@ pub enum QueryEnum {
     Context(NamedQuery<ContextQuery<Vector>>),
 }
 
-impl QueryEnum {}
-
 impl From<DenseVector> for QueryEnum {
     fn from(vector: DenseVector) -> Self {
         QueryEnum::Nearest(NamedVectorStruct::Default(vector))

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -26,9 +26,7 @@ use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStructInternal, DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
-    Distance, Filter, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType,
-    QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
-    WithPayloadInterface, WithVector,
+    Distance, Filter, MultiVectorConfig, Order, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype, WithPayloadInterface, WithVector
 };
 use semver::Version;
 use serde;
@@ -772,6 +770,11 @@ pub struct PointGroup {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct GroupsResult {
     pub groups: Vec<PointGroup>,
+}
+
+pub struct OrderedItems<T> {
+    pub items: Vec<T>,
+    pub order: Order,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -26,7 +26,9 @@ use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStructInternal, DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
-    Distance, Filter, MultiVectorConfig, Order, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype, WithPayloadInterface, WithVector
+    Distance, Filter, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType,
+    QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
+    WithPayloadInterface, WithVector,
 };
 use semver::Version;
 use serde;
@@ -770,11 +772,6 @@ pub struct PointGroup {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct GroupsResult {
     pub groups: Vec<PointGroup>,
-}
-
-pub struct OrderedItems<T> {
-    pub items: Vec<T>,
-    pub order: Order,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -198,9 +198,10 @@ impl LocalShard {
 
         let (values, point_ids): (Vec<_>, Vec<_>) = all_reads
             .into_iter()
-            .kmerge_by(|a, b| match order_by.direction() {
-                Direction::Asc => a <= b,
-                Direction::Desc => a >= b,
+            .flatten()
+            .sorted_unstable_by(|a, b| match order_by.direction() {
+                Direction::Asc => a.cmp(b),
+                Direction::Desc => b.cmp(a),
             })
             .dedup()
             .take(limit)

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -198,10 +198,9 @@ impl LocalShard {
 
         let (values, point_ids): (Vec<_>, Vec<_>) = all_reads
             .into_iter()
-            .flatten()
-            .sorted_unstable_by(|a, b| match order_by.direction() {
-                Direction::Asc => a.cmp(b),
-                Direction::Desc => b.cmp(a),
+            .kmerge_by(|a, b| match order_by.direction() {
+                Direction::Asc => a < b,
+                Direction::Desc => a > b,
             })
             .dedup()
             .take(limit)

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::FutureExt as _;
-use segment::data_types::order_by::OrderBy;
+use segment::data_types::order_by::{Direction, OrderBy};
 use segment::types::*;
 
 use super::ShardReplicaSet;
@@ -22,7 +22,7 @@ impl ShardReplicaSet {
         read_consistency: Option<ReadConsistency>,
         local_only: bool,
         order_by: Option<&OrderBy>,
-    ) -> CollectionResult<Vec<Record>> {
+    ) -> CollectionResult<(Vec<Record>, Option<Direction>)> {
         let with_payload_interface = Arc::new(with_payload_interface.clone());
         let with_vector = Arc::new(with_vector.clone());
         let filter = filter.map(|filter| Arc::new(filter.clone()));
@@ -48,6 +48,7 @@ impl ShardReplicaSet {
                             order_by.as_deref(),
                         )
                         .await
+                        .map(|response| (response, order_by.map(|order_by| order_by.direction())))
                 }
                 .boxed()
             },

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -860,7 +860,7 @@ async fn stage_propagate_deletes(
                     false,
                     None,
                 )
-                .await?;
+                .await?.0;
 
             offset = if points.len() > DELETE_BATCH_SIZE {
                 points.pop().map(|point| point.id)

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -860,7 +860,8 @@ async fn stage_propagate_deletes(
                     false,
                     None,
                 )
-                .await?.0;
+                .await?
+                .0;
 
             offset = if points.len() > DELETE_BATCH_SIZE {
                 points.pop().map(|point| point.id)

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -45,9 +45,7 @@ impl Resolve for CountResult {
 
 impl Resolve for Vec<Record> {
     fn resolve(records: Vec<Self>, condition: ResolveCondition) -> Self {
-        let mut resolved = Resolver::resolve(records, |record| record.id, record_eq, condition);
-        resolved.sort_unstable_by_key(|record| record.id);
-        resolved
+        Resolver::resolve(records, |record| record.id, record_eq, condition)
     }
 }
 
@@ -59,13 +57,7 @@ impl Resolve for Vec<Vec<ScoredPoint>> {
         let batches = transposed_iter(batches);
 
         batches
-            .map(|points| {
-                let mut resolved =
-                    Resolver::resolve(points, |point| point.id, scored_point_eq, condition);
-
-                resolved.sort_unstable();
-                resolved
-            })
+            .map(|points| Resolver::resolve(points, |point| point.id, scored_point_eq, condition))
             .collect()
     }
 }

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -36,11 +36,11 @@ impl Direction {
             },
         }
     }
-    
+
     fn json_value_to_ordering_value(&self, value: Option<serde_json::Value>) -> OrderValue {
         value
             .and_then(|v| OrderValue::try_from(v).ok())
-            .unwrap_or_else(|| match self {
+            .unwrap_or(match self {
                 Direction::Asc => OrderValue::MAX,
                 Direction::Desc => OrderValue::MIN,
             })
@@ -137,15 +137,6 @@ impl OrderBy {
             .0
             .insert(INTERNAL_KEY_OF_ORDER_BY_VALUE.to_string(), value.into());
         new_payload
-    }
-
-    fn json_value_to_ordering_value(&self, value: Option<serde_json::Value>) -> OrderValue {
-        value
-            .and_then(|v| OrderValue::try_from(v).ok())
-            .unwrap_or_else(|| match self.direction() {
-                Direction::Asc => OrderValue::MAX,
-                Direction::Desc => OrderValue::MIN,
-            })
     }
 
     pub fn get_order_value_from_payload(&self, payload: Option<&Payload>) -> OrderValue {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -195,7 +195,7 @@ impl Distance {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Order {
     LargeBetter,
     SmallBetter,

--- a/tests/consensus_tests/test_points_query.py
+++ b/tests/consensus_tests/test_points_query.py
@@ -280,15 +280,11 @@ def test_points_query(tmp_path: pathlib.Path):
             ("scroll", "id", {
                 "limit": 5,
                 "order_by": "count",
-                "direction": "asc",
             }),
             ("query", "id", {
                 "limit": 5,
                 "query": {
-                    "order_by": {
-                        "key": "count",
-                        "direction": "asc",
-                    }
+                    "order_by": "count"
                 }
             }),
         ),

--- a/tests/consensus_tests/test_points_query.py
+++ b/tests/consensus_tests/test_points_query.py
@@ -393,7 +393,7 @@ def test_points_query(tmp_path: pathlib.Path):
 
             # assert same number of results
             assert len(r_one) == len(r_two), f"Different number of results for {action1} and {action2}"
-            if action1 in ["search", "recommend", "scroll"]:
+            if action1 in ["query", "search", "recommend", "scroll"]:
                 # assert same order of results
                 assert [str(d) for d in r_one] == [str(d) for d in r_two], f"Different order of results for {action1} and {action2}"
                 # assert stable across peers


### PR DESCRIPTION
Supersedes #4510 

Fixes same issue as #4510, but now this is what I consider a proper fix. Now the resolver knows which way to order. 
