### PR TITLE
Enable new idtracker

### DIFF
--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -252,7 +252,7 @@ impl ImmutableIdTracker {
         })
     }
 
-    pub(super) fn new(
+    pub fn new(
         path: &Path,
         internal_to_version: &[SeqNumberType],
         mappings: PointMappings,

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -22,6 +22,8 @@ use super::{
 use crate::common::error_logging::LogError;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::entry::entry_point::SegmentEntry;
+use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
+use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum};
 use crate::index::field_index::FieldIndex;
 use crate::index::sparse_index::sparse_vector_index::SparseVectorIndexOpenArgs;
@@ -69,8 +71,11 @@ impl SegmentBuilder {
 
         let database = open_segment_db(&temp_path, segment_config)?;
 
-        let id_tracker =
-            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(database.clone())?);
+        let id_tracker = if segment_config.is_appendable() {
+            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(database.clone())?)
+        } else {
+            IdTrackerEnum::InMemoryIdTracker(InMemoryIdTracker::new())
+        };
 
         let payload_storage = create_payload_storage(database.clone(), segment_config)?;
 
@@ -403,6 +408,19 @@ impl SegmentBuilder {
             payload_storage.flusher()()?;
             let payload_storage_arc = Arc::new(AtomicRefCell::new(payload_storage));
 
+            let id_tracker = match id_tracker {
+                IdTrackerEnum::InMemoryIdTracker(in_memory_id_tracker) => {
+                    let (versions, mappings) = in_memory_id_tracker.into_internal();
+                    let immutable_id_tracker =
+                        ImmutableIdTracker::new(&temp_path, &versions, mappings)?;
+                    IdTrackerEnum::ImmutableIdTracker(immutable_id_tracker)
+                }
+                IdTrackerEnum::MutableIdTracker(_) => id_tracker,
+                IdTrackerEnum::ImmutableIdTracker(_) => {
+                    unreachable!("ImmutableIdTracker should not be used for building segment")
+                }
+            };
+
             id_tracker.mapping_flusher()()?;
             id_tracker.versions_flusher()()?;
             let id_tracker_arc = Arc::new(AtomicRefCell::new(id_tracker));
@@ -486,16 +504,6 @@ impl SegmentBuilder {
                     tick_progress: || (),
                 })?;
             }
-
-            // TODO: uncomment when releasing the next version! Also in segment_constructor_base.rs:403
-            // Make the IdTracker immutable if segment is not appendable.
-            /*
-            if !appendable_flag {
-                if let IdTrackerEnum::MutableIdTracker(mutable) = &*id_tracker_arc.borrow() {
-                    mutable.make_immutable(&temp_path)?;
-                }
-            }
-             */
 
             // We're done with CPU-intensive tasks, release CPU permit
             debug_assert_eq!(

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -383,9 +383,6 @@ impl SegmentBuilder {
             }
         }
 
-        self.id_tracker.mapping_flusher()()?;
-        self.id_tracker.versions_flusher()()?;
-
         Ok(true)
     }
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
+use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
 use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
@@ -290,11 +291,11 @@ pub(crate) fn create_mutable_id_tracker(
     SimpleIdTracker::open(database)
 }
 
-/*pub(crate) fn create_immutable_id_tracker(
+pub(crate) fn create_immutable_id_tracker(
     segment_path: &Path,
 ) -> OperationResult<ImmutableIdTracker> {
     ImmutableIdTracker::open(segment_path)
-}*/
+}
 
 pub(crate) fn get_payload_index_path(segment_path: &Path) -> PathBuf {
     segment_path.join(PAYLOAD_INDEX_PATH)
@@ -416,8 +417,6 @@ fn create_segment(
 
     let appendable_flag = config.is_appendable();
 
-    // TODO: uncomment when releasing the next version! Also in segment_builder.rs:353
-    /*
     let mutable_id_tracker =
         appendable_flag || !ImmutableIdTracker::mappings_file_path(segment_path).is_file();
 
@@ -430,11 +429,6 @@ fn create_segment(
             create_immutable_id_tracker(segment_path)?,
         ))
     };
-     */
-
-    let id_tracker = sp(IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
-        database.clone(),
-    )?));
 
     let payload_index_path = get_payload_index_path(segment_path);
     let payload_index: Arc<AtomicRefCell<StructPayloadIndex>> = sp(StructPayloadIndex::open(


### PR DESCRIPTION
Enables the `ImmutableIdTracker` and `InMemroyIdTracker`.
Marked as draft until next release.