### PR TITLE
Add defragmentation configuration to the API

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1043,6 +1043,9 @@ To disable vector indexing, set to `0`.
 Note: 1kB = 1 vector of size 256. |
 | flush_interval_sec | [uint64](#uint64) | optional | Interval between forced flushes. |
 | max_optimization_threads | [uint64](#uint64) | optional | Max number of threads (jobs) for running optimizations per shard. Note: each optimization job will also use `max_indexing_threads` threads by itself for index building. If null - have no limit and choose dynamically to saturate CPU. If 0 - no optimization threads, optimizations will be disabled. |
+| defragmentation_keys | [string](#string) | repeated | Payload keys to use for defragmentation. The keys configured will be used to sort vectors internally to take advantage from memory/storage locality. The keys are applied in order, where the first key is most important. (For now, only the firts one is applied)
+
+Note: The keys need to be indexed. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6184,6 +6184,14 @@
             "format": "uint",
             "minimum": 0,
             "nullable": true
+          },
+          "defragmentation_keys": {
+            "description": "Payload keys to use for defragmentation. The keys configured will be used to sort vectors internally to take advantage from memory/storage locality. The keys are applied in order, where the first key is most important. (For now, only the firts one is applied)\n\nNote: The keys need to be indexed.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -8219,6 +8227,14 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0,
+            "nullable": true
+          },
+          "defragmentation_keys": {
+            "description": "Payload keys to use for defragmentation. The keys configured will be used to sort vectors internally to take advantage from memory/storage locality. The keys are applied in order, where the first key is most important. (For now, only the firts one is applied)\n\nNote: The keys need to be indexed.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
             "nullable": true
           }
         }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -266,6 +266,16 @@ message OptimizersConfigDiff {
   If 0 - no optimization threads, optimizations will be disabled.
   */
   optional uint64 max_optimization_threads = 8;
+
+  /*
+  Payload keys to use for defragmentation. The keys configured will be used
+  to sort vectors internally to take advantage from memory/storage locality.
+  The keys are applied in order, where the first key is most important.
+  (For now, only the firts one is applied)
+
+  Note: The keys need to be indexed.
+  */
+  repeated string defragmentation_keys = 9;
 }
 
 message ScalarQuantization {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -352,6 +352,15 @@ pub struct OptimizersConfigDiff {
     /// If 0 - no optimization threads, optimizations will be disabled.
     #[prost(uint64, optional, tag = "8")]
     pub max_optimization_threads: ::core::option::Option<u64>,
+    ///
+    /// Payload keys to use for defragmentation. The keys configured will be used
+    /// to sort vectors internally to take advantage from memory/storage locality.
+    /// The keys are applied in order, where the first key is most important.
+    /// (For now, only the firts one is applied)
+    ///
+    /// Note: The keys need to be indexed.
+    #[prost(string, repeated, tag = "9")]
+    pub defragmentation_keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -77,6 +77,7 @@ fn batch_search_bench(c: &mut Criterion) {
             indexing_threshold: Some(50_000),
             flush_interval_sec: 30,
             max_optimization_threads: Some(2),
+            defragmentation_keys: vec![],
         },
         wal_config,
         hnsw_config: Default::default(),

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -229,6 +229,7 @@ pub(crate) fn get_merge_optimizer(
         },
         Default::default(),
         Default::default(),
+        None,
     )
 }
 
@@ -254,5 +255,6 @@ pub(crate) fn get_indexing_optimizer(
         },
         Default::default(),
         Default::default(),
+        None,
     )
 }

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -7,6 +7,7 @@ use parking_lot::Mutex;
 use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::types::{HnswConfig, QuantizationConfig, SegmentType};
 
+use super::segment_optimizer::DefragmentationConfig;
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
 };
@@ -30,6 +31,7 @@ pub struct MergeOptimizer {
     hnsw_config: HnswConfig,
     quantization_config: Option<QuantizationConfig>,
     telemetry_durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
+    defragmentation_config: Option<DefragmentationConfig>,
 }
 
 impl MergeOptimizer {
@@ -42,6 +44,7 @@ impl MergeOptimizer {
         collection_params: CollectionParams,
         hnsw_config: HnswConfig,
         quantization_config: Option<QuantizationConfig>,
+        defragmentation_config: Option<DefragmentationConfig>,
     ) -> Self {
         MergeOptimizer {
             default_segments_number,
@@ -52,6 +55,7 @@ impl MergeOptimizer {
             hnsw_config,
             quantization_config,
             telemetry_durations_aggregator: OperationDurationsAggregator::new(),
+            defragmentation_config,
         }
     }
 }
@@ -145,6 +149,10 @@ impl SegmentOptimizer for MergeOptimizer {
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {
         &self.telemetry_durations_aggregator
+    }
+
+    fn defragmentation_config(&self) -> Option<&DefragmentationConfig> {
+        self.defragmentation_config.as_ref()
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -10,6 +10,7 @@ use segment::index::VectorIndex;
 use segment::types::{HnswConfig, QuantizationConfig, SegmentType};
 use segment::vector_storage::VectorStorage;
 
+use super::segment_optimizer::DefragmentationConfig;
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
 };
@@ -34,6 +35,7 @@ pub struct VacuumOptimizer {
     hnsw_config: HnswConfig,
     quantization_config: Option<QuantizationConfig>,
     telemetry_durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
+    defragmentation_config: Option<DefragmentationConfig>,
 }
 
 impl VacuumOptimizer {
@@ -47,6 +49,7 @@ impl VacuumOptimizer {
         collection_params: CollectionParams,
         hnsw_config: HnswConfig,
         quantization_config: Option<QuantizationConfig>,
+        defragmentation_config: Option<DefragmentationConfig>,
     ) -> Self {
         VacuumOptimizer {
             deleted_threshold,
@@ -58,6 +61,7 @@ impl VacuumOptimizer {
             hnsw_config,
             quantization_config,
             telemetry_durations_aggregator: OperationDurationsAggregator::new(),
+            defragmentation_config,
         }
     }
 
@@ -205,6 +209,10 @@ impl SegmentOptimizer for VacuumOptimizer {
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {
         &self.telemetry_durations_aggregator
     }
+
+    fn defragmentation_config(&self) -> Option<&DefragmentationConfig> {
+        self.defragmentation_config.as_ref()
+    }
 }
 
 #[cfg(test)]
@@ -305,6 +313,7 @@ mod tests {
             },
             Default::default(),
             Default::default(),
+            None,
         );
 
         let suggested_to_optimize =
@@ -447,6 +456,7 @@ mod tests {
             collection_params.clone(),
             hnsw_config.clone(),
             Default::default(),
+            None,
         );
         let vacuum_optimizer = VacuumOptimizer::new(
             0.2,
@@ -456,6 +466,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params,
             hnsw_config,
+            None,
             Default::default(),
         );
 

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -162,6 +162,14 @@ pub struct OptimizersConfigDiff {
     /// If null - have no limit and choose dynamically to saturate CPU.
     /// If 0 - no optimization threads, optimizations will be disabled.
     pub max_optimization_threads: Option<usize>,
+
+    /// Payload keys to use for defragmentation. The keys configured will be used
+    /// to sort vectors internally to take advantage from memory/storage locality.
+    /// The keys are applied in order, where the first key is most important.
+    /// (For now, only the firts one is applied)
+    ///
+    /// Note: The keys need to be indexed.
+    pub defragmentation_keys: Option<Vec<String>>,
 }
 
 impl std::hash::Hash for OptimizersConfigDiff {
@@ -174,6 +182,7 @@ impl std::hash::Hash for OptimizersConfigDiff {
         self.indexing_threshold.hash(state);
         self.flush_interval_sec.hash(state);
         self.max_optimization_threads.hash(state);
+        self.defragmentation_keys.hash(state);
     }
 }
 
@@ -188,6 +197,7 @@ impl PartialEq for OptimizersConfigDiff {
             && self.indexing_threshold == other.indexing_threshold
             && self.flush_interval_sec == other.flush_interval_sec
             && self.max_optimization_threads == other.max_optimization_threads
+            && self.defragmentation_keys == other.defragmentation_keys
     }
 }
 
@@ -376,6 +386,7 @@ mod tests {
             indexing_threshold: Some(50_000),
             flush_interval_sec: 30,
             max_optimization_threads: Some(1),
+            defragmentation_keys: vec![],
         };
         let update: OptimizersConfigDiff =
             serde_json::from_str(r#"{ "indexing_threshold": 10000 }"#).unwrap();

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -290,6 +290,9 @@ impl TryFrom<api::grpc::qdrant::CollectionParamsDiff> for CollectionParamsDiff {
 
 impl From<api::grpc::qdrant::OptimizersConfigDiff> for OptimizersConfigDiff {
     fn from(value: api::grpc::qdrant::OptimizersConfigDiff) -> Self {
+        let defragmentation_keys =
+            (!value.defragmentation_keys.is_empty()).then_some(value.defragmentation_keys);
+
         Self {
             deleted_threshold: value.deleted_threshold,
             vacuum_min_vector_number: value.vacuum_min_vector_number.map(|v| v as usize),
@@ -299,6 +302,7 @@ impl From<api::grpc::qdrant::OptimizersConfigDiff> for OptimizersConfigDiff {
             indexing_threshold: value.indexing_threshold.map(|v| v as usize),
             flush_interval_sec: value.flush_interval_sec,
             max_optimization_threads: value.max_optimization_threads.map(|v| v as usize),
+            defragmentation_keys,
         }
     }
 }
@@ -423,6 +427,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                         .optimizer_config
                         .max_optimization_threads
                         .map(|n| n as u64),
+                    defragmentation_keys: config.optimizer_config.defragmentation_keys,
                 }),
                 wal_config: Some(api::grpc::qdrant::WalConfigDiff {
                     wal_capacity_mb: Some(config.wal_config.wal_capacity_mb as u64),
@@ -481,6 +486,7 @@ impl From<api::grpc::qdrant::OptimizersConfigDiff> for OptimizersConfig {
             max_optimization_threads: optimizer_config
                 .max_optimization_threads
                 .map(|n| n as usize),
+            defragmentation_keys: optimizer_config.defragmentation_keys,
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -554,6 +554,7 @@ mod tests {
         indexing_threshold: Some(50_000),
         flush_interval_sec: 30,
         max_optimization_threads: Some(2),
+        defragmentation_keys: vec![],
     };
 
     async fn new_shard_replica_set(collection_dir: &TempDir) -> ShardReplicaSet {

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -21,6 +21,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     indexing_threshold: Some(50_000),
     flush_interval_sec: 30,
     max_optimization_threads: Some(2),
+    defragmentation_keys: vec![],
 };
 
 pub fn create_collection_config() -> CollectionConfig {

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -30,6 +30,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     indexing_threshold: Some(50_000),
     flush_interval_sec: 30,
     max_optimization_threads: Some(2),
+    defragmentation_keys: vec![],
 };
 
 #[cfg(test)]

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -51,7 +51,7 @@ pub struct SegmentBuilder {
     indexed_fields: HashMap<PayloadKeyType, PayloadFieldSchema>,
 
     // Payload key to deframent data to
-    defragment_key: Option<PayloadKeyType>,
+    defragment_keys: Option<Vec<PayloadKeyType>>,
 }
 
 impl SegmentBuilder {
@@ -109,12 +109,12 @@ impl SegmentBuilder {
             destination_path,
             temp_path,
             indexed_fields: Default::default(),
-            defragment_key: None,
+            defragment_keys: None,
         })
     }
 
-    pub fn set_defragment_key(&mut self, key: PayloadKeyType) {
-        self.defragment_key = Some(key);
+    pub fn set_defragment_keys(&mut self, key: Vec<PayloadKeyType>) {
+        self.defragment_keys = Some(key);
     }
 
     pub fn remove_indexed_field(&mut self, field: &PayloadKeyType) {
@@ -181,8 +181,10 @@ impl SegmentBuilder {
 
                 // If payload key is set, sort the points to add. For this we fetch the payload and
                 // hash it.
-                let payload_index = self.defragment_key.as_ref().and_then(|defragment_key| {
-                    payloads[pd.segment_index].field_indexes.get(defragment_key)
+                let payload_index = self.defragment_keys.as_ref().and_then(|defragment_key| {
+                    payloads[pd.segment_index]
+                        .field_indexes
+                        .get(&defragment_key[0])
                 });
                 if let Some(payload_indexes) = payload_index {
                     // Try to find an index we can use for hashing.
@@ -339,7 +341,7 @@ impl SegmentBuilder {
                 destination_path,
                 temp_path,
                 indexed_fields,
-                defragment_key: _,
+                defragment_keys: _,
             } = self;
 
             let appendable_flag = segment_config.is_appendable();

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -128,7 +128,7 @@ fn test_building_new_defragmented_segment() {
     let segment1 = Arc::new(RwLock::new(segment1));
     let segment2 = Arc::new(RwLock::new(segment2));
 
-    builder.set_defragment_key(defragment_key.clone());
+    builder.set_defragment_keys(vec![defragment_key.clone()]);
 
     builder
         .update(&[segment1.clone(), segment2.clone()], &stopped)

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -45,6 +45,7 @@ fn test_alias_operation() {
             indexing_threshold: Some(100),
             flush_interval_sec: 2,
             max_optimization_threads: Some(2),
+            defragmentation_keys: vec![],
         },
         optimizers_overwrite: None,
         wal: Default::default(),


### PR DESCRIPTION
Depends on #4610 

Adds defragmentation keys to the optimizers configuration.
I decided to use an array so we can extend it later with multiple keys for sorting.
