### PR TITLE
order_by: Order by value, then id. Dedup by both

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -319,12 +319,16 @@ impl Collection {
                         })
                     })
                     // Get top results
-                    .kmerge_by(|(value_a, _), (value_b, _)| match order_by.direction() {
-                        Direction::Asc => value_a <= value_b,
-                        Direction::Desc => value_a >= value_b,
+                    .kmerge_by(|(value_a, record_a), (value_b, record_b)| {
+                        match order_by.direction() {
+                            Direction::Asc => (value_a, record_a.id) < (value_b, record_b.id),
+                            Direction::Desc => (value_a, record_a.id) > (value_b, record_b.id),
+                        }
                     })
-                    // Add each point only once, deduplicate point IDs
-                    .dedup_by(|(_, record_a), (_, record_b)| record_a.id == record_b.id)
+                    // Add each point only once, deduplicate on same (value, IDs) combination
+                    .dedup_by(|(value_a, record_a), (value_b, record_b)| {
+                        (value_a, record_a.id) == (value_b, record_b.id)
+                    })
                     .map(|(_, record)| api::rest::Record::from(record))
                     .take(limit)
                     .collect_vec()

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -325,10 +325,8 @@ impl Collection {
                             Direction::Desc => (value_a, record_a.id) > (value_b, record_b.id),
                         }
                     })
-                    // Add each point only once, deduplicate on same (value, IDs) combination
-                    .dedup_by(|(value_a, record_a), (value_b, record_b)| {
-                        (value_a, record_a.id) == (value_b, record_b.id)
-                    })
+                    // Only keep the point with the most "valuable" order value
+                    .dedup_by(|(_, record_a), (_, record_b)| record_a.id == record_b.id)
                     .map(|(_, record)| api::rest::Record::from(record))
                     .take(limit)
                     .collect_vec()

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -192,14 +192,10 @@ async fn test_scroll_dedup() {
     assert!(!result.points.is_empty(), "expected some points");
 
     let mut seen = HashSet::new();
-    for value_and_id in result
-        .points
-        .iter()
-        .map(|point| (point.order_value, point.id))
-    {
+    for point_id in result.points.iter().map(|point| point.id) {
         assert!(
-            seen.insert(value_and_id),
-            "got point id {value_and_id:?} more than once, they should be deduplicated",
+            seen.insert(point_id),
+            "got point id {point_id:?} more than once, they should be deduplicated",
         );
     }
 }

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -192,10 +192,14 @@ async fn test_scroll_dedup() {
     assert!(!result.points.is_empty(), "expected some points");
 
     let mut seen = HashSet::new();
-    for point_id in result.points.iter().map(|point| point.id) {
+    for value_and_id in result
+        .points
+        .iter()
+        .map(|point| (point.order_value, point.id))
+    {
         assert!(
-            seen.insert(point_id),
-            "got point id {point_id} more than once, they should be deduplicated",
+            seen.insert(value_and_id),
+            "got point id {value_and_id:?} more than once, they should be deduplicated",
         );
     }
 }

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -147,6 +147,15 @@ pub enum OrderValue {
     Float(FloatPayloadType),
 }
 
+#[cfg(any(test, feature = "testing"))]
+impl std::hash::Hash for OrderValue {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            OrderValue::Int(i) => i.hash(state),
+            OrderValue::Float(f) => f.to_bits().hash(state),
+        }
+    }
+}
 impl OrderValue {
     const MAX: Self = Self::Float(f64::NAN);
     const MIN: Self = Self::Float(f64::MIN);


### PR DESCRIPTION
Once implementing resharding deduplication, we introduced deduping by id. However, this broke one behavior for `order_by` in scroll: to repeat points if they had multiple values to order from.

With these changes now we output consistent (value, id) order, and we de-duplicate on the combination too.