### PR TITLE
Double timeout in resharding with concurrent updates test one more time

### DIFF
--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -233,7 +233,7 @@ def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
         # Wait for resharding operation to start and stop
         wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
         for uri in peer_api_uris:
-            wait_for_collection_resharding_operations_count(uri, COLLECTION_NAME, 0, wait_for_timeout=60)
+            wait_for_collection_resharding_operations_count(uri, COLLECTION_NAME, 0, wait_for_timeout=120)
 
         # Assert node shard count
         for uri in peer_api_uris:


### PR DESCRIPTION
Tracked in: #4213 

We already doubled the timeout in <https://github.com/qdrant/qdrant/pull/4687>, but apparently that isn't good enough for GitHub CI machines. 👴

Here I double it once again.

Failing case:
- https://github.com/qdrant/qdrant/actions/runs/10043751950/job/27757211802?pr=4723#step:11:131

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?