### PR TITLE
Ensure payload is deleted on flush only

### DIFF
--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -3,8 +3,9 @@ use std::mem;
 use std::sync::Arc;
 
 use parking_lot::{Mutex, RwLock};
-use rocksdb::DB;
+use rocksdb::{ColumnFamily, DB};
 
+use super::operation_error::OperationError;
 use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_wrapper::{DatabaseColumnWrapper, LockedDatabaseColumnWrapper};
 use crate::common::Flusher;
@@ -18,15 +19,14 @@ use crate::common::Flusher;
 #[derive(Debug)]
 pub struct DatabaseColumnScheduledDeleteWrapper {
     db: DatabaseColumnWrapper,
-    deleted_pending_persistence: Mutex<HashSet<Vec<u8>>>,
+    deleted_pending_persistence: Arc<Mutex<HashSet<Vec<u8>>>>,
 }
 
 impl Clone for DatabaseColumnScheduledDeleteWrapper {
     fn clone(&self) -> Self {
-        let deleted_pending_persistence = self.deleted_pending_persistence.lock().clone();
         Self {
             db: self.db.clone(),
-            deleted_pending_persistence: Mutex::new(deleted_pending_persistence),
+            deleted_pending_persistence: self.pending_deletes(),
         }
     }
 }
@@ -35,7 +35,7 @@ impl DatabaseColumnScheduledDeleteWrapper {
     pub fn new(db: DatabaseColumnWrapper) -> Self {
         Self {
             db,
-            deleted_pending_persistence: Mutex::new(HashSet::new()),
+            deleted_pending_persistence: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -82,6 +82,10 @@ impl DatabaseColumnScheduledDeleteWrapper {
         self.db.lock_db()
     }
 
+    pub fn pending_deletes(&self) -> Arc<Mutex<HashSet<Vec<u8>>>> {
+        self.deleted_pending_persistence.clone()
+    }
+
     pub fn get_pinned<T, F>(&self, key: &[u8], f: F) -> OperationResult<Option<T>>
     where
         F: FnOnce(&[u8]) -> T,
@@ -110,5 +114,63 @@ impl DatabaseColumnScheduledDeleteWrapper {
 
     pub fn remove_column_family(&self) -> OperationResult<()> {
         self.db.remove_column_family()
+    }
+}
+
+/// RocksDB column iterator like `DatabaseColumnIterator`, but excluding pending deletes
+pub struct DatabaseColumnScheduledDeleteWrapperIterator<'a> {
+    pub handle: &'a ColumnFamily,
+    pub iter: rocksdb::DBRawIterator<'a>,
+    pub pending_deletes: Arc<Mutex<HashSet<Vec<u8>>>>,
+}
+
+impl<'a> DatabaseColumnScheduledDeleteWrapperIterator<'a> {
+    pub fn new(
+        db: &'a DB,
+        column_name: &str,
+        pending_deletes: Arc<Mutex<HashSet<Vec<u8>>>>,
+    ) -> OperationResult<Self> {
+        let handle = db.cf_handle(column_name).ok_or_else(|| {
+            OperationError::service_error(format!(
+                "RocksDB cf_handle error: Cannot find column family {column_name}"
+            ))
+        })?;
+        let mut iter = db.raw_iterator_cf(&handle);
+        iter.seek_to_first();
+        Ok(Self {
+            handle,
+            iter,
+            pending_deletes,
+        })
+    }
+}
+
+impl<'a> Iterator for DatabaseColumnScheduledDeleteWrapperIterator<'a> {
+    type Item = (Box<[u8]>, Box<[u8]>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut key;
+
+        // Loop until we find a key that is not deleted
+        loop {
+            // Stop if iterator has ended or errored
+            if !self.iter.valid() {
+                return None;
+            }
+
+            key = self.iter.key().unwrap();
+            if !self.pending_deletes.lock().contains(key) {
+                break;
+            }
+
+            self.iter.next();
+        }
+
+        let item = (Box::from(key), Box::from(self.iter.value().unwrap()));
+
+        // Search to next item for next iteration
+        self.iter.next();
+
+        Some(item)
     }
 }

--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -58,6 +58,15 @@ impl DatabaseColumnScheduledDeleteWrapper {
         Ok(())
     }
 
+    pub fn is_pending_removal<K>(&self, key: K) -> bool
+    where
+        K: AsRef<[u8]>,
+    {
+        self.deleted_pending_persistence
+            .lock()
+            .contains(key.as_ref())
+    }
+
     pub fn flusher(&self) -> Flusher {
         let ids_to_delete = mem::take(&mut *self.deleted_pending_persistence.lock());
         let wrapper = self.db.clone();

--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -58,7 +58,7 @@ impl DatabaseColumnScheduledDeleteWrapper {
         Ok(())
     }
 
-    pub fn is_pending_removal<K>(&self, key: K) -> bool
+    fn is_pending_removal<K>(&self, key: K) -> bool
     where
         K: AsRef<[u8]>,
     {
@@ -86,6 +86,9 @@ impl DatabaseColumnScheduledDeleteWrapper {
     where
         F: FnOnce(&[u8]) -> T,
     {
+        if self.is_pending_removal(key) {
+            return Ok(None);
+        }
         self.db.get_pinned(key, f)
     }
 

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -23,8 +23,8 @@ pub const DB_DEFAULT_CF: &str = "default";
 
 #[derive(Clone, Debug)]
 pub struct DatabaseColumnWrapper {
-    pub database: Arc<RwLock<DB>>,
-    pub column_name: String,
+    database: Arc<RwLock<DB>>,
+    column_name: String,
 }
 
 pub struct DatabaseColumnIterator<'a> {
@@ -231,6 +231,14 @@ impl DatabaseColumnWrapper {
                 &self.column_name
             ))
         })
+    }
+
+    pub fn get_database(&self) -> Arc<RwLock<DB>> {
+        self.database.clone()
+    }
+
+    pub fn get_column_name(&self) -> &str {
+        &self.column_name
     }
 }
 

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -221,7 +221,10 @@ impl PayloadFieldIndex for BinaryIndex {
             return Ok(false);
         }
 
-        for (key, value) in self.db_wrapper.lock_db().iter()? {
+        let db_lock = self.db_wrapper.lock_db();
+        let pending_deletes = self.db_wrapper.pending_deletes();
+
+        for (key, value) in db_lock.iter_pending_deletes(pending_deletes)? {
             let idx = PointOffsetType::from_be_bytes(key.as_ref().try_into().unwrap());
 
             debug_assert_eq!(value.len(), 1);

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::data_types::index::TextIndexParams;
@@ -23,7 +24,7 @@ use crate::types::{FieldCondition, Match, PayloadKeyType};
 
 pub struct FullTextIndex {
     inverted_index: InvertedIndex,
-    db_wrapper: DatabaseColumnWrapper,
+    db_wrapper: DatabaseColumnScheduledDeleteWrapper,
     config: TextIndexParams,
 }
 
@@ -70,7 +71,10 @@ impl FullTextIndex {
         is_appendable: bool,
     ) -> Self {
         let store_cf_name = Self::storage_cf_name(field);
-        let db_wrapper = DatabaseColumnWrapper::new(db, &store_cf_name);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            &store_cf_name,
+        ));
         FullTextIndex {
             inverted_index: InvertedIndex::new(is_appendable),
             db_wrapper,

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -1,6 +1,3 @@
-pub mod immutable_geo_index;
-pub mod mutable_geo_index;
-
 use std::cmp::{max, min};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -14,7 +11,7 @@ use serde_json::Value;
 use self::immutable_geo_index::ImmutableGeoMapIndex;
 use self::mutable_geo_index::MutableGeoMapIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::Flusher;
 use crate::index::field_index::geo_hash::{
     circle_hashes, common_hash_prefix, geo_hash_to_box, polygon_hashes, polygon_hashes_estimation,
@@ -26,6 +23,9 @@ use crate::index::field_index::{
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
+
+pub mod immutable_geo_index;
+pub mod mutable_geo_index;
 
 /// Max number of sub-regions computed for an input geo query
 // TODO discuss value, should it be dynamically computed?
@@ -46,7 +46,7 @@ impl GeoMapIndex {
         }
     }
 
-    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+    fn db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         match self {
             GeoMapIndex::Mutable(index) => index.db_wrapper(),
             GeoMapIndex::Immutable(index) => index.db_wrapper(),

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -8,6 +8,7 @@ use rocksdb::DB;
 
 use super::GeoMapIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::index::field_index::geo_hash::{encode_max_precision, GeoHash};
 use crate::types::GeoPoint;
@@ -38,12 +39,15 @@ pub struct MutableGeoMapIndex {
     pub points_count: usize,
     pub points_values_count: usize,
     pub max_values_per_point: usize,
-    db_wrapper: DatabaseColumnWrapper,
+    db_wrapper: DatabaseColumnScheduledDeleteWrapper,
 }
 
 impl MutableGeoMapIndex {
     pub fn new(db: Arc<RwLock<DB>>, store_cf_name: &str) -> Self {
-        let db_wrapper = DatabaseColumnWrapper::new(db, store_cf_name);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            store_cf_name,
+        ));
         Self {
             points_per_hash: Default::default(),
             values_per_hash: Default::default(),
@@ -56,7 +60,7 @@ impl MutableGeoMapIndex {
         }
     }
 
-    pub fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+    pub fn db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         &self.db_wrapper
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -89,34 +89,39 @@ impl MutableGeoMapIndex {
 
         let mut points_to_hashes: BTreeMap<PointOffsetType, Vec<GeoHash>> = Default::default();
 
-        for (key, value) in self.db_wrapper.lock_db().iter()? {
-            let key_str = std::str::from_utf8(&key).map_err(|_| {
-                OperationError::service_error("Index load error: UTF8 error while DB parsing")
-            })?;
+        {
+            let db_lock = self.db_wrapper.lock_db();
+            let pending_deletes = self.db_wrapper.pending_deletes();
 
-            let (geo_hash, idx) = GeoMapIndex::decode_db_key(key_str)?;
-            let geo_point = GeoMapIndex::decode_db_value(value)?;
+            for (key, value) in db_lock.iter_pending_deletes(pending_deletes)? {
+                let key_str = std::str::from_utf8(&key).map_err(|_| {
+                    OperationError::service_error("Index load error: UTF8 error while DB parsing")
+                })?;
 
-            if self.point_to_values.len() <= idx as usize {
-                self.point_to_values.resize_with(idx as usize + 1, Vec::new);
+                let (geo_hash, idx) = GeoMapIndex::decode_db_key(key_str)?;
+                let geo_point = GeoMapIndex::decode_db_value(value)?;
+
+                if self.point_to_values.len() <= idx as usize {
+                    self.point_to_values.resize_with(idx as usize + 1, Vec::new);
+                }
+
+                if self.point_to_values[idx as usize].is_empty() {
+                    self.points_count += 1;
+                }
+
+                points_to_hashes
+                    .entry(idx)
+                    .or_default()
+                    .push(geo_hash.clone());
+
+                self.point_to_values[idx as usize].push(geo_point);
+                self.points_map
+                    .entry(geo_hash.clone())
+                    .or_default()
+                    .insert(idx);
+
+                self.points_values_count += 1;
             }
-
-            if self.point_to_values[idx as usize].is_empty() {
-                self.points_count += 1;
-            }
-
-            points_to_hashes
-                .entry(idx)
-                .or_default()
-                .push(geo_hash.clone());
-
-            self.point_to_values[idx as usize].push(geo_point);
-            self.points_map
-                .entry(geo_hash.clone())
-                .or_default()
-                .insert(idx);
-
-            self.points_values_count += 1;
         }
 
         for (_idx, geo_hashes) in points_to_hashes.into_iter() {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -1,6 +1,3 @@
-pub mod immutable_map_index;
-pub mod mutable_map_index;
-
 use std::fmt::Display;
 use std::hash::{BuildHasher, Hash};
 use std::str::FromStr;
@@ -17,7 +14,7 @@ use serde_json::Value;
 use smol_str::SmolStr;
 
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::Flusher;
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::{
@@ -29,6 +26,9 @@ use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
     PayloadKeyType, ValueVariants,
 };
+
+pub mod immutable_map_index;
+pub mod mutable_map_index;
 
 pub enum MapIndex<N: Hash + Eq + Clone + Display + FromStr + Default> {
     Mutable(MutableMapIndex<N>),
@@ -44,7 +44,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MapIndex<N> {
         }
     }
 
-    fn get_db_wrapper(&self) -> &DatabaseColumnWrapper {
+    fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         match self {
             MapIndex::Mutable(index) => index.get_db_wrapper(),
             MapIndex::Immutable(index) => index.get_db_wrapper(),

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -100,7 +100,11 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MutableMapIndex<N> {
             return Ok(false);
         }
         self.indexed_points = 0;
-        for (record, _) in self.db_wrapper.lock_db().iter()? {
+
+        let db_lock = self.db_wrapper.lock_db();
+        let pending_deletes = self.db_wrapper.pending_deletes();
+
+        for (record, _) in db_lock.iter_pending_deletes(pending_deletes)? {
             let record = std::str::from_utf8(&record).map_err(|_| {
                 OperationError::service_error("Index load error: UTF8 error while DB parsing")
             })?;

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -9,13 +9,14 @@ use rocksdb::DB;
 use super::mutable_numeric_index::MutableNumericIndex;
 use super::{Encodable, NumericIndex, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
 use crate::common::operation_error::OperationResult;
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues;
 
 pub struct ImmutableNumericIndex<T: Encodable + Numericable + Default> {
     map: NumericKeySortedVec<T>,
-    db_wrapper: DatabaseColumnWrapper,
+    db_wrapper: DatabaseColumnScheduledDeleteWrapper,
     pub(super) histogram: Histogram<T>,
     pub(super) points_count: usize,
     pub(super) max_values_per_point: usize,
@@ -202,7 +203,10 @@ impl<'a, T: Encodable + Numericable> DoubleEndedIterator for NumericKeySortedVec
 impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
     pub(super) fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
         let store_cf_name = NumericIndex::<T>::storage_cf_name(field);
-        let db_wrapper = DatabaseColumnWrapper::new(db, &store_cf_name);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            &store_cf_name,
+        ));
         Self {
             map: NumericKeySortedVec {
                 data: Default::default(),
@@ -216,7 +220,7 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
         }
     }
 
-    pub(super) fn get_db_wrapper(&self) -> &DatabaseColumnWrapper {
+    pub(super) fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         &self.db_wrapper
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use self::immutable_numeric_index::{ImmutableNumericIndex, NumericIndexKey};
 use super::utils::check_boundaries;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::Flusher;
 use crate::index::field_index::histogram::{Histogram, Numericable};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
@@ -152,7 +152,7 @@ impl<T: Encodable + Numericable + Default> NumericIndex<T> {
         }
     }
 
-    fn get_db_wrapper(&self) -> &DatabaseColumnWrapper {
+    fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         match self {
             NumericIndex::Mutable(index) => index.get_db_wrapper(),
             NumericIndex::Immutable(index) => index.get_db_wrapper(),

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -104,7 +104,10 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
             return Ok(false);
         };
 
-        for (key, value) in self.db_wrapper.lock_db().iter()? {
+        let db_lock = self.db_wrapper.lock_db();
+        let pending_deletes = self.db_wrapper.pending_deletes();
+
+        for (key, value) in db_lock.iter_pending_deletes(pending_deletes)? {
             let value_idx = u32::from_be_bytes(value.as_ref().try_into().unwrap());
             let (idx, value) = T::decode_key(&key);
 

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -9,12 +9,13 @@ use rocksdb::DB;
 
 use super::{Encodable, NumericIndex, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 
 pub struct MutableNumericIndex<T: Encodable + Numericable> {
     pub(super) map: BTreeMap<Vec<u8>, PointOffsetType>,
-    pub(super) db_wrapper: DatabaseColumnWrapper,
+    pub(super) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
     pub(super) histogram: Histogram<T>,
     pub(super) points_count: usize,
     pub(super) max_values_per_point: usize,
@@ -24,7 +25,10 @@ pub struct MutableNumericIndex<T: Encodable + Numericable> {
 impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
     pub fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
         let store_cf_name = NumericIndex::<T>::storage_cf_name(field);
-        let db_wrapper = DatabaseColumnWrapper::new(db, &store_cf_name);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            &store_cf_name,
+        ));
         Self {
             map: BTreeMap::new(),
             db_wrapper,
@@ -35,7 +39,7 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
         }
     }
 
-    pub fn get_db_wrapper(&self) -> &DatabaseColumnWrapper {
+    pub fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         &self.db_wrapper
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -303,7 +303,7 @@ fn test_numeric_index(#[case] immutable: bool) {
 
     // if immutable, we have to reload the index
     let index = if immutable {
-        let db_ref = index.get_db_wrapper().get_database().clone();
+        let db_ref = index.get_db_wrapper().get_database();
         let mut new_index: NumericIndex<f64> = NumericIndex::new(db_ref, COLUMN_NAME, false);
         new_index.load().unwrap();
         new_index

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -43,7 +43,7 @@ fn random_index(
 
     // if immutable, we have to reload the index
     if immutable {
-        let db_ref = index.get_db_wrapper().database.clone();
+        let db_ref = index.get_db_wrapper().get_database();
         let mut new_index: NumericIndex<f64> = NumericIndex::new(db_ref, COLUMN_NAME, false);
         new_index.load().unwrap();
         (temp_dir, new_index)
@@ -213,7 +213,7 @@ fn test_payload_blocks_small(#[case] immutable: bool) {
 
     // if immutable, we have to reload the index
     let index = if immutable {
-        let db_ref = index.get_db_wrapper().database.clone();
+        let db_ref = index.get_db_wrapper().get_database();
         let mut new_index: NumericIndex<f64> = NumericIndex::new(db_ref, COLUMN_NAME, false);
         new_index.load().unwrap();
         new_index
@@ -255,7 +255,7 @@ fn test_numeric_index_load_from_disk(#[case] immutable: bool) {
 
     index.flusher()().unwrap();
 
-    let db_ref = index.get_db_wrapper().database.clone();
+    let db_ref = index.get_db_wrapper().get_database();
     let mut new_index: NumericIndex<f64> = NumericIndex::new(db_ref, COLUMN_NAME, !immutable);
     new_index.load().unwrap();
 
@@ -303,7 +303,7 @@ fn test_numeric_index(#[case] immutable: bool) {
 
     // if immutable, we have to reload the index
     let index = if immutable {
-        let db_ref = index.get_db_wrapper().database.clone();
+        let db_ref = index.get_db_wrapper().get_database().clone();
         let mut new_index: NumericIndex<f64> = NumericIndex::new(db_ref, COLUMN_NAME, false);
         new_index.load().unwrap();
         new_index

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -49,8 +49,6 @@ impl OnDiskPayloadStorage {
         let key = serde_cbor::to_vec(&point_id).unwrap();
         self.db_wrapper
             .get_pinned(&key, |raw| serde_cbor::from_slice(raw))?
-            // Don't return the payload if a removal is pending flush
-            .filter(|_| !self.db_wrapper.is_pending_removal(key))
             .transpose()
             .map_err(OperationError::from)
     }

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -6,6 +6,7 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::{DatabaseColumnWrapper, DB_PAYLOAD_CF};
 use crate::common::Flusher;
 use crate::json_path::JsonPath;
@@ -16,12 +17,15 @@ use crate::types::Payload;
 /// Persists all changes to disk using `store`, does not keep payload in memory
 #[derive(Debug)]
 pub struct OnDiskPayloadStorage {
-    db_wrapper: DatabaseColumnWrapper,
+    db_wrapper: DatabaseColumnScheduledDeleteWrapper,
 }
 
 impl OnDiskPayloadStorage {
     pub fn open(database: Arc<RwLock<DB>>) -> OperationResult<Self> {
-        let db_wrapper = DatabaseColumnWrapper::new(database, DB_PAYLOAD_CF);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            database,
+            DB_PAYLOAD_CF,
+        ));
         Ok(OnDiskPayloadStorage { db_wrapper })
     }
 

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -49,6 +49,8 @@ impl OnDiskPayloadStorage {
         let key = serde_cbor::to_vec(&point_id).unwrap();
         self.db_wrapper
             .get_pinned(&key, |raw| serde_cbor::from_slice(raw))?
+            // Don't return the payload if a removal is pending flush
+            .filter(|_| !self.db_wrapper.is_pending_removal(key))
             .transpose()
             .map_err(OperationError::from)
     }

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -27,12 +27,17 @@ impl SimplePayloadStorage {
             DB_PAYLOAD_CF,
         ));
 
-        for (key, val) in db_wrapper.lock_db().iter()? {
-            let point_id: PointOffsetType = serde_cbor::from_slice(&key)
-                .map_err(|_| OperationError::service_error("cannot deserialize point id"))?;
-            let payload: Payload = serde_cbor::from_slice(&val)
-                .map_err(|_| OperationError::service_error("cannot deserialize payload"))?;
-            payload_map.insert(point_id, payload);
+        {
+            let db_lock = db_wrapper.lock_db();
+            let pending_deletes = db_wrapper.pending_deletes();
+
+            for (key, value) in db_lock.iter_pending_deletes(pending_deletes)? {
+                let point_id: PointOffsetType = serde_cbor::from_slice(&key)
+                    .map_err(|_| OperationError::service_error("cannot deserialize point id"))?;
+                let payload: Payload = serde_cbor::from_slice(&value)
+                    .map_err(|_| OperationError::service_error("cannot deserialize payload"))?;
+                payload_map.insert(point_id, payload);
+            }
         }
 
         Ok(SimplePayloadStorage {


### PR DESCRIPTION

If the user sends "delete by filter" requests, which request will do the following things:

- Mark point as deleted (persisted on flush)
- Remove associated payload from rocksdb (persisted at random moment)

If the service is killed before delete flags are persisted, but after payload removals, on recover from WAL we won't be able to delete partially deleted point, because we won't have payload anymore to identify it.

This PR changes persistence of payload storage to enforce persistence on flush in the same way it is enforced in IdTracker for Id mapper.


Important: further implementations of payload index, which won't rely on rocksdb _must_ also ensure that deletes are only persisted on flush.