### PR TITLE
Limit snapshot recovery file uri to snapshots dir

### DIFF
--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -114,6 +114,11 @@ pub async fn download_snapshot(
         "http" | "https" => {
             let download_to = snapshots_dir.join(snapshot_name(&url));
 
+            log::debug!(
+                "Downloading snapshot from {url} to {}",
+                snapshots_dir.display(),
+            );
+
             let temp_path = download_file(client, &url, &download_to).await?;
             Ok((download_to, Some(temp_path)))
         }

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -90,6 +90,7 @@ pub async fn download_snapshot(
                 )));
             }
 
+            // If we fail, don't return an error right away to prevent leaking file existence
             let local_path = local_path.canonicalize().unwrap_or(local_path);
 
             // Prevent using arbitrary files from our file system, enforce the file to be in the

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -65,7 +65,7 @@ async fn download_file(
 /// Download remote snapshot file, or use local snapshot file.
 ///
 /// If an HTTP/HTTPS URL is provided, the snapshot file will be downloaded to `downloads_dir`.
-/// If an file URL is provided, the local file will be used directly.
+/// If a file URL is provided, the local file will be used directly.
 ///
 /// If remote file was downloaded, an optional `TempPath` is also returned. When `TempFile` is dropped, it will delete downloaded file automatically. See [`TempPath::keep`] and [`TempPath::persist`] to preserve the file.
 ///
@@ -110,7 +110,8 @@ pub async fn download_or_local_snapshot(
                 .map_or(false, |snapshots_dir| local_path.starts_with(snapshots_dir));
             if !inside_snapshots_dir {
                 return Err(StorageError::forbidden(format!(
-                    "Snapshot file {local_path:?} must be inside snapshots directory",
+                    "Snapshot file {} must be inside snapshots directory",
+                    local_path.display(),
                 )));
             }
 

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -61,20 +61,17 @@ async fn download_file(
     Ok(temp_path)
 }
 
-/// Download a snapshot file an URI, return a file path to it
+/// Download remote snapshot file and return path to downloaded file.
+/// Downloaded file will be saved into `snapshots_dir`.
 ///
-/// For remote resources such as an URL, this downloads the given file and puts it in
-/// `snapshots_dir`. A path to the downloaded file is returned.
+/// If URL is a `file://` URL, the path to the local file is returned.
 ///
-/// For `file://` URIs a direct path is returned.
-///
-/// May returen a `TempPath` if a file was downloaded from a remote source. If it is dropped the
-/// downloaded file is deleted automatically. To keep the file `keep()` may be used.
+/// If remote file was downloaded, an optional `TempPath` is also returned. When `TempFile` is dropped, it will delete downloaded file automatically. See [`TempPath::keep`] and [`TempPath::persist`] to preserve the file.
 ///
 /// # Security
 ///
 /// A `file://` URI may point to arbitrary files on the file system, which could be a security
-/// concern. Set `strict_file` to `true` to enforce a local file to be inside `snapshots_dir`.
+/// concern. Set `only_snapshot_dir` to `true` to only accept local files inside the `snapshots_dir`.
 #[must_use = "may return a TempPath, if dropped the downloaded file is deleted"]
 pub async fn download_snapshot(
     client: &reqwest::Client,

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -87,8 +87,10 @@ pub async fn download_snapshot(
                 )
             })?;
             if !local_path.exists() {
+                // Report user provided URL here to prevent leaking the local path
                 return Err(StorageError::bad_request(format!(
-                    "Snapshot file {local_path:?} does not exist"
+                    "Snapshot file {:?} does not exist",
+                    url.to_string(),
                 )));
             }
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -98,8 +98,7 @@ async fn _do_recover_from_snapshot(
 
     let is_distributed = toc.is_distributed();
 
-    let snapshots_path =
-        TableOfContent::collection_snapshots_path(Path::new(toc.snapshots_path()), collection_name);
+    let snapshots_path = toc.snapshots_path_for_collection(collection_name);
     let (snapshot_path, snapshot_temp_path) =
         download_snapshot(client, location, &snapshots_path, only_snapshot_dir).await?;
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 use crate::content_manager::collection_meta_ops::{
     CollectionMetaOperations, CreateCollectionOperation,
 };
-use crate::content_manager::snapshots::download::download_snapshot;
+use crate::content_manager::snapshots::download::download_or_local_snapshot;
 use crate::dispatcher::Dispatcher;
 use crate::rbac::{Access, AccessRequirements, CollectionPass};
 use crate::{StorageError, TableOfContent};
@@ -96,9 +96,10 @@ async fn _do_recover_from_snapshot(
 
     let is_distributed = toc.is_distributed();
 
+    let download_dir = toc.snapshots_download_tempdir()?;
     let snapshots_path = toc.snapshots_path_for_collection(collection_name);
     let (snapshot_path, snapshot_temp_path) =
-        download_snapshot(client, location, &snapshots_path, only_snapshot_dir).await?;
+        download_or_local_snapshot(client, location, download_dir.path(), &snapshots_path, only_snapshot_dir).await?;
 
     if let Some(checksum) = checksum {
         let snapshot_checksum = hash_file(&snapshot_path).await?;

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use collection::collection::Collection;
 use collection::common::sha_256::{hash_file, hashes_equal};
 use collection::config::CollectionConfig;
@@ -93,15 +95,9 @@ async fn _do_recover_from_snapshot(
 
     let is_distributed = toc.is_distributed();
 
-    let download_dir = toc.snapshots_download_tempdir()?;
-
-    log::debug!(
-        "Downloading snapshot from {location} to {}",
-        download_dir.path().display(),
-    );
-
+    let snapshots_path = Path::new(toc.snapshots_path());
     let (snapshot_path, snapshot_temp_path) =
-        download_snapshot(client, location, download_dir.path(), only_snapshot_dir).await?;
+        download_snapshot(client, location, snapshots_path, only_snapshot_dir).await?;
 
     if let Some(checksum) = checksum {
         let snapshot_checksum = hash_file(&snapshot_path).await?;

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -53,7 +53,6 @@ pub fn do_recover_from_snapshot(
     collection_name: &str,
     source: SnapshotRecover,
     access: Access,
-    only_snapshot_dir: bool,
     client: reqwest::Client,
 ) -> Result<JoinHandle<Result<bool, StorageError>>, StorageError> {
     let multipass = access.check_global_access(AccessRequirements::new().manage())?;
@@ -68,7 +67,6 @@ pub fn do_recover_from_snapshot(
             &collection_name,
             collection_pass,
             source,
-            only_snapshot_dir,
             &client,
         )
         .await
@@ -81,7 +79,6 @@ async fn _do_recover_from_snapshot(
     collection_name: &str,
     collection_pass: CollectionPass<'static>,
     source: SnapshotRecover,
-    only_snapshot_dir: bool,
     client: &reqwest::Client,
 ) -> Result<bool, StorageError> {
     let SnapshotRecover {
@@ -99,7 +96,7 @@ async fn _do_recover_from_snapshot(
     let download_dir = toc.snapshots_download_tempdir()?;
     let snapshots_path = toc.snapshots_path_for_collection(collection_name);
     let (snapshot_path, snapshot_temp_path) =
-        download_or_local_snapshot(client, location, download_dir.path(), &snapshots_path, only_snapshot_dir).await?;
+        download_or_local_snapshot(client, location, download_dir.path(), &snapshots_path).await?;
 
     if let Some(checksum) = checksum {
         let snapshot_checksum = hash_file(&snapshot_path).await?;

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use collection::collection::Collection;
 use collection::common::sha_256::{hash_file, hashes_equal};
 use collection::config::CollectionConfig;

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -211,6 +211,8 @@ async fn upload_snapshot(
             &collection.name,
             snapshot_recover,
             access,
+            // No need to limit to snapshot directory, only uploaded file is used
+            false,
             http_client,
         )
     })
@@ -234,6 +236,8 @@ async fn recover_from_snapshot(
             &collection.name,
             snapshot_recover,
             access,
+            // Limit files to snapshot directory to prevent users from recoverying arbitrary files with file://
+            true,
             http_client,
         )
     })

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -211,7 +211,6 @@ async fn upload_snapshot(
             &collection.name,
             snapshot_recover,
             access,
-            true,
             http_client,
         )
     })
@@ -235,8 +234,6 @@ async fn recover_from_snapshot(
             &collection.name,
             snapshot_recover,
             access,
-            // Limit files to snapshot directory to prevent users from recoverying arbitrary files with file://
-            true,
             http_client,
         )
     })

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -211,8 +211,7 @@ async fn upload_snapshot(
             &collection.name,
             snapshot_recover,
             access,
-            // No need to limit to snapshot directory, only uploaded file is used
-            false,
+            true,
             http_client,
         )
     })

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -128,8 +128,13 @@ pub async fn recover_shard_snapshot(
                     let client = client.client(api_key.as_deref())?;
 
                     let (snapshot_path, snapshot_temp_path) =
-                        snapshots::download::download_snapshot(&client, url, download_dir.path())
-                            .await?;
+                        snapshots::download::download_snapshot(
+                            &client,
+                            url,
+                            download_dir.path(),
+                            false,
+                        )
+                        .await?;
 
                     (snapshot_path, snapshot_temp_path)
                 }

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -133,7 +133,6 @@ pub async fn recover_shard_snapshot(
                             url,
                             download_dir.path(),
                             collection.snapshots_path(),
-                            false,
                         )
                         .await?;
 

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -128,10 +128,11 @@ pub async fn recover_shard_snapshot(
                     let client = client.client(api_key.as_deref())?;
 
                     let (snapshot_path, snapshot_temp_path) =
-                        snapshots::download::download_snapshot(
+                        snapshots::download::download_or_local_snapshot(
                             &client,
                             url,
                             download_dir.path(),
+                            collection.snapshots_path(),
                             false,
                         )
                         .await?;

--- a/tests/consensus_tests/auth_tests/test_jwt_access.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_access.py
@@ -1262,7 +1262,7 @@ def test_recover_collection_snapshot(collection_snapshot: bytes):
 
     check_access(
         "recover_collection_snapshot",
-        rest_request={"location": f"file://{file}"},
+        rest_request={"location": f"file://./{file}"},
         path_params={"collection_name": COLL_NAME},
     )
 

--- a/tests/openapi/openapi_integration/helpers/helpers.py
+++ b/tests/openapi/openapi_integration/helpers/helpers.py
@@ -37,7 +37,7 @@ def request_with_validation(
         method: str,
         path_params: dict = None,
         query_params: dict = None,
-        body: dict = None
+        body: dict = None,
 ) -> requests.Response:
     operation: APIOperation = SCHEMA[api][method]
 
@@ -80,6 +80,35 @@ def request_with_validation(
     )
 
     operation.validate_response(response)
+
+    return response
+
+
+def request_without_validation(
+        api: str,
+        method: str,
+        path_params: dict = None,
+        query_params: dict = None,
+        body: dict = None,
+) -> requests.Response:
+    operation: APIOperation = SCHEMA[api][method]
+
+    assert isinstance(operation.schema, OpenApi30)
+
+    if path_params is None:
+        path_params = {}
+    if query_params is None:
+        query_params = {}
+    action = getattr(requests, method.lower(), None)
+
+    if not action:
+        raise RuntimeError(f"Method {method} does not exists")
+
+    response = action(
+        url=get_api_string(QDRANT_HOST, api, path_params),
+        params=query_params,
+        json=body
+    )
 
     return response
 

--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -340,7 +340,7 @@ def test_snapshot_invalid_file_uri():
         }
     )
     assert response.status_code == 400
-    assert response.json()["status"]["error"] == "Bad request: Invalid snapshot URI, file path must be absolute or on localhost"
+    assert response.json()["status"]["error"] == "Bad request: Malformed file URI"
 
     # Absolute path that does not exist
     response = request_with_validation(

--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -424,3 +424,15 @@ def test_collection_snapshot_security():
     )
     assert not response.ok
     assert response.status_code == 404
+
+    # Path must be inside snapshots directory
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots/recover',
+        method="PUT",
+        path_params={'collection_name': "somethingthatdoesnotexist"},
+        body={
+            "location": "file:///etc/passwd",
+        }
+    )
+    assert response.status_code == 403
+    assert response.json()["status"]["error"] == "Forbidden: Snapshot file \"/etc/passwd\" must be inside snapshots directory"

--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -352,7 +352,7 @@ def test_snapshot_invalid_file_uri():
         }
     )
     assert response.status_code == 400
-    assert response.json()["status"]["error"] == "Bad request: Snapshot file \"/whatever.snapshot\" does not exist"
+    assert response.json()["status"]["error"] == "Bad request: Snapshot file \"file:///whatever.snapshot\" does not exist"
 
     # Path that does not exist
     response = request_with_validation(
@@ -364,7 +364,7 @@ def test_snapshot_invalid_file_uri():
         }
     )
     assert response.status_code == 400
-    assert response.json()["status"]["error"] == "Bad request: Snapshot file \"/whatever.snapshot\" does not exist"
+    assert response.json()["status"]["error"] == "Bad request: Snapshot file \"file:///whatever.snapshot\" does not exist"
 
 
 def test_full_snapshot_security():

--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -488,7 +488,7 @@ def test_collection_snapshot_security():
         }
     )
     assert response.status_code == 403
-    assert response.json()["status"]["error"] == "Forbidden: Snapshot file \"/etc/passwd\" must be inside snapshots directory"
+    assert response.json()["status"]["error"] == "Forbidden: Snapshot file /etc/passwd must be inside snapshots directory"
 
     # Absolute paths must not be accessible through relative interface
     response = request_without_validation(


### PR DESCRIPTION
Re-implements: <https://github.com/qdrant/qdrant/pull/2415>

Fixes a security issue where arbitrary files from the file system could be read as snapshot.

This limits recovering snapshots with the `file://` URI to the snapshots directory.

We've opened this change before for discussion but it became stale. This reopens it. I don't see a problem with this limitation and it's good practice anyway.

Even though `file://` normally doesn't support relative paths, I've added support for this to keep backward compatibility. Of course, these files are jailed within the snapshot directory as well.

This:

```json
PUT /collections/pentest/snapshots/recover
{
  "location": "file:///etc/passwd"
}
```

now returns:

```json
{
  "error": "Forbidden: Snapshot file \"/etc/passwd\" must be inside snapshots directory"
}
```

With support for relative files this also works if the given snapshot file exists:

```json
PUT /collections/pentest/snapshots/recover
{
  "location": "file://./my_snapshot.snapshot"
}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?