### PR TITLE
Fix discovery API id exclusion and lookup

### DIFF
--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -96,20 +96,22 @@ fn discovery_into_core_search(
         _ => referenced_ids,
     };
 
-    let filter = {
+    let filter = if reference_vectors_ids_to_exclude.is_empty() {
+        request.filter
+    } else {
         let not_ids = Filter::new_must_not(Condition::HasId(HasIdCondition {
             has_id: reference_vectors_ids_to_exclude.into_iter().collect(),
         }));
 
         match &request.filter {
-            None => not_ids,
-            Some(filter) => not_ids.merge(filter),
+            None => Some(not_ids),
+            Some(filter) => Some(not_ids.merge(filter)),
         }
     };
 
     let core_search = CoreSearchRequest {
         query,
-        filter: Some(filter),
+        filter,
         params: request.params,
         limit: request.limit,
         offset: request.offset.unwrap_or_default(),

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -22,12 +22,15 @@ use crate::operations::types::{
 };
 
 fn discovery_into_core_search(
+    collection_name: &str,
     request: DiscoverRequestInternal,
     all_vectors_records_map: &ReferencedVectors,
 ) -> CollectionResult<CoreSearchRequest> {
-    let lookup_collection_name = request.lookup_from.as_ref().map(|x| &x.collection);
+    let lookup_collection_name = request.get_lookup_collection();
 
     let lookup_vector_name = request.get_lookup_vector_name();
+
+    let using = request.using.as_ref().map(|using| using.as_string());
 
     // Check we actually fetched all referenced vectors in this request
     let referenced_ids = request.get_referenced_point_ids();
@@ -77,19 +80,25 @@ fn discovery_into_core_search(
         // Target with/without pairs => Discovery
         (Some(target), pairs) => QueryEnum::Discover(NamedQuery {
             query: DiscoveryQuery::new(target, pairs),
-            using: Some(lookup_vector_name),
+            using,
         }),
 
         // Only pairs => Context
         (None, pairs) => QueryEnum::Context(NamedQuery {
             query: ContextQuery::new(pairs),
-            using: Some(lookup_vector_name),
+            using,
         }),
+    };
+
+    // do not exclude vector ids from different lookup collection
+    let reference_vectors_ids_to_exclude = match lookup_collection_name {
+        Some(lookup_collection_name) if lookup_collection_name != collection_name => vec![],
+        _ => referenced_ids,
     };
 
     let filter = {
         let not_ids = Filter::new_must_not(Condition::HasId(HasIdCondition {
-            has_id: referenced_ids.into_iter().collect(),
+            has_id: reference_vectors_ids_to_exclude.into_iter().collect(),
         }));
 
         match &request.filter {
@@ -193,9 +202,11 @@ where
         request_batch,
         |(_req, shard)| shard,
         |(req, _), acc| {
-            discovery_into_core_search(req, &all_vectors_records_map).map(|core_req| {
-                acc.push(core_req);
-            })
+            discovery_into_core_search(&collection.name(), req, &all_vectors_records_map).map(
+                |core_req| {
+                    acc.push(core_req);
+                },
+            )
         },
         |shard_selector, core_searches, requests| {
             if core_searches.is_empty() {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -499,6 +499,14 @@ pub enum UsingVector {
     Name(String),
 }
 
+impl UsingVector {
+    pub fn as_string(&self) -> String {
+        match self {
+            UsingVector::Name(name) => name.to_string(),
+        }
+    }
+}
+
 impl From<String> for UsingVector {
     fn from(name: String) -> Self {
         UsingVector::Name(name)


### PR DESCRIPTION
Similar to https://github.com/qdrant/qdrant/pull/4551 but for the discovery API.

Additionally the `lookup_from` was wrongly used for the `using` field of the search query.