### PR TITLE
Fix new appendable segments not having payload indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5482,6 +5482,7 @@ dependencies = [
  "serde-value",
  "serde_cbor",
  "serde_json",
+ "serde_variant",
  "smallvec",
  "smol_str",
  "sparse",
@@ -5619,6 +5620,15 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_variant"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0068df419f9d9b6488fdded3f1c818522cdea328e02ce9d9f147380265a432"
+dependencies = [
  "serde",
 ]
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -102,6 +102,7 @@ impl Collection {
                     &to_replica_set.shard_path,
                     self.collection_config.clone(),
                     self.shared_storage_config.clone(),
+                    self.payload_index_schema.clone(),
                     self.update_runtime.clone(),
                     self.optimizer_cpu_budget.clone(),
                     effective_optimizers_config,

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -40,6 +40,7 @@ impl Collection {
             self.collection_config.clone(),
             effective_optimizers_config,
             self.shared_storage_config.clone(),
+            self.payload_index_schema.clone(),
             self.channel_service.clone(),
             self.update_runtime.clone(),
             self.search_runtime.clone(),

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -16,6 +16,7 @@ use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
 use segment::types::{PointIdType, SegmentConfig, SeqNumberType};
 
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::config::CollectionParams;
 use crate::operations::types::CollectionError;
@@ -829,6 +830,7 @@ impl<'s> SegmentHolder {
         &mut self,
         segments_path: &Path,
         collection_params: &CollectionParams,
+        _payload_index_schema: Option<&PayloadIndexSchema>,
     ) -> OperationResult<LockedSegment> {
         let segment = self.build_tmp_segment(segments_path, Some(collection_params), true)?;
         self.add_new_locked(segment.clone());

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -330,7 +330,7 @@ impl LocalShard {
             segment_holder.create_appendable_segment(
                 &segments_path,
                 &collection_params,
-                Some(&payload_index_schema),
+                &payload_index_schema,
             )?;
         }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -24,6 +24,7 @@ use super::local_shard::LocalShard;
 use super::remote_shard::RemoteShard;
 use super::transfer::ShardTransfer;
 use super::CollectionId;
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::common::snapshots_manager::SnapshotStorageManager;
 use crate::config::CollectionConfig;
 use crate::operations::shared_storage_config::SharedStorageConfig;
@@ -96,6 +97,7 @@ pub struct ShardReplicaSet {
     collection_config: Arc<RwLock<CollectionConfig>>,
     optimizers_config: OptimizersConfig,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
+    payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     update_runtime: Handle,
     search_runtime: Handle,
     optimizer_cpu_budget: CpuBudget,
@@ -125,6 +127,7 @@ impl ShardReplicaSet {
         collection_config: Arc<RwLock<CollectionConfig>>,
         effective_optimizers_config: OptimizersConfig,
         shared_storage_config: Arc<SharedStorageConfig>,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         channel_service: ChannelService,
         update_runtime: Handle,
         search_runtime: Handle,
@@ -139,6 +142,7 @@ impl ShardReplicaSet {
                 &shard_path,
                 collection_config.clone(),
                 shared_storage_config.clone(),
+                payload_index_schema.clone(),
                 update_runtime.clone(),
                 optimizer_cpu_budget.clone(),
                 effective_optimizers_config.clone(),
@@ -189,6 +193,7 @@ impl ShardReplicaSet {
             collection_config,
             optimizers_config: effective_optimizers_config,
             shared_storage_config,
+            payload_index_schema,
             update_runtime,
             search_runtime,
             optimizer_cpu_budget,
@@ -210,6 +215,7 @@ impl ShardReplicaSet {
         collection_config: Arc<RwLock<CollectionConfig>>,
         effective_optimizers_config: OptimizersConfig,
         shared_storage_config: Arc<SharedStorageConfig>,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         channel_service: ChannelService,
         on_peer_failure: ChangePeerState,
         abort_shard_transfer: AbortShardTransfer,
@@ -256,6 +262,7 @@ impl ShardReplicaSet {
                     collection_config.clone(),
                     effective_optimizers_config.clone(),
                     shared_storage_config.clone(),
+                    payload_index_schema.clone(),
                     update_runtime.clone(),
                     optimizer_cpu_budget.clone(),
                 )
@@ -303,6 +310,7 @@ impl ShardReplicaSet {
             collection_config,
             optimizers_config: effective_optimizers_config,
             shared_storage_config,
+            payload_index_schema,
             update_runtime,
             search_runtime,
             optimizer_cpu_budget,
@@ -469,6 +477,7 @@ impl ShardReplicaSet {
             &self.shard_path,
             self.collection_config.clone(),
             self.shared_storage_config.clone(),
+            self.payload_index_schema.clone(),
             self.update_runtime.clone(),
             self.optimizer_cpu_budget.clone(),
             self.optimizers_config.clone(),
@@ -653,6 +662,7 @@ impl ShardReplicaSet {
                     &self.shard_path,
                     self.collection_config.clone(),
                     self.shared_storage_config.clone(),
+                    self.payload_index_schema.clone(),
                     self.update_runtime.clone(),
                     self.optimizer_cpu_budget.clone(),
                     self.optimizers_config.clone(),

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -113,6 +113,7 @@ impl ShardReplicaSet {
                 self.collection_config.clone(),
                 self.optimizers_config.clone(),
                 self.shared_storage_config.clone(),
+                self.payload_index_schema.clone(),
                 self.update_runtime.clone(),
                 self.optimizer_cpu_budget.clone(),
             )

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -524,6 +524,7 @@ mod tests {
     use crate::operations::types::VectorsConfig;
     use crate::operations::vector_params_builder::VectorParamsBuilder;
     use crate::optimizers_builder::OptimizersConfig;
+    use crate::save_on_disk::SaveOnDisk;
     use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState};
 
     #[tokio::test]
@@ -580,6 +581,11 @@ mod tests {
             quantization_config: None,
         };
 
+        let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+        let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
         let shared_config = Arc::new(RwLock::new(config.clone()));
         let remotes = HashSet::from([2, 3, 4, 5]);
         ShardReplicaSet::build(
@@ -594,6 +600,7 @@ mod tests {
             shared_config,
             config.optimizer_config.clone(),
             Default::default(),
+            payload_index_schema,
             Default::default(),
             update_runtime,
             search_runtime,

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -16,6 +16,7 @@ use tokio::sync::{broadcast, RwLock};
 use super::replica_set::AbortShardTransfer;
 use super::resharding::{ReshardKey, ReshardStage, ReshardState};
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::common::validate_snapshot_archive::validate_open_snapshot_archive;
 use crate::config::{CollectionConfig, ShardingMethod};
 use crate::hash_ring::{self, HashRing};
@@ -796,6 +797,7 @@ impl ShardHolder {
         collection_config: Arc<RwLock<CollectionConfig>>,
         effective_optimizers_config: OptimizersConfig,
         shared_storage_config: Arc<SharedStorageConfig>,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         channel_service: ChannelService,
         on_peer_failure: ChangePeerState,
         abort_shard_transfer: AbortShardTransfer,
@@ -841,6 +843,7 @@ impl ShardHolder {
                     collection_config.clone(),
                     effective_optimizers_config.clone(),
                     shared_storage_config.clone(),
+                    payload_index_schema.clone(),
                     channel_service.clone(),
                     on_peer_failure.clone(),
                     abort_shard_transfer.clone(),
@@ -862,6 +865,7 @@ impl ShardHolder {
                             collection_config.clone(),
                             effective_optimizers_config.clone(),
                             shared_storage_config.clone(),
+                            payload_index_schema.clone(),
                             update_runtime.clone(),
                             optimizer_cpu_budget.clone(),
                         )
@@ -888,6 +892,7 @@ impl ShardHolder {
                             collection_config.clone(),
                             effective_optimizers_config.clone(),
                             shared_storage_config.clone(),
+                            payload_index_schema.clone(),
                             update_runtime.clone(),
                             optimizer_cpu_budget.clone(),
                         )

--- a/lib/collection/src/tests/fix_payload_indices.rs
+++ b/lib/collection/src/tests/fix_payload_indices.rs
@@ -82,9 +82,11 @@ async fn test_fix_payload_indices() {
     .unwrap();
 
     let info = shard.info().await.unwrap();
-    assert!(!info
-        .payload_schema
-        .contains_key(&"location".parse().unwrap()));
+    // Deleting existing payload index is not supported
+    // assert!(!info
+    //     .payload_schema
+    //     .contains_key(&"location".parse().unwrap()));
+
     assert_eq!(
         info.payload_schema
             .get(&"a".parse().unwrap())

--- a/lib/collection/src/tests/fix_payload_indices.rs
+++ b/lib/collection/src/tests/fix_payload_indices.rs
@@ -12,7 +12,7 @@ use crate::shards::shard_trait::ShardOperation;
 use crate::tests::fixtures::*;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_delete_from_indexed_payload() {
+async fn test_fix_payload_indices() {
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
 
     let config = create_collection_config();
@@ -41,55 +41,31 @@ async fn test_delete_from_indexed_payload() {
     .unwrap();
 
     let upsert_ops = upsert_operation();
-
     shard.update(upsert_ops.into(), true).await.unwrap();
 
+    // Create payload index in shard locally, not in global collection configuration
     let index_op = create_payload_index_operation();
-
-    payload_index_schema
-        .write(|schema| {
-            schema.schema.insert(
-                "location".parse().unwrap(),
-                PayloadFieldSchema::FieldType(PayloadSchemaType::Geo),
-            );
-        })
-        .unwrap();
     shard.update(index_op.into(), true).await.unwrap();
 
     let delete_point_op = delete_point_operation(4);
     shard.update(delete_point_op.into(), true).await.unwrap();
 
-    let info = shard.info().await.unwrap();
-    eprintln!("info = {:#?}", info.payload_schema);
-    let number_of_indexed_points = info
-        .payload_schema
-        .get(&"location".parse().unwrap())
-        .unwrap()
-        .points;
+    std::thread::sleep(std::time::Duration::from_secs(1));
 
     drop(shard);
 
-    let shard = LocalShard::load(
-        0,
-        collection_name.clone(),
-        collection_dir.path(),
-        Arc::new(RwLock::new(config.clone())),
-        config.optimizer_config.clone(),
-        Arc::new(Default::default()),
-        payload_index_schema.clone(),
-        current_runtime.clone(),
-        CpuBudget::default(),
-    )
-    .await
-    .unwrap();
-
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-    eprintln!("dropping point 5");
-    let delete_point_op = delete_point_operation(5);
-    shard.update(delete_point_op.into(), true).await.unwrap();
-
-    drop(shard);
+    payload_index_schema
+        .write(|schema| {
+            schema.schema.insert(
+                "a".parse().unwrap(),
+                PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
+            );
+            schema.schema.insert(
+                "b".parse().unwrap(),
+                PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword),
+            );
+        })
+        .unwrap();
 
     let shard = LocalShard::load(
         0,
@@ -106,14 +82,21 @@ async fn test_delete_from_indexed_payload() {
     .unwrap();
 
     let info = shard.info().await.unwrap();
-    eprintln!("info = {:#?}", info.payload_schema);
-
-    let number_of_indexed_points_after_load = info
+    assert!(!info
         .payload_schema
-        .get(&"location".parse().unwrap())
-        .unwrap()
-        .points;
-
-    assert_eq!(number_of_indexed_points, 4);
-    assert_eq!(number_of_indexed_points_after_load, 3);
+        .contains_key(&"location".parse().unwrap()));
+    assert_eq!(
+        info.payload_schema
+            .get(&"a".parse().unwrap())
+            .unwrap()
+            .data_type,
+        PayloadSchemaType::Integer
+    );
+    assert_eq!(
+        info.payload_schema
+            .get(&"b".parse().unwrap())
+            .unwrap()
+            .data_type,
+        PayloadSchemaType::Keyword
+    );
 }

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod fix_payload_indices;
 pub mod fixtures;
 mod points_dedup;
 mod sha_256_test;

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -20,6 +20,7 @@ use segment::types::{Distance, PointIdType};
 use tempfile::Builder;
 use tokio::time::{sleep, Instant};
 
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection::Collection;
 use crate::collection_manager::fixtures::{
     get_indexing_optimizer, get_merge_optimizer, random_segment, PointIdGenerator,
@@ -222,6 +223,7 @@ async fn test_new_segment_when_all_over_capacity() {
         memmap_threshold_kb: 1_000_000,
         indexing_threshold_kb: 1_000_000,
     };
+    let payload_index_schema = PayloadIndexSchema::default();
     let mut holder = SegmentHolder::default();
 
     holder.add_new(random_segment(dir.path(), 100, 3, dim));
@@ -241,6 +243,7 @@ async fn test_new_segment_when_all_over_capacity() {
         dir.path(),
         &collection_params,
         &optimizer_thresholds,
+        &payload_index_schema,
     )
     .unwrap();
     assert_eq!(segments.read().len(), 6);
@@ -251,6 +254,7 @@ async fn test_new_segment_when_all_over_capacity() {
         dir.path(),
         &collection_params,
         &optimizer_thresholds,
+        &payload_index_schema,
     )
     .unwrap();
 
@@ -288,6 +292,7 @@ async fn test_new_segment_when_all_over_capacity() {
         dir.path(),
         &collection_params,
         &optimizer_thresholds,
+        &payload_index_schema,
     )
     .unwrap();
     assert_eq!(segments.read().len(), 7);

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -12,6 +12,7 @@ use crate::operations::types::CollectionError;
 use crate::operations::universal_query::shard_query::{
     Fusion, ScoringQuery, ShardPrefetch, ShardQueryRequest,
 };
+use crate::save_on_disk::SaveOnDisk;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
 use crate::tests::fixtures::*;
@@ -26,12 +27,18 @@ async fn test_shard_query_rrf_rescoring() {
 
     let current_runtime: Handle = Handle::current();
 
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
     let shard = LocalShard::build(
         0,
         collection_name.clone(),
         collection_dir.path(),
         Arc::new(RwLock::new(config.clone())),
         Arc::new(Default::default()),
+        payload_index_schema,
         current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),
@@ -204,12 +211,18 @@ async fn test_shard_query_vector_rescoring() {
 
     let current_runtime: Handle = Handle::current();
 
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
     let shard = LocalShard::build(
         0,
         collection_name.clone(),
         collection_dir.path(),
         Arc::new(RwLock::new(config.clone())),
         Arc::new(Default::default()),
+        payload_index_schema,
         current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),
@@ -329,12 +342,18 @@ async fn test_shard_query_payload_vector() {
 
     let current_runtime: Handle = Handle::current();
 
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
     let shard = LocalShard::build(
         0,
         collection_name.clone(),
         collection_dir.path(),
         Arc::new(RwLock::new(config.clone())),
         Arc::new(Default::default()),
+        payload_index_schema,
         current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -5,6 +5,7 @@ use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
+use crate::save_on_disk::SaveOnDisk;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
 use crate::tests::fixtures::*;
@@ -19,12 +20,18 @@ async fn test_delete_from_indexed_payload() {
 
     let current_runtime: Handle = Handle::current();
 
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
     let shard = LocalShard::build(
         0,
         collection_name.clone(),
         collection_dir.path(),
         Arc::new(RwLock::new(config.clone())),
         Arc::new(Default::default()),
+        payload_index_schema.clone(),
         current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),
@@ -60,6 +67,7 @@ async fn test_delete_from_indexed_payload() {
         Arc::new(RwLock::new(config.clone())),
         config.optimizer_config.clone(),
         Arc::new(Default::default()),
+        payload_index_schema.clone(),
         current_runtime.clone(),
         CpuBudget::default(),
     )
@@ -81,6 +89,7 @@ async fn test_delete_from_indexed_payload() {
         Arc::new(RwLock::new(config.clone())),
         config.optimizer_config.clone(),
         Arc::new(Default::default()),
+        payload_index_schema,
         current_runtime,
         CpuBudget::default(),
     )

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use common::cpu::CpuBudget;
+use segment::types::{PayloadFieldSchema, PayloadSchemaType};
 use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
@@ -45,6 +46,9 @@ async fn test_delete_from_indexed_payload() {
 
     let index_op = create_payload_index_operation();
 
+    payload_index_schema.write(|schema| {
+        schema.schema.insert("location".parse().unwrap(), PayloadFieldSchema::FieldType(PayloadSchemaType::Geo));
+    }).unwrap();
     shard.update(index_op.into(), true).await.unwrap();
 
     let delete_point_op = delete_point_operation(4);

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -424,7 +424,7 @@ impl UpdateHandler {
             segments.write().create_appendable_segment(
                 segments_path,
                 collection_params,
-                Some(payload_index_schema),
+                payload_index_schema,
             )?;
         }
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -19,6 +19,7 @@ use tokio::task::{self, JoinHandle};
 use tokio::time::error::Elapsed;
 use tokio::time::{timeout, Duration};
 
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::collection_manager::holders::segment_holder::LockedSegmentHolder;
 use crate::collection_manager::optimizers::segment_optimizer::{
@@ -30,6 +31,7 @@ use crate::config::CollectionParams;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
+use crate::save_on_disk::SaveOnDisk;
 use crate::shards::local_shard::LocalShardClocks;
 use crate::wal::WalError;
 use crate::wal_delta::LockedWal;
@@ -81,6 +83,7 @@ pub enum OptimizerSignal {
 /// Structure, which holds object, required for processing updates of the collection
 pub struct UpdateHandler {
     shared_storage_config: Arc<SharedStorageConfig>,
+    payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     /// List of used optimizers
     pub optimizers: Arc<Vec<Arc<Optimizer>>>,
     /// Log of optimizer statuses
@@ -123,6 +126,7 @@ impl UpdateHandler {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         shared_storage_config: Arc<SharedStorageConfig>,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         optimizers_log: Arc<Mutex<TrackerLog>>,
         optimizer_cpu_budget: CpuBudget,
@@ -136,6 +140,7 @@ impl UpdateHandler {
     ) -> UpdateHandler {
         UpdateHandler {
             shared_storage_config,
+            payload_index_schema,
             optimizers,
             segments,
             update_worker: None,
@@ -169,6 +174,7 @@ impl UpdateHandler {
             self.optimizer_cpu_budget.clone(),
             self.max_optimization_threads,
             self.has_triggered_optimizers.clone(),
+            self.payload_index_schema.clone(),
         )));
         self.update_worker = Some(self.runtime_handle.spawn(Self::update_worker_fn(
             update_receiver,
@@ -391,6 +397,7 @@ impl UpdateHandler {
         segments_path: &Path,
         collection_params: &CollectionParams,
         thresholds_config: &OptimizerThresholds,
+        payload_index_schema: &PayloadIndexSchema,
     ) -> OperationResult<()> {
         let no_segment_with_capacity = {
             let segments_read = segments.read();
@@ -414,9 +421,11 @@ impl UpdateHandler {
 
         if no_segment_with_capacity {
             log::debug!("Creating new appendable segment, all existing segments are over capacity");
-            segments
-                .write()
-                .create_appendable_segment(segments_path, collection_params)?;
+            segments.write().create_appendable_segment(
+                segments_path,
+                collection_params,
+                Some(payload_index_schema),
+            )?;
         }
 
         Ok(())
@@ -505,6 +514,7 @@ impl UpdateHandler {
         optimizer_cpu_budget: CpuBudget,
         max_handles: Option<usize>,
         has_triggered_optimizers: Arc<AtomicBool>,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     ) {
         let max_handles = max_handles.unwrap_or(usize::MAX);
         let max_indexing_threads = optimizers
@@ -539,6 +549,7 @@ impl UpdateHandler {
                             optimizer.segments_path(),
                             &optimizer.collection_params(),
                             optimizer.threshold_config(),
+                            &payload_index_schema.read(),
                         );
                         if let Err(err) = result {
                             log::error!("Failed to ensure there are appendable segments with capacity: {err}");

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -44,6 +44,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_cbor = { workspace = true }
 serde-value = "0.7"
+serde_variant = "0.1.3"
 serde-untagged = "0.1.6"
 ordered-float = "4.2"
 thiserror = "1.0"

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -944,7 +944,6 @@ impl Segment {
             }
         }
 
-
         // Do not delete extra payload indices, because collection-level information about
         // the payload indices might be incomplete due to migrations from older versions.
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -911,6 +911,57 @@ impl Segment {
         Ok(())
     }
 
+    /// Update all payload/field indices to match `desired_schemas`
+    ///
+    /// Missing payload indices are created. Incorrectly configured payload indices are recreated.
+    /// Extra payload indices are deleted.
+    ///
+    /// This does nothing if the current payload indices state matches `desired_schemas` exactly.
+    pub fn update_all_field_indices(
+        &mut self,
+        desired_schemas: &HashMap<PayloadKeyType, PayloadFieldSchema>,
+    ) -> OperationResult<()> {
+        let schema_applied = self.payload_index.borrow().indexed_fields();
+        let schema_config = desired_schemas;
+
+        // Create or update payload indices if they don't match configuration
+        for (key, schema) in schema_config {
+            match schema_applied.get(key) {
+                Some(existing_schema) if existing_schema == schema => continue,
+                Some(existing_schema) => log::warn!("Segment has incorrect payload index for{key}, recreating it now (current: {:?}, configured: {:?})",
+                    existing_schema.name(),
+                    schema.name(),
+                ),
+                None => log::warn!(
+                    "Segment is missing a {} payload index for {key}, creating it now",
+                    schema.name(),
+                ),
+            }
+
+            let created = self.create_field_index(self.version(), key, Some(schema))?;
+            if !created {
+                log::warn!("Failed to create payload index for {key} in segment");
+            }
+        }
+
+        // Remove existing payload indices not in the configuration
+        for key in schema_applied.keys() {
+            if schema_config.contains_key(key) {
+                continue;
+            }
+
+            log::warn!(
+                "Segment has payload index for {key} which is not configured, deleting it now"
+            );
+            let deleted = self.delete_field_index(self.version(), key)?;
+            if !deleted {
+                log::warn!("Failed to delete payload index for {key} in segment");
+            }
+        }
+
+        Ok(())
+    }
+
     /// Check data consistency of the segment
     /// - internal id without external id
     /// - external id without internal

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -914,7 +914,7 @@ impl Segment {
     /// Update all payload/field indices to match `desired_schemas`
     ///
     /// Missing payload indices are created. Incorrectly configured payload indices are recreated.
-    /// Extra payload indices are deleted.
+    /// Extra payload indices are NOT deleted.
     ///
     /// This does nothing if the current payload indices state matches `desired_schemas` exactly.
     pub fn update_all_field_indices(
@@ -944,20 +944,9 @@ impl Segment {
             }
         }
 
-        // Remove existing payload indices not in the configuration
-        for key in schema_applied.keys() {
-            if schema_config.contains_key(key) {
-                continue;
-            }
 
-            log::warn!(
-                "Segment has payload index for {key} which is not configured, deleting it now"
-            );
-            let deleted = self.delete_field_index(self.version(), key)?;
-            if !deleted {
-                log::warn!("Failed to delete payload index for {key} in segment");
-            }
-        }
+        // Do not delete extra payload indices, because collection-level information about
+        // the payload indices might be incomplete due to migrations from older versions.
 
         Ok(())
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1155,12 +1155,26 @@ pub enum PayloadSchemaType {
     Datetime,
 }
 
+impl PayloadSchemaType {
+    /// Human readable type name
+    pub fn name(&self) -> &'static str {
+        serde_variant::to_variant_name(&self).unwrap_or("unknown")
+    }
+}
+
 /// Payload type with parameters
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum PayloadSchemaParams {
     Text(TextIndexParams),
     Integer(IntegerIndexParams),
+}
+
+impl PayloadSchemaParams {
+    /// Human readable type name
+    pub fn name(&self) -> &'static str {
+        serde_variant::to_variant_name(&self).unwrap_or("unknown")
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
@@ -1187,6 +1201,14 @@ impl PayloadFieldSchema {
                 range,
                 ..
             })) => *range,
+        }
+    }
+
+    /// Human readable type name
+    pub fn name(&self) -> &'static str {
+        match self {
+            PayloadFieldSchema::FieldType(field_type) => field_type.name(),
+            PayloadFieldSchema::FieldParams(field_params) => field_params.name(),
         }
     }
 }

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -111,6 +111,25 @@ def drop_collection(peer_url, collection="test_collection", timeout=10, headers=
     assert_http_ok(r_delete)
 
 
+def create_field_index(
+    peer_url,
+    collection="test_collection",
+    field_name="city",
+    field_schema="keyword",
+    headers={},
+):
+    # Create collection in peer_url
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}/index",
+        json={
+            "field_name": field_name,
+            "field_schema": field_schema,
+        },
+        headers=headers,
+    )
+    assert_http_ok(r_batch)
+
+
 def search(peer_url, vector, city, collection="test_collection"):
     q = {
         "vector": vector,

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -118,7 +118,7 @@ def create_field_index(
     field_schema="keyword",
     headers={},
 ):
-    # Create collection in peer_url
+    # Create field index in peer_url
     r_batch = requests.put(
         f"{peer_url}/collections/{collection}/index",
         json={

--- a/tests/consensus_tests/test_segment_max_size.py
+++ b/tests/consensus_tests/test_segment_max_size.py
@@ -1,0 +1,50 @@
+import multiprocessing
+import pathlib
+import random
+from time import sleep
+
+from .fixtures import upsert_random_points, create_collection, create_field_index
+from .utils import *
+
+COLLECTION_NAME = "test_collection"
+
+
+# Test node recovery with a WAL delta transfer.
+#
+# The second node is killed while operations are ongoing. We later restart the
+# node, and manually trigger rereplication to sync it up again.
+#
+# Test that data on the both sides is consistent
+def test_max_segment_size(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    # Set a low segment size limit and disable indexing
+    env={
+        "QDRANT__STORAGE__OPTIMIZERS__DEFAULT_SEGMENT_NUMBER": "2",
+        "QDRANT__STORAGE__OPTIMIZERS__MAX_SEGMENT_SIZE_KB": "1",
+        "QDRANT__STORAGE__OPTIMIZERS__INDEXING_THRESHOLD_KB": "0",
+    }
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 1, 20000, extra_env=env)
+
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=1)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+    create_field_index(peer_api_uris[0], COLLECTION_NAME, "city", "keyword")
+
+    collection_cluster_info_before = get_collection_info(peer_api_uris[0], COLLECTION_NAME)
+
+    assert collection_cluster_info_before["segments_count"] == 2
+    assert collection_cluster_info_before["payload_schema"]["city"]["points"] == 0
+
+    upsert_random_points(peer_api_uris[0], 20, batch_size=5)
+
+    collection_cluster_info_after = get_collection_info(peer_api_uris[0], COLLECTION_NAME)
+
+    # Number of segments must have grown due to limited segment size
+    assert collection_cluster_info_before["segments_count"] < collection_cluster_info_after["segments_count"]
+
+    # We must have indexed all points
+    assert collection_cluster_info_after["payload_schema"]["city"]["points"] == 20

--- a/tests/consensus_tests/test_segment_max_size.py
+++ b/tests/consensus_tests/test_segment_max_size.py
@@ -9,12 +9,13 @@ from .utils import *
 COLLECTION_NAME = "test_collection"
 
 
-# Test node recovery with a WAL delta transfer.
+# Test that the maximum segment size property is respected
 #
-# The second node is killed while operations are ongoing. We later restart the
-# node, and manually trigger rereplication to sync it up again.
+# It sets a very low limit and inserts some points. Qdrant should dynamically
+# create a few new appendable segments for all the data to fit.
 #
-# Test that data on the both sides is consistent
+# It also confirms payload indices are configured properly and all payload
+# fields are indexed.
 def test_max_segment_size(tmp_path: pathlib.Path):
     assert_project_root()
 


### PR DESCRIPTION
We had a case where payload indexes were missing from some segments. This was caused by <https://github.com/qdrant/qdrant/pull/4416> not configuring these.

This primarily does two things:
- when creating a new appendable segment (if all are at max_segment_size capacity), create configured payload indexes in them
- when loading segments, re-apply the configure payload indexes if there are any differences

It can easily be tested with the following command, where before this PR it would not index a lot of points:

```bash
bfb -n 100000 -d 256 --keywords 10 --indexing-threshold 0 --max-segment-size 1000
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?