### PR TITLE
set comment field via collection create/update api

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -449,7 +449,11 @@
 | optimizer_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) |  | Configuration of the optimizers |
 | wal_config | [WalConfigDiff](#qdrant-WalConfigDiff) |  | Configuration of the Write-Ahead-Log |
 | quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Configuration of the vector quantization |
+<<<<<<< HEAD
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration of strict mode. |
+=======
+| comment | [string](#string) | optional | Collection-level-metadata for simple description, data title etc |
+>>>>>>> 234cbc85b (enable configuring comment on collection create api)
 
 
 
@@ -649,7 +653,11 @@
 | quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Quantization configuration of vector |
 | sharding_method | [ShardingMethod](#qdrant-ShardingMethod) | optional | Sharding method |
 | sparse_vectors_config | [SparseVectorConfig](#qdrant-SparseVectorConfig) | optional | Configuration for sparse vectors |
+<<<<<<< HEAD
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration for strict mode |
+=======
+| comment | [string](#string) | optional | Collection-level-metadata for simple description, data title etc |
+>>>>>>> 234cbc85b (enable configuring comment on collection create api)
 
 
 
@@ -1469,7 +1477,11 @@ Note: 1kB = 1 vector of size 256. |
 | vectors_config | [VectorsConfigDiff](#qdrant-VectorsConfigDiff) | optional | New vector parameters |
 | quantization_config | [QuantizationConfigDiff](#qdrant-QuantizationConfigDiff) | optional | Quantization configuration of vector |
 | sparse_vectors_config | [SparseVectorConfig](#qdrant-SparseVectorConfig) | optional | New sparse vector parameters |
+<<<<<<< HEAD
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | New strict mode configuration |
+=======
+| comment | [string](#string) | optional | Collection-level-metadata for simple description, data title etc |
+>>>>>>> 234cbc85b (enable configuring comment on collection create api)
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -449,11 +449,8 @@
 | optimizer_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) |  | Configuration of the optimizers |
 | wal_config | [WalConfigDiff](#qdrant-WalConfigDiff) |  | Configuration of the Write-Ahead-Log |
 | quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Configuration of the vector quantization |
-<<<<<<< HEAD
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration of strict mode. |
-=======
 | comment | [string](#string) | optional | Collection-level-metadata for simple description, data title etc |
->>>>>>> 234cbc85b (enable configuring comment on collection create api)
 
 
 
@@ -653,11 +650,8 @@
 | quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Quantization configuration of vector |
 | sharding_method | [ShardingMethod](#qdrant-ShardingMethod) | optional | Sharding method |
 | sparse_vectors_config | [SparseVectorConfig](#qdrant-SparseVectorConfig) | optional | Configuration for sparse vectors |
-<<<<<<< HEAD
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration for strict mode |
-=======
 | comment | [string](#string) | optional | Collection-level-metadata for simple description, data title etc |
->>>>>>> 234cbc85b (enable configuring comment on collection create api)
 
 
 
@@ -1477,11 +1471,8 @@ Note: 1kB = 1 vector of size 256. |
 | vectors_config | [VectorsConfigDiff](#qdrant-VectorsConfigDiff) | optional | New vector parameters |
 | quantization_config | [QuantizationConfigDiff](#qdrant-QuantizationConfigDiff) | optional | Quantization configuration of vector |
 | sparse_vectors_config | [SparseVectorConfig](#qdrant-SparseVectorConfig) | optional | New sparse vector parameters |
-<<<<<<< HEAD
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | New strict mode configuration |
-=======
 | comment | [string](#string) | optional | Collection-level-metadata for simple description, data title etc |
->>>>>>> 234cbc85b (enable configuring comment on collection create api)
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8699,6 +8699,12 @@
                 "nullable": true
               }
             ]
+          },
+          "comment": {
+            "description": "Collection-level-metadata for simple description, data title etc",
+            "default": null,
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -8916,7 +8922,6 @@
               }
             ]
           },
-<<<<<<< HEAD
           "strict_mode_config": {
             "anyOf": [
               {
@@ -8926,13 +8931,12 @@
                 "nullable": true
               }
             ]
-=======
+          },
           "comment": {
             "description": "Collection-level-metadata for simple description, data title etc",
             "default": null,
             "type": "string",
             "nullable": true
->>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6118,6 +6118,11 @@
                 "nullable": true
               }
             ]
+          },
+          "comment": {
+            "description": "Collection-level-metadata for simple description, data title etc",
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -8911,6 +8916,7 @@
               }
             ]
           },
+<<<<<<< HEAD
           "strict_mode_config": {
             "anyOf": [
               {
@@ -8920,6 +8926,13 @@
                 "nullable": true
               }
             ]
+=======
+          "comment": {
+            "description": "Collection-level-metadata for simple description, data title etc",
+            "default": null,
+            "type": "string",
+            "nullable": true
+>>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
           }
         }
       },

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -340,6 +340,7 @@ message CreateCollection {
   optional ShardingMethod sharding_method = 15; // Sharding method
   optional SparseVectorConfig sparse_vectors_config = 16; // Configuration for sparse vectors
   optional StrictModeConfig strict_mode_config = 17; // Configuration for strict mode
+  optional string comment = 18; // Collection-level-metadata for simple description, data title etc
 }
 
 message UpdateCollection {
@@ -352,7 +353,7 @@ message UpdateCollection {
   optional QuantizationConfigDiff quantization_config = 7; // Quantization configuration of vector
   optional SparseVectorConfig sparse_vectors_config = 8; // New sparse vector parameters
   optional StrictModeConfig strict_mode_config = 9; // New strict mode configuration
-  optional string comment = 10; // Collection-level-metadata 
+  optional string comment = 10; // Collection-level-metadata for simple description, data title etc
 }
 
 message DeleteCollection {
@@ -392,7 +393,7 @@ message CollectionConfig {
   WalConfigDiff wal_config = 4; // Configuration of the Write-Ahead-Log
   optional QuantizationConfig quantization_config = 5; // Configuration of the vector quantization
   optional StrictModeConfig strict_mode_config = 6; // Configuration of strict mode.
-  optional string comment = 7; // Collection-level-metadata 
+  optional string comment = 7; // Collection-level-metadata for simple description, data title etc
 }
 
 enum TokenizerType {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -352,6 +352,7 @@ message UpdateCollection {
   optional QuantizationConfigDiff quantization_config = 7; // Quantization configuration of vector
   optional SparseVectorConfig sparse_vectors_config = 8; // New sparse vector parameters
   optional StrictModeConfig strict_mode_config = 9; // New strict mode configuration
+  optional string comment = 10; // Collection-level-metadata 
 }
 
 message DeleteCollection {
@@ -391,6 +392,7 @@ message CollectionConfig {
   WalConfigDiff wal_config = 4; // Configuration of the Write-Ahead-Log
   optional QuantizationConfig quantization_config = 5; // Configuration of the vector quantization
   optional StrictModeConfig strict_mode_config = 6; // Configuration of strict mode.
+  optional string comment = 7; // Collection-level-metadata 
 }
 
 enum TokenizerType {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -552,6 +552,9 @@ pub struct UpdateCollection {
     /// New strict mode configuration
     #[prost(message, optional, tag = "9")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
+    /// Collection-level-metadata
+    #[prost(string, optional, tag = "10")]
+    pub comment: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -653,6 +656,9 @@ pub struct CollectionConfig {
     /// Configuration of strict mode.
     #[prost(message, optional, tag = "6")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
+    /// Collection-level-metadata
+    #[prost(string, optional, tag = "7")]
+    pub comment: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -555,7 +555,7 @@ pub struct UpdateCollection {
     /// New strict mode configuration
     #[prost(message, optional, tag = "9")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
-    /// Collection-level-metadata
+    /// Collection-level-metadata for simple description, data title etc
     #[prost(string, optional, tag = "10")]
     pub comment: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -512,6 +512,9 @@ pub struct CreateCollection {
     /// Configuration for strict mode
     #[prost(message, optional, tag = "17")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
+    /// Collection-level-metadata for simple description, data title etc
+    #[prost(string, optional, tag = "18")]
+    pub comment: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -656,7 +659,7 @@ pub struct CollectionConfig {
     /// Configuration of strict mode.
     #[prost(message, optional, tag = "6")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
-    /// Collection-level-metadata
+    /// Collection-level-metadata for simple description, data title etc
     #[prost(string, optional, tag = "7")]
     pub comment: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -63,6 +63,7 @@ fn setup() -> (TempDir, LocalShard) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        comment: None,
     };
 
     let optimizers_config = collection_config.optimizer_config.clone();

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -82,6 +82,7 @@ fn batch_search_bench(c: &mut Criterion) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        comment: None,
     };
 
     let optimizers_config = collection_config.optimizer_config.clone();

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -245,6 +245,15 @@ impl Collection {
         Ok(())
     }
 
+    pub async fn update_comment(&self, comment: String) -> CollectionResult<()> {
+        {
+            let mut config = self.collection_config.write().await;
+            config.comment = Some(comment);
+        }
+        self.collection_config.read().await.save(&self.path)?;
+        Ok(())
+    }
+
     /// Recreate the optimizers on all shards for this collection
     ///
     /// This will stop existing optimizers, and start new ones with new configurations.

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -165,6 +165,9 @@ pub struct CollectionConfig {
     #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub strict_mode_config: Option<StrictModeConfig>,
+    /// Collection-level-metadata for simple description, data title etc
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
 
 impl CollectionConfig {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -777,6 +777,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                 }
             },
             strict_mode_config: config.strict_mode_config.map(StrictModeConfig::from),
+            comment: None, // TODO
         })
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -778,7 +778,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                 }
             },
             strict_mode_config: config.strict_mode_config.map(StrictModeConfig::from),
-            comment: config.comment, 
+            comment: config.comment,
         })
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -437,6 +437,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                 strict_mode_config: config
                     .strict_mode_config
                     .map(api::grpc::qdrant::StrictModeConfig::from),
+                comment: config.comment,
             }),
             payload_schema: payload_schema
                 .into_iter()
@@ -777,7 +778,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                 }
             },
             strict_mode_config: config.strict_mode_config.map(StrictModeConfig::from),
-            comment: None, // TODO
+            comment: config.comment, 
         })
     }
 }

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -416,6 +416,7 @@ mod test {
             hnsw_config: Default::default(),
             quantization_config: Default::default(),
             strict_mode_config: Some(strict_mode_config.clone()),
+            comment: None,
         };
 
         let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -592,6 +592,7 @@ mod tests {
             hnsw_config: Default::default(),
             quantization_config: None,
             strict_mode_config: None,
+            comment: None,
         };
 
         let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -49,6 +49,7 @@ impl Anonymize for CollectionConfig {
             wal_config: self.wal_config.clone(),
             quantization_config: self.quantization_config.clone(),
             strict_mode_config: self.strict_mode_config.clone(),
+            comment: self.comment.clone(),
         }
     }
 }

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -48,6 +48,7 @@ pub fn create_collection_config() -> CollectionConfig {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        comment: None,
     }
 }
 

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -58,6 +58,7 @@ async fn fixture() -> Collection {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        comment: None,
     };
 
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -53,6 +53,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        comment: None,
     };
 
     let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -52,6 +52,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        comment: None,
     };
 
     let snapshot_path = collection_path.join("snapshots");

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -59,7 +59,11 @@ pub async fn multi_vec_collection_fixture(collection_path: &Path, shard_number: 
         wal_config,
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
+<<<<<<< HEAD
         strict_mode_config: Default::default(),
+=======
+        comment: None,
+>>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
     };
 
     let snapshot_path = collection_path.join("snapshots");

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -59,11 +59,8 @@ pub async fn multi_vec_collection_fixture(collection_path: &Path, shard_number: 
         wal_config,
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
-<<<<<<< HEAD
         strict_mode_config: Default::default(),
-=======
         comment: None,
->>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
     };
 
     let snapshot_path = collection_path.join("snapshots");

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -42,6 +42,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        comment: None,
     };
 
     let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -230,6 +230,9 @@ pub struct UpdateCollection {
     pub sparse_vectors: Option<SparseVectorsConfig>,
     #[validate(nested)]
     pub strict_mode_config: Option<StrictModeConfig>,
+    /// Collection-level-metadata for simple description, data title etc
+    #[serde(default)]
+    pub comment: Option<String>,
 }
 
 /// Operation for updating parameters of the existing collection
@@ -252,7 +255,11 @@ impl UpdateCollectionOperation {
                 optimizers_config: None,
                 quantization_config: None,
                 sparse_vectors: None,
+<<<<<<< HEAD
                 strict_mode_config: None,
+=======
+                comment: None,
+>>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
             },
             shard_replica_changes: None,
         }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -171,6 +171,9 @@ pub struct CreateCollection {
     /// Strict-mode config.
     #[validate(nested)]
     pub strict_mode_config: Option<StrictModeConfig>,
+    /// Collection-level-metadata for simple description, data title etc
+    #[serde(default)]
+    pub comment: Option<String>,
 }
 
 /// Operation for creating new collection and (optionally) specify index params
@@ -411,6 +414,7 @@ impl From<CollectionConfig> for CreateCollection {
             quantization_config: value.quantization_config,
             sparse_vectors: value.params.sparse_vectors,
             strict_mode_config: value.strict_mode_config,
+            comment: value.comment,
         }
     }
 }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -255,11 +255,8 @@ impl UpdateCollectionOperation {
                 optimizers_config: None,
                 quantization_config: None,
                 sparse_vectors: None,
-<<<<<<< HEAD
                 strict_mode_config: None,
-=======
                 comment: None,
->>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
             },
             shard_replica_changes: None,
         }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -113,6 +113,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                     .map(SparseVectorsConfig::try_from)
                     .transpose()?,
                 strict_mode_config: value.strict_mode_config.map(StrictModeConfig::from),
+                comment: None, // TODO
             },
         )))
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -114,7 +114,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                     .map(SparseVectorsConfig::try_from)
                     .transpose()?,
                 strict_mode_config: value.strict_mode_config.map(StrictModeConfig::from),
-                comment: value.comment, 
+                comment: value.comment,
             },
         )))
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -68,6 +68,7 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
                     .map(sharding_method_from_proto)
                     .transpose()?,
                 strict_mode_config: value.strict_mode_config.map(strict_mode_from_api),
+                comment: value.comment,
             },
         )))
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -113,7 +113,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                     .map(SparseVectorsConfig::try_from)
                     .transpose()?,
                 strict_mode_config: value.strict_mode_config.map(StrictModeConfig::from),
-                comment: None, // TODO
+                comment: value.comment, 
             },
         )))
     }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -136,6 +136,7 @@ pub mod consensus_ops {
                     quantization_config: None,
                     sparse_vectors: None,
                     strict_mode_config: None,
+                    comment: None,
                 },
             );
             operation

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -126,7 +126,11 @@ impl TableOfContent {
             optimizers_config,
             quantization_config,
             sparse_vectors,
+<<<<<<< HEAD
             strict_mode_config: strict_mode,
+=======
+            comment,
+>>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
         } = operation.update_collection;
         let collection = self
             .get_collection_unchecked(&operation.collection_name)
@@ -164,6 +168,8 @@ impl TableOfContent {
         }
         if let Some(strict_mode) = strict_mode {
             collection.update_strict_mode_config(strict_mode).await?;
+        if let Some(comment) = comment {
+            collection.update_comment(comment).await?;
         }
 
         // Recreate optimizers

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -126,11 +126,8 @@ impl TableOfContent {
             optimizers_config,
             quantization_config,
             sparse_vectors,
-<<<<<<< HEAD
             strict_mode_config: strict_mode,
-=======
             comment,
->>>>>>> 5eda4b598 (store collection-wise comment as config value via rest api)
         } = operation.update_collection;
         let collection = self
             .get_collection_unchecked(&operation.collection_name)
@@ -168,6 +165,7 @@ impl TableOfContent {
         }
         if let Some(strict_mode) = strict_mode {
             collection.update_strict_mode_config(strict_mode).await?;
+        }
         if let Some(comment) = comment {
             collection.update_comment(comment).await?;
         }

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -44,11 +44,8 @@ impl TableOfContent {
             init_from,
             quantization_config,
             sparse_vectors,
-<<<<<<< HEAD
             strict_mode_config,
-=======
             comment,
->>>>>>> 234cbc85b (enable configuring comment on collection create api)
         } = operation;
 
         self.collections
@@ -209,12 +206,8 @@ impl TableOfContent {
             optimizer_config: optimizers_config,
             hnsw_config,
             quantization_config,
-<<<<<<< HEAD
             strict_mode_config,
-            comment: None,
-=======
             comment,
->>>>>>> 234cbc85b (enable configuring comment on collection create api)
         };
         let collection = Collection::new(
             collection_name.to_string(),

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -44,7 +44,11 @@ impl TableOfContent {
             init_from,
             quantization_config,
             sparse_vectors,
+<<<<<<< HEAD
             strict_mode_config,
+=======
+            comment,
+>>>>>>> 234cbc85b (enable configuring comment on collection create api)
         } = operation;
 
         self.collections
@@ -205,8 +209,12 @@ impl TableOfContent {
             optimizer_config: optimizers_config,
             hnsw_config,
             quantization_config,
+<<<<<<< HEAD
             strict_mode_config,
             comment: None,
+=======
+            comment,
+>>>>>>> 234cbc85b (enable configuring comment on collection create api)
         };
         let collection = Collection::new(
             collection_name.to_string(),

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -206,6 +206,7 @@ impl TableOfContent {
             hnsw_config,
             quantization_config,
             strict_mode_config,
+            comment: None,
         };
         let collection = Collection::new(
             collection_name.to_string(),

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -114,6 +114,7 @@ fn test_alias_operation() {
                         quantization_config: None,
                         sharding_method: None,
                         strict_mode_config: None,
+                        comment: None,
                     },
                 )),
                 FULL_ACCESS.clone(),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1460,6 +1460,7 @@ mod tests {
                             quantization_config: None,
                             sharding_method: None,
                             strict_mode_config: None,
+                            comment: None,
                         },
                     )),
                     Access::full("For test"),

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -63,6 +63,7 @@ pub async fn handle_existing_collections(
                 init_from: None,
                 quantization_config: collection_state.config.quantization_config,
                 strict_mode_config: collection_state.config.strict_mode_config,
+                comment: None,
             },
         );
 

--- a/tests/openapi/test_collection_update.py
+++ b/tests/openapi/test_collection_update.py
@@ -90,6 +90,7 @@ def test_edit_collection_params(on_disk_vectors, on_disk_payload):
     assert config["hnsw_config"]["m"] == 16
     assert config["hnsw_config"]["ef_construct"] == 100
     assert config["quantization_config"] is None
+    assert "comment" not in config
 
     response = request_with_validation(
         api='/collections/{collection_name}',

--- a/tests/openapi/test_collection_update.py
+++ b/tests/openapi/test_collection_update.py
@@ -120,6 +120,7 @@ def test_edit_collection_params(on_disk_vectors, on_disk_payload):
                     "always_ram": True
                 }
             },
+            "comment": "test collection for update",
             "params": {
                 "on_disk_payload": on_disk_payload,
             },
@@ -146,6 +147,7 @@ def test_edit_collection_params(on_disk_vectors, on_disk_payload):
     assert config["quantization_config"]["scalar"]["type"] == "int8"
     assert config["quantization_config"]["scalar"]["quantile"] == 0.99
     assert config["quantization_config"]["scalar"]["always_ram"]
+    assert config["comment"] == "test collection for update"
 
     response = request_with_validation(
         api='/collections/{collection_name}',


### PR DESCRIPTION
/claim #3957 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
There's an open pr for this issue, but it seems like idle at this moment. 
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Description
This PR adds an optional comment field to the config and enhances the collection create/update API to set this field. 
I have tested both REST and gRPC APIs via the web UI and terminal, and added an integration test for the comment update in `tests/openapi/openapi_integration/test_collection_update.py`.
