### PR TITLE
Introduce FieldIndexBuilder

### DIFF
--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -3,9 +3,13 @@ use std::sync::Arc;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
+use serde_json::Value;
 
 use self::memory::{BinaryItem, BinaryMemory};
-use super::{CardinalityEstimation, PayloadFieldIndex, PrimaryCondition, ValueIndexer};
+use super::{
+    CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndex, PrimaryCondition,
+    ValueIndexer,
+};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
@@ -178,6 +182,10 @@ impl BinaryIndex {
         }
     }
 
+    pub fn builder(db: Arc<RwLock<DB>>, field_name: &str) -> BinaryIndexBuilder {
+        BinaryIndexBuilder(Self::new(db, field_name))
+    }
+
     fn storage_cf_name(field: &str) -> String {
         format!("{}_binary", field)
     }
@@ -212,6 +220,24 @@ impl BinaryIndex {
     /// Check if the point has a false value
     pub fn values_has_false(&self, point_id: PointOffsetType) -> bool {
         self.memory.get(point_id).has_false()
+    }
+}
+
+pub struct BinaryIndexBuilder(BinaryIndex);
+
+impl FieldIndexBuilderTrait for BinaryIndexBuilder {
+    type FieldIndexType = BinaryIndex;
+
+    fn init(&mut self) -> OperationResult<()> {
+        self.0.recreate()
+    }
+
+    fn add_point(&mut self, id: PointOffsetType, payload: &[&Value]) -> OperationResult<()> {
+        self.0.add_point(id, payload)
+    }
+
+    fn finalize(self) -> OperationResult<Self::FieldIndexType> {
+        Ok(self.0)
     }
 }
 

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use self::immutable_geo_index::ImmutableGeoMapIndex;
 use self::mutable_geo_index::MutableGeoMapIndex;
+use super::FieldIndexBuilderTrait;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::Flusher;
@@ -44,6 +45,10 @@ impl GeoMapIndex {
         } else {
             GeoMapIndex::Immutable(ImmutableGeoMapIndex::new(db, &store_cf_name))
         }
+    }
+
+    pub fn builder(db: Arc<RwLock<DB>>, field: &str) -> GeoMapIndexBuilder {
+        GeoMapIndexBuilder(Self::new(db, field, true))
     }
 
     fn db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
@@ -284,6 +289,24 @@ impl GeoMapIndex {
 
     pub fn values_is_empty(&self, idx: PointOffsetType) -> bool {
         self.values_count(idx) == 0
+    }
+}
+
+pub struct GeoMapIndexBuilder(GeoMapIndex);
+
+impl FieldIndexBuilderTrait for GeoMapIndexBuilder {
+    type FieldIndexType = GeoMapIndex;
+
+    fn init(&mut self) -> OperationResult<()> {
+        self.0.db_wrapper().recreate_column_family()
+    }
+
+    fn add_point(&mut self, id: PointOffsetType, payload: &[&Value]) -> OperationResult<()> {
+        self.0.add_point(id, payload)
+    }
+
+    fn finalize(self) -> OperationResult<Self::FieldIndexType> {
+        Ok(self.0)
     }
 }
 

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -5,6 +5,7 @@ use rocksdb::DB;
 
 use super::binary_index::BinaryIndex;
 use super::map_index::MapIndex;
+use super::FieldIndexBuilder;
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::numeric_index::NumericIndex;
@@ -60,6 +61,52 @@ pub fn index_selector(
                 db,
                 field,
                 is_appendable,
+            ))]
+        }
+    }
+}
+
+/// Selects index builder based on field type
+pub fn index_builder_selector(
+    field: &JsonPath,
+    payload_schema: &PayloadFieldSchema,
+    db: Arc<RwLock<DB>>,
+) -> Vec<FieldIndexBuilder> {
+    let field: String = field.to_string();
+    let field = field.as_str();
+
+    match payload_schema.expand().as_ref() {
+        PayloadSchemaParams::Keyword(_) => vec![FieldIndexBuilder::KeywordIndex(
+            MapIndex::builder(db, field),
+        )],
+        PayloadSchemaParams::Integer(integer_params) => {
+            let lookup = integer_params
+                .lookup
+                .then(|| FieldIndexBuilder::IntMapIndex(MapIndex::builder(db.clone(), field)));
+            let range = integer_params
+                .range
+                .then(|| FieldIndexBuilder::IntIndex(NumericIndex::builder(db, field)));
+            lookup.into_iter().chain(range).collect()
+        }
+        PayloadSchemaParams::Float(_) => {
+            vec![FieldIndexBuilder::FloatIndex(NumericIndex::builder(
+                db, field,
+            ))]
+        }
+        PayloadSchemaParams::Geo(_) => {
+            vec![FieldIndexBuilder::GeoIndex(GeoMapIndex::builder(db, field))]
+        }
+        PayloadSchemaParams::Text(text_index_params) => vec![FieldIndexBuilder::FullTextIndex(
+            FullTextIndex::builder(db, text_index_params.clone(), field),
+        )],
+        PayloadSchemaParams::Bool(_) => {
+            vec![FieldIndexBuilder::BinaryIndex(BinaryIndex::builder(
+                db, field,
+            ))]
+        }
+        PayloadSchemaParams::Datetime(_) => {
+            vec![FieldIndexBuilder::DatetimeIndex(NumericIndex::builder(
+                db, field,
             ))]
         }
     }


### PR DESCRIPTION
Tracking issue: #4502. Continuation of #4690.

This PR introduces the following items:
- `trait FieldIndexBuilderTrait`.
- `enum FieldIndexBuilder` (contains all `FieldIndexBuilderTrait` implementations).
- `index_builder_selector()` which is similar to `index_selector()`.
- An implementation of `FieldIndexBuilderTrait` for each index type.

Right now, the builders are merely single-line methods that implement the same old logic. In subsequent PRs they will be extended to support mmap indices.