### PR TITLE
Fix hash ring rebuilding and loading while resharding

### DIFF
--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -281,8 +281,8 @@ impl<T: Hash + Copy> HashRing<T> {
         T: std::cmp::PartialEq,
     {
         match self {
-            Inner::Raw(ring) => ring.clone().into_iter().any(|node| node == *shard),
-            Inner::Fair { ring, .. } => ring.clone().into_iter().any(|(node, _)| node == *shard),
+            HashRing::Raw(ring) => ring.clone().into_iter().any(|node| node == *shard),
+            HashRing::Fair { ring, .. } => ring.clone().into_iter().any(|(node, _)| node == *shard),
         }
     }
 

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -59,7 +59,7 @@ impl<T: Hash + Copy + PartialEq> HashRingRouter<T> {
         match self {
             Self::Single(ring) => ring.add(shard),
             Self::Resharding { old, new } => {
-                if new.get(&shard).is_none() {
+                if !new.contains_shard(&shard) {
                     old.add(shard);
                     new.add(shard);
                 }
@@ -267,6 +267,17 @@ impl<T: Hash + Copy> HashRing<T> {
                 }
                 removed
             }
+        }
+    }
+
+    /// Check whether this hash ring contains the given shard.
+    pub fn contains_shard(&self, shard: &T) -> bool
+    where
+        T: std::cmp::PartialEq,
+    {
+        match self {
+            Inner::Raw(ring) => ring.clone().into_iter().any(|node| node == *shard),
+            Inner::Fair { ring, .. } => ring.clone().into_iter().any(|(node, _)| node == *shard),
         }
     }
 

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -58,9 +58,14 @@ impl<T: Hash + Copy + PartialEq> HashRingRouter<T> {
     pub fn add(&mut self, shard: T) {
         match self {
             Self::Single(ring) => ring.add(shard),
-            Self::Resharding { old, new } => {
+            Self::Resharding { new, old: _ } => {
                 if !new.contains_shard(&shard) {
-                    old.add(shard);
+                    // The new shard is already added when switching to a resharding hash ring
+                    debug_assert!(
+                        false,
+                        "should never add new shard to hash ring during resharding",
+                    );
+
                     new.add(shard);
                 }
             }


### PR DESCRIPTION
Tracked in: #4213 
Depends on: #4697

Update hash ring rebuilding to incorporate the resharding state.

Also fixes a few other hash ring state issues when reloading from disk.

### Tasks
- [x] Merge #4697
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?