### PR TITLE
Histogram save load

### DIFF
--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -138,8 +138,7 @@ impl<T: Numericable + Serialize + DeserializeOwned> Histogram<T> {
     }
 
     #[allow(dead_code)]
-    pub fn load(path: impl AsRef<Path>) -> OperationResult<Self> {
-        let path = path.as_ref().to_owned();
+    pub fn load(path: &Path) -> OperationResult<Self> {
         let config_path = path.join(CONFIG_PATH);
         let borders_path = path.join(BORDERS_PATH);
 
@@ -155,8 +154,7 @@ impl<T: Numericable + Serialize + DeserializeOwned> Histogram<T> {
     }
 
     #[allow(dead_code)]
-    pub fn save(&self, path: impl AsRef<Path>) -> OperationResult<()> {
-        let path = path.as_ref().to_owned();
+    pub fn save(&self, path: &Path) -> OperationResult<()> {
         let config_path = path.join(CONFIG_PATH);
         let borders_path = path.join(BORDERS_PATH);
 

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -17,7 +17,7 @@ const MIN_BUCKET_SIZE: usize = 10;
 const CONFIG_PATH: &str = "histogram_config.json";
 const BORDERS_PATH: &str = "histogram_borders.bin";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Counts {
     pub left: usize,
     pub right: usize,
@@ -110,7 +110,7 @@ impl Numericable for f64 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Histogram<T: Numericable + Serialize + DeserializeOwned> {
     max_bucket_size: usize,
     precision: f64,

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -2,21 +2,28 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Included, Unbounded};
 use std::ops::Bound;
+use std::path::Path;
 
+use io::file_operations::{atomic_save_bin, atomic_save_json, read_bin, read_json};
 use itertools::Itertools;
 use num_traits::{Num, Signed};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
+use crate::common::operation_error::OperationResult;
 use crate::index::field_index::utils::check_boundaries;
 
 const MIN_BUCKET_SIZE: usize = 10;
+const CONFIG_PATH: &str = "histogram_config.json";
+const BORDERS_PATH: &str = "histogram_borders.bin";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Counts {
     pub left: usize,
     pub right: usize,
 }
 
-#[derive(PartialEq, PartialOrd, Debug, Clone)]
+#[derive(PartialEq, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 pub struct Point<T> {
     pub val: T,
     pub idx: usize,
@@ -104,14 +111,21 @@ impl Numericable for f64 {
 }
 
 #[derive(Debug)]
-pub struct Histogram<T: Numericable + PartialEq + PartialOrd + Copy> {
+pub struct Histogram<T: Numericable + Serialize + DeserializeOwned> {
     max_bucket_size: usize,
     precision: f64,
     total_count: usize,
     borders: BTreeMap<Point<T>, Counts>,
 }
 
-impl<T: Numericable> Histogram<T> {
+#[derive(Debug, Serialize, Deserialize)]
+struct HistogramConfig {
+    max_bucket_size: usize,
+    precision: f64,
+    total_count: usize,
+}
+
+impl<T: Numericable + Serialize + DeserializeOwned> Histogram<T> {
     pub fn new(max_bucket_size: usize, precision: f64) -> Self {
         assert!(precision < 1.0);
         assert!(precision > 0.0);
@@ -121,6 +135,47 @@ impl<T: Numericable> Histogram<T> {
             total_count: 0,
             borders: BTreeMap::default(),
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn load(path: impl AsRef<Path>) -> OperationResult<Self> {
+        let path = path.as_ref().to_owned();
+        let config_path = path.join(CONFIG_PATH);
+        let borders_path = path.join(BORDERS_PATH);
+
+        let histogram_config: HistogramConfig = read_json(&config_path)?;
+        let histogram_buckets: Vec<(Point<T>, Counts)> = read_bin(&borders_path)?;
+
+        Ok(Self {
+            max_bucket_size: histogram_config.max_bucket_size,
+            precision: histogram_config.precision,
+            total_count: histogram_config.total_count,
+            borders: histogram_buckets.into_iter().collect(),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn save(&self, path: impl AsRef<Path>) -> OperationResult<()> {
+        let path = path.as_ref().to_owned();
+        let config_path = path.join(CONFIG_PATH);
+        let borders_path = path.join(BORDERS_PATH);
+
+        atomic_save_json(
+            &config_path,
+            &HistogramConfig {
+                max_bucket_size: self.max_bucket_size,
+                precision: self.precision,
+                total_count: self.total_count,
+            },
+        )?;
+
+        let borders: Vec<(Point<T>, Counts)> = self
+            .borders
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        atomic_save_bin(&borders_path, &borders)?;
+        Ok(())
     }
 
     #[cfg(test)]

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -15,6 +15,8 @@ use common::types::PointOffsetType;
 use mutable_numeric_index::MutableNumericIndex;
 use parking_lot::RwLock;
 use rocksdb::DB;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use serde_json::Value;
 
 use self::immutable_numeric_index::{ImmutableNumericIndex, NumericIndexKey};
@@ -47,7 +49,7 @@ pub trait StreamRange<T> {
     ) -> Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_>;
 }
 
-pub trait Encodable: Copy {
+pub trait Encodable: Copy + Serialize + DeserializeOwned {
     fn encode_key(&self, id: PointOffsetType) -> Vec<u8>;
 
     fn decode_key(key: &[u8]) -> (PointOffsetType, Self);

--- a/lib/segment/src/index/field_index/tests/histogram_test_utils.rs
+++ b/lib/segment/src/index/field_index/tests/histogram_test_utils.rs
@@ -3,10 +3,13 @@ use std::fmt::Display;
 use std::io;
 use std::io::Write;
 
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 
 #[allow(dead_code)]
-pub fn print_results<T: Numericable + Display>(
+pub fn print_results<T: Numericable + Serialize + DeserializeOwned + Display>(
     points_index: &BTreeSet<Point<T>>,
     histogram: &Histogram<T>,
     pnt: Option<Point<T>>,

--- a/lib/segment/src/index/field_index/tests/histogram_tests.rs
+++ b/lib/segment/src/index/field_index/tests/histogram_tests.rs
@@ -274,8 +274,8 @@ fn test_save_load_histogram() {
         .prefix("histogram_dir")
         .tempdir()
         .unwrap();
-    histogram.save(&dir).unwrap();
+    histogram.save(dir.path()).unwrap();
 
-    let loaded_histogram = Histogram::<f64>::load(&dir).unwrap();
+    let loaded_histogram = Histogram::<f64>::load(dir.path()).unwrap();
     assert_eq!(histogram, loaded_histogram);
 }

--- a/lib/segment/src/index/field_index/tests/histogram_tests.rs
+++ b/lib/segment/src/index/field_index/tests/histogram_tests.rs
@@ -262,7 +262,12 @@ fn test_save_load_histogram() {
     let num_samples = 100_000;
     let mut rnd = StdRng::seed_from_u64(42);
 
-    let points = (0..num_samples).map(|i| Point { val: rnd.gen_range(-10.0..10.0), idx: i }).collect_vec();
+    let points = (0..num_samples)
+        .map(|i| Point {
+            val: rnd.gen_range(-10.0..10.0),
+            idx: i,
+        })
+        .collect_vec();
     let (histogram, _) = build_histogram(max_bucket_size, precision, points);
 
     let dir = tempfile::Builder::new()


### PR DESCRIPTION
This PR is a part of on-disk-payload-feature.

For the on-disk numeric index, it was decided that the histogram would be still on RAM because it's pretty small. But we need persistence anyway to avoid a full scan while loading.

This PR adds save-load for histogram and use it in histogram unit test.