### PR TITLE
Field index values as iterator instead of slice

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -374,7 +374,6 @@ impl<'a> NumericFieldIndex<'a> {
                     .get_values(idx)
                     .into_iter()
                     .flatten()
-                    .copied()
                     .map(OrderValue::Int),
             ),
             NumericFieldIndex::FloatIndex(index) => Box::new(
@@ -382,7 +381,6 @@ impl<'a> NumericFieldIndex<'a> {
                     .get_values(idx)
                     .into_iter()
                     .flatten()
-                    .copied()
                     .map(OrderValue::Float),
             ),
         }

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -48,8 +48,21 @@ impl ImmutableGeoMapIndex {
         &self.db_wrapper
     }
 
-    pub fn get_values(&self, idx: PointOffsetType) -> Option<&[GeoPoint]> {
-        self.point_to_values.get_values(idx)
+    pub fn get_values(
+        &self,
+        idx: PointOffsetType,
+    ) -> Option<Box<dyn Iterator<Item = GeoPoint> + '_>> {
+        Some(Box::new(
+            self.point_to_values
+                .get_values(idx)
+                .map(|iter| iter.cloned())?,
+        ))
+    }
+
+    pub fn values_count(&self, idx: PointOffsetType) -> usize {
+        self.point_to_values
+            .get_values_count(idx)
+            .unwrap_or_default()
     }
 
     pub fn get_points_per_hash(&self) -> impl Iterator<Item = (&GeoHash, usize)> {

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -60,8 +60,22 @@ impl MutableGeoMapIndex {
         &self.db_wrapper
     }
 
-    pub fn get_values(&self, idx: PointOffsetType) -> Option<&[GeoPoint]> {
-        self.point_to_values.get(idx as usize).map(Vec::as_slice)
+    pub fn get_values(
+        &self,
+        idx: PointOffsetType,
+    ) -> Option<Box<dyn Iterator<Item = GeoPoint> + '_>> {
+        Some(Box::new(
+            self.point_to_values
+                .get(idx as usize)
+                .map(|v| v.iter().cloned())?,
+        ))
+    }
+
+    pub fn values_count(&self, idx: PointOffsetType) -> usize {
+        self.point_to_values
+            .get(idx as usize)
+            .map(Vec::len)
+            .unwrap_or_default()
     }
 
     pub fn get_points_per_hash(&self) -> impl Iterator<Item = (&GeoHash, usize)> {

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -33,10 +33,16 @@ impl<N: Default> ImmutablePointToValues<N> {
         }
     }
 
-    pub fn get_values(&self, idx: PointOffsetType) -> Option<&[N]> {
+    pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {
         let range = self.point_to_values.get(idx as usize)?.clone();
         let range = range.start as usize..range.end as usize;
-        Some(&self.point_to_values_container[range])
+        Some(self.point_to_values_container[range].iter())
+    }
+
+    pub fn get_values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        self.point_to_values
+            .get(idx as usize)
+            .map(|range| (range.end - range.start) as usize)
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) -> Vec<N> {
@@ -79,23 +85,23 @@ mod tests {
 
         let check = |point_to_values: &ImmutablePointToValues<_>, values: &[Vec<_>]| {
             for (idx, values) in values.iter().enumerate() {
-                assert_eq!(
-                    point_to_values.get_values(idx as PointOffsetType),
-                    Some(values.as_slice()),
-                );
+                let values_vec: Option<Vec<_>> = point_to_values
+                    .get_values(idx as PointOffsetType)
+                    .map(|i| i.copied().collect());
+                assert_eq!(values_vec, Some(values.clone()),);
             }
         };
 
-        check(&point_to_values, &values);
+        check(&point_to_values, values.as_slice());
 
         point_to_values.remove_point(0);
         values[0].clear();
 
-        check(&point_to_values, &values);
+        check(&point_to_values, values.as_slice());
 
         point_to_values.remove_point(3);
         values[3].clear();
 
-        check(&point_to_values, &values);
+        check(&point_to_values, values.as_slice());
     }
 }

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -141,7 +141,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> ImmutableMapIndex<N> {
             }
             self.values_count = self
                 .values_count
-                .checked_div(removed_values_count)
+                .checked_sub(removed_values_count)
                 .unwrap_or_default();
         }
         self.point_to_values.remove_point(idx);

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -122,11 +122,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> ImmutableMapIndex<N> {
 
     pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
         if let Some(removed_values) = self.point_to_values.get_values(idx) {
-            if !removed_values.is_empty() {
-                self.indexed_points -= 1;
-            }
-            self.values_count -= removed_values.len();
-
+            let mut removed_values_count = 0;
             for value in removed_values {
                 Self::remove_idx_from_value_list(
                     &mut self.value_to_points,
@@ -137,7 +133,16 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> ImmutableMapIndex<N> {
                 // update db
                 let key = MapIndex::encode_db_record(value, idx);
                 self.db_wrapper.remove(key)?;
+                removed_values_count += 1;
             }
+
+            if removed_values_count > 0 {
+                self.indexed_points -= 1;
+            }
+            self.values_count = self
+                .values_count
+                .checked_div(removed_values_count)
+                .unwrap_or_default();
         }
         self.point_to_values.remove_point(idx);
         Ok(())
@@ -186,8 +191,12 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> ImmutableMapIndex<N> {
         Ok(result)
     }
 
-    pub fn get_values(&self, idx: PointOffsetType) -> Option<&[N]> {
+    pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {
         self.point_to_values.get_values(idx)
+    }
+
+    pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        self.point_to_values.get_values_count(idx)
     }
 
     pub fn get_indexed_points(&self) -> usize {

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -116,8 +116,12 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MutableMapIndex<N> {
         Ok(true)
     }
 
-    pub fn get_values(&self, idx: PointOffsetType) -> Option<&[N]> {
-        self.point_to_values.get(idx as usize).map(|v| v.as_slice())
+    pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {
+        Some(self.point_to_values.get(idx as usize)?.iter())
+    }
+
+    pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        self.point_to_values.get(idx as usize).map(Vec::len)
     }
 
     pub fn get_indexed_points(&self) -> usize {

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -220,11 +220,19 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
         &self.db_wrapper
     }
 
-    pub(super) fn get_values(&self, idx: PointOffsetType) -> Option<&[T]> {
-        self.point_to_values.get_values(idx)
+    pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
+        Some(Box::new(
+            self.point_to_values
+                .get_values(idx)
+                .map(|iter| iter.copied())?,
+        ))
     }
 
-    pub(super) fn get_values_count(&self) -> usize {
+    pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        self.point_to_values.get_values_count(idx)
+    }
+
+    pub(super) fn total_unique_values_count(&self) -> usize {
         self.map.len()
     }
 
@@ -279,10 +287,7 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
 
     pub(super) fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
         if let Some(removed_values) = self.point_to_values.get_values(idx) {
-            if !removed_values.is_empty() {
-                self.points_count -= 1;
-            }
-
+            let mut removed_count = 0;
             for value in removed_values {
                 let key = NumericIndexKey::new(*value, idx);
                 Self::remove_from_map(&mut self.map, &mut self.histogram, key);
@@ -290,6 +295,11 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
                 // update db
                 let encoded = value.encode_key(idx);
                 self.db_wrapper.remove(encoded)?;
+
+                removed_count += 1;
+            }
+            if removed_count > 0 {
+                self.points_count -= 1;
             }
         }
         self.point_to_values.remove_point(idx);

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -39,11 +39,19 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
         &self.db_wrapper
     }
 
-    pub fn get_values(&self, idx: PointOffsetType) -> Option<&[T]> {
-        self.point_to_values.get(idx as usize).map(|v| v.as_slice())
+    pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
+        Some(Box::new(
+            self.point_to_values
+                .get(idx as usize)
+                .map(|v| v.iter().cloned())?,
+        ))
     }
 
-    pub fn get_values_count(&self) -> usize {
+    pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        self.point_to_values.get(idx as usize).map(Vec::len)
+    }
+
+    pub fn total_unique_values_count(&self) -> usize {
         self.map.len()
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -77,16 +77,16 @@ fn test_set_empty_payload() {
 
     let point_id = 42;
 
-    let value = index.get_values(point_id).unwrap();
+    let values_count = index.get_values(point_id).unwrap().count();
 
-    assert!(!value.is_empty());
+    assert!(values_count > 0);
 
     let payload = serde_json::json!(null);
     index.add_point(point_id, &[&payload]).unwrap();
 
-    let value = index.get_values(point_id).unwrap();
+    let values_count = index.get_values(point_id).unwrap().count();
 
-    assert!(value.is_empty());
+    assert_eq!(values_count, 0);
 }
 
 #[rstest]

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -79,7 +79,7 @@ fn test_set_empty_payload() {
 
     let values_count = index.get_values(point_id).unwrap().count();
 
-    assert!(values_count > 0);
+    assert_ne!(values_count, 0);
 
     let payload = serde_json::json!(null);
     index.add_point(point_id, &[&payload]).unwrap();


### PR DESCRIPTION
Tracking issue: #4502.

Integration of this PR https://github.com/qdrant/qdrant/pull/4641.

This PR changes signature of `[ImmutablePointToValues::get_values](https://github.com/qdrant/qdrant/blob/field-index-values-as-iterator-instead-of-slice/lib/segment/src/index/field_index/immutable_point_to_values.rs#L36)`

We cannot use slice anymore because we cannot store slice of strings in mmap file. Instead, `get_values` returns values iterator.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
