### PR TITLE
Refactor: Convert app and cluster info metrics from counters to gauges #4696

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -285,7 +285,7 @@
               "text/plain": {
                 "schema": {
                   "type": "string",
-                  "example": "# HELP app_info information about qdrant server\n# TYPE app_info counter\napp_info{name=\"qdrant\",version=\"0.11.1\"} 1\n# HELP cluster_enabled is cluster support enabled\n# TYPE cluster_enabled gauge\ncluster_enabled 0\n# HELP collections_total number of collections\n# TYPE collections_total gauge\ncollections_total 1\n"
+                  "example": "# HELP app_info information about qdrant server\n# TYPE app_info gauge\napp_info{name=\"qdrant\",version=\"0.11.1\"} 1\n# HELP cluster_enabled is cluster support enabled\n# TYPE cluster_enabled gauge\ncluster_enabled 0\n# HELP collections_total number of collections\n# TYPE collections_total gauge\ncollections_total 1\n"
                 }
               }
             }

--- a/openapi/openapi-service.ytt.yaml
+++ b/openapi/openapi-service.ytt.yaml
@@ -57,7 +57,7 @@ paths:
                 type: string
                 example: |
                   # HELP app_info information about qdrant server
-                  # TYPE app_info counter
+                  # TYPE app_info gauge
                   app_info{name="qdrant",version="0.11.1"} 1
                   # HELP cluster_enabled is cluster support enabled
                   # TYPE cluster_enabled gauge

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -91,8 +91,8 @@ impl MetricsProvider for AppBuildTelemetry {
         metrics.push(metric_family(
             "app_info",
             "information about qdrant server",
-            MetricType::COUNTER,
-            vec![counter(
+            MetricType::GAUGE,
+            vec![gauge(
                 1.0,
                 &[("name", &self.name), ("version", &self.version)],
             )],
@@ -106,8 +106,8 @@ impl MetricsProvider for AppFeaturesTelemetry {
         metrics.push(metric_family(
             "app_status_recovery_mode",
             "features enabled in qdrant server",
-            MetricType::COUNTER,
-            vec![counter(if self.recovery_mode { 1.0 } else { 0.0 }, &[])],
+            MetricType::GAUGE,
+            vec![gauge(if self.recovery_mode { 1.0 } else { 0.0 }, &[])],
         ))
     }
 }
@@ -149,8 +149,8 @@ impl MetricsProvider for ClusterTelemetry {
         metrics.push(metric_family(
             "cluster_enabled",
             "is cluster support enabled",
-            MetricType::COUNTER,
-            vec![counter(if *enabled { 1.0 } else { 0.0 }, &[])],
+            MetricType::GAUGE,
+            vec![gauge(if *enabled { 1.0 } else { 0.0 }, &[])],
         ));
 
         if let Some(ref status) = status {

--- a/tests/openapi/openapi_integration/test_service.py
+++ b/tests/openapi/openapi_integration/test_service.py
@@ -23,7 +23,7 @@ def test_metrics():
 
     # Probe some strings that must exist in the metrics output
     assert '# HELP app_info information about qdrant server' in response.text
-    assert '# TYPE app_info counter' in response.text
+    assert '# TYPE app_info gauge' in response.text
     assert 'app_info{name="qdrant",version="' in response.text
     assert 'collections_total ' in response.text
 


### PR DESCRIPTION
This PR addresses #4696 by:
- Changing app_info, app_status_recovery_mode, and cluster_enabled metrics from COUNTER to GAUGE
- Convert boolean to its f64 representation `true => 1.0` or `false => 0.0`


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?