### PR TITLE
Fix id exclusion when recommending from a different collection

### DIFF
--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -92,7 +92,7 @@ impl GroupRequest {
                 )
                 .await?;
 
-                recommend_into_core_search(recommend_req, &referenced_vectors)?
+                recommend_into_core_search(&collection.id, recommend_req, &referenced_vectors)?
             }
         };
 

--- a/tests/openapi/openapi_integration/test_multicollection_reco.py
+++ b/tests/openapi/openapi_integration/test_multicollection_reco.py
@@ -239,3 +239,86 @@ def test_recommend_from_another_collection(on_disk_vectors):
         path_params={'collection_name': collection_name2},
     )
     assert response.ok
+
+
+def test_recommend_lookup():
+    # delete lookup collection if exists
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name2},
+    )
+    assert response.ok, response.text
+
+    # re-create lookup collection
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name2},
+        body={
+            "vectors": {
+                "other": {
+                    "size": 4,
+                    "distance": "Dot",
+                }
+            }
+        }
+    )
+    assert response.ok, response.text
+
+    # insert vectors to lookup collection
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name2},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {"other": [1.0, 0.0, 0.0, 0.0]},
+                },
+                {
+                    "id": 2,
+                    "vector": {"other": [0.0, 0.0, 0.0, 2.0]},
+                },
+            ]
+        }
+    )
+    assert response.ok, response.text
+
+    # check recommend by id + lookup_from
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [1],
+            "negative": [2],
+            "limit": 10,
+            "lookup_from": {
+                "collection": collection_name2,
+                "vector": "other"
+            }
+        },
+    )
+    assert response.ok, response.text
+    recommend_result_by_id = response.json()["result"]
+
+    # check recommend by vector + lookup_from
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [[1.0, 0.0, 0.0, 0.0]],
+            "negative": [[0.0, 0.0, 0.0, 2.0]],
+            "limit": 10,
+        },
+    )
+    assert response.ok, response.text
+    recommend_result_by_vector = response.json()["result"]
+
+    # results should be equivalent
+    assert recommend_result_by_id == recommend_result_by_vector,\
+        f"recommend_result_by_id: {recommend_result_by_id}, recommend_result_by_vector: {recommend_result_by_vector}"

--- a/tests/openapi/openapi_integration/test_multicollection_reco.py
+++ b/tests/openapi/openapi_integration/test_multicollection_reco.py
@@ -320,5 +320,5 @@ def test_recommend_lookup():
     recommend_result_by_vector = response.json()["result"]
 
     # results should be equivalent
-    assert recommend_result_by_id == recommend_result_by_vector,\
+    assert recommend_result_by_id == recommend_result_by_vector, \
         f"recommend_result_by_id: {recommend_result_by_id}, recommend_result_by_vector: {recommend_result_by_vector}"


### PR DESCRIPTION
This PR fixes a bug in the current recommendation (discovered while working on https://github.com/qdrant/qdrant/pull/4508)

The recommendation API excludes from the results the vector ids used in the query (positives & negatives).
However, this should not happen when using `lookup_from` as the ids are pointing to a different collection.