### PR TITLE
Set USE_COMPRESSED to true

### DIFF
--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -21,7 +21,7 @@ use segment::types::{Condition, FieldCondition, Filter, Payload};
 use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_positive_sparse_vector, random_sparse_vector};
-use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::loaders::Csr;
 use tempfile::Builder;
@@ -104,7 +104,7 @@ fn sparse_vector_index_search_benchmark_impl(
     let sparse_index_config =
         SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap, None);
     let pb = progress("Indexing (2/2)", vectors_len);
-    let sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
+    let sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexCompressedMmap<f32>> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_index.id_tracker().clone(),

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -114,12 +114,23 @@ pub fn fixture_sparse_index<I: InvertedIndex + Debug, R: Rng + ?Sized>(
 macro_rules! fixture_for_all_indices {
     ($test:ident::<_>($($args:tt)*)) => {
         eprintln!("InvertedIndexCompressedImmutableRam<f32>");
-        $test::<InvertedIndexCompressedImmutableRam<f32>>($($args)*);
+        $test::<
+            ::sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam<f32>
+        >($($args)*);
+
         eprintln!("InvertedIndexCompressedMmap<f32>");
-        $test::<InvertedIndexCompressedMmap<f32>>($($args)*);
+        $test::<
+            ::sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap<f32>
+        >($($args)*);
+
         eprintln!("InvertedIndexImmutableRam");
-        $test::<InvertedIndexImmutableRam>($($args)*);
+        $test::<
+            ::sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam
+        >($($args)*);
+
         eprintln!("InvertedIndexMmap");
-        $test::<InvertedIndexMmap>($($args)*);
+        $test::<
+            ::sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap
+        >($($args)*);
     };
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -38,9 +38,8 @@ use crate::vector_storage::{
     check_deleted_condition, new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum,
 };
 
-// TODO(1.10): remove this in the next minor release to expose the compressed sparse index
 /// Whether to use the new compressed format.
-pub const USE_COMPRESSED: bool = false;
+pub const USE_COMPRESSED: bool = true;
 
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     config: SparseIndexConfig,

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -36,8 +36,6 @@ use sparse::common::sparse_vector_fixture::{random_full_sparse_vector, random_sp
 use sparse::common::types::DimId;
 use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
 use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
-use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
-use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::posting_list_common::PostingListIter as _;
@@ -64,7 +62,7 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
 
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
 
-    let sparse_vector_index = fixture_sparse_index::<InvertedIndexImmutableRam, _>(
+    let sparse_vector_index = fixture_sparse_index::<InvertedIndexCompressedImmutableRam<f32>, _>(
         &mut rnd,
         NUM_VECTORS,
         MAX_SPARSE_DIM,
@@ -196,7 +194,7 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut rnd = StdRng::seed_from_u64(42);
 
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
-    let sparse_vector_ram_index = fixture_sparse_index::<InvertedIndexImmutableRam, _>(
+    let sparse_vector_ram_index = fixture_sparse_index::<InvertedIndexCompressedImmutableRam<f32>, _>(
         &mut rnd,
         NUM_VECTORS,
         MAX_SPARSE_DIM,
@@ -212,7 +210,7 @@ fn sparse_vector_index_consistent_with_storage() {
     // create mmap sparse vector index
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
-    let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
+    let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexCompressedMmap<f32>> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_ram_index.id_tracker().clone(),
@@ -238,7 +236,7 @@ fn sparse_vector_index_consistent_with_storage() {
     // load index from memmap file
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
-    let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
+    let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexCompressedMmap<f32>> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker: sparse_vector_ram_index.id_tracker().clone(),
@@ -262,7 +260,7 @@ fn sparse_vector_index_consistent_with_storage() {
 #[test]
 fn sparse_vector_index_load_missing_mmap() {
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
-    let sparse_vector_index: OperationResult<SparseVectorIndex<InvertedIndexMmap>> =
+    let sparse_vector_index: OperationResult<SparseVectorIndex<InvertedIndexCompressedMmap<f32>>> =
         fixture_sparse_index_from_iter(
             data_dir.path(),
             [].iter().cloned(),
@@ -355,7 +353,7 @@ fn sparse_vector_index_ram_filtered_search() {
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
 
     // setup index
-    let sparse_vector_index = fixture_sparse_index::<InvertedIndexImmutableRam, _>(
+    let sparse_vector_index = fixture_sparse_index::<InvertedIndexCompressedImmutableRam<f32>, _>(
         &mut rnd,
         NUM_VECTORS,
         MAX_SPARSE_DIM,
@@ -446,7 +444,7 @@ fn sparse_vector_index_plain_search() {
 
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
     // setup index
-    let sparse_vector_index = fixture_sparse_index::<InvertedIndexImmutableRam, _>(
+    let sparse_vector_index = fixture_sparse_index::<InvertedIndexCompressedImmutableRam<f32>, _>(
         &mut rnd,
         NUM_VECTORS,
         MAX_SPARSE_DIM,
@@ -522,7 +520,7 @@ fn handling_empty_sparse_vectors() {
     let mut rnd = StdRng::seed_from_u64(42);
 
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
-    let sparse_vector_index: SparseVectorIndex<InvertedIndexImmutableRam> =
+    let sparse_vector_index: SparseVectorIndex<InvertedIndexCompressedImmutableRam<f32>> =
         fixture_sparse_index_from_iter(
             data_dir.path(),
             (0..NUM_VECTORS).map(|_| SparseVector::default()),


### PR DESCRIPTION
* Set `USE_COMPRESSED` to true to enable sparse vector.
* Switch to using compressed posting lists in tests.