### PR TITLE
Fix flaky resharding CI test

### DIFF
--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -233,7 +233,7 @@ def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
         # Wait for resharding operation to start and stop
         wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
         for uri in peer_api_uris:
-            wait_for_collection_resharding_operations_count(uri, COLLECTION_NAME, 0)
+            wait_for_collection_resharding_operations_count(uri, COLLECTION_NAME, 0, wait_for_timeout=60)
 
         # Assert node shard count
         for uri in peer_api_uris:


### PR DESCRIPTION
Tracked in: #4213 

The resharding CI test with concurrent updates appears to be a bit too heavy. I've seen some flakyness due to it timing out.

This attempts to fix that by doubling the allowed wait time.

Example failures:
- https://github.com/qdrant/qdrant/actions/runs/9957803914/job/27510643527?pr=4617#step:11:131
- https://github.com/qdrant/qdrant/actions/runs/9976681020/job/27569481287?pr=4682#step:11:131
- https://github.com/qdrant/qdrant/actions/runs/9980253921/job/27581182721#step:11:131

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?