### PR TITLE
Abort resharding when relevant consensus events happen

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -216,6 +216,13 @@ impl Collection {
                         .await?;
                 }
             }
+
+            // We can't remove the last repilca of a shard, so this should prevent removing
+            // resharding shard, because it's always the *only* replica.
+            //
+            // And if we remove some other shard, that is currently doing resharding transfer,
+            // the transfer should be cancelled (see the block right above this comment),
+            // so no special handling is needed.
         }
         Ok(())
     }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -530,6 +530,8 @@ impl Collection {
     }
 
     pub async fn remove_shards_at_peer(&self, peer_id: PeerId) -> CollectionResult<()> {
+        // Abort resharding, if shards are removed from peer driving resharding
+        // (which *usually* means the *peer* is being removed from consensus)
         let resharding_state = self
             .resharding_state()
             .await

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -407,11 +407,14 @@ impl Collection {
 
             drop(shard_holder);
 
-            self.abort_resharding(ReshardKey {
-                peer_id,
-                shard_id,
-                shard_key,
-            })
+            self.abort_resharding(
+                ReshardKey {
+                    peer_id,
+                    shard_id,
+                    shard_key,
+                },
+                false,
+            )
             .await?;
 
             // TODO(resharding): Abort all resharding transfers!?

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -193,6 +193,8 @@ impl Collection {
 
         if !force {
             shard_holder.check_abort_resharding(&resharding_key)?;
+        } else {
+            log::warn!("Force-aborting resharding {resharding_key}");
         }
 
         let _ = self.stop_resharding_task(&resharding_key).await;

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -184,7 +184,17 @@ impl Collection {
         Ok(())
     }
 
-    pub async fn abort_resharding(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
+    pub async fn abort_resharding(
+        &self,
+        resharding_key: ReshardKey,
+        force: bool,
+    ) -> CollectionResult<()> {
+        let mut shard_holder = self.shards_holder.write().await;
+
+        if !force {
+            shard_holder.check_abort_resharding(&resharding_key)?;
+        }
+
         let _ = self.stop_resharding_task(&resharding_key).await;
 
         // Decrease the persisted shard count, ensures we don't load dropped shard on restart
@@ -200,21 +210,18 @@ impl Collection {
 
             config.params.shard_number = NonZeroU32::new(config.params.shard_number.get() - 1)
                 .expect("cannot have zero shards after aborting resharding");
+
             if let Err(err) = config.save(&self.path) {
                 log::error!("Failed to update and save collection config during resharding: {err}");
             }
         }
 
-        self.shards_holder
-            .write()
-            .await
-            .abort_resharding(resharding_key)
-            .await?;
+        shard_holder.abort_resharding(resharding_key, force).await?;
 
         Ok(())
     }
 
-    async fn stop_resharding_task(
+    pub(super) async fn stop_resharding_task(
         &self,
         resharding_key: &ReshardKey,
     ) -> Option<resharding::tasks_pool::TaskResult> {

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -143,6 +143,20 @@ impl Collection {
             ShardingMethod::Custom => {}
         }
 
+        let resharding_state = self
+            .resharding_state()
+            .await
+            .filter(|state| state.shard_key.as_ref() == Some(&shard_key));
+
+        if let Some(state) = resharding_state {
+            if let Err(err) = self.abort_resharding(state.key(), true).await {
+                log::error!(
+                    "failed to abort resharding {} while deleting shard key {shard_key}: {err}",
+                    state.key(),
+                );
+            }
+        }
+
         self.shards_holder
             .write()
             .await

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -17,8 +17,8 @@ use crate::operations::types::{CollectionError, CollectionResult};
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::resharding::{
-    stage_commit_hashring, stage_finalize, stage_init, stage_migrate_points,
-    stage_propagate_deletes, stage_replicate,
+    stage_commit_read_hashring, stage_commit_write_hashring, stage_finalize, stage_init,
+    stage_migrate_points, stage_propagate_deletes, stage_replicate,
 };
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_holder::LockedShardHolder;
@@ -122,12 +122,13 @@ impl DriverState {
                 self.key.shard_id,
             ),
             Stage::S3_Replicate => "replicate: replicate new shard to other peers".into(),
-            Stage::S4_CommitHashring => "commit hash ring: switching reads and writes".into(),
-            Stage::S5_PropagateDeletes => format!(
+            Stage::S4_CommitReadHashring => "commit read hash ring: switching reads".into(),
+            Stage::S5_CommitWriteHashring => "commit write hash ring: switching writes".into(),
+            Stage::S6_PropagateDeletes => format!(
                 "propagate deletes: deleting migrated points from shards {:?}",
                 self.shards_to_delete().collect::<Vec<_>>(),
             ),
-            Stage::S6_Finalize => "finalize".into(),
+            Stage::S7_Finalize => "finalize".into(),
             Stage::Finished => "finished".into(),
         }
     }
@@ -149,12 +150,14 @@ pub(super) enum Stage {
     S2_MigratePoints,
     #[serde(rename = "replicate")]
     S3_Replicate,
-    #[serde(rename = "commit_hash_ring")]
-    S4_CommitHashring,
+    #[serde(rename = "commit_read_hash_ring")]
+    S4_CommitReadHashring,
+    #[serde(rename = "commit_write_hash_ring")]
+    S5_CommitWriteHashring,
     #[serde(rename = "propagate_deletes")]
-    S5_PropagateDeletes,
+    S6_PropagateDeletes,
     #[serde(rename = "finalize")]
-    S6_Finalize,
+    S7_Finalize,
     #[serde(rename = "finished")]
     Finished,
 }
@@ -164,10 +167,11 @@ impl Stage {
         match self {
             Self::S1_Init => Self::S2_MigratePoints,
             Self::S2_MigratePoints => Self::S3_Replicate,
-            Self::S3_Replicate => Self::S4_CommitHashring,
-            Self::S4_CommitHashring => Self::S5_PropagateDeletes,
-            Self::S5_PropagateDeletes => Self::S6_Finalize,
-            Self::S6_Finalize => Self::Finished,
+            Self::S3_Replicate => Self::S4_CommitReadHashring,
+            Self::S4_CommitReadHashring => Self::S5_CommitWriteHashring,
+            Self::S5_CommitWriteHashring => Self::S6_PropagateDeletes,
+            Self::S6_PropagateDeletes => Self::S7_Finalize,
+            Self::S7_Finalize => Self::Finished,
             Self::Finished => unreachable!(),
         }
     }
@@ -266,10 +270,10 @@ pub async fn drive_resharding(
         .await?;
     }
 
-    // Stage 4: commit new hashring
-    if !stage_commit_hashring::is_completed(&state) {
-        log::debug!("Resharding {collection_id}:{to_shard_id} stage: commit hashring");
-        stage_commit_hashring::drive(
+    // Stage 4: commit read hashring
+    if !stage_commit_read_hashring::is_completed(&state) {
+        log::debug!("Resharding {collection_id}:{to_shard_id} stage: commit read hashring");
+        stage_commit_read_hashring::drive(
             &reshard_key,
             &state,
             &progress,
@@ -280,7 +284,21 @@ pub async fn drive_resharding(
         .await?;
     }
 
-    // Stage 5: propagate deletes
+    // Stage 5: commit write hashring
+    if !stage_commit_write_hashring::is_completed(&state) {
+        log::debug!("Resharding {collection_id}:{to_shard_id} stage: commit write hashring");
+        stage_commit_write_hashring::drive(
+            &reshard_key,
+            &state,
+            &progress,
+            consensus,
+            &channel_service,
+            &collection_id,
+        )
+        .await?;
+    }
+
+    // Stage 6: propagate deletes
     if !stage_propagate_deletes::is_completed(&state) {
         log::debug!("Resharding {collection_id}:{to_shard_id} stage: propagate deletes");
         stage_propagate_deletes::drive(
@@ -293,7 +311,7 @@ pub async fn drive_resharding(
         .await?;
     }
 
-    // Stage 6: finalize
+    // Stage 7: finalize
     log::debug!("Resharding {collection_id}:{to_shard_id} stage: finalize");
     stage_finalize::drive(&state, &progress, consensus)?;
 

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -1,7 +1,8 @@
 pub mod driver;
 pub mod tasks_pool;
 
-mod stage_commit_hashring;
+mod stage_commit_read_hashring;
+mod stage_commit_write_hashring;
 mod stage_finalize;
 mod stage_init;
 mod stage_migrate_points;

--- a/lib/collection/src/shards/resharding/stage_commit_write_hashring.rs
+++ b/lib/collection/src/shards/resharding/stage_commit_write_hashring.rs
@@ -1,0 +1,53 @@
+use parking_lot::Mutex;
+
+use super::driver::{PersistedState, Stage};
+use super::tasks_pool::ReshardTaskProgress;
+use super::ReshardKey;
+use crate::operations::types::CollectionResult;
+use crate::shards::channel_service::ChannelService;
+use crate::shards::transfer::ShardTransferConsensus;
+use crate::shards::{await_consensus_sync, CollectionId};
+
+/// Stage 5: commit write hashring
+///
+/// Check whether the new hashring still needs to be committed.
+pub(super) fn is_completed(state: &PersistedState) -> bool {
+    state
+        .read()
+        .all_peers_completed(Stage::S5_CommitWriteHashring)
+}
+
+/// Stage 5: commit write hashring
+///
+/// Do commit the new hashring.
+pub(super) async fn drive(
+    reshard_key: &ReshardKey,
+    state: &PersistedState,
+    progress: &Mutex<ReshardTaskProgress>,
+    consensus: &dyn ShardTransferConsensus,
+    channel_service: &ChannelService,
+    collection_id: &CollectionId,
+) -> CollectionResult<()> {
+    // Commit write hashring
+    progress
+        .lock()
+        .description
+        .replace(format!("{} (switching write)", state.read().describe()));
+    consensus
+        .commit_write_hashring_confirm_and_retry(collection_id, reshard_key)
+        .await?;
+
+    // Sync cluster
+    progress.lock().description.replace(format!(
+        "{} (await cluster sync for write)",
+        state.read().describe(),
+    ));
+    await_consensus_sync(consensus, channel_service).await;
+
+    state.write(|data| {
+        data.complete_for_all_peers(Stage::S5_CommitWriteHashring);
+        data.update(progress, consensus);
+    })?;
+
+    Ok(())
+}

--- a/lib/collection/src/shards/resharding/stage_finalize.rs
+++ b/lib/collection/src/shards/resharding/stage_finalize.rs
@@ -14,7 +14,7 @@ pub(super) fn drive(
     consensus: &dyn ShardTransferConsensus,
 ) -> CollectionResult<()> {
     state.write(|data| {
-        data.complete_for_all_peers(Stage::S6_Finalize);
+        data.complete_for_all_peers(Stage::S7_Finalize);
         data.update(progress, consensus);
     })?;
 

--- a/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
+++ b/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
@@ -20,7 +20,7 @@ const DELETE_BATCH_SIZE: usize = 500;
 /// Check whether migrated points still need to be deleted in their old shards.
 pub(super) fn is_completed(state: &PersistedState) -> bool {
     let state_read = state.read();
-    state_read.all_peers_completed(Stage::S5_PropagateDeletes)
+    state_read.all_peers_completed(Stage::S6_PropagateDeletes)
         && state_read.shards_to_delete().next().is_none()
 }
 
@@ -109,7 +109,7 @@ pub(super) async fn drive(
     }
 
     state.write(|data| {
-        data.complete_for_all_peers(Stage::S5_PropagateDeletes);
+        data.complete_for_all_peers(Stage::S6_PropagateDeletes);
         data.update(progress, consensus);
     })?;
 

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -200,7 +200,7 @@ impl ShardHolder {
         Err(CollectionError::bad_request(format!(
             "can't abort resharding {resharding_key}, \
              because write hash ring has been committed already, \
-             resharding have to be driven to completion",
+             resharding must be completed",
         )))
     }
 

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -176,7 +176,39 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub async fn abort_resharding(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
+    pub fn check_abort_resharding(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
+        let state = self.resharding_state.read();
+
+        // `abort_resharding` designed to be self-healing, so...
+        //
+        // - it's safe to run, if resharding is *not* in progress
+        let Some(state) = state.deref() else {
+            return Ok(());
+        };
+
+        // - it's safe to run, if *another* resharding is in progress
+        if !state.matches(resharding_key) {
+            return Ok(());
+        }
+
+        // - it's safe to run, if write hash ring was not committed yet
+        if state.stage < ReshardStage::WriteHashRingCommitted {
+            return Ok(());
+        }
+
+        // - but resharding can't be aborted, after write hash ring has been committed
+        Err(CollectionError::bad_request(format!(
+            "can't abort resharding {resharding_key}, \
+             because write hash ring has been committed already, \
+             resharding have to be driven to completion",
+        )))
+    }
+
+    pub async fn abort_resharding(
+        &mut self,
+        resharding_key: ReshardKey,
+        force: bool,
+    ) -> CollectionResult<()> {
         let ReshardKey {
             peer_id,
             shard_id,
@@ -184,7 +216,17 @@ impl ShardHolder {
         } = resharding_key;
 
         let is_in_progress = match self.resharding_state.read().deref() {
-            Some(state) if state.matches(&resharding_key) => true,
+            Some(state) if state.matches(&resharding_key) => {
+                if !force && state.stage >= ReshardStage::WriteHashRingCommitted {
+                    return Err(CollectionError::bad_request(format!(
+                        "can't abort resharding {resharding_key}, \
+                         because write hash ring has been committed already, \
+                         resharding have to be driven to completion",
+                    )));
+                }
+
+                true
+            }
 
             Some(state) => {
                 log::warn!(

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -221,7 +221,7 @@ impl ShardHolder {
                     return Err(CollectionError::bad_request(format!(
                         "can't abort resharding {resharding_key}, \
                          because write hash ring has been committed already, \
-                         resharding have to be driven to completion",
+                         resharding must be completed",
                     )));
                 }
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -181,6 +181,8 @@ impl TableOfContent {
                 .remove_collection(collection_name)?;
 
             let path = self.get_collection_path(collection_name);
+
+            // TODO(resharding): Gracefully cancel resharding and shard transfer tasks!?
             drop(removed);
 
             // Move collection to ".deleted" folder to prevent accidental reuse

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -340,7 +340,7 @@ impl TableOfContent {
             }
 
             ReshardingOperation::Abort(key) => {
-                collection.abort_resharding(key).await?;
+                collection.abort_resharding(key, false).await?;
             }
         }
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -182,7 +182,16 @@ impl TableOfContent {
 
             let path = self.get_collection_path(collection_name);
 
-            // TODO(resharding): Gracefully cancel resharding and shard transfer tasks!?
+            if let Some(state) = removed.resharding_state().await {
+                if let Err(err) = removed.abort_resharding(state.key(), true).await {
+                    log::error!(
+                        "Failed to abort resharding {} when deleting collection {collection_name}: \
+                         {err}",
+                        state.key(),
+                    );
+                }
+            }
+
             drop(removed);
 
             // Move collection to ".deleted" folder to prevent accidental reuse

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -838,7 +838,7 @@ def test_resharding_try_abort_on_remove_shard_before_replicate(tmp_path: pathlib
     assert resp.status_code == 400
 
 # Test that resharding is automatically restarted, when we remove new shard during replication
-@pytest.mark.skip(reason="removing transfer source shard is broken at the moment (in generall, not just for resharding)")
+@pytest.mark.skip(reason="removing transfer source shard is broken at the moment (in general, not just for resharding)")
 def test_resharding_restart_on_remove_src_shard_during_replicate(tmp_path: pathlib.Path):
     resharding_restart_on_remove_shard_during_replicate(tmp_path, 'from')
 

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -3,6 +3,8 @@ import pathlib
 import random
 from time import sleep
 
+from .test_dummy_shard import assert_http_response
+
 from .fixtures import upsert_random_points, create_collection, random_dense_vector
 from .utils import *
 
@@ -712,6 +714,256 @@ def test_resharding_resume_on_restart(tmp_path: pathlib.Path):
         assert_http_ok(r)
         data.append(r.json()["result"])
     check_data_consistency(data)
+
+
+# Test that resharding can be aborted (before it reached `WriteHashRingCommitted` stage)
+def test_resharding_abort(tmp_path: pathlib.Path):
+    peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
+
+    # Abort resharding
+    resp = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "abort_resharding": {}
+        }
+    )
+
+    assert_http_ok(resp)
+
+    # Wait for resharding to abort
+    wait_for_resharding_to_finish(peer_api_uris, 3)
+
+# Test that resharding *can't* be aborted, once it reached `WriteHashRingCommitted` stage
+def test_resharding_try_abort_after_write_hash_ring_committed(tmp_path: pathlib.Path):
+    peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
+
+    # Wait for `propagate deletes` resharding stage
+    wait_for_collection_resharding_operation_stage(peer_api_uris[0], COLLECTION_NAME, "propagate deletes")
+
+    # Try to abort resharding
+    resp = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "abort_resharding": {}
+        }
+    )
+
+    assert resp.status_code == 400
+
+    # Wait for resharding to finish successfully
+    wait_for_resharding_to_finish(peer_api_uris, 4)
+
+# Test that resharding is automatically aborted, when collection is deleted
+def test_resharding_abort_on_delete_collection(tmp_path: pathlib.Path):
+    peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
+
+    # Delete collection
+    resp = requests.delete(f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}")
+    assert_http_ok(resp)
+
+    # TODO: Check... *something*? What? 🤔
+
+# Test that resharding is automatically aborted, when custom shard key is deleted
+def test_resharding_abort_on_delete_shard_key(tmp_path: pathlib.Path):
+    peer_api_uris, peer_ids = bootstrap_resharding(
+        tmp_path,
+        shard_keys=["custom_shard_key_1", "custom_shard_key_2"],
+        resharding_shard_key="custom_shard_key_2",
+    )
+
+    # Delete shard key
+    resp = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/shards/delete", json={
+            "shard_key": "custom_shard_key_2",
+        }
+    )
+
+    assert_http_ok(resp)
+
+    # Wait for resharding to abort (!?)
+    wait_for_resharding_to_finish(peer_api_uris, 3)
+
+# Test that resharding is automatically aborted, when we force-remove resharding peer
+def test_resharding_abort_on_remove_peer(tmp_path: pathlib.Path):
+    peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
+
+    # Remove peer
+    resp = requests.delete(f"{peer_api_uris[0]}/cluster/peer/{peer_ids[-1]}", json={
+        "force": True,
+    })
+
+    assert_http_ok(resp)
+
+    # Wait for resharding to abort
+    wait_for_resharding_to_finish(peer_api_uris[:-1], 3)
+
+# Test that resharding is automatically restarted, when we force-remove a peer,
+# that receives a *replica* of the new shard during replication
+def test_resharding_restart_on_remove_peer_during_replicate(tmp_path: pathlib.Path, peer_to_remove: str):
+    peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
+
+    # Wait for `stream_records` shard tranfer (during `replicate` resharding stage)
+    info = wait_for_resharding_shard_transfer_info(peer_api_uris[0], 'replicate', 'stream_records')
+
+    # Remove peer
+    resp = requests.delete(f"{peer_api_uris[0]}/cluster/peer/{info['to']}", json={
+        "force": True,
+    })
+
+    assert_http_ok(resp)
+
+    # Wait for resharding to restart and finish successfully
+    wait_for_resharding_restart(peer_api_uris[0])
+    wait_for_resharding_to_finish(peer_api_uris, 4)
+
+# Test that new shard *can't* be removed during resharding (before it has been replicated at least once)
+def test_resharding_try_abort_on_remove_shard_before_replicate(tmp_path: pathlib.Path):
+    peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
+
+    # Try to remove new shard (before it has been replicated at least once)
+    resp = requests.post(f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+        "drop_replica": {
+            "peer_id": peer_ids[-1],
+            "shard_id": 3,
+        }
+    })
+
+    assert resp.status_code == 400
+
+# Test that resharding is automatically restarted, when we remove new shard during replication
+def test_resharding_restart_on_remove_src_shard_during_replicate(tmp_path: pathlib.Path):
+    resharding_restart_on_remove_shard_during_replicate(tmp_path, 'from')
+
+# Test that resharding is automatically restarted, when we remove new shard during replication
+def test_resharding_restart_on_remove_dst_shard_during_replicate(tmp_path: pathlib.Path):
+    resharding_restart_on_remove_shard_during_replicate(tmp_path, 'to')
+
+def resharding_restart_on_remove_shard_during_replicate(tmp_path: pathlib.Path, shard_to_remove: str):
+    peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
+
+    # Wait for `stream_records` shard transfer (during `replicate` resharding stage)
+    info = wait_for_resharding_shard_transfer_info(peer_api_uris[0], 'replicate', 'stream_records')
+
+    # Remove replica of the new shard
+    resp = requests.post(f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+        "drop_replica": {
+            "peer_id": info[shard_to_remove],
+            "shard_id": 3,
+        }
+    })
+
+    assert_http_ok(resp)
+
+    # Wait for resharding to restart and finish successfully
+    wait_for_resharding_restart(peer_api_uris)
+    wait_for_resharding_to_finish(peer_api_uris, 4)
+
+
+def bootstrap_resharding(
+    tmp_path: pathlib.Path,
+    shard_keys: list[str] | str | None = None,
+    shard_number: int = 3,
+    replication_factor: int = 2,
+    replication_peer_idx: int = -1,
+    resharding_shard_key: str | None = None,
+):
+    peer_api_uris, peer_ids = bootstrap_cluster(tmp_path)
+
+    # Start resharding
+    resp = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "start_resharding": {
+                "peer_id": peer_ids[replication_peer_idx],
+                "shard_key": resharding_shard_key,
+            }
+        })
+
+    assert_http_ok(resp)
+
+    # Wait for resharding to start
+    wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
+
+    return (peer_api_uris, peer_ids)
+
+def bootstrap_cluster(
+    tmp_path: pathlib.Path,
+    shard_keys: list[str] | str | None = None,
+    shard_number: int = 3,
+    replication_factor: int = 2,
+) -> tuple[list[str], list[str]]:
+    assert_project_root()
+
+    num_points = 10000
+
+    # Prevent optimizers messing with point counts
+    env={
+        "QDRANT__STORAGE__OPTIMIZERS__INDEXING_THRESHOLD_KB": "0",
+    }
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
+
+    peer_ids = []
+    for peer_uri in peer_api_uris:
+        peer_ids.append(get_cluster_info(peer_api_uris[0])['peer_id'])
+
+    # Create collection
+    create_collection(
+        peer_api_uris[0],
+        COLLECTION_NAME,
+        shard_number,
+        replication_factor,
+        sharding_method='auto' if shard_keys is None else 'custom',
+    )
+
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris,
+    )
+
+    # Create custom shard keys (if required), and upload points to collection
+    if type(shard_keys) is not list:
+        shard_keys: list[str | None] = [shard_keys]
+
+    for shard_key in shard_keys:
+        # Create custom shard key (if required)
+        if shard_key is not None:
+            resp = requests.put(
+                f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/shards", json={
+                    "shard_key": shard_key,
+                    "shards_number": shard_number,
+                    "replication_factor": replication_factor,
+                }
+            )
+
+            assert_http_ok(resp)
+
+        # Upsert points to collection
+        upsert_random_points(peer_api_uris[0], num_points, shard_key=shard_key)
+
+    sleep(1)
+
+    return (peer_api_uris, peer_ids)
+
+def wait_for_resharding_shard_transfer_info(peer_uri: str, expected_stage: str | None, expected_method: str):
+    if expected_stage is not None:
+        wait_for_collection_resharding_operation_stage(peer_uri, COLLECTION_NAME, expected_stage)
+
+    wait_for_collection_shard_transfer_method(peer_uri, COLLECTION_NAME, expected_method)
+
+    info = get_collection_cluster_info(peer_uri, COLLECTION_NAME)
+    return info['shard_transfers'][0]
+
+def wait_for_resharding_restart(peer_uri: str):
+    wait_for_collection_resharding_operations_count(peer_uri, COLLECTION_NAME, 0)
+    wait_for_collection_resharding_operations_count(peer_uri, COLLECTION_NAME, 1)
+
+def wait_for_resharding_to_finish(peer_uris: list[str], expected_shard_number: int):
+    # Wait for resharding to finish
+    for peer_uri in peer_uris:
+        wait_for_collection_resharding_operations_count(peer_uri, COLLECTION_NAME, 0)
+
+    # Check that new shard was created
+    for peer_uri in peer_uris:
+        resp = get_collection_cluster_info(peer_uri, COLLECTION_NAME)
+        assert resp['shard_count'] == 4
 
 
 def run_in_background(run, *args, **kwargs):

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -800,7 +800,7 @@ def test_resharding_abort_on_remove_peer(tmp_path: pathlib.Path):
 def test_resharding_restart_on_remove_peer_during_replicate(tmp_path: pathlib.Path, peer_to_remove: str):
     peer_api_uris, peer_ids = bootstrap_resharding(tmp_path)
 
-    # Wait for `stream_records` shard tranfer (during `replicate` resharding stage)
+    # Wait for `stream_records` shard transfer (during `replicate` resharding stage)
     info = wait_for_resharding_shard_transfer_info(peer_api_uris[0], 'replicate', 'stream_records')
 
     # Remove peer

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -790,6 +790,7 @@ def test_resharding_abort_on_delete_shard_key(tmp_path: pathlib.Path):
     wait_for_resharding_to_finish(peer_api_uris, 3)
 
 # Test that resharding is automatically aborted, when we force-remove resharding peer
+@pytest.mark.skip(reason="seems like a deadlock is sometimes possible during explicit (?) abort, so the test is disabled until deadlock is fixed, to reduce flakiness")
 def test_resharding_abort_on_remove_peer(tmp_path: pathlib.Path):
     # Place resharding shard on the *last* peer for this test, so that the first peer would still
     # be available, after we remove *resharding* peer...

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -843,7 +843,7 @@ def test_resharding_restart_on_remove_src_shard_during_replicate(tmp_path: pathl
     resharding_restart_on_remove_shard_during_replicate(tmp_path, 'from')
 
 # Test that resharding is automatically restarted, when we remove new shard during replication
-@pytest.mark.skip(reason="resharding detects removing destination shard of replication shard transfer as successfull transfer")
+@pytest.mark.skip(reason="resharding detects removing destination shard of replication shard transfer as successful transfer")
 def test_resharding_restart_on_remove_dst_shard_during_replicate(tmp_path: pathlib.Path):
     resharding_restart_on_remove_shard_during_replicate(tmp_path, 'to')
 


### PR DESCRIPTION
Tracked in #4213.

This PR adds two main features:
- forbid to abort resharding, if it reached `ReshardStage::WriteHashRingCommitted` stage
- automatically cancel/abort resharding, when certain consensus operations applied, that affect collection or shards that is involved in resharding:
	- if collection is deleted, resharding is automatically aborted
	- if shard key is deleted, resharding is automatically aborted
	- if peer is force-removed from cluster, resharding is automatically aborted
- a few other relevant operations does not require special handling:
	- it's impossible to delete last repilca of a shard, so no special handling required before new shard is replicated
	- and it seems like if either replica of new shard is removed *during* replication, it should restart the whole resharding, which is good-enough, IMO
		- however, there seem to be some bugs related to removing replicas involved in stream-records transfer 😬
- tests are implemented for all scenarios
	- they are super flakey though
	- tests for removing shard replicas are also implemented, but currently disabled due to bugs

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
