### PR TITLE
set RocksDB compression to lz4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,7 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "lz4-sys",
 ]
 
 [[package]]
@@ -3394,6 +3395,16 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -42,7 +42,7 @@ tempfile = { workspace = true }
 parking_lot = { workspace = true }
 rayon = "1.10.0"
 itertools = { workspace = true }
-rocksdb = { version = "0.22.0", default-features = false, features = ["snappy"] }
+rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "lz4"] }
 uuid = { workspace = true }
 bincode = "1.3"
 serde = { workspace = true }

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -49,6 +49,7 @@ pub fn db_options() -> Options {
     options.set_delete_obsolete_files_period_micros(DB_DELETE_OBSOLETE_FILES_PERIOD);
     options.create_missing_column_families(true);
     options.set_max_open_files(DB_MAX_OPEN_FILES as i32);
+    options.set_compression_type(rocksdb::DBCompressionType::Lz4);
 
     // Qdrant relies on it's own WAL for durability
     options.set_wal_recovery_mode(DBRecoveryMode::TolerateCorruptedTailRecords);


### PR DESCRIPTION
context: #804 

This PR changes the compression scheme used by RocksDB from Snappy to LZ4.

The change is visible in the `LOG` file for each segment:

```
2024/07/24-12:28:44.220547 63740 Compression algorithms supported:
2024/07/24-12:28:44.220552 63740 	kZSTD supported: 0
2024/07/24-12:28:44.220556 63740 	kXpressCompression supported: 0
2024/07/24-12:28:44.220558 63740 	kBZip2Compression supported: 0
2024/07/24-12:28:44.220561 63740 	kZSTDNotFinalCompression supported: 0
2024/07/24-12:28:44.220564 63740 	kLZ4Compression supported: 1
2024/07/24-12:28:44.220566 63740 	kZlibCompression supported: 0
2024/07/24-12:28:44.220568 63740 	kLZ4HCCompression supported: 1
2024/07/24-12:28:44.220570 63740 	kSnappyCompression supported: 1
...
2024/07/24-12:28:44.221588 63740        Options.write_buffer_size: 10485760
2024/07/24-12:28:44.221590 63740  Options.max_write_buffer_number: 2
2024/07/24-12:28:44.221593 63740          Options.compression: LZ4
2024/07/24-12:28:44.221595 63740                  Options.bottommost_compression: Disabled
```

The new RocksDB binary that is built:
- supports Snappy and LZ4 when reading data.
- uses LZ4 when compressing

## Motivation

- Snappy is not the recommended compression scheme by the RockdDB team

> Use options.compression to specify the compression to use. By default it is Snappy. We believe LZ4 is almost always better than Snappy. We leave Snappy as default to avoid unexpected compatibility problems to previous users.

source: https://github.com/facebook/rocksdb/wiki/Compression

- Snappy shows up in our profiling traces (#804) and we expect LZ4 to be more performant for decompression

- LZ4 has a slightly better compression rate

source: https://www.percona.com/blog/evaluating-database-compression-methods-update/

## Why LZ4 and not ZSTD?

> If you want to further reduce space and have some free CPU to use, you can try to set a heavy-weight compression by setting options.bottommost_compression. The bottommost level will be compressed using this compression style. Usually the bottommost level contains majority of the data, so users get an almost optimal space setting, without paying CPU for compressing all the data at any level. We recommend ZSTD. If it is not available, Zlib is the second choice. If you have a lot of free CPU and want to reduce not just space but write amplification too, try to set options.compression to heavy weight compression type. We recommend ZSTD.

source: https://github.com/facebook/rocksdb/wiki/Compression

ZSTD seems to offer a better compression ratio but consumes more free CPU.

LZ4 seems like a safer alternative and a net win coming from Snappy.

## Storage compatibility

The compression scheme is encoded into each SSTable independently.
This means that as long as we keep the `snappy` feature flag, we will be able to read the existing legacy SSTable.

This can be observed with our storage compatibility tests on this PR which are able to read and restore Snappy storages and snapshots.

LZ4 will then be used for newly created SSTable, so that overtime all data using Snappy should be phased out.

Trying to read LZ4 compressed data using the `dev` branch fails with.

```
2024-07-24T11:01:13.628213Z ERROR collection::shards::replica_set: Failed to load local shard "./storage/collections/neurIPS_sparse_1M_bench/0", initializing "dummy" shard instead: Service internal error: RocksDB open error: Not implemented: Unsupported compression method for this build: LZ4
```

## Performance gains

### No change on CI benchmarks

I tried several datasets with [manual](http://78.47.239.240:3000/d/f5679ed0-2076-479f-995a-227d6d886b2c/manual-benchmarks?orgId=1) CI benchmarks:

- laion-small-clip
- h-and-m-2048-angular-filters 
- msmarco-sparse-100K 

### Filtered search

Benching filtered payload search with payload on disk improvements with `bfb`

`cargo run -r -- -n 100000 --on-disk-vectors false --on-disk-payload --keywords 2 --search --search-with-payload`

#### Snappy

```
--- RPS ---
Min rps: 389.49048099067477
Avg rps: 1255.6717303238847
Median rps: 1264.3980889476318
Max rps: 1286.1560395475747
```

#### LZ4

```
--- RPS ---
Min rps: 985.7070155820244
Avg rps: 1024.175021636829
Median rps: 998.7657853295858
Max rps: 1520.7703775981486
```

LZ4 has much better min and max, Snappy is better in the center of the distribution.

### Writes

LZ4 shows up as well in the profile when performing heavy writes

![lz4-compress](https://github.com/user-attachments/assets/345d2aa7-2a27-4902-b7f5-5690fc129ee5)

But the write throughput is equivalent to Snappy's when using `bfb`

`cargo run -r -- -n 5000000 --on-disk-vectors false --on-disk-payload --keywords 2`

### Segment load time

Using `bfb` to inject 5M dense vectors

`cargo run -r -- -n 5000000 --on-disk-vectors false --on-disk-payload --keywords 2`

#### snappy

11 seconds

```
2024-07-24T11:37:27.669470Z  INFO storage::content_manager::toc: Loading collection: benchmark
2024-07-24T11:37:27.980746Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 91800
2024-07-24T11:37:27.980767Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 44 MB
2024-07-24T11:37:29.747222Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 764100
2024-07-24T11:37:29.747262Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 373 MB
2024-07-24T11:37:30.926450Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 1031800
2024-07-24T11:37:30.926526Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 503 MB
2024-07-24T11:37:38.221742Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 3112300
2024-07-24T11:37:38.221770Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 1519 MB
2024-07-24T11:37:38.668723Z DEBUG qdrant: Loaded collection: benchmark
```


#### LZ4

9 seconds

```
2024-07-24T12:18:18.763587Z  INFO storage::content_manager::toc: Loading collection: benchmark
2024-07-24T12:18:19.086210Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 90500
2024-07-24T12:18:19.086239Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 44 MB
2024-07-24T12:18:20.809734Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 744700
2024-07-24T12:18:20.809766Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 363 MB
2024-07-24T12:18:21.665604Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 1051100
2024-07-24T12:18:21.665625Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 513 MB
2024-07-24T12:18:26.685881Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Segment vectors: 3113700
2024-07-24T12:18:26.685906Z DEBUG segment::vector_storage::dense::simple_dense_vector_storage: Estimated segment size 1520 MB
2024-07-24T12:18:27.036696Z DEBUG qdrant: Loaded collection: benchmark
```

### Compression ratio

Testing against a storage of 1M sparse vectors:

`find storage -type f -name '*.sst' -exec du -b {} + | awk '{total += $1} END {print total " bytes"}'`

- Snappy : 1076737788 bytes
- LZ4        : 1077566575 bytes

They seem equivalent.

## Conclusion

Going with LZ4 improves our segment load time and search to some extend.

## Future work

Experiment with the `bottommost_compression` option with LZ4 and investigate extensively the tradeoff for switching to ZSTD.
