### PR TITLE
When opening a snapshot file, mask its contents on error

### DIFF
--- a/lib/segment/src/common/validate_snapshot_archive.rs
+++ b/lib/segment/src/common/validate_snapshot_archive.rs
@@ -18,10 +18,10 @@ pub fn open_snapshot_archive_with_validation<P: AsRef<Path>>(
         let mut ar = Archive::new(archive_file);
 
         for entry in ar.entries_with_seek()? {
-            // Read next archive entry
+            // Read next archive entry type
             // Deliberately mask real error here for API users, it can expose arbitrary file contents
-            let entry = match entry {
-                Ok(entry) => entry,
+            let entry_type = match entry {
+                Ok(entry) => entry.header().entry_type(),
                 Err(err) => {
                     log::warn!("Error while reading snapshot archive, malformed entry: {err}");
                     return Err(OperationError::service_error(
@@ -29,8 +29,6 @@ pub fn open_snapshot_archive_with_validation<P: AsRef<Path>>(
                     ));
                 }
             };
-
-            let entry_type = entry.header().entry_type();
             if !matches!(
                 entry_type,
                 tar::EntryType::Regular | tar::EntryType::Directory,


### PR DESCRIPTION
Before, file contents were simply dumped to the end user if reading an (arbitrary) snapshot file failed. This now masks the error, and only reports the real error in stdout.

Try:

```json
PUT /collections/pentest/snapshots/recover
{
  "location": "file:///etc/passwd"
}
```

Before, it showed:

```json
{
  "error": "Service internal error: IO Error: numeric field was not a number: login\nsy when getting cksum for root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\nbin:x:2:2:bin:/bin:/"
}
```

Now it shows:

```json
{
  "error": "Service internal error: Failed to open snapshot archive, malformed format"
}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?