### PR TITLE
universal-query: handle score threshold at collection level

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -99,9 +99,16 @@ impl Collection {
 
                 let result = if let Some(ScoringQuery::Fusion(fusion)) = &request.query {
                     // If the root query is a Fusion, the returned results correspond to each the prefetches.
-                    match fusion {
+                    let mut fused = match fusion {
                         Fusion::Rrf => rrf_scoring(merged_intermediates),
+                    };
+                    if let Some(score_threshold) = request.score_threshold {
+                        fused = fused
+                            .into_iter()
+                            .take_while(|point| point.score >= score_threshold)
+                            .collect();
                     }
+                    fused
                 } else {
                     // Otherwise, it will be a list with a single list of scored points.
                     debug_assert_eq!(merged_intermediates.len(), 1);

--- a/tests/openapi/openapi_integration/test_query.py
+++ b/tests/openapi/openapi_integration/test_query.py
@@ -378,3 +378,45 @@ def test_basic_rrf():
         assert expected["id"] == result["id"]
         assert expected.get("payload") == result.get("payload")
         assert isclose(expected["score"], result["score"], rel_tol=1e-5)
+        
+
+@pytest.mark.parametrize("body", [
+    {
+        "prefetch": [
+            { "query": [0.1, 0.2, 0.3, 0.4] },
+            { "query": [0.5, 0.6, 0.7, 0.8] },
+        ],
+        "query": {"fusion": "rrf"},
+    },
+    { "query": [0.1, 0.2, 0.3, 0.4] }
+])
+def test_score_threshold(body):
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            **body
+        },
+    )
+    assert response.ok, response.json()
+    points = response.json()["result"]["points"]
+    
+    assert len(points) == 8
+    score_threshold = points[3]["score"]
+    
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "score_threshold": score_threshold,
+            **body
+        },
+    )
+    assert response.ok, response.json()
+    points = response.json()["result"]["points"]
+    
+    assert len(points) < 8
+    for point in points:
+        assert point["score"] >= score_threshold


### PR DESCRIPTION
We forgot to handle the `score_threshold` parameter when it was present in the root query. This PR fixes it.

We only need to handle it for fusions because it is the only case where we generate a new scoring at collection level.
For the other cases, it should already be resolved from shard level