### PR TITLE
Fix Charabia Chinese tokenization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "lindera",
  "litemap",
  "once_cell",
+ "pinyin",
  "serde",
  "slice-group-by",
  "unicode-normalization",
@@ -4010,6 +4011,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pinyin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f2611cd06a1ac239a0cea4521de9eb068a6ca110324ee00631aa68daa74fc0"
 
 [[package]]
 name = "pkg-config"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 workspace = true
 
 [features]
-multiling-chinese = ["charabia/chinese"]
+multiling-chinese = ["charabia/chinese-segmentation", "charabia/chinese-normalization", "charabia/chinese-normalization-pinyin"]
 multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
 testing = ["common/testing", "sparse/testing"]


### PR DESCRIPTION
Charabia [0.8.9](https://github.com/meilisearch/charabia/releases/tag/v0.8.9) broke our chinese tokenization by splitting the feature `chinese` into 3 different components.

https://github.com/meilisearch/charabia/pull/282

This PR reinstates the previous behavior.

Locally tested with:

```
qdrant on  fix-charabia-chinese-toknenization [!] is 📦 v1.10.2-dev via 🦀 v1.79.0 took 1m43s
❯ cargo t -p segment --lib test_multilingual_tokenizer_chinese --all-features
     Locking 1 package to latest compatible version
      Adding pinyin v0.10.0
   Compiling pinyin v0.10.0
   Compiling segment v0.6.0 (/home/agourlay/Workspace/qdrant/lib/segment)
   Compiling charabia v0.8.12
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 39s
     Running unittests src/lib.rs (target/debug/deps/segment-ea2d056be7f88852)

running 1 test
test index::field_index::full_text_index::tokenizers::tests::test_multilingual_tokenizer_chinese ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 365 filtered out; finished in 2.11s
```

