### PR TITLE
Add resharding tests

### DIFF
--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -877,8 +877,10 @@ async fn stage_propagate_deletes(
             let operation =
                 CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints { ids });
 
+            // Wait on all updates here, not just the last batch
+            // If we don't wait on all updates it somehow results in inconsistent deletes
             replica_set
-                .update_with_consistency(operation, offset.is_none(), WriteOrdering::Weak)
+                .update_with_consistency(operation, true, WriteOrdering::Weak)
                 .await?;
 
             if offset.is_none() {

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -62,3 +62,54 @@ def test_resharding(tmp_path: pathlib.Path):
         for uri in peer_api_uris:
             assert check_collection_local_shards_count(uri, COLLECTION_NAME, shard_count)
             assert get_collection_local_shards_point_count(uri, COLLECTION_NAME) == num_points
+
+
+# Test resharding shard balancing.
+#
+# Sets up a 3 node cluster and a collection with 1 shard and 2 replicas.
+# Performs resharding 7 times and asserts the shards replicas are evenly
+# balanced across all nodes.
+#
+# In this case the replicas are balanced on the second and third node. The first
+# node has all shards because we explicitly set it as shard target all the time.
+def test_resharding_balance(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    # Prevent optimizers messing with point counts
+    env={
+        "QDRANT__STORAGE__OPTIMIZERS__MAX_OPTIMIZATION_THREADS": "0",
+    }
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
+    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
+
+    # Create collection, insert points
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=2)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+    upsert_random_points(peer_api_uris[0], 100)
+
+    # Reshard 5 times in sequence
+    for _shard_count in range(2, 7):
+        # Start resharding
+        r = requests.post(
+            f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+                "start_resharding": {
+                    "peer_id": first_peer_id,
+                    "shard_key": None,
+                }
+            })
+        assert_http_ok(r)
+
+        # Wait for resharding operation to start and stop
+        wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
+        wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 0)
+
+    # We must end up with:
+    # - 6 shards on first node, it was the resharding target
+    # - 3 shards on the other two nodes, 6 replicas spread over 2 nodes
+    assert check_collection_local_shards_count(peer_api_uris[0], COLLECTION_NAME, 6)
+    for uri in peer_api_uris[1:]:
+        assert check_collection_local_shards_count(uri, COLLECTION_NAME, 3)

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -136,9 +136,13 @@ def test_resharding_balance(tmp_path: pathlib.Path):
         for uri in peer_api_uris:
             wait_for_collection_resharding_operations_count(uri, COLLECTION_NAME, 0)
 
+        # Point count across cluster must be stable
+        for uri in peer_api_uris:
+            assert get_collection_point_count(uri, COLLECTION_NAME, exact=False) == num_points
+
     # We must end up with:
     # - 6 shards on first node, it was the resharding target
-    # - 3 shards on the other two nodes, 6 replicas spread over 2 nodes
+    # - 3 shards on the other two nodes, 6 replicas balanced over 2 nodes
     assert check_collection_local_shards_count(peer_api_uris[0], COLLECTION_NAME, 6)
     for uri in peer_api_uris[1:]:
         assert check_collection_local_shards_count(uri, COLLECTION_NAME, 3)

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -146,3 +146,130 @@ def test_resharding_balance(tmp_path: pathlib.Path):
     assert check_collection_local_shards_count(peer_api_uris[0], COLLECTION_NAME, 6)
     for uri in peer_api_uris[1:]:
         assert check_collection_local_shards_count(uri, COLLECTION_NAME, 3)
+
+
+# Test resharding with concurrent updates.
+#
+# This performs resharding a few times while sending point updates to all peers
+# concurrently. At the end of the whole process it asserts the expected point
+# count.
+#
+# The concurrent update tasks consist of:
+# - 3 threads upserting new points on all peers
+# - 1 threads updating existing points on the first peer
+# - 2 threads deleting points on the first two peers
+def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    num_points = 1000
+    num_upserts = 100
+    num_deletes = 33
+
+    # Prevent optimizers messing with point counts
+    env={
+        "QDRANT__STORAGE__OPTIMIZERS__INDEXING_THRESHOLD_KB": "0",
+    }
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
+    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
+
+    # Create collection, insert points
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris,
+    )
+    upsert_random_points(peer_api_uris[0], num_points)
+
+    sleep(1)
+
+    # Assert node shard and point sum count
+    for uri in peer_api_uris:
+        assert check_collection_local_shards_count(uri, COLLECTION_NAME, 1)
+        assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, num_points)
+
+    # During resharding, keep pushing updates into the collection
+    update_tasks = [
+        # Upsert new points on all peers
+        run_in_background(upsert_points_throttled, peer_api_uris[0], COLLECTION_NAME, start=10000, end=10000 + num_upserts),
+        run_in_background(upsert_points_throttled, peer_api_uris[1], COLLECTION_NAME, start=20000, end=20000 + num_upserts),
+        run_in_background(upsert_points_throttled, peer_api_uris[2], COLLECTION_NAME, start=30000, end=30000 + num_upserts),
+        # Update existing points on the first peer
+        run_in_background(upsert_points_throttled, peer_api_uris[0], COLLECTION_NAME, start=0, end=num_upserts),
+        # Delete points on the first two peers
+        run_in_background(delete_points_throttled, peer_api_uris[0], COLLECTION_NAME, start=500, end=500 + num_deletes),
+        run_in_background(delete_points_throttled, peer_api_uris[1], COLLECTION_NAME, start=600, end=600 + num_deletes),
+    ]
+
+    # Reshard 3 times in sequence
+    for shard_count in range(2, 5):
+        # Start resharding
+        r = requests.post(
+            f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+                "start_resharding": {
+                    "peer_id": first_peer_id,
+                    "shard_key": None,
+                }
+            })
+        assert_http_ok(r)
+
+        # Wait for resharding operation to start and stop
+        wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
+        for uri in peer_api_uris:
+            wait_for_collection_resharding_operations_count(uri, COLLECTION_NAME, 0)
+
+        # Assert node shard count
+        for uri in peer_api_uris:
+            assert check_collection_local_shards_count(uri, COLLECTION_NAME, shard_count)
+
+    # Wait for background updates to finish
+    for task in update_tasks:
+        while task.is_alive():
+            pass
+
+    # Assert node shard and point sum count
+    # Expects base points + 3x upserts - 2x deletes
+    expected_points = num_points + num_upserts * 3 - num_deletes * 2
+    for uri in peer_api_uris:
+        assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, expected_points)
+
+
+def run_in_background(run, *args, **kwargs):
+    p = multiprocessing.Process(target=run, args=args, kwargs=kwargs)
+    p.start()
+    return p
+
+
+def upsert_points_throttled(peer_url, collection_name, start=0, end=None):
+    batch_size = 3
+    offset = start
+
+    while True:
+        count = min(end - offset, batch_size) if end is not None else batch_size
+        if count <= 0:
+            return
+
+        upsert_random_points(peer_url, count, collection_name, offset=offset)
+        offset += count
+
+        sleep(random.uniform(0.4, 0.6))
+
+
+def delete_points_throttled(peer_url, collection_name, start=0, end=None):
+    batch_size = 3
+    offset = start
+
+    while True:
+        count = min(end - offset, batch_size) if end is not None else batch_size
+        if count <= 0:
+            return
+
+        r = requests.post(
+            f"{peer_url}/collections/{collection_name}/points/delete?wait=true", json={
+                "points": list(range(offset, offset + count)),
+            }
+        )
+        assert_http_ok(r)
+        offset += count
+
+        sleep(random.uniform(0.4, 0.6))

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -30,7 +30,6 @@ def run_update_points_in_background(peer_url, collection_name, init_offset=0, th
 
 
 def check_data_consistency(data):
-
     assert(len(data) > 1)
 
     for i in range(len(data) - 1):

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -254,7 +254,7 @@ def get_collection_info(peer_api_uri: str, collection_name: str) -> dict:
 
 
 def get_collection_point_count(peer_api_uri: str, collection_name: str, exact: bool = False) -> int:
-    r = requests.post(f"{peer_api_uri}/collections/test_collection/points/count", json={"exact": exact})
+    r = requests.post(f"{peer_api_uri}/collections/{collection_name}/points/count", json={"exact": exact})
     assert_http_ok(r)
     res = r.json()["result"]["count"]
     return res
@@ -378,7 +378,7 @@ def check_collection_local_shards_point_count(peer_api_uri: str, collection_name
 
     is_correct = point_count == expected_count
     if not is_correct:
-        print(f"Collection '{collection_name}' on peer {peer_api_uri}: {json.dumps(collection_cluster_info, indent=4)}")
+        print(f"Collection '{collection_name}' on peer {peer_api_uri} ({point_count} != {expected_count}): {json.dumps(collection_cluster_info, indent=4)}")
 
     return is_correct
 

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -368,10 +368,16 @@ def check_collection_local_shards_count(peer_api_uri: str, collection_name: str,
     return local_shard_count == expected_local_shard_count
 
 
-def get_collection_local_shards_point_count(peer_api_uri: str, collection_name: str) -> int:
+def check_collection_local_shards_point_count(peer_api_uri: str, collection_name: str,
+                                            expected_count: int) -> int:
     collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name)
     point_count = sum(map(lambda shard: shard["points_count"], collection_cluster_info["local_shards"]))
-    return point_count
+
+    is_correct = point_count == expected_count
+    if not is_correct:
+        print(f"Collection '{collection_name}' on peer {peer_api_uri}: {json.dumps(collection_cluster_info, indent=4)}")
+
+    return is_correct
 
 
 def check_collection_shard_transfers_count(peer_api_uri: str, collection_name: str,

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -363,9 +363,12 @@ def collection_exists_on_all_peers(collection_name: str, peer_api_uris: [str]) -
 
 def check_collection_local_shards_count(peer_api_uri: str, collection_name: str,
                                         expected_local_shard_count: int) -> bool:
+    return get_collection_local_shards_count(peer_api_uri, collection_name) == expected_local_shard_count
+
+
+def get_collection_local_shards_count(peer_api_uri: str, collection_name: str) -> bool:
     collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name)
-    local_shard_count = len(collection_cluster_info["local_shards"])
-    return local_shard_count == expected_local_shard_count
+    return len(collection_cluster_info["local_shards"])
 
 
 def check_collection_local_shards_point_count(peer_api_uri: str, collection_name: str,


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/4213>

Add a few resharding integration tests in our consensus testing suite.

Currently this covers:
- reshard 3 times in sequence, asserts shard/point counts and point data consistency
- reshard 5 times in sequence, asserts replicas are automatically balanced on peers
- reshard 3 times with concurrent inserts, updates and deletes, asserts shard/point counts and point data consistency 

Later we may extend this with even more complex scenarios as we see fit.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
