### PR TITLE
universal-query: Distribution-Based Score Fusion

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -4115,6 +4115,7 @@ Vector type to be used in queries. Ids will be substituted with their correspond
 | Name | Number | Description |
 | ---- | ------ | ----------- |
 | RRF | 0 | Reciprocal Rank Fusion |
+| DBSF | 1 | Distribution-Based Score Fusion |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12040,7 +12040,8 @@
         "description": "Fusion algorithm allows to combine results of multiple prefetches. Available fusion algorithms: * `rrf` - Rank Reciprocal Fusion",
         "type": "string",
         "enum": [
-          "rrf"
+          "rrf",
+          "dbsf"
         ]
       },
       "QueryRequestBatch": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12037,7 +12037,7 @@
         }
       },
       "Fusion": {
-        "description": "Fusion algorithm allows to combine results of multiple prefetches. Available fusion algorithms: * `rrf` - Rank Reciprocal Fusion",
+        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion * `dbsf` - Distribution-Based Score Fusion",
         "type": "string",
         "enum": [
           "rrf",

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -505,6 +505,7 @@ message ContextInput {
 
 enum Fusion {
     RRF = 0; // Reciprocal Rank Fusion
+    DBSF = 1; // Distribution-Based Score Fusion
 }
 
 message Query {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5906,6 +5906,8 @@ impl RecommendStrategy {
 pub enum Fusion {
     /// Reciprocal Rank Fusion
     Rrf = 0,
+    /// Distribution-Based Score Fusion
+    Dbsf = 1,
 }
 impl Fusion {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -5915,12 +5917,14 @@ impl Fusion {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Fusion::Rrf => "RRF",
+            Fusion::Dbsf => "DBSF",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "RRF" => Some(Self::Rrf),
+            "DBSF" => Some(Self::Dbsf),
             _ => None,
         }
     }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -139,8 +139,11 @@ pub enum OrderByInterface {
 }
 
 /// Fusion algorithm allows to combine results of multiple prefetches.
+///
 /// Available fusion algorithms:
-/// * `rrf` - Rank Reciprocal Fusion
+///
+/// * `rrf` - Reciprocal Rank Fusion
+/// * `dbsf` - Distribution-Based Score Fusion
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Fusion {

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -145,6 +145,7 @@ pub enum OrderByInterface {
 #[serde(rename_all = "snake_case")]
 pub enum Fusion {
     Rrf,
+    Dbsf,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -124,7 +124,7 @@ impl Validate for ContextInput {
 impl Validate for Fusion {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
-            Fusion::Rrf => Ok(()),
+            Fusion::Rrf | Fusion::Dbsf => Ok(()),
         }
     }
 }

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use futures::{future, TryFutureExt};
 use itertools::{Either, Itertools};
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
+use segment::common::score_fusion::{score_fusion, ScoreFusion};
 use segment::types::{Order, ScoredPoint};
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tokio::sync::RwLockReadGuard;
@@ -101,6 +102,7 @@ impl Collection {
                     // If the root query is a Fusion, the returned results correspond to each the prefetches.
                     let mut fused = match fusion {
                         Fusion::Rrf => rrf_scoring(merged_intermediates),
+                        Fusion::Dbsf => score_fusion(merged_intermediates, ScoreFusion::dbsf()),
                     };
                     if let Some(score_threshold) = request.score_threshold {
                         fused = fused

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -689,6 +689,7 @@ mod from_rest {
         fn from(value: rest::Fusion) -> Self {
             match value {
                 rest::Fusion::Rrf => Fusion::Rrf,
+                rest::Fusion::Dbsf => Fusion::Dbsf,
             }
         }
     }

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -45,7 +45,10 @@ impl ShardQueryRequest {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Fusion {
+    /// Reciprocal Rank Fusion
     Rrf,
+    /// Distribution-based score fusion
+    Dbsf,
 }
 
 /// Same as `Query`, but with the resolved vector references.
@@ -66,6 +69,7 @@ impl ScoringQuery {
         match self {
             ScoringQuery::Fusion(fusion) => match fusion {
                 Fusion::Rrf => true,
+                Fusion::Dbsf => true,
             },
             ScoringQuery::Vector(_) | ScoringQuery::OrderBy(_) => false,
         }
@@ -96,7 +100,7 @@ impl ScoringQuery {
                     }
                 }
                 ScoringQuery::Fusion(fusion) => match fusion {
-                    Fusion::Rrf => Order::LargeBetter,
+                    Fusion::Rrf | Fusion::Dbsf => Order::LargeBetter,
                 },
                 ScoringQuery::OrderBy(order_by) => Order::from(order_by.direction()),
             },
@@ -292,6 +296,7 @@ impl From<api::grpc::qdrant::Fusion> for Fusion {
     fn from(fusion: api::grpc::qdrant::Fusion) -> Self {
         match fusion {
             api::grpc::qdrant::Fusion::Rrf => Fusion::Rrf,
+            api::grpc::qdrant::Fusion::Dbsf => Fusion::Dbsf,
         }
     }
 }
@@ -300,6 +305,7 @@ impl From<Fusion> for api::grpc::qdrant::Fusion {
     fn from(fusion: Fusion) -> Self {
         match fusion {
             Fusion::Rrf => api::grpc::qdrant::Fusion::Rrf,
+            Fusion::Dbsf => api::grpc::qdrant::Fusion::Dbsf,
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -7,6 +7,7 @@ use api::rest::OrderByInterface;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
+use segment::common::score_fusion::{score_fusion, ScoreFusion};
 use segment::types::{Filter, HasIdCondition, ScoredPoint, WithPayloadInterface, WithVector};
 use tokio::runtime::Handle;
 
@@ -301,6 +302,7 @@ impl LocalShard {
 
         let fused = match fusion {
             Fusion::Rrf => rrf_scoring(sources),
+            Fusion::Dbsf => score_fusion(sources, ScoreFusion::dbsf()),
         };
 
         let top_fused: Vec<_> = if let Some(score_threshold) = score_threshold {

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -213,26 +213,16 @@ impl LocalShard {
         } = rescore_params;
 
         match rescore {
-            ScoringQuery::Fusion(Fusion::Rrf) => {
-                let sources: Vec<_> = sources.map(Cow::into_owned).collect();
-
-                let top_rrf = rrf_scoring(sources);
-
-                let top_rrf: Vec<_> = if let Some(score_threshold) = score_threshold {
-                    top_rrf
-                        .into_iter()
-                        .take_while(|point| point.score >= score_threshold)
-                        .take(limit)
-                        .collect()
-                } else {
-                    top_rrf.into_iter().take(limit).collect()
-                };
-
-                let filled_top_rrf = self
-                    .fill_with_payload_or_vectors(top_rrf, with_payload, with_vector)
-                    .await?;
-
-                Ok(filled_top_rrf)
+            ScoringQuery::Fusion(fusion) => {
+                self.fusion_rescore(
+                    sources,
+                    fusion,
+                    score_threshold,
+                    limit,
+                    with_payload,
+                    with_vector,
+                )
+                .await
             }
             ScoringQuery::OrderBy(order_by) => {
                 // create single scroll request for rescoring query
@@ -295,6 +285,39 @@ impl LocalShard {
                 })
             }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn fusion_rescore<'a>(
+        &self,
+        sources: impl Iterator<Item = Cow<'a, Vec<ScoredPoint>>>,
+        fusion: Fusion,
+        score_threshold: Option<f32>,
+        limit: usize,
+        with_payload: WithPayloadInterface,
+        with_vector: WithVector,
+    ) -> Result<Vec<ScoredPoint>, CollectionError> {
+        let sources: Vec<_> = sources.map(Cow::into_owned).collect();
+
+        let fused = match fusion {
+            Fusion::Rrf => rrf_scoring(sources),
+        };
+
+        let top_fused: Vec<_> = if let Some(score_threshold) = score_threshold {
+            fused
+                .into_iter()
+                .take_while(|point| point.score >= score_threshold)
+                .take(limit)
+                .collect()
+        } else {
+            fused.into_iter().take(limit).collect()
+        };
+
+        let filled_top_fused = self
+            .fill_with_payload_or_vectors(top_fused, with_payload, with_vector)
+            .await?;
+
+        Ok(filled_top_fused)
     }
 }
 

--- a/lib/segment/src/common/score_fusion.rs
+++ b/lib/segment/src/common/score_fusion.rs
@@ -22,7 +22,7 @@ impl ScoreFusion {
     /// Params for the distribution-based score fusion
     pub fn dbsf() -> Self {
         Self {
-            method: CombMethod::Sum,
+            method: Aggregation::Sum,
             norm: Normalization::Distr,
             weights: vec![],
             order: Order::LargeBetter,

--- a/lib/segment/src/common/score_fusion.rs
+++ b/lib/segment/src/common/score_fusion.rs
@@ -18,6 +18,18 @@ pub struct ScoreFusion {
     pub order: Order,
 }
 
+impl ScoreFusion {
+    /// Params for the distribution-based score fusion
+    pub fn dbsf() -> Self {
+        Self {
+            method: CombMethod::Sum,
+            norm: Normalization::Distr,
+            weights: vec![],
+            order: Order::LargeBetter,
+        }
+    }
+}
+
 /// Defines how to combine the scores of the same point in different lists
 pub enum Aggregation {
     /// Sums the scores


### PR DESCRIPTION
Needs #4601 

Exposes the ability to use [distribution-based score fusion](https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18) as 
```javascript
{
  "prefetch": [ ... ],
  "query": { "fusion": "dbsf" }
}
```