### PR TITLE
Drop FieldIndex::recreate() method

### DIFF
--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -391,7 +391,7 @@ mod tests {
     fn new_binary_index() -> (TempDir, BinaryIndex) {
         let tmp_dir = Builder::new().prefix(DB_NAME).tempdir().unwrap();
         let db = open_db_with_existing_cf(tmp_dir.path()).unwrap();
-        let index = BinaryIndex::builder(db, FIELD_NAME).make_empty();
+        let index = BinaryIndex::builder(db, FIELD_NAME).make_empty().unwrap();
         (tmp_dir, index)
     }
 

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -190,10 +190,6 @@ impl BinaryIndex {
         format!("{field}_binary")
     }
 
-    pub fn recreate(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
-    }
-
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
         PayloadIndexTelemetry {
             field_name: None,
@@ -229,7 +225,7 @@ impl FieldIndexBuilderTrait for BinaryIndexBuilder {
     type FieldIndexType = BinaryIndex;
 
     fn init(&mut self) -> OperationResult<()> {
-        self.0.recreate()
+        self.0.db_wrapper.recreate_column_family()
     }
 
     fn add_point(&mut self, id: PointOffsetType, payload: &[&Value]) -> OperationResult<()> {
@@ -386,7 +382,7 @@ mod tests {
 
     use super::BinaryIndex;
     use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
-    use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
+    use crate::index::field_index::{FieldIndexBuilderTrait as _, PayloadFieldIndex, ValueIndexer};
     use crate::json_path::JsonPath;
 
     const FIELD_NAME: &str = "bool_field";
@@ -395,8 +391,7 @@ mod tests {
     fn new_binary_index() -> (TempDir, BinaryIndex) {
         let tmp_dir = Builder::new().prefix(DB_NAME).tempdir().unwrap();
         let db = open_db_with_existing_cf(tmp_dir.path()).unwrap();
-        let index = BinaryIndex::new(db, FIELD_NAME);
-        index.recreate().unwrap();
+        let index = BinaryIndex::builder(db, FIELD_NAME).make_empty();
         (tmp_dir, index)
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -349,12 +349,12 @@ pub trait FieldIndexBuilderTrait {
 
     /// Create an empty index for testing purposes.
     #[cfg(test)]
-    fn make_empty(mut self) -> Self::FieldIndexType
+    fn make_empty(mut self) -> OperationResult<Self::FieldIndexType>
     where
         Self: Sized,
     {
-        self.init().unwrap();
-        self.finalize().unwrap()
+        self.init()?;
+        self.finalize()
     }
 }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -207,19 +207,6 @@ impl FieldIndex {
         }
     }
 
-    pub fn recreate(&self) -> OperationResult<()> {
-        match self {
-            FieldIndex::IntIndex(index) => index.recreate(),
-            FieldIndex::DatetimeIndex(index) => index.recreate(),
-            FieldIndex::IntMapIndex(index) => index.recreate(),
-            FieldIndex::KeywordIndex(index) => index.recreate(),
-            FieldIndex::FloatIndex(index) => index.recreate(),
-            FieldIndex::GeoIndex(index) => index.recreate(),
-            FieldIndex::BinaryIndex(index) => index.recreate(),
-            FieldIndex::FullTextIndex(index) => index.recreate(),
-        }
-    }
-
     pub fn count_indexed_points(&self) -> usize {
         self.get_payload_field_index().count_indexed_points()
     }
@@ -347,15 +334,28 @@ impl FieldIndex {
     }
 }
 
+/// Common interface for all index builders.
 pub trait FieldIndexBuilderTrait {
-    /// The resulting type of the index
+    /// The resulting type of the index.
     type FieldIndexType;
 
+    /// Start building the index, e.g. create a database column or a directory.
+    /// Expected to be called exactly once before any other method.
     fn init(&mut self) -> OperationResult<()>;
 
     fn add_point(&mut self, id: PointOffsetType, payload: &[&Value]) -> OperationResult<()>;
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType>;
+
+    /// Create an empty index for testing purposes.
+    #[cfg(test)]
+    fn make_empty(mut self) -> Self::FieldIndexType
+    where
+        Self: Sized,
+    {
+        self.init().unwrap();
+        self.finalize().unwrap()
+    }
 }
 
 /// Builders for all index types

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -5,7 +5,7 @@ use tempfile::Builder;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::data_types::index::{TextIndexParams, TextIndexType, TokenizerType};
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
-use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
+use crate::index::field_index::{FieldIndexBuilderTrait as _, PayloadFieldIndex, ValueIndexer};
 
 fn get_texts() -> Vec<String> {
     vec![
@@ -164,8 +164,7 @@ fn test_prefix_search(#[case] immutable: bool) {
     };
 
     let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-    let mut index = FullTextIndex::new(db.clone(), config.clone(), "text", true);
-    index.recreate().unwrap();
+    let mut index = FullTextIndex::builder(db.clone(), config.clone(), "text").make_empty();
 
     let texts = get_texts();
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -164,7 +164,9 @@ fn test_prefix_search(#[case] immutable: bool) {
     };
 
     let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-    let mut index = FullTextIndex::builder(db.clone(), config.clone(), "text").make_empty();
+    let mut index = FullTextIndex::builder(db.clone(), config.clone(), "text")
+        .make_empty()
+        .unwrap();
 
     let texts = get_texts();
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -100,10 +100,6 @@ impl FullTextIndex {
         }
     }
 
-    pub fn recreate(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
-    }
-
     pub fn parse_query(&self, text: &str) -> ParsedQuery {
         let mut tokens = HashSet::new();
         Tokenizer::tokenize_query(text, &self.config, |token| {
@@ -149,7 +145,7 @@ impl FieldIndexBuilderTrait for FullTextIndexBuilder {
     type FieldIndexType = FullTextIndex;
 
     fn init(&mut self) -> OperationResult<()> {
-        self.0.recreate()
+        self.0.db_wrapper.recreate_column_family()
     }
 
     fn add_point(&mut self, id: PointOffsetType, payload: &[&Value]) -> OperationResult<()> {
@@ -309,9 +305,7 @@ mod tests {
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-            let mut index = FullTextIndex::new(db, config.clone(), "text", true);
-
-            index.recreate().unwrap();
+            let mut index = FullTextIndex::builder(db, config.clone(), "text").make_empty();
 
             for (idx, payload) in payloads.iter().enumerate() {
                 index.add_point(idx as PointOffsetType, &[payload]).unwrap();

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -305,7 +305,9 @@ mod tests {
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-            let mut index = FullTextIndex::builder(db, config.clone(), "text").make_empty();
+            let mut index = FullTextIndex::builder(db, config.clone(), "text")
+                .make_empty()
+                .unwrap();
 
             for (idx, payload) in payloads.iter().enumerate() {
                 index.add_point(idx as PointOffsetType, &[payload]).unwrap();

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -539,7 +539,9 @@ mod tests {
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
         let mut rnd = StdRng::seed_from_u64(42);
-        let mut index = GeoMapIndex::builder(db.clone(), FIELD_NAME).make_empty();
+        let mut index = GeoMapIndex::builder(db.clone(), FIELD_NAME)
+            .make_empty()
+            .unwrap();
 
         for idx in 0..num_points {
             let geo_points = random_geo_payload(&mut rnd, num_geo_values..=num_geo_values);
@@ -883,7 +885,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-        let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
+        let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty().unwrap();
 
         let r_meters = 100.0;
         let geo_values = json!([
@@ -965,7 +967,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-        let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
+        let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty().unwrap();
 
         let geo_values = json!([
             {
@@ -1010,7 +1012,7 @@ mod tests {
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
+            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty().unwrap();
 
             let geo_values = json!([
                 {
@@ -1055,7 +1057,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
+            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty().unwrap();
 
             let geo_values = json!([
                 {
@@ -1172,7 +1174,7 @@ mod tests {
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
+            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty().unwrap();
 
             // Index BERLIN
             let geo_values = json!([

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -102,10 +102,6 @@ impl GeoMapIndex {
         format!("{field}_geo")
     }
 
-    pub fn recreate(&self) -> OperationResult<()> {
-        self.db_wrapper().recreate_column_family()
-    }
-
     fn encode_db_key(value: &str, idx: PointOffsetType) -> String {
         format!("{value}/{idx}")
     }
@@ -543,9 +539,7 @@ mod tests {
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
         let mut rnd = StdRng::seed_from_u64(42);
-        let mut index = GeoMapIndex::new(db.clone(), FIELD_NAME, true);
-
-        index.recreate().unwrap();
+        let mut index = GeoMapIndex::builder(db.clone(), FIELD_NAME).make_empty();
 
         for idx in 0..num_points {
             let geo_points = random_geo_payload(&mut rnd, num_geo_values..=num_geo_values);
@@ -889,9 +883,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-        let mut index = GeoMapIndex::new(db, FIELD_NAME, true);
-
-        index.recreate().unwrap();
+        let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
 
         let r_meters = 100.0;
         let geo_values = json!([
@@ -973,9 +965,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-        let mut index = GeoMapIndex::new(db, FIELD_NAME, true);
-
-        index.recreate().unwrap();
+        let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
 
         let geo_values = json!([
             {
@@ -1020,9 +1010,7 @@ mod tests {
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-            let mut index = GeoMapIndex::new(db, FIELD_NAME, true);
-
-            index.recreate().unwrap();
+            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
 
             let geo_values = json!([
                 {
@@ -1067,8 +1055,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-            let mut index = GeoMapIndex::new(db, FIELD_NAME, true);
-            index.recreate().unwrap();
+            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
 
             let geo_values = json!([
                 {
@@ -1185,9 +1172,7 @@ mod tests {
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-            let mut index = GeoMapIndex::new(db, FIELD_NAME, true);
-
-            index.recreate().unwrap();
+            let mut index = GeoMapIndex::builder(db, FIELD_NAME).make_empty();
 
             // Index BERLIN
             let geo_values = json!([

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -154,10 +154,6 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
         format!("{field}_map")
     }
 
-    pub fn recreate(&self) -> OperationResult<()> {
-        self.get_db_wrapper().recreate_column_family()
-    }
-
     fn flusher(&self) -> Flusher {
         self.get_db_wrapper().flusher()
     }
@@ -337,7 +333,7 @@ where
     type FieldIndexType = MapIndex<N>;
 
     fn init(&mut self) -> OperationResult<()> {
-        self.0.recreate()
+        self.0.get_db_wrapper().recreate_column_family()
     }
 
     fn add_point(&mut self, id: PointOffsetType, values: &[&Value]) -> OperationResult<()> {
@@ -647,10 +643,12 @@ mod tests {
 
     const FIELD_NAME: &str = "test";
 
-    fn save_map_index<N: MapIndexKey + ?Sized>(data: &[Vec<N::Owned>], path: &Path) {
-        let mut index =
-            MapIndex::<N>::new(open_db_with_existing_cf(path).unwrap(), FIELD_NAME, true);
-        index.recreate().unwrap();
+    fn save_map_index<N: MapIndexKey + ?Sized>(data: &[Vec<N::Owned>], path: &Path)
+    where
+        MapIndex<N>: PayloadFieldIndex + ValueIndexer,
+    {
+        let mut index = MapIndex::<N>::builder(open_db_with_existing_cf(path).unwrap(), FIELD_NAME)
+            .make_empty();
         for (idx, values) in data.iter().enumerate() {
             match &mut index {
                 MapIndex::Mutable(index) => index

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -648,7 +648,8 @@ mod tests {
         MapIndex<N>: PayloadFieldIndex + ValueIndexer,
     {
         let mut index = MapIndex::<N>::builder(open_db_with_existing_cf(path).unwrap(), FIELD_NAME)
-            .make_empty();
+            .make_empty()
+            .unwrap();
         for (idx, values) in data.iter().enumerate() {
             match &mut index {
                 MapIndex::Mutable(index) => index

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -197,10 +197,6 @@ impl<T: Encodable + Numericable + Default> NumericIndexInner<T> {
         format!("{field}_numeric")
     }
 
-    pub fn recreate(&self) -> OperationResult<()> {
-        self.get_db_wrapper().recreate_column_family()
-    }
-
     pub fn load(&mut self) -> OperationResult<bool> {
         match self {
             NumericIndexInner::Mutable(index) => index.load(),
@@ -368,7 +364,6 @@ impl<T: Encodable + Numericable + Default, P> NumericIndex<T, P> {
             pub fn clear(self) -> OperationResult<()>;
             pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
             pub fn load(&mut self) -> OperationResult<bool>;
-            pub fn recreate(&self) -> OperationResult<()>;
             pub fn values_count(&self, idx: PointOffsetType) -> usize;
             pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>>;
             pub fn values_is_empty(&self, idx: PointOffsetType) -> bool;

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -17,7 +17,7 @@ fn get_index() -> (TempDir, NumericIndexInner<f64>) {
         .unwrap();
     let db = open_db_with_existing_cf(temp_dir.path()).unwrap();
     let index: NumericIndexInner<_> = NumericIndexInner::new(db, COLUMN_NAME, true);
-    index.recreate().unwrap();
+    index.get_db_wrapper().recreate_column_family().unwrap();
     (temp_dir, index)
 }
 


### PR DESCRIPTION
Fixup for #4717.
This PR drops `FieldIndex::recreate()` as requested in https://github.com/qdrant/qdrant/pull/4717#discussion_r1686167578.