### PR TITLE
Replica resolver sorts by overall index

### DIFF
--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -154,11 +154,9 @@ where
                         .map(move |(index, item)| (row, index, item))
                 })
                 .filter_map(|(row, index, item)| {
-                    if let Some(precedence) = resolved_items.get(&(row, index)) {
-                        Some((item, precedence))
-                    } else {
-                        None
-                    }
+                    resolved_items
+                        .get(&(row, index))
+                        .map(|precedence| (item, precedence))
                 })
                 .sorted_unstable_by_key(|(_, precedence)| *precedence)
                 .map(|(item, _)| item)

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -290,7 +290,7 @@ where
         debug_assert!(row_ids.len() >= self.resolution_count);
 
         let mut merged_item = None;
-        for (position, row) in row_ids.into_iter().with_position() {
+        for (position, row) in row_ids.iter().with_position() {
             match position {
                 Position::First => {
                     // use this one to return

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -115,7 +115,7 @@ struct Resolver<'a, Item, Id, Ident, Cmp> {
 impl<'a, Item, Id, Ident, Cmp> Resolver<'a, Item, Id, Ident, Cmp>
 where
     Id: Eq + hash::Hash,
-    Ident: Fn(&Item) -> Id + Clone,
+    Ident: Fn(&Item) -> Id + Copy,
     Cmp: Fn(&Item, &Item) -> bool,
 {
     pub fn resolve(
@@ -129,8 +129,7 @@ where
             ResolveCondition::Majority => items.len() / 2 + 1,
         };
 
-        let mut resolver =
-            Resolver::new(items.first().map_or(0, Vec::len), identify.clone(), compare);
+        let mut resolver = Resolver::new(items.first().map_or(0, Vec::len), identify, compare);
         resolver.add_all(&items);
 
         // Select coordinates of accepted items, avoiding copying

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -272,7 +272,7 @@ where
     }
 
     /// Peeks each row, then maps IDs to the peeked rows in which each ID appears
-    fn heads_map(&mut self) -> HashMap<Id, Vec<usize>> {
+    fn heads_map(&mut self) -> HashMap<Id, TinyVec<[usize; EXPECTED_REPLICAS]>> {
         let capacity = self.resolved_iters.len();
         self.peek_heads()
             .fold(HashMap::with_capacity(capacity), |mut map, (row, id)| {
@@ -559,6 +559,10 @@ mod test {
         [1, 2, 3, 4, 6, 7]
     }
 
+    fn expected_5_all() -> [i32; 0] {
+        []
+    }
+
     #[test]
     fn resolve_0_all() {
         resolve_0(ResolveCondition::All);
@@ -627,6 +631,11 @@ mod test {
     #[test]
     fn resolve_5_majority() {
         test_resolve_simple(input_5(), expected_5_majority(), ResolveCondition::Majority);
+    }
+
+    #[test]
+    fn resolve_5_all() {
+        test_resolve_simple(input_5(), expected_5_all(), ResolveCondition::All);
     }
 
     fn test_resolve<T, E>(input: Vec<T>, expected: E, condition: ResolveCondition)

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -78,12 +78,16 @@ impl Resolve for Vec<ShardQueryResponse> {
 }
 
 fn record_eq(this: &Record, other: &Record) -> bool {
-    this.id == other.id && this.vector == other.vector && payload_eq(&this.payload, &other.payload)
+    this.id == other.id
+        && this.order_value == other.order_value
+        && this.vector == other.vector
+        && payload_eq(&this.payload, &other.payload)
 }
 
 fn scored_point_eq(this: &ScoredPoint, other: &ScoredPoint) -> bool {
     this.id == other.id
         && this.score == other.score
+        && this.order_value == other.order_value
         && this.vector == other.vector
         && payload_eq(&this.payload, &other.payload)
 }

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -465,6 +465,19 @@ mod test {
         [3, 6, 9, 12, 13, 16, 19, 22, 26, 27]
     }
 
+    #[rustfmt::skip]
+    fn input_5() -> [Vec<i32>; 3] {
+        [
+            vec![1, 2, 3, 4, 5, 6, 7],
+            vec![               6, 7],
+            vec![1, 2, 3, 4         ],
+        ]
+    }
+
+    fn expected_5_majority() -> [i32; 6] {
+        [1, 2, 3, 4, 6, 7]
+    }
+
     #[test]
     fn resolve_0_all() {
         resolve_0(ResolveCondition::All);
@@ -530,6 +543,11 @@ mod test {
         test_resolve_simple(input_4(), expected_4_majority(), ResolveCondition::Majority);
     }
 
+    #[test]
+    fn resolve_5_majority() {
+        test_resolve_simple(input_5(), expected_5_majority(), ResolveCondition::Majority);
+    }
+
     fn test_resolve<T, E>(input: Vec<T>, expected: E, condition: ResolveCondition)
     where
         T: Resolve + Clone + PartialEq<E> + fmt::Debug,
@@ -570,10 +588,7 @@ mod test {
 
     impl Resolve for Vec<Val> {
         fn resolve(values: Vec<Self>, condition: ResolveCondition) -> Self {
-            let mut resolved = Resolver::resolve(values, |val| val.0, PartialEq::eq, condition);
-
-            resolved.sort_unstable();
-            resolved
+            Resolver::resolve(values, |val| val.0, PartialEq::eq, condition)
         }
     }
 }


### PR DESCRIPTION
Fixes same issue as #4511:

The order of results is not always the same, as the implementation had been considering. Nearest search can have different order direction depending on the metric (Euclidean vs Dot), and order-by can select its direction too.

~To preserve this ordering, I am introducing an extra `precedence` field in `ResolverRecord` to aggregate the sum of the positions of the same item in different results.~

~By having this number, in the end we can just sort in ascending order, and the resolved list should be ordered correctly.~

~I have not written any new tests yet, but the [`resolve_scored_points_batch_4_majority`](https://github.com/qdrant/qdrant/blob/dev/lib/collection/src/shards/resolve.rs#L397) test failed once we [stopped sorting `Vec<Vec<ScoredPoint>>`](https://github.com/qdrant/qdrant/compare/dev...replica-resolver-also-resolves-order?body=&expand=1#diff-c0decfb6f5c7e6dd8e2f779deee8d7dc971600d003faa3a9da2e79d1a2cc81f4L62-L68), and now it passes again with the new approach.~

Edit: it does not always work.

Edit2: I have now solved the issue by creating a custom iterator which takes a vec of filtered rows, and advances them in relation to their heads. So that they advance once enough heads have the same item.