### PR TITLE
Hide resharding types and parameters in OpenAPI spec until we release

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9039,12 +9039,6 @@
             "format": "uint32",
             "minimum": 0
           },
-          "to_shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0,
-            "nullable": true
-          },
           "from": {
             "description": "Source peer id",
             "type": "integer",
@@ -10272,12 +10266,6 @@
             "format": "uint32",
             "minimum": 0
           },
-          "to_shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0,
-            "nullable": true
-          },
           "to_peer_id": {
             "type": "integer",
             "format": "uint64",
@@ -10325,12 +10313,6 @@
             "format": "uint32",
             "minimum": 0
           },
-          "to_shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0,
-            "nullable": true
-          },
           "to_peer_id": {
             "type": "integer",
             "format": "uint64",
@@ -10377,12 +10359,6 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 0
-          },
-          "to_shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0,
-            "nullable": true
           },
           "to_peer_id": {
             "type": "integer",
@@ -10518,12 +10494,6 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 0
-          },
-          "to_shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0,
-            "nullable": true
           },
           "from_peer_id": {
             "type": "integer",

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -96,6 +96,7 @@ pub struct DropShardingKey {
 pub struct RestartTransfer {
     pub shard_id: ShardId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
     pub from_peer_id: PeerId,
     pub to_peer_id: PeerId,
@@ -165,6 +166,7 @@ pub struct AbortReshardingOperation {
 pub struct ReplicateShard {
     pub shard_id: ShardId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,
@@ -183,6 +185,7 @@ impl Validate for ReplicateShard {
 pub struct MoveShard {
     pub shard_id: ShardId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,
@@ -214,6 +217,7 @@ pub struct Replica {
 pub struct AbortShardTransfer {
     pub shard_id: ShardId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -208,6 +208,7 @@ pub struct ShardTransferInfo {
     pub shard_id: ShardId,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
 
     /// Source peer id

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -34,6 +34,7 @@ pub struct ShardTransfer {
     /// For resharding, a different target shard ID may be configured
     /// By default the shard ID on the target peer is the same.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
     pub from: PeerId,
     pub to: PeerId,
@@ -60,6 +61,7 @@ impl ShardTransfer {
 pub struct ShardTransferRestart {
     pub shard_id: ShardId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
     pub from: PeerId,
     pub to: PeerId,
@@ -94,6 +96,7 @@ impl From<ShardTransfer> for ShardTransferRestart {
 pub struct ShardTransferKey {
     pub shard_id: ShardId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     pub to_shard_id: Option<ShardId>,
     pub from: PeerId,
     pub to: PeerId,
@@ -118,8 +121,7 @@ pub enum ShardTransferMethod {
     WalDelta,
     /// Shard transfer for resharding: stream all records in batches until all points are
     /// transferred.
-    #[doc(hidden)]
-    #[schemars(skip)]
+    #[schemars(skip)] // TODO(resharding): expose once we release resharding
     ReshardingStreamRecords,
 }
 


### PR DESCRIPTION
Tracked in: #4213 

This hides resharding types and parameters from the OpenAPI spec for the upcoming release. We'll expose them when we actually release resharding functionality.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?