### PR TITLE
random-query: Implement random reads from segments up to local shard

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -21,7 +21,7 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::common::operation_error::OperationError;
 use segment::data_types::groups::GroupId;
-use segment::data_types::order_by::OrderValue;
+use segment::data_types::order_by::{OrderBy, OrderValue};
 use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStructInternal, DEFAULT_VECTOR_NAME,
 };
@@ -342,6 +342,14 @@ pub struct ScrollRequestInternal {
     pub order_by: Option<OrderByInterface>,
 }
 
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum ScrollOrder {
+    #[default]
+    ById,
+    ByField(OrderBy),
+    Random,
+}
+
 /// Scroll request, used as a part of query request
 #[derive(Debug, Clone, PartialEq)]
 pub struct QueryScrollRequestInternal {
@@ -358,7 +366,7 @@ pub struct QueryScrollRequestInternal {
     pub with_vector: WithVector,
 
     /// Order the records by a payload field.
-    pub order_by: Option<OrderByInterface>,
+    pub scroll_order: ScrollOrder,
 }
 
 impl ScrollRequestInternal {

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -1,12 +1,11 @@
 //! Types used within `LocalShard` to represent a planned `ShardQueryRequest`
 
-use api::rest::OrderByInterface;
 use common::types::ScoreType;
 use segment::types::{Filter, WithPayloadInterface, WithVector};
 
 use super::shard_query::{ScoringQuery, ShardPrefetch, ShardQueryRequest};
 use crate::operations::types::{
-    CollectionError, CollectionResult, CoreSearchRequest, QueryScrollRequestInternal,
+    CollectionError, CollectionResult, CoreSearchRequest, QueryScrollRequestInternal, ScrollOrder,
 };
 
 const MAX_PREFETCH_DEPTH: usize = 64;
@@ -171,7 +170,7 @@ impl PlannedQuery {
                 Some(ScoringQuery::OrderBy(order_by)) => {
                     // Everything should come from 1 scroll
                     let scroll = QueryScrollRequestInternal {
-                        order_by: Some(OrderByInterface::Struct(order_by)),
+                        scroll_order: ScrollOrder::ByField(order_by),
                         limit,
                         filter,
                         with_vector,
@@ -186,7 +185,7 @@ impl PlannedQuery {
                 None => {
                     // Everything should come from 1 scroll
                     let scroll = QueryScrollRequestInternal {
-                        order_by: None,
+                        scroll_order: ScrollOrder::ById,
                         limit,
                         filter,
                         with_vector,
@@ -299,7 +298,7 @@ fn recurse_prefetches(
                 }
                 Some(ScoringQuery::OrderBy(order_by)) => {
                     let scroll = QueryScrollRequestInternal {
-                        order_by: Some(OrderByInterface::Struct(order_by)),
+                        scroll_order: ScrollOrder::ByField(order_by),
                         filter,
                         with_vector: with_vector.clone(),
                         with_payload: with_payload.clone(),
@@ -313,7 +312,7 @@ fn recurse_prefetches(
                 }
                 None => {
                     let scroll = QueryScrollRequestInternal {
-                        order_by: None,
+                        scroll_order: Default::default(),
                         filter,
                         with_vector: with_vector.clone(),
                         with_payload: with_payload.clone(),

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -3,7 +3,6 @@ use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 
-use api::rest::OrderByInterface;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use parking_lot::Mutex;
@@ -16,7 +15,7 @@ use super::LocalShard;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::operations::types::{
     CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch,
-    QueryScrollRequestInternal,
+    QueryScrollRequestInternal, ScrollOrder,
 };
 use crate::operations::universal_query::planned_query::{
     MergePlan, PlannedQuery, RescoreParams, Source,
@@ -230,7 +229,7 @@ impl LocalShard {
                     filter: Some(filter),
                     with_payload,
                     with_vector,
-                    order_by: Some(OrderByInterface::Struct(order_by)),
+                    scroll_order: ScrollOrder::ByField(order_by),
                 };
 
                 self.query_scroll_batch(

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -126,6 +126,8 @@ pub trait SegmentEntry {
         order_by: &'a OrderBy,
     ) -> OperationResult<Vec<(OrderValue, PointIdType)>>;
 
+    fn read_random_filtered(&self, limit: usize, filter: Option<&Filter>) -> Vec<PointIdType>;
+
     /// Read points in [from; to) range
     fn read_range(&self, from: Option<PointIdType>, to: Option<PointIdType>) -> Vec<PointIdType>;
 

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -120,6 +120,14 @@ impl IdTracker for FixtureIdTracker {
         )
     }
 
+    /// Not actually random, but it's enough for tests
+    fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_> {
+        Box::new(
+            self.iter_ids()
+                .map(|id| (PointIdType::NumId(id as u64), id)),
+        )
+    }
+
     fn total_point_count(&self) -> usize {
         self.ids.len()
     }

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -120,12 +120,8 @@ impl IdTracker for FixtureIdTracker {
         )
     }
 
-    /// Not actually random, but it's enough for tests
     fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_> {
-        Box::new(
-            self.iter_ids()
-                .map(|id| (PointIdType::NumId(id as u64), id)),
-        )
+        unimplemented!("Not used for tests yet")
     }
 
     fn total_point_count(&self) -> usize {

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -67,6 +67,8 @@ pub trait IdTracker: fmt::Debug {
     /// - excludes removed points
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;
 
+    fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_>;
+
     /// Iterate over internal IDs (offsets)
     ///
     /// - excludes removed points
@@ -243,6 +245,13 @@ impl IdTracker for IdTrackerEnum {
         match self {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_ids(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_ids(),
+        }
+    }
+
+    fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_> {
+        match self {
+            IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_random(),
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_random(),
         }
     }
 

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use bincode;
 use bitvec::prelude::{BitSlice, BitVec};
 use common::types::PointOffsetType;
+use itertools::Itertools;
 use parking_lot::RwLock;
+use rand::distributions::Distribution;
 use rocksdb::DB;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -342,6 +344,28 @@ impl IdTracker for SimpleIdTracker {
                 }
             },
         }
+    }
+
+    fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_> {
+        let rng = rand::thread_rng();
+        let available = self.internal_to_external.len();
+        let uniform = rand::distributions::Uniform::new(0, available);
+        let iter = Distribution::sample_iter(uniform, rng)
+            // TODO: this is not efficient if `available` is large and we iterate over most of them,
+            // but it's good enough for low limits.
+            //
+            // We could improve it by using a variable-period PRNG to adjust depending on the number of available points.
+            .unique()
+            .take(available)
+            .filter_map(move |i| {
+                if self.deleted[i] {
+                    None
+                } else {
+                    Some((self.internal_to_external[i], i as PointOffsetType))
+                }
+            });
+
+        Box::new(iter)
     }
 
     fn total_point_count(&self) -> usize {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -14,7 +14,7 @@ use io::storage_version::{StorageVersion, VERSION_FILE};
 use itertools::Either;
 use memory::mmap_ops;
 use parking_lot::{Mutex, RwLock};
-use rand::seq::SliceRandom;
+use rand::seq::{IteratorRandom, SliceRandom};
 use rand::thread_rng;
 use rocksdb::DB;
 use tar::Builder;
@@ -824,6 +824,26 @@ impl Segment {
         Ok(page)
     }
 
+    fn filtered_read_by_index_shuffled(
+        &self,
+        limit: usize,
+        condition: &Filter,
+    ) -> Vec<PointIdType> {
+        let payload_index = self.payload_index.borrow();
+        let id_tracker = self.id_tracker.borrow();
+
+        let ids_iterator = payload_index
+            .query_points(condition)
+            .into_iter()
+            .filter_map(|internal_id| id_tracker.external_id(internal_id));
+
+        let mut rng = rand::thread_rng();
+        let mut shuffled = ids_iterator.choose_multiple(&mut rng, limit);
+        shuffled.shuffle(&mut rng);
+
+        shuffled
+    }
+
     pub fn filtered_read_by_id_stream(
         &self,
         offset: Option<PointIdType>,
@@ -1424,10 +1444,7 @@ impl SegmentEntry for Segment {
             None => self.read_by_random_id(limit),
             Some(condition) => {
                 if self.should_pre_filter(condition, Some(limit)) {
-                    let mut points = self.filtered_read_by_index(None, Some(limit), condition);
-                    let mut rng = thread_rng();
-                    points.shuffle(&mut rng);
-                    points
+                    self.filtered_read_by_index_shuffled(limit, condition)
                 } else {
                     self.filtered_read_by_random_stream(limit, condition)
                 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -15,7 +15,6 @@ use itertools::Either;
 use memory::mmap_ops;
 use parking_lot::{Mutex, RwLock};
 use rand::seq::{IteratorRandom, SliceRandom};
-use rand::thread_rng;
 use rocksdb::DB;
 use tar::Builder;
 use uuid::Uuid;


### PR DESCRIPTION
Implements reading randomly from segments.

The way it reads is not entirely optimal for large limits (it has rejection sampling to avoid repetition), but since we will not promise stable random output, offset won't affect the limit. In other words, it should be "fine" for most use-cases.

The other thing changed here is that I've edited the `QueryScrollRequestInternal` so that ordering is always specified, as by id, by field, or random.

