### PR TITLE
remove testing non-defragmented segments for non-defragmentation

### DIFF
--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -91,11 +91,6 @@ fn test_building_new_segment() {
     );
 
     assert_eq!(merged_segment.point_version(3.into()), Some(100));
-
-    // Test that our defragmentation algorithm and test works properly by checking for an error against
-    // a non defragmented segment.
-    let defragment_key = JsonPath::from_str(PAYLOAD_KEY).unwrap();
-    assert!(check_points_defragmented(&merged_segment, &defragment_key).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Fixes flaky test #4708 

When not defragmented, points in a newly built segment get placed in random order, which means it is possible they are already ordered - especially for segments with only a few points. However we assert that a non-defragmented segment always is unsorted.
This PR removes this part.

I think we can safely remove this part because:
- It was initially just to test that the defragmentation checking-logic was working properly.
- The important part, checking defragmented segments are sorted is untouched.
- I don't think another fix, addressing the actual issue, is worth the work that would be needed to fix it.

If you think it is still important to test the checking logic too, I'll create a fix that preserves the test.