### PR TITLE
ValueIndexer get value without self

### DIFF
--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -362,7 +362,7 @@ impl ValueIndexer for BinaryIndex {
         Ok(())
     }
 
-    fn get_value(&self, value: &serde_json::Value) -> Option<bool> {
+    fn get_value(value: &serde_json::Value) -> Option<bool> {
         value.as_bool()
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -70,13 +70,13 @@ pub trait ValueIndexer {
     ) -> OperationResult<()>;
 
     /// Extract index-able value from payload `Value`
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType>;
+    fn get_value(value: &Value) -> Option<Self::ValueType>;
 
     /// Try to extract index-able values from payload `Value`, even if it is an array
-    fn get_values(&self, value: &Value) -> Vec<Self::ValueType> {
+    fn get_values(value: &Value) -> Vec<Self::ValueType> {
         match value {
-            Value::Array(values) => values.iter().filter_map(|x| self.get_value(x)).collect(),
-            _ => self.get_value(value).map(|x| vec![x]).unwrap_or_default(),
+            Value::Array(values) => values.iter().filter_map(|x| Self::get_value(x)).collect(),
+            _ => Self::get_value(value).map(|x| vec![x]).unwrap_or_default(),
         }
     }
 
@@ -87,10 +87,10 @@ pub trait ValueIndexer {
         for value in payload.iter() {
             match value {
                 Value::Array(values) => {
-                    flatten_values.extend(values.iter().filter_map(|x| self.get_value(x)));
+                    flatten_values.extend(values.iter().filter_map(|x| Self::get_value(x)));
                 }
                 _ => {
-                    if let Some(x) = self.get_value(value) {
+                    if let Some(x) = Self::get_value(value) {
                         flatten_values.push(x);
                     }
                 }
@@ -155,7 +155,7 @@ impl FieldIndex {
             FieldIndex::FullTextIndex(full_text_index) => match &condition.r#match {
                 Some(Match::Text(MatchText { text })) => {
                     let query = full_text_index.parse_query(text);
-                    for value in full_text_index.get_values(payload_value) {
+                    for value in FullTextIndex::get_values(payload_value) {
                         let document = full_text_index.parse_document(&value);
                         if query.check_match(&document) {
                             return Some(true);

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -184,7 +184,7 @@ impl ValueIndexer for FullTextIndex {
         Ok(())
     }
 
-    fn get_value(&self, value: &Value) -> Option<String> {
+    fn get_value(value: &Value) -> Option<String> {
         if let Value::String(keyword) = value {
             return Some(keyword.to_owned());
         }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -316,7 +316,7 @@ impl ValueIndexer for GeoMapIndex {
         }
     }
 
-    fn get_value(&self, value: &Value) -> Option<GeoPoint> {
+    fn get_value(value: &Value) -> Option<GeoPoint> {
         match value {
             Value::Object(obj) => {
                 let lon_op = obj.get("lon").and_then(|x| x.as_f64());

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -585,7 +585,7 @@ impl ValueIndexer for MapIndex<str> {
         }
     }
 
-    fn get_value(&self, value: &Value) -> Option<String> {
+    fn get_value(value: &Value) -> Option<String> {
         if let Value::String(keyword) = value {
             return Some(keyword.to_owned());
         }
@@ -616,7 +616,7 @@ impl ValueIndexer for MapIndex<IntPayloadType> {
         }
     }
 
-    fn get_value(&self, value: &Value) -> Option<IntPayloadType> {
+    fn get_value(value: &Value) -> Option<IntPayloadType> {
         if let Value::Number(num) = value {
             return num.as_i64();
         }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -551,7 +551,7 @@ impl ValueIndexer for NumericIndex<IntPayloadType, IntPayloadType> {
         }
     }
 
-    fn get_value(&self, value: &Value) -> Option<IntPayloadType> {
+    fn get_value(value: &Value) -> Option<IntPayloadType> {
         value.as_i64()
     }
 
@@ -578,7 +578,7 @@ impl ValueIndexer for NumericIndex<IntPayloadType, DateTimePayloadType> {
         }
     }
 
-    fn get_value(&self, value: &Value) -> Option<DateTimePayloadType> {
+    fn get_value(value: &Value) -> Option<DateTimePayloadType> {
         DateTimePayloadType::from_str(value.as_str()?).ok()
     }
 
@@ -603,7 +603,7 @@ impl ValueIndexer for NumericIndex<FloatPayloadType, FloatPayloadType> {
         }
     }
 
-    fn get_value(&self, value: &Value) -> Option<FloatPayloadType> {
+    fn get_value(value: &Value) -> Option<FloatPayloadType> {
         value.as_f64()
     }
 


### PR DESCRIPTION
Value indexer does not need `self` for value conversion. Removing `self` is important for mmap field index builder, where value conversion may be applied without created field index