### PR TITLE
Make `SegmentsSearcher::retrieve` return a hashmap

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -72,6 +72,7 @@ impl CollectionUpdater {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use segment::data_types::vectors::{
         only_default_vector, VectorStructInternal, DEFAULT_VECTOR_NAME,
     };
@@ -160,7 +161,9 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
         )
-        .unwrap();
+        .unwrap()
+        .into_values()
+        .collect_vec();
 
         assert_eq!(records.len(), 3);
 
@@ -192,7 +195,9 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
         )
-        .unwrap();
+        .unwrap()
+        .into_values()
+        .collect_vec();
 
         for record in records {
             assert!(record.vector.is_some());
@@ -223,7 +228,9 @@ mod tests {
 
         let res =
             SegmentsSearcher::retrieve(&segments, &points, &WithPayload::from(true), &false.into())
-                .unwrap();
+                .unwrap()
+                .into_values()
+                .collect_vec();
 
         assert_eq!(res.len(), 3);
 
@@ -255,7 +262,10 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
         )
-        .unwrap();
+        .unwrap()
+        .into_values()
+        .collect_vec();
+
         assert_eq!(res.len(), 1);
         assert!(!res[0].payload.as_ref().unwrap().contains_key("color"));
 
@@ -267,7 +277,10 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
         )
-        .unwrap();
+        .unwrap()
+        .into_values()
+        .collect_vec();
+
         assert_eq!(res.len(), 1);
         assert!(res[0].payload.as_ref().unwrap().contains_key("color"));
 
@@ -285,7 +298,10 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
         )
-        .unwrap();
+        .unwrap()
+        .into_values()
+        .collect_vec();
+
         assert_eq!(res.len(), 1);
         assert!(!res[0].payload.as_ref().unwrap().contains_key("color"));
     }

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -340,7 +340,6 @@ impl SegmentsSearcher {
     /// - if vector is enabled, vector will be fetched
     ///
     /// The points ids can contain duplicates, the records will be fetched only once
-    /// and returned in the same order as the input points.
     ///
     /// If an id is not found in the segments, it won't be included in the output.
     pub fn retrieve(
@@ -348,7 +347,7 @@ impl SegmentsSearcher {
         points: &[PointIdType],
         with_payload: &WithPayload,
         with_vector: &WithVector,
-    ) -> CollectionResult<Vec<Record>> {
+    ) -> CollectionResult<HashMap<PointIdType, Record>> {
         let mut point_version: HashMap<PointIdType, SeqNumberType> = Default::default();
         let mut point_records: HashMap<PointIdType, Record> = Default::default();
 
@@ -395,14 +394,7 @@ impl SegmentsSearcher {
             Ok(true)
         })?;
 
-        // TODO(luis): remove this property of returning the records in the same order as the input, return the hashmap instead
-        // Restore the order the ids came in
-        let ordered_records = points
-            .iter()
-            .filter_map(|point| point_records.get(point).cloned())
-            .collect();
-
-        Ok(ordered_records)
+        Ok(point_records)
     }
 }
 

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -109,22 +109,19 @@ impl LocalShard {
             .collect();
 
         // Collect retrieved records into a hashmap for fast lookup
-        let records_iter: HashMap<_, _> = SegmentsSearcher::retrieve(
+        let records_map = SegmentsSearcher::retrieve(
             self.segments(),
             &point_ids,
             &(&with_payload).into(),
             &with_vector,
-        )?
-        .into_iter()
-        .map(|record| (record.id, record))
-        .collect();
+        )?;
 
         // It might be possible, that we won't find all records,
         // so we need to re-collect the results
         let query_response: Vec<_> = query_response
             .into_iter()
             .filter_map(|mut point| {
-                records_iter.get(&point.id).map(|record| {
+                records_map.get(&point.id).map(|record| {
                     point.payload.clone_from(&record.payload);
                     point.vector.clone_from(&record.vector);
                     point

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -154,12 +154,15 @@ impl LocalShard {
             .collect_vec();
 
         let with_payload = WithPayload::from(with_payload_interface);
-        let mut points =
+        let records_map =
             SegmentsSearcher::retrieve(segments, &point_ids, &with_payload, with_vector)?;
 
-        points.sort_by_key(|point| point.id);
+        let ordered_records = point_ids
+            .iter()
+            .filter_map(|point| records_map.get(point).cloned())
+            .collect();
 
-        Ok(points)
+        Ok(ordered_records)
     }
 
     pub async fn scroll_by_field(
@@ -209,8 +212,14 @@ impl LocalShard {
         let with_payload = WithPayload::from(with_payload_interface);
 
         // Fetch with the requested vector and payload
-        let records = SegmentsSearcher::retrieve(segments, &point_ids, &with_payload, with_vector)?;
+        let records_map =
+            SegmentsSearcher::retrieve(segments, &point_ids, &with_payload, with_vector)?;
 
-        Ok((records, values))
+        let ordered_records = point_ids
+            .iter()
+            .filter_map(|point| records_map.get(point).cloned())
+            .collect();
+
+        Ok((ordered_records, values))
     }
 }

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -182,7 +182,16 @@ impl ShardOperation for LocalShard {
         with_payload: &WithPayload,
         with_vector: &WithVector,
     ) -> CollectionResult<Vec<Record>> {
-        SegmentsSearcher::retrieve(self.segments(), &request.ids, with_payload, with_vector)
+        let records_map =
+            SegmentsSearcher::retrieve(self.segments(), &request.ids, with_payload, with_vector)?;
+
+        let ordered_records = request
+            .ids
+            .iter()
+            .filter_map(|point| records_map.get(point).cloned())
+            .collect();
+
+        Ok(ordered_records)
     }
 
     async fn query_batch(


### PR DESCRIPTION
Slight improvement. I have modified the return type of `SegmentsSearcher::retrieve` function to return the produced hashmap directly, to let the callers decide how to process it. 

Sometimes we were re-collecting it into a hashmap right away, which didn't make much sense
