### PR TITLE
When resharding is aborted, update the shard key mapping

### DIFF
--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -244,7 +244,21 @@ impl ShardHolder {
 
             if shard.peers().is_empty() {
                 log::debug!("removing {shard_id} replica set, because replica set is empty");
+
+                if let Some(shard_key) = shard_key {
+                    self.key_mapping.write_optional(|key_mapping| {
+                        if !key_mapping.contains_key(shard_key) {
+                            return None;
+                        }
+
+                        let mut key_mapping = key_mapping.clone();
+                        key_mapping.get_mut(shard_key).unwrap().remove(&shard_id);
+                        Some(key_mapping)
+                    })?;
+                }
+
                 self.drop_and_remove_shard(shard_id).await?;
+                self.shard_id_to_key_mapping.remove(&shard_id);
             }
         } else {
             log::warn!(


### PR DESCRIPTION
Tracked in: #4213 

When resharding is aborted, we need to update the shard key mapping. This was not done.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?