### PR TITLE
fix: fix root response structure

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -202,20 +202,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
                       "$ref": "#/components/schemas/VersionInfo"
-                    }
-                  }
                 }
               }
             }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -177,35 +177,18 @@
           "service"
         ],
         "responses": {
-          "default": {
-            "description": "error",
+          "200": {
+            "description": "Qdrant server version information",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/VersionInfo"
                 }
               }
             }
           },
           "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                      "$ref": "#/components/schemas/VersionInfo"
-                }
-              }
-            }
+            "description": "error"
           }
         }
       }

--- a/openapi/openapi-service.ytt.yaml
+++ b/openapi/openapi-service.ytt.yaml
@@ -8,7 +8,15 @@ paths:
       operationId: root
       tags:
         - service
-      responses: #@ response(reference("VersionInfo"))
+      responses:
+        "200":
+          description: Qdrant server version information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VersionInfo"
+        "4XX":
+          description: error
 
   /telemetry:
     get:


### PR DESCRIPTION
This PR proposes a fix for "/" response structure

During implementing https://github.com/qdrant/qdrant-client/pull/678

It was found out, that openapi scheme for `"/"` is no coherent with the actual implementation:

https://github.com/qdrant/qdrant/blob/851f03bbf6644116da56f6bc7b0baa04274e8057/docs/redoc/master/openapi.json#L200-L225

As it can be seen, it returns an object with `result`, `time`, `status` keys, however the actual implementation just returns an http response with `VersionInfo`

https://github.com/qdrant/qdrant/blob/851f03bbf6644116da56f6bc7b0baa04274e8057/src/actix/mod.rs#L48-L51

Usually, we use `accepted_response` or `process_response` methods, e.g. like in:

https://github.com/qdrant/qdrant/blob/851f03bbf6644116da56f6bc7b0baa04274e8057/src/actix/api/collections_api.rs#L52-L61

`accepted_response` and `processed_response` implementation are:

https://github.com/qdrant/qdrant/blob/851f03bbf6644116da56f6bc7b0baa04274e8057/src/actix/helpers.rs#L12-L32



