### PR TITLE
When resharding down, migrate points with shard transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,6 +1126,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "serde_variant",
  "sha2",
  "smallvec",
  "sparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ used_underscore_binding = "warn"
 
 [workspace.dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
-data-encoding = { version = "2.6.0" }
+data-encoding = "2.6.0"
 delegate = "0.12.0"
 fnv = "1.0"
 futures = "0.3.30"
@@ -171,7 +171,8 @@ reqwest = { version = "0.12.5", default-features = false, features = ["http2", "
 schemars = { version = "0.8.21", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive", "rc"] }
-serde_cbor = { version = "0.11.2" }
+serde_cbor = "0.11.2"
+serde_variant = "0.1.3"
 sha2 = "0.10.8"
 serde_json = {version = "~1.0", features = ["preserve_order"]}
 strum = { version = "0.26.3", features = ["derive"] }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9335,6 +9335,7 @@
       "ReshardingInfo": {
         "type": "object",
         "required": [
+          "direction",
           "peer_id",
           "shard_id"
         ],
@@ -9348,6 +9349,9 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0
+          },
+          "direction": {
+            "$ref": "#/components/schemas/ReshardingDirection"
           },
           "shard_key": {
             "anyOf": [
@@ -9365,6 +9369,25 @@
             "nullable": true
           }
         }
+      },
+      "ReshardingDirection": {
+        "description": "Resharding direction, scale up or down in number of shards",
+        "oneOf": [
+          {
+            "description": "Scale up, add a new shard",
+            "type": "string",
+            "enum": [
+              "up"
+            ]
+          },
+          {
+            "description": "Scale down, remove a shard",
+            "type": "string",
+            "enum": [
+              "down"
+            ]
+          }
+        ]
       },
       "TelemetryData": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9340,6 +9340,9 @@
           "shard_id"
         ],
         "properties": {
+          "direction": {
+            "$ref": "#/components/schemas/ReshardingDirection"
+          },
           "shard_id": {
             "type": "integer",
             "format": "uint32",
@@ -9349,9 +9352,6 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0
-          },
-          "direction": {
-            "$ref": "#/components/schemas/ReshardingDirection"
           },
           "shard_key": {
             "anyOf": [

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1.0"
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
+serde_variant = { workspace = true }
 rmp-serde = "~1.3"
 wal = { workspace = true }
 ordered-float = "4.2"

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -409,11 +409,11 @@ impl Collection {
             drop(shard_holder);
 
             self.abort_resharding(ReshardKey {
+                // Always up when setting resharding replica set state
+                direction: ReshardingDirection::Up,
                 peer_id,
                 shard_id,
                 shard_key,
-                // TODO(resharding): define proper direction here, likely up with resharding state
-                direction: ReshardingDirection::Up,
             })
             .await?;
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -27,6 +27,7 @@ use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_state::{ShardInfo, State};
 use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfig;
+use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::config_diff::{DiffConfig, OptimizersConfigDiff};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult, NodeType};
@@ -411,6 +412,8 @@ impl Collection {
                 peer_id,
                 shard_id,
                 shard_key,
+                // TODO(resharding): define proper direction here, likely up with resharding state
+                direction: ReshardingDirection::Up,
             })
             .await?;
 

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -189,6 +189,9 @@ impl Collection {
 
         if resharding_key.direction == ReshardingDirection::Down {
             // Remove the shard we've now migrated all points out of
+            if let Some(shard_key) = &resharding_key.shard_key {
+                shard_holder.remove_shard_from_key_mapping(&resharding_key.shard_id, shard_key)?;
+            }
             shard_holder
                 .drop_and_remove_shard(resharding_key.shard_id)
                 .await?;

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -211,21 +211,16 @@ pub struct AbortShardTransfer {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct StartResharding {
-    // TODO(resharding): expose when releasing resharding with scaling down, remove default
-    #[serde(default)]
-    #[schemars(skip)]
     pub direction: ReshardingDirection,
     pub peer_id: Option<PeerId>,
     pub shard_key: Option<ShardKey>,
 }
 
 /// Resharding direction, scale up or down in number of shards
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, Eq, PartialEq, Hash)]
 #[serde(rename_all = "snake_case")]
-// TODO(resharding): expose when releasing resharding with scaling down
 pub enum ReshardingDirection {
     /// Scale up, add a new shard
-    #[default]
     Up,
     /// Scale down, remove a shard
     Down,

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -211,12 +211,12 @@ pub struct AbortShardTransfer {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct StartResharding {
-    pub peer_id: Option<PeerId>,
-    pub shard_key: Option<ShardKey>,
+    // TODO(resharding): expose when releasing resharding with scaling down, remove default
     #[serde(default)]
-    // TODO(resharding): expose when releasing resharding with scaling down
     #[schemars(skip)]
     pub direction: ReshardingDirection,
+    pub peer_id: Option<PeerId>,
+    pub shard_key: Option<ShardKey>,
 }
 
 /// Resharding direction, scale up or down in number of shards

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -213,6 +213,22 @@ pub struct AbortShardTransfer {
 pub struct StartResharding {
     pub peer_id: Option<PeerId>,
     pub shard_key: Option<ShardKey>,
+    #[serde(default)]
+    // TODO(resharding): expose when releasing resharding with scaling down
+    #[schemars(skip)]
+    pub direction: ReshardingDirection,
+}
+
+/// Resharding direction, scale up or down in number of shards
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, Copy, Eq, PartialEq, Hash)]
+#[serde(rename_all = "snake_case")]
+// TODO(resharding): expose when releasing resharding with scaling down
+pub enum ReshardingDirection {
+    /// Scale up, add a new shard
+    #[default]
+    Up,
+    /// Scale down, remove a shard
+    Down,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -45,6 +45,7 @@ use validator::{Validate, ValidationError, ValidationErrors};
 use super::config_diff::{self};
 use super::ClockTag;
 use crate::config::{CollectionConfig, CollectionParams};
+use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::universal_query::shard_query::{ScoringQuery, ShardQueryRequest};
@@ -241,6 +242,8 @@ pub struct ReshardingInfo {
     pub shard_id: ShardId,
 
     pub peer_id: PeerId,
+
+    pub direction: ReshardingDirection,
 
     pub shard_key: Option<ShardKey>,
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -239,11 +239,11 @@ pub struct ShardTransferInfo {
 
 #[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct ReshardingInfo {
+    pub direction: ReshardingDirection,
+
     pub shard_id: ShardId,
 
     pub peer_id: PeerId,
-
-    pub direction: ReshardingDirection,
 
     pub shard_key: Option<ShardKey>,
 

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -97,7 +97,7 @@ impl DriverState {
 
     /// List the shard ID pairs we still need to migrate
     ///
-    /// When scaling up this produces shard IDs to migrate points from. Whe scaling down this
+    /// When scaling up this produces shard IDs to migrate points from. When scaling down this
     /// produces shard IDs to migrate points into.
     pub fn shards_to_migrate(&self) -> impl Iterator<Item = ShardId> + '_ {
         self.shards()

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -97,7 +97,7 @@ impl DriverState {
     /// List the shard ID pairs we still need to migrate
     pub fn shards_to_migrate(&self) -> impl Iterator<Item = ShardId> + '_ {
         self.shards()
-            // Exlude current resharding shard, and already migrated shards
+            // Exclude current resharding shard, and already migrated shards
             .filter(|shard_id| {
                 *shard_id != self.key.shard_id && !self.migrated_shards.contains(shard_id)
             })
@@ -106,7 +106,7 @@ impl DriverState {
     /// List the shard IDs in which we still need to propagate point deletions.
     pub fn shards_to_delete(&self) -> impl Iterator<Item = ShardId> + '_ {
         self.shards()
-            // Exlude current resharding shard, and already deleted shards
+            // Exclude current resharding shard, and already deleted shards
             .filter(|shard_id| {
                 *shard_id != self.key.shard_id && !self.deleted_shards.contains(shard_id)
             })
@@ -133,9 +133,9 @@ impl DriverState {
                 self.key.shard_id,
             ),
             (Stage::S2_MigratePoints, ReshardingDirection::Down) => format!(
-                "migrate points: migrating points from shards {:?} to {}",
-                self.shards_to_migrate().collect::<Vec<_>>(),
+                "migrate points: migrating points from shard {} to shards {:?}",
                 self.key.shard_id,
+                self.shards_to_migrate().collect::<Vec<_>>(),
             ),
             (Stage::S3_Replicate, _) => "replicate: replicate new shard to other peers".into(),
             (Stage::S4_CommitHashring, _) => "commit hash ring: switching reads and writes".into(),

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -207,7 +207,7 @@ pub async fn drive_resharding(
     channel_service: ChannelService,
     can_resume: bool,
 ) -> CollectionResult<bool> {
-    let to_shard_id = reshard_key.shard_id;
+    let shard_id = reshard_key.shard_id;
     let hash_ring = shard_holder
         .read()
         .await
@@ -231,19 +231,19 @@ pub async fn drive_resharding(
     progress.lock().description.replace(state.read().describe());
 
     log::debug!(
-        "Resharding {collection_id}:{to_shard_id} from shards {:?}",
-        state.read().shards().collect::<Vec<_>>(),
+        "Resharding {collection_id}:{shard_id} with shards {:?}",
+        state.read().shards().filter(|id| shard_id != *id).collect::<Vec<_>>(),
     );
 
     // Stage 1: init
     if !stage_init::is_completed(&state) {
-        log::debug!("Resharding {collection_id}:{to_shard_id} stage: init");
+        log::debug!("Resharding {collection_id}:{shard_id} stage: init");
         stage_init::drive(&state, &progress, consensus)?;
     }
 
     // Stage 2: migrate points
     if !stage_migrate_points::is_completed(&state) {
-        log::debug!("Resharding {collection_id}:{to_shard_id} stage: migrate points");
+        log::debug!("Resharding {collection_id}:{shard_id} stage: migrate points");
         stage_migrate_points::drive(
             &reshard_key,
             &state,
@@ -261,7 +261,7 @@ pub async fn drive_resharding(
     if !stage_replicate::is_completed(&reshard_key, &state, &shard_holder, &collection_config)
         .await?
     {
-        log::debug!("Resharding {collection_id}:{to_shard_id} stage: replicate");
+        log::debug!("Resharding {collection_id}:{shard_id} stage: replicate");
         stage_replicate::drive(
             &reshard_key,
             &state,
@@ -277,7 +277,7 @@ pub async fn drive_resharding(
 
     // Stage 4: commit new hashring
     if !stage_commit_hashring::is_completed(&state) {
-        log::debug!("Resharding {collection_id}:{to_shard_id} stage: commit hashring");
+        log::debug!("Resharding {collection_id}:{shard_id} stage: commit hashring");
         stage_commit_hashring::drive(
             &reshard_key,
             &state,
@@ -291,7 +291,7 @@ pub async fn drive_resharding(
 
     // Stage 5: propagate deletes
     if !stage_propagate_deletes::is_completed(&state) {
-        log::debug!("Resharding {collection_id}:{to_shard_id} stage: propagate deletes");
+        log::debug!("Resharding {collection_id}:{shard_id} stage: propagate deletes");
         stage_propagate_deletes::drive(
             &reshard_key,
             &state,
@@ -303,7 +303,7 @@ pub async fn drive_resharding(
     }
 
     // Stage 6: finalize
-    log::debug!("Resharding {collection_id}:{to_shard_id} stage: finalize");
+    log::debug!("Resharding {collection_id}:{shard_id} stage: finalize");
     stage_finalize::drive(&state, &progress, consensus)?;
 
     // Delete the state file after successful resharding

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -339,7 +339,11 @@ pub async fn drive_resharding(
 }
 
 fn resharding_state_path(reshard_key: &ReshardKey, collection_path: &Path) -> PathBuf {
-    collection_path.join(format!("resharding_state_{}.json", reshard_key.shard_id))
+    let up_down = serde_variant::to_variant_name(&reshard_key.direction).unwrap_or_default();
+    collection_path.join(format!(
+        "resharding_state_{up_down}_{}.json",
+        reshard_key.shard_id,
+    ))
 }
 
 /// Await for a resharding shard transfer to succeed.

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -38,8 +38,8 @@ pub(super) struct DriverState {
     key: ReshardKey,
     /// Stage each peer is currently in
     peers: HashMap<PeerId, Stage>,
-    /// List of shard IDs that must be migrated into the new shard
-    source_shard_ids: HashSet<ShardId>,
+    /// List of shard IDs that participate in the resharding process
+    shard_ids: HashSet<ShardId>,
     /// List of shard IDs successfully migrated to the new shard
     pub migrated_shards: Vec<ShardId>,
     /// List of shard IDs in which we successfully deleted migrated points
@@ -47,14 +47,14 @@ pub(super) struct DriverState {
 }
 
 impl DriverState {
-    pub fn new(key: ReshardKey, source_shard_ids: HashSet<ShardId>, peers: &[PeerId]) -> Self {
+    pub fn new(key: ReshardKey, shard_ids: HashSet<ShardId>, peers: &[PeerId]) -> Self {
         Self {
             key,
             peers: peers
                 .iter()
                 .map(|peer_id| (*peer_id, Stage::default()))
                 .collect(),
-            source_shard_ids,
+            shard_ids,
             migrated_shards: vec![],
             deleted_shards: vec![],
         }
@@ -94,21 +94,29 @@ impl DriverState {
             .for_each(|peer_stage| *peer_stage = next_stage.max(*peer_stage));
     }
 
-    /// List the shard IDs we still need to migrate.
+    /// List the shard ID pairs we still need to migrate
     pub fn shards_to_migrate(&self) -> impl Iterator<Item = ShardId> + '_ {
-        self.source_shards()
-            .filter(|shard_id| !self.migrated_shards.contains(shard_id))
+        self.shards()
+            // Exlude current resharding shard, and already migrated shards
+            .filter(|shard_id| {
+                *shard_id != self.key.shard_id && !self.migrated_shards.contains(shard_id)
+            })
     }
 
     /// List the shard IDs in which we still need to propagate point deletions.
     pub fn shards_to_delete(&self) -> impl Iterator<Item = ShardId> + '_ {
-        self.source_shards()
-            .filter(|shard_id| !self.deleted_shards.contains(shard_id))
+        self.shards()
+            // Exlude current resharding shard, and already deleted shards
+            .filter(|shard_id| {
+                *shard_id != self.key.shard_id && !self.deleted_shards.contains(shard_id)
+            })
     }
 
-    /// Get all the shard IDs which points are sourced from.
-    pub fn source_shards(&self) -> impl Iterator<Item = ShardId> + '_ {
-        self.source_shard_ids.iter().copied()
+    /// Get all shard IDs which are participating in this resharding process.
+    ///
+    /// Includes the newly added or to be removed shard.
+    fn shards(&self) -> impl Iterator<Item = ShardId> + '_ {
+        self.shard_ids.iter().copied()
     }
 
     /// Describe the current stage and state in a human readable string.
@@ -211,9 +219,7 @@ pub async fn drive_resharding(
 
     // Load or initialize resharding state
     let init_state = || {
-        let mut shard_ids = hash_ring.unique_nodes();
-        shard_ids.remove(&reshard_key.shard_id);
-
+        let shard_ids = hash_ring.unique_nodes();
         DriverState::new(reshard_key.clone(), shard_ids, &consensus.peers())
     };
     let state: PersistedState = if can_resume {
@@ -226,7 +232,7 @@ pub async fn drive_resharding(
 
     log::debug!(
         "Resharding {collection_id}:{to_shard_id} from shards {:?}",
-        state.read().source_shards().collect::<Vec<_>>(),
+        state.read().shards().collect::<Vec<_>>(),
     );
 
     // Stage 1: init

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -47,33 +47,33 @@ pub struct ReshardState {
 
 impl ReshardState {
     pub fn new(
+        direction: ReshardingDirection,
         peer_id: PeerId,
         shard_id: ShardId,
         shard_key: Option<ShardKey>,
-        direction: ReshardingDirection,
     ) -> Self {
         Self {
+            direction,
             peer_id,
             shard_id,
             shard_key,
-            direction,
             stage: ReshardStage::MigratingPoints,
         }
     }
 
     pub fn matches(&self, key: &ReshardKey) -> bool {
-        self.peer_id == key.peer_id
+        self.direction == key.direction
+            && self.peer_id == key.peer_id
             && self.shard_id == key.shard_id
             && self.shard_key == key.shard_key
-            && self.direction == key.direction
     }
 
     pub fn key(&self) -> ReshardKey {
         ReshardKey {
+            direction: self.direction,
             peer_id: self.peer_id,
             shard_id: self.shard_id,
             shard_key: self.shard_key.clone(),
-            direction: self.direction,
         }
     }
 }
@@ -95,13 +95,13 @@ pub enum ReshardStage {
 /// Unique identifier of a resharding task
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema)]
 pub struct ReshardKey {
+    // TODO(resharding): expose when releasing resharding with scaling down, remove default
+    #[serde(default)]
+    #[schemars(skip)]
+    pub direction: ReshardingDirection,
     pub peer_id: PeerId,
     pub shard_id: ShardId,
     pub shard_key: Option<ShardKey>,
-    #[serde(default)]
-    // TODO(resharding): expose when releasing resharding with scaling down
-    #[schemars(skip)]
-    pub direction: ReshardingDirection,
 }
 
 impl fmt::Display for ReshardKey {

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -95,9 +95,6 @@ pub enum ReshardStage {
 /// Unique identifier of a resharding task
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema)]
 pub struct ReshardKey {
-    // TODO(resharding): expose when releasing resharding with scaling down, remove default
-    #[serde(default)]
-    #[schemars(skip)]
     pub direction: ReshardingDirection,
     pub peer_id: PeerId,
     pub shard_id: ShardId,

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -10,12 +10,8 @@ use super::driver::{PersistedState, Stage};
 use super::tasks_pool::ReshardTaskProgress;
 use super::ReshardKey;
 use crate::operations::cluster_ops::ReshardingDirection;
-use crate::operations::point_ops::{
-    PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
-};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
-use crate::operations::CollectionUpdateOperations;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ReplicaState;
@@ -27,13 +23,10 @@ use crate::shards::shard_holder::LockedShardHolder;
 use crate::shards::transfer::resharding_stream_records::transfer_resharding_stream_records;
 use crate::shards::transfer::transfer_tasks_pool::TransferTaskProgress;
 use crate::shards::transfer::{ShardTransfer, ShardTransferConsensus, ShardTransferMethod};
-use crate::shards::{await_consensus_sync, CollectionId};
+use crate::shards::CollectionId;
 
 /// Maximum time a point migration transfer might take.
 const MIGRATE_POINT_TRANSFER_MAX_DURATION: Duration = Duration::from_secs(24 * 60 * 60);
-
-/// Batch size for migrating points between shards on scale down.
-const MIGRATE_BATCH_SIZE: usize = 100;
 
 /// Stage 2: migrate points
 ///
@@ -82,6 +75,8 @@ pub(super) async fn drive(
                 shard_holder,
                 consensus,
                 channel_service,
+                collection_id,
+                shared_storage_config,
             )
             .await?;
         }
@@ -173,7 +168,6 @@ async fn drive_up(
 
                 // Configure shard transfer object, or use none if doing a local transfer
                 if source_peer_id != this_peer_id {
-                    debug_assert_ne!(source_peer_id, this_peer_id);
                     debug_assert_ne!(source_shard_id, reshard_key.shard_id);
                     let transfer = ShardTransfer {
                         shard_id: source_shard_id,
@@ -224,7 +218,7 @@ async fn drive_up(
             }
             // Transfer locally, within this peer
             None => {
-                migrate_local(
+                migrate_local_up(
                     reshard_key,
                     shard_holder.clone(),
                     consensus,
@@ -259,6 +253,7 @@ async fn drive_up(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn drive_down(
     reshard_key: &ReshardKey,
     state: &PersistedState,
@@ -266,106 +261,154 @@ async fn drive_down(
     shard_holder: Arc<LockedShardHolder>,
     consensus: &dyn ShardTransferConsensus,
     channel_service: &ChannelService,
+    collection_id: &CollectionId,
+    shared_storage_config: &SharedStorageConfig,
 ) -> CollectionResult<()> {
-    // Sync cluster
-    // We move points without a proxy, so all peers must have the updated hash ring to also forward
-    // updates to the new shard
-    progress
-        .lock()
-        .description
-        .replace(format!("{} (await cluster sync)", state.read().describe()));
-    await_consensus_sync(consensus, channel_service).await;
-    progress.lock().description.replace(state.read().describe());
+    let this_peer_id = consensus.this_peer_id();
 
-    let hashring = {
-        let shard_holder = shard_holder.read().await;
-        let shard_key = shard_holder
-            .get_shard_id_to_key_mapping()
-            .get(&reshard_key.shard_id)
-            .cloned();
-        shard_holder.rings.get(&shard_key).cloned().ok_or_else(|| {
-            CollectionError::service_error(format!(
-                "Cannot delete migrated points while resharding shard {}, failed to get shard hash ring",
-                reshard_key.shard_id,
-            ))
-        })?
-    };
+    while let Some((target_shard_id, target_peer_id)) = block_in_place(|| {
+        state
+            .read()
+            .replicas_to_migrate(shard_holder.clone())
+            .next()
+    }) {
+        let ongoing_transfer = shard_holder
+            .read()
+            .await
+            .get_transfers(|transfer| {
+                transfer.method == Some(ShardTransferMethod::ReshardingStreamRecords)
+                    && transfer.shard_id == reshard_key.shard_id
+                    && transfer.to_shard_id == Some(target_shard_id)
+                    && transfer.to == target_peer_id
+            })
+            .pop();
 
-    while let Some(target_shard_id) = block_in_place(|| state.read().shards_to_migrate().next()) {
-        let mut offset = None;
+        // Take the existing transfer if ongoing, or decide on what new transfer we want to start
+        let (transfer, start_transfer) = match ongoing_transfer {
+            Some(transfer) => (Some(transfer), false),
+            None => {
+                let incoming_limit = shared_storage_config
+                    .incoming_shard_transfers_limit
+                    .unwrap_or(usize::MAX);
+                let outgoing_limit = shared_storage_config
+                    .outgoing_shard_transfers_limit
+                    .unwrap_or(usize::MAX);
 
-        loop {
-            let shard_holder = shard_holder.read().await;
+                let source_peer_ids = {
+                    let shard_holder = shard_holder.read().await;
+                    let replica_set =
+                        shard_holder.get_shard(&reshard_key.shard_id).ok_or_else(|| {
+                            CollectionError::service_error(format!(
+                                "Shard {target_shard_id} not found in the shard holder for resharding",
+                            ))
+                        })?;
 
-            let source_replica_set =
-                shard_holder
-                    .get_shard(&reshard_key.shard_id)
-                    .ok_or_else(|| {
-                        CollectionError::service_error(format!(
-                            "Shard {} not found in the shard holder for resharding",
-                            reshard_key.shard_id,
-                        ))
-                    })?;
-            let target_replica_set = shard_holder.get_shard(&target_shard_id).ok_or_else(|| {
-                CollectionError::service_error(format!(
-                    "Shard {target_shard_id} not found in the shard holder for resharding",
-                ))
-            })?;
+                    let active_peer_ids = replica_set.active_shards().await;
+                    if active_peer_ids.is_empty() {
+                        return Err(CollectionError::service_error(format!(
+                            "No peer with shard {target_shard_id} in active state for resharding",
+                        )));
+                    }
 
-            // Take batch of points, if full, pop the last entry as next batch offset
-            let mut points = source_replica_set
-                .scroll_by(
-                    offset,
-                    MIGRATE_BATCH_SIZE + 1,
-                    &true.into(),
-                    &true.into(),
-                    // TODO(resharding): directly apply hash ring filter here?
-                    None,
-                    None,
-                    false,
-                    None,
+                    // Respect shard transfer limits, always allow local transfers
+                    let (incoming, _) = shard_holder.count_shard_transfer_io(&target_peer_id);
+                    if incoming < incoming_limit {
+                        active_peer_ids
+                            .into_iter()
+                            .filter(|peer_id| {
+                                let (_, outgoing) = shard_holder.count_shard_transfer_io(peer_id);
+                                outgoing < outgoing_limit
+                                    || (peer_id == &target_peer_id && peer_id == &this_peer_id)
+                            })
+                            .collect()
+                    } else if active_peer_ids.contains(&this_peer_id)
+                        && target_peer_id == this_peer_id
+                    {
+                        vec![this_peer_id]
+                    } else {
+                        vec![]
+                    }
+                };
+
+                if source_peer_ids.is_empty() {
+                    log::trace!("Postponing resharding migration transfer from shard {} to stay below transfer limit on peers", reshard_key.shard_id);
+                    sleep(SHARD_TRANSFER_IO_LIMIT_RETRY_INTERVAL).await;
+                    continue;
+                }
+
+                let source_peer_id = *source_peer_ids.choose(&mut rand::thread_rng()).unwrap();
+
+                // Configure shard transfer object, or use none if doing a local transfer
+                if source_peer_id != target_peer_id || source_peer_id != this_peer_id {
+                    debug_assert_ne!(target_shard_id, reshard_key.shard_id);
+                    let transfer = ShardTransfer {
+                        shard_id: reshard_key.shard_id,
+                        to_shard_id: Some(target_shard_id),
+                        from: source_peer_id,
+                        to: target_peer_id,
+                        sync: true,
+                        method: Some(ShardTransferMethod::ReshardingStreamRecords),
+                    };
+                    (Some(transfer), true)
+                } else {
+                    (None, false)
+                }
+            }
+        };
+
+        match transfer {
+            // Transfer from a different peer, start the transfer if needed and await completion
+            Some(transfer) => {
+                // Create listener for transfer end before proposing to start the transfer
+                // That way we're sure we receive all transfer notifications the next operation might create
+                let await_transfer_end = shard_holder
+                    .read()
+                    .await
+                    .await_shard_transfer_end(transfer.key(), MIGRATE_POINT_TRANSFER_MAX_DURATION);
+
+                if start_transfer {
+                    consensus
+                        .start_shard_transfer_confirm_and_retry(&transfer, collection_id)
+                        .await?;
+                }
+
+                await_transfer_success(
+                    reshard_key,
+                    &transfer,
+                    &shard_holder,
+                    collection_id,
+                    consensus,
+                    await_transfer_end,
+                )
+                .await
+                .map_err(|err| {
+                    CollectionError::service_error(format!(
+                        "Failed to migrate points from shard {} to {target_shard_id} for resharding: {err}",
+                        reshard_key.shard_id,
+                    ))
+                })?;
+            }
+            // Transfer locally, within this peer
+            None => {
+                migrate_local_down(
+                    reshard_key,
+                    shard_holder.clone(),
+                    consensus,
+                    channel_service.clone(),
+                    collection_id,
+                    target_shard_id,
                 )
                 .await?;
-
-            offset = if points.len() > MIGRATE_BATCH_SIZE {
-                points.pop().map(|point| point.id)
-            } else {
-                None
-            };
-
-            let points: Result<Vec<_>, _> = points
-                .into_iter()
-                .filter(|point| hashring.is_in_shard(&point.id, target_shard_id))
-                .map(PointStruct::try_from)
-                .collect();
-            let points = points.map_err(|err| {
-                CollectionError::service_error(format!(
-                    "Failed to migrate points from shard {target_shard_id} to {} for resharding: {err}",
-                    reshard_key.shard_id,
-                ))
-            })?;
-
-            let operation = CollectionUpdateOperations::PointOperation(
-                PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(points)),
-            );
-
-            // Wait on all updates here, not just the last batch
-            // If we don't wait on all updates it somehow results in inconsistent results
-            target_replica_set
-                .update_with_consistency(operation, true, WriteOrdering::Weak)
-                .await?;
-
-            if offset.is_none() {
-                break;
             }
         }
 
         state.write(|data| {
-            data.migrated_shards.push(target_shard_id);
+            data.migrated_replicas
+                .push((target_shard_id, target_peer_id));
             data.update(progress, consensus);
         })?;
         log::debug!(
-            "Points of shard {} successfully migrated into shard {target_shard_id} for resharding",
+            "Points of shard {} successfully migrated into replica {target_peer_id}:{target_shard_id} for resharding",
             reshard_key.shard_id,
         );
     }
@@ -379,7 +422,7 @@ async fn drive_down(
 /// same source and target node.
 // TODO(resharding): improve this, don't rely on shard transfers and remote shards, copy directly
 // between the two local shard replica
-async fn migrate_local(
+async fn migrate_local_up(
     reshard_key: &ReshardKey,
     shard_holder: Arc<LockedShardHolder>,
     consensus: &dyn ShardTransferConsensus,
@@ -419,6 +462,60 @@ async fn migrate_local(
                 "Shard {source_shard_id} not found in the shard holder for resharding",
             ))
         })?;
+        replica_set.un_proxify_local().await?;
+    }
+
+    result
+}
+
+/// Migrate a shard locally, within the same node.
+///
+/// This is a special case for migration transfers, because normal shard transfer don't support the
+/// same source and target node.
+async fn migrate_local_down(
+    reshard_key: &ReshardKey,
+    shard_holder: Arc<LockedShardHolder>,
+    consensus: &dyn ShardTransferConsensus,
+    channel_service: ChannelService,
+    collection_id: &CollectionId,
+    target_shard_id: ShardId,
+) -> CollectionResult<()> {
+    log::debug!(
+        "Migrating points of shard {} into shard {} locally for resharding",
+        reshard_key.shard_id,
+        target_shard_id,
+    );
+
+    // Target shard is on the same node, but has a different shard ID
+    let target_shard = RemoteShard::new(
+        target_shard_id,
+        collection_id.clone(),
+        consensus.this_peer_id(),
+        channel_service,
+    );
+
+    let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
+    let result = transfer_resharding_stream_records(
+        Arc::clone(&shard_holder),
+        progress,
+        reshard_key.shard_id,
+        target_shard,
+        collection_id,
+    )
+    .await;
+
+    // Unproxify forward proxy on local shard we just transferred
+    // Normally consensus takes care of this, but we don't use consensus here
+    {
+        let shard_holder = shard_holder.read().await;
+        let replica_set = shard_holder
+            .get_shard(&reshard_key.shard_id)
+            .ok_or_else(|| {
+                CollectionError::service_error(format!(
+                    "Shard {} not found in the shard holder for resharding",
+                    reshard_key.shard_id,
+                ))
+            })?;
         replica_set.un_proxify_local().await?;
     }
 

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -10,8 +10,12 @@ use super::driver::{PersistedState, Stage};
 use super::tasks_pool::ReshardTaskProgress;
 use super::ReshardKey;
 use crate::operations::cluster_ops::ReshardingDirection;
+use crate::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
+};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::CollectionUpdateOperations;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ReplicaState;
@@ -27,6 +31,9 @@ use crate::shards::CollectionId;
 
 /// Maximum time a point migration transfer might take.
 const MIGRATE_POINT_TRANSFER_MAX_DURATION: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Batch size for migrating points between shards on scale down.
+const MIGRATE_BATCH_SIZE: usize = 100;
 
 /// Stage 2: migrate points
 ///
@@ -259,145 +266,94 @@ async fn drive_down(
     reshard_key: &ReshardKey,
     state: &PersistedState,
     progress: &Mutex<ReshardTaskProgress>,
-    _shard_holder: Arc<LockedShardHolder>,
+    shard_holder: Arc<LockedShardHolder>,
     consensus: &dyn ShardTransferConsensus,
     _channel_service: &ChannelService,
     _collection_id: &CollectionId,
     _shared_storage_config: &SharedStorageConfig,
 ) -> CollectionResult<()> {
-    let _this_peer_id = consensus.this_peer_id();
+    let hashring = {
+        let shard_holder = shard_holder.read().await;
+        let shard_key = shard_holder
+            .get_shard_id_to_key_mapping()
+            .get(&reshard_key.shard_id)
+            .cloned();
+        shard_holder.rings.get(&shard_key).cloned().ok_or_else(|| {
+            CollectionError::service_error(format!(
+                "Cannot delete migrated points while resharding shard {}, failed to get shard hash ring",
+                reshard_key.shard_id,
+            ))
+        })?
+    };
 
     while let Some(target_shard_id) = block_in_place(|| state.read().shards_to_migrate().next()) {
-        // TODO(resharding): move points back to original shard here!
+        let mut offset = None;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        loop {
+            let shard_holder = shard_holder.read().await;
 
-        // let ongoing_transfer = shard_holder
-        //     .read()
-        //     .await
-        //     .get_transfers(|transfer| {
-        //         transfer.method == Some(ShardTransferMethod::ReshardingStreamRecords)
-        //             && transfer.shard_id == target_shard_id
-        //             && transfer.to_shard_id == Some(reshard_key.shard_id)
-        //     })
-        //     .pop();
+            let source_replica_set =
+                shard_holder
+                    .get_shard(&reshard_key.shard_id)
+                    .ok_or_else(|| {
+                        CollectionError::service_error(format!(
+                            "Shard {} not found in the shard holder for resharding",
+                            reshard_key.shard_id,
+                        ))
+                    })?;
+            let target_replica_set = shard_holder.get_shard(&target_shard_id).ok_or_else(|| {
+                CollectionError::service_error(format!(
+                    "Shard {target_shard_id} not found in the shard holder for resharding",
+                ))
+            })?;
 
-        // // Take the existing transfer if ongoing, or decide on what new transfer we want to start
-        // let (transfer, start_transfer) = match ongoing_transfer {
-        //     Some(transfer) => (Some(transfer), false),
-        //     None => {
-        //         let incoming_limit = shared_storage_config
-        //             .incoming_shard_transfers_limit
-        //             .unwrap_or(usize::MAX);
-        //         let outgoing_limit = shared_storage_config
-        //             .outgoing_shard_transfers_limit
-        //             .unwrap_or(usize::MAX);
+            // Take batch of points, if full, pop the last entry as next batch offset
+            let mut points = source_replica_set
+                .scroll_by(
+                    offset,
+                    MIGRATE_BATCH_SIZE + 1,
+                    &true.into(),
+                    &true.into(),
+                    // TODO(resharding): directly apply hash ring filter here?
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await?;
 
-        //         let source_peer_ids = {
-        //             let shard_holder = shard_holder.read().await;
-        //             let replica_set =
-        //                 shard_holder.get_shard(&target_shard_id).ok_or_else(|| {
-        //                     CollectionError::service_error(format!(
-        //                         "Shard {target_shard_id} not found in the shard holder for resharding",
-        //                     ))
-        //                 })?;
+            offset = if points.len() > MIGRATE_BATCH_SIZE {
+                points.pop().map(|point| point.id)
+            } else {
+                None
+            };
 
-        //             let active_peer_ids = replica_set.active_shards().await;
-        //             if active_peer_ids.is_empty() {
-        //                 return Err(CollectionError::service_error(format!(
-        //                     "No peer with shard {target_shard_id} in active state for resharding",
-        //                 )));
-        //             }
+            let points: Result<Vec<_>, _> = points
+                .into_iter()
+                .filter(|point| hashring.is_in_shard(&point.id, target_shard_id))
+                .map(PointStruct::try_from)
+                .collect();
+            let points = points.map_err(|err| {
+                CollectionError::service_error(format!(
+                    "Failed to migrate points from shard {target_shard_id} to {} for resharding: {err}",
+                    reshard_key.shard_id,
+                ))
+            })?;
 
-        //             // Respect shard transfer limits, always allow local transfers
-        //             let (incoming, _) = shard_holder.count_shard_transfer_io(&this_peer_id);
-        //             if incoming < incoming_limit {
-        //                 active_peer_ids
-        //                     .into_iter()
-        //                     .filter(|peer_id| {
-        //                         let (_, outgoing) = shard_holder.count_shard_transfer_io(peer_id);
-        //                         outgoing < outgoing_limit || peer_id == &this_peer_id
-        //                     })
-        //                     .collect()
-        //             } else if active_peer_ids.contains(&this_peer_id) {
-        //                 vec![this_peer_id]
-        //             } else {
-        //                 vec![]
-        //             }
-        //         };
+            let operation = CollectionUpdateOperations::PointOperation(
+                PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(points)),
+            );
 
-        //         if source_peer_ids.is_empty() {
-        //             log::trace!("Postponing resharding migration transfer from shard {target_shard_id} to stay below transfer limit on peers");
-        //             sleep(SHARD_TRANSFER_IO_LIMIT_RETRY_INTERVAL).await;
-        //             continue;
-        //         }
+            // Wait on all updates here, not just the last batch
+            // If we don't wait on all updates it somehow results in inconsistent results
+            target_replica_set
+                .update_with_consistency(operation, true, WriteOrdering::Weak)
+                .await?;
 
-        //         let source_peer_id = *source_peer_ids.choose(&mut rand::thread_rng()).unwrap();
-
-        //         // Configure shard transfer object, or use none if doing a local transfer
-        //         if source_peer_id != this_peer_id {
-        //             debug_assert_ne!(source_peer_id, this_peer_id);
-        //             debug_assert_ne!(target_shard_id, reshard_key.shard_id);
-        //             let transfer = ShardTransfer {
-        //                 shard_id: target_shard_id,
-        //                 to_shard_id: Some(reshard_key.shard_id),
-        //                 from: source_peer_id,
-        //                 to: this_peer_id,
-        //                 sync: true,
-        //                 method: Some(ShardTransferMethod::ReshardingStreamRecords),
-        //             };
-        //             (Some(transfer), true)
-        //         } else {
-        //             (None, false)
-        //         }
-        //     }
-        // };
-
-        // match transfer {
-        //     // Transfer from a different peer, start the transfer if needed and await completion
-        //     Some(transfer) => {
-        //         // Create listener for transfer end before proposing to start the transfer
-        //         // That way we're sure we receive all transfer notifications the next operation might create
-        //         let await_transfer_end = shard_holder
-        //             .read()
-        //             .await
-        //             .await_shard_transfer_end(transfer.key(), MIGRATE_POINT_TRANSFER_MAX_DURATION);
-
-        //         if start_transfer {
-        //             consensus
-        //                 .start_shard_transfer_confirm_and_retry(&transfer, collection_id)
-        //                 .await?;
-        //         }
-
-        //         await_transfer_success(
-        //             reshard_key,
-        //             &transfer,
-        //             &shard_holder,
-        //             collection_id,
-        //             consensus,
-        //             await_transfer_end,
-        //         )
-        //         .await
-        //         .map_err(|err| {
-        //             CollectionError::service_error(format!(
-        //                 "Failed to migrate points from shard {target_shard_id} to {} for resharding: {err}",
-        //                 reshard_key.shard_id,
-        //             ))
-        //         })?;
-        //     }
-        //     // Transfer locally, within this peer
-        //     None => {
-        //         migrate_local(
-        //             reshard_key,
-        //             shard_holder.clone(),
-        //             consensus,
-        //             channel_service.clone(),
-        //             collection_id,
-        //             target_shard_id,
-        //         )
-        //         .await?;
-        //     }
-        // }
+            if offset.is_none() {
+                break;
+            }
+        }
 
         state.write(|data| {
             data.migrated_shards.push(target_shard_id);

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -244,6 +244,7 @@ async fn drive_up(
     consensus
         .set_shard_replica_set_state_confirm_and_retry(
             collection_id,
+            None,
             reshard_key.shard_id,
             ReplicaState::Active,
             Some(ReplicaState::Resharding),
@@ -387,6 +388,17 @@ async fn drive_down(
                         reshard_key.shard_id,
                     ))
                 })?;
+
+                // Switch target replica back into active state
+                consensus
+                    .set_shard_replica_set_state_confirm_and_retry(
+                        collection_id,
+                        Some(target_peer_id),
+                        target_shard_id,
+                        ReplicaState::Active,
+                        Some(ReplicaState::Resharding),
+                    )
+                    .await?;
             }
             // Transfer locally, within this peer
             None => {

--- a/lib/collection/src/shards/resharding/stage_replicate.rs
+++ b/lib/collection/src/shards/resharding/stage_replicate.rs
@@ -11,6 +11,7 @@ use super::driver::{PersistedState, Stage};
 use super::tasks_pool::ReshardTaskProgress;
 use super::ReshardKey;
 use crate::config::CollectionConfig;
+use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::resharding::driver::{
@@ -174,6 +175,11 @@ async fn has_enough_replicas(
     shard_holder: &Arc<LockedShardHolder>,
     collection_config: &Arc<RwLock<CollectionConfig>>,
 ) -> CollectionResult<bool> {
+    // We don't need to replicate when scaling down
+    if reshard_key.direction == ReshardingDirection::Down {
+        return Ok(true);
+    }
+
     let desired_replication_factor = collection_config
         .read()
         .await

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -118,6 +118,25 @@ impl ShardHolder {
         Ok(())
     }
 
+    pub fn remove_shard_from_key_mapping(
+        &mut self,
+        shard_id: &ShardId,
+        shard_key: &ShardKey,
+    ) -> Result<(), CollectionError> {
+        self.key_mapping.write_optional(|key_mapping| {
+            if !key_mapping.contains_key(shard_key) {
+                return None;
+            }
+
+            let mut key_mapping = key_mapping.clone();
+            key_mapping.get_mut(shard_key).unwrap().remove(shard_id);
+            Some(key_mapping)
+        })?;
+        self.shard_id_to_key_mapping.remove(shard_id);
+
+        Ok(())
+    }
+
     pub fn add_shard(
         &mut self,
         shard_id: ShardId,

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -106,7 +106,10 @@ impl ShardHolder {
         self.key_mapping.read().clone()
     }
 
-    async fn drop_and_remove_shard(&mut self, shard_id: ShardId) -> Result<(), CollectionError> {
+    pub async fn drop_and_remove_shard(
+        &mut self,
+        shard_id: ShardId,
+    ) -> Result<(), CollectionError> {
         if let Some(replica_set) = self.shards.remove(&shard_id) {
             let shard_path = replica_set.shard_path.clone();
             drop(replica_set);

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -405,6 +405,7 @@ impl ShardHolder {
             resharding_operations.push(ReshardingInfo {
                 shard_id: resharding_state.shard_id,
                 peer_id: resharding_state.peer_id,
+                direction: resharding_state.direction,
                 shard_key: resharding_state.shard_key.clone(),
                 comment: status.map(|p| p.comment),
             });

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -650,7 +650,7 @@ impl ShardHolder {
         if let Some(state) = self.resharding_state.read().clone() {
             self.rings
                 .entry(state.shard_key)
-                .and_modify(|ring| ring.add_resharding(state.shard_id));
+                .and_modify(|ring| ring.start_resharding(state.shard_id, state.direction));
         }
     }
 

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -7,6 +7,7 @@ use segment::types::{Condition, Filter, ShardKey};
 
 use super::ShardHolder;
 use crate::hash_ring::{self, HashRing};
+use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::{ReplicaState, ShardReplicaSet};
 use crate::shards::resharding::{ReshardKey, ReshardStage, ReshardState};
@@ -59,6 +60,7 @@ impl ShardHolder {
             peer_id,
             shard_id,
             shard_key,
+            direction,
         } = resharding_key;
 
         // TODO(resharding): Delete shard on error!?
@@ -74,7 +76,7 @@ impl ShardHolder {
                 "resharding is already in progress:\n{state:#?}"
             );
 
-            *state = Some(ReshardState::new(peer_id, shard_id, shard_key));
+            *state = Some(ReshardState::new(peer_id, shard_id, shard_key, direction));
         })?;
 
         Ok(())
@@ -180,6 +182,7 @@ impl ShardHolder {
         let ReshardKey {
             peer_id,
             shard_id,
+            direction,
             ref shard_key,
         } = resharding_key;
 

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -39,10 +39,22 @@ impl ShardHolder {
             }
         }
 
-        if self.shards.contains_key(shard_id) {
-            return Err(CollectionError::bad_request(format!(
-                "shard holder already contains shard {shard_id} replica set",
-            )));
+        let has_shard = self.shards.contains_key(shard_id);
+        match resharding_key.direction {
+            ReshardingDirection::Up => {
+                if has_shard {
+                    return Err(CollectionError::bad_request(format!(
+                        "shard holder already contains shard {shard_id} replica set",
+                    )));
+                }
+            }
+            ReshardingDirection::Down => {
+                if !has_shard {
+                    return Err(CollectionError::bad_request(format!(
+                        "shard holder does not contain shard {shard_id} replica set",
+                    )));
+                }
+            }
         }
 
         // TODO(resharding): Check that peer exists!?

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -69,10 +69,10 @@ impl ShardHolder {
         new_shard: Option<ShardReplicaSet>,
     ) -> CollectionResult<()> {
         let ReshardKey {
+            direction,
             peer_id,
             shard_id,
             shard_key,
-            direction,
         } = resharding_key;
 
         // TODO(resharding): Delete shard on error!?
@@ -92,7 +92,7 @@ impl ShardHolder {
                 "resharding is already in progress:\n{state:#?}",
             );
 
-            *state = Some(ReshardState::new(peer_id, shard_id, shard_key, direction));
+            *state = Some(ReshardState::new(direction, peer_id, shard_id, shard_key));
         })?;
 
         Ok(())
@@ -196,9 +196,9 @@ impl ShardHolder {
 
     pub async fn abort_resharding(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
         let ReshardKey {
+            direction,
             peer_id,
             shard_id,
-            direction,
             ref shard_key,
         } = resharding_key;
 

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -406,6 +406,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     async fn set_shard_replica_set_state(
         &self,
         collection_id: CollectionId,
+        peer_id: Option<PeerId>,
         shard_id: ShardId,
         state: ReplicaState,
         from_state: Option<ReplicaState>,
@@ -418,6 +419,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     async fn set_shard_replica_set_state_confirm_and_retry(
         &self,
         collection_id: &CollectionId,
+        peer_id: Option<PeerId>,
         shard_id: ShardId,
         state: ReplicaState,
         from_state: Option<ReplicaState>,
@@ -434,7 +436,13 @@ pub trait ShardTransferConsensus: Send + Sync {
 
             log::trace!("Propose and confirm set shard replica set state");
             result = self
-                .set_shard_replica_set_state(collection_id.clone(), shard_id, state, from_state)
+                .set_shard_replica_set_state(
+                    collection_id.clone(),
+                    peer_id,
+                    shard_id,
+                    state,
+                    from_state,
+                )
                 .await;
 
             match &result {

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -49,7 +49,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_cbor = { workspace = true }
 serde-value = "0.7"
-serde_variant = "0.1.3"
+serde_variant = { workspace = true }
 serde-untagged = "0.1.6"
 ordered-float = "4.2"
 thiserror = "1.0"

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -146,6 +146,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
     async fn set_shard_replica_set_state(
         &self,
         collection_id: CollectionId,
+        peer_id: Option<PeerId>,
         shard_id: ShardId,
         state: ReplicaState,
         from_state: Option<ReplicaState>,
@@ -153,7 +154,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
         let operation = ConsensusOperations::set_replica_state(
             collection_id,
             shard_id,
-            self.this_peer_id(),
+            peer_id.unwrap_or_else(|| self.this_peer_id()),
             state,
             from_state,
         );

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -524,9 +524,9 @@ pub async fn do_update_collection_cluster(
         }
         ClusterOperations::StartResharding(op) => {
             let StartResharding {
+                direction,
                 peer_id,
                 shard_key,
-                direction,
             } = op.start_resharding;
 
             let collection_state = collection.state().await;
@@ -627,10 +627,10 @@ pub async fn do_update_collection_cluster(
                     CollectionMetaOperations::Resharding(
                         collection_name.clone(),
                         ReshardingOperation::Start(ReshardKey {
+                            direction,
                             peer_id,
                             shard_id,
                             shard_key,
-                            direction,
                         }),
                     ),
                     access,
@@ -650,10 +650,10 @@ pub async fn do_update_collection_cluster(
                     CollectionMetaOperations::Resharding(
                         collection_name.clone(),
                         ReshardingOperation::Abort(ReshardKey {
+                            direction: state.direction,
                             peer_id: state.peer_id,
                             shard_id: state.shard_id,
                             shard_key: state.shard_key.clone(),
-                            direction: state.direction,
                         }),
                     ),
                     access,

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -585,16 +585,10 @@ pub async fn do_update_collection_cluster(
                             *counts.entry(*peer_id).or_insert(0) += 1;
                             counts
                         });
-                    consensus_state
-                        .persistent
-                        .read()
-                        .peer_address_by_id
-                        .read()
-                        .keys()
-                        .for_each(|peer_id| {
-                            // Add registered peers not holding any shard yet
-                            shards_on_peers.entry(*peer_id).or_insert(0);
-                        });
+                    for peer_id in get_all_peer_ids() {
+                        // Add registered peers not holding any shard yet
+                        shards_on_peers.entry(peer_id).or_insert(0);
+                    }
                     shards_on_peers
                         .into_iter()
                         .min_by_key(|(_, count)| *count)

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -6,7 +6,8 @@ use api::grpc::qdrant::CollectionExists;
 use collection::config::ShardingMethod;
 use collection::operations::cluster_ops::{
     AbortTransferOperation, ClusterOperations, DropReplicaOperation, MoveShardOperation,
-    ReplicateShardOperation, RestartTransfer, RestartTransferOperation, StartResharding,
+    ReplicateShardOperation, ReshardingDirection, RestartTransfer, RestartTransferOperation,
+    StartResharding,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::snapshot_ops::SnapshotDescription;
@@ -520,7 +521,11 @@ pub async fn do_update_collection_cluster(
                 .await
         }
         ClusterOperations::StartResharding(op) => {
-            let StartResharding { peer_id, shard_key } = op.start_resharding;
+            let StartResharding {
+                peer_id,
+                shard_key,
+                direction,
+            } = op.start_resharding;
 
             let peer_id = match peer_id {
                 Some(peer_id) => {
@@ -575,6 +580,7 @@ pub async fn do_update_collection_cluster(
                             peer_id,
                             shard_id,
                             shard_key,
+                            direction,
                         }),
                     ),
                     access,
@@ -597,6 +603,7 @@ pub async fn do_update_collection_cluster(
                             peer_id: state.peer_id,
                             shard_id: state.shard_id,
                             shard_key: state.shard_key.clone(),
+                            direction: state.direction,
                         }),
                     ),
                     access,

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -11,11 +11,11 @@ COLLECTION_NAME = "test_collection"
 
 # Test resharding.
 #
-# On a static collection, this performs resharding a few times and asserts the
-# shard and point counts are correct.
+# On a static collection, this performs resharding up and down a few times and
+# asserts the shard and point counts are correct.
 #
-# More specifically this starts at 1 shard, reshards 3 times and ends up with 4
-# shards.
+# More specifically this starts at 1 shard, reshards 3 times to 4 shards, and
+# reshards 3 times back to 1 shard.
 def test_resharding(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -44,7 +44,7 @@ def test_resharding(tmp_path: pathlib.Path):
         assert check_collection_local_shards_count(uri, COLLECTION_NAME, 1)
         assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, num_points)
 
-    # Reshard 3 times in sequence
+    # Reshard up 3 times in sequence
     for shard_count in range(2, 5):
         # Start resharding
         r = requests.post(
@@ -52,6 +52,46 @@ def test_resharding(tmp_path: pathlib.Path):
                 "start_resharding": {
                     "peer_id": first_peer_id,
                     "shard_key": None,
+                    "direction": "up"
+                }
+            })
+        assert_http_ok(r)
+
+        # Wait for resharding operation to start and stop
+        wait_for_collection_resharding_operations_count(peer_api_uris[0], COLLECTION_NAME, 1)
+        for uri in peer_api_uris:
+            wait_for_collection_resharding_operations_count(uri, COLLECTION_NAME, 0)
+
+        # Assert node shard and point sum count
+        for uri in peer_api_uris:
+            assert check_collection_local_shards_count(uri, COLLECTION_NAME, shard_count)
+            assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, num_points)
+
+    sleep(1)
+
+    # Match all points on all nodes exactly
+    data = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
+                "limit": 999999999,
+                "with_vectors": True,
+                "with_payload": True,
+            }
+        )
+        assert_http_ok(r)
+        data.append(r.json()["result"])
+    check_data_consistency(data)
+
+    # Reshard down 3 times in sequence
+    for shard_count in range(3, 0, -1):
+        # Start resharding
+        r = requests.post(
+            f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+                "start_resharding": {
+                    "peer_id": first_peer_id,
+                    "shard_key": None,
+                    "direction": "down"
                 }
             })
         assert_http_ok(r)

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -27,7 +27,6 @@ def test_resharding(tmp_path: pathlib.Path):
     }
 
     peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
-    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
 
     # Create collection, insert points
     create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
@@ -50,8 +49,7 @@ def test_resharding(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "direction": "up",
-                    "peer_id": first_peer_id
+                    "direction": "up"
                 }
             })
         assert_http_ok(r)
@@ -88,8 +86,7 @@ def test_resharding(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "direction": "down",
-                    "peer_id": first_peer_id
+                    "direction": "down"
                 }
             })
         assert_http_ok(r)

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -51,7 +51,6 @@ def test_resharding(tmp_path: pathlib.Path):
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
                     "peer_id": first_peer_id,
-                    "shard_key": None,
                     "direction": "up"
                 }
             })
@@ -90,7 +89,6 @@ def test_resharding(tmp_path: pathlib.Path):
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
                     "peer_id": first_peer_id,
-                    "shard_key": None,
                     "direction": "down"
                 }
             })
@@ -182,7 +180,7 @@ def test_resharding_balance(tmp_path: pathlib.Path):
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
                     "peer_id": first_peer_id,
-                    "shard_key": None,
+                    "direction": "up"
                 }
             })
         assert_http_ok(r)
@@ -228,7 +226,6 @@ def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
     }
 
     peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
-    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
 
     # Create collection, insert points
     create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
@@ -264,8 +261,7 @@ def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "shard_key": None,
+                    "direction": "up"
                 }
             })
         assert_http_ok(r)
@@ -324,7 +320,6 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
     }
 
     peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
-    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
 
     # Create collection, insert points
     create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
@@ -347,8 +342,7 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "shard_key": None,
+                    "direction": "up"
                 }
             })
         assert_http_ok(r)
@@ -409,7 +403,6 @@ def test_resharding_indexing_stable_point_count(tmp_path: pathlib.Path):
     }
 
     peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
-    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
 
     # Create collection, insert points
     create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
@@ -432,8 +425,7 @@ def test_resharding_indexing_stable_point_count(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "shard_key": None,
+                    "direction": "up"
                 }
             })
         assert_http_ok(r)
@@ -498,7 +490,6 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
     }
 
     peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
-    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
 
     # Create collection, insert points
     create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
@@ -535,8 +526,7 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "shard_key": None,
+                    "direction": "up"
                 }
             })
         assert_http_ok(r)
@@ -590,7 +580,6 @@ def test_resharding_stable_query(tmp_path: pathlib.Path):
     }
 
     peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None, extra_env=env)
-    first_peer_id = get_cluster_info(peer_api_uris[0])['peer_id']
 
     # Create collection, insert points
     create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
@@ -627,8 +616,7 @@ def test_resharding_stable_query(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "shard_key": None,
+                    "direction": "up"
                 }
             })
         assert_http_ok(r)
@@ -709,7 +697,7 @@ def test_resharding_resume_on_restart(tmp_path: pathlib.Path):
         f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
             "start_resharding": {
                 "peer_id": first_peer_id,
-                "shard_key": None,
+                "direction": "up"
             }
         })
     assert_http_ok(r)

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -43,6 +43,16 @@ def test_resharding(tmp_path: pathlib.Path):
         assert check_collection_local_shards_count(uri, COLLECTION_NAME, 1)
         assert check_collection_local_shards_point_count(uri, COLLECTION_NAME, num_points)
 
+    # We cannot reshard down now, because we only have one shard
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "start_resharding": {
+                "direction": "down"
+            }
+        })
+    assert r.status_code == 400
+    assert r.json()["status"]["error"] == "Bad request: cannot remove shard 0 by resharding down, it is the last shard"
+
     # Reshard up 3 times in sequence
     for shard_count in range(2, 5):
         # Start resharding

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -50,8 +50,8 @@ def test_resharding(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "direction": "up"
+                    "direction": "up",
+                    "peer_id": first_peer_id
                 }
             })
         assert_http_ok(r)
@@ -88,8 +88,8 @@ def test_resharding(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "direction": "down"
+                    "direction": "down",
+                    "peer_id": first_peer_id
                 }
             })
         assert_http_ok(r)
@@ -179,8 +179,8 @@ def test_resharding_balance(tmp_path: pathlib.Path):
         r = requests.post(
             f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
                 "start_resharding": {
-                    "peer_id": first_peer_id,
-                    "direction": "up"
+                    "direction": "up",
+                    "peer_id": first_peer_id
                 }
             })
         assert_http_ok(r)
@@ -696,8 +696,8 @@ def test_resharding_resume_on_restart(tmp_path: pathlib.Path):
     r = requests.post(
         f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
             "start_resharding": {
-                "peer_id": first_peer_id,
-                "direction": "up"
+                "direction": "up",
+                "peer_id": first_peer_id
             }
         })
     assert_http_ok(r)


### PR DESCRIPTION
Tracked in: #4213 
Depends on: #4697

_WIP_

Revise point migration transfers when resharding down. Rather than a manual scroll+upsert loop, this utilizes shard transfers to make the point migrations. The catch here is that it needs a transfer to every replica separately.

Resharding down with 3 shards and 3 replicas on each would mean 2*3 migration transfers.

Another problem is that the these transfers currently switch the active replicas into `Resharding` state. That means that **all** shards changed into this state at some point during resharding. We can't leave them `Active`, because our shard transfer logic does not support that right now. I'm not sure if this is easily fixable. Ideally we don't touch their state at all and leave them `Active`.

### Open problems
- [ ] Shard holder reading for getting replicas to migrate is currently badly implemented
- [ ] Target replicas are switched into `Resharding` state during transfer

### Tasks
- [ ] Merge #4697
- [ ] Rebase on `dev`
- [ ] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?