### PR TITLE
Atomic create_and_ensure_length

### DIFF
--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -17,7 +17,7 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<File> 
         let file = OpenOptions::new()
             .read(true)
             .write(true)
-            .create(true)
+            .create(false)
             // Don't truncate because we explicitly set the length later
             .truncate(false)
             .open(path)?;

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -26,14 +26,18 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<File> 
         Ok(file)
     } else {
         let temp_path = path.with_extension(TEMP_FILE_EXTENSION);
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            // Don't truncate because we explicitly set the length later
-            .truncate(false)
-            .open(&temp_path)?;
-        file.set_len(length as u64)?;
+        {
+            // create temporary file with the required length
+            // Temp file is used to avoid situations, where crash happens between file creation and setting the length
+            let temp_file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                // Don't truncate because we explicitly set the length later
+                .truncate(false)
+                .open(&temp_path)?;
+            temp_file.set_len(length as u64)?;
+        }
 
         std::fs::rename(&temp_path, path)?;
 

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -10,17 +10,27 @@ use memmap2::{Mmap, MmapMut};
 use crate::madvise;
 use crate::madvise::Madviseable;
 
+pub const TEMP_FILE_EXTENSION: &str = "tmp";
+
 pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<File> {
+    let temp_path = path.with_extension(TEMP_FILE_EXTENSION);
     let file = OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         // Don't truncate because we explicitly set the length later
         .truncate(false)
-        .open(path)?;
+        .open(&temp_path)?;
     file.set_len(length as u64)?;
 
-    Ok(file)
+    std::fs::rename(&temp_path, path)?;
+
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(false)
+        .truncate(false)
+        .open(path)
 }
 
 pub fn open_read_mmap(path: &Path) -> io::Result<Mmap> {

--- a/lib/segment/src/vector_storage/chunked_utils.rs
+++ b/lib/segment/src/vector_storage/chunked_utils.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-use memory::mmap_ops::{create_and_ensure_length, open_write_mmap, TEMP_FILE_EXTENSION};
+use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 
 use crate::common::mmap_type::MmapSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -27,8 +26,7 @@ pub fn read_mmaps<T: Sized>(directory: &Path) -> OperationResult<Vec<MmapChunk<T
     for entry in directory.read_dir()? {
         let entry = entry?;
         let path = entry.path();
-        if path.is_file() && path.extension().map(OsStr::to_str) != Some(Some(TEMP_FILE_EXTENSION))
-        {
+        if path.is_file() {
             let chunk_id = path
                 .file_name()
                 .and_then(|file_name| file_name.to_str())

--- a/lib/segment/src/vector_storage/chunked_utils.rs
+++ b/lib/segment/src/vector_storage/chunked_utils.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
+use memory::mmap_ops::{create_and_ensure_length, open_write_mmap, TEMP_FILE_EXTENSION};
 
 use crate::common::mmap_type::MmapSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -26,7 +27,8 @@ pub fn read_mmaps<T: Sized>(directory: &Path) -> OperationResult<Vec<MmapChunk<T
     for entry in directory.read_dir()? {
         let entry = entry?;
         let path = entry.path();
-        if path.is_file() {
+        if path.is_file() && path.extension().map(OsStr::to_str) != Some(Some(TEMP_FILE_EXTENSION))
+        {
             let chunk_id = path
                 .file_name()
                 .and_then(|file_name| file_name.to_str())


### PR DESCRIPTION
There is a possibility to fails with file creation. Crash may happen between file creation and settings size. Solution: create temporary file and rename when ready