### PR TITLE
Use stabilized Bound::map

### DIFF
--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ops::Bound;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -34,16 +33,6 @@ pub fn check_is_null<'a>(values: impl IntoIterator<Item = &'a Value>) -> bool {
 
 pub fn rev_range(a: usize, b: usize) -> impl Iterator<Item = usize> {
     (b + 1..=a).rev()
-}
-
-/// Alternative to [core::ops::Bound::map](https://doc.rust-lang.org/std/ops/enum.Bound.html#method.map)
-// TODO(luis): replace with the stabilized function. It is already merged, seems like it will be available in 1.76
-pub fn bound_map<T, U, F: FnOnce(T) -> U>(bound: Bound<T>, f: F) -> Bound<U> {
-    match bound {
-        Bound::Unbounded => Bound::Unbounded,
-        Bound::Included(x) => Bound::Included(f(x)),
-        Bound::Excluded(x) => Bound::Excluded(f(x)),
-    }
 }
 
 /// Parse array path and index from path

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -164,9 +164,6 @@ impl<T: Numericable> Histogram<T> {
     ///
     /// Returns `Unbounded` if there are no points stored
     pub fn get_range_by_size(&self, from: Bound<T>, range_size: usize) -> Bound<T> {
-        // bound_map is unstable, but can be used here
-        // let from_ = from.map(|val| Point { val, idx: usize::MIN });
-
         let from_ = match from {
             Included(val) => Included(Point {
                 val,

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -21,7 +21,6 @@ use self::immutable_numeric_index::{ImmutableNumericIndex, NumericIndexKey};
 use super::utils::check_boundaries;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
-use crate::common::utils::bound_map;
 use crate::common::Flusher;
 use crate::index::field_index::histogram::{Histogram, Numericable};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
@@ -356,8 +355,8 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T>
 
         Ok(match self {
             NumericIndex::Mutable(index) => {
-                let start_bound = bound_map(start_bound, |k| k.encode());
-                let end_bound = bound_map(end_bound, |k| k.encode());
+                let start_bound = start_bound.map(|k| k.encode());
+                let end_bound = end_bound.map(|k| k.encode());
                 Box::new(index.values_range(start_bound, end_bound))
             }
             NumericIndex::Immutable(index) => Box::new(index.values_range(start_bound, end_bound)),
@@ -547,8 +546,8 @@ where
 
         match self {
             NumericIndex::Mutable(index) => {
-                let start_bound = bound_map(start_bound, |k| k.encode());
-                let end_bound = bound_map(end_bound, |k| k.encode());
+                let start_bound = start_bound.map(|k| k.encode());
+                let end_bound = end_bound.map(|k| k.encode());
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
             NumericIndex::Immutable(index) => {


### PR DESCRIPTION
This PR replaces `segment::common::utils::bound_map()` with `std::ops::Bound::map()` which is stabilized in 1.77.