### PR TITLE
Apply resharding filter to query API for consistent reads

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -486,24 +486,14 @@ impl Collection {
     }
 }
 
-#[inline]
-fn merge_filters(filter: &mut Option<Filter>, resharding_filter: Option<Filter>) {
-    if let Some(resharding_filter) = resharding_filter {
-        *filter = Some(match filter.take() {
-            Some(filter) => filter.merge_owned(resharding_filter),
-            None => resharding_filter,
-        });
-    }
-}
-
 /// Merge a regular and resharding filter
 ///
-/// The first element is always the given `filter`.
+/// The first element is always the given `request`.
 ///
-/// The second element is the `filter` with `resharding_filter` merged into it. It's None if no
+/// The second element is the `request` with `resharding_filter` merged into it. It's None if no
 /// resharding filter was given.
 ///
-/// This function minimizes cloning of the filter to when it's strictly necessary.
+/// This function minimizes cloning of the request to when it's strictly necessary.
 #[inline]
 fn normal_and_resharding_count_request(
     mut request: CountRequestInternal,
@@ -512,7 +502,7 @@ fn normal_and_resharding_count_request(
     match resharding_filter {
         None => (Arc::new(request), None),
         Some(resharding_filter) => (Arc::new(request.clone()), {
-            merge_filters(&mut request.filter, Some(resharding_filter));
+            super::resharding::merge_filters(&mut request.filter, Some(resharding_filter));
             Some(Arc::new(request))
         }),
     }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use futures::Future;
 use parking_lot::Mutex;
+use segment::types::Filter;
 
 use super::Collection;
 use crate::operations::types::CollectionResult;
@@ -132,5 +133,15 @@ impl Collection {
             .await
             .stop_task(resharding_key)
             .await
+    }
+}
+
+#[inline]
+pub(super) fn merge_filters(filter: &mut Option<Filter>, resharding_filter: Option<Filter>) {
+    if let Some(resharding_filter) = resharding_filter {
+        *filter = Some(match filter.take() {
+            Some(filter) => filter.merge_owned(resharding_filter),
+            None => resharding_filter,
+        });
     }
 }


### PR DESCRIPTION
Tracked in: #4213 

Apply resharding filter from <https://github.com/qdrant/qdrant/pull/4617> to the query API.

This ensures consistent reads from the query API, including <https://github.com/qdrant/qdrant/pull/4619>/<https://github.com/qdrant/qdrant/pull/4657>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?