### PR TITLE
universal-query: Add farthest query

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3075,6 +3075,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | recommend | [RecommendInput](#qdrant-RecommendInput) |  | Use multiple positive and negative vectors to find the results. |
 | discover | [DiscoverInput](#qdrant-DiscoverInput) |  | Search for nearest points, but constrain the search space with context |
 | context | [ContextInput](#qdrant-ContextInput) |  | Return points that live in positive areas. |
+| farthest | [VectorInput](#qdrant-VectorInput) |  | Return points that are the farthest apart from this vector. Shorthand for recommend best_score with only one negative input |
 | order_by | [OrderBy](#qdrant-OrderBy) |  | Order the points by a payload field. |
 | fusion | [Fusion](#qdrant-Fusion) |  | Fuse the results of multiple prefetches. |
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11727,6 +11727,9 @@
             "$ref": "#/components/schemas/ContextQuery"
           },
           {
+            "$ref": "#/components/schemas/FarthestQuery"
+          },
+          {
             "$ref": "#/components/schemas/OrderByQuery"
           },
           {
@@ -11869,6 +11872,17 @@
             "nullable": true
           }
         ]
+      },
+      "FarthestQuery": {
+        "type": "object",
+        "required": [
+          "furthest"
+        ],
+        "properties": {
+          "furthest": {
+            "$ref": "#/components/schemas/VectorInput"
+          }
+        }
       },
       "OrderByQuery": {
         "type": "object",

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -512,8 +512,9 @@ message Query {
     RecommendInput recommend = 2; // Use multiple positive and negative vectors to find the results.
     DiscoverInput discover = 3; // Search for nearest points, but constrain the search space with context
     ContextInput context = 4; // Return points that live in positive areas.
-    OrderBy order_by = 5; // Order the points by a payload field.
-    Fusion fusion = 6; // Fuse the results of multiple prefetches.
+    VectorInput farthest = 5; // Return points that are the farthest apart from this vector. Shorthand for recommend best_score with only one negative input
+    OrderBy order_by = 6; // Order the points by a payload field.
+    Fusion fusion = 7; // Fuse the results of multiple prefetches.
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4790,7 +4790,7 @@ pub struct ContextInput {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Query {
-    #[prost(oneof = "query::Variant", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "query::Variant", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub variant: ::core::option::Option<query::Variant>,
 }
 /// Nested message and enum types in `Query`.
@@ -4811,11 +4811,14 @@ pub mod query {
         /// Return points that live in positive areas.
         #[prost(message, tag = "4")]
         Context(super::ContextInput),
-        /// Order the points by a payload field.
+        /// Return points that are the farthest apart from this vector. Shorthand for recommend best_score with only one negative input
         #[prost(message, tag = "5")]
+        Farthest(super::VectorInput),
+        /// Order the points by a payload field.
+        #[prost(message, tag = "6")]
         OrderBy(super::OrderBy),
         /// Fuse the results of multiple prefetches.
-        #[prost(enumeration = "super::Fusion", tag = "6")]
+        #[prost(enumeration = "super::Fusion", tag = "7")]
         Fusion(i32),
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -235,6 +235,9 @@ pub enum Query {
 
     /// Return points that live in positive areas.
     Context(ContextQuery),
+    
+    /// Return points that are the farthest apart from this vector. Shorthand for recommend best_score with only one negative input
+    Farthest(FarthestQuery),
 
     /// Order the points by a payload field.
     OrderBy(OrderByQuery),
@@ -265,6 +268,12 @@ pub struct DiscoverQuery {
 #[serde(rename_all = "snake_case")]
 pub struct ContextQuery {
     pub context: ContextInput,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct FarthestQuery {
+    pub furthest: VectorInput,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -235,7 +235,7 @@ pub enum Query {
 
     /// Return points that live in positive areas.
     Context(ContextQuery),
-    
+
     /// Return points that are the farthest apart from this vector. Shorthand for recommend best_score with only one negative input
     Farthest(FarthestQuery),
 

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -70,6 +70,7 @@ impl Validate for Query {
             Query::Recommend(recommend) => recommend.recommend.validate(),
             Query::Discover(discover) => discover.discover.validate(),
             Query::Context(context) => context.context.validate(),
+            Query::Farthest(farthest) => farthest.furthest.validate(),
             Query::Fusion(fusion) => fusion.fusion.validate(),
             Query::OrderBy(order_by) => order_by.order_by.validate(),
         }

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -474,6 +474,7 @@ mod from_rest {
                 rest::Query::Recommend(recommend) => Query::Vector(From::from(recommend.recommend)),
                 rest::Query::Discover(discover) => Query::Vector(From::from(discover.discover)),
                 rest::Query::Context(context) => Query::Vector(From::from(context.context)),
+                rest::Query::Farthest(farthest) => Query::Vector(From::from(farthest)),
                 rest::Query::OrderBy(order_by) => Query::OrderBy(OrderBy::from(order_by.order_by)),
                 rest::Query::Fusion(fusion) => Query::Fusion(Fusion::from(fusion.fusion)),
             }
@@ -526,6 +527,16 @@ mod from_rest {
                 .collect();
 
             VectorQuery::Context(ContextQuery::new(context))
+        }
+    }
+
+    impl From<rest::FarthestQuery> for VectorQuery<VectorInput> {
+        fn from(value: rest::FarthestQuery) -> Self {
+            let rest::FarthestQuery { furthest: farthest } = value;
+
+            let vector_input = From::from(farthest);
+
+            VectorQuery::RecommendBestScore(RecoQuery::new(vec![], vec![vector_input]))
         }
     }
 
@@ -673,6 +684,9 @@ pub mod from_grpc {
                 Variant::Recommend(recommend) => Query::Vector(TryFrom::try_from(recommend)?),
                 Variant::Discover(discover) => Query::Vector(TryFrom::try_from(discover)?),
                 Variant::Context(context) => Query::Vector(TryFrom::try_from(context)?),
+                Variant::Farthest(farthest) => Query::Vector(VectorQuery::RecommendBestScore(
+                    RecoQuery::new(vec![], vec![TryFrom::try_from(farthest)?]),
+                )),
                 Variant::OrderBy(order_by) => Query::OrderBy(OrderBy::try_from(order_by)?),
                 Variant::Fusion(fusion) => Query::Fusion(Fusion::try_from(fusion)?),
             };


### PR DESCRIPTION
Adds a `{ query: { farthest: vector_input } }` shorthand for `{query: { recommend: { negative: [vector_input], strategy: "best_score" } } }` for better discoverability of features