### PR TITLE
universal-query: Expose random sampling query

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -242,6 +242,7 @@
     - [Fusion](#qdrant-Fusion)
     - [ReadConsistencyType](#qdrant-ReadConsistencyType)
     - [RecommendStrategy](#qdrant-RecommendStrategy)
+    - [Sample](#qdrant-Sample)
     - [UpdateStatus](#qdrant-UpdateStatus)
     - [WriteOrderingType](#qdrant-WriteOrderingType)
   
@@ -3163,6 +3164,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | context | [ContextInput](#qdrant-ContextInput) |  | Return points that live in positive areas. |
 | order_by | [OrderBy](#qdrant-OrderBy) |  | Order the points by a payload field. |
 | fusion | [Fusion](#qdrant-Fusion) |  | Fuse the results of multiple prefetches. |
+| sample | [Sample](#qdrant-Sample) |  | Sample points from the collection. |
 
 
 
@@ -4196,6 +4198,21 @@ How to use positive and negative vectors to find the results, default is `Averag
 | ---- | ------ | ----------- |
 | AverageVector | 0 | Average positive and negative vectors and create a single query with the formula `query = avg_pos &#43; avg_pos - avg_neg`. Then performs normal search. |
 | BestScore | 1 | Uses custom search objective. Each candidate is compared against all examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. If the `max_neg_score` is chosen then it is squared and negated. |
+
+
+
+<a name="qdrant-Sample"></a>
+
+### Sample
+Sample points from the collection
+/
+/ Available sampling methods:
+/
+/ * `random` - Random sampling
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| RANDOM | 0 |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11991,6 +11991,9 @@
           },
           {
             "$ref": "#/components/schemas/FusionQuery"
+          },
+          {
+            "$ref": "#/components/schemas/SampleQuery"
           }
         ]
       },
@@ -12158,6 +12161,23 @@
         "enum": [
           "rrf",
           "dbsf"
+        ]
+      },
+      "SampleQuery": {
+        "type": "object",
+        "required": [
+          "sample"
+        ],
+        "properties": {
+          "sample": {
+            "$ref": "#/components/schemas/Sample"
+          }
+        }
+      },
+      "Sample": {
+        "type": "string",
+        "enum": [
+          "random"
         ]
       },
       "QueryRequestBatch": {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -508,6 +508,15 @@ enum Fusion {
     DBSF = 1; // Distribution-Based Score Fusion
 }
 
+/// Sample points from the collection
+///
+/// Available sampling methods:
+///
+/// * `random` - Random sampling
+enum Sample {
+    RANDOM = 0;
+}
+
 message Query {
   oneof variant {
     VectorInput nearest = 1; // Find the nearest neighbors to this vector.
@@ -516,6 +525,7 @@ message Query {
     ContextInput context = 4; // Return points that live in positive areas.
     OrderBy order_by = 5; // Order the points by a payload field.
     Fusion fusion = 6; // Fuse the results of multiple prefetches.
+    Sample sample = 7; // Sample points from the collection.
   }
 }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -242,6 +242,7 @@ message QueryShardPoints {
       RawQuery vector = 1; // (re)score against a vector query
       Fusion fusion = 2; // One of the fusion methods
       OrderBy order_by = 3; // Order by a field
+      Sample sample = 4; // Sample points
     }
   }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4840,7 +4840,7 @@ pub struct ContextInput {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Query {
-    #[prost(oneof = "query::Variant", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "query::Variant", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub variant: ::core::option::Option<query::Variant>,
 }
 /// Nested message and enum types in `Query`.
@@ -4867,6 +4867,9 @@ pub mod query {
         /// Fuse the results of multiple prefetches.
         #[prost(enumeration = "super::Fusion", tag = "6")]
         Fusion(i32),
+        /// Sample points from the collection.
+        #[prost(enumeration = "super::Sample", tag = "7")]
+        Sample(i32),
     }
 }
 #[derive(serde::Serialize)]
@@ -5998,6 +6001,35 @@ impl Fusion {
         match value {
             "RRF" => Some(Self::Rrf),
             "DBSF" => Some(Self::Dbsf),
+            _ => None,
+        }
+    }
+}
+/// / Sample points from the collection
+/// /
+/// / Available sampling methods:
+/// /
+/// / * `random` - Random sampling
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Sample {
+    Random = 0,
+}
+impl Sample {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Sample::Random => "RANDOM",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "RANDOM" => Some(Self::Random),
             _ => None,
         }
     }
@@ -8737,7 +8769,7 @@ pub mod query_shard_points {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Query {
-        #[prost(oneof = "query::Score", tags = "1, 2, 3")]
+        #[prost(oneof = "query::Score", tags = "1, 2, 3, 4")]
         pub score: ::core::option::Option<query::Score>,
     }
     /// Nested message and enum types in `Query`.
@@ -8755,6 +8787,9 @@ pub mod query_shard_points {
             /// Order by a field
             #[prost(message, tag = "3")]
             OrderBy(super::super::OrderBy),
+            /// Sample points
+            #[prost(enumeration = "super::super::Sample", tag = "4")]
+            Sample(i32),
         }
     }
     #[derive(serde::Serialize)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -284,6 +284,9 @@ pub enum Query {
 
     /// Fuse the results of multiple prefetches.
     Fusion(FusionQuery),
+
+    /// Sample points from the collection, non-deterministically.
+    Sample(SampleQuery),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -320,6 +323,12 @@ pub struct OrderByQuery {
 #[serde(rename_all = "snake_case")]
 pub struct FusionQuery {
     pub fusion: Fusion,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct SampleQuery {
+    pub sample: Sample,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
@@ -432,6 +441,12 @@ impl ContextPair {
     pub fn iter(&self) -> impl Iterator<Item = &VectorInput> {
         std::iter::once(&self.positive).chain(std::iter::once(&self.negative))
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Sample {
+    Random,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -3,7 +3,8 @@ use validator::{Validate, ValidationError};
 
 use super::schema::{BatchVectorStruct, Vector, VectorStruct};
 use super::{
-    ContextInput, Fusion, OrderByInterface, Query, QueryInterface, RecommendInput, VectorInput,
+    ContextInput, Fusion, OrderByInterface, Query, QueryInterface, RecommendInput, Sample,
+    VectorInput,
 };
 use crate::rest::NamedVectorStruct;
 
@@ -72,6 +73,7 @@ impl Validate for Query {
             Query::Context(context) => context.context.validate(),
             Query::Fusion(fusion) => fusion.fusion.validate(),
             Query::OrderBy(order_by) => order_by.order_by.validate(),
+            Query::Sample(sample) => sample.sample.validate(),
         }
     }
 }
@@ -134,6 +136,14 @@ impl Validate for OrderByInterface {
         match self {
             OrderByInterface::Key(_key) => Ok(()), // validated during parsing
             OrderByInterface::Struct(order_by) => order_by.validate(),
+        }
+    }
+}
+
+impl Validate for Sample {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            Sample::Random => Ok(()),
         }
     }
 }

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -25,7 +25,7 @@ use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::collection_query::CollectionQueryRequest;
 use crate::operations::universal_query::shard_query::{
-    Fusion, Sample, ScoringQuery, ShardQueryRequest, ShardQueryResponse,
+    Fusion, ScoringQuery, ShardQueryRequest, ShardQueryResponse,
 };
 
 struct IntermediateQueryInfo<'a> {
@@ -160,7 +160,7 @@ impl Collection {
         mut intermediates: Vec<Vec<ScoredPoint>>,
         query: Option<&ScoringQuery>,
         limit: usize,
-        mut offset: usize,
+        offset: usize,
         score_threshold: Option<ScoreType>,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         let result = match query {
@@ -178,19 +178,6 @@ impl Collection {
                 }
                 fused
             }
-            Some(ScoringQuery::Sample(sample)) => match sample {
-                Sample::Random => {
-                    // Random sampling is non-deterministic, we ignore offset params.
-                    offset = 0;
-
-                    debug_assert_eq!(intermediates.len(), 1);
-                    intermediates.pop().ok_or_else(|| {
-                        CollectionError::service_error(
-                            "Query response was expected to have one list of results.",
-                        )
-                    })?
-                }
-            },
             _ => {
                 // Otherwise, it will be a list with a single list of scored points.
                 debug_assert_eq!(intermediates.len(), 1);

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -14,7 +14,7 @@ use segment::types::{
 };
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 
-use super::shard_query::{Fusion, ScoringQuery, ShardPrefetch, ShardQueryRequest};
+use super::shard_query::{Fusion, Sample, ScoringQuery, ShardPrefetch, ShardQueryRequest};
 use crate::common::fetch_vectors::ReferencedVectors;
 use crate::lookup::WithLookup;
 use crate::operations::query_enum::QueryEnum;
@@ -86,6 +86,9 @@ pub enum Query {
 
     /// Order by a payload field
     OrderBy(OrderBy),
+
+    /// Sample points
+    Sample(Sample),
 }
 
 impl Query {
@@ -107,6 +110,7 @@ impl Query {
             }
             Query::Fusion(fusion) => ScoringQuery::Fusion(fusion),
             Query::OrderBy(order_by) => ScoringQuery::OrderBy(order_by),
+            Query::Sample(sample) => ScoringQuery::Sample(sample),
         };
 
         Ok(scoring_query)
@@ -465,6 +469,12 @@ impl CollectionQueryRequest {
             self.score_threshold,
         )?;
 
+        let mut offset = self.offset;
+        if let Some(Query::Sample(Sample::Random)) = &self.query {
+            // Don't fail if offset is used with random sampling, just ignore it.
+            offset = 0;
+        }
+
         let query_lookup_collection = self.get_lookup_collection().cloned();
         let query_lookup_vector_name = self.get_lookup_vector_name();
         let using = self.using.clone();
@@ -499,7 +509,7 @@ impl CollectionQueryRequest {
             filter,
             score_threshold: self.score_threshold,
             limit: self.limit,
-            offset: self.offset,
+            offset,
             params: self.params,
             with_vector: self.with_vector,
             with_payload: self.with_payload,
@@ -666,6 +676,7 @@ mod from_rest {
                 rest::Query::Context(context) => Query::Vector(From::from(context.context)),
                 rest::Query::OrderBy(order_by) => Query::OrderBy(OrderBy::from(order_by.order_by)),
                 rest::Query::Fusion(fusion) => Query::Fusion(Fusion::from(fusion.fusion)),
+                rest::Query::Sample(sample) => Query::Sample(Sample::from(sample.sample)),
             }
         }
     }
@@ -749,6 +760,14 @@ mod from_rest {
             match value {
                 rest::Fusion::Rrf => Fusion::Rrf,
                 rest::Fusion::Dbsf => Fusion::Dbsf,
+            }
+        }
+    }
+
+    impl From<rest::Sample> for Sample {
+        fn from(value: rest::Sample) -> Self {
+            match value {
+                rest::Sample::Random => Sample::Random,
             }
         }
     }
@@ -921,6 +940,7 @@ pub mod from_grpc {
                 Variant::Context(context) => Query::Vector(TryFrom::try_from(context)?),
                 Variant::OrderBy(order_by) => Query::OrderBy(OrderBy::try_from(order_by)?),
                 Variant::Fusion(fusion) => Query::Fusion(Fusion::try_from(fusion)?),
+                Variant::Sample(sample) => Query::Sample(Sample::try_from(sample)?),
             };
 
             Ok(query)

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -470,8 +470,8 @@ impl CollectionQueryRequest {
         )?;
 
         let mut offset = self.offset;
-        if let Some(Query::Sample(Sample::Random)) = &self.query {
-            // Don't fail if offset is used with random sampling, just ignore it.
+        if matches!(self.query, Some(Query::Sample(Sample::Random))) && self.prefetch.is_empty() {
+            // Shortcut: Ignore offset with random query, since output is not stable.
             offset = 0;
         }
 

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -51,6 +51,11 @@ pub enum Fusion {
     Dbsf,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum Sample {
+    Random,
+}
+
 /// Same as `Query`, but with the resolved vector references.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScoringQuery {
@@ -62,23 +67,26 @@ pub enum ScoringQuery {
 
     /// Order by a payload field
     OrderBy(OrderBy),
+
+    /// Sample points
+    Sample(Sample),
 }
 
 impl ScoringQuery {
     pub fn needs_intermediate_results(&self) -> bool {
         match self {
-            ScoringQuery::Fusion(fusion) => match fusion {
+            Self::Fusion(fusion) => match fusion {
                 Fusion::Rrf => true,
                 Fusion::Dbsf => true,
             },
-            ScoringQuery::Vector(_) | ScoringQuery::OrderBy(_) => false,
+            Self::Vector(_) | Self::OrderBy(_) | Self::Sample(_) => false,
         }
     }
 
     /// Get the vector name if it is scored against a vector
     pub fn get_vector_name(&self) -> Option<&str> {
         match self {
-            ScoringQuery::Vector(query) => Some(query.get_vector_name()),
+            Self::Vector(query) => Some(query.get_vector_name()),
             _ => None,
         }
     }
@@ -87,26 +95,30 @@ impl ScoringQuery {
     pub fn order(
         opt_self: Option<&Self>,
         collection_params: &CollectionParams,
-    ) -> CollectionResult<Order> {
+    ) -> CollectionResult<Option<Order>> {
         let order = match opt_self {
             Some(scoring_query) => match scoring_query {
                 ScoringQuery::Vector(query_enum) => {
                     if query_enum.is_distance_scored() {
-                        collection_params
-                            .get_distance(query_enum.get_vector_name())?
-                            .distance_order()
+                        Some(
+                            collection_params
+                                .get_distance(query_enum.get_vector_name())?
+                                .distance_order(),
+                        )
                     } else {
-                        Order::LargeBetter
+                        Some(Order::LargeBetter)
                     }
                 }
                 ScoringQuery::Fusion(fusion) => match fusion {
-                    Fusion::Rrf | Fusion::Dbsf => Order::LargeBetter,
+                    Fusion::Rrf | Fusion::Dbsf => Some(Order::LargeBetter),
                 },
-                ScoringQuery::OrderBy(order_by) => Order::from(order_by.direction()),
+                ScoringQuery::OrderBy(order_by) => Some(Order::from(order_by.direction())),
+                // Random sample does not require ordering
+                ScoringQuery::Sample(Sample::Random) => None,
             },
             None => {
                 // Order by ID
-                Order::SmallBetter
+                Some(Order::SmallBetter)
             }
         };
         Ok(order)
@@ -285,10 +297,22 @@ impl TryFrom<i32> for Fusion {
 
     fn try_from(fusion: i32) -> Result<Self, Self::Error> {
         let fusion = api::grpc::qdrant::Fusion::from_i32(fusion).ok_or_else(|| {
-            tonic::Status::invalid_argument(format!("invalid read fusion type value {fusion}",))
+            tonic::Status::invalid_argument(format!("invalid fusion type value {fusion}",))
         })?;
 
         Ok(Fusion::from(fusion))
+    }
+}
+
+impl TryFrom<i32> for Sample {
+    type Error = tonic::Status;
+
+    fn try_from(sample: i32) -> Result<Self, Self::Error> {
+        let sample = api::grpc::qdrant::Sample::from_i32(sample).ok_or_else(|| {
+            tonic::Status::invalid_argument(format!("invalid sample type value {sample}",))
+        })?;
+
+        Ok(Sample::from(sample))
     }
 }
 
@@ -310,6 +334,22 @@ impl From<Fusion> for api::grpc::qdrant::Fusion {
     }
 }
 
+impl From<Sample> for api::grpc::qdrant::Sample {
+    fn from(value: Sample) -> Self {
+        match value {
+            Sample::Random => api::grpc::qdrant::Sample::Random,
+        }
+    }
+}
+
+impl From<api::grpc::qdrant::Sample> for Sample {
+    fn from(value: api::grpc::qdrant::Sample) -> Self {
+        match value {
+            api::grpc::qdrant::Sample::Random => Sample::Random,
+        }
+    }
+}
+
 impl ScoringQuery {
     fn try_from_grpc_query(
         query: grpc::query_shard_points::Query,
@@ -327,6 +367,9 @@ impl ScoringQuery {
             }
             grpc::query_shard_points::query::Score::OrderBy(order_by) => {
                 ScoringQuery::OrderBy(OrderBy::try_from(order_by)?)
+            }
+            grpc::query_shard_points::query::Score::Sample(sample) => {
+                ScoringQuery::Sample(Sample::try_from(sample)?)
             }
         };
 
@@ -370,6 +413,9 @@ impl From<ScoringQuery> for grpc::query_shard_points::Query {
             },
             ScoringQuery::OrderBy(order_by) => Self {
                 score: Some(Score::OrderBy(grpc::OrderBy::from(order_by))),
+            },
+            ScoringQuery::Sample(sample) => Self {
+                score: Some(Score::Sample(api::grpc::qdrant::Sample::from(sample) as i32)),
             },
         }
     }

--- a/tests/openapi/openapi_integration/test_query.py
+++ b/tests/openapi/openapi_integration/test_query.py
@@ -345,10 +345,11 @@ def test_basic_random_query():
         assert len(points) == 10
         assert set(point["id"] for point in points) == set(range(1, 11))
         
-        # check the order of ids are different every time
         ids = str([point["id"] for point in points])
-        assert ids not in ids_lists
         ids_lists.add(ids)
+        
+    # check the order of ids are different at least once
+    assert len(ids_lists) > 1
     
 
 def test_basic_rrf():

--- a/tests/openapi/openapi_integration/test_query.py
+++ b/tests/openapi/openapi_integration/test_query.py
@@ -340,17 +340,17 @@ def test_basic_random_query():
             },
         )
         assert response.ok, response.text
-        
+
         points = response.json()["result"]["points"]
         assert len(points) == 10
         assert set(point["id"] for point in points) == set(range(1, 11))
-        
+
         ids = str([point["id"] for point in points])
         ids_lists.add(ids)
-        
+
     # check the order of ids are different at least once
     assert len(ids_lists) > 1
-    
+
 
 def test_basic_rrf():
     response = request_with_validation(

--- a/tests/openapi/openapi_integration/test_query.py
+++ b/tests/openapi/openapi_integration/test_query.py
@@ -328,6 +328,29 @@ def test_basic_order_by():
         assert record.get("payload") == scored_point.get("payload")
 
 
+def test_basic_random_query():
+    ids_lists = set()
+    for _ in range(4):
+        response = request_with_validation(
+            api="/collections/{collection_name}/points/query",
+            method="POST",
+            path_params={"collection_name": collection_name},
+            body={
+                "query": { "sample": "random" }
+            },
+        )
+        assert response.ok, response.text
+        
+        points = response.json()["result"]["points"]
+        assert len(points) == 10
+        assert set(point["id"] for point in points) == set(range(1, 11))
+        
+        # check the order of ids are different every time
+        ids = str([point["id"] for point in points])
+        assert ids not in ids_lists
+        ids_lists.add(ids)
+    
+
 def test_basic_rrf():
     response = request_with_validation(
         api="/collections/{collection_name}/points/search",

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -1290,7 +1290,7 @@ def test_random_rescore_with_offset():
     
     # assert offset is propagated to prefetch
     seen = set()
-    for _ in range(20):
+    for _ in range(100):
         response = request_with_validation(
             api="/collections/{collection_name}/points/query",
             method="POST",
@@ -1306,7 +1306,9 @@ def test_random_rescore_with_offset():
         assert len(random_result) == 1
     
         seen.add(random_result[0]["id"])
+        if seen == {1, 2}:
+            return
     
     # Although prefetch limit is 1, offset should be propagated, so randomness is applied to points 1 and 2.
     # By this point we should've seen both points.
-    assert seen == {1, 2}
+    assert False, f"after 100 tries, `seen` is expected to be {{1, 2}}, but it was {seen}"

--- a/tests/openapi/openapi_integration/test_query_full.py
+++ b/tests/openapi/openapi_integration/test_query_full.py
@@ -1271,3 +1271,42 @@ def test_recommend_lookup_group():
 
     # check equivalence nested query id vs nested query vector
     assert nested_query_result_id == nested_query_result_vector, f"{nested_query_result_id} != {nested_query_result_vector}"
+
+
+def test_random_rescore_with_offset():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": { "limit": 1 },
+            "query": {"sample": "random"},
+        },
+    )
+    assert response.ok, response.json()
+    random_result = response.json()["result"]["points"]
+    assert len(random_result) == 1
+    assert random_result[0]["id"] == 1
+    
+    # assert offset is propagated to prefetch
+    seen = set()
+    for _ in range(20):
+        response = request_with_validation(
+            api="/collections/{collection_name}/points/query",
+            method="POST",
+            path_params={"collection_name": collection_name},
+            body={
+                "prefetch": { "limit": 1 },
+                "query": {"sample": "random"},
+                "offset": 1,
+            },
+        )
+        assert response.ok, response.json()
+        random_result = response.json()["result"]["points"]
+        assert len(random_result) == 1
+    
+        seen.add(random_result[0]["id"])
+    
+    # Although prefetch limit is 1, offset should be propagated, so randomness is applied to points 1 and 2.
+    # By this point we should've seen both points.
+    assert seen == {1, 2}


### PR DESCRIPTION
Finishes implementation from collection to rest and grpc API, effectively exposing it.

Sample REST request:
```
POST collections/{collection_name}/points/query
{
  "query": { "sample": "random" }
}
```

It will produce a random, unstable output. If used without prefetches, offset will be ignored.
