### PR TITLE
Remove clock tags when forwarding operations during reshading shard transfer

### DIFF
--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -12,6 +12,7 @@ use segment::types::{
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
+use super::shard::ShardId;
 use super::update_tracker::UpdateTracker;
 use crate::hash_ring::HashRing;
 use crate::operations::point_ops::{
@@ -37,6 +38,7 @@ use crate::shards::telemetry::LocalShardTelemetry;
 /// It can be used to provide all read and write operations while the wrapped shard is being transferred to another node.
 /// Proxy forwards all operations to remote shards.
 pub struct ForwardProxyShard {
+    shard_id: ShardId,
     pub(crate) wrapped_shard: LocalShard,
     pub(crate) remote_shard: RemoteShard,
     /// Lock required to protect transfer-in-progress updates.
@@ -45,8 +47,9 @@ pub struct ForwardProxyShard {
 }
 
 impl ForwardProxyShard {
-    pub fn new(wrapped_shard: LocalShard, remote_shard: RemoteShard) -> Self {
+    pub fn new(shard_id: ShardId, wrapped_shard: LocalShard, remote_shard: RemoteShard) -> Self {
         Self {
+            shard_id,
             wrapped_shard,
             remote_shard,
             update_lock: Mutex::new(()),
@@ -191,7 +194,7 @@ impl ShardOperation for ForwardProxyShard {
     /// This method is *not* cancel safe.
     async fn update(
         &self,
-        operation: OperationWithClockTag,
+        mut operation: OperationWithClockTag,
         _wait: bool,
     ) -> CollectionResult<UpdateResult> {
         // If we apply `local_shard` update, we *have to* execute `remote_shard` update to completion
@@ -206,6 +209,10 @@ impl ShardOperation for ForwardProxyShard {
         // We always have to wait for the result of the update, cause after we release the lock,
         // the transfer needs to have access to the latest version of points.
         let mut result = self.wrapped_shard.update(operation.clone(), true).await?;
+
+        if self.shard_id != self.remote_shard.id {
+            operation.clock_tag = None;
+        }
 
         let remote_result = self
             .remote_shard

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -75,7 +75,7 @@ impl ShardReplicaSet {
             _ => unreachable!(),
         };
 
-        let proxy_shard = ForwardProxyShard::new(local_shard, remote_shard);
+        let proxy_shard = ForwardProxyShard::new(self.shard_id, local_shard, remote_shard);
         let _ = local.insert(Shard::ForwardProxy(proxy_shard));
 
         Ok(())
@@ -459,7 +459,7 @@ impl ShardReplicaSet {
         };
 
         let (local_shard, remote_shard) = queue_proxy.forget_updates_and_finalize();
-        let forward_proxy = ForwardProxyShard::new(local_shard, remote_shard);
+        let forward_proxy = ForwardProxyShard::new(self.shard_id, local_shard, remote_shard);
         let _ = local.insert(Shard::ForwardProxy(forward_proxy));
 
         Ok(())


### PR DESCRIPTION
Resharding shard transfer initializes `ForwardProxy` that forwards incoming updates from local shard `X` to remote shard `Y`.

Our clock tag logic does not work well enough in such case (though, it still _kinda_ works!), so we just remove clock tags during `ForwardProxy::update`, if `wrapped_shard` and `remote_shard` IDs are different.

**TODO (for a follow-up PR):**

When `ForwardProxy` forwards updates from one shard to *another* one, it should also "split" the operation with a hashring and only forward relevant *part* of the operation to the remote shard. (Or, alternatively, *remote* shard should split incoming operations and only apply relevant part.)

It seems a lot more annoying to implement, though, so I'll leave it for a separate PR.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
