### PR TITLE
order_by: Begin migration to `order_value` in `Record`

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3387,6 +3387,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | payload | [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry) | repeated |  |
 | vectors | [Vectors](#qdrant-Vectors) | optional |  |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
+| order_value | [OrderValue](#qdrant-OrderValue) | optional | Order-by value |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6468,6 +6468,16 @@
                 "nullable": true
               }
             ]
+          },
+          "order_value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrderValue"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -6553,6 +6563,18 @@
             }
           }
         }
+      },
+      "OrderValue": {
+        "anyOf": [
+          {
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "type": "number",
+            "format": "double"
+          }
+        ]
       },
       "SearchRequest": {
         "description": "Search request. Holds all conditions and parameters for the search of most similar points by vector similarity given the filtering restrictions.",
@@ -7388,18 +7410,6 @@
             ]
           }
         }
-      },
-      "OrderValue": {
-        "anyOf": [
-          {
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "type": "number",
-            "format": "double"
-          }
-        ]
       },
       "UpdateResult": {
         "type": "object",

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -724,6 +724,7 @@ message RetrievedPoint {
   reserved 3; // deprecated "vector" field
   optional Vectors vectors = 4;
   optional ShardKey shard_key = 5; // Shard key
+  optional OrderValue order_value = 6; // Order-by value
 }
 
 message GetResponse {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5300,6 +5300,9 @@ pub struct RetrievedPoint {
     /// Shard key
     #[prost(message, optional, tag = "5")]
     pub shard_key: ::core::option::Option<ShardKey>,
+    /// Order-by value
+    #[prost(message, optional, tag = "6")]
+    pub order_value: ::core::option::Option<OrderValue>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -102,6 +102,8 @@ pub struct Record {
     /// Shard Key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<segment::types::ShardKey>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_value: Option<segment::data_types::order_by::OrderValue>,
 }
 
 /// Vector data separator for named and unnamed modes

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -294,14 +294,18 @@ impl Collection {
                 retrieved_iter
                     // Extract and remove order value from payload
                     .map(|records| {
+                        // TODO(1.11): read value only from record.order_value, remove & cleanup this part
                         records.into_iter().map(|mut record| {
                             let value;
                             if local_only {
-                                value =
-                                    order_by.get_order_value_from_payload(record.payload.as_ref());
+                                value = record.order_value.unwrap_or_else(|| {
+                                    order_by.get_order_value_from_payload(record.payload.as_ref())
+                                });
                             } else {
-                                value = order_by
-                                    .remove_order_value_from_payload(record.payload.as_mut());
+                                value = record.order_value.unwrap_or_else(|| {
+                                    order_by
+                                        .remove_order_value_from_payload(record.payload.as_mut())
+                                });
                                 if !with_payload_interface.is_required() {
                                     // Use None instead of empty hashmap
                                     record.payload = None;

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -388,6 +388,7 @@ impl SegmentsSearcher {
                             vector.map(Into::into)
                         },
                         shard_key: None,
+                        order_value: None,
                     },
                 );
                 point_version.insert(id, version);

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -136,11 +136,17 @@ pub fn try_record_from_grpc(
         .map(|vectors| vectors.try_into())
         .transpose()?;
 
+    let order_value = point
+        .order_value
+        .map(|ov| TryFrom::try_from(ov))
+        .transpose()?;
+
     Ok(Record {
         id,
         payload,
         vector,
         shard_key: convert_shard_key_from_grpc_opt(point.shard_key),
+        order_value,
     })
 }
 
@@ -444,6 +450,7 @@ impl From<Record> for api::grpc::qdrant::RetrievedPoint {
             payload: record.payload.map(payload_to_proto).unwrap_or_default(),
             vectors: vectors.map(api::grpc::qdrant::Vectors::from),
             shard_key: record.shard_key.map(convert_shard_key_to_grpc),
+            order_value: record.order_value.map(From::from),
         }
     }
 }

--- a/lib/collection/src/operations/conversions_rest.rs
+++ b/lib/collection/src/operations/conversions_rest.rs
@@ -9,6 +9,7 @@ impl From<Record> for api::rest::Record {
             payload: value.payload,
             vector: value.vector.map(api::rest::VectorStruct::from),
             shard_key: value.shard_key,
+            order_value: value.order_value,
         }
     }
 }
@@ -20,6 +21,7 @@ impl From<api::rest::Record> for Record {
             payload: value.payload,
             vector: value.vector.map(VectorStructInternal::from),
             shard_key: value.shard_key,
+            order_value: value.order_value,
         }
     }
 }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -57,6 +57,7 @@ impl TryFrom<Record> for PointStruct {
             payload,
             vector,
             shard_key: _,
+            order_value: _,
         } = record;
 
         if vector.is_none() {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -21,6 +21,7 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::common::operation_error::OperationError;
 use segment::data_types::groups::GroupId;
+use segment::data_types::order_by::OrderValue;
 use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStructInternal, DEFAULT_VECTOR_NAME,
 };
@@ -98,6 +99,8 @@ pub struct Record {
     pub vector: Option<VectorStructInternal>,
     /// Shard Key
     pub shard_key: Option<ShardKey>,
+    /// Order value, if used for order_by
+    pub order_value: Option<OrderValue>,
 }
 
 /// Current statistics and configuration of the collection

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -139,11 +139,13 @@ impl ShardOperation for LocalShard {
                     .await?;
 
                 records.iter_mut().zip(values).for_each(|(record, value)| {
+                    // TODO(1.11): stop inserting the value in the payload, only use the order_value
                     // Add order_by value to the payload. It will be removed in the next step, after crossing the shard boundary.
                     let new_payload =
                         OrderBy::insert_order_value_in_payload(record.payload.take(), value);
 
                     record.payload = Some(new_payload);
+                    record.order_value = Some(value);
                 });
 
                 Ok(records)


### PR DESCRIPTION
Adds a skippable `order_value` field to `Record`, in the same way as it is now for `ScoredPoint`.

This will help us get rid of the insert-value-in-payload hack in 1.11. For now we will insert and read at the field AND the payload.

Interface change: now the value by which the record is ordered will be shown to the user