### PR TITLE
universal-query: gRPC group API

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -186,6 +186,8 @@
     - [Query](#qdrant-Query)
     - [QueryBatchPoints](#qdrant-QueryBatchPoints)
     - [QueryBatchResponse](#qdrant-QueryBatchResponse)
+    - [QueryGroupsResponse](#qdrant-QueryGroupsResponse)
+    - [QueryPointGroups](#qdrant-QueryPointGroups)
     - [QueryPoints](#qdrant-QueryPoints)
     - [QueryResponse](#qdrant-QueryResponse)
     - [Range](#qdrant-Range)
@@ -3195,6 +3197,52 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 
 
+<a name="qdrant-QueryGroupsResponse"></a>
+
+### QueryGroupsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| result | [GroupsResult](#qdrant-GroupsResult) |  |  |
+| time | [double](#double) |  | Time spent to process |
+
+
+
+
+
+
+<a name="qdrant-QueryPointGroups"></a>
+
+### QueryPointGroups
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | Name of the collection |
+| prefetch | [PrefetchQuery](#qdrant-PrefetchQuery) | repeated | Sub-requests to perform first. If present, the query will be performed on the results of the prefetches. |
+| query | [Query](#qdrant-Query) | optional | Query to perform. If missing, returns points ordered by their IDs. |
+| using | [string](#string) | optional | Define which vector to use for querying. If missing, the default vector is used. |
+| filter | [Filter](#qdrant-Filter) | optional | Filter conditions - return only those points that satisfy the specified conditions. |
+| params | [SearchParams](#qdrant-SearchParams) | optional | Search params for when there is no prefetch. |
+| score_threshold | [float](#float) | optional | Return points with scores better than this threshold. |
+| with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) |  | Options for specifying which payload to include or not |
+| with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) | optional | Options for specifying which vectors to include into response |
+| limit | [uint64](#uint64) | optional | Max number of points. Default is 3. |
+| group_size | [uint64](#uint64) | optional | Maximum amount of points to return per group. Default to 10. |
+| group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |
+| read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
+| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
+| timeout | [uint64](#uint64) | optional | If set, overrides global timeout setting for this request. Unit is seconds. |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Specify in which shards to look for the points, if not specified - look in all shards |
+
+
+
+
+
+
 <a name="qdrant-QueryPoints"></a>
 
 ### QueryPoints
@@ -4227,6 +4275,7 @@ When using target (with or without context), the score behaves a little differen
 | UpdateBatch | [UpdateBatchPoints](#qdrant-UpdateBatchPoints) | [UpdateBatchResponse](#qdrant-UpdateBatchResponse) | Perform multiple update operations in one request |
 | Query | [QueryPoints](#qdrant-QueryPoints) | [QueryResponse](#qdrant-QueryResponse) | Universally query points. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries. |
 | QueryBatch | [QueryBatchPoints](#qdrant-QueryBatchPoints) | [QueryBatchResponse](#qdrant-QueryBatchResponse) | Universally query points in a batch fashion. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries. |
+| QueryGroups | [QueryPointGroups](#qdrant-QueryPointGroups) | [QueryGroupsResponse](#qdrant-QueryGroupsResponse) | Universally query points in a group fashion. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries. |
 
  
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -554,6 +554,25 @@ message QueryBatchPoints {
   optional uint64 timeout = 4; // If set, overrides global timeout setting for this request. Unit is seconds.
 }
 
+message QueryPointGroups {
+  string collection_name = 1; // Name of the collection
+  repeated PrefetchQuery prefetch = 2; // Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.
+  optional Query query = 3; // Query to perform. If missing, returns points ordered by their IDs.
+  optional string using = 4; // Define which vector to use for querying. If missing, the default vector is used.
+  optional Filter filter = 5; // Filter conditions - return only those points that satisfy the specified conditions.
+  optional SearchParams params = 6; // Search params for when there is no prefetch.
+  optional float score_threshold = 7; // Return points with scores better than this threshold.
+  WithPayloadSelector with_payload = 8; // Options for specifying which payload to include or not
+  optional WithVectorsSelector with_vectors = 9; // Options for specifying which vectors to include into response
+  optional uint64 limit = 10; // Max number of points. Default is 3.
+  optional uint64 group_size = 11; // Maximum amount of points to return per group. Default to 10.
+  string group_by = 12; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+  optional ReadConsistency read_consistency = 13; // Options for specifying read consistency guarantees
+  optional WithLookup with_lookup = 14; // Options for specifying how to use the group id to lookup points in another collection
+  optional uint64 timeout = 15; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 16; // Specify in which shards to look for the points, if not specified - look in all shards
+}
+
 message PointsUpdateOperation {
   message PointStructList {
     repeated PointStruct points = 1;
@@ -687,6 +706,11 @@ message QueryResponse {
 
 message QueryBatchResponse {
   repeated BatchResult result = 1;
+  double time = 2; // Time spent to process
+}
+
+message QueryGroupsResponse {
+  GroupsResult result = 1;
   double time = 2; // Time spent to process
 }
 

--- a/lib/api/src/grpc/proto/points_service.proto
+++ b/lib/api/src/grpc/proto/points_service.proto
@@ -117,4 +117,8 @@ service Points {
   Universally query points in a batch fashion. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
   */
   rpc QueryBatch (QueryBatchPoints) returns (QueryBatchResponse) {}
+  /*
+  Universally query points in a group fashion. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
+  */
+  rpc QueryGroups (QueryPointGroups) returns (QueryGroupsResponse) {}
 }

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
 use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
-use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 use segment::json_path::JsonPath;
 use segment::types::{
     AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
@@ -268,22 +267,22 @@ impl From<CollectionQueryGroupsRequest> for GroupRequest {
         let collection_query_request = CollectionQueryRequest {
             prefetch: prefetch.into_iter().map(From::from).collect(),
             query: query.map(From::from),
-            using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+            using,
             filter,
             score_threshold,
-            limit: limit.unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
+            limit,
             offset: 0,
             params,
-            with_vector: with_vector.unwrap_or(CollectionQueryRequest::DEFAULT_WITH_VECTOR),
-            with_payload: with_payload.unwrap_or(CollectionQueryRequest::DEFAULT_WITH_PAYLOAD),
+            with_vector,
+            with_payload,
             lookup_from: None,
         };
 
         GroupRequest {
             source: SourceRequest::Query(collection_query_request),
             group_by,
-            group_size: group_size.unwrap_or(CollectionQueryRequest::DEFAULT_GROUP_SIZE),
-            limit: limit.unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
+            group_size,
+            limit,
             with_lookup: with_lookup_interface.map(Into::into),
         }
     }

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -2,7 +2,9 @@ use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
-use collection::operations::universal_query::collection_query::CollectionQueryRequest;
+use collection::operations::universal_query::collection_query::{
+    CollectionQueryGroupsRequest, CollectionQueryRequest,
+};
 use itertools::Itertools;
 use storage::content_manager::errors::StorageError;
 use storage::dispatcher::Dispatcher;
@@ -127,10 +129,12 @@ async fn query_points_groups(
             Some(shard_keys) => shard_keys.into(),
         };
 
+        let query_group_request = CollectionQueryGroupsRequest::from(search_group_request);
+
         do_query_point_groups(
             dispatcher.toc(&access),
             &collection.name,
-            search_group_request,
+            query_group_request,
             params.consistency,
             shard_selection,
             access,

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use api::rest::{QueryGroupsRequestInternal, SearchGroupsRequestInternal, ShardKeySelector};
+use api::rest::{SearchGroupsRequestInternal, ShardKeySelector};
 use collection::common::batching::batch_requests;
 use collection::grouping::group_by::GroupRequest;
 use collection::operations::consistency_params::ReadConsistency;
@@ -18,7 +18,9 @@ use collection::operations::types::{
     DiscoverRequestBatch, GroupsResult, PointRequestInternal, RecommendGroupsRequestInternal,
     Record, ScrollRequestInternal, ScrollResult, UpdateResult,
 };
-use collection::operations::universal_query::collection_query::CollectionQueryRequest;
+use collection::operations::universal_query::collection_query::{
+    CollectionQueryGroupsRequest, CollectionQueryRequest,
+};
 use collection::operations::vector_ops::{
     DeleteVectors, UpdateVectors, UpdateVectorsOp, VectorOperations,
 };
@@ -996,7 +998,7 @@ pub async fn do_query_batch_points(
 pub async fn do_query_point_groups(
     toc: &TableOfContent,
     collection_name: &str,
-    request: QueryGroupsRequestInternal,
+    request: CollectionQueryGroupsRequest,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
     access: Access,

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -6,20 +6,20 @@ use api::grpc::qdrant::{
     ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
     DeleteFieldIndexCollection, DeletePayloadPoints, DeletePointVectors, DeletePoints,
     DiscoverBatchPoints, DiscoverBatchResponse, DiscoverPoints, DiscoverResponse, GetPoints,
-    GetResponse, PointsOperationResponse, QueryBatchPoints, QueryBatchResponse, QueryPoints,
-    QueryResponse, RecommendBatchPoints, RecommendBatchResponse, RecommendGroupsResponse,
-    RecommendPointGroups, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse,
-    SearchBatchPoints, SearchBatchResponse, SearchGroupsResponse, SearchPointGroups, SearchPoints,
-    SearchResponse, SetPayloadPoints, UpdateBatchPoints, UpdateBatchResponse, UpdatePointVectors,
-    UpsertPoints,
+    GetResponse, PointsOperationResponse, QueryBatchPoints, QueryBatchResponse,
+    QueryGroupsResponse, QueryPointGroups, QueryPoints, QueryResponse, RecommendBatchPoints,
+    RecommendBatchResponse, RecommendGroupsResponse, RecommendPointGroups, RecommendPoints,
+    RecommendResponse, ScrollPoints, ScrollResponse, SearchBatchPoints, SearchBatchResponse,
+    SearchGroupsResponse, SearchPointGroups, SearchPoints, SearchResponse, SetPayloadPoints,
+    UpdateBatchPoints, UpdateBatchResponse, UpdatePointVectors, UpsertPoints,
 };
 use collection::operations::types::CoreSearchRequest;
 use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status};
 
 use super::points_common::{
-    delete_vectors, discover, discover_batch, query, query_batch, recommend_groups, search_groups,
-    update_batch, update_vectors,
+    delete_vectors, discover, discover_batch, query, query_batch, query_groups, recommend_groups,
+    search_groups, update_batch, update_vectors,
 };
 use super::validate;
 use crate::tonic::api::points_common::{
@@ -482,6 +482,20 @@ impl Points for PointsService {
             read_consistency,
             access,
             timeout,
+        )
+        .await
+    }
+
+    async fn query_groups(
+        &self,
+        mut request: Request<QueryPointGroups>,
+    ) -> Result<Response<QueryGroupsResponse>, Status> {
+        let access = extract_access(&mut request);
+        query_groups(
+            self.dispatcher.toc(&access),
+            request.into_inner(),
+            None,
+            access,
         )
         .await
     }

--- a/tests/basic_query_grpc_test.sh
+++ b/tests/basic_query_grpc_test.sh
@@ -81,6 +81,21 @@ $docker_grpcurl -d '{
 
 $docker_grpcurl -d '{
   "collection_name": "test_collection",
+  "query": {
+    "nearest": {
+      "dense": {
+        "data": [0.2,0.1,0.9,0.7]
+      }
+    }
+  },
+  "limit": 3,
+  "group_size": 2,
+  "group_by": "city"
+}' $QDRANT_HOST qdrant.Points/QueryGroups
+
+
+$docker_grpcurl -d '{
+  "collection_name": "test_collection",
   "filter": {
     "should": [
       {

--- a/tests/consensus_tests/auth_tests/test_jwt_access.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_access.py
@@ -535,7 +535,7 @@ ACTION_ACCESS = {
         True,
         True,
         "POST /collections/{collection_name}/points/query/groups",
-        #"qdrant.Points/QueryGroups",
+        "qdrant.Points/QueryGroups",
     ),
     ### Service ###
     "root": EndpointAccess(True, True, True, "GET /", "qdrant.Qdrant/HealthCheck"),
@@ -1762,17 +1762,25 @@ def test_query_batch_points():
 def test_query_points_groups():
     check_access(
         "query_points_groups",
-        rest_request={"query": [0.1, 0.2, 0.3, 0.4]},
         path_params={"collection_name": COLL_NAME},
+        rest_request={
+            "query": [0.1, 0.2, 0.3, 0.4],
+            "limit": 3,
+            "group_size": 2,
+            "group_by": FIELD_NAME
+        },
         grpc_request={
             "collection_name": COLL_NAME,
             "query": {
                 "nearest": {
                     "dense": {
-                        "data": [0.1,0.2,0.3,0.4]
+                        "data": [0.1, 0.2, 0.3, 0.4]
                     }
                 }
             },
+            "limit": 3,
+            "group_size": 2,
+            "group_by": FIELD_NAME
         },
     )
 


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/4616 for the gRPC API.

I introduced `CollectionQueryGroupsRequest` as a convergence type for REST and gRPC.