### PR TITLE
Add MmapHashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "binout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60b1af88a588fca5fe424ae7d735bc52814f80ff57614f57043cc4e2024f2ea"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06e8e5bec3490b9f6f3adbb78aa4f53e8396fd9994e8a62a346b44ea7c15f35"
+dependencies = [
+ "dyn_size_of",
 ]
 
 [[package]]
@@ -1152,14 +1167,19 @@ name = "common"
 version = "0.0.0"
 dependencies = [
  "lazy_static",
+ "memmap2 0.9.4",
  "num_cpus",
  "ordered-float 4.2.1",
+ "ph",
+ "rand 0.8.5",
  "semver",
  "serde",
+ "tempfile",
  "thiserror",
  "thread-priority",
  "tokio",
  "validator",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1669,6 +1689,12 @@ name = "dyn-clone"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+
+[[package]]
+name = "dyn_size_of"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d4f78a40b1ec35bf8cafdaaf607ba2f773c366b0b3bda48937cacd7a8d5134"
 
 [[package]]
 name = "earcutr"
@@ -3876,6 +3902,19 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap 1.9.2",
+]
+
+[[package]]
+name = "ph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b7b74d575d7c11fb653fae69688be5206cafc1ead33c01ce61ac7f36eae45b"
+dependencies = [
+ "binout",
+ "bitm",
+ "dyn_size_of",
+ "rayon",
+ "wyhash",
 ]
 
 [[package]]
@@ -7239,6 +7278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyhash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7275,18 +7323,19 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ data-consistency-check = ["collection/data-consistency-check"]
 serde_urlencoded = "0.7"
 sealed_test = "1.1.0"
 
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 rusty-hook = "^0.11.2"
 
 
@@ -132,6 +132,7 @@ indexmap = { version = "2", features = ["serde"] }
 indicatif = "0.17.8"
 itertools = "0.13.0"
 log = "0.4.22"
+memmap2 = "0.9.4"
 num-traits = "0.2.19"
 parking_lot = { version = "0.12.3", features = ["deadlock_detection", "serde"] }
 pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }
@@ -146,6 +147,7 @@ serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tar = "0.4.41"
+tempfile = "3.10.1"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-util = "0.7"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ log = "0.4.22"
 memmap2 = "0.9.4"
 num-traits = "0.2.19"
 parking_lot = { version = "0.12.3", features = ["deadlock_detection", "serde"] }
+ph = "0.8.3"
 pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }
 prost = "0.11.9"
 prost-wkt-types = "0.4.2"
@@ -156,6 +157,7 @@ tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.9", features = ["v4", "serde"] }
 validator = { version = "0.16.1", features = ["derive"] }
 wal = { git = "https://github.com/qdrant/wal.git", rev = "a7870900f29811a24e20882887d60e6a2febf945" }
+zerocopy = { version = "0.7.34", features = ["derive"] }
 
 [[bin]]
 name = "schema_generator"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -74,7 +74,7 @@ schemars = { workspace = true }
 tar = { workspace = true }
 fs_extra = "1.3.0"
 semver = { workspace = true }
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 sha2 = "0.10.8"
 bytes = "1.6.0"
 fnv = { workspace = true }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -15,11 +15,18 @@ testing = []
 [dependencies]
 num_cpus = "1.16"
 ordered-float = "4.2"
+ph = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 validator = { workspace = true }
 lazy_static = "1.5.0"
+memmap2 = { workspace = true }
 semver = { workspace = true }
+zerocopy = { workspace = true }
+
+[dev-dependencies]
+rand = { workspace = true }
+tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 thiserror = "1.0"

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -17,6 +17,7 @@ num_cpus = "1.16"
 ordered-float = "4.2"
 ph = { workspace = true }
 serde = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 validator = { workspace = true }
 lazy_static = "1.5.0"
@@ -26,7 +27,6 @@ zerocopy = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
-tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 thiserror = "1.0"

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -3,6 +3,7 @@ pub mod defaults;
 pub mod disk;
 pub mod fixed_length_priority_queue;
 pub mod math;
+pub mod mmap_hashmap;
 pub mod panic;
 pub mod top_k;
 pub mod types;

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -1,0 +1,233 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{self, Cursor, Write as _};
+use std::mem::size_of;
+use std::path::Path;
+use std::str;
+
+use memmap2::Mmap;
+use ph::fmph::Function;
+#[cfg(test)]
+use rand::rngs::StdRng;
+#[cfg(test)]
+use rand::{Rng as _, SeedableRng as _};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+/// On-disk hash map baked by a memory-mapped file.
+pub struct MmapHashMap {
+    mmap: Mmap,
+    header: Header,
+    phf: Function,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
+struct Header {
+    buckets_pos: u64,
+    buckets_count: u64,
+}
+
+const PADDING_SIZE: usize = 4096;
+
+impl MmapHashMap {
+    /// Save `map` contents to `path`.
+    pub fn create(path: &Path, map: BTreeMap<String, BTreeSet<u32>>) -> io::Result<()> {
+        let phf = Function::from(map.keys().collect::<Vec<_>>().as_slice());
+
+        // == First pass ==
+
+        let mut file_size = 0;
+        // 1. Header
+        file_size += size_of::<Header>();
+
+        // 2. PHF
+        file_size += phf.write_bytes();
+
+        // 3. Padding
+        let padding_len = (PADDING_SIZE - (file_size % PADDING_SIZE)) % PADDING_SIZE;
+        file_size += padding_len;
+
+        // 4. Buckets
+        let buckets_pos = file_size;
+        file_size += map.len() * size_of::<u64>();
+
+        // 5. Data
+        let mut buckets = vec![0u64; map.len()];
+        let mut last_bucket = 0;
+        for (k, v) in map.iter() {
+            buckets[phf.get(k).expect("Key not found in phf") as usize] = last_bucket as u64;
+            last_bucket += entry_size(k, v);
+        }
+        file_size += last_bucket;
+        _ = file_size;
+
+        // == Second pass ==
+
+        let mut bufw = io::BufWriter::new(File::create(path)?);
+
+        // 1. Header
+        let header = Header {
+            buckets_pos: buckets_pos as u64,
+            buckets_count: map.len() as u64,
+        };
+        bufw.write_all(header.as_bytes())?;
+
+        // 2. PHF
+        phf.write(&mut bufw)?;
+
+        // 3. Padding
+        bufw.write_all(zeroes(padding_len))?;
+
+        // 4. Buckets
+        bufw.write_all(buckets.as_bytes())?;
+
+        // 5. Data
+        let mut pos = 0;
+        for (k, v) in map.iter() {
+            buckets.push(pos as u64);
+            pos += entry_size(k, v);
+
+            // Lengths
+            bufw.write_all((k.len() as u64).as_bytes())?;
+            bufw.write_all((v.len() as u64).as_bytes())?;
+
+            // Key
+            bufw.write_all(k.as_bytes())?;
+
+            bufw.write_all(zeroes(k.len().next_multiple_of(4) - k.len()))?;
+
+            // Values
+            for i in v.iter() {
+                bufw.write_all(i.as_bytes())?;
+            }
+        }
+        bufw.flush()?;
+
+        Ok(())
+    }
+
+    /// Load the hash map from file.
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let file = File::open(path)?;
+
+        // SAFETY: Assume other processes do not modify the file.
+        // See https://docs.rs/memmap2/latest/memmap2/struct.Mmap.html#safety
+        let mmap = unsafe { Mmap::map(&file)? };
+
+        let header = Header::read_from_prefix(mmap.as_ref()).ok_or(io::ErrorKind::InvalidData)?;
+
+        let phf = Function::read(&mut Cursor::new(
+            &mmap
+                .get(size_of::<Header>()..header.buckets_pos as usize)
+                .ok_or(io::ErrorKind::InvalidData)?,
+        ))?;
+
+        Ok(MmapHashMap { mmap, header, phf })
+    }
+
+    /// Get the values associated with `key`. It will return `None` in the following cases:
+    /// - The key is not present in this hash map.
+    /// - The data is corrupted, e.g. invalid UTF-8 or wrong alignment. (should not happen during
+    ///   normal operation)
+    pub fn get(&self, key: &str) -> Option<&[u32]> {
+        let hash = self.phf.get(key)?;
+
+        let buckets = u64::slice_from(self.mmap.get(
+            self.header.buckets_pos as usize
+                ..self.header.buckets_pos as usize
+                    + self.header.buckets_count as usize * size_of::<u64>(),
+        )?)?;
+        let bucket_val = *buckets.get(hash as usize)?;
+
+        let entry = &self.mmap.get(
+            self.header.buckets_pos as usize
+                + self.header.buckets_count as usize * size_of::<u64>()
+                + bucket_val as usize..,
+        )?;
+
+        let key_len = u64::read_from(entry.get(0..size_of::<u64>())?)? as usize;
+        let values_len =
+            u64::read_from(entry.get(size_of::<u64>()..2 * size_of::<u64>())?)? as usize;
+
+        let hash_key =
+            str::from_utf8(entry.get(2 * size_of::<u64>()..2 * size_of::<u64>() + key_len)?)
+                .ok()?;
+
+        if hash_key != key {
+            return None;
+        }
+
+        u32::slice_from(entry.get(
+            2 * size_of::<u64>() + key_len.next_multiple_of(4)
+                ..2 * size_of::<u64>()
+                    + key_len.next_multiple_of(4)
+                    + values_len * size_of::<u32>(),
+        )?)
+    }
+}
+
+fn entry_size(key: &str, values: &BTreeSet<u32>) -> usize {
+    2 * size_of::<u64>()
+        + key.as_bytes().len().next_multiple_of(4)
+        + values.len() * size_of::<u32>()
+}
+
+/// Returns a reference to a slice of zeroes of length `len`.
+#[inline]
+fn zeroes(len: usize) -> &'static [u8] {
+    const ZEROES: [u8; PADDING_SIZE] = [0u8; PADDING_SIZE];
+    &ZEROES[..len]
+}
+
+#[cfg(test)]
+fn random_map(rng: &mut StdRng, count: usize) -> BTreeMap<String, BTreeSet<u32>> {
+    let mut map = BTreeMap::new();
+
+    for _ in 0..count {
+        let ident = rand_ident(rng, |ident| !map.contains_key(ident));
+        let set = (0..rng.gen_range(1..=100))
+            .map(|_| rng.gen_range(0..=1000))
+            .collect::<BTreeSet<_>>();
+        map.insert(ident, set);
+    }
+
+    map
+}
+
+#[cfg(test)]
+fn rand_ident(rng: &mut StdRng, cond: impl Fn(&str) -> bool) -> String {
+    loop {
+        let ident = (0..rng.gen_range(5..=32))
+            .map(|_| rng.gen_range(b'a'..=b'z') as char)
+            .collect::<String>();
+        if cond(&ident) {
+            return ident;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mmap_hash() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+
+        let map = random_map(&mut rng, 1000);
+        MmapHashMap::create(&tmpdir.path().join("map"), map.clone()).unwrap();
+        let mmap = MmapHashMap::open(&tmpdir.path().join("map")).unwrap();
+
+        // Non-existing keys should return None
+        for _ in 0..1000 {
+            let key = rand_ident(&mut rng, |i| !map.contains_key(i));
+            assert!(mmap.get(&key).is_none());
+        }
+
+        // Existing keys should return the correct values
+        for (k, v) in map.into_iter() {
+            assert_eq!(mmap.get(&k).unwrap(), &v.into_iter().collect::<Vec<_>>());
+        }
+    }
+}

--- a/lib/common/memory/Cargo.toml
+++ b/lib/common/memory/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-memmap2 = "0.9.4"
+memmap2 = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -33,7 +33,7 @@ pprof = { workspace = true }
 
 [dependencies]
 bitpacking = "0.9.2"
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 parking_lot = { workspace = true }
 rayon = "1.10.0"
 itertools = { workspace = true }
@@ -50,7 +50,7 @@ ordered-float = "4.2"
 thiserror = "1.0"
 atomic_refcell = "0.1.13"
 atomicwrites = "0.4.3"
-memmap2 = "0.9.4"
+memmap2 = { workspace = true }
 schemars = { workspace = true }
 log = { workspace = true }
 geo = "0.28.0"

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -18,11 +18,11 @@ half = { workspace = true }
 io = { path = "../common/io" }
 memory = { path = "../common/memory" }
 num-traits = { workspace = true }
-memmap2 = "0.9.4"
+memmap2 = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 ordered-float = "4.2"
 rand = { workspace = true }
 validator = { workspace = true }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 tracing = ["dep:tracing", "api/tracing", "collection/tracing", "segment/tracing"]
 
 [dev-dependencies]
-tempfile = "3.10.1"
 proptest = "1.5.0"
 env_logger = "0.11"
 
@@ -54,7 +53,7 @@ anyhow = "1.0.86"
 uuid = { workspace = true }
 url = "2.5.2"
 reqwest = { workspace = true }
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 async-trait = "0.1.80"
 
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
Tracking issue: #4502.
This PR adds `MmapHashMap`, an on-disk hash map baked by a memory-mapped file.

Some design decisions:
- Use `zerocopy` as a sound/safe alternative to our [`mmap_ops`](https://github.com/qdrant/qdrant/blob/v1.10.0/lib/common/memory/src/mmap_ops.rs#L124-L188).
- Put the implementation into the `lib/common/common` crate. It wouldn't make compilation of this crate noticeable slower.
- Make `MmapHashMap::create()` take `BTreeMap<String, BTreeSet<u32>>`, not `impl Iterator<…>`. Since this structure would be used in a single place (`segment`), we could hardcode it to take a specific data structure for better compile times.