### PR TITLE
Fix resharding replication getting stuck, transfer limit was inverted

### DIFF
--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -610,7 +610,7 @@ async fn stage_replicate(
             // Ensure we don't exceed the outgoing transfer limits
             let shard_holder = shard_holder.read().await;
             let (_, outgoing) = shard_holder.count_shard_transfer_io(&this_peer_id);
-            if outgoing < outgoing_limit {
+            if outgoing >= outgoing_limit {
                 log::trace!("Postponing resharding replication transfer to stay below transfer limit (outgoing: {outgoing})");
                 sleep(SHARD_TRANSFER_IO_LIMIT_RETRY_INTERVAL).await;
                 continue;


### PR DESCRIPTION
Tracked in: #4213 

Fix the resharding transfer limit check being inverted.

This also fixes the resharding replication stage getting stuck.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?