### PR TITLE
Fix sparse vector mmap index conversion panic

### DIFF
--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -175,10 +175,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
         // Simple migration mechanism for 0.1.0.
         let old_path = path.join(OLD_INDEX_FILE_NAME);
-        if TInvertedIndex::Version::current() == Version::new(0, 1, 0)
-            && stored_version.is_none()
-            && old_path.exists()
-        {
+        if TInvertedIndex::Version::current() == Version::new(0, 1, 0) && old_path.exists() {
             rename(old_path, path.join(INDEX_FILE_NAME))?;
             TInvertedIndex::Version::save(path)?;
             stored_version = Some(TInvertedIndex::Version::current());


### PR DESCRIPTION
This check prevented converting from 1.9.3 or 1.9.4 into newer versions, causing a panic in 1.9.5 or 1.9.6.

Removing this check makes us convert in all cases, which is what we want.

I've manually tested the conversion to work between versions:
- 1.8.4 -> PR
- 1.9.0 -> PR
- 1.9.2 -> PR
- 1.9.3 -> PR

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?