### PR TITLE
Fix resharding local transfer leaving proxy

### DIFF
--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -211,8 +211,8 @@ impl ShardReplicaSet {
 
         if active_remote_shards.is_empty() && !local_is_updatable {
             return Err(CollectionError::service_error(format!(
-                "The replica set for shard {} on peer {} has no active replica",
-                self.shard_id, this_peer_id
+                "The replica set for shard {} on peer {this_peer_id} has no active replica",
+                self.shard_id,
             )));
         }
 
@@ -297,7 +297,7 @@ impl ShardReplicaSet {
                 if echo_tag.peer_id != clock_tag.peer_id {
                     debug_assert!(
                         false,
-                        "Echoed clock tag peer_id does not match the original"
+                        "Echoed clock tag peer_id does not match the original",
                     );
                     return None;
                 }
@@ -305,7 +305,7 @@ impl ShardReplicaSet {
                 if echo_tag.clock_id != clock_tag.clock_id {
                     debug_assert!(
                         false,
-                        "Echoed clock tag clock_id does not match the original"
+                        "Echoed clock tag clock_id does not match the original",
                     );
                     return None;
                 }

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -531,13 +531,25 @@ async fn migrate_local(
 
     let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
     transfer_resharding_stream_records(
-        shard_holder,
+        Arc::clone(&shard_holder),
         progress,
         source_shard_id,
         target_shard,
         collection_id,
     )
     .await?;
+
+    // Unproxify forward proxy on local shard we just transferred
+    // Normally consensus takes care of this, but we don't use consensus here
+    {
+        let shard_holder = shard_holder.read().await;
+        let replica_set = shard_holder.get_shard(&source_shard_id).ok_or_else(|| {
+            CollectionError::service_error(format!(
+                "Shard {source_shard_id} not found in the shard holder for resharding",
+            ))
+        })?;
+        replica_set.un_proxify_local().await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Tracked in: #4213 

While migration points as part of resharding we might do a 'local transfer' if the source and target shard are on the same node.

This logic did not clean up the forward proxy that is created. This PR fixes that.

Normally consensus takes care of this for us, but we don't use consensus here.

This also fixes randomly deleting points from the newly created resharded-shard during the delete propagation stage.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?