### PR TITLE
Workaround for "missing payload" bug

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -817,13 +817,13 @@ impl SegmentEntry for ProxySegment {
         true
     }
 
-    fn flush(&self, sync: bool) -> OperationResult<SeqNumberType> {
+    fn flush(&self, sync: bool, force: bool) -> OperationResult<SeqNumberType> {
         let deleted_points_guard = self.deleted_points.read();
         let deleted_indexes_guard = self.deleted_indexes.read();
         let created_indexes_guard = self.created_indexes.read();
 
-        let wrapped_version = self.wrapped_segment.get().read().flush(sync)?;
-        let write_segment_version = self.write_segment.get().read().flush(sync)?;
+        let wrapped_version = self.wrapped_segment.get().read().flush(sync, force)?;
+        let write_segment_version = self.write_segment.get().read().flush(sync, force)?;
 
         let is_all_empty = deleted_points_guard.is_empty()
             && deleted_indexes_guard.is_empty()
@@ -1696,7 +1696,7 @@ mod tests {
         //   - `wrapped_segment` is flushed
         //   - `ProxySegment::flush` returns `wrapped_segment`'s persisted version
 
-        let flushed_version = proxy_segment.flush(true).unwrap();
+        let flushed_version = proxy_segment.flush(true, false).unwrap();
         let wrapped_segment_persisted_version = *wrapped_segment.read().persisted_version.lock();
         assert_eq!(Some(flushed_version), wrapped_segment_persisted_version);
 
@@ -1727,7 +1727,7 @@ mod tests {
             )
             .unwrap();
 
-        let flushed_version = proxy_segment.flush(true).unwrap();
+        let flushed_version = proxy_segment.flush(true, false).unwrap();
         let wrapped_segment_persisted_version = *wrapped_segment.read().persisted_version.lock();
         let write_segment_persisted_version = *write_segment.read().persisted_version.lock();
 
@@ -1762,7 +1762,7 @@ mod tests {
             )
             .unwrap();
 
-        let flushed_version = proxy_segment.flush(true).unwrap();
+        let flushed_version = proxy_segment.flush(true, false).unwrap();
         let wrapped_segment_persisted_version = *wrapped_segment.read().persisted_version.lock();
         let write_segment_persisted_version = *write_segment.read().persisted_version.lock();
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -647,7 +647,7 @@ impl<'s> SegmentHolder {
     ///
     /// If there are unsaved changes after flush - detects lowest unsaved change version.
     /// If all changes are saved - returns max version.
-    pub fn flush_all(&self, sync: bool) -> OperationResult<SeqNumberType> {
+    pub fn flush_all(&self, sync: bool, force: bool) -> OperationResult<SeqNumberType> {
         // Grab and keep to segment RwLock's until the end of this function
         let segments = self.segment_locks(self.segment_flush_ordering())?;
 
@@ -697,7 +697,7 @@ impl<'s> SegmentHolder {
         // Flush and release each segment
         for read_segment in segment_reads {
             let segment_version = read_segment.version();
-            let segment_persisted_version = read_segment.flush(sync)?;
+            let segment_persisted_version = read_segment.flush(sync, force)?;
 
             if segment_version > segment_persisted_version {
                 has_unsaved = true;

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -634,7 +634,11 @@ impl LocalShard {
                     }
                 }
             }
-            segments.flush_all(true)?;
+
+            // Force a flush after re-applying WAL operations, to ensure we maintain on-disk data
+            // consistency, if we happened to only apply *past* operations to a segment with newer
+            // version.
+            segments.flush_all(true, true)?;
         }
 
         bar.finish();

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -767,7 +767,7 @@ impl UpdateHandler {
     /// Returns an error on flush failure
     fn flush_segments(segments: LockedSegmentHolder) -> OperationResult<SeqNumberType> {
         let read_segments = segments.read();
-        let flushed_version = read_segments.flush_all(false)?;
+        let flushed_version = read_segments.flush_all(false, false)?;
         Ok(match read_segments.failed_operation.iter().cloned().min() {
             None => flushed_version,
             Some(failed_operation) => min(failed_operation, flushed_version),

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -173,7 +173,7 @@ pub trait SegmentEntry {
     /// if sync == true, block current thread while flushing
     ///
     /// Returns maximum version number which is guaranteed to be persisted.
-    fn flush(&self, sync: bool) -> OperationResult<SeqNumberType>;
+    fn flush(&self, sync: bool, force: bool) -> OperationResult<SeqNumberType>;
 
     /// Removes all persisted data and forces to destroy segment
     fn drop_data(self) -> OperationResult<()>;

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -189,7 +189,7 @@ fn ordered_deletion_test() {
         let mut segment = build_segment_1(dir.path());
         segment.delete_point(6, 5.into()).unwrap();
         segment.delete_point(6, 4.into()).unwrap();
-        segment.flush(true).unwrap();
+        segment.flush(true, false).unwrap();
         segment.current_path.clone()
     };
 
@@ -221,7 +221,7 @@ fn skip_deleted_segment() {
         let mut segment = build_segment_1(dir.path());
         segment.delete_point(6, 5.into()).unwrap();
         segment.delete_point(6, 4.into()).unwrap();
-        segment.flush(true).unwrap();
+        segment.flush(true, false).unwrap();
         segment.current_path.clone()
     };
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -597,7 +597,7 @@ fn sparse_vector_index_persistence_test() {
             .upsert_point(n as SeqNumberType, idx, named_vector)
             .unwrap();
     }
-    segment.flush(true).unwrap();
+    segment.flush(true, false).unwrap();
 
     let search_vector = random_sparse_vector(&mut rnd, dim);
     let query_vector: QueryVector = search_vector.into();


### PR DESCRIPTION
It's always flushing, isn't it? 😂🔫

Let's look at [`Segment::flush`] implementation first:
- there's a [check at the top][segment-flush-version-change-check] that checks if current version of the segment changed since last flush
- if current version *did not* change since last flush
	- we "skip" flushing
	- and report current segment version as "successfully flushed"

Generally, this behavior is desirable: it allows us to "skip" flushing if no changes were applied to the segment in between two flushes.

But let's look at [`LocalShard::load_from_wal`] now:
- during `load_from_wal` we (re-)apply all un-acknowledged operations from the WAL
- these operations may be *older* than the version of the segment the operations applied to
- most of these operations will be skipped due to further version checks inside the segment
	- if operation targets a particular point by ID
	- and the point is currently present in the segment
	- and the version of the point is *newer* than the operation
	- then the operation will be skipped without introducing any changes into the segment
- **but**
	- if the point is *not* present in the segment
	- the operation will *always* be applied, even if the segment version is *newer* than the operation
	- and when such operation is applied, it *does not update the version of the segment*

This is trivial to reproduce:
- imagine we have a single appendable segment
- the segment was successfully flushed at version 11
- but Qdrant crashed right before operation 11 was acknowledged to the WAL
- so now we re-apply the following operations on restart:
	- 10 - insert point `{ id: 42, vector: [1.0, 3.0, 3.0, 7.0], payload: { "what": "ever" } }`
	- 11 - delete point 42
- point 42 was already *deleted* from the segment, so we *will* insert it, and then delete it *once again*

So, during `load_from_wal`, it is possible to
- (re-)introduce some *older* changes to the segment without updating segment version
- and so these changes **won't be flushed**, but will be **reported as flushed**
	- (until some *newer* operation is applied to the segment and updates its version)
- and [`flush_worker`] **[acknowledges WAL][flush-worker-wal-ack]** after it successfully flushed the segments
- so these changes **won't be re-applied after the next restart**, after the first flush by `flush_worker`

And to make this worse, let's finally look into [`SimpleIdTracker`] implementation:
- `SimpleIdTracker` uses [`DatabaseColumnScheduledDeleteWrapper`] and [`DatabaseColumnScheduledUpdateWrapper`] to store ID and version mappings on disk
- and both of these wrapers "cache" changes to the RockDB in RAM
- and only **persist** these changes on disk **on flush**

So, if Qdrant crashes after recovery (and a single flush by the `flush_worker`) under all these conditions, the changes cached in `DBColumnScheduled*Wrapper`s will be lost, and **will introduce persistent data inconsistency** on the next restart.

This PR attempts the most trivial (if not the most efficient) fix: just **force** a flush after collection recovery.

A more elaborate fix might be:
- introduce `is_changed` flag to the segment, that is set if *any* changes introduced into a segment, and skip flushes based on this flag
- refactor `flush` return value to be `Option<SeqNumberType>`, so that `flush_worker` can distinguish if the flush was skipped, and don't acknowledge WAL in such case
- try to add more safeguards into/around `IdTracker`, so that we can better detect on-disk inconsistencies when `DBColumnScheduled*Wrapper` might not have been persisted on disk


[`Segment::flush`]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/segment/src/segment.rs#L1507
[segment-flush-version-change-check]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/segment/src/segment.rs#L1520-L1523

[`LocalShard::load_from_wal`]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/collection/src/shards/local_shard/mod.rs#L540

[`flush_worker`]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/collection/src/update_handler.rs#L695
[flush-worker-wal-ack]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/collection/src/update_handler.rs#L743

[`SimpleIdTracker`]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/segment/src/id_tracker/simple_id_tracker.rs#L60-L68
[`DatabaseColumnScheduledDeleteWrapper`]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs#L10-L19
[`DatabaseColumnScheduledUpdateWrapper`]: https://github.com/qdrant/qdrant/blob/9daf5799d2bd56f88b259a64f95c7f02bb582f3d/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs#L10-L20


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
