### PR TITLE
Drop SparseVectorIndexDatatype in favor of VectorStorageDatatype

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9691,7 +9691,7 @@
             "description": "Datatype used to store weights in the index.",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SparseVectorIndexDatatype"
+                "$ref": "#/components/schemas/VectorStorageDatatype"
               },
               {
                 "nullable": true
@@ -9724,15 +9724,6 @@
               "Mmap"
             ]
           }
-        ]
-      },
-      "SparseVectorIndexDatatype": {
-        "description": "Storage types for vectors",
-        "type": "string",
-        "enum": [
-          "float32",
-          "float16",
-          "uint8"
         ]
       },
       "PayloadStorageType": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5722,6 +5722,7 @@
             "nullable": true
           },
           "datatype": {
+            "description": "Defines which datatype should be used to represent vectors in the storage. Choosing different datatypes allows to optimize memory usage and performance vs accuracy.\n\n- For `float32` datatype - vectors are stored as single-precision floating point numbers, 4 bytes. - For `float16` datatype - vectors are stored as half-precision floating point numbers, 2 bytes. - For `uint8` datatype - vectors are stored as unsigned 8-bit integers, 1 byte. It expects vector elements to be in range `[0, 255]`.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Datatype"
@@ -5909,7 +5910,6 @@
         }
       },
       "Datatype": {
-        "description": "Defines which datatype should be used to represent vectors in the storage. Choosing different datatypes allows to optimize memory usage and performance vs accuracy. - For `float32` datatype - vectors are stored as single-precision floating point numbers, 4bytes. - For `uint8` datatype - vectors are stored as unsigned 8-bit integers, 1byte. It expects vector elements to be in range `[0, 255]`.",
         "type": "string",
         "enum": [
           "float32",
@@ -5986,7 +5986,7 @@
             "nullable": true
           },
           "datatype": {
-            "description": "Datatype used to store weights in the index.",
+            "description": "Defines which datatype should be used for the index. Choosing different datatypes allows to optimize memory usage and performance vs accuracy.\n\n- For `float32` datatype - vectors are stored as single-precision floating point numbers, 4 bytes. - For `float16` datatype - vectors are stored as half-precision floating point numbers, 2 bytes. - For `uint8` datatype - vectors are quantized to unsigned 8-bit integers, 1 byte. Quantization to fit byte range `[0, 255]` happens during indexing automatically, so the actual vector data does not need to conform to this range.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Datatype"

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -9,9 +9,7 @@ use atomicwrites::OverwriteBehavior::AllowOverwrite;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
-use segment::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::types::{
     default_replication_factor_const, default_shard_number_const,
     default_write_consistency_factor_const, Distance, HnswConfig, Indexes, PayloadStorageType,
@@ -391,8 +389,7 @@ impl CollectionParams {
                                 datatype: params
                                     .index
                                     .and_then(|index| index.datatype)
-                                    .map(SparseVectorIndexDatatype::try_from)
-                                    .transpose()?,
+                                    .map(VectorStorageDatatype::from),
                             },
                         },
                     ))

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1199,10 +1199,6 @@ impl Record {
 
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Copy, Clone, Hash)]
 #[serde(rename_all = "snake_case")]
-/// Defines which datatype should be used to represent vectors in the storage.
-/// Choosing different datatypes allows to optimize memory usage and performance vs accuracy.
-/// - For `float32` datatype - vectors are stored as single-precision floating point numbers, 4bytes.
-/// - For `uint8` datatype - vectors are stored as unsigned 8-bit integers, 1byte. It expects vector elements to be in range `[0, 255]`.
 pub enum Datatype {
     #[default]
     Float32,
@@ -1247,6 +1243,15 @@ pub struct VectorParams {
     pub on_disk: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Defines which datatype should be used to represent vectors in the storage.
+    /// Choosing different datatypes allows to optimize memory usage and performance vs accuracy.
+    ///
+    /// - For `float32` datatype - vectors are stored as single-precision floating point numbers,
+    ///   4 bytes.
+    /// - For `float16` datatype - vectors are stored as half-precision floating point numbers,
+    ///   2 bytes.
+    /// - For `uint8` datatype - vectors are stored as unsigned 8-bit integers, 1 byte.
+    ///   It expects vector elements to be in range `[0, 255]`.
     pub datatype: Option<Datatype>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1320,7 +1325,16 @@ pub struct SparseIndexParams {
     /// Store index on disk. If set to false, the index will be stored in RAM. Default: false
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on_disk: Option<bool>,
-    /// Datatype used to store weights in the index.
+    /// Defines which datatype should be used for the index.
+    /// Choosing different datatypes allows to optimize memory usage and performance vs accuracy.
+    ///
+    /// - For `float32` datatype - vectors are stored as single-precision floating point numbers,
+    ///   4 bytes.
+    /// - For `float16` datatype - vectors are stored as half-precision floating point numbers,
+    ///   2 bytes.
+    /// - For `uint8` datatype - vectors are quantized to unsigned 8-bit integers, 1 byte.
+    ///   Quantization to fit byte range `[0, 255]` happens during indexing automatically, so the
+    ///   actual vector data does not need to conform to this range.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub datatype: Option<Datatype>,
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -25,7 +25,6 @@ use segment::data_types::order_by::OrderValue;
 use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStructInternal, DEFAULT_VECTOR_NAME,
 };
-use segment::index::sparse_index::sparse_index_config::SparseVectorIndexDatatype;
 use segment::types::{
     Distance, Filter, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType,
     QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
@@ -1217,18 +1216,6 @@ impl From<Datatype> for VectorStorageDatatype {
             Datatype::Float32 => VectorStorageDatatype::Float32,
             Datatype::Uint8 => VectorStorageDatatype::Uint8,
             Datatype::Float16 => VectorStorageDatatype::Float16,
-        }
-    }
-}
-
-impl TryFrom<Datatype> for SparseVectorIndexDatatype {
-    type Error = CollectionError;
-
-    fn try_from(value: Datatype) -> Result<Self, Self::Error> {
-        match value {
-            Datatype::Float32 => Ok(Self::Float32),
-            Datatype::Float16 => Ok(Self::Float16),
-            Datatype::Uint8 => Ok(Self::Uint8),
         }
     }
 }

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -13,15 +13,14 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
-use segment::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::VectorIndex;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
+use segment::types::VectorStorageDatatype;
 use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use segment::vector_storage::VectorStorage;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
@@ -72,7 +71,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     let index_config = SparseIndexConfig::new(
         Some(10_000),
         SparseIndexType::ImmutableRam,
-        Some(SparseVectorIndexDatatype::Float32),
+        Some(VectorStorageDatatype::Float32),
     );
 
     let vector_storage = Arc::new(AtomicRefCell::new(vector_storage));

--- a/lib/segment/src/index/sparse_index/sparse_index_config.rs
+++ b/lib/segment/src/index/sparse_index/sparse_index_config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::anonymize::Anonymize;
 use crate::common::operation_error::OperationResult;
+use crate::types::VectorStorageDatatype;
 
 pub const SPARSE_INDEX_CONFIG_FILE: &str = "sparse_index_config.json";
 
@@ -39,19 +40,6 @@ impl SparseIndexType {
     }
 }
 
-/// Storage types for vectors
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum SparseVectorIndexDatatype {
-    // Single-precision floating point
-    #[default]
-    Float32,
-    // Half-precision floating point
-    Float16,
-    // Unsigned 8-bit integer
-    Uint8,
-}
-
 /// Configuration for sparse inverted index.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -65,7 +53,7 @@ pub struct SparseIndexConfig {
     /// Datatype used to store weights in the index.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub datatype: Option<SparseVectorIndexDatatype>,
+    pub datatype: Option<VectorStorageDatatype>,
 }
 
 impl Anonymize for SparseIndexConfig {
@@ -82,7 +70,7 @@ impl SparseIndexConfig {
     pub fn new(
         full_scan_threshold: Option<usize>,
         index_type: SparseIndexType,
-        datatype: Option<SparseVectorIndexDatatype>,
+        datatype: Option<VectorStorageDatatype>,
     ) -> Self {
         SparseIndexConfig {
             full_scan_threshold,

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -21,7 +21,7 @@ use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
 use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use crate::index::plain_payload_index::PlainIndex;
-use crate::index::sparse_index::sparse_index_config::{SparseIndexType, SparseVectorIndexDatatype};
+use crate::index::sparse_index::sparse_index_config::SparseIndexType;
 use crate::index::sparse_index::sparse_vector_index::{
     self, SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -348,7 +348,7 @@ pub(crate) fn create_sparse_vector_index(
         args.config.datatype.unwrap_or_default(),
         sparse_vector_index::USE_COMPRESSED,
     ) {
-        (_, a @ (SparseVectorIndexDatatype::Float16 | SparseVectorIndexDatatype::Uint8), false) => {
+        (_, a @ (VectorStorageDatatype::Float16 | VectorStorageDatatype::Uint8), false) => {
             Err(OperationError::ValidationError {
                 description: format!("{:?} datatype is not supported", a),
             })?
@@ -359,30 +359,30 @@ pub(crate) fn create_sparse_vector_index(
         }
 
         // Non-compressed
-        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Float32, false) => {
+        (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float32, false) => {
             VectorIndexEnum::SparseImmutableRam(SparseVectorIndex::open(args)?)
         }
-        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Float32, false) => {
+        (SparseIndexType::Mmap, VectorStorageDatatype::Float32, false) => {
             VectorIndexEnum::SparseMmap(SparseVectorIndex::open(args)?)
         }
 
         // Compressed
-        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Float32, true) => {
+        (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float32, true) => {
             VectorIndexEnum::SparseCompressedImmutableRamF32(SparseVectorIndex::open(args)?)
         }
-        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Float32, true) => {
+        (SparseIndexType::Mmap, VectorStorageDatatype::Float32, true) => {
             VectorIndexEnum::SparseCompressedMmapF32(SparseVectorIndex::open(args)?)
         }
-        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Float16, true) => {
+        (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float16, true) => {
             VectorIndexEnum::SparseCompressedImmutableRamF16(SparseVectorIndex::open(args)?)
         }
-        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Float16, true) => {
+        (SparseIndexType::Mmap, VectorStorageDatatype::Float16, true) => {
             VectorIndexEnum::SparseCompressedMmapF16(SparseVectorIndex::open(args)?)
         }
-        (SparseIndexType::ImmutableRam, SparseVectorIndexDatatype::Uint8, true) => {
+        (SparseIndexType::ImmutableRam, VectorStorageDatatype::Uint8, true) => {
             VectorIndexEnum::SparseCompressedImmutableRamU8(SparseVectorIndex::open(args)?)
         }
-        (SparseIndexType::Mmap, SparseVectorIndexDatatype::Uint8, true) => {
+        (SparseIndexType::Mmap, VectorStorageDatatype::Uint8, true) => {
             VectorIndexEnum::SparseCompressedMmapU8(SparseVectorIndex::open(args)?)
         }
     };

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -9,15 +9,13 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{QueryVector, VectorElementType};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
-use segment::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::SparseVectorIndexOpenArgs;
 use segment::index::VectorIndex;
 use segment::segment_constructor::{build_segment, create_sparse_vector_index_test};
 use segment::types::{
     Distance, Indexes, SegmentConfig, SeqNumberType, SparseVectorDataConfig, VectorDataConfig,
-    VectorStorageType, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
+    VectorStorageDatatype, VectorStorageType, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use sparse::common::sparse_vector::SparseVector;
@@ -121,7 +119,7 @@ fn sparse_index_discover_test() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
-                    datatype: Some(SparseVectorIndexDatatype::Float32),
+                    datatype: Some(VectorStorageDatatype::Float32),
                 },
             },
         )]),
@@ -166,7 +164,7 @@ fn sparse_index_discover_test() {
         config: SparseIndexConfig {
             full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
             index_type: SparseIndexType::ImmutableRam,
-            datatype: Some(SparseVectorIndexDatatype::Float32),
+            datatype: Some(VectorStorageDatatype::Float32),
         },
         id_tracker: sparse_segment.id_tracker.clone(),
         vector_storage: vector_storage.clone(),

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -15,9 +15,7 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::fixture_for_all_indices;
 use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::fixtures::sparse_fixtures::{fixture_sparse_index, fixture_sparse_index_from_iter};
-use segment::index::sparse_index::sparse_index_config::{
-    SparseIndexConfig, SparseIndexType, SparseVectorIndexDatatype,
-};
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
@@ -29,7 +27,7 @@ use segment::types::PayloadFieldSchema::FieldType;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
     Condition, FieldCondition, Filter, Payload, ScoredPoint, SegmentConfig, SeqNumberType,
-    SparseVectorDataConfig, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
+    SparseVectorDataConfig, VectorStorageDatatype, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
 use segment::vector_storage::VectorStorage;
 use serde_json::json;
@@ -584,7 +582,7 @@ fn sparse_vector_index_persistence_test() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
-                    datatype: Some(SparseVectorIndexDatatype::Float32),
+                    datatype: Some(VectorStorageDatatype::Float32),
                 },
             },
         )]),
@@ -667,7 +665,7 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
             config: SparseIndexConfig {
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::Mmap,
-                datatype: Some(SparseVectorIndexDatatype::Float32),
+                datatype: Some(VectorStorageDatatype::Float32),
             },
             id_tracker: segment.id_tracker.clone(),
             vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
@@ -752,7 +750,7 @@ fn sparse_vector_test_large_index() {
                 index: SparseIndexConfig {
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
-                    datatype: Some(SparseVectorIndexDatatype::Float32),
+                    datatype: Some(VectorStorageDatatype::Float32),
                 },
             },
         )]),


### PR DESCRIPTION
Fixup for #4514.
Drop `SparseVectorIndexDatatype` in favor of `VectorStorageDatatype`, as requested by @generall.