### PR TITLE
Add JsonPath::filename()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "dataset"
 version = "0.0.0"
 dependencies = [
@@ -5410,6 +5416,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
+ "data-encoding",
  "dataset",
  "fnv",
  "fs_extra",
@@ -5455,6 +5462,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_variant",
+ "sha2",
  "smallvec",
  "smol_str",
  "sparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
+sha2 = "0.10.8"
 strum = { version = "0.26.3", features = ["derive"] }
 tar = "0.4.41"
 tempfile = "3.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ tikv-jemallocator = "0.6"
 
 [workspace.dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
+data-encoding = { version = "2.6.0" }
 fnv = "1.0"
 futures = "0.3.30"
 futures-util = "0.3.30"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -75,7 +75,7 @@ tar = { workspace = true }
 fs_extra = "1.3.0"
 semver = { workspace = true }
 tempfile = { workspace = true }
-sha2 = "0.10.8"
+sha2 = { workspace = true }
 bytes = "1.6.1"
 fnv = { workspace = true }
 indexmap = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -33,6 +33,7 @@ pprof = { workspace = true }
 
 [dependencies]
 bitpacking = "0.9.2"
+data-encoding = { workspace = true }
 tempfile = { workspace = true }
 parking_lot = { workspace = true }
 rayon = "1.10.0"
@@ -73,6 +74,7 @@ fnv = { workspace = true }
 indexmap = { workspace = true }
 ahash = { version = "0.8.11", features = ["serde"] }
 http = "1.0.0"
+sha2 = { workspace = true }
 smallvec = "1.13.2"
 is_sorted = "0.1.1"
 strum = { workspace = true }

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -281,6 +281,7 @@ impl JsonPath {
 
     /// Convert the path into a string suitable for use as a filename by adhering to the following
     /// restrictions: max length, limited character set, but still being unique.
+    // TODO(1.11): Avoid creating long paths, see https://github.com/qdrant/qdrant/pull/4677.
     pub fn filename(&self) -> String {
         const MAX_LENGTH: usize = 64;
         const HASH_LENGTH: usize = 32; // In base32 characters, i.e. 5 bits per character.


### PR DESCRIPTION
Tracking issue: #4502.
This PR adds the method `JsonPath::filename()`. It would be used as a directory name for on-disk indices.