### PR TITLE
Split-by-shard when forwarding operations during resharding shard transfer

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -261,7 +261,7 @@ pub struct RemoteShardInfo {
 
 /// `Acknowledged` - Request is saved to WAL and will be process in a queue.
 /// `Completed` - Request is completed, changes are actual.
-#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateStatus {
     Acknowledged,
@@ -271,7 +271,7 @@ pub enum UpdateStatus {
     ClockRejected,
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct UpdateResult {
     /// Sequential number of the operation

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -23,7 +23,7 @@ impl ShardReplicaSet {
     pub async fn proxify_local(
         &self,
         remote_shard: RemoteShard,
-        hash_ring: Option<HashRing>,
+        resharding_hash_ring: Option<HashRing>,
     ) -> CollectionResult<()> {
         let mut local = self.local.write().await;
 
@@ -79,8 +79,12 @@ impl ShardReplicaSet {
             _ => unreachable!(),
         };
 
-        let proxy_shard =
-            ForwardProxyShard::new(self.shard_id, local_shard, remote_shard, hash_ring);
+        let proxy_shard = ForwardProxyShard::new(
+            self.shard_id,
+            local_shard,
+            remote_shard,
+            resharding_hash_ring,
+        );
         let _ = local.insert(Shard::ForwardProxy(proxy_shard));
 
         Ok(())

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -51,13 +51,16 @@ pub(crate) async fn transfer_resharding_stream_records(
             .get_shard_id_to_key_mapping()
             .get(&shard_id)
             .cloned();
+
         hashring = shard_holder.rings.get(&shard_key).cloned().ok_or_else(|| {
             CollectionError::service_error(format!(
                 "Shard {shard_id} cannot be transferred for resharding, failed to get shard hash ring"
             ))
         })?;
 
-        replica_set.proxify_local(remote_shard.clone()).await?;
+        replica_set
+            .proxify_local(remote_shard.clone(), Some(hashring.clone()))
+            .await?;
 
         let Some(count_result) = replica_set
             .count_local(Arc::new(CountRequestInternal {

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -43,7 +43,9 @@ pub(super) async fn transfer_stream_records(
             )));
         };
 
-        replica_set.proxify_local(remote_shard.clone()).await?;
+        replica_set
+            .proxify_local(remote_shard.clone(), None)
+            .await?;
 
         let Some(count_result) = replica_set
             .count_local(Arc::new(CountRequestInternal {


### PR DESCRIPTION
Tracked in #4213.
Follow-up to #4516.

Resharding shard transfer initializes `ForwardProxyShard` that forwards incoming updates from local shard `X` to remote shard `Y`.

In such case, `ForwardProxyShard` should additionally split operation by shard, and only forward a *part* of operation, that belongs to the remote shard.

E.g.:
- we are resharding from 2 shards to 3 shards
- there's a resharding shard transfer from shard 1 to shard 3
  - and so, there's a `ForwardProxyShard` from shard 1 to shard 3
- user sends `upsert 42, 69, 128, 228, 666, 1337`
- we split-by-shard on the collection/shard-holder level and get
  - shard 1: `upsert 42, 128, 228`
  - shard 2: `upsert 69, 666, 1337`
  - shard 3: `upsert 42, 69`
- now, imagine if we go down the callstack, to the local shard of shard 1 replica set
- it is a `ForwardProxyShard`, so `ForwardProxyShard::update` is called
- the operation is already split-by-shard on collection/shard-holder level
- so we will be forwarding `upsert 42, 128, 228`
- but in case of *resharding* shard transfer, we only have to forward `upsert 42`
- so we have to, once again, split-by-shard this operation, to only forward relevant part of it to remote shard

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
