### PR TITLE
Mmap points to values map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,6 +5489,7 @@ dependencies = [
  "uuid",
  "validator",
  "walkdir",
+ "zerocopy",
 ]
 
 [[package]]

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -121,6 +121,7 @@ where
         instant.elapsed()
     );
 }
+
 pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     debug_assert_eq!(v.len(), size_of::<T>());
 
@@ -137,6 +138,24 @@ pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     );
 
     unsafe { &*(v.as_ptr() as *const T) }
+}
+
+pub fn transmute_from_u8_mut<T>(v: &mut [u8]) -> &mut T {
+    debug_assert_eq!(v.len(), size_of::<T>());
+
+    debug_assert_eq!(
+        v.as_ptr().align_offset(align_of::<T>()),
+        0,
+        "transmuting byte slice {:p} into {}: \
+         required alignment is {} bytes, \
+         byte slice misaligned by {} bytes",
+        v.as_ptr(),
+        std::any::type_name::<T>(),
+        align_of::<T>(),
+        v.as_ptr().align_offset(align_of::<T>()),
+    );
+
+    unsafe { &mut *(v.as_mut_ptr() as *mut T) }
 }
 
 pub fn transmute_to_u8<T>(v: &T) -> &[u8] {

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -121,7 +121,6 @@ where
         instant.elapsed()
     );
 }
-
 pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     debug_assert_eq!(v.len(), size_of::<T>());
 
@@ -138,24 +137,6 @@ pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     );
 
     unsafe { &*(v.as_ptr() as *const T) }
-}
-
-pub fn transmute_from_u8_mut<T>(v: &mut [u8]) -> &mut T {
-    debug_assert_eq!(v.len(), size_of::<T>());
-
-    debug_assert_eq!(
-        v.as_ptr().align_offset(align_of::<T>()),
-        0,
-        "transmuting byte slice {:p} into {}: \
-         required alignment is {} bytes, \
-         byte slice misaligned by {} bytes",
-        v.as_ptr(),
-        std::any::type_name::<T>(),
-        align_of::<T>(),
-        v.as_ptr().align_offset(align_of::<T>()),
-    );
-
-    unsafe { &mut *(v.as_mut_ptr() as *mut T) }
 }
 
 pub fn transmute_to_u8<T>(v: &T) -> &[u8] {

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -80,6 +80,7 @@ smallvec = "1.13.2"
 is_sorted = "0.1.1"
 strum = { workspace = true }
 byteorder = { workspace = true }
+zerocopy = { workspace = true }
 
 sysinfo = "0.30"
 charabia = { version = "0.8.12", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -1,131 +1,137 @@
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
-use itertools::Itertools;
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
-use crate::{common::{mmap_type::MmapSlice, operation_error::{OperationError, OperationResult}, Flusher}, types::{FloatPayloadType, GeoPoint, IntPayloadType}};
+use crate::common::mmap_type::MmapSlice;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::Flusher;
+use crate::types::{FloatPayloadType, GeoPoint, IntPayloadType};
 
-pub trait MmapValue: Clone + Default {
+const POINT_TO_VALUES_PATH: &str = "point_to_values.bin";
+const NOT_ENOUGHT_BYTES_ERROR_MESSAGE: &str =
+    "Not enough bytes to operate with mmaped file `point_to_values.bin`. Is the storage corrupted?";
+
+/// Trait for values that can be stored in mmaped file. It's used in `MmapPointToValues` to store values.
+/// Lifetime `'a` is used to define lifetime for `&'a str` case
+pub trait MmapValue<'a>: Clone + Default + 'a {
     fn mmaped_size(&self) -> usize;
 
-    fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self>;
+    fn read_from_mmap(bytes: &'a [u8], offset: usize) -> OperationResult<Self>;
 
     fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()>;
 }
 
-impl MmapValue for IntPayloadType {
+impl<'a> MmapValue<'a> for IntPayloadType {
     fn mmaped_size(&self) -> usize {
         std::mem::size_of::<Self>()
     }
 
     fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
-        let bytes = &bytes[offset..];
-        if bytes.len() < std::mem::size_of::<Self>() {
-            return Err(OperationError::service_error("Not enough bytes to read int payload index"));
-        }
-
-        Ok(Self::from_le_bytes(bytes[..std::mem::size_of::<Self>()].try_into().unwrap()))
+        Self::read_from_prefix(&bytes[offset..])
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))
     }
 
     fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
-        let bytes = &mut bytes[offset..];
-        if bytes.len() < self.mmaped_size() {
-            return Err(OperationError::service_error("Not enough bytes to write string key index"));
-        }
-        Self::to_le_bytes(*self).iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
-        Ok(())
+        self.write_to_prefix(&mut bytes[offset..])
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))
     }
 }
 
-impl MmapValue for FloatPayloadType {
+impl<'a> MmapValue<'a> for FloatPayloadType {
     fn mmaped_size(&self) -> usize {
         std::mem::size_of::<Self>()
     }
 
     fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
-        let bytes = &bytes[offset..];
-        if bytes.len() < std::mem::size_of::<Self>() {
-            return Err(OperationError::service_error("Not enough bytes to read int payload index"));
-        }
-
-        Ok(Self::from_le_bytes(bytes[..std::mem::size_of::<Self>()].try_into().unwrap()))
+        Self::read_from_prefix(&bytes[offset..])
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))
     }
 
     fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
-        let bytes = &mut bytes[offset..];
-        if bytes.len() < self.mmaped_size() {
-            return Err(OperationError::service_error("Not enough bytes to write string key index"));
-        }
-        Self::to_le_bytes(*self).iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
-        Ok(())
+        self.write_to_prefix(&mut bytes[offset..])
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))
     }
 }
 
-impl MmapValue for String {
-    fn mmaped_size(&self) -> usize {
-        self.as_bytes().len() + std::mem::size_of::<u32>()
-    }
-
-    fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
-        const ERROR_MESSAGE: &str = "Not enough bytes to read string payload index";
-
-        let bytes = &bytes[offset..];
-        if bytes.len() < std::mem::size_of::<u32>() {
-            return Err(OperationError::service_error(ERROR_MESSAGE));
-        }
-
-        let size = u32::from_le_bytes(bytes[..std::mem::size_of::<u32>()].try_into().unwrap()) as usize;
-
-        let bytes = &bytes[std::mem::size_of::<u32>()..];
-        if bytes.len() < size {
-            return Err(OperationError::service_error(ERROR_MESSAGE));
-        }
-
-        let bytes = &bytes[..size];
-
-        let string = std::str::from_utf8(bytes).map_err(|_| OperationError::service_error("UFT8 conversion error. Is the storage corrupted?"))?;
-        Ok(string.to_owned())
-    }
-
-    fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
-        let bytes = &mut bytes[offset..];
-        if bytes.len() < self.mmaped_size() {
-            return Err(OperationError::service_error("Not enough bytes to write string key index"));
-        }
-
-        u32::to_le_bytes(self.len() as u32).iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
-
-        let bytes = &mut bytes[std::mem::size_of::<u32>()..];
-        self.as_bytes().iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
-        Ok(())
-    }
-}
-
-impl MmapValue for GeoPoint {
+impl<'a> MmapValue<'a> for GeoPoint {
     fn mmaped_size(&self) -> usize {
         2 * std::mem::size_of::<f64>()
     }
 
     fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
-        todo!()
+        Ok(Self {
+            lon: f64::read_from_prefix(&bytes[offset..])
+                .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?,
+            lat: f64::read_from_prefix(&bytes[offset + std::mem::size_of::<f64>()..])
+                .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?,
+        })
     }
 
     fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
-        todo!()
+        self.lon
+            .write_to_prefix(&mut bytes[offset..])
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?;
+        self.lat
+            .write_to_prefix(&mut bytes[offset + std::mem::size_of::<f64>()..])
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))
     }
 }
 
-// Flatten points-to-values map
-// It's an analogue of `Vec<Vec<N>>` but in mmaped file.
-// This structure doesn't support adding new values, only removing.
-// It's used in mmap field indices like `ImmutableMapIndex`, `ImmutableNumericIndex`, etc to store points-to-values map.
-pub struct MmapPointToValues<T: MmapValue> {
+impl<'a> MmapValue<'a> for &'a str {
+    fn mmaped_size(&self) -> usize {
+        self.as_bytes().len() + std::mem::size_of::<u32>()
+    }
+
+    fn read_from_mmap(bytes: &'a [u8], offset: usize) -> OperationResult<&'a str> {
+        let bytes = &bytes[offset..];
+        let size = u32::read_from_prefix(bytes)
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?
+            as usize;
+
+        let bytes = &bytes[std::mem::size_of::<u32>()..];
+        if bytes.len() < size {
+            return Err(OperationError::service_error(
+                NOT_ENOUGHT_BYTES_ERROR_MESSAGE,
+            ));
+        }
+
+        let bytes = &bytes[..size];
+
+        let string = std::str::from_utf8(bytes).map_err(|_| OperationError::service_error(format!("UTF8 conversion error while reading {POINT_TO_VALUES_PATH}. Is the storage corrupted?")))?;
+        Ok(string)
+    }
+
+    fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
+        let bytes = &mut bytes[offset..];
+        if bytes.len() < self.mmaped_size() {
+            return Err(OperationError::service_error(
+                NOT_ENOUGHT_BYTES_ERROR_MESSAGE,
+            ));
+        }
+
+        u32::write_to_prefix(&(self.len() as u32), bytes)
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?;
+
+        let bytes = &mut bytes[std::mem::size_of::<u32>()..];
+        self.as_bytes()
+            .iter()
+            .enumerate()
+            .for_each(|(i, &b)| bytes[i] = b);
+        Ok(())
+    }
+}
+
+/// Flattened mmaped points-to-values map
+/// It's an analogue of `Vec<Vec<N>>` but in mmaped file.
+/// This structure doesn't support adding new values, only removing.
+/// It's used in mmap field indices like `MmapMapIndex`, `MmapNumericIndex`, etc to store points-to-values map.
+/// This structure is not generic to avoid boxing lifetimes for `&str` values.
+pub struct MmapPointToValues {
     file_name: PathBuf,
     mmap: MmapSlice<u8>,
     header: Header,
-    phantom: std::marker::PhantomData<T>,
 }
 
 #[repr(C)]
@@ -142,49 +148,82 @@ struct Header {
     points_count: u64,
 }
 
-impl<T: MmapValue> MmapPointToValues<T> {
-    pub fn from_iter(
+#[allow(dead_code)]
+impl MmapPointToValues {
+    pub fn from_iter<'a, T: MmapValue<'a>>(
         path: &Path,
         iter: impl Iterator<Item = (PointOffsetType, Vec<T>)> + Clone,
     ) -> OperationResult<Self> {
-        let points_count = iter.clone().count();
+        // calculate file size
         let header_size = std::mem::size_of::<Header>();
+        let points_count = iter
+            .clone()
+            .map(|(point_id, _)| (point_id + 1) as usize)
+            .max()
+            .unwrap_or(0);
         let ranges_size = points_count * std::mem::size_of::<MmapRange>();
-        let values_size = iter.clone().map(|v| v.1.iter().map(|v| v.mmaped_size()).sum::<usize>()).sum::<usize>();
+        let values_size = iter
+            .clone()
+            .map(|v| v.1.iter().map(|v| v.mmaped_size()).sum::<usize>())
+            .sum::<usize>();
         let file_size = header_size + ranges_size + values_size;
 
-        let file_name = Self::get_file_name(path);
+        // create new file amd mmap
+        let file_name = path.join(POINT_TO_VALUES_PATH);
         create_and_ensure_length(&file_name, file_size)?;
-        let mmap = open_write_mmap(&file_name)?;
+        let mut mmap = open_write_mmap(&file_name)?;
 
-        // fill mmap
+        // fill mmap file data
         let header = Header {
             ranges_start: header_size as u64,
             points_count: points_count as u64,
         };
+        header
+            .write_to_prefix(mmap.as_mut())
+            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?;
+
+        // counter for values offset
+        let mut point_values_offset = header_size + ranges_size;
+        for (point_id, values) in iter {
+            let range = MmapRange {
+                start: point_values_offset as u64,
+                count: values.len() as u64,
+            };
+            range
+                .write_to_prefix(
+                    &mut mmap[header_size + point_id as usize * std::mem::size_of::<MmapRange>()..],
+                )
+                .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?;
+
+            for value in values {
+                value.write_to_mmap(mmap.as_mut(), point_values_offset)?;
+                point_values_offset += value.mmaped_size();
+            }
+        }
 
         let mmap = unsafe { MmapSlice::try_from(mmap)? };
+        mmap.flusher()()?;
+
         Ok(Self {
             file_name,
             mmap,
             header,
-            phantom: std::marker::PhantomData,
         })
     }
 
     pub fn open(path: &Path) -> OperationResult<Self> {
-        let file_name = Self::get_file_name(path);
+        let file_name = path.join(POINT_TO_VALUES_PATH);
         let mmap = open_write_mmap(&file_name)?;
-        let header = Header::read_from_prefix(mmap.as_ref()).ok_or(OperationError::InconsistentStorage {
-            description: format!("Error while field index header conversion")
-        })?;
+        let header =
+            Header::read_from_prefix(mmap.as_ref()).ok_or(OperationError::InconsistentStorage {
+                description: NOT_ENOUGHT_BYTES_ERROR_MESSAGE.to_owned(),
+            })?;
         let mmap = unsafe { MmapSlice::try_from(mmap)? };
 
         Ok(Self {
             file_name,
             mmap,
             header,
-            phantom: std::marker::PhantomData,
         })
     }
 
@@ -196,88 +235,153 @@ impl<T: MmapValue> MmapPointToValues<T> {
         vec![self.file_name.clone()]
     }
 
-    pub fn get_values(&self, point_id: PointOffsetType) -> OperationResult<Box<dyn Iterator<Item = T> + '_>> {
+    pub fn get_values<'a, T: MmapValue<'a>>(
+        &'a self,
+        point_id: PointOffsetType,
+    ) -> OperationResult<Box<dyn Iterator<Item = OperationResult<T>> + 'a>> {
+        // first, get range of values for point
         let range = if point_id < self.header.points_count as PointOffsetType {
-            let range_offset = (self.header.ranges_start as usize) + (point_id as usize) * std::mem::size_of::<MmapRange>();
-            self
-                .mmap
+            let range_offset = (self.header.ranges_start as usize)
+                + (point_id as usize) * std::mem::size_of::<MmapRange>();
+            self.mmap
                 .get(range_offset..range_offset + std::mem::size_of::<MmapRange>())
-                .and_then(|bytes| MmapRange::read_from(bytes))
+                .and_then(MmapRange::read_from)
                 .unwrap_or_default()
         } else {
             MmapRange { start: 0, count: 0 }
         };
 
+        // second, define iteration step for values
+        // iteration step gets remainder range from mmaped file and returns next range with left range
         let bytes: &[u8] = self.mmap.as_ref();
-        let read_value = move |range: MmapRange| -> Option<(T, MmapRange)> {
+        let read_value = move |range: MmapRange| -> Option<(OperationResult<T>, MmapRange)> {
             if range.count > 0 {
-                let value = T::read_from_mmap(bytes, range.start as usize).unwrap();
-                let range = MmapRange { start: range.start + value.mmaped_size() as u64, count: range.count - 1 };
-                Some((value, range))
+                let value = T::read_from_mmap(bytes, range.start as usize);
+                match value {
+                    Ok(value) => {
+                        let range = MmapRange {
+                            start: range.start + value.mmaped_size() as u64,
+                            count: range.count - 1,
+                        };
+                        Some((Ok(value), range))
+                    }
+                    // if error occurs, return error and empty range to stop iteration
+                    Err(err) => Some((Err(err), MmapRange::default())),
+                }
             } else {
                 None
             }
         };
-        Ok(Box::new(std::iter::successors(read_value(range), move |range| read_value(range.1)).map(|(value, _)| value)))
+
+        // finally, return iterator
+        Ok(Box::new(
+            std::iter::successors(read_value(range), move |range| read_value(range.1))
+                .map(|(value, _)| value),
+        ))
     }
 
-    pub fn remove_point(&mut self, point_id: PointOffsetType) -> OperationResult<Vec<T>> {
-        let values = self.get_values(point_id)?.collect_vec();
-
+    pub fn remove_point(&mut self, point_id: PointOffsetType) -> OperationResult<()> {
         // change points values range to empty
-        let range_offset = (self.header.ranges_start as usize) + (point_id as usize) * std::mem::size_of::<MmapRange>();
-        self
+        let range_offset = (self.header.ranges_start as usize)
+            + (point_id as usize) * std::mem::size_of::<MmapRange>();
+        if let Some(range) = self
             .mmap
             .get_mut(range_offset..range_offset + std::mem::size_of::<MmapRange>())
-            .and_then(|bytes| MmapRange::mut_from(bytes))
-            .map(|range| *range = MmapRange { start: 0, count: 0 });
-
-        Ok(values)
-    }
-
-    fn get_file_name(path: &Path) -> PathBuf {
-        // TODO
-        path.join("")
+            .and_then(MmapRange::mut_from)
+        {
+            *range = Default::default();
+            Ok(())
+        } else {
+            Err(OperationError::InconsistentStorage {
+                description: NOT_ENOUGHT_BYTES_ERROR_MESSAGE.to_owned(),
+            })
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use tempfile::Builder;
 
     use super::*;
 
     #[test]
-    fn test_immutable_point_to_values_remove() {
+    fn test_mmap_point_to_values_remove() {
         let mut values: Vec<Vec<String>> = vec![
-            vec!["0".to_owned(), "1".to_owned(), "2".to_owned(), "3".to_owned(), "4".to_owned()],
-            vec!["5".to_owned(), "6".to_owned(), "7".to_owned(), "8".to_owned(), "9".to_owned()],
-            vec!["0".to_owned(), "1".to_owned(), "2".to_owned(), "3".to_owned(), "4".to_owned()],
-            vec!["5".to_owned(), "6".to_owned(), "7".to_owned(), "8".to_owned(), "9".to_owned()],
-            vec!["10".to_owned(), "11".to_owned(), "12".to_owned()],
+            vec![
+                "fox".to_owned(),
+                "driver".to_owned(),
+                "point".to_owned(),
+                "it".to_owned(),
+                "box".to_owned(),
+            ],
+            vec![
+                "alice".to_owned(),
+                "red".to_owned(),
+                "yellow".to_owned(),
+                "blue".to_owned(),
+                "apple".to_owned(),
+            ],
+            vec![
+                "box".to_owned(),
+                "qdrant".to_owned(),
+                "line".to_owned(),
+                "bash".to_owned(),
+                "reproduction".to_owned(),
+            ],
+            vec![
+                "list".to_owned(),
+                "vitamin".to_owned(),
+                "one".to_owned(),
+                "two".to_owned(),
+                "three".to_owned(),
+            ],
+            vec![
+                "tree".to_owned(),
+                "metallic".to_owned(),
+                "ownership".to_owned(),
+            ],
             vec![],
-            vec!["13".to_owned()],
-            vec!["14".to_owned(), "15".to_owned()],
+            vec!["slice".to_owned()],
+            vec!["red".to_owned(), "pink".to_owned()],
         ];
 
-        let dir = Builder::new().prefix("mmap_point_to_values").tempdir().unwrap();
-        let mut point_to_values = MmapPointToValues::from_iter(dir.path(), values.clone().into_iter().enumerate().map(|(id, values)| (id as PointOffsetType, values))).unwrap();
+        let dir = Builder::new()
+            .prefix("mmap_point_to_values")
+            .tempdir()
+            .unwrap();
+        MmapPointToValues::from_iter(
+            dir.path(),
+            values.iter().enumerate().map(|(id, values)| {
+                (
+                    id as PointOffsetType,
+                    values.iter().map(|s| s.as_str()).collect_vec(),
+                )
+            }),
+        )
+        .unwrap();
+        let mut point_to_values = MmapPointToValues::open(dir.path()).unwrap();
 
-        let check = |point_to_values: &MmapPointToValues<_>, values: &[Vec<_>]| {
+        let check = |point_to_values: &MmapPointToValues, values: &[Vec<_>]| {
             for (idx, values) in values.iter().enumerate() {
-                let v = point_to_values.get_values(idx as PointOffsetType).unwrap().collect_vec();
+                let v: Vec<String> = point_to_values
+                    .get_values(idx as PointOffsetType)
+                    .unwrap()
+                    .map(|s: OperationResult<&str>| s.unwrap().to_owned())
+                    .collect_vec();
                 assert_eq!(&v, values);
             }
         };
 
         check(&point_to_values, &values);
 
-        point_to_values.remove_point(0);
+        point_to_values.remove_point(0).unwrap();
         values[0].clear();
 
         check(&point_to_values, &values);
 
-        point_to_values.remove_point(3);
+        point_to_values.remove_point(3).unwrap();
         values[3].clear();
 
         check(&point_to_values, &values);

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -369,7 +369,7 @@ mod tests {
             values.iter().enumerate().map(|(id, values)| {
                 (
                     id as PointOffsetType,
-                    values.iter().map(|s| s.clone()).collect_vec(),
+                    values.iter().cloned().collect_vec(),
                 )
             }),
         )

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -366,12 +366,10 @@ mod tests {
             .unwrap();
         MmapPointToValues::from_iter(
             dir.path(),
-            values.iter().enumerate().map(|(id, values)| {
-                (
-                    id as PointOffsetType,
-                    values.iter().cloned().collect_vec(),
-                )
-            }),
+            values
+                .iter()
+                .enumerate()
+                .map(|(id, values)| (id as PointOffsetType, values.iter().cloned().collect_vec())),
         )
         .unwrap();
         let point_to_values = MmapPointToValues::open(dir.path()).unwrap();

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -1,0 +1,186 @@
+use std::path::Path;
+
+use common::types::PointOffsetType;
+
+use crate::{common::operation_error::{OperationError, OperationResult}, types::{FloatPayloadType, GeoPoint, IntPayloadType}};
+
+use super::immutable_point_to_values::ImmutablePointToValues;
+
+pub trait MmapValue: Clone + Default {
+    fn mmaped_size(&self) -> usize;
+
+    fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self>;
+
+    fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()>;
+}
+
+impl MmapValue for IntPayloadType {
+    fn mmaped_size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
+        let bytes = &bytes[offset..];
+        if bytes.len() < std::mem::size_of::<Self>() {
+            return Err(OperationError::service_error("Not enough bytes to read int payload index"));
+        }
+
+        Ok(Self::from_le_bytes(bytes[..std::mem::size_of::<Self>()].try_into().unwrap()))
+    }
+
+    fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
+        let bytes = &mut bytes[offset..];
+        if bytes.len() < self.mmaped_size() {
+            return Err(OperationError::service_error("Not enough bytes to write string key index"));
+        }
+        Self::to_le_bytes(*self).iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
+        Ok(())
+    }
+}
+
+impl MmapValue for FloatPayloadType {
+    fn mmaped_size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
+        let bytes = &bytes[offset..];
+        if bytes.len() < std::mem::size_of::<Self>() {
+            return Err(OperationError::service_error("Not enough bytes to read int payload index"));
+        }
+
+        Ok(Self::from_le_bytes(bytes[..std::mem::size_of::<Self>()].try_into().unwrap()))
+    }
+
+    fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
+        let bytes = &mut bytes[offset..];
+        if bytes.len() < self.mmaped_size() {
+            return Err(OperationError::service_error("Not enough bytes to write string key index"));
+        }
+        Self::to_le_bytes(*self).iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
+        Ok(())
+    }
+}
+
+impl MmapValue for String {
+    fn mmaped_size(&self) -> usize {
+        self.as_bytes().len() + std::mem::size_of::<u32>()
+    }
+
+    fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
+        const ERROR_MESSAGE: &str = "Not enough bytes to read string payload index";
+
+        let bytes = &bytes[offset..];
+        if bytes.len() < std::mem::size_of::<u32>() {
+            return Err(OperationError::service_error(ERROR_MESSAGE));
+        }
+
+        let size = u32::from_le_bytes(bytes[..std::mem::size_of::<u32>()].try_into().unwrap()) as usize;
+
+        let bytes = &bytes[std::mem::size_of::<u32>()..];
+        if bytes.len() < size {
+            return Err(OperationError::service_error(ERROR_MESSAGE));
+        }
+
+        let bytes = &bytes[..size];
+
+        let string = std::str::from_utf8(bytes).map_err(|_| OperationError::service_error(ERROR_MESSAGE))?;
+        Ok(string.to_owned())
+    }
+
+    fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
+        let bytes = &mut bytes[offset..];
+        if bytes.len() < self.mmaped_size() {
+            return Err(OperationError::service_error("Not enough bytes to write string key index"));
+        }
+
+        u32::to_le_bytes(self.len() as u32).iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
+
+        let bytes = &mut bytes[std::mem::size_of::<u32>()..];
+        self.as_bytes().iter().enumerate().for_each(|(i, &b)| bytes[i] = b);
+        Ok(())
+    }
+}
+
+impl MmapValue for GeoPoint {
+    fn mmaped_size(&self) -> usize {
+        2 * std::mem::size_of::<f64>()
+    }
+
+    fn read_from_mmap(bytes: &[u8], offset: usize) -> OperationResult<Self> {
+        todo!()
+    }
+
+    fn write_to_mmap(&self, bytes: &mut [u8], offset: usize) -> OperationResult<()> {
+        todo!()
+    }
+}
+
+// Flatten points-to-values map
+// It's an analogue of `Vec<Vec<N>>` but in mmaped file.
+// This structure doesn't support adding new values, only removing.
+// It's used in mmap field indices like `ImmutableMapIndex`, `ImmutableNumericIndex`, etc to store points-to-values map.
+pub struct MmapPointToValues<T: MmapValue> {
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: MmapValue> MmapPointToValues<T> {
+    pub fn from_vec(path: &Path, src: Vec<Vec<T>>) -> OperationResult<Self> {
+        todo!()
+    }
+
+    pub fn from_immutable(path: &Path, src: ImmutablePointToValues<T>) -> OperationResult<Self> {
+        todo!()
+    }
+
+    pub fn get_values(&self, idx: PointOffsetType) -> Option<Vec<T>> {
+        todo!()
+    }
+
+    pub fn remove_point(&mut self, idx: PointOffsetType) -> Option<Vec<T>> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::Builder;
+
+    use super::*;
+
+    #[test]
+    fn test_immutable_point_to_values_remove() {
+        let mut values: Vec<Vec<String>> = vec![
+            vec!["0".to_owned(), "1".to_owned(), "2".to_owned(), "3".to_owned(), "4".to_owned()],
+            vec!["5".to_owned(), "6".to_owned(), "7".to_owned(), "8".to_owned(), "9".to_owned()],
+            vec!["0".to_owned(), "1".to_owned(), "2".to_owned(), "3".to_owned(), "4".to_owned()],
+            vec!["5".to_owned(), "6".to_owned(), "7".to_owned(), "8".to_owned(), "9".to_owned()],
+            vec!["10".to_owned(), "11".to_owned(), "12".to_owned()],
+            vec![],
+            vec!["13".to_owned()],
+            vec!["14".to_owned(), "15".to_owned()],
+        ];
+
+        let dir = Builder::new().prefix("mmap_point_to_values").tempdir().unwrap();
+        let mut point_to_values = MmapPointToValues::from_vec(dir.path(), values.clone()).unwrap();
+
+        let check = |point_to_values: &MmapPointToValues<_>, values: &[Vec<_>]| {
+            for (idx, values) in values.iter().enumerate() {
+                let v = point_to_values.get_values(idx as PointOffsetType).unwrap();
+                assert_eq!(&v, values);
+            }
+        };
+
+        check(&point_to_values, &values);
+
+        point_to_values.remove_point(0);
+        values[0].clear();
+
+        check(&point_to_values, &values);
+
+        point_to_values.remove_point(3);
+        values[3].clear();
+
+        check(&point_to_values, &values);
+    }
+}

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -11,9 +11,9 @@ use crate::types::{FloatPayloadType, GeoPoint, IntPayloadType};
 
 const POINT_TO_VALUES_PATH: &str = "point_to_values.bin";
 const NOT_ENOUGHT_BYTES_ERROR_MESSAGE: &str =
-    "Not enough bytes to operate with mmaped file `point_to_values.bin`. Is the storage corrupted?";
+    "Not enough bytes to operate with memmaped file `point_to_values.bin`. Is the storage corrupted?";
 
-/// Trait for values that can be stored in mmaped file. It's used in `MmapPointToValues` to store values.
+/// Trait for values that can be stored in memmaped file. It's used in `MmapPointToValues` to store values.
 /// Lifetime `'a` is used to define lifetime for `&'a str` case
 pub trait MmapValue<'a>: Clone + Default + 'a {
     fn mmaped_size(&self) -> usize;
@@ -123,8 +123,8 @@ impl<'a> MmapValue<'a> for &'a str {
     }
 }
 
-/// Flattened mmaped points-to-values map
-/// It's an analogue of `Vec<Vec<N>>` but in mmaped file.
+/// Flattened memmaped points-to-values map
+/// It's an analogue of `Vec<Vec<N>>` but in memmaped file.
 /// This structure doesn't support adding new values, only removing.
 /// It's used in mmap field indices like `MmapMapIndex`, `MmapNumericIndex`, etc to store points-to-values map.
 /// This structure is not generic to avoid boxing lifetimes for `&str` values.
@@ -252,7 +252,7 @@ impl MmapPointToValues {
         };
 
         // second, define iteration step for values
-        // iteration step gets remainder range from mmaped file and returns next range with left range
+        // iteration step gets remainder range from memmaped file and returns next range with left range
         let bytes: &[u8] = self.mmap.as_ref();
         let read_value = move |range: MmapRange| -> Option<(OperationResult<T>, MmapRange)> {
             if range.count > 0 {

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -422,7 +422,7 @@ mod tests {
         for (idx, values) in values.iter().enumerate() {
             let iter = point_to_values.get_values(idx as PointOffsetType);
             let v: Vec<GeoPoint> = iter
-                .map(|iter| iter.map(|s: GeoPoint| s.clone()).collect_vec())
+                .map(|iter| iter.collect_vec())
                 .unwrap_or_default();
             assert_eq!(&v, values);
         }

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -225,24 +225,20 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
         point_id: PointOffsetType,
         check_fn: impl Fn(T::Referenced<'_>) -> bool,
     ) -> bool {
-        if point_id < self.header.points_count as PointOffsetType {
-            self.get_range(point_id)
-                .map(|range| {
-                    let mut value_offset = range.start as usize;
-                    for _ in 0..range.count {
-                        let bytes = self.mmap.get(value_offset..).unwrap();
-                        let value = T::read_from_mmap(bytes).unwrap();
-                        if check_fn(value.clone()) {
-                            return true;
-                        }
-                        value_offset += T::mmaped_size(value);
+        self.get_range(point_id)
+            .map(|range| {
+                let mut value_offset = range.start as usize;
+                for _ in 0..range.count {
+                    let bytes = self.mmap.get(value_offset..).unwrap();
+                    let value = T::read_from_mmap(bytes).unwrap();
+                    if check_fn(value.clone()) {
+                        return true;
                     }
-                    false
-                })
-                .unwrap_or(false)
-        } else {
-            false
-        }
+                    value_offset += T::mmaped_size(value);
+                }
+                false
+            })
+            .unwrap_or(false)
     }
 
     pub fn get_values<'a>(

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -10,6 +10,7 @@ pub mod geo_hash;
 pub mod geo_index;
 mod histogram;
 mod immutable_point_to_values;
+mod mmap_point_to_values;
 pub mod index_selector;
 pub mod map_index;
 pub mod numeric_index;

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -10,9 +10,9 @@ pub mod geo_hash;
 pub mod geo_index;
 mod histogram;
 mod immutable_point_to_values;
-mod mmap_point_to_values;
 pub mod index_selector;
 pub mod map_index;
+mod mmap_point_to_values;
 pub mod numeric_index;
 mod stat_tools;
 


### PR DESCRIPTION
This PR introduces a mmap analog of `ImmutablePointToValues`, which is required for mmap field indexes.

`MmapPointToValues` has almost the same API. The main difference is that the method returns an iterator of values instead of a slice. It's necessary because mmap file cannot contain slice of strings, we have to parse it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
