### PR TITLE
Fix full payload update

### DIFF
--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -58,11 +58,7 @@ pub trait PayloadIndex {
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_>;
 
     /// Assign same payload to each given point
-    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
-        self.drop(point_id)?;
-        self.assign(point_id, payload, &None)?;
-        Ok(())
-    }
+    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
 
     /// Assign payload to a concrete point with a concrete payload value
     fn assign(

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -158,6 +158,14 @@ impl PayloadIndex for PlainPayloadIndex {
         Box::new(vec![].into_iter())
     }
 
+    fn assign_all(
+        &mut self,
+        _point_id: PointOffsetType,
+        _payload: &Payload,
+    ) -> OperationResult<()> {
+        unreachable!()
+    }
+
     fn assign(
         &mut self,
         _point_id: PointOffsetType,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -333,6 +333,18 @@ impl StructPayloadIndex {
     ) -> OperationResult<()> {
         crate::rocksdb_backup::restore(snapshot_path, &segment_path.join("payload_index"))
     }
+
+    fn clear_index_for_point(
+        &mut self,
+        point_id: PointOffsetType,
+    ) -> OperationResult<()> {
+        for (_, field_indexes) in self.field_indexes.iter_mut() {
+            for index in field_indexes {
+                index.remove_point(point_id)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl PayloadIndex for StructPayloadIndex {
@@ -475,6 +487,24 @@ impl PayloadIndex for StructPayloadIndex {
         }
     }
 
+    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+        self.payload.borrow_mut().assign(point_id, payload)?;
+
+        for (field, field_index) in &mut self.field_indexes {
+            let field_value = payload.get_value(field);
+            if !field_value.is_empty() {
+                for index in field_index {
+                    index.add_point(point_id, &field_value)?;
+                }
+            } else {
+                for index in field_index {
+                    index.remove_point(point_id)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn assign(
         &mut self,
         point_id: PointOffsetType,
@@ -526,11 +556,7 @@ impl PayloadIndex for StructPayloadIndex {
     }
 
     fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
-        for (_, field_indexes) in self.field_indexes.iter_mut() {
-            for index in field_indexes {
-                index.remove_point(point_id)?;
-            }
-        }
+        self.clear_index_for_point(point_id)?;
         self.payload.borrow_mut().drop(point_id)
     }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -485,7 +485,7 @@ impl PayloadIndex for StructPayloadIndex {
     }
 
     fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
-        self.payload.borrow_mut().assign(point_id, payload)?;
+        self.payload.borrow_mut().assign_all(point_id, payload)?;
 
         for (field, field_index) in &mut self.field_indexes {
             let field_value = payload.get_value(field);

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -334,10 +334,7 @@ impl StructPayloadIndex {
         crate::rocksdb_backup::restore(snapshot_path, &segment_path.join("payload_index"))
     }
 
-    fn clear_index_for_point(
-        &mut self,
-        point_id: PointOffsetType,
-    ) -> OperationResult<()> {
+    fn clear_index_for_point(&mut self, point_id: PointOffsetType) -> OperationResult<()> {
         for (_, field_indexes) in self.field_indexes.iter_mut() {
             for index in field_indexes {
                 index.remove_point(point_id)?;

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -11,6 +11,11 @@ use crate::payload_storage::PayloadStorage;
 use crate::types::Payload;
 
 impl PayloadStorage for InMemoryPayloadStorage {
+    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+        self.payload.insert(point_id, payload.to_owned());
+        Ok(())
+    }
+
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         match self.payload.get_mut(&point_id) {
             Some(point_payload) => point_payload.merge(payload),

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -9,11 +9,7 @@ use crate::types::{Filter, Payload};
 /// Trait for payload data storage. Should allow filter checks
 pub trait PayloadStorage {
     /// Assign same payload to each given point
-    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
-        self.drop(point_id)?;
-        self.assign(point_id, payload)?;
-        Ok(())
-    }
+    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
 
     /// Assign payload to a concrete point with a concrete payload value
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -53,6 +53,15 @@ impl PayloadStorageEnum {
 }
 
 impl PayloadStorage for PayloadStorageEnum {
+    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.assign_all(point_id, payload),
+            PayloadStorageEnum::SimplePayloadStorage(s) => s.assign_all(point_id, payload),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.assign_all(point_id, payload),
+        }
+    }
+
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         match self {
             #[cfg(feature = "testing")]

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -11,6 +11,12 @@ use crate::payload_storage::PayloadStorage;
 use crate::types::{Payload, PayloadKeyTypeRef};
 
 impl PayloadStorage for SimplePayloadStorage {
+    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+        self.payload.insert(point_id, payload.to_owned());
+        self.update_storage(&point_id)?;
+        Ok(())
+    }
+
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         match self.payload.get_mut(&point_id) {
             Some(point_payload) => point_payload.merge(payload),


### PR DESCRIPTION
Current full payload update deletes existing payload and then writes a new one, which is:

- sub-optimal
- may lead to the lost payload if the service is killed with partial flush (not verified)