### PR TITLE
Fix incorrect source shards, fix source shards from hash ring

### DIFF
--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::hash::Hash;
 use std::{any, fmt};
 
@@ -179,6 +180,16 @@ impl<T: Hash + Copy + PartialEq> HashRing<T> {
     }
 }
 
+impl<T: Hash + Copy + PartialEq + Eq> HashRing<T> {
+    /// Get unique nodes from the hashring
+    pub fn unique_nodes(&self) -> HashSet<T> {
+        match self {
+            Self::Single(ring) => ring.unique_nodes(),
+            Self::Resharding { old: _, new } => new.unique_nodes(),
+        }
+    }
+}
+
 /// List type for shard IDs
 ///
 /// Uses a `SmallVec` putting two IDs on the stack. That's the maximum number of shards we expect
@@ -254,6 +265,18 @@ impl<T: Hash + Copy> Inner<T> {
         match self {
             Inner::Raw(ring) => ring.len(),
             Inner::Fair { ring, scale } => ring.len() / *scale as usize,
+        }
+    }
+}
+
+impl<T: Hash + Copy + PartialEq + Eq> Inner<T> {
+    /// Get unique nodes from the hashring
+    pub fn unique_nodes(&self) -> HashSet<T> {
+        match self {
+            Inner::Raw(ring) => ring.clone().into_iter().collect(),
+            Inner::Fair { ring, scale: _ } => {
+                ring.clone().into_iter().map(|(node, _)| node).collect()
+            }
         }
     }
 }


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>

While resharding, the source shards aren't just `0..to_shard_id`. This logic breaks when custom sharding is used.

This PR changes it to fetch the source shards from the hash ring.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?