### PR TITLE
Fix DynamicMmapFlag counting by not using get proxy

### DIFF
--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -216,13 +216,9 @@ impl DynamicMmapFlags {
 
     /// Count number of set flags
     pub fn count_flags(&self) -> usize {
-        let mut ones = self.flags.count_ones();
-
-        // Subtract flags in extra capacity we don't use
-        // They may have been set before shrinking the bitvec again
-        ones -= self.flags[self.status.len..].iter().filter(|i| **i).count();
-
-        ones
+        // Take a bitslice of our set length, count ones in it
+        // This uses bit-indexing, returning a new bitslice, extra bits within capacity are not counted
+        self.flags[..self.status.len].count_ones()
     }
 
     /// Set the `true` value of the flag at the given index.

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -220,9 +220,7 @@ impl DynamicMmapFlags {
 
         // Subtract flags in extra capacity we don't use
         // They may have been set before shrinking the bitvec again
-        ones -= (self.status.len..self.flags.len())
-            .filter(|&i| self.get(i))
-            .count();
+        ones -= self.flags[self.status.len..].iter().filter(|i| **i).count();
 
         ones
     }


### PR DESCRIPTION
I think `DynamicMmapFlag::count_flags` is not entirely correct as it relies on the `get` function to verify if a given position is set.

```rust
pub fn get<TKey>(&self, key: TKey) -> bool
    where
        TKey: num_traits::cast::AsPrimitive<usize>,
    {
        let key: usize = key.as_();
        if key >= self.status.len {
            return false;
        }
        self.flags[key]
    }
```

However this function shortcuts any lookup for keys above `self.status.len` which prevents us from getting the real number of positive flag to subtract.

This PR proposes to look directly into the `flags` to fix the count.