### PR TITLE
Don't disable last peer locally

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -827,7 +827,7 @@ impl ShardReplicaSet {
 
     /// Locally disable given peer
     ///
-    /// Disables the peer and notifies consnesus periodically.
+    /// Disables the peer and notifies consensus periodically.
     ///
     /// Prevents disabling the last peer (according to consensus).
     fn add_locally_disabled(&self, peer_id: PeerId) {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -99,7 +99,7 @@ impl ShardReplicaSet {
                 .map_err(|err| {
                     if err.is_transient() {
                         // Deactivate the peer if forwarding failed with transient error
-                        self.add_locally_disabled(leader_peer);
+                        self.add_locally_disabled(&self.replica_state.read(), leader_peer);
 
                         // Return service error
                         CollectionError::service_error(format!(
@@ -472,7 +472,7 @@ impl ShardReplicaSet {
                 self.shard_id
             );
 
-            self.add_locally_disabled(*peer_id);
+            self.add_locally_disabled(state, *peer_id);
         }
 
         wait_for_deactivation


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/4629>

Prevents a shard becoming unresponsive because the last replica was locally disabled. This was possible when using medium/strong ordering. Now it does not allow locally disabling the last replica anymore.

I believe is the simplest approach and covers both scenarios we spoke about, for having just one or multiple replicas.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?