### PR TITLE
universal-search: Query group API should support lookup_from

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3236,6 +3236,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | score_threshold | [float](#float) | optional | Return points with scores better than this threshold. |
 | with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) |  | Options for specifying which payload to include or not |
 | with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) | optional | Options for specifying which vectors to include into response |
+| lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | The location to use for IDs lookup, if not specified - use the current collection and the &#39;using&#39; vector |
 | limit | [uint64](#uint64) | optional | Max number of points. Default is 3. |
 | group_size | [uint64](#uint64) | optional | Maximum amount of points to return per group. Default to 10. |
 | group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12288,6 +12288,18 @@
               }
             ]
           },
+          "lookup_from": {
+            "description": "The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector Note: the other collection vectors should have the same vector size as the 'using' vector in the current collection",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LookupLocation"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "group_by": {
             "description": "Payload field to group by, must be a string or number field. If the field contains more than 1 value, all values will be used for grouping. One point can be in multiple groups.",
             "type": "string",

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -565,13 +565,14 @@ message QueryPointGroups {
   optional float score_threshold = 7; // Return points with scores better than this threshold.
   WithPayloadSelector with_payload = 8; // Options for specifying which payload to include or not
   optional WithVectorsSelector with_vectors = 9; // Options for specifying which vectors to include into response
-  optional uint64 limit = 10; // Max number of points. Default is 3.
-  optional uint64 group_size = 11; // Maximum amount of points to return per group. Default to 10.
-  string group_by = 12; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
-  optional ReadConsistency read_consistency = 13; // Options for specifying read consistency guarantees
-  optional WithLookup with_lookup = 14; // Options for specifying how to use the group id to lookup points in another collection
-  optional uint64 timeout = 15; // If set, overrides global timeout setting for this request. Unit is seconds.
-  optional ShardKeySelector shard_key_selector = 16; // Specify in which shards to look for the points, if not specified - look in all shards
+  optional LookupLocation lookup_from = 10; // The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+  optional uint64 limit = 11; // Max number of points. Default is 3.
+  optional uint64 group_size = 12; // Maximum amount of points to return per group. Default to 10.
+  string group_by = 13; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+  optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
+  optional WithLookup with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
+  optional uint64 timeout = 16; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 17; // Specify in which shards to look for the points, if not specified - look in all shards
 }
 
 message PointsUpdateOperation {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5004,26 +5004,29 @@ pub struct QueryPointGroups {
     /// Options for specifying which vectors to include into response
     #[prost(message, optional, tag = "9")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    #[prost(message, optional, tag = "10")]
+    pub lookup_from: ::core::option::Option<LookupLocation>,
     /// Max number of points. Default is 3.
-    #[prost(uint64, optional, tag = "10")]
+    #[prost(uint64, optional, tag = "11")]
     pub limit: ::core::option::Option<u64>,
     /// Maximum amount of points to return per group. Default to 10.
-    #[prost(uint64, optional, tag = "11")]
+    #[prost(uint64, optional, tag = "12")]
     pub group_size: ::core::option::Option<u64>,
     /// Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
-    #[prost(string, tag = "12")]
+    #[prost(string, tag = "13")]
     pub group_by: ::prost::alloc::string::String,
     /// Options for specifying read consistency guarantees
-    #[prost(message, optional, tag = "13")]
+    #[prost(message, optional, tag = "14")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
     /// Options for specifying how to use the group id to lookup points in another collection
-    #[prost(message, optional, tag = "14")]
+    #[prost(message, optional, tag = "15")]
     pub with_lookup: ::core::option::Option<WithLookup>,
     /// If set, overrides global timeout setting for this request. Unit is seconds.
-    #[prost(uint64, optional, tag = "15")]
+    #[prost(uint64, optional, tag = "16")]
     pub timeout: ::core::option::Option<u64>,
     /// Specify in which shards to look for the points, if not specified - look in all shards
-    #[prost(message, optional, tag = "16")]
+    #[prost(message, optional, tag = "17")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -617,6 +617,11 @@ pub struct QueryGroupsRequestInternal {
     /// Options for specifying which payload to include or not. Default is false.
     pub with_payload: Option<WithPayloadInterface>,
 
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    /// Note: the other collection vectors should have the same vector size as the 'using' vector in the current collection
+    #[serde(default)]
+    pub lookup_from: Option<LookupLocation>,
+
     #[serde(flatten)]
     #[validate]
     pub group_request: QueryBaseGroupRequest,

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -264,6 +264,7 @@ impl From<CollectionQueryGroupsRequest> for GroupRequest {
             score_threshold,
             with_vector,
             with_payload,
+            lookup_from,
             group_by,
             group_size,
             limit,
@@ -281,7 +282,7 @@ impl From<CollectionQueryGroupsRequest> for GroupRequest {
             params,
             with_vector,
             with_payload,
-            lookup_from: None,
+            lookup_from,
         };
 
         GroupRequest {

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -69,6 +69,7 @@ pub struct CollectionQueryGroupsRequest {
     pub score_threshold: Option<ScoreType>,
     pub with_vector: WithVector,
     pub with_payload: WithPayloadInterface,
+    pub lookup_from: Option<LookupLocation>,
     pub group_by: JsonPath,
     pub group_size: usize,
     pub limit: usize,
@@ -564,6 +565,7 @@ mod from_rest {
                 params,
                 with_vector,
                 with_payload,
+                lookup_from,
                 group_request,
             } = value;
 
@@ -576,6 +578,7 @@ mod from_rest {
                 params,
                 with_vector: with_vector.unwrap_or(CollectionQueryRequest::DEFAULT_WITH_VECTOR),
                 with_payload: with_payload.unwrap_or(CollectionQueryRequest::DEFAULT_WITH_PAYLOAD),
+                lookup_from,
                 limit: group_request
                     .limit
                     .unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
@@ -772,6 +775,7 @@ pub mod from_grpc {
                 score_threshold,
                 with_payload,
                 with_vectors,
+                lookup_from,
                 limit,
                 group_size,
                 group_by,
@@ -797,6 +801,7 @@ pub mod from_grpc {
                     .map(TryFrom::try_from)
                     .transpose()?
                     .unwrap_or(CollectionQueryRequest::DEFAULT_WITH_PAYLOAD),
+                lookup_from: lookup_from.map(From::from),
                 group_by: json_path_from_proto(&group_by)?,
                 group_size: group_size
                     .map(|s| s as usize)


### PR DESCRIPTION
This PR adds the support for `lookup_from` in the query group API which was missing from https://github.com/qdrant/qdrant/pull/4656

It enables to reproduce the legacy recommend groups API.

