### PR TITLE
U8 quantization for sparse vector index

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9731,7 +9731,8 @@
         "type": "string",
         "enum": [
           "float32",
-          "float16"
+          "float16",
+          "uint8"
         ]
       },
       "PayloadStorageType": {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1228,9 +1228,7 @@ impl TryFrom<Datatype> for SparseVectorIndexDatatype {
         match value {
             Datatype::Float32 => Ok(Self::Float32),
             Datatype::Float16 => Ok(Self::Float16),
-            Datatype::Uint8 => Err(CollectionError::BadInput {
-                description: "Uint8 datatype is not supported for sparse vectors".to_string(),
-            }),
+            Datatype::Uint8 => Ok(Self::Uint8),
         }
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_index_config.rs
+++ b/lib/segment/src/index/sparse_index/sparse_index_config.rs
@@ -48,6 +48,8 @@ pub enum SparseVectorIndexDatatype {
     Float32,
     // Half-precision floating point
     Float16,
+    // Unsigned 8-bit integer
+    Uint8,
 }
 
 /// Configuration for sparse inverted index.

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use half::f16;
-use sparse::common::types::DimId;
+use sparse::common::types::{DimId, QuantizedU8};
 use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
 use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
@@ -64,8 +64,12 @@ pub enum VectorIndexEnum {
     SparseMmap(SparseVectorIndex<InvertedIndexMmap>),
     SparseCompressedImmutableRamF32(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f32>>),
     SparseCompressedImmutableRamF16(SparseVectorIndex<InvertedIndexCompressedImmutableRam<f16>>),
+    SparseCompressedImmutableRamU8(
+        SparseVectorIndex<InvertedIndexCompressedImmutableRam<QuantizedU8>>,
+    ),
     SparseCompressedMmapF32(SparseVectorIndex<InvertedIndexCompressedMmap<f32>>),
     SparseCompressedMmapF16(SparseVectorIndex<InvertedIndexCompressedMmap<f16>>),
+    SparseCompressedMmapU8(SparseVectorIndex<InvertedIndexCompressedMmap<QuantizedU8>>),
 }
 
 impl VectorIndexEnum {
@@ -79,8 +83,10 @@ impl VectorIndexEnum {
             Self::SparseMmap(_) => true,
             Self::SparseCompressedImmutableRamF32(_) => true,
             Self::SparseCompressedImmutableRamF16(_) => true,
+            Self::SparseCompressedImmutableRamU8(_) => true,
             Self::SparseCompressedMmapF32(_) => true,
             Self::SparseCompressedMmapF16(_) => true,
+            Self::SparseCompressedMmapU8(_) => true,
         }
     }
 
@@ -92,8 +98,10 @@ impl VectorIndexEnum {
             Self::SparseMmap(index) => index.fill_idf_statistics(idf),
             Self::SparseCompressedImmutableRamF32(index) => index.fill_idf_statistics(idf),
             Self::SparseCompressedImmutableRamF16(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompressedImmutableRamU8(index) => index.fill_idf_statistics(idf),
             Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf),
             Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf),
+            Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf),
         }
     }
 }
@@ -132,10 +140,16 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::SparseCompressedImmutableRamF16(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
+            VectorIndexEnum::SparseCompressedImmutableRamU8(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
             VectorIndexEnum::SparseCompressedMmapF32(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
             VectorIndexEnum::SparseCompressedMmapF16(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            VectorIndexEnum::SparseCompressedMmapU8(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
         }
@@ -155,8 +169,12 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::SparseCompressedImmutableRamF16(index) => {
                 index.get_telemetry_data(detail)
             }
+            VectorIndexEnum::SparseCompressedImmutableRamU8(index) => {
+                index.get_telemetry_data(detail)
+            }
             VectorIndexEnum::SparseCompressedMmapF32(index) => index.get_telemetry_data(detail),
             VectorIndexEnum::SparseCompressedMmapF16(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseCompressedMmapU8(index) => index.get_telemetry_data(detail),
         }
     }
 
@@ -170,8 +188,10 @@ impl VectorIndex for VectorIndexEnum {
             VectorIndexEnum::SparseMmap(index) => index.files(),
             VectorIndexEnum::SparseCompressedImmutableRamF32(index) => index.files(),
             VectorIndexEnum::SparseCompressedImmutableRamF16(index) => index.files(),
+            VectorIndexEnum::SparseCompressedImmutableRamU8(index) => index.files(),
             VectorIndexEnum::SparseCompressedMmapF32(index) => index.files(),
             VectorIndexEnum::SparseCompressedMmapF16(index) => index.files(),
+            VectorIndexEnum::SparseCompressedMmapU8(index) => index.files(),
         }
     }
 
@@ -185,8 +205,10 @@ impl VectorIndex for VectorIndexEnum {
             Self::SparseMmap(index) => index.indexed_vector_count(),
             Self::SparseCompressedImmutableRamF32(index) => index.indexed_vector_count(),
             Self::SparseCompressedImmutableRamF16(index) => index.indexed_vector_count(),
+            Self::SparseCompressedImmutableRamU8(index) => index.indexed_vector_count(),
             Self::SparseCompressedMmapF32(index) => index.indexed_vector_count(),
             Self::SparseCompressedMmapF16(index) => index.indexed_vector_count(),
+            Self::SparseCompressedMmapU8(index) => index.indexed_vector_count(),
         }
     }
 
@@ -204,8 +226,10 @@ impl VectorIndex for VectorIndexEnum {
             Self::SparseMmap(index) => index.update_vector(id, vector),
             Self::SparseCompressedImmutableRamF32(index) => index.update_vector(id, vector),
             Self::SparseCompressedImmutableRamF16(index) => index.update_vector(id, vector),
+            Self::SparseCompressedImmutableRamU8(index) => index.update_vector(id, vector),
             Self::SparseCompressedMmapF32(index) => index.update_vector(id, vector),
             Self::SparseCompressedMmapF16(index) => index.update_vector(id, vector),
+            Self::SparseCompressedMmapU8(index) => index.update_vector(id, vector),
         }
     }
 }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -348,9 +348,11 @@ pub(crate) fn create_sparse_vector_index(
         args.config.datatype.unwrap_or_default(),
         sparse_vector_index::USE_COMPRESSED,
     ) {
-        (_, SparseVectorIndexDatatype::Float16, false) => Err(OperationError::ValidationError {
-            description: "Float16 datatype is not supported".to_string(),
-        })?,
+        (_, a @ (SparseVectorIndexDatatype::Float16 | SparseVectorIndexDatatype::Uint8), false) => {
+            Err(OperationError::ValidationError {
+                description: format!("{:?} datatype is not supported", a),
+            })?
+        }
 
         (SparseIndexType::MutableRam, _, _) => {
             VectorIndexEnum::SparseRam(SparseVectorIndex::open(args)?)
@@ -376,6 +378,12 @@ pub(crate) fn create_sparse_vector_index(
         }
         (SparseIndexType::Mmap, SparseVectorIndexDatatype::Float16, true) => {
             VectorIndexEnum::SparseCompressedMmapF16(SparseVectorIndex::open(args)?)
+        }
+        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Uint8, true) => {
+            VectorIndexEnum::SparseCompressedImmutableRamU8(SparseVectorIndex::open(args)?)
+        }
+        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Uint8, true) => {
+            VectorIndexEnum::SparseCompressedMmapU8(SparseVectorIndex::open(args)?)
         }
     };
 

--- a/lib/sparse/src/common/types.rs
+++ b/lib/sparse/src/common/types.rs
@@ -1,39 +1,160 @@
 use std::fmt::Debug;
 
 use half::slice::HalfFloatSliceExt;
+use itertools::{Itertools, MinMaxResult};
 
 pub type DimOffset = u32;
 pub type DimId = u32;
 pub type DimWeight = f32;
 
-pub trait Weight: PartialEq + Copy + Debug + Into<DimWeight> + 'static {
-    fn from_f32(value: f32) -> Self;
+pub trait Weight: PartialEq + Copy + Debug + 'static {
+    type QuantizationParams: Copy + PartialEq + Debug;
 
-    fn into_f32_slice<'a>(weights: &'a [Self], buffer: &'a mut [f32]) -> &'a [f32];
+    fn quantization_params_for(
+        values: impl ExactSizeIterator<Item = DimWeight> + Clone,
+    ) -> Self::QuantizationParams;
+
+    fn from_f32(params: Self::QuantizationParams, value: f32) -> Self;
+
+    fn to_f32(self, params: Self::QuantizationParams) -> f32;
+
+    fn into_f32_slice<'a>(
+        params: Self::QuantizationParams,
+        weights: &'a [Self],
+        buffer: &'a mut [f32],
+    ) -> &'a [f32];
 }
 
 impl Weight for f32 {
+    type QuantizationParams = ();
+
     #[inline]
-    fn from_f32(value: f32) -> Self {
+    fn quantization_params_for(_values: impl ExactSizeIterator<Item = DimWeight> + Clone) {}
+
+    #[inline]
+    fn from_f32(_: (), value: f32) -> Self {
         value
     }
 
     #[inline]
-    fn into_f32_slice<'a>(weights: &'a [Self], _buffer: &'a mut [f32]) -> &'a [f32] {
+    fn to_f32(self, _: ()) -> f32 {
+        self
+    }
+
+    #[inline]
+    fn into_f32_slice<'a>(_: (), weights: &'a [Self], _buffer: &'a mut [f32]) -> &'a [f32] {
         // Zero-copy conversion, ignore buffer
         weights
     }
 }
 
 impl Weight for half::f16 {
+    type QuantizationParams = ();
+
     #[inline]
-    fn from_f32(value: f32) -> Self {
+    fn quantization_params_for(_values: impl ExactSizeIterator<Item = DimWeight> + Clone) {}
+
+    #[inline]
+    fn from_f32(_: (), value: f32) -> Self {
         half::f16::from_f32(value)
     }
 
+    fn to_f32(self, _: ()) -> f32 {
+        self.to_f32()
+    }
+
     #[inline]
-    fn into_f32_slice<'a>(weights: &'a [Self], buffer: &'a mut [f32]) -> &'a [f32] {
+    fn into_f32_slice<'a>(_: (), weights: &'a [Self], buffer: &'a mut [f32]) -> &'a [f32] {
         weights.convert_to_f32_slice(buffer);
+        buffer
+    }
+}
+
+#[cfg(feature = "testing")]
+impl Weight for u8 {
+    type QuantizationParams = ();
+
+    #[inline]
+    fn quantization_params_for(_values: impl ExactSizeIterator<Item = DimWeight> + Clone) {}
+
+    #[inline]
+    fn from_f32(_: (), value: f32) -> Self {
+        value as u8
+    }
+
+    #[inline]
+    fn to_f32(self, _: ()) -> f32 {
+        self as f32
+    }
+
+    #[inline]
+    fn into_f32_slice<'a>(_: (), weights: &'a [Self], buffer: &'a mut [f32]) -> &'a [f32] {
+        for (i, &weight) in weights.iter().enumerate() {
+            buffer[i] = weight as f32;
+        }
+        buffer
+    }
+}
+
+#[derive(PartialEq, Copy, Clone, Debug)]
+pub struct QuantizedU8(u8);
+
+impl From<QuantizedU8> for DimWeight {
+    fn from(val: QuantizedU8) -> Self {
+        val.0 as f32
+    }
+}
+
+#[derive(PartialEq, Default, Copy, Clone, Debug)]
+pub struct QuantizedU8Params {
+    /// Minimum value in the range
+    min: f32,
+    /// Difference divided by 256, aka `(max - min) / 255`
+    diff256: f32,
+}
+
+impl Weight for QuantizedU8 {
+    type QuantizationParams = QuantizedU8Params;
+
+    #[inline]
+    fn quantization_params_for(
+        values: impl Iterator<Item = DimWeight>,
+    ) -> Self::QuantizationParams {
+        let (min, max) = match values.minmax() {
+            MinMaxResult::NoElements => return QuantizedU8Params::default(),
+            MinMaxResult::OneElement(e) => (e, e),
+            MinMaxResult::MinMax(min, max) => (min, max),
+        };
+        QuantizedU8Params {
+            min,
+            diff256: (max - min) / 255.0,
+        }
+    }
+
+    #[inline]
+    fn from_f32(params: QuantizedU8Params, value: f32) -> Self {
+        QuantizedU8(
+            ((value - params.min) / params.diff256)
+                .round()
+                .clamp(0.0, 255.0) as u8,
+        )
+    }
+
+    #[inline]
+    fn to_f32(self, params: QuantizedU8Params) -> f32 {
+        params.min + self.0 as f32 * params.diff256
+    }
+
+    #[inline]
+    fn into_f32_slice<'a>(
+        params: QuantizedU8Params,
+        weights: &'a [Self],
+        buffer: &'a mut [f32],
+    ) -> &'a [f32] {
+        assert_eq!(weights.len(), buffer.len());
+        for (i, &weight) in weights.iter().enumerate() {
+            buffer[i] = weight.to_f32(params);
+        }
         buffer
     }
 }

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -14,7 +14,7 @@ use crate::index::compressed_posting_list::{
 use crate::index::posting_list_common::PostingListIter as _;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct InvertedIndexCompressedImmutableRam<W> {
+pub struct InvertedIndexCompressedImmutableRam<W: Weight> {
     pub(super) postings: Vec<CompressedPostingList<W>>,
     pub(super) vector_count: usize,
 }
@@ -94,7 +94,7 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
         for old_posting_list in &ram_index.postings {
             let mut new_posting_list = CompressedPostingBuilder::new();
             for elem in &old_posting_list.elements {
-                new_posting_list.add(elem.record_id, Weight::from_f32(elem.weight));
+                new_posting_list.add(elem.record_id, elem.weight);
             }
             postings.push(new_posting_list.build());
         }
@@ -122,6 +122,7 @@ mod tests {
 
     use super::*;
     use crate::common::sparse_vector_fixture::random_sparse_vector;
+    use crate::common::types::QuantizedU8;
     use crate::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
 
     #[test]
@@ -134,6 +135,8 @@ mod tests {
 
         check_save_load::<f32>(&inverted_index_ram);
         check_save_load::<half::f16>(&inverted_index_ram);
+        check_save_load::<u8>(&inverted_index_ram);
+        check_save_load::<QuantizedU8>(&inverted_index_ram);
     }
 
     #[test]
@@ -148,6 +151,8 @@ mod tests {
 
         check_save_load::<f32>(&inverted_index_ram);
         check_save_load::<half::f16>(&inverted_index_ram);
+        check_save_load::<u8>(&inverted_index_ram);
+        check_save_load::<QuantizedU8>(&inverted_index_ram);
     }
 
     fn check_save_load<W: Weight>(inverted_index_ram: &InvertedIndexRam) {

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -20,7 +20,7 @@ pub mod inverted_index_ram_builder;
 pub const OLD_INDEX_FILE_NAME: &str = "inverted_index.data";
 pub const INDEX_FILE_NAME: &str = "inverted_index.dat";
 
-pub trait InvertedIndex: Sized + Debug {
+pub trait InvertedIndex: Sized + Debug + 'static {
     type Iter<'a>: PostingListIter + Clone
     where
         Self: 'a;

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -475,9 +475,9 @@ mod tests {
             TypeId::of::<InvertedIndexCompressedMmap<QuantizedU8>>(),
         ];
         if errors_allowed_for.contains(&TypeId::of::<I>()) {
-            let precission = 0.25;
+            let precision = 0.25;
             scores.iter_mut().for_each(|score| {
-                score.score = (score.score / precission).round() * precission;
+                score.score = (score.score / precision).round() * precision;
             });
             scores
         } else {

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -391,6 +391,7 @@ mod tests {
     use crate::common::scores_memory_pool::ScoresMemoryPool;
     use crate::common::sparse_vector::SparseVector;
     use crate::common::sparse_vector_fixture::random_sparse_vector;
+    use crate::common::types::QuantizedU8;
     use crate::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
     use crate::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
     use crate::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
@@ -415,11 +416,23 @@ mod tests {
     #[instantiate_tests(<InvertedIndexCompressedImmutableRam<half::f16>>)]
     mod iram_f16 {}
 
+    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<u8>>)]
+    mod iram_u8 {}
+
+    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<QuantizedU8>>)]
+    mod iram_q8 {}
+
     #[instantiate_tests(<InvertedIndexCompressedMmap<f32>>)]
     mod mmap_f32 {}
 
     #[instantiate_tests(<InvertedIndexCompressedMmap<half::f16>>)]
     mod mmap_f16 {}
+
+    #[instantiate_tests(<InvertedIndexCompressedMmap<u8>>)]
+    mod mmap_u8 {}
+
+    #[instantiate_tests(<InvertedIndexCompressedMmap<QuantizedU8>>)]
+    mod mmap_q8 {}
 
     // --- End of test instantiations ---
 
@@ -452,6 +465,23 @@ mod tests {
                 index: I::from_ram_index(Cow::Owned(ram_index), &temp_dir).unwrap(),
                 temp_dir,
             }
+        }
+    }
+
+    /// Round scores to allow some quantization errors
+    fn round_scores<I: 'static>(mut scores: Vec<ScoredPointOffset>) -> Vec<ScoredPointOffset> {
+        let errors_allowed_for = [
+            TypeId::of::<InvertedIndexCompressedImmutableRam<QuantizedU8>>(),
+            TypeId::of::<InvertedIndexCompressedMmap<QuantizedU8>>(),
+        ];
+        if errors_allowed_for.contains(&TypeId::of::<I>()) {
+            let precission = 0.25;
+            scores.iter_mut().for_each(|score| {
+                score.score = (score.score / precission).round() * precission;
+            });
+            scores
+        } else {
+            scores
         }
     }
 
@@ -493,7 +523,7 @@ mod tests {
         );
 
         assert_eq!(
-            search_context.search(&match_all),
+            round_scores::<I>(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -539,7 +569,7 @@ mod tests {
         );
 
         assert_eq!(
-            search_context.search(&match_all),
+            round_scores::<I>(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -629,7 +659,7 @@ mod tests {
         );
 
         assert_eq!(
-            search_context.search(&match_all),
+            round_scores::<I>(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -658,7 +688,7 @@ mod tests {
         );
 
         assert_eq!(
-            search_context.search(&match_all),
+            round_scores::<I>(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -870,7 +900,7 @@ mod tests {
 
         let scores = search_context.plain_search(&[1, 3, 2]);
         assert_eq!(
-            scores,
+            round_scores::<I>(scores),
             vec![
                 ScoredPointOffset {
                     idx: 3,
@@ -913,7 +943,7 @@ mod tests {
 
         let scores = search_context.plain_search(&[1, 2, 3]);
         assert_eq!(
-            scores,
+            round_scores::<I>(scores),
             vec![
                 ScoredPointOffset {
                     idx: 2,


### PR DESCRIPTION
This PR add Uint8 quantization for the sparse vector index.

Depends on #4490.

## Benchmarks

### basic
task | ram | ram_c32 | ram_c16 | ram_q8
| - | -: | -: | -: | -:|
random-50k | 0.78408<br>0% | 0.98727 <br> +25% | 1.1809 <br> +50% | 1.0488 <br> +33%
random-500k | 7.2848<br>0% | 8.7678 <br> +20% | 10.746 <br> +47% | 9.5777 <br> +31%
neurips2023-1M | 12.374<br>0% | 13.244 <br> +7% | 14.783 <br> +19% | 13.539 <br> +9%
neurips2023-full-25pct | 28.023<br>0% | 31.649 <br> +12% | 35.216 <br> +25% | 31.377 <br> +11%
movies | 3.3650<br>0% | 4.1182 <br> +22% | 4.6996 <br> +39% | 4.1280 <br> +22%

### hottest
task | ram | ram_c32 | ram_c16 | ram_q8
| - | -: | -: | -: | -:|
random-50k | 0.18915<br>0% | 0.19317 <br> +2% | 0.19577 <br> +3% | 0.20082 <br> +6%
random-500k | 1.6066<br>0% | 1.6242 <br> +1% | 1.6740 <br> +4% | 1.7004 <br> +5%
neurips2023-1M | 8.8450<br>0% | 8.9318 <br> +0% | 9.4094 <br> +6% | 9.1269 <br> +3%
neurips2023-full-25pct | 19.900<br>0% | 19.950 <br> +0% | 20.706 <br> +4% | 20.210 <br> +1%
movies | 0.18421<br>0% | 0.21036 <br> +14% | 0.24037 <br> +30% | 0.20955 <br> +13%