### PR TITLE
Fix NaN score for zeroed uint8 vectors

### DIFF
--- a/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
@@ -95,6 +95,10 @@ pub unsafe fn avx_cosine_similarity_bytes(v1: &[u8], v2: &[u8]) -> f32 {
         norm2 += remainder_norm2 as f32;
     }
 
+    if norm1 == 0.0 || norm2 == 0.0 {
+        return 0.0;
+    }
+
     dot_product / ((norm1 * norm2).sqrt())
 }
 

--- a/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
@@ -95,11 +95,12 @@ pub unsafe fn avx_cosine_similarity_bytes(v1: &[u8], v2: &[u8]) -> f32 {
         norm2 += remainder_norm2 as f32;
     }
 
-    if norm1 == 0.0 || norm2 == 0.0 {
+    let denominator = norm1 * norm2;
+    if denominator == 0.0 {
         return 0.0;
     }
 
-    dot_product / ((norm1 * norm2).sqrt())
+    dot_product / denominator.sqrt()
 }
 
 #[cfg(test)]

--- a/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
@@ -137,4 +137,20 @@ mod tests {
             println!("avx2 test skipped");
         }
     }
+
+    #[test]
+    fn test_zero_avx() {
+        if is_x86_feature_detected!("avx")
+            && is_x86_feature_detected!("avx2")
+            && is_x86_feature_detected!("fma")
+        {
+            let v1: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0];
+            let v2: Vec<u8> = vec![255, 255, 0, 254, 253, 252, 251, 250];
+
+            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v2) };
+            assert_eq!(dot_simd, 0.0);
+        } else {
+            println!("avx2 test skipped");
+        }
+    }
 }

--- a/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/avx2/cosine.rs
@@ -149,6 +149,12 @@ mod tests {
 
             let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v2) };
             assert_eq!(dot_simd, 0.0);
+
+            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v2, &v1) };
+            assert_eq!(dot_simd, 0.0);
+
+            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v1) };
+            assert_eq!(dot_simd, 0.0);
         } else {
             println!("avx2 test skipped");
         }

--- a/lib/segment/src/spaces/metric_uint/neon/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/neon/cosine.rs
@@ -114,13 +114,13 @@ mod tests {
             let v1: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0];
             let v2: Vec<u8> = vec![255, 255, 0, 254, 253, 252, 251, 250];
 
-            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v2) };
+            let dot_simd = unsafe { neon_cosine_similarity_bytes(&v1, &v2) };
             assert_eq!(dot_simd, 0.0);
 
-            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v2, &v1) };
+            let dot_simd = unsafe { neon_cosine_similarity_bytes(&v2, &v1) };
             assert_eq!(dot_simd, 0.0);
 
-            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v1) };
+            let dot_simd = unsafe { neon_cosine_similarity_bytes(&v1, &v1) };
             assert_eq!(dot_simd, 0.0);
         } else {
             println!("avx2 test skipped");

--- a/lib/segment/src/spaces/metric_uint/neon/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/neon/cosine.rs
@@ -107,10 +107,7 @@ mod tests {
 
     #[test]
     fn test_zero_neon() {
-        if is_x86_feature_detected!("avx")
-            && is_x86_feature_detected!("avx2")
-            && is_x86_feature_detected!("fma")
-        {
+        if is_aarch64_feature_detected!("neon") {
             let v1: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0];
             let v2: Vec<u8> = vec![255, 255, 0, 254, 253, 252, 251, 250];
 
@@ -123,7 +120,7 @@ mod tests {
             let dot_simd = unsafe { neon_cosine_similarity_bytes(&v1, &v1) };
             assert_eq!(dot_simd, 0.0);
         } else {
-            println!("avx2 test skipped");
+            println!("neon test skipped");
         }
     }
 }

--- a/lib/segment/src/spaces/metric_uint/neon/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/neon/cosine.rs
@@ -63,6 +63,10 @@ pub unsafe fn neon_cosine_similarity_bytes(v1: &[u8], v2: &[u8]) -> f32 {
         norm2 += remainder_norm2 as f32;
     }
 
+    if norm1 == 0.0 || norm2 == 0.0 {
+        return 0.0;
+    }
+
     dot_product / ((norm1 * norm2).sqrt())
 }
 

--- a/lib/segment/src/spaces/metric_uint/neon/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/neon/cosine.rs
@@ -63,11 +63,12 @@ pub unsafe fn neon_cosine_similarity_bytes(v1: &[u8], v2: &[u8]) -> f32 {
         norm2 += remainder_norm2 as f32;
     }
 
-    if norm1 == 0.0 || norm2 == 0.0 {
+    let denominator = norm1 * norm2;
+    if denominator == 0.0 {
         return 0.0;
     }
 
-    dot_product / ((norm1 * norm2).sqrt())
+    dot_product / denominator.sqrt()
 }
 
 #[cfg(test)]

--- a/lib/segment/src/spaces/metric_uint/neon/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/neon/cosine.rs
@@ -104,4 +104,20 @@ mod tests {
             println!("neon test skipped");
         }
     }
+
+    #[test]
+    fn test_zero_neon() {
+        if is_x86_feature_detected!("avx")
+            && is_x86_feature_detected!("avx2")
+            && is_x86_feature_detected!("fma")
+        {
+            let v1: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0];
+            let v2: Vec<u8> = vec![255, 255, 0, 254, 253, 252, 251, 250];
+
+            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v2) };
+            assert_eq!(dot_simd, 0.0);
+        } else {
+            println!("avx2 test skipped");
+        }
+    }
 }

--- a/lib/segment/src/spaces/metric_uint/neon/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/neon/cosine.rs
@@ -116,6 +116,12 @@ mod tests {
 
             let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v2) };
             assert_eq!(dot_simd, 0.0);
+
+            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v2, &v1) };
+            assert_eq!(dot_simd, 0.0);
+
+            let dot_simd = unsafe { avx_cosine_similarity_bytes(&v1, &v1) };
+            assert_eq!(dot_simd, 0.0);
         } else {
             println!("avx2 test skipped");
         }

--- a/lib/segment/src/spaces/metric_uint/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_cosine.rs
@@ -73,7 +73,7 @@ pub fn cosine_similarity_bytes(
         return 0.0;
     }
 
-    dot_product as ScoreType / ((norm1 as ScoreType * norm2 as ScoreType).sqrt())
+    dot_product as ScoreType / (norm1 as ScoreType * norm2 as ScoreType).sqrt()
 }
 
 #[test]

--- a/lib/segment/src/spaces/metric_uint/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_cosine.rs
@@ -75,3 +75,13 @@ pub fn cosine_similarity_bytes(
 
     dot_product as ScoreType / ((norm1 as ScoreType * norm2 as ScoreType).sqrt())
 }
+
+#[test]
+fn test_zero() {
+    let v1: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0];
+    let v2: Vec<u8> = vec![255, 255, 0, 254, 253, 252, 251, 250];
+
+    assert_eq!(cosine_similarity_bytes(&v1, &v2), 0.0);
+    assert_eq!(cosine_similarity_bytes(&v2, &v1), 0.0);
+    assert_eq!(cosine_similarity_bytes(&v1, &v1), 0.0);
+}

--- a/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
@@ -106,7 +106,7 @@ mod tests {
     use crate::spaces::metric_uint::simple_cosine::cosine_similarity_bytes;
 
     #[test]
-    fn test_spaces_avx() {
+    fn test_spaces_sse2() {
         if is_x86_feature_detected!("sse2") && is_x86_feature_detected!("sse") {
             let v1: Vec<u8> = vec![
                 255, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 255, 255,

--- a/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
@@ -93,6 +93,10 @@ pub unsafe fn sse_cosine_similarity_bytes(v1: &[u8], v2: &[u8]) -> f32 {
         norm2 += remainder_norm2 as f32;
     }
 
+    if norm1 == 0.0 || norm2 == 0.0 {
+        return 0.0;
+    }
+
     dot_product / ((norm1 * norm2).sqrt())
 }
 

--- a/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
@@ -141,6 +141,12 @@ mod tests {
 
             let dot_simd = unsafe { sse_cosine_similarity_bytes(&v1, &v2) };
             assert_eq!(dot_simd, 0.0);
+
+            let dot_simd = unsafe { sse_cosine_similarity_bytes(&v2, &v1) };
+            assert_eq!(dot_simd, 0.0);
+
+            let dot_simd = unsafe { sse_cosine_similarity_bytes(&v1, &v1) };
+            assert_eq!(dot_simd, 0.0);
         } else {
             println!("sse2 test skipped");
         }

--- a/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
@@ -93,11 +93,12 @@ pub unsafe fn sse_cosine_similarity_bytes(v1: &[u8], v2: &[u8]) -> f32 {
         norm2 += remainder_norm2 as f32;
     }
 
-    if norm1 == 0.0 || norm2 == 0.0 {
+    let denominator = norm1 * norm2;
+    if denominator == 0.0 {
         return 0.0;
     }
 
-    dot_product / ((norm1 * norm2).sqrt())
+    dot_product / denominator.sqrt()
 }
 
 #[cfg(test)]

--- a/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/sse2/cosine.rs
@@ -132,4 +132,17 @@ mod tests {
             println!("sse2 test skipped");
         }
     }
+
+    #[test]
+    fn test_zero_sse2() {
+        if is_x86_feature_detected!("sse2") && is_x86_feature_detected!("sse") {
+            let v1: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0];
+            let v2: Vec<u8> = vec![255, 255, 0, 254, 253, 252, 251, 250];
+
+            let dot_simd = unsafe { sse_cosine_similarity_bytes(&v1, &v2) };
+            assert_eq!(dot_simd, 0.0);
+        } else {
+            println!("sse2 test skipped");
+        }
+    }
 }


### PR DESCRIPTION
Fixes: <https://github.com/qdrant/qdrant/issues/4654>

Fixes NaN score on for zero vectors using the uint8 data type.

This occurred on machines supporting SSE2, AVX or NEON. The naive implementation was fine.

Our naive implementation prevents this with a zero norm check. I've added the same check in the above mentioned implementations: https://github.com/qdrant/qdrant/blob/85b0c5ba8f90e18cc3ec1f6096513b4a9ab37a30/lib/segment/src/spaces/metric_uint/simple_cosine.rs#L72-L74

Note that I did not test the NEON implementation myself as I don't have hardware available for it. Since the change is so simple, I'm not worried about problems.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
