### PR TITLE
Derive/implement `fmt::Debug` for `Segment`

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -30,6 +30,7 @@ type LockedFieldsMap = Arc<RwLock<HashMap<PayloadKeyType, PayloadFieldSchema>>>;
 /// This object is a wrapper around read-only segment.
 /// It could be used to provide all read and write operations while wrapped segment is being optimized (i.e. not available for writing)
 /// It writes all changed records into a temporary `write_segment` and keeps track on changed points
+#[derive(Debug)]
 pub struct ProxySegment {
     pub write_segment: LockedSegment,
     pub wrapped_segment: LockedSegment,

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -29,6 +29,7 @@ const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 /// Object, which unifies the access to different types of segments, but still allows to
 /// access the original type of the segment if it is required for more efficient operations.
+#[derive(Clone, Debug)]
 pub enum LockedSegment {
     Original(Arc<RwLock<Segment>>),
     Proxy(Arc<RwLock<ProxySegment>>),
@@ -115,15 +116,6 @@ impl LockedSegment {
     }
 }
 
-impl Clone for LockedSegment {
-    fn clone(&self) -> Self {
-        match self {
-            LockedSegment::Original(x) => LockedSegment::Original(x.clone()),
-            LockedSegment::Proxy(x) => LockedSegment::Proxy(x.clone()),
-        }
-    }
-}
-
 impl From<Segment> for LockedSegment {
     fn from(s: Segment) -> Self {
         LockedSegment::Original(Arc::new(RwLock::new(s)))
@@ -136,7 +128,7 @@ impl From<ProxySegment> for LockedSegment {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SegmentHolder {
     appendable_segments: HashMap<SegmentId, LockedSegment>,
     non_appendable_segments: HashMap<SegmentId, LockedSegment>,

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -24,7 +24,7 @@
 
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use std::{mem, slice};
+use std::{fmt, mem, slice};
 
 use bitvec::slice::BitSlice;
 use memmap2::MmapMut;
@@ -70,6 +70,14 @@ where
     /// `r#type`. That must be used instead. The sole purpose of this is to keep ownership of the
     /// mmap, and to allow properly cleaning up when this struct is dropped.
     mmap: Arc<MmapMut>,
+}
+
+impl<T: ?Sized> fmt::Debug for MmapType<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MmapType")
+            .field("mmap", &self.mmap)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T> MmapType<T>
@@ -198,6 +206,14 @@ where
     mmap: MmapType<[T]>,
 }
 
+impl<T> fmt::Debug for MmapSlice<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MmapSlice")
+            .field("mmap", &self.mmap)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<T> MmapSlice<T> {
     /// Transform a mmap into a typed slice mmap of type `&[T]`.
     ///
@@ -259,6 +275,7 @@ impl<T> DerefMut for MmapSlice<T> {
 /// [`BitSlice`] on a memory mapped file
 ///
 /// Functions as if it is a [`BitSlice`] because this implements [`Deref`] and [`DerefMut`].
+#[derive(Debug)]
 pub struct MmapBitSlice {
     mmap: MmapType<BitSlice>,
 }

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -49,6 +49,7 @@ pub struct OperationDurationStatistics {
     pub duration_micros_histogram: Vec<(f32, usize)>,
 }
 
+#[derive(Debug)]
 pub struct OperationDurationsAggregator {
     ok_count: usize,
     fail_count: usize,

--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -13,6 +13,7 @@ use crate::common::Flusher;
 /// This might be required to guarantee consistency of the database component.
 /// E.g. copy-on-write implementation should guarantee that data in the `write` component is
 /// persisted before it is removed from the `copy` component.
+#[derive(Debug)]
 pub struct DatabaseColumnScheduledDeleteWrapper {
     db: DatabaseColumnWrapper,
     deleted_pending_persistence: Mutex<HashSet<Vec<u8>>>,

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -13,6 +13,7 @@ use crate::common::Flusher;
 /// This might be required to guarantee consistency of the database component.
 /// E.g. copy-on-write implementation should guarantee that data in the `write` component is
 /// persisted before it is removed from the `copy` component.
+#[derive(Debug)]
 pub struct DatabaseColumnScheduledUpdateWrapper {
     db: DatabaseColumnWrapper,
     deleted_pending_persistence: Mutex<HashSet<Vec<u8>>>,

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -21,7 +21,7 @@ pub const DB_VERSIONS_CF: &str = "version";
 /// If there is no Column Family specified, key-value pair is associated with Column Family "default".
 pub const DB_DEFAULT_CF: &str = "default";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DatabaseColumnWrapper {
     pub database: Arc<RwLock<DB>>,
     pub column_name: String,

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -25,6 +25,7 @@ use crate::types::{PayloadSchemaType, PointIdType, SeqNumberType};
 /// Warn: Use for tests only
 ///
 /// This struct mimics the interface of `PointsIterator` and `IdTracker` only for basic cases
+#[derive(Debug)]
 pub struct FixtureIdTracker {
     ids: Vec<PointOffsetType>,
     deleted: BitVec,

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
 use rand::rngs::StdRng;
@@ -19,7 +21,7 @@ const SEED: u64 = 0b101100001101111000111001010100101000101100110100101001000111
 /// This tracker is used to convert external (i.e. user-facing) point id into internal point id
 /// as well as for keeping track on point version
 /// Internal ids are useful for contiguous-ness
-pub trait IdTracker {
+pub trait IdTracker: fmt::Debug {
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType>;
 
     fn set_internal_version(
@@ -146,6 +148,7 @@ pub trait IdTracker {
 
 pub type IdTrackerSS = dyn IdTracker + Sync + Send;
 
+#[derive(Debug)]
 pub enum IdTrackerEnum {
     MutableIdTracker(SimpleIdTracker),
     ImmutableIdTracker(SimpleIdTracker),

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -57,6 +57,7 @@ fn external_to_stored_id(point_id: &PointIdType) -> StoredPointId {
     point_id.into()
 }
 
+#[derive(Debug)]
 pub struct SimpleIdTracker {
     deleted: BitVec,
     internal_to_external: Vec<PointIdType>,

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -46,7 +46,7 @@ for lvl > 0:
 links offset = level_offsets[level] + offsets[reindex[point_id]]
 */
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct GraphLinksFileHeader {
     pub point_count: u64,
     pub levels_count: u64,
@@ -400,7 +400,7 @@ pub trait GraphLinks: Default {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct GraphLinksRam {
     // all flattened links of all levels
     links: Vec<PointOffsetType>,
@@ -500,7 +500,7 @@ impl GraphLinks for GraphLinksRam {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct GraphLinksMmap {
     mmap: Option<Arc<Mmap>>,
     header: GraphLinksFileHeader,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -58,6 +58,7 @@ const SINGLE_THREADED_HNSW_BUILD_THRESHOLD: usize = 32;
 #[cfg(not(debug_assertions))]
 const SINGLE_THREADED_HNSW_BUILD_THRESHOLD: usize = 256;
 
+#[derive(Debug)]
 pub struct HNSWIndex<TGraphLinks: GraphLinks> {
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
@@ -69,6 +70,7 @@ pub struct HNSWIndex<TGraphLinks: GraphLinks> {
     searches_telemetry: HNSWSearchesTelemetry,
 }
 
+#[derive(Debug)]
 struct HNSWSearchesTelemetry {
     unfiltered_plain: Arc<Mutex<OperationDurationsAggregator>>,
     unfiltered_hnsw: Arc<Mutex<OperationDurationsAggregator>>,

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -201,6 +201,7 @@ impl PayloadIndex for PlainPayloadIndex {
     }
 }
 
+#[derive(Debug)]
 pub struct PlainIndex {
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,

--- a/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
+++ b/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
@@ -6,6 +6,7 @@ use parking_lot::Mutex;
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 
+#[derive(Debug)]
 pub struct SparseSearchesTelemetry {
     pub filtered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
     pub unfiltered_sparse: Arc<Mutex<OperationDurationsAggregator>>,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -41,6 +41,7 @@ use crate::vector_storage::{
 /// Whether to use the new compressed format.
 pub const USE_COMPRESSED: bool = true;
 
+#[derive(Debug)]
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     config: SparseIndexConfig,
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -37,6 +37,7 @@ use crate::types::{
 };
 
 /// `PayloadIndex` implementation, which actually uses index structures for providing faster search
+#[derive(Debug)]
 pub struct StructPayloadIndex {
     /// Payload storage
     payload: Arc<AtomicRefCell<PayloadStorageEnum>>,

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -55,6 +55,7 @@ pub trait VectorIndex {
     ) -> OperationResult<()>;
 }
 
+#[derive(Debug)]
 pub enum VectorIndexEnum {
     Plain(PlainIndex),
     HnswRam(HNSWIndex<GraphLinksRam>),

--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -7,7 +7,7 @@ use crate::types::Payload;
 
 /// Same as `SimplePayloadStorage` but without persistence
 /// Warn: for tests only
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct InMemoryPayloadStorage {
     pub(crate) payload: HashMap<PointOffsetType, Payload>,
 }

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -14,6 +14,7 @@ use crate::types::Payload;
 
 /// On-disk implementation of `PayloadStorage`.
 /// Persists all changes to disk using `store`, does not keep payload in memory
+#[derive(Debug)]
 pub struct OnDiskPayloadStorage {
     db_wrapper: DatabaseColumnWrapper,
 }

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -11,6 +11,7 @@ use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::payload_storage::PayloadStorage;
 use crate::types::Payload;
 
+#[derive(Debug)]
 pub enum PayloadStorageEnum {
     #[cfg(feature = "testing")]
     InMemoryPayloadStorage(InMemoryPayloadStorage),

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -11,6 +11,7 @@ use crate::types::Payload;
 
 /// In-memory implementation of `PayloadStorage`.
 /// Persists all changes to disk using `store`, but only uses this storage during the initial load
+#[derive(Debug)]
 pub struct SimplePayloadStorage {
     pub(crate) payload: HashMap<PointOffsetType, Payload>,
     pub(crate) db_wrapper: DatabaseColumnWrapper,

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,5 +1,6 @@
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -69,6 +70,7 @@ impl StorageVersion for SegmentVersion {
 /// - Keeps track of point versions
 /// - Persists data
 /// - Keeps track of occurred errors
+#[derive(Debug)]
 pub struct Segment {
     /// Latest update operation number, applied to this segment
     /// If None, there were no updates and segment is empty
@@ -97,6 +99,12 @@ pub struct VectorData {
     pub vector_index: Arc<AtomicRefCell<VectorIndexEnum>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
     pub quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+}
+
+impl fmt::Debug for VectorData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VectorData").finish_non_exhaustive()
+    }
 }
 
 impl VectorData {
@@ -1539,7 +1547,7 @@ impl SegmentEntry for Segment {
 
         // Flush order is important:
         //
-        // 1. Flush id mapping. So during recovery the point will be recovered er in proper segment.
+        // 1. Flush id mapping. So during recovery the point will be recovered in proper segment.
         // 2. Flush vectors and payloads.
         // 3. Flush id versions last. So presence of version indicates that all other data is up-to-date.
         //

--- a/lib/segment/src/vector_storage/async_io.rs
+++ b/lib/segment/src/vector_storage/async_io.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::fs::File;
 use std::os::fd::AsRawFd;
 
@@ -10,6 +11,7 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 
 const DISK_PARALLELISM: usize = 16; // TODO: benchmark it better, or make it configurable
 
+#[derive(Debug)]
 struct BufferMeta {
     /// Sequential index of the processing point
     pub index: usize,
@@ -17,6 +19,7 @@ struct BufferMeta {
     pub point_id: PointOffsetType,
 }
 
+#[derive(Debug)]
 struct Buffer {
     /// Stores the buffer for the point vectors
     pub buffer: Vec<u8>,
@@ -24,6 +27,7 @@ struct Buffer {
     pub meta: Option<BufferMeta>,
 }
 
+#[derive(Debug)]
 struct BufferStore {
     /// Stores the buffer for the point vectors
     pub buffers: Vec<Buffer>,
@@ -49,6 +53,18 @@ pub struct UringReader<T: PrimitiveVectorElement> {
     raw_size: usize,
     header_size: usize,
     _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: PrimitiveVectorElement> fmt::Debug for UringReader<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VectorData")
+            .field("file", &self.file)
+            .field("buffers", &self.buffers)
+            .field("raw_size", &self.raw_size)
+            .field("header_size", &self.header_size)
+            .field("_phantom", &self._phantom)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T: PrimitiveVectorElement> UringReader<T> {

--- a/lib/segment/src/vector_storage/async_io_mock.rs
+++ b/lib/segment/src/vector_storage/async_io_mock.rs
@@ -5,6 +5,7 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 
 // This is a mock implementation of the async_io module for those platforms that don't support io_uring.
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct UringReader<T: PrimitiveVectorElement> {
     _phantom: std::marker::PhantomData<T>,
 }

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -26,13 +26,14 @@ pub struct Status {
     pub len: usize,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct ChunkedMmapConfig {
     chunk_size_bytes: usize,
     chunk_size_vectors: usize,
     dim: usize,
 }
 
+#[derive(Debug)]
 pub struct ChunkedMmapVectors<T: Sized + 'static> {
     config: ChunkedMmapConfig,
     status: MmapType<Status>,

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -15,6 +15,7 @@ pub const CHUNK_SIZE: usize = 32 * 1024 * 1024;
 // if dimension is too high, use this capacity
 const MIN_CHUNK_CAPACITY: usize = 16;
 
+#[derive(Debug)]
 pub struct ChunkedVectors<T> {
     /// Vector's dimension.
     ///

--- a/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
@@ -20,6 +20,7 @@ use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum
 const VECTORS_DIR_PATH: &str = "vectors";
 const DELETED_DIR_PATH: &str = "deleted";
 
+#[derive(Debug)]
 pub struct AppendableMmapDenseVectorStorage<T: PrimitiveVectorElement> {
     vectors: ChunkedMmapVectors<T>,
     deleted: DynamicMmapFlags,

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{fmt, fs};
 
 use bitvec::prelude::BitSlice;
 use memmap2::MmapMut;
@@ -83,6 +83,16 @@ pub struct DynamicMmapFlags {
     flags_flusher: Arc<Mutex<Option<Flusher>>>,
     status: MmapType<DynamicMmapStatus>,
     directory: PathBuf,
+}
+
+impl fmt::Debug for DynamicMmapFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynamicMmapFlags")
+            .field("flags", &self.flags)
+            .field("status", &self.status)
+            .field("directory", &self.directory)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Based on the number of flags determines the size of the mmap file.

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -28,6 +28,7 @@ const DELETED_PATH: &str = "deleted.dat";
 /// but possible to mark some vectors as removed
 ///
 /// Mem-mapped storage can only be constructed from another storage
+#[derive(Debug)]
 pub struct MemmapDenseVectorStorage<T: PrimitiveVectorElement> {
     vectors_path: PathBuf,
     deleted_path: PathBuf,

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -25,6 +25,7 @@ const VECTORS_HEADER: &[u8; HEADER_SIZE] = b"data";
 const DELETED_HEADER: &[u8; HEADER_SIZE] = b"drop";
 
 /// Mem-mapped file for dense vectors
+#[derive(Debug)]
 pub struct MmapDenseVectors<T: PrimitiveVectorElement> {
     pub dim: usize,
     pub num_vectors: usize,

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -25,6 +25,7 @@ use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum
 type StoredDenseVector<T> = StoredRecord<Vec<T>>;
 
 /// In-memory vector storage with on-update persistence using `store`
+#[derive(Debug)]
 pub struct SimpleDenseVectorStorage<T: PrimitiveVectorElement> {
     dim: usize,
     distance: Distance,

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -27,6 +27,7 @@ struct MultivectorMmapOffset {
     capacity: PointOffsetType,
 }
 
+#[derive(Debug)]
 pub struct AppendableMmapMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     vectors: ChunkedMmapVectors<T>,
     offsets: ChunkedMmapVectors<MultivectorMmapOffset>,

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -45,6 +46,20 @@ pub struct SimpleMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     deleted: BitVec,
     /// Current number of deleted vectors.
     deleted_count: usize,
+}
+
+impl<T: fmt::Debug + PrimitiveVectorElement> fmt::Debug for SimpleMultiDenseVectorStorage<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SimpleMultiDenseVectorStorage")
+            .field("dim", &self.dim)
+            .field("distance", &self.distance)
+            .field("multi_vector_config", &self.multi_vector_config)
+            .field("vectors", &self.vectors)
+            .field("vectors_metadata", &self.vectors_metadata)
+            .field("db_wrapper", &self.db_wrapper)
+            .field("deleted_count", &self.deleted_count)
+            .finish_non_exhaustive()
+    }
 }
 
 pub fn open_simple_multi_dense_vector_storage(

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use memmap2::{Mmap, MmapMut};
 use memory::madvise;
 
+#[derive(Debug)]
 pub struct QuantizedMmapStorage {
     mmap: Mmap,
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -49,6 +49,7 @@ impl MultivectorOffsetsStorage for Vec<MultivectorOffset> {
     }
 }
 
+#[derive(Debug)]
 pub struct MultivectorOffsetsStorageMmap {
     path: PathBuf,
     offsets: MmapSlice<MultivectorOffset>,
@@ -83,6 +84,7 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
     }
 }
 
+#[derive(Debug)]
 pub struct QuantizedMultivectorStorage<TEncodedQuery, QuantizedStorage, TMultivectorOffsetsStorage>
 where
     TEncodedQuery: Sized,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -41,6 +42,14 @@ pub const QUANTIZED_OFFSETS_PATH: &str = "quantized.offsets.data";
 pub struct QuantizedVectorsConfig {
     pub quantization_config: QuantizationConfig,
     pub vector_parameters: quantization::VectorParameters,
+}
+
+impl fmt::Debug for QuantizedVectorsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuantizedVectorsConfig")
+            .field("quantization_config", &self.quantization_config)
+            .finish_non_exhaustive()
+    }
 }
 
 type ScalarRamMulti = QuantizedMultivectorStorage<
@@ -94,6 +103,13 @@ pub enum QuantizedVectorStorage {
     BinaryMmapMulti(BinaryMmapMulti),
 }
 
+impl fmt::Debug for QuantizedVectorStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("QuantizedVectorStorage").finish()
+    }
+}
+
+#[derive(Debug)]
 pub struct QuantizedVectors {
     storage_impl: QuantizedVectorStorage,
     config: QuantizedVectorsConfig,

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -24,6 +24,7 @@ pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;
 type StoredSparseVector = StoredRecord<SparseVector>;
 
 /// In-memory vector storage with on-update persistence using `store`
+#[derive(Debug)]
 pub struct SimpleSparseVectorStorage {
     db_wrapper: DatabaseColumnWrapper,
     /// BitVec for deleted flags. Grows dynamically upto last set flag.

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -118,6 +118,7 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     fn multi_vector_config(&self) -> &MultiVectorConfig;
 }
 
+#[derive(Debug)]
 pub enum VectorStorageEnum {
     DenseSimple(SimpleDenseVectorStorage<VectorElementType>),
     DenseSimpleByte(SimpleDenseVectorStorage<VectorElementTypeByte>),


### PR DESCRIPTION
This PR derives/implements `fmt::Debug` for `Segment`/`ProxySegment`.

It's a leftover from the "missing payloads" debug. It was pretty useful to be able to look into in-memory state of the segment.

The PR is trivial, just bulky.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
