### PR TITLE
Make ValueIndexer trait non-generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,6 +1604,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5419,6 +5430,7 @@ dependencies = [
  "criterion",
  "data-encoding",
  "dataset",
+ "delegate",
  "fnv",
  "fs_extra",
  "generic-tests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ tikv-jemallocator = "0.6"
 [workspace.dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
 data-encoding = { version = "2.6.0" }
+delegate = "0.12.0"
 fnv = "1.0"
 futures = "0.3.30"
 futures-util = "0.3.30"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -34,6 +34,7 @@ pprof = { workspace = true }
 [dependencies]
 bitpacking = "0.9.2"
 data-encoding = { workspace = true }
+delegate = { workspace = true }
 tempfile = { workspace = true }
 parking_lot = { workspace = true }
 rayon = "1.10.0"

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -320,7 +320,9 @@ impl PayloadFieldIndex for BinaryIndex {
     }
 }
 
-impl ValueIndexer<bool> for BinaryIndex {
+impl ValueIndexer for BinaryIndex {
+    type ValueType = bool;
+
     fn add_many(&mut self, id: PointOffsetType, values: Vec<bool>) -> OperationResult<()> {
         if values.is_empty() {
             return Ok(());

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -54,16 +54,22 @@ pub trait PayloadFieldIndex {
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_>;
 }
 
-pub trait ValueIndexer<T> {
+pub trait ValueIndexer {
+    type ValueType;
+
     /// Add multiple values associated with a single point
     /// This function should be called only once for each point
-    fn add_many(&mut self, id: PointOffsetType, values: Vec<T>) -> OperationResult<()>;
+    fn add_many(
+        &mut self,
+        id: PointOffsetType,
+        values: Vec<Self::ValueType>,
+    ) -> OperationResult<()>;
 
     /// Extract index-able value from payload `Value`
-    fn get_value(&self, value: &Value) -> Option<T>;
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType>;
 
     /// Try to extract index-able values from payload `Value`, even if it is an array
-    fn get_values(&self, value: &Value) -> Vec<T> {
+    fn get_values(&self, value: &Value) -> Vec<Self::ValueType> {
         match value {
             Value::Array(values) => values.iter().flat_map(|x| self.get_value(x)).collect(),
             _ => self.get_value(value).map(|x| vec![x]).unwrap_or_default(),

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -134,7 +134,9 @@ impl FullTextIndex {
     }
 }
 
-impl ValueIndexer<String> for FullTextIndex {
+impl ValueIndexer for FullTextIndex {
+    type ValueType = String;
+
     fn add_many(&mut self, idx: PointOffsetType, values: Vec<String>) -> OperationResult<()> {
         if values.is_empty() {
             return Ok(());

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -287,7 +287,9 @@ impl GeoMapIndex {
     }
 }
 
-impl ValueIndexer<GeoPoint> for GeoMapIndex {
+impl ValueIndexer for GeoMapIndex {
+    type ValueType = GeoPoint;
+
     fn add_many(&mut self, id: PointOffsetType, values: Vec<GeoPoint>) -> OperationResult<()> {
         match self {
             GeoMapIndex::Mutable(index) => index.add_many_geo_points(id, &values),

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -10,7 +10,7 @@ use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::numeric_index::NumericIndex;
 use crate::index::field_index::FieldIndex;
 use crate::json_path::JsonPath;
-use crate::types::{FloatPayloadType, IntPayloadType, PayloadFieldSchema, PayloadSchemaParams};
+use crate::types::{PayloadFieldSchema, PayloadSchemaParams};
 
 /// Selects index types based on field type
 pub fn index_selector(
@@ -32,19 +32,17 @@ pub fn index_selector(
             let lookup = integer_params
                 .lookup
                 .then(|| FieldIndex::IntMapIndex(MapIndex::new(db.clone(), field, is_appendable)));
-            let range = integer_params.range.then(|| {
-                FieldIndex::IntIndex(NumericIndex::<IntPayloadType>::new(
-                    db,
-                    field,
-                    is_appendable,
-                ))
-            });
+            let range = integer_params
+                .range
+                .then(|| FieldIndex::IntIndex(NumericIndex::new(db, field, is_appendable)));
             lookup.into_iter().chain(range).collect()
         }
         PayloadSchemaParams::Float(_) => {
-            vec![FieldIndex::FloatIndex(
-                NumericIndex::<FloatPayloadType>::new(db, field, is_appendable),
-            )]
+            vec![FieldIndex::FloatIndex(NumericIndex::new(
+                db,
+                field,
+                is_appendable,
+            ))]
         }
         PayloadSchemaParams::Geo(_) => vec![FieldIndex::GeoIndex(GeoMapIndex::new(
             db,
@@ -58,9 +56,11 @@ pub fn index_selector(
             vec![FieldIndex::BinaryIndex(BinaryIndex::new(db, field))]
         }
         PayloadSchemaParams::Datetime(_) => {
-            vec![FieldIndex::DatetimeIndex(
-                NumericIndex::<IntPayloadType>::new(db, field, is_appendable),
-            )]
+            vec![FieldIndex::DatetimeIndex(NumericIndex::new(
+                db,
+                field,
+                is_appendable,
+            ))]
         }
     }
 }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -552,7 +552,9 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
     }
 }
 
-impl ValueIndexer<String> for MapIndex<str> {
+impl ValueIndexer for MapIndex<str> {
+    type ValueType = String;
+
     fn add_many(&mut self, id: PointOffsetType, values: Vec<String>) -> OperationResult<()> {
         match self {
             MapIndex::Mutable(index) => index.add_many_to_map(id, values),
@@ -577,7 +579,9 @@ impl ValueIndexer<String> for MapIndex<str> {
     }
 }
 
-impl ValueIndexer<IntPayloadType> for MapIndex<IntPayloadType> {
+impl ValueIndexer for MapIndex<IntPayloadType> {
+    type ValueType = IntPayloadType;
+
     fn add_many(
         &mut self,
         id: PointOffsetType,

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 
 use super::mutable_numeric_index::MutableNumericIndex;
-use super::{Encodable, NumericIndex, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
+use super::{Encodable, NumericIndexInner, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
 use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
@@ -202,7 +202,7 @@ impl<'a, T: Encodable + Numericable> DoubleEndedIterator for NumericKeySortedVec
 
 impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
     pub(super) fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
-        let store_cf_name = NumericIndex::<T>::storage_cf_name(field);
+        let store_cf_name = NumericIndexInner::<T>::storage_cf_name(field);
         let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
             db,
             &store_cf_name,

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -5,6 +5,7 @@ mod mutable_numeric_index;
 mod tests;
 
 use std::cmp::{max, min};
+use std::marker::PhantomData;
 use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::str::FromStr;
@@ -12,6 +13,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use common::types::PointOffsetType;
+use delegate::delegate;
 use mutable_numeric_index::MutableNumericIndex;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -138,45 +140,53 @@ impl<T: Encodable + Numericable> Range<T> {
     }
 }
 
-pub enum NumericIndex<T: Encodable + Numericable + Default> {
+pub enum NumericIndexInner<T: Encodable + Numericable + Default> {
     Mutable(MutableNumericIndex<T>),
     Immutable(ImmutableNumericIndex<T>),
 }
 
-impl<T: Encodable + Numericable + Default> NumericIndex<T> {
+impl<T: Encodable + Numericable + Default> NumericIndexInner<T> {
     pub fn new(db: Arc<RwLock<DB>>, field: &str, is_appendable: bool) -> Self {
         if is_appendable {
-            NumericIndex::Mutable(MutableNumericIndex::new(db, field))
+            NumericIndexInner::Mutable(MutableNumericIndex::new(db, field))
         } else {
-            NumericIndex::Immutable(ImmutableNumericIndex::new(db, field))
+            NumericIndexInner::Immutable(ImmutableNumericIndex::new(db, field))
+        }
+    }
+
+    #[cfg(test)]
+    pub fn wrap<P>(self) -> NumericIndex<T, P> {
+        NumericIndex {
+            inner: self,
+            _phantom: PhantomData,
         }
     }
 
     fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         match self {
-            NumericIndex::Mutable(index) => index.get_db_wrapper(),
-            NumericIndex::Immutable(index) => index.get_db_wrapper(),
+            NumericIndexInner::Mutable(index) => index.get_db_wrapper(),
+            NumericIndexInner::Immutable(index) => index.get_db_wrapper(),
         }
     }
 
     fn get_histogram(&self) -> &Histogram<T> {
         match self {
-            NumericIndex::Mutable(index) => &index.histogram,
-            NumericIndex::Immutable(index) => &index.histogram,
+            NumericIndexInner::Mutable(index) => &index.histogram,
+            NumericIndexInner::Immutable(index) => &index.histogram,
         }
     }
 
     fn get_points_count(&self) -> usize {
         match self {
-            NumericIndex::Mutable(index) => index.points_count,
-            NumericIndex::Immutable(index) => index.points_count,
+            NumericIndexInner::Mutable(index) => index.points_count,
+            NumericIndexInner::Immutable(index) => index.points_count,
         }
     }
 
     fn total_unique_values_count(&self) -> usize {
         match self {
-            NumericIndex::Mutable(index) => index.total_unique_values_count(),
-            NumericIndex::Immutable(index) => index.total_unique_values_count(),
+            NumericIndexInner::Mutable(index) => index.total_unique_values_count(),
+            NumericIndexInner::Immutable(index) => index.total_unique_values_count(),
         }
     }
 
@@ -190,8 +200,8 @@ impl<T: Encodable + Numericable + Default> NumericIndex<T> {
 
     pub fn load(&mut self) -> OperationResult<bool> {
         match self {
-            NumericIndex::Mutable(index) => index.load(),
-            NumericIndex::Immutable(index) => index.load(),
+            NumericIndexInner::Mutable(index) => index.load(),
+            NumericIndexInner::Immutable(index) => index.load(),
         }
     }
 
@@ -201,29 +211,29 @@ impl<T: Encodable + Numericable + Default> NumericIndex<T> {
 
     pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
         match self {
-            NumericIndex::Mutable(index) => index.remove_point(idx),
-            NumericIndex::Immutable(index) => index.remove_point(idx),
+            NumericIndexInner::Mutable(index) => index.remove_point(idx),
+            NumericIndexInner::Immutable(index) => index.remove_point(idx),
         }
     }
 
     pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&T) -> bool) -> bool {
         match self {
-            NumericIndex::Mutable(index) => index.check_values_any(idx, check_fn),
-            NumericIndex::Immutable(index) => index.check_values_any(idx, check_fn),
+            NumericIndexInner::Mutable(index) => index.check_values_any(idx, check_fn),
+            NumericIndexInner::Immutable(index) => index.check_values_any(idx, check_fn),
         }
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
         match self {
-            NumericIndex::Mutable(index) => index.get_values(idx),
-            NumericIndex::Immutable(index) => index.get_values(idx),
+            NumericIndexInner::Mutable(index) => index.get_values(idx),
+            NumericIndexInner::Immutable(index) => index.get_values(idx),
         }
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> usize {
         match self {
-            NumericIndex::Mutable(index) => index.values_count(idx).unwrap_or_default(),
-            NumericIndex::Immutable(index) => index.values_count(idx).unwrap_or_default(),
+            NumericIndexInner::Mutable(index) => index.values_count(idx).unwrap_or_default(),
+            NumericIndexInner::Immutable(index) => index.values_count(idx).unwrap_or_default(),
         }
     }
 
@@ -234,8 +244,8 @@ impl<T: Encodable + Numericable + Default> NumericIndex<T> {
     /// Zero if the index is empty.
     pub fn max_values_per_point(&self) -> usize {
         match self {
-            NumericIndex::Mutable(index) => index.max_values_per_point,
-            NumericIndex::Immutable(index) => index.max_values_per_point,
+            NumericIndexInner::Mutable(index) => index.max_values_per_point,
+            NumericIndexInner::Immutable(index) => index.max_values_per_point,
         }
     }
 
@@ -321,13 +331,47 @@ impl<T: Encodable + Numericable + Default> NumericIndex<T> {
     }
 }
 
-impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T> {
+pub struct NumericIndex<T: Encodable + Numericable + Default, P> {
+    inner: NumericIndexInner<T>,
+    _phantom: PhantomData<P>,
+}
+
+impl<T: Encodable + Numericable + Default, P> NumericIndex<T, P> {
+    pub fn new(db: Arc<RwLock<DB>>, field: &str, is_appendable: bool) -> Self {
+        Self {
+            inner: NumericIndexInner::new(db, field, is_appendable),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn inner(&self) -> &NumericIndexInner<T> {
+        &self.inner
+    }
+
+    pub fn mut_inner(&mut self) -> &mut NumericIndexInner<T> {
+        &mut self.inner
+    }
+
+    delegate! {
+        to self.inner {
+            pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&T) -> bool) -> bool;
+            pub fn clear(self) -> OperationResult<()>;
+            pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
+            pub fn load(&mut self) -> OperationResult<bool>;
+            pub fn recreate(&self) -> OperationResult<()>;
+            pub fn values_count(&self, idx: PointOffsetType) -> usize;
+            pub fn values_is_empty(&self, idx: PointOffsetType) -> bool;
+        }
+    }
+}
+
+impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndexInner<T> {
     fn count_indexed_points(&self) -> usize {
         self.get_points_count()
     }
 
     fn load(&mut self) -> OperationResult<bool> {
-        NumericIndex::load(self)
+        NumericIndexInner::load(self)
     }
 
     fn clear(self) -> OperationResult<()> {
@@ -335,7 +379,7 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T>
     }
 
     fn flusher(&self) -> Flusher {
-        NumericIndex::flusher(self)
+        NumericIndexInner::flusher(self)
     }
 
     fn filter(
@@ -362,12 +406,14 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T>
         }
 
         Ok(match self {
-            NumericIndex::Mutable(index) => {
+            NumericIndexInner::Mutable(index) => {
                 let start_bound = start_bound.map(|k| k.encode());
                 let end_bound = end_bound.map(|k| k.encode());
                 Box::new(index.values_range(start_bound, end_bound))
             }
-            NumericIndex::Immutable(index) => Box::new(index.values_range(start_bound, end_bound)),
+            NumericIndexInner::Immutable(index) => {
+                Box::new(index.values_range(start_bound, end_bound))
+            }
         })
     }
 
@@ -460,15 +506,15 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T>
     }
 }
 
-impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType> {
+impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType, IntPayloadType> {
     fn add_many(
         &mut self,
         id: PointOffsetType,
         values: Vec<IntPayloadType>,
     ) -> OperationResult<()> {
-        match self {
-            NumericIndex::Mutable(index) => index.add_many_to_list(id, values),
-            NumericIndex::Immutable(_) => Err(OperationError::service_error(
+        match &mut self.inner {
+            NumericIndexInner::Mutable(index) => index.add_many_to_list(id, values),
+            NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
             )),
         }
@@ -479,21 +525,21 @@ impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType> {
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        NumericIndex::remove_point(self, id)
+        self.inner.remove_point(id)
     }
 }
 
-impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType> {
+impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType, DateTimePayloadType> {
     fn add_many(
         &mut self,
         id: PointOffsetType,
         values: Vec<DateTimePayloadType>,
     ) -> OperationResult<()> {
-        match self {
-            NumericIndex::Mutable(index) => {
+        match &mut self.inner {
+            NumericIndexInner::Mutable(index) => {
                 index.add_many_to_list(id, values.into_iter().map(|x| x.timestamp()))
             }
-            NumericIndex::Immutable(_) => Err(OperationError::service_error(
+            NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
             )),
         }
@@ -504,19 +550,19 @@ impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType> {
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        NumericIndex::remove_point(self, id)
+        self.inner.remove_point(id)
     }
 }
 
-impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType> {
+impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType, FloatPayloadType> {
     fn add_many(
         &mut self,
         id: PointOffsetType,
         values: Vec<FloatPayloadType>,
     ) -> OperationResult<()> {
-        match self {
-            NumericIndex::Mutable(index) => index.add_many_to_list(id, values),
-            NumericIndex::Immutable(_) => Err(OperationError::service_error(
+        match &mut self.inner {
+            NumericIndexInner::Mutable(index) => index.add_many_to_list(id, values),
+            NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
             )),
         }
@@ -527,11 +573,11 @@ impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType> {
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        NumericIndex::remove_point(self, id)
+        self.inner.remove_point(id)
     }
 }
 
-impl<T> StreamRange<T> for NumericIndex<T>
+impl<T> StreamRange<T> for NumericIndexInner<T>
 where
     T: Encodable + Numericable + Default,
 {
@@ -554,12 +600,12 @@ where
         }
 
         match self {
-            NumericIndex::Mutable(index) => {
+            NumericIndexInner::Mutable(index) => {
                 let start_bound = start_bound.map(|k| k.encode());
                 let end_bound = end_bound.map(|k| k.encode());
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
-            NumericIndex::Immutable(index) => {
+            NumericIndexInner::Immutable(index) => {
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
         }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -506,7 +506,9 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndexInn
     }
 }
 
-impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType, IntPayloadType> {
+impl ValueIndexer for NumericIndex<IntPayloadType, IntPayloadType> {
+    type ValueType = IntPayloadType;
+
     fn add_many(
         &mut self,
         id: PointOffsetType,
@@ -529,7 +531,9 @@ impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType, IntPayloadTyp
     }
 }
 
-impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType, DateTimePayloadType> {
+impl ValueIndexer for NumericIndex<IntPayloadType, DateTimePayloadType> {
+    type ValueType = DateTimePayloadType;
+
     fn add_many(
         &mut self,
         id: PointOffsetType,
@@ -554,7 +558,9 @@ impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType, DateTime
     }
 }
 
-impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType, FloatPayloadType> {
+impl ValueIndexer for NumericIndex<FloatPayloadType, FloatPayloadType> {
+    type ValueType = FloatPayloadType;
+
     fn add_many(
         &mut self,
         id: PointOffsetType,

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -7,7 +7,7 @@ use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
-use super::{Encodable, NumericIndex, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
+use super::{Encodable, NumericIndexInner, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
@@ -24,7 +24,7 @@ pub struct MutableNumericIndex<T: Encodable + Numericable> {
 
 impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
     pub fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
-        let store_cf_name = NumericIndex::<T>::storage_cf_name(field);
+        let store_cf_name = NumericIndexInner::<T>::storage_cf_name(field);
         let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
             db,
             &store_cf_name,


### PR DESCRIPTION
```rust
// This PR replaces this trait (old):
trait ValueIndexer<T> {
    …
}

// With this trait (new):
trait ValueIndexer {
    type ValueType;
    …
}
```

# Why/general direction
We have this implementation of `build_field_indexes`: https://github.com/qdrant/qdrant/blob/v1.10.1/lib/segment/src/index/struct_payload_index.rs#L172-L191
How it build both appendable and non-appendable segments: it creates mutable index no matter what kind of segments it builds, and appends point into it. It assumes ("the assumption") that we have two kind of payload indices: mutable and immutable; and both of them use the same on-disk representation (aka rocksdb).

The on-disk payload index doesn't fit into this model: it's immutable and it doesn't have a mutable counterpart.

I am trying to untangle this code by moving "the assumption" from the `build_field_indexes` method into implementations of a `trait PayloadIndexBuilder` (yet to be introduced). One particular roadblock for this is `trait ValueIndexer<T>`, particularly the generic parameter `T`. The type parameter `T` is an implementation detail that exposes what kind of internal representation a particular index uses. So, this PR moves this generic parameter into the associated type so users of this trait can stop caring what internal representation is used.

# Implementation details
Previously the same `NumericIndex` were used to handle multiple kind of payloads (thus multiple impls of `ValueIndexer<T>` for different `T`). Now `NumericIndex` is a wrapper parametrized with a payload type, so it knows the type of payload it works with. But internally it's still the same payload-agnostic index.

```rust
// Old
pub enum FieldIndex {
    IntIndex(NumericIndex<IntPayloadType>), // same
    DatetimeIndex(NumericIndex<IntPayloadType>), // same
    FloatIndex(NumericIndex<FloatPayloadType>),
    …
}

pub enum NumericIndex<T: Encodable + Numericable + Default> {
    Mutable(MutableNumericIndex<T>),
    Immutable(ImmutableNumericIndex<T>),
}
```

```rust
// New
pub enum FieldIndex {
    IntIndex(NumericIndex<IntPayloadType, IntPayloadType>),
    DatetimeIndex(NumericIndex<IntPayloadType, DateTimePayloadType>),
    FloatIndex(NumericIndex<FloatPayloadType, FloatPayloadType>),
    …
}

pub struct NumericIndex<T: Encodable + Numericable + Default, P> {
    inner: NumericIndexInner<T>,
    _phantom: PhantomData<P>,
}

pub enum NumericIndexInner<T: Encodable + Numericable + Default> {
    Mutable(MutableNumericIndex<T>),
    Immutable(ImmutableNumericIndex<T>),
}
```

