### PR TITLE
Stop resharding task on resharding finish and abort

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -23,7 +23,7 @@ impl Collection {
 
     pub async fn start_resharding<T, F>(
         &self,
-        reshard_key: ReshardKey,
+        resharding_key: ReshardKey,
         consensus: Box<dyn ShardTransferConsensus>,
         temp_dir: PathBuf,
         on_finish: T,
@@ -35,23 +35,23 @@ impl Collection {
     {
         let mut shard_holder = self.shards_holder.write().await;
 
-        shard_holder.check_start_resharding(&reshard_key)?;
+        shard_holder.check_start_resharding(&resharding_key)?;
 
         let replica_set = self
             .create_replica_set(
-                reshard_key.shard_id,
-                &[reshard_key.peer_id],
+                resharding_key.shard_id,
+                &[resharding_key.peer_id],
                 Some(ReplicaState::Resharding),
             )
             .await?;
 
-        shard_holder.start_resharding_unchecked(reshard_key.clone(), replica_set)?;
+        shard_holder.start_resharding_unchecked(resharding_key.clone(), replica_set)?;
 
         // If this peer is responsible for driving the resharding, start the task for it
-        if reshard_key.peer_id == self.this_peer_id {
+        if resharding_key.peer_id == self.this_peer_id {
             // Stop any already active resharding task to allow starting a new one
             let mut active_reshard_tasks = self.reshard_tasks.lock().await;
-            let task_result = active_reshard_tasks.stop_task(&reshard_key).await;
+            let task_result = active_reshard_tasks.stop_task(&resharding_key).await;
             debug_assert!(task_result.is_none(), "Reshard task already exists");
 
             let shard_holder = self.shards_holder.clone();
@@ -62,7 +62,7 @@ impl Collection {
             let spawned_task = resharding::spawn_resharding_task(
                 shard_holder,
                 progress.clone(),
-                reshard_key.clone(),
+                resharding_key.clone(),
                 consensus,
                 collection_id,
                 self.path.clone(),
@@ -75,7 +75,7 @@ impl Collection {
             );
 
             active_reshard_tasks.add_task(
-                reshard_key,
+                resharding_key,
                 ReshardTaskItem {
                     task: spawned_task,
                     started_at: chrono::Utc::now(),
@@ -111,13 +111,13 @@ impl Collection {
         Ok(())
     }
 
-    pub async fn abort_resharding(&self, reshard_key: ReshardKey) -> CollectionResult<()> {
-        let _ = self.stop_resharding_task(&reshard_key).await;
+    pub async fn abort_resharding(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
+        let _ = self.stop_resharding_task(&resharding_key).await;
 
         self.shards_holder
             .write()
             .await
-            .abort_resharding(reshard_key)
+            .abort_resharding(resharding_key)
             .await?;
 
         Ok(())

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -102,10 +102,10 @@ impl Collection {
     }
 
     pub async fn finish_resharding(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
-        self.shards_holder
-            .write()
-            .await
-            .finish_resharding(resharding_key)
+        let mut shard_holder = self.shards_holder.write().await;
+        shard_holder.check_finish_resharding(&resharding_key)?;
+        shard_holder.finish_resharding_unchecked(resharding_key)?;
+        Ok(())
     }
 
     pub async fn abort_resharding(&self, reshard_key: ReshardKey) -> CollectionResult<()> {

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -130,7 +130,7 @@ impl Collection {
         self.reshard_tasks
             .lock()
             .await
-            .stop_task(&resharding_key)
+            .stop_task(resharding_key)
             .await
     }
 }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -116,7 +116,7 @@ impl ShardHolder {
 
     pub fn check_finish_resharding(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
         self.check_resharding(
-            &resharding_key,
+            resharding_key,
             check_stage(ReshardStage::WriteHashRingCommitted),
         )?;
 

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -114,12 +114,16 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn finish_resharding(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
+    pub fn check_finish_resharding(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
         self.check_resharding(
             &resharding_key,
             check_stage(ReshardStage::WriteHashRingCommitted),
         )?;
 
+        Ok(())
+    }
+
+    pub fn finish_resharding_unchecked(&mut self, _: ReshardKey) -> CollectionResult<()> {
         self.resharding_state.write(|state| {
             debug_assert!(state.is_some(), "resharding is not in progress");
             *state = None;


### PR DESCRIPTION
Tracked in #4213.
Currently based on #4561.

Basically, subject. Stop task when `Resharding::Finish` or `Resharding::Abort` consensus message is received, similar to how shard transfer task is handled.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
