### PR TITLE
Defragmentation in api

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -858,6 +858,7 @@
 | ----- | ---- | ----- | ----------- |
 | lookup | [bool](#bool) |  | If true - support direct lookups. |
 | range | [bool](#bool) |  | If true - support ranges filters. |
+| is_tenant | [bool](#bool) | optional | If true - used for tenant optimization. Currently only compatible with lookup. |
 
 
 
@@ -868,6 +869,11 @@
 
 ### KeywordIndexParams
 
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| is_tenant | [bool](#bool) | optional | If true - used for tenant optimization. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -858,7 +858,7 @@
 | ----- | ---- | ----- | ----------- |
 | lookup | [bool](#bool) |  | If true - support direct lookups. |
 | range | [bool](#bool) |  | If true - support ranges filters. |
-| is_tenant | [bool](#bool) | optional | If true - used for tenant optimization. Currently only compatible with lookup. |
+| is_primary | [bool](#bool) | optional | If true - used for tenant optimization. Currently only compatible with lookup. |
 
 
 
@@ -873,7 +873,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| is_tenant | [bool](#bool) | optional | If true - used for tenant optimization. |
+| is_primary | [bool](#bool) | optional | If true - used for tenant optimization. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6285,7 +6285,7 @@
           "type": {
             "$ref": "#/components/schemas/KeywordIndexType"
           },
-          "is_tenant": {
+          "is_primary": {
             "description": "If true - used for tenant optimization. Default: false.",
             "type": "boolean",
             "nullable": true
@@ -6317,7 +6317,7 @@
             "description": "If true - support ranges filters.",
             "type": "boolean"
           },
-          "is_tenant": {
+          "is_primary": {
             "description": "If true - used for tenant optimization. Currently only compatible with lookup.",
             "type": "boolean",
             "nullable": true

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6284,6 +6284,11 @@
         "properties": {
           "type": {
             "$ref": "#/components/schemas/KeywordIndexType"
+          },
+          "is_tenant": {
+            "description": "If true - used for tenant optimization. Default: false.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -6311,6 +6316,11 @@
           "range": {
             "description": "If true - support ranges filters.",
             "type": "boolean"
+          },
+          "is_tenant": {
+            "description": "If true - used for tenant optimization. Currently only compatible with lookup.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -222,9 +222,11 @@ impl From<segment::data_types::index::TokenizerType> for TokenizerType {
 }
 
 impl From<segment::data_types::index::KeywordIndexParams> for PayloadIndexParams {
-    fn from(_params: segment::data_types::index::KeywordIndexParams) -> Self {
+    fn from(params: segment::data_types::index::KeywordIndexParams) -> Self {
         PayloadIndexParams {
-            index_params: Some(IndexParams::KeywordIndexParams(KeywordIndexParams {})),
+            index_params: Some(IndexParams::KeywordIndexParams(KeywordIndexParams {
+                is_tenant: params.is_tenant,
+            })),
         }
     }
 }
@@ -235,6 +237,7 @@ impl From<segment::data_types::index::IntegerIndexParams> for PayloadIndexParams
             index_params: Some(IndexParams::IntegerIndexParams(IntegerIndexParams {
                 lookup: params.lookup,
                 range: params.range,
+                is_tenant: params.is_tenant,
             })),
         }
     }
@@ -355,9 +358,10 @@ impl From<segment::types::PayloadSchemaParams> for PayloadIndexParams {
 
 impl TryFrom<KeywordIndexParams> for segment::data_types::index::KeywordIndexParams {
     type Error = Status;
-    fn try_from(_params: KeywordIndexParams) -> Result<Self, Self::Error> {
+    fn try_from(params: KeywordIndexParams) -> Result<Self, Self::Error> {
         Ok(segment::data_types::index::KeywordIndexParams {
             r#type: KeywordIndexType::Keyword,
+            is_tenant: params.is_tenant,
         })
     }
 }
@@ -369,6 +373,7 @@ impl TryFrom<IntegerIndexParams> for segment::data_types::index::IntegerIndexPar
             r#type: IntegerIndexType::Integer,
             lookup: params.lookup,
             range: params.range,
+            is_tenant: params.is_tenant,
         })
     }
 }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -225,7 +225,7 @@ impl From<segment::data_types::index::KeywordIndexParams> for PayloadIndexParams
     fn from(params: segment::data_types::index::KeywordIndexParams) -> Self {
         PayloadIndexParams {
             index_params: Some(IndexParams::KeywordIndexParams(KeywordIndexParams {
-                is_tenant: params.is_tenant,
+                is_primary: params.is_primary,
             })),
         }
     }
@@ -237,7 +237,7 @@ impl From<segment::data_types::index::IntegerIndexParams> for PayloadIndexParams
             index_params: Some(IndexParams::IntegerIndexParams(IntegerIndexParams {
                 lookup: params.lookup,
                 range: params.range,
-                is_tenant: params.is_tenant,
+                is_primary: params.is_primary,
             })),
         }
     }
@@ -361,7 +361,7 @@ impl TryFrom<KeywordIndexParams> for segment::data_types::index::KeywordIndexPar
     fn try_from(params: KeywordIndexParams) -> Result<Self, Self::Error> {
         Ok(segment::data_types::index::KeywordIndexParams {
             r#type: KeywordIndexType::Keyword,
-            is_tenant: params.is_tenant,
+            is_primary: params.is_primary,
         })
     }
 }
@@ -373,7 +373,7 @@ impl TryFrom<IntegerIndexParams> for segment::data_types::index::IntegerIndexPar
             r#type: IntegerIndexType::Integer,
             lookup: params.lookup,
             range: params.range,
-            is_tenant: params.is_tenant,
+            is_primary: params.is_primary,
         })
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -386,11 +386,13 @@ enum TokenizerType {
 }
 
 message KeywordIndexParams {
+    optional bool is_tenant = 3; // If true - used for tenant optimization.
 }
 
 message IntegerIndexParams {
   bool lookup = 1; // If true - support direct lookups.
   bool range = 2; // If true - support ranges filters.
+  optional bool is_tenant = 3; // If true - used for tenant optimization. Currently only compatible with lookup.
 }
 
 message FloatIndexParams {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -386,13 +386,13 @@ enum TokenizerType {
 }
 
 message KeywordIndexParams {
-    optional bool is_tenant = 3; // If true - used for tenant optimization.
+    optional bool is_primary = 3; // If true - used for tenant optimization.
 }
 
 message IntegerIndexParams {
   bool lookup = 1; // If true - support direct lookups.
   bool range = 2; // If true - support ranges filters.
-  optional bool is_tenant = 3; // If true - used for tenant optimization. Currently only compatible with lookup.
+  optional bool is_primary = 3; // If true - used for tenant optimization. Currently only compatible with lookup.
 }
 
 message FloatIndexParams {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -641,7 +641,7 @@ pub struct CollectionConfig {
 pub struct KeywordIndexParams {
     /// If true - used for tenant optimization.
     #[prost(bool, optional, tag = "3")]
-    pub is_tenant: ::core::option::Option<bool>,
+    pub is_primary: ::core::option::Option<bool>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -655,7 +655,7 @@ pub struct IntegerIndexParams {
     pub range: bool,
     /// If true - used for tenant optimization. Currently only compatible with lookup.
     #[prost(bool, optional, tag = "3")]
-    pub is_tenant: ::core::option::Option<bool>,
+    pub is_primary: ::core::option::Option<bool>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -638,7 +638,11 @@ pub struct CollectionConfig {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct KeywordIndexParams {}
+pub struct KeywordIndexParams {
+    /// If true - used for tenant optimization.
+    #[prost(bool, optional, tag = "3")]
+    pub is_tenant: ::core::option::Option<bool>,
+}
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -649,6 +653,9 @@ pub struct IntegerIndexParams {
     /// If true - support ranges filters.
     #[prost(bool, tag = "2")]
     pub range: bool,
+    /// If true - used for tenant optimization. Currently only compatible with lookup.
+    #[prost(bool, optional, tag = "3")]
+    pub is_tenant: ::core::option::Option<bool>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -422,7 +422,7 @@ pub trait SegmentOptimizer {
             })
             .collect();
 
-        let mut defragmentation_keys = vec![];
+        let mut defragmentation_keys = HashSet::new();
         for segment in &segments {
             let payload_index = &segment.read().payload_index;
             let payload_index = payload_index.borrow();
@@ -437,7 +437,7 @@ pub trait SegmentOptimizer {
         }
 
         if !defragmentation_keys.is_empty() {
-            segment_builder.set_defragment_keys(defragmentation_keys);
+            segment_builder.set_defragment_keys(defragmentation_keys.into_iter().collect());
         }
 
         segment_builder.update(&segments, stopped)?;

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -422,21 +422,22 @@ pub trait SegmentOptimizer {
             })
             .collect();
 
-        // TODO: use a different approach to select the key to use for defragmentation
+        let mut defragmentation_keys = vec![];
         for segment in &segments {
-            let defragment_key = segment
-                .read()
-                .payload_index
-                .borrow()
-                .field_indexes
-                .iter()
-                .next()
-                .map(|(k, _)| k.clone());
+            let payload_index = &segment.read().payload_index;
+            let payload_index = payload_index.borrow();
 
-            if let Some(defragment_key) = defragment_key {
-                segment_builder.set_defragment_key(defragment_key);
-                break;
-            }
+            let keys = payload_index
+                .config()
+                .indexed_fields
+                .iter()
+                .filter_map(|(key, schema)| schema.is_tenant().then_some(key))
+                .cloned();
+            defragmentation_keys.extend(keys);
+        }
+
+        if !defragmentation_keys.is_empty() {
+            segment_builder.set_defragment_keys(defragmentation_keys);
         }
 
         segment_builder.update(&segments, stopped)?;

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -431,7 +431,7 @@ pub trait SegmentOptimizer {
                 .config()
                 .indexed_fields
                 .iter()
-                .filter_map(|(key, schema)| schema.is_tenant().then_some(key))
+                .filter_map(|(key, schema)| schema.is_primary().then_some(key))
                 .cloned();
             defragmentation_keys.extend(keys);
         }

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -18,7 +18,7 @@ pub struct KeywordIndexParams {
 
     /// If true - used for tenant optimization. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub is_tenant: Option<bool>,
+    pub is_primary: Option<bool>,
 
     /// If true, store the index on disk. Default: false.
     #[cfg(any())]
@@ -48,7 +48,7 @@ pub struct IntegerIndexParams {
     pub range: bool,
 
     /// If true - used for tenant optimization. Currently only compatible with lookup.
-    pub is_tenant: Option<bool>,
+    pub is_primary: Option<bool>,
 
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -62,7 +62,7 @@ impl Default for IntegerIndexParams {
             r#type: Default::default(),
             lookup: true,
             range: true,
-            is_tenant: None,
+            is_primary: None,
         }
     }
 }

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -16,6 +16,10 @@ pub struct KeywordIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
     pub r#type: KeywordIndexType,
 
+    /// If true - used for tenant optimization. Default: false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_tenant: Option<bool>,
+
     /// If true, store the index on disk. Default: false.
     #[cfg(any())]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -43,6 +47,9 @@ pub struct IntegerIndexParams {
     /// If true - support ranges filters.
     pub range: bool,
 
+    /// If true - used for tenant optimization. Currently only compatible with lookup.
+    pub is_tenant: Option<bool>,
+
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg(any())]
@@ -55,6 +62,7 @@ impl Default for IntegerIndexParams {
             r#type: Default::default(),
             lookup: true,
             range: true,
+            is_tenant: None,
         }
     }
 }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -333,6 +333,10 @@ impl StructPayloadIndex {
     ) -> OperationResult<()> {
         crate::rocksdb_backup::restore(snapshot_path, &segment_path.join("payload_index"))
     }
+
+    pub fn config(&self) -> &PayloadConfig {
+        &self.config
+    }
 }
 
 impl PayloadIndex for StructPayloadIndex {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -51,7 +51,7 @@ pub struct SegmentBuilder {
     indexed_fields: HashMap<PayloadKeyType, PayloadFieldSchema>,
 
     // Payload key to deframent data to
-    defragment_key: Option<PayloadKeyType>,
+    defragment_keys: Vec<PayloadKeyType>,
 }
 
 impl SegmentBuilder {
@@ -109,12 +109,12 @@ impl SegmentBuilder {
             destination_path,
             temp_path,
             indexed_fields: Default::default(),
-            defragment_key: None,
+            defragment_keys: vec![],
         })
     }
 
-    pub fn set_defragment_key(&mut self, key: PayloadKeyType) {
-        self.defragment_key = Some(key);
+    pub fn set_defragment_keys(&mut self, keys: Vec<PayloadKeyType>) {
+        self.defragment_keys = keys;
     }
 
     pub fn remove_indexed_field(&mut self, field: &PayloadKeyType) {
@@ -249,7 +249,7 @@ impl SegmentBuilder {
 
         let mut points_to_insert: Vec<_> = merged_points.into_values().collect();
 
-        if let Some(defragment_key) = &self.defragment_key {
+        if let Some(defragment_key) = self.defragment_keys.first() {
             for point_data in &mut points_to_insert {
                 let Some(payload_indices) = payloads[point_data.segment_index]
                     .field_indexes
@@ -388,7 +388,7 @@ impl SegmentBuilder {
                 destination_path,
                 temp_path,
                 indexed_fields,
-                defragment_key: _,
+                defragment_keys: _,
             } = self;
 
             let appendable_flag = segment_config.is_appendable();

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1158,10 +1158,10 @@ impl PayloadSchemaParams {
         }
     }
 
-    pub fn is_tenant(&self) -> bool {
+    pub fn is_primary(&self) -> bool {
         match self {
-            PayloadSchemaParams::Keyword(keyword) => keyword.is_tenant.unwrap_or_default(),
-            PayloadSchemaParams::Integer(integer) => integer.is_tenant.unwrap_or_default(),
+            PayloadSchemaParams::Keyword(keyword) => keyword.is_primary.unwrap_or_default(),
+            PayloadSchemaParams::Integer(integer) => integer.is_primary.unwrap_or_default(),
             _ => false,
         }
     }
@@ -1190,10 +1190,10 @@ impl PayloadFieldSchema {
         }
     }
 
-    pub fn is_tenant(&self) -> bool {
+    pub fn is_primary(&self) -> bool {
         match self {
             PayloadFieldSchema::FieldType(_) => false,
-            PayloadFieldSchema::FieldParams(params) => params.is_tenant(),
+            PayloadFieldSchema::FieldParams(params) => params.is_primary(),
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1157,6 +1157,14 @@ impl PayloadSchemaParams {
             PayloadSchemaParams::Datetime(_) => PayloadSchemaType::Datetime,
         }
     }
+
+    pub fn is_tenant(&self) -> bool {
+        match self {
+            PayloadSchemaParams::Keyword(keyword) => keyword.is_tenant.unwrap_or_default(),
+            PayloadSchemaParams::Integer(integer) => integer.is_tenant.unwrap_or_default(),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
@@ -1179,6 +1187,13 @@ impl PayloadFieldSchema {
         match self {
             PayloadFieldSchema::FieldType(field_type) => field_type.name(),
             PayloadFieldSchema::FieldParams(field_params) => field_params.name(),
+        }
+    }
+
+    pub fn is_tenant(&self) -> bool {
+        match self {
+            PayloadFieldSchema::FieldType(_) => false,
+            PayloadFieldSchema::FieldParams(params) => params.is_tenant(),
         }
     }
 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -110,6 +110,7 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
                     r#type: IntegerIndexType::Integer,
                     lookup: true,
                     range: false,
+                    is_tenant: None,
                 },
             ))),
         )
@@ -123,6 +124,7 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
                     r#type: IntegerIndexType::Integer,
                     lookup: false,
                     range: true,
+                    is_tenant: None,
                 },
             ))),
         )

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -110,7 +110,7 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
                     r#type: IntegerIndexType::Integer,
                     lookup: true,
                     range: false,
-                    is_tenant: None,
+                    is_primary: None,
                 },
             ))),
         )
@@ -124,7 +124,7 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
                     r#type: IntegerIndexType::Integer,
                     lookup: false,
                     range: true,
-                    is_tenant: None,
+                    is_primary: None,
                 },
             ))),
         )

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -128,7 +128,7 @@ fn test_building_new_defragmented_segment() {
     let segment1 = Arc::new(RwLock::new(segment1));
     let segment2 = Arc::new(RwLock::new(segment2));
 
-    builder.set_defragment_key(defragment_key.clone());
+    builder.set_defragment_keys(vec![defragment_key.clone()]);
 
     builder
         .update(&[segment1.clone(), segment2.clone()], &stopped)


### PR DESCRIPTION
Replaces #4652 

In this version we don't automatically decide on a defragmentation key and only defragment if a user configured Qdrant to do so.
If we still agree on doing otherwise and intelligently try to automatically find a key to use for defragmentation, we can still implement this in a separate PR.

Also note that this PR only uses the first found key configured as tenant. To fix this, we need to agree on an algorithm for applying multiple keys, which I also suggest to use in a separate PR.