### PR TITLE
On resharding start, wipe any existing state

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -1,5 +1,4 @@
 use std::num::NonZeroU32;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use futures::Future;
@@ -29,7 +28,6 @@ impl Collection {
         &self,
         resharding_key: ReshardKey,
         consensus: Box<dyn ShardTransferConsensus>,
-        temp_dir: PathBuf,
         on_finish: T,
         on_error: F,
     ) -> CollectionResult<()>
@@ -74,15 +72,8 @@ impl Collection {
         }
 
         // Drive resharding
-        self.drive_resharding(
-            resharding_key,
-            consensus,
-            temp_dir,
-            false,
-            on_finish,
-            on_error,
-        )
-        .await?;
+        self.drive_resharding(resharding_key, consensus, false, on_finish, on_error)
+            .await?;
 
         Ok(())
     }
@@ -98,7 +89,6 @@ impl Collection {
     pub async fn resume_resharding_unchecked<T, F>(
         &self,
         consensus: Box<dyn ShardTransferConsensus>,
-        temp_dir: PathBuf,
         on_finish: T,
         on_error: F,
     ) -> CollectionResult<()>
@@ -110,7 +100,7 @@ impl Collection {
             return Ok(());
         };
 
-        self.drive_resharding(state.key(), consensus, temp_dir, true, on_finish, on_error)
+        self.drive_resharding(state.key(), consensus, true, on_finish, on_error)
             .await?;
 
         Ok(())
@@ -120,7 +110,6 @@ impl Collection {
         &self,
         resharding_key: ReshardKey,
         consensus: Box<dyn ShardTransferConsensus>,
-        temp_dir: PathBuf,
         can_resume: bool,
         on_finish: T,
         on_error: F,
@@ -154,7 +143,6 @@ impl Collection {
             collection_config,
             self.shared_storage_config.clone(),
             channel_service,
-            temp_dir,
             can_resume,
             on_finish,
             on_error,

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -74,8 +74,15 @@ impl Collection {
         }
 
         // Drive resharding
-        self.drive_resharding(resharding_key, consensus, temp_dir, on_finish, on_error)
-            .await?;
+        self.drive_resharding(
+            resharding_key,
+            consensus,
+            temp_dir,
+            false,
+            on_finish,
+            on_error,
+        )
+        .await?;
 
         Ok(())
     }
@@ -103,7 +110,7 @@ impl Collection {
             return Ok(());
         };
 
-        self.drive_resharding(state.key(), consensus, temp_dir, on_finish, on_error)
+        self.drive_resharding(state.key(), consensus, temp_dir, true, on_finish, on_error)
             .await?;
 
         Ok(())
@@ -114,6 +121,7 @@ impl Collection {
         resharding_key: ReshardKey,
         consensus: Box<dyn ShardTransferConsensus>,
         temp_dir: PathBuf,
+        can_resume: bool,
         on_finish: T,
         on_error: F,
     ) -> CollectionResult<()>
@@ -147,6 +155,7 @@ impl Collection {
             self.shared_storage_config.clone(),
             channel_service,
             temp_dir,
+            can_resume,
             on_finish,
             on_error,
         );

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -58,6 +58,8 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
     }
 
     /// Initialize data with `init`, even if data already exists.
+    ///
+    /// Will immediately save the new `init` state on disk, only if the file already exists.
     pub fn init(path: impl Into<PathBuf>, init: impl FnOnce() -> T) -> Result<Self, Error> {
         let path: PathBuf = path.into();
         let exists = path.exists();

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -57,21 +57,18 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
         })
     }
 
-    /// Initialize data with `init`, even if data already exists.
+    /// Initialize new data, even if it already exists on disk at the given path.
     ///
-    /// Will immediately save the new `init` state on disk, only if the file already exists.
-    pub fn init(path: impl Into<PathBuf>, init: impl FnOnce() -> T) -> Result<Self, Error> {
-        let path: PathBuf = path.into();
-        let exists = path.exists();
+    /// If data already exists on disk, it will be immediately overwritten.
+    pub fn new(path: impl Into<PathBuf>, data: T) -> Result<Self, Error> {
         let data = Self {
             change_notification: Condvar::new(),
             notification_lock: Default::default(),
-            data: RwLock::new(init()),
-            path,
+            data: RwLock::new(data),
+            path: path.into(),
         };
 
-        // Overwrite existing data if it exists
-        if exists {
+        if data.path.exists() {
             data.save()?;
         }
 

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -207,7 +207,6 @@ pub async fn drive_resharding(
     collection_config: Arc<RwLock<CollectionConfig>>,
     shared_storage_config: &SharedStorageConfig,
     channel_service: ChannelService,
-    _temp_dir: &Path,
     can_resume: bool,
 ) -> CollectionResult<bool> {
     let to_shard_id = reshard_key.shard_id;

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -229,7 +229,7 @@ pub async fn drive_resharding(
     let state: PersistedState = if can_resume {
         SaveOnDisk::load_or_init(&resharding_state_path, init_state)?
     } else {
-        SaveOnDisk::init(&resharding_state_path, init_state)?
+        SaveOnDisk::new(&resharding_state_path, init_state())?
     };
 
     progress.lock().description.replace(state.read().describe());

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -208,6 +208,7 @@ pub async fn drive_resharding(
     shared_storage_config: &SharedStorageConfig,
     channel_service: ChannelService,
     _temp_dir: &Path,
+    can_resume: bool,
 ) -> CollectionResult<bool> {
     let to_shard_id = reshard_key.shard_id;
     let hash_ring = shard_holder
@@ -218,12 +219,20 @@ pub async fn drive_resharding(
         .cloned()
         .unwrap();
     let resharding_state_path = resharding_state_path(&reshard_key, &collection_path);
-    let state: PersistedState = SaveOnDisk::load_or_init(&resharding_state_path, || {
+
+    // Load or initialize resharding state
+    let init_state = || {
         let mut shard_ids = hash_ring.unique_nodes();
         shard_ids.remove(&reshard_key.shard_id);
 
         DriverState::new(reshard_key.clone(), shard_ids, &consensus.peers())
-    })?;
+    };
+    let state: PersistedState = if can_resume {
+        SaveOnDisk::load_or_init(&resharding_state_path, init_state)?
+    } else {
+        SaveOnDisk::init(&resharding_state_path, init_state)?
+    };
+
     progress.lock().description.replace(state.read().describe());
 
     log::debug!(

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -102,7 +102,6 @@ pub fn spawn_resharding_task<T, F>(
     collection_config: Arc<RwLock<CollectionConfig>>,
     shared_storage_config: Arc<SharedStorageConfig>,
     channel_service: ChannelService,
-    temp_dir: PathBuf,
     can_resume: bool,
     on_finish: T,
     on_error: F,
@@ -135,7 +134,6 @@ where
                     collection_config.clone(),
                     &shared_storage_config,
                     channel_service.clone(),
-                    &temp_dir,
                     can_resume,
                 )
                 .await

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -103,6 +103,7 @@ pub fn spawn_resharding_task<T, F>(
     shared_storage_config: Arc<SharedStorageConfig>,
     channel_service: ChannelService,
     temp_dir: PathBuf,
+    can_resume: bool,
     on_finish: T,
     on_error: F,
 ) -> CancellableAsyncTaskHandle<bool>
@@ -135,6 +136,7 @@ where
                     &shared_storage_config,
                     channel_service.clone(),
                     &temp_dir,
+                    can_resume,
                 )
                 .await
             };

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -322,9 +322,8 @@ impl TableOfContent {
                     }
                 };
 
-                let temp_dir = self.optional_temp_or_storage_temp_path()?;
                 collection
-                    .start_resharding(key, consensus, temp_dir, on_finish, on_failure)
+                    .start_resharding(key, consensus, on_finish, on_failure)
                     .await?;
             }
 
@@ -424,9 +423,8 @@ impl TableOfContent {
             }
         };
 
-        let temp_dir = self.optional_temp_or_storage_temp_path()?;
         collection
-            .resume_resharding_unchecked(consensus, temp_dir, on_finish, on_failure)
+            .resume_resharding_unchecked(consensus, on_finish, on_failure)
             .await?;
 
         Ok(())


### PR DESCRIPTION
Tracked in: #4213 
Depends on: <https://github.com/qdrant/qdrant/pull/4666>

When starting the resharding driver, wipe any existing state that may have been left on disk.

This prevents unintentionally trying to resume a resharding operation that has already been aborted, but wasn't cleaned up properly. It is important not to corrupt the cluster.

Resuming the operation on restart works fine, as this does not wipe the state file.

### Tasks

- [x] Merge <https://github.com/qdrant/qdrant/pull/4666>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?