### PR TITLE
New Subset Matching in Array Fields

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7121,6 +7121,9 @@
           },
           {
             "$ref": "#/components/schemas/MatchExcept"
+          },
+          {
+            "$ref": "#/components/schemas/MatchSubset"
           }
         ]
       },
@@ -7201,6 +7204,18 @@
         ],
         "properties": {
           "except": {
+            "$ref": "#/components/schemas/AnyVariants"
+          }
+        }
+      },
+      "MatchSubset": {
+        "description": "Should have all values matching any of the given values",
+        "type": "object",
+        "required": [
+          "subset"
+        ],
+        "properties": {
+          "subset": {
             "$ref": "#/components/schemas/AnyVariants"
           }
         }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1557,16 +1557,16 @@ impl TryFrom<Match> for segment::types::Match {
                 MatchValue::Integers(ints) => ints.integers.into(),
                 MatchValue::ExceptKeywords(kwds) => {
                     segment::types::Match::Except(kwds.strings.into())
-                },
+                }
                 MatchValue::ExceptIntegers(ints) => {
                     segment::types::Match::Except(ints.integers.into())
-                },
+                }
                 MatchValue::SubsetKeywords(kwds) => {
                     segment::types::Match::Subset(kwds.strings.into())
-                },
+                }
                 MatchValue::SubsetIntegers(ints) => {
                     segment::types::Match::Subset(ints.integers.into())
-                },
+                }
             }),
             _ => Err(Status::invalid_argument("Malformed Match condition")),
         }
@@ -1613,7 +1613,7 @@ impl From<segment::types::Match> for Match {
                     let integers = integers.into_iter().collect();
                     MatchValue::SubsetIntegers(RepeatedIntegers { integers })
                 }
-            }
+            },
         };
         Self {
             match_value: Some(match_value),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1555,12 +1555,18 @@ impl TryFrom<Match> for segment::types::Match {
                 MatchValue::Text(text) => segment::types::Match::Text(text.into()),
                 MatchValue::Keywords(kwds) => kwds.strings.into(),
                 MatchValue::Integers(ints) => ints.integers.into(),
-                MatchValue::ExceptIntegers(kwds) => {
-                    segment::types::Match::Except(kwds.integers.into())
-                }
-                MatchValue::ExceptKeywords(ints) => {
-                    segment::types::Match::Except(ints.strings.into())
-                }
+                MatchValue::ExceptKeywords(kwds) => {
+                    segment::types::Match::Except(kwds.strings.into())
+                },
+                MatchValue::ExceptIntegers(ints) => {
+                    segment::types::Match::Except(ints.integers.into())
+                },
+                MatchValue::SubsetKeywords(kwds) => {
+                    segment::types::Match::Subset(kwds.strings.into())
+                },
+                MatchValue::SubsetIntegers(ints) => {
+                    segment::types::Match::Subset(ints.integers.into())
+                },
             }),
             _ => Err(Status::invalid_argument("Malformed Match condition")),
         }
@@ -1598,6 +1604,16 @@ impl From<segment::types::Match> for Match {
                     MatchValue::ExceptIntegers(RepeatedIntegers { integers })
                 }
             },
+            segment::types::Match::Subset(subset) => match subset.subset {
+                segment::types::AnyVariants::Keywords(strings) => {
+                    let strings = strings.into_iter().collect();
+                    MatchValue::SubsetKeywords(RepeatedStrings { strings })
+                }
+                segment::types::AnyVariants::Integers(integers) => {
+                    let integers = integers.into_iter().collect();
+                    MatchValue::SubsetIntegers(RepeatedIntegers { integers })
+                }
+            }
         };
         Self {
             match_value: Some(match_value),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -854,6 +854,8 @@ message Match {
     RepeatedIntegers integers = 6; // Match multiple integers
     RepeatedIntegers except_integers = 7; // Match any other value except those integers
     RepeatedStrings except_keywords = 8; // Match any other value except those keywords
+    RepeatedStrings subset_integers = 9; // Match all integers are in those integers
+    RepeatedStrings subset_keywords = 10; // Match all keywords are in those keywords
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5616,7 +5616,7 @@ pub struct FieldCondition {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Match {
-    #[prost(oneof = "r#match::MatchValue", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
+    #[prost(oneof = "r#match::MatchValue", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub match_value: ::core::option::Option<r#match::MatchValue>,
 }
 /// Nested message and enum types in `Match`.
@@ -5649,6 +5649,12 @@ pub mod r#match {
         /// Match any other value except those keywords
         #[prost(message, tag = "8")]
         ExceptKeywords(super::RepeatedStrings),
+        /// Match all integers are in those integers
+        #[prost(message, tag = "9")]
+        SubsetIntegers(super::RepeatedIntegers),
+        /// Match all keywords are in those keywords
+        #[prost(message, tag = "10")]
+        SubsetKeywords(super::RepeatedStrings),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -48,6 +48,21 @@ impl<N: Default> ImmutablePointToValues<N> {
         }
     }
 
+    pub fn check_values_all(&self, idx: PointOffsetType, check_fn: impl Fn(&N) -> bool) -> bool {
+        let range = if let Some(range) = self.point_to_values.get(idx as usize).cloned() {
+            range
+        } else {
+            return false;
+        };
+
+        let range = range.start as usize..range.end as usize;
+        if let Some(values) = self.point_to_values_container.get(range) {
+            values.iter().all(check_fn)
+        } else {
+            false
+        }
+    }
+
     pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {
         let range = self.point_to_values.get(idx as usize)?.clone();
         let range = range.start as usize..range.end as usize;

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -198,6 +198,11 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
             .check_values_any(idx, |v| check_fn(v.borrow()))
     }
 
+    pub fn check_values_all(&self, idx: PointOffsetType, check_fn: impl Fn(&N) -> bool) -> bool {
+        self.point_to_values
+            .check_values_all(idx, |v| check_fn(v.borrow()))
+    }
+
     pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {
         Some(self.point_to_values.get_values(idx)?.map(|v| v.borrow()))
     }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -89,6 +89,13 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
         }
     }
 
+    pub fn check_values_all(&self, idx: PointOffsetType, check_fn: impl Fn(&N) -> bool) -> bool {
+        match self {
+            MapIndex::Mutable(index) => index.check_values_all(idx, check_fn),
+            MapIndex::Immutable(index) => index.check_values_all(idx, check_fn),
+        }
+    }
+
     pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = &N> + '_>> {
         match self {
             MapIndex::Mutable(index) => Some(Box::new(index.get_values(idx)?)),

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -125,6 +125,13 @@ impl<N: MapIndexKey + ?Sized> MutableMapIndex<N> {
             .unwrap_or(false)
     }
 
+    pub fn check_values_all(&self, idx: PointOffsetType, check_fn: impl Fn(&N) -> bool) -> bool {
+        self.point_to_values
+            .get(idx as usize)
+            .map(|values| values.iter().all(|v| check_fn(v.borrow())))
+            .unwrap_or(false)
+    }
+
     pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {
         Some(
             self.point_to_values

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -15,8 +15,8 @@ use crate::payload_storage::query_checker::{
 };
 use crate::types::{
     AnyVariants, Condition, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox,
-    GeoPolygon, GeoRadius, IntPayloadType, Match, MatchAny, MatchExcept, MatchSubset,
-    MatchText, MatchValue, OwnedPayloadRef, PayloadContainer, Range, RangeInterface, ValueVariants,
+    GeoPolygon, GeoRadius, IntPayloadType, Match, MatchAny, MatchExcept, MatchSubset, MatchText,
+    MatchValue, OwnedPayloadRef, PayloadContainer, Range, RangeInterface, ValueVariants,
 };
 
 pub fn condition_converter<'a>(
@@ -344,12 +344,13 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
                 index.values_count(point_id) > 0
             })),
         },
-        Match::Subset(MatchSubset{subset}) => match (subset, index) {
+        Match::Subset(MatchSubset { subset }) => match (subset, index) {
             (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
                     index.get_values(point_id).map_or(false, |values| {
                         if list.len() < INDEXSET_ITER_THRESHOLD {
-                            list.iter().all(|s| values.iter().any(|k| s.as_str() == k.as_ref()))
+                            list.iter()
+                                .all(|s| values.iter().any(|k| s.as_str() == k.as_ref()))
                         } else {
                             list.iter().all(|s| values.iter().any(|k| s == k.as_str()))
                         }

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -369,7 +369,7 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
                     }))
                 }
             }
-            _ => None
+            _ => None,
         },
     }
 }

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -146,7 +146,7 @@ impl ValueChecker for Match {
                 (Value::Number(_), _) => true,
                 (Value::String(_), _) => true,
             },
-            Match::Subset(MatchSubset{subset}) => match (payload, subset) {
+            Match::Subset(MatchSubset { subset }) => match (payload, subset) {
                 (Value::String(stored), AnyVariants::Keywords(list)) => {
                     if list.len() < INDEXSET_ITER_THRESHOLD {
                         list.iter().any(|i| i.as_str() == stored.as_str())
@@ -165,7 +165,7 @@ impl ValueChecker for Match {
                     })
                     .unwrap_or(false),
                 _ => false,
-            }
+            },
         }
     }
 }

--- a/lib/segment/src/problems/unindexed_field.rs
+++ b/lib/segment/src/problems/unindexed_field.rs
@@ -212,6 +212,7 @@ fn infer_schema_from_field_condition(field_condition: &FieldCondition) -> Vec<Pa
             }
             Match::Any(match_any) => infer_schema_from_any_variants(&match_any.any),
             Match::Except(match_except) => infer_schema_from_any_variants(&match_except.except),
+            Match::Subset(match_subset) => infer_schema_from_any_variants(&match_subset.subset),
         })
     }
     if let Some(range_interface) = range {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1344,6 +1344,13 @@ pub struct MatchExcept {
     pub except: AnyVariants,
 }
 
+/// Should have all the values matching any of the given values
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct MatchSubset {
+    pub subset: AnyVariants,
+}
+
 /// Match filter request
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(untagged, rename_all = "snake_case")]
@@ -1352,6 +1359,7 @@ pub enum MatchInterface {
     Text(MatchText),
     Any(MatchAny),
     Except(MatchExcept),
+    Subset(MatchSubset),
 }
 
 /// Match filter request
@@ -1362,6 +1370,7 @@ pub enum Match {
     Text(MatchText),
     Any(MatchAny),
     Except(MatchExcept),
+    Subset(MatchSubset),
 }
 
 impl Match {
@@ -1380,6 +1389,10 @@ impl Match {
     pub fn new_except(except: AnyVariants) -> Self {
         Self::Except(MatchExcept { except })
     }
+
+    pub fn new_subset(subset: AnyVariants) -> Self {
+        Self::Subset(MatchSubset { subset })
+    }
 }
 
 impl From<AnyVariants> for Match {
@@ -1396,6 +1409,9 @@ impl From<MatchInterface> for Match {
             MatchInterface::Any(any) => Self::Any(MatchAny { any: any.any }),
             MatchInterface::Except(except) => Self::Except(MatchExcept {
                 except: except.except,
+            }),
+            MatchInterface::Subset(subset) => Self::Subset(MatchSubset {
+                subset: subset.subset,
             }),
         }
     }
@@ -1451,6 +1467,15 @@ impl From<Vec<String>> for MatchExcept {
     }
 }
 
+impl From<Vec<String>> for MatchSubset {
+    fn from(keywords: Vec<String>) -> Self {
+        let keywords: IndexSet<String, FnvBuildHasher> = keywords.into_iter().collect();
+        MatchSubset {
+            subset: AnyVariants::Keywords(keywords),
+        }
+    }
+}
+
 impl From<Vec<IntPayloadType>> for Match {
     fn from(integers: Vec<IntPayloadType>) -> Self {
         let integers: IndexSet<_, FnvBuildHasher> = integers.into_iter().collect();
@@ -1465,6 +1490,15 @@ impl From<Vec<IntPayloadType>> for MatchExcept {
         let integers: IndexSet<_, FnvBuildHasher> = integers.into_iter().collect();
         MatchExcept {
             except: AnyVariants::Integers(integers),
+        }
+    }
+}
+
+impl From<Vec<IntPayloadType>> for MatchSubset {
+    fn from(integers: Vec<IntPayloadType>) -> Self {
+        let integers: IndexSet<_, FnvBuildHasher> = integers.into_iter().collect();
+        MatchSubset {
+            subset: AnyVariants::Integers(integers),
         }
     }
 }

--- a/tests/openapi/openapi_integration/test_filter.py
+++ b/tests/openapi/openapi_integration/test_filter.py
@@ -67,3 +67,34 @@ def test_just_key():
     error = response.json()["status"]["error"]
     assert "Validation error in JSON body" in error
     assert "At least one field condition must be specified" in error
+
+
+def test_match_subset():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "limit": 3,
+            "filter": {
+                "must": [
+                    {
+                        "key": "city",
+                        "match": {
+                            "subset": ["Berlin", "Moscow"]
+                        }
+                    }
+                ]
+            }
+        }
+    )
+    assert response.ok
+
+    json = response.json()
+    assert len(json['result']) == 3
+
+    ids = [x['id'] for x in json['result']]
+    assert 1 in ids
+    assert 3 in ids
+    assert 8 in ids


### PR DESCRIPTION
Following the feature request I opened here: #4679, I tried to implement a new subset filter that we could express like this:

> Given a match query for a field with an array, match all the points that have a subset of the array query for this field.

(See the feature request for more information about this new feature.)

- As this is my first contribution to Qdrant and Rust is not my primary programming language, please let me know if I need to change anything.
- I created a PR to update the documentation to include this new filter (https://github.com/qdrant/landing_page/pull/1038).
- Since this filter is crucial for our use case, please let me know if you could consider merging this PR. If not, we could quickly consider alternative solutions.
- I'm not sure if the client libraries are autogenerated from the server or if we need to modify them to include this new feature. If you approve this PR and we need to change all the clients, I would be willing to do it 🙂

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

resolve #4679 
