### PR TITLE
Make reads and point counts consistent during resharding 

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -389,9 +389,10 @@ impl Collection {
             .map(|(shard, _shard_key)| {
                 // Take resharding request if available on existing shards, otherwise take normal request
                 let request = reshard_request
-                    .clone()
+                    .as_ref()
                     .filter(|_| Some(shard.shard_id) != reshard_shard_id)
-                    .unwrap_or_else(|| normal_request.clone());
+                    .unwrap_or(&normal_request)
+                    .clone();
 
                 shard.count(request, read_consistency, shard_selection.is_shard_id())
             })

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -62,6 +62,11 @@ impl ReshardState {
     }
 }
 
+/// Reshard stages
+///
+/// # Warning
+///
+/// This enum is ordered!
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReshardStage {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -15,7 +15,7 @@ use tokio::sync::{broadcast, RwLock};
 
 use super::replica_set::AbortShardTransfer;
 use super::resharding::tasks_pool::ReshardTasksPool;
-use super::resharding::ReshardState;
+use super::resharding::{ReshardStage, ReshardState};
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::common::validate_snapshot_archive::validate_open_snapshot_archive;
@@ -452,15 +452,14 @@ impl ShardHolder {
             }
             ShardSelectorInternal::All => {
                 for (&shard_id, shard) in self.shards.iter() {
-                    // TODO(resharding): Handle resharded shard!?
-
-                    let is_resharding = self
-                        .resharding_state
-                        .read()
-                        .clone()
-                        .map_or(false, |state| state.shard_id == shard_id);
-
-                    if is_resharding {
+                    // Ignore a new resharding shard until it completed point migration
+                    // The shard will be marked as active at the end of the migration stage
+                    let resharding_migrating =
+                        self.resharding_state.read().clone().map_or(false, |state| {
+                            state.shard_id == shard_id
+                                && state.stage <= ReshardStage::MigratingPoints
+                        });
+                    if resharding_migrating {
                         continue;
                     }
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -457,7 +457,7 @@ impl ShardHolder {
                     let resharding_migrating =
                         self.resharding_state.read().clone().map_or(false, |state| {
                             state.shard_id == shard_id
-                                && state.stage <= ReshardStage::MigratingPoints
+                                && state.stage < ReshardStage::ReadHashRingCommitted
                         });
                     if resharding_migrating {
                         continue;

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -270,6 +270,8 @@ impl ShardHolder {
     }
 
     /// A filter that excludes points migrated to a different shard, as part of resharding.
+    ///
+    /// `None` if resharding is not active or if the read hash ring is not committed yet.
     pub fn resharding_filter(&self) -> Option<Filter> {
         let filter = self.resharding_filter_impl()?;
         let filter = Filter::new_must_not(Condition::Resharding(Arc::new(filter)));

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -278,7 +278,8 @@ impl ShardHolder {
         Some(filter)
     }
 
-    pub fn resharding_filter_impl(&self) -> Option<hash_ring::Filter> {
+    #[inline]
+    fn resharding_filter_impl(&self) -> Option<hash_ring::Filter> {
         let state = self.resharding_state.read();
 
         let Some(state) = state.deref() else {

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -279,7 +279,7 @@ impl ShardHolder {
     }
 
     #[inline]
-    fn resharding_filter_impl(&self) -> Option<hash_ring::Filter> {
+    pub fn resharding_filter_impl(&self) -> Option<hash_ring::Filter> {
         let state = self.resharding_state.read();
 
         let Some(state) = state.deref() else {

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -3,7 +3,7 @@ import pathlib
 import random
 from time import sleep
 
-from .fixtures import upsert_random_points, create_collection
+from .fixtures import upsert_random_points, create_collection, random_dense_vector
 from .utils import *
 
 COLLECTION_NAME = "test_collection"
@@ -351,7 +351,7 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
     check_data_consistency(data)
 
 
-# Test point scroll during resharding.
+# Test point scroll stability during resharding.
 #
 # On a static collection, this performs resharding a few times and asserts
 # scrolling remains stable on all peers during the whole process.
@@ -359,7 +359,7 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
     assert_project_root()
 
     num_points = 1000
-    scroll_sample_size = 25
+    scroll_limit = 25
 
     # Prevent optimizers messing with point counts
     env={
@@ -384,14 +384,14 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
         assert check_collection_local_shards_count(uri, COLLECTION_NAME, 1)
         assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, num_points)
 
-    # Match all points on all nodes exactly
+    # Match scroll sample of points on all nodes exactly
     data = []
     for uri in peer_api_uris:
         r = requests.post(
             f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
-                "limit": scroll_sample_size,
+                "limit": scroll_limit,
                 "with_vectors": True,
-                "with_payload": True,
+                "with_payload": False,
             }
         )
         assert_http_ok(r)
@@ -413,15 +413,15 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
         # Wait for resharding to start
         wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
 
-        # Continously assert point count on all peers, must be stable
+        # Continously assert point scroll samples on all peers, must be stable
         # Stop once all peers reported completed resharding
         while True:
-            # Match all points on all nodes exactly
+            # Match scroll sample of points on all nodes exactly
             data = []
             for uri in peer_api_uris:
                 r = requests.post(
                     f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
-                        "limit": scroll_sample_size,
+                        "limit": scroll_limit,
                         "with_vectors": True,
                         "with_payload": False,
                     }
@@ -429,6 +429,98 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
                 assert_http_ok(r)
                 data.append(r.json()["result"])
             check_data_consistency(data)
+
+            all_completed = True
+            for uri in peer_api_uris:
+                if not check_collection_resharding_operations_count(uri, COLLECTION_NAME, 0):
+                    all_completed = False
+                    break
+            if all_completed:
+                break
+
+        # Assert node shard count
+        for uri in peer_api_uris:
+            assert check_collection_local_shards_count(uri, COLLECTION_NAME, shard_count)
+
+
+# Test point search stability during resharding.
+#
+# On a static collection, this performs resharding a few times and asserts
+# search remains stable on all peers during the whole process.
+def test_resharding_stable_search(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    num_points = 1000
+    search_limit = 10
+
+    # Prevent optimizers messing with point counts
+    env={
+        "QDRANT__STORAGE__OPTIMIZERS__INDEXING_THRESHOLD_KB": "0",
+    }
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
+    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
+
+    # Create collection, insert points
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris,
+    )
+    upsert_random_points(peer_api_uris[0], num_points)
+
+    sleep(1)
+
+    # Assert node shard and point sum count
+    for uri in peer_api_uris:
+        assert check_collection_local_shards_count(uri, COLLECTION_NAME, 1)
+        assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, num_points)
+
+    # Match search sample of points on all nodes exactly
+    data = []
+    search_vector = random_dense_vector()
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/query", json={
+                "vector": search_vector,
+                "limit": search_limit,
+            }
+        )
+        assert_http_ok(r)
+        data.append(r.json()["result"])
+    check_query_consistency(data)
+
+    # Reshard 3 times in sequence
+    for shard_count in range(2, 5):
+        # Start resharding
+        r = requests.post(
+            f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+                "start_resharding": {
+                    "peer_id": first_peer_id,
+                    "shard_key": None,
+                }
+            })
+        assert_http_ok(r)
+
+        # Wait for resharding to start
+        wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
+
+        # Continously assert point search samples on all peers, must be stable
+        # Stop once all peers reported completed resharding
+        while True:
+            # Match search sample of points on all nodes exactly
+            data = []
+            search_vector = random_dense_vector()
+            for uri in peer_api_uris:
+                r = requests.post(
+                    f"{uri}/collections/{COLLECTION_NAME}/points/query", json={
+                        "vector": search_vector,
+                        "limit": search_limit,
+                    }
+                )
+                assert_http_ok(r)
+                data.append(r.json()["result"])
+            check_query_consistency(data)
 
             all_completed = True
             for uri in peer_api_uris:
@@ -490,12 +582,12 @@ def check_data_consistency(data):
     for i in range(len(data) - 1):
         j = i + 1
 
-        data_i = data[i]
-        data_j = data[j]
+        data_i = data[i]["points"]
+        data_j = data[j]["points"]
 
         if data_i != data_j:
-            ids_i = set(x.id for x in data_i["points"])
-            ids_j = set(x.id for x in data_j["points"])
+            ids_i = set(x.id for x in data_i)
+            ids_j = set(x.id for x in data_j)
 
             diff = ids_i - ids_j
 
@@ -505,3 +597,33 @@ def check_data_consistency(data):
                 print(f"Diff len between {i} and {j}: {len(diff)}")
 
             assert False, "Data on all nodes should be consistent"
+
+
+def check_query_consistency(data):
+    assert(len(data) > 1)
+
+    for i in range(len(data) - 1):
+        j = i + 1
+
+        data_i = data[i]["points"]
+        data_j = data[j]["points"]
+
+        for item in data_i:
+            if "version" in item:
+                del item["version"]
+        for item in data_j:
+            if "version" in item:
+                del item["version"]
+
+        if data_i != data_j:
+            ids_i = set(x["id"] for x in data_i)
+            ids_j = set(x["id"] for x in data_j)
+
+            diff = ids_i - ids_j
+
+            if len(diff) < 100:
+                print(f"Diff between {i} and {j}: {diff}")
+            else:
+                print(f"Diff len between {i} and {j}: {len(diff)}")
+
+            assert False, "Query results on all nodes should be consistent"

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -321,6 +321,8 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
         while True:
             for uri in peer_api_uris:
                 assert get_collection_point_count(uri, COLLECTION_NAME, exact=True) == num_points
+                cardinality_count = get_collection_point_count(uri, COLLECTION_NAME, exact=False)
+                assert cardinality_count >= num_points / 2 and cardinality_count < num_points * 2
 
             all_completed = True
             for uri in peer_api_uris:

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -269,6 +269,88 @@ def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
     check_data_consistency(data)
 
 
+# Test point count during resharding.
+#
+# On a static collection, this performs resharding a few times and asserts the
+# exact point count remains stable on all peers during the whole process.
+def test_resharding_stable_point_count(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    num_points = 1000
+
+    # Prevent optimizers messing with point counts
+    env={
+        "QDRANT__STORAGE__OPTIMIZERS__INDEXING_THRESHOLD_KB": "0",
+    }
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
+    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
+
+    # Create collection, insert points
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris,
+    )
+    upsert_random_points(peer_api_uris[0], num_points)
+
+    sleep(1)
+
+    # Assert node shard and point sum count
+    for uri in peer_api_uris:
+        assert check_collection_local_shards_count(uri, COLLECTION_NAME, 1)
+        assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, num_points)
+
+    # Reshard 3 times in sequence
+    for shard_count in range(2, 5):
+        # Start resharding
+        r = requests.post(
+            f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+                "start_resharding": {
+                    "peer_id": first_peer_id,
+                    "shard_key": None,
+                }
+            })
+        assert_http_ok(r)
+
+        # Wait for resharding to start
+        wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
+
+        while True:
+            # Continously assert point count on all peers, must be stable
+            for uri in peer_api_uris:
+                assert get_collection_point_count(uri, COLLECTION_NAME, exact=True) == num_points
+
+            # Only stop looping if resharding completed on all nodes
+            all_completed = True
+            for uri in peer_api_uris:
+                if not check_collection_resharding_operations_count(uri, COLLECTION_NAME, 0):
+                    all_completed = False
+                    break
+            if all_completed:
+                break
+
+        # Assert node shard count
+        for uri in peer_api_uris:
+            assert check_collection_local_shards_count(uri, COLLECTION_NAME, shard_count)
+
+    sleep(1)
+
+    # Match all points on all nodes exactly
+    data = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
+                "limit": 999999999,
+                "with_vectors": True,
+                "with_payload": True,
+            }
+        )
+        assert_http_ok(r)
+        data.append(r.json()["result"])
+    check_data_consistency(data)
+
+
 def run_in_background(run, *args, **kwargs):
     p = multiprocessing.Process(target=run, args=args, kwargs=kwargs)
     p.start()

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -316,7 +316,7 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
         # Wait for resharding to start
         wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
 
-        # Continously assert point count on all peers, must be stable
+        # Continuously assert point count on all peers, must be stable
         # Stop once all peers reported completed resharding
         while True:
             for uri in peer_api_uris:
@@ -415,7 +415,7 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
         # Wait for resharding to start
         wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
 
-        # Continously assert point scroll samples on all peers, must be stable
+        # Continuously assert point scroll samples on all peers, must be stable
         # Stop once all peers reported completed resharding
         while True:
             # Match scroll sample of points on all nodes exactly
@@ -445,15 +445,15 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
             assert check_collection_local_shards_count(uri, COLLECTION_NAME, shard_count)
 
 
-# Test point search stability during resharding.
+# Test point query stability during resharding.
 #
 # On a static collection, this performs resharding a few times and asserts
-# search remains stable on all peers during the whole process.
-def test_resharding_stable_search(tmp_path: pathlib.Path):
+# query remains stable on all peers during the whole process.
+def test_resharding_stable_query(tmp_path: pathlib.Path):
     assert_project_root()
 
     num_points = 1000
-    search_limit = 10
+    query_limit = 10
 
     # Prevent optimizers messing with point counts
     env={
@@ -485,7 +485,7 @@ def test_resharding_stable_search(tmp_path: pathlib.Path):
         r = requests.post(
             f"{uri}/collections/{COLLECTION_NAME}/points/query", json={
                 "vector": search_vector,
-                "limit": search_limit,
+                "limit": query_limit,
             }
         )
         assert_http_ok(r)
@@ -507,7 +507,7 @@ def test_resharding_stable_search(tmp_path: pathlib.Path):
         # Wait for resharding to start
         wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
 
-        # Continously assert point search samples on all peers, must be stable
+        # Continuously assert point search samples on all peers, must be stable
         # Stop once all peers reported completed resharding
         while True:
             # Match search sample of points on all nodes exactly
@@ -517,7 +517,7 @@ def test_resharding_stable_search(tmp_path: pathlib.Path):
                 r = requests.post(
                     f"{uri}/collections/{COLLECTION_NAME}/points/query", json={
                         "vector": search_vector,
-                        "limit": search_limit,
+                        "limit": query_limit,
                     }
                 )
                 assert_http_ok(r)

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -353,6 +353,95 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
     check_data_consistency(data)
 
 
+# Test point count during resharding and indexing.
+#
+# On a static collection, this performs resharding and indexing a few times and
+# asserts the exact point count remains stable on all peers during the whole
+# process.
+def test_resharding_indexing_stable_point_count(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    num_points = 1000
+
+    # Configure optimizers to index right away with a low vector count
+    env={
+        "QDRANT__STORAGE__OPTIMIZERS__INDEXING_THRESHOLD_KB": "1",
+    }
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
+    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
+
+    # Create collection, insert points
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris,
+    )
+    upsert_random_points(peer_api_uris[0], num_points)
+
+    sleep(1)
+
+    # Assert node shard and exact point count
+    for uri in peer_api_uris:
+        assert check_collection_local_shards_count(uri, COLLECTION_NAME, 1)
+        assert get_collection_point_count(uri, COLLECTION_NAME, exact=True) == num_points
+
+    # Reshard 3 times in sequence
+    for shard_count in range(2, 5):
+        # Start resharding
+        r = requests.post(
+            f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+                "start_resharding": {
+                    "peer_id": first_peer_id,
+                    "shard_key": None,
+                }
+            })
+        assert_http_ok(r)
+
+        # Wait for resharding operation to start and stop
+        wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
+
+        # Continuously assert exact point count on all peers, must be stable
+        # Stop once all peers reported completed resharding
+        while True:
+            for uri in peer_api_uris:
+                assert get_collection_point_count(uri, COLLECTION_NAME, exact=True) == num_points
+
+            all_completed = True
+            for uri in peer_api_uris:
+                if not check_collection_resharding_operations_count(uri, COLLECTION_NAME, 0):
+                    all_completed = False
+                    break
+            if all_completed:
+                break
+
+        # Assert node shard count
+        for uri in peer_api_uris:
+            assert check_collection_local_shards_count(uri, COLLECTION_NAME, shard_count)
+
+    # Wait for optimizations to complete
+    for uri in peer_api_uris:
+        wait_collection_green(uri, COLLECTION_NAME)
+
+    # Assert exact point count one more time
+    for uri in peer_api_uris:
+        assert get_collection_point_count(uri, COLLECTION_NAME, exact=True) == num_points
+
+    # Match all points on all nodes exactly
+    data = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
+                "limit": 999999999,
+                "with_vectors": True,
+                "with_payload": True,
+            }
+        )
+        assert_http_ok(r)
+        data.append(r.json()["result"])
+    check_data_consistency(data)
+
+
 # Test point scroll stability during resharding.
 #
 # On a static collection, this performs resharding a few times and asserts

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -316,12 +316,12 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
         # Wait for resharding to start
         wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
 
+        # Continously assert point count on all peers, must be stable
+        # Stop once all peers reported completed resharding
         while True:
-            # Continously assert point count on all peers, must be stable
             for uri in peer_api_uris:
                 assert get_collection_point_count(uri, COLLECTION_NAME, exact=True) == num_points
 
-            # Only stop looping if resharding completed on all nodes
             all_completed = True
             for uri in peer_api_uris:
                 if not check_collection_resharding_operations_count(uri, COLLECTION_NAME, 0):

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -469,6 +469,14 @@ def wait_peer_added(peer_api_uri: str, expected_size: int = 1, headers={}) -> st
     return get_leader(peer_api_uri, headers=headers)
 
 
+def wait_collection_green(peer_api_uri: str, collection_name: str):
+    try:
+        wait_for(check_collection_green, peer_api_uri, collection_name)
+    except Exception as e:
+        print_clusters_info([peer_api_uri])
+        raise e
+
+
 def wait_for_some_replicas_not_active(peer_api_uri: str, collection_name: str):
     try:
         wait_for(check_some_replicas_not_active, peer_api_uri, collection_name)
@@ -588,6 +596,11 @@ def wait_for_peer_online(peer_api_uri: str, path="/readyz"):
     except Exception as e:
         print_clusters_info([peer_api_uri])
         raise e
+
+
+def check_collection_green(peer_api_uri: str, collection_name: str, expected_status: str = "green") -> bool:
+    collection_cluster_info = get_collection_info(peer_api_uri, collection_name)
+    return collection_cluster_info['status'] == expected_status
 
 
 def check_collection_points_count(peer_api_uri: str, collection_name: str, expected_size: int) -> bool:


### PR DESCRIPTION
Tracked in: #4213 
Depends on: #4609

This PR ensures that reads and point counting remain consistent while resharding is going on. It adds some tests to assert this behavior.

Most importantly, two changes in our read/filtering logic were required:
1. don't always apply resharding point filter, apply on _old_ shards, but not the _new_ shard
2. `select_shards` should include the _new_ shard on read hash ring commit (right after migrating points)

Tests cover stability assertions for point counts, scrolling and the query API. For each test we reshard 3 times in sequence and make sure the responses remain exactly the same.

### Tasks
- [x] Merge https://github.com/qdrant/qdrant/pull/4609
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
