### PR TITLE
Update MmapHashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,8 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
+ "common",
+ "criterion",
  "lazy_static",
  "memmap2 0.9.4",
  "num_cpus",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -16,6 +16,7 @@ testing = []
 num_cpus = "1.16"
 ordered-float = "4.2"
 ph = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
@@ -26,8 +27,13 @@ semver = { workspace = true }
 zerocopy = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
+common = { path = ".", features = ["testing"] }
+criterion = "0.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 thiserror = "1.0"
 thread-priority = "1.1"
+
+[[bench]]
+name = "mmap_hashmap"
+harness = false

--- a/lib/common/common/benches/mmap_hashmap.rs
+++ b/lib/common/common/benches/mmap_hashmap.rs
@@ -1,0 +1,37 @@
+use common::mmap_hashmap::{gen_ident, gen_map, MmapHashMap};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+fn bench_mmap_hashmap(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let map = gen_map(&mut rng, gen_ident, 100_000);
+
+    let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+    let mmap_path = tmpdir.path().join("data");
+    let mut keys = map.keys().cloned().collect::<Vec<_>>();
+    keys.sort_unstable();
+
+    MmapHashMap::<str>::create(
+        &mmap_path,
+        map.iter().map(|(k, v)| (k.as_str(), v.iter().copied())),
+    )
+    .unwrap();
+
+    let mmap = MmapHashMap::<str>::open(&mmap_path).unwrap();
+
+    let mut it = keys.iter().cycle();
+    c.bench_function("get", |b| {
+        b.iter(|| mmap.get(it.next().unwrap()).iter().copied().max())
+    });
+
+    drop(tmpdir);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench_mmap_hashmap,
+}
+
+criterion_main!(benches);

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -272,35 +272,29 @@ impl Key for str {
     }
 }
 
-macro_rules! impl_key {
-    ($t:ty) => {
-        impl Key for $t {
-            fn name() -> [u8; 8] {
-                let name = stringify!($t).as_bytes();
-                let mut result = [0; 8];
-                result[..name.len()].copy_from_slice(name);
-                result
-            }
+impl Key for i64 {
+    fn name() -> [u8; 8] {
+        let name = stringify!(i64).as_bytes();
+        let mut result = [0; 8];
+        result[..name.len()].copy_from_slice(name);
+        result
+    }
 
-            fn write_bytes(&self) -> usize {
-                size_of::<$t>()
-            }
+    fn write_bytes(&self) -> usize {
+        size_of::<i64>()
+    }
 
-            fn write(&self, buf: &mut impl Write) -> io::Result<()> {
-                buf.write_all(AsBytes::as_bytes(self))
-            }
+    fn write(&self, buf: &mut impl Write) -> io::Result<()> {
+        buf.write_all(AsBytes::as_bytes(self))
+    }
 
-            fn matches(&self, buf: &[u8]) -> bool {
-                if buf.len() < self.write_bytes() {
-                    return false;
-                }
-                &buf[..size_of::<$t>()] == AsBytes::as_bytes(self)
-            }
+    fn matches(&self, buf: &[u8]) -> bool {
+        if buf.len() < self.write_bytes() {
+            return false;
         }
-    };
+        &buf[..size_of::<i64>()] == AsBytes::as_bytes(self)
+    }
 }
-
-impl_key!(i64);
 
 /// Returns a reference to a slice of zeroes of length `len`.
 #[inline]


### PR DESCRIPTION
Tracking issue: #4502.

This PR amends #4612 with the following changes:
- Make `MmapHashMap` generic over `str` and `i64`.
- Add benchmarks.
- Slightly improve on-disk size:
  - Do not store string lengths, instead add `0xffu8` as terminator byte.
  - Use `u32` for `values.len()` instead of `u64` since `values` itself are `u32` and supposed to be unique.