### PR TITLE
Fail early when encountering out-of-storage during optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,6 +5310,7 @@ dependencies = [
  "criterion",
  "dataset",
  "fnv",
+ "fs4",
  "fs_extra",
  "generic-tests",
  "geo",

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -4,10 +4,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
+use common::disk::dir_size;
 use io::storage_version::StorageVersion;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
-use segment::common::dir_size;
 use segment::common::operation_error::check_process_stopped;
 use segment::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,

--- a/lib/common/common/src/disk.rs
+++ b/lib/common/common/src/disk.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+/// How many bytes a directory takes.
+pub fn dir_size(path: impl Into<PathBuf>) -> std::io::Result<u64> {
+    fn dir_size(mut dir: std::fs::ReadDir) -> std::io::Result<u64> {
+        dir.try_fold(0, |acc, file| {
+            let file = file?;
+            let size = match file.metadata()? {
+                data if data.is_dir() => dir_size(std::fs::read_dir(file.path())?)?,
+                data => data.len(),
+            };
+            Ok(acc + size)
+        })
+    }
+
+    dir_size(std::fs::read_dir(path.into())?)
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cpu;
 pub mod defaults;
+pub mod disk;
 pub mod fixed_length_priority_queue;
 pub mod math;
 pub mod panic;

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -87,6 +87,7 @@ memory = { path = "../common/memory" }
 sparse = { path = "../sparse" }
 
 tracing = { workspace = true, optional = true }
+fs4 = "0.8.4"
 macro_rules_attribute = "0.2.0"
 generic-tests = { workspace = true }
 nom = "7.1.3"

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -12,7 +12,6 @@ pub mod utils;
 pub mod validate_snapshot_archive;
 pub mod vector_utils;
 
-use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -21,23 +20,6 @@ use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::types::{SegmentConfig, SparseVectorDataConfig, VectorDataConfig};
 
 pub type Flusher = Box<dyn FnOnce() -> OperationResult<()> + Send>;
-
-/// How many bytes a directory takes.
-pub fn dir_size(path: impl Into<PathBuf>) -> std::io::Result<u64> {
-    fn dir_size(mut dir: std::fs::ReadDir) -> std::io::Result<u64> {
-        dir.try_fold(0, |acc, file| {
-            let file = file?;
-            let size = match file.metadata()? {
-                data if data.is_dir() => dir_size(std::fs::read_dir(file.path())?)?,
-                data => data.len(),
-            };
-            Ok(acc + size)
-        })
-    }
-
-    dir_size(std::fs::read_dir(path.into())?)
-}
-
 /// Check that the given vector name is part of the segment config.
 ///
 /// Returns an error if incompatible.

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -12,6 +12,7 @@ pub mod utils;
 pub mod validate_snapshot_archive;
 pub mod vector_utils;
 
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -20,6 +21,22 @@ use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::types::{SegmentConfig, SparseVectorDataConfig, VectorDataConfig};
 
 pub type Flusher = Box<dyn FnOnce() -> OperationResult<()> + Send>;
+
+/// How many bytes a directory takes.
+pub fn dir_size(path: impl Into<PathBuf>) -> std::io::Result<u64> {
+    fn dir_size(mut dir: std::fs::ReadDir) -> std::io::Result<u64> {
+        dir.try_fold(0, |acc, file| {
+            let file = file?;
+            let size = match file.metadata()? {
+                data if data.is_dir() => dir_size(std::fs::read_dir(file.path())?)?,
+                data => data.len(),
+            };
+            Ok(acc + size)
+        })
+    }
+
+    dir_size(std::fs::read_dir(path.into())?)
+}
 
 /// Check that the given vector name is part of the segment config.
 ///

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -46,8 +46,6 @@ pub enum OperationError {
     InconsistentStorage { description: String },
     #[error("Out of memory, free: {free}, {description}")]
     OutOfMemory { description: String, free: u64 },
-    #[error("Out of storage space")]
-    OutOfStorage,
     #[error("Operation cancelled: {description}")]
     Cancelled { description: String },
     #[error("Validation failed: {description}")]

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -1,7 +1,6 @@
 use std::backtrace::Backtrace;
 use std::collections::TryReserveError;
 use std::io::{Error as IoError, ErrorKind};
-use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomicwrites::Error as AtomicIoError;
@@ -79,35 +78,6 @@ pub fn check_process_stopped(stopped: &AtomicBool) -> OperationResult<()> {
         });
     }
     Ok(())
-}
-
-/// How many bytes a directory takes.
-fn dir_size(path: impl Into<PathBuf>) -> std::io::Result<u64> {
-    fn dir_size(mut dir: std::fs::ReadDir) -> std::io::Result<u64> {
-        dir.try_fold(0, |acc, file| {
-            let file = file?;
-            let size = match file.metadata()? {
-                data if data.is_dir() => dir_size(std::fs::read_dir(file.path())?)?,
-                data => data.len(),
-            };
-            Ok(acc + size)
-        })
-    }
-
-    dir_size(std::fs::read_dir(path.into())?)
-}
-
-/// Judge if the available storage space within a volume is less than
-/// the given threshold so that we won't leave a collection in half-updated state.
-/// This is a best guess and the real error might still happen down the line.
-pub fn check_enough_storage_space(temp_path: &Path, segments_path: &Path) -> OperationResult<()> {
-    let free_space = fs4::available_space(temp_path)?;
-
-    let existing_segments_size: u64 = dir_size(segments_path)?;
-
-    (free_space >= 2 * existing_segments_size)
-        .then_some(())
-        .ok_or(OperationError::OutOfStorage)
 }
 
 /// Contains information regarding last operation error, which should be fixed before next operation could be processed


### PR DESCRIPTION
/claim #4297

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

What this does is checks if there is twice as much free space on the volume as what the collection being optimized already takes.

I'm not happy with this, and I'm not sure this submission worth the hassle as it is, but I'd like to compare opinions.

## Why it's bad
* The free space checking works synchronously; even though the optimizations themselves take up background threads, I feel uneasy about it.
* The checking happens in the moment the optimization is about to start, not well beforehand.
* We still might run into OOD down the line because FS is non-atomic.
* It still logs the error, perhaps we want to special-case it as we do with `CollectionError::Cancelled`.

## What else have I tried
* Capture write error from `db.put_cf_opt`; it first happens somewhere around `lib/segment/src/segment_constructor/segment_builder.rs:197`, but I could not find a way to cleanly rollback a partially done optimization.
* Utilize the existing `DiskUsageWatcher` to do the checking before the optimization starts, but it does not have a dynamic threshold, so far as I understand it, and overall it gets a larger change that doing how it's done now.
* Add a method `check_environment` to the trait `SegmentOptimizer` in the same spirit as the existing `SegmentOptimizer::check_condition` so that all the implementors could tailor it to their taste, but for now this approach adds no value.
