### PR TITLE
Resume resharding driver on node restart

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -56,7 +56,7 @@ impl Collection {
                 let mut config = self.collection_config.write().await;
 
                 if config.params.sharding_method.unwrap_or_default() == ShardingMethod::Auto {
-                    debug_assert_eq!(config.params.shard_number.get(), resharding_key.shard_id,);
+                    debug_assert_eq!(config.params.shard_number.get(), resharding_key.shard_id);
                 }
 
                 config.params.shard_number = config

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -68,7 +68,6 @@ impl Collection {
     /// If no resharding is active, this returns early without error.
     pub async fn resume_resharding_unchecked<T, F>(
         &self,
-        // resharding_key: ReshardKey,
         consensus: Box<dyn ShardTransferConsensus>,
         temp_dir: PathBuf,
         on_finish: T,

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -55,9 +55,8 @@ impl Collection {
             {
                 let mut config = self.collection_config.write().await;
 
-                #[cfg(debug_assertions)]
                 if config.params.sharding_method.unwrap_or_default() == ShardingMethod::Auto {
-                    assert_eq!(config.params.shard_number.get(), resharding_key.shard_id);
+                    debug_assert_eq!(config.params.shard_number.get(), resharding_key.shard_id,);
                 }
 
                 config.params.shard_number = config
@@ -194,11 +193,10 @@ impl Collection {
         {
             let mut config = self.collection_config.write().await;
 
-            #[cfg(debug_assertions)]
             if config.params.sharding_method.unwrap_or_default() == ShardingMethod::Auto {
-                assert_eq!(
+                debug_assert_eq!(
                     config.params.shard_number.get() - 1,
-                    resharding_key.shard_id
+                    resharding_key.shard_id,
                 );
             }
 

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -57,10 +57,13 @@ impl Collection {
 
                 #[cfg(debug_assertions)]
                 if config.params.sharding_method.unwrap_or_default() == ShardingMethod::Auto {
-                    assert_eq!(config.params.shard_number.get(), resharding_key.shard_id,);
+                    assert_eq!(config.params.shard_number.get(), resharding_key.shard_id);
                 }
 
-                config.params.shard_number = NonZeroU32::new(config.params.shard_number.get() + 1)
+                config.params.shard_number = config
+                    .params
+                    .shard_number
+                    .checked_add(1)
                     .expect("cannot have more than u32::MAX shards after resharding");
                 if let Err(err) = config.save(&self.path) {
                     log::error!(

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -5,6 +5,7 @@ use futures::Future;
 use parking_lot::Mutex;
 
 use super::Collection;
+use crate::config::ShardingMethod;
 use crate::operations::types::CollectionResult;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::resharding::tasks_pool::{ReshardTaskItem, ReshardTaskProgress};
@@ -21,6 +22,7 @@ impl Collection {
             .clone()
     }
 
+    /// Start a new resharding operation
     pub async fn start_resharding<T, F>(
         &self,
         resharding_key: ReshardKey,
@@ -33,56 +35,109 @@ impl Collection {
         T: Future<Output = ()> + Send + 'static,
         F: Future<Output = ()> + Send + 'static,
     {
-        let mut shard_holder = self.shards_holder.write().await;
+        {
+            let mut shard_holder = self.shards_holder.write().await;
 
-        shard_holder.check_start_resharding(&resharding_key)?;
+            shard_holder.check_start_resharding(&resharding_key)?;
 
-        let replica_set = self
-            .create_replica_set(
-                resharding_key.shard_id,
-                &[resharding_key.peer_id],
-                Some(ReplicaState::Resharding),
-            )
+            let replica_set = self
+                .create_replica_set(
+                    resharding_key.shard_id,
+                    &[resharding_key.peer_id],
+                    Some(ReplicaState::Resharding),
+                )
+                .await?;
+
+            shard_holder.start_resharding_unchecked(resharding_key.clone(), replica_set)?;
+        }
+
+        // Drive resharding
+        self.drive_resharding(resharding_key, consensus, temp_dir, on_finish, on_error)
             .await?;
 
-        shard_holder.start_resharding_unchecked(resharding_key.clone(), replica_set)?;
+        Ok(())
+    }
 
-        // If this peer is responsible for driving the resharding, start the task for it
-        if resharding_key.peer_id == self.this_peer_id {
-            // Stop any already active resharding task to allow starting a new one
-            let mut active_reshard_tasks = self.reshard_tasks.lock().await;
-            let task_result = active_reshard_tasks.stop_task(&resharding_key).await;
-            debug_assert!(task_result.is_none(), "Reshard task already exists");
+    /// Resume an existing resharding operation
+    ///
+    /// This method will check if a resharding operation is in progress according to our state, and
+    /// it will start and resume the driving task accordingly.
+    ///
+    /// This does not check whether the task is already active.
+    ///
+    /// If no resharding is active, this returns early without error.
+    pub async fn resume_resharding_unchecked<T, F>(
+        &self,
+        // resharding_key: ReshardKey,
+        consensus: Box<dyn ShardTransferConsensus>,
+        temp_dir: PathBuf,
+        on_finish: T,
+        on_error: F,
+    ) -> CollectionResult<()>
+    where
+        T: Future<Output = ()> + Send + 'static,
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let Some(state) = self.resharding_state().await else {
+            return Ok(());
+        };
 
-            let shard_holder = self.shards_holder.clone();
-            let collection_id = self.id.clone();
-            let collection_config = Arc::clone(&self.collection_config);
-            let channel_service = self.channel_service.clone();
-            let progress = Arc::new(Mutex::new(ReshardTaskProgress::new()));
-            let spawned_task = resharding::spawn_resharding_task(
-                shard_holder,
-                progress.clone(),
-                resharding_key.clone(),
-                consensus,
-                collection_id,
-                self.path.clone(),
-                collection_config,
-                self.shared_storage_config.clone(),
-                channel_service,
-                temp_dir,
-                on_finish,
-                on_error,
-            );
+        self.drive_resharding(state.key(), consensus, temp_dir, on_finish, on_error)
+            .await?;
 
-            active_reshard_tasks.add_task(
-                resharding_key,
-                ReshardTaskItem {
-                    task: spawned_task,
-                    started_at: chrono::Utc::now(),
-                    progress,
-                },
-            );
+        Ok(())
+    }
+
+    async fn drive_resharding<T, F>(
+        &self,
+        resharding_key: ReshardKey,
+        consensus: Box<dyn ShardTransferConsensus>,
+        temp_dir: PathBuf,
+        on_finish: T,
+        on_error: F,
+    ) -> CollectionResult<()>
+    where
+        T: Future<Output = ()> + Send + 'static,
+        F: Future<Output = ()> + Send + 'static,
+    {
+        // Skip if this peer is not responsible for driving the resharding
+        if resharding_key.peer_id != self.this_peer_id {
+            return Ok(());
         }
+
+        // Stop any already active resharding task to allow starting a new one
+        let mut active_reshard_tasks = self.reshard_tasks.lock().await;
+        let task_result = active_reshard_tasks.stop_task(&resharding_key).await;
+        debug_assert!(task_result.is_none(), "Reshard task already exists");
+
+        let shard_holder = self.shards_holder.clone();
+        let collection_id = self.id.clone();
+        let collection_config = Arc::clone(&self.collection_config);
+        let channel_service = self.channel_service.clone();
+        let progress = Arc::new(Mutex::new(ReshardTaskProgress::new()));
+        let spawned_task = resharding::spawn_resharding_task(
+            shard_holder,
+            progress.clone(),
+            resharding_key.clone(),
+            consensus,
+            collection_id,
+            self.path.clone(),
+            collection_config,
+            self.shared_storage_config.clone(),
+            channel_service,
+            temp_dir,
+            on_finish,
+            on_error,
+        );
+
+        active_reshard_tasks.add_task(
+            resharding_key,
+            ReshardTaskItem {
+                task: spawned_task,
+                started_at: chrono::Utc::now(),
+                progress,
+            },
+        );
 
         Ok(())
     }
@@ -106,7 +161,25 @@ impl Collection {
 
         shard_holder.check_finish_resharding(&resharding_key)?;
         let _ = self.stop_resharding_task(&resharding_key).await;
-        shard_holder.finish_resharding_unchecked(resharding_key)?;
+        shard_holder.finish_resharding_unchecked(&resharding_key)?;
+
+        // Update the stored shard count, ensures we load the new shard on restart
+        {
+            let mut config = self.collection_config.write().await;
+            config.params.shard_number = config.params.shard_number.saturating_add(1);
+
+            // If using automatic sharding, the reshard key shard ID must correspond with number
+            if config.params.sharding_method.unwrap_or_default() == ShardingMethod::Auto {
+                debug_assert_eq!(
+                    config.params.shard_number.get() - 1,
+                    resharding_key.shard_id,
+                );
+            }
+
+            if let Err(err) = config.save(&self.path) {
+                log::error!("Failed to update and save collection config during resharding: {err}");
+            }
+        }
 
         Ok(())
     }

--- a/lib/collection/src/shards/resharding/tasks_pool.rs
+++ b/lib/collection/src/shards/resharding/tasks_pool.rs
@@ -65,7 +65,7 @@ impl ReshardTasksPool {
             parts.push(description.clone());
         }
         parts.push(format!(
-            "started {}s ago",
+            "since {}s ago",
             chrono::Utc::now()
                 .signed_duration_since(task.started_at)
                 .num_seconds(),

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -526,16 +526,6 @@ impl ShardHolder {
             .unwrap_or_default()
         {
             ShardingMethod::Auto => {
-                let mut shard_number = shard_number;
-
-                // If resharding is active, we should load an extra shard
-                // TODO(resharding): prevent error if extra shard cannot be loaded?
-                // TODO(resharding): may be needed if resharding starts and crashes before migrate
-                let is_resharding = self.resharding_state.read().is_some();
-                if is_resharding {
-                    shard_number += 1;
-                }
-
                 let ids_list = (0..shard_number).collect::<Vec<_>>();
                 let shard_id_to_key_mapping = HashMap::new();
                 (ids_list, shard_id_to_key_mapping)

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -77,14 +77,7 @@ impl ShardHolder {
             }
         }
 
-        let mut rings = HashMap::from([(None, HashRing::single())]);
-
-        if let Some(shard_id) = resharding_state.read().clone().map(|state| state.shard_id) {
-            rings.insert(
-                shard_id_to_key_mapping.get(&shard_id).cloned(),
-                HashRing::resharding(shard_id),
-            );
-        }
+        let rings = HashMap::from([(None, HashRing::single())]);
 
         let (shard_transfer_changes, _) = broadcast::channel(64);
 
@@ -661,6 +654,13 @@ impl ShardHolder {
                 let shard_key = shard_id_to_key_mapping.get(&shard_id).cloned();
                 self.add_shard(shard_id, replica_set, shard_key).unwrap();
             }
+        }
+
+        // After loading shards, recover the resharding hash ring state
+        if let Some(state) = self.resharding_state.read().clone() {
+            self.rings
+                .entry(state.shard_key)
+                .and_modify(|ring| ring.add_resharding(state.shard_id));
         }
     }
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -533,6 +533,16 @@ impl ShardHolder {
             .unwrap_or_default()
         {
             ShardingMethod::Auto => {
+                let mut shard_number = shard_number;
+
+                // If resharding is active, we should load an extra shard
+                // TODO(resharding): prevent error if extra shard cannot be loaded?
+                // TODO(resharding): may be needed if resharding starts and crashes before migrate
+                let is_resharding = self.resharding_state.read().is_some();
+                if is_resharding {
+                    shard_number += 1;
+                }
+
                 let ids_list = (0..shard_number).collect::<Vec<_>>();
                 let shard_id_to_key_mapping = HashMap::new();
                 (ids_list, shard_id_to_key_mapping)

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -123,7 +123,7 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn finish_resharding_unchecked(&mut self, _: ReshardKey) -> CollectionResult<()> {
+    pub fn finish_resharding_unchecked(&mut self, _: &ReshardKey) -> CollectionResult<()> {
         self.resharding_state.write(|state| {
             debug_assert!(state.is_some(), "resharding is not in progress");
             *state = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,10 @@ fn main() -> anyhow::Result<()> {
             }
         });
 
+        runtime_handle.block_on(async {
+            toc_arc.resume_resharding_tasks().await;
+        });
+
         let collections_to_recover_in_consensus = if is_new_deployment {
             let existing_collections =
                 runtime_handle.block_on(toc_arc.all_collections(&FULL_ACCESS));

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -401,6 +401,14 @@ def check_collection_resharding_operations_count(peer_api_uri: str, collection_n
     return local_resharding_count == expected_resharding_operations_count
 
 
+def check_collection_resharding_operation_state(peer_api_uri: str, collection_name: str, expected_state: str, headers={}) -> bool:
+    collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
+    for resharding in collection_cluster_info["resharding_operations"] or []:
+        if "comment" in resharding and resharding["comment"].startswith(expected_state):
+            return True
+    return False
+
+
 def check_collection_shard_transfer_method(peer_api_uri: str, collection_name: str,
                                            expected_method: str) -> bool:
     collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name)
@@ -558,6 +566,14 @@ def wait_for_collection_resharding_operations_count(peer_api_uri: str, collectio
                                               expected_resharding_operations_count: int, headers={}):
     try:
         wait_for(check_collection_resharding_operations_count, peer_api_uri, collection_name, expected_resharding_operations_count, headers=headers)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
+        raise e
+
+
+def wait_for_collection_resharding_operation_state(peer_api_uri: str, collection_name: str, expected_state: str, headers={}):
+    try:
+        wait_for(check_collection_resharding_operation_state, peer_api_uri, collection_name, expected_state, headers=headers)
     except Exception as e:
         print_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
         raise e

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -401,10 +401,12 @@ def check_collection_resharding_operations_count(peer_api_uri: str, collection_n
     return local_resharding_count == expected_resharding_operations_count
 
 
-def check_collection_resharding_operation_state(peer_api_uri: str, collection_name: str, expected_state: str, headers={}) -> bool:
+def check_collection_resharding_operation_stage(peer_api_uri: str, collection_name: str, expected_stage: str, headers={}) -> bool:
     collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
-    for resharding in collection_cluster_info["resharding_operations"] or []:
-        if "comment" in resharding and resharding["comment"].startswith(expected_state):
+    if "resharding_operations" not in collection_cluster_info:
+        return False
+    for resharding in collection_cluster_info["resharding_operations"]:
+        if "comment" in resharding and resharding["comment"].startswith(expected_stage):
             return True
     return False
 
@@ -571,9 +573,9 @@ def wait_for_collection_resharding_operations_count(peer_api_uri: str, collectio
         raise e
 
 
-def wait_for_collection_resharding_operation_state(peer_api_uri: str, collection_name: str, expected_state: str, headers={}):
+def wait_for_collection_resharding_operation_stage(peer_api_uri: str, collection_name: str, expected_stage: str, headers={}):
     try:
-        wait_for(check_collection_resharding_operation_state, peer_api_uri, collection_name, expected_state, headers=headers)
+        wait_for(check_collection_resharding_operation_stage, peer_api_uri, collection_name, expected_stage, headers=headers)
     except Exception as e:
         print_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
         raise e


### PR DESCRIPTION
Tracked in: #4213 
Depends on: <https://github.com/qdrant/qdrant/pull/4617>

Allow the resharding driver to resume at any arbitrary point. This allows the driving node to restart as if nothing has happened.

There is more to be done in terms of resumption and the ability to abort, but that'll be for separate PRs.

A new test is added interrupting the process at various stages, asserting the end result is what we expect.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/4617>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
