### PR TITLE
Fix web UI index path http security headers

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -12,8 +12,10 @@ use std::sync::Arc;
 
 use ::api::grpc::models::{ApiResponse, ApiStatus, VersionInfo};
 use actix_cors::Cors;
+use actix_files::NamedFile;
 use actix_multipart::form::tempfile::TempFileConfig;
 use actix_multipart::form::MultipartFormConfig;
+use actix_web::http::header::{self, HeaderValue};
 use actix_web::middleware::{Compress, Condition, Logger};
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use actix_web_extras::middleware::Condition as ConditionEx;
@@ -46,6 +48,35 @@ use crate::tracing::LoggerHandle;
 
 const DEFAULT_STATIC_DIR: &str = "./static";
 const WEB_UI_PATH: &str = "/dashboard";
+
+struct WebUISettings {
+    static_folder: String,
+}
+
+impl WebUISettings {
+    pub fn new(static_folder: String) -> Self {
+        Self { static_folder }
+    }
+}
+
+async fn web_ui_index(
+    req: HttpRequest,
+    web_ui_settings: web::Data<WebUISettings>,
+) -> impl Responder {
+    match NamedFile::open(
+        Path::new(&web_ui_settings.static_folder)
+            .join("index.html")
+            .as_path(),
+    ) {
+        Ok(file) => {
+            let mut res = file.respond_to(&req);
+            res.headers_mut()
+                .insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+            res
+        }
+        Err(err) => HttpResponse::from_error(err),
+    }
+}
 
 #[get("/")]
 pub async fn index() -> impl Responder {
@@ -183,7 +214,22 @@ pub fn init(
 
             if web_ui_available {
                 app = app.service(
-                    actix_files::Files::new(WEB_UI_PATH, &static_folder).index_file("index.html"),
+                    actix_web::web::scope(WEB_UI_PATH)
+                        .app_data(actix_web::web::Data::new(WebUISettings::new(
+                            static_folder.to_owned(),
+                        )))
+                        .service(
+                            actix_web::web::resource("")
+                                .route(actix_web::web::get().to(web_ui_index)),
+                        )
+                        .service(
+                            actix_web::web::resource("/")
+                                .route(actix_web::web::get().to(web_ui_index)),
+                        )
+                        .service(
+                            actix_files::Files::new("/", &static_folder)
+                                .path_filter(|path, _| Path::new("index.html").ne(path)),
+                        ),
                 )
             }
             app

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -63,15 +63,14 @@ async fn web_ui_index(
     req: HttpRequest,
     web_ui_settings: web::Data<WebUISettings>,
 ) -> impl Responder {
-    match NamedFile::open(
-        Path::new(&web_ui_settings.static_folder)
-            .join("index.html")
-            .as_path(),
-    ) {
+    let path = Path::new(&web_ui_settings.static_folder).join("index.html");
+
+    match NamedFile::open_async(path).await {
         Ok(file) => {
             let mut res = file.respond_to(&req);
             res.headers_mut()
                 .insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+
             res
         }
         Err(err) => HttpResponse::from_error(err),

--- a/tools/sync-web-ui.sh
+++ b/tools/sync-web-ui.sh
@@ -10,7 +10,12 @@ OPENAPI_FILE=${OPENAPI_DIR:-"./docs/redoc/master/openapi.json"}
 # Get latest dist.zip, assume jq is installed
 DOWNLOAD_LINK=$(curl --silent "https://api.github.com/repos/qdrant/qdrant-web-ui/releases/latest" | jq -r '.assets[] | select(.name=="dist-qdrant.zip") | .browser_download_url')
 
-wget -O dist-qdrant.zip $DOWNLOAD_LINK
+if command -v wget &> /dev/null
+then
+    wget -O dist-qdrant.zip $DOWNLOAD_LINK
+else
+    curl -L -o dist-qdrant.zip $DOWNLOAD_LINK
+fi
 
 rm -rf "${STATIC_DIR}/"*
 unzip -o dist-qdrant.zip -d "${STATIC_DIR}"


### PR DESCRIPTION
The web-ui `/dashboard` endpoint can currently be embedded as an iframe. Adding the header `X-Frame-Options: DENY` shall protect against it.

In terms of the approach taken with actix_web, it would have been ideal if `actix_files::Files` allowed to set HTTP headers, but it only allows a handful of flags like `etag`, `last_modified` or `content_disposition`, which fall short of our needs.

This is why for the root path reading the `index.html` file a custom handler has been introduced: `web_ui_index`.

Awaiting for feedback in the approach before writing any kind of tests.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
