### PR TITLE
Remove NumericIndexKey and use histogram point

### DIFF
--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -23,7 +23,7 @@ pub struct Counts {
     pub right: usize,
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Point<T> {
     pub val: T,
@@ -38,21 +38,12 @@ impl<T> Point<T> {
 
 impl<T: PartialEq> Eq for Point<T> {}
 
-impl<T: PartialEq + PartialOrd> PartialOrd for Point<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T: PartialEq + PartialOrd> Ord for Point<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match self.val.partial_cmp(&other.val) {
-            Some(cmp) => match cmp {
-                std::cmp::Ordering::Equal => self.idx.cmp(&other.idx),
-                ord => ord,
-            },
-            None => self.idx.cmp(&other.idx),
-        }
+#[allow(clippy::derive_ord_xor_partial_ord)]
+impl<T: PartialOrd + Copy> Ord for Point<T> {
+    fn cmp(&self, other: &Point<T>) -> std::cmp::Ordering {
+        (self.val, self.idx)
+            .partial_cmp(&(other.val, other.idx))
+            .unwrap()
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -143,7 +143,7 @@ impl<'a, T: Encodable + Numericable> DoubleEndedIterator for NumericKeySortedVec
             let deleted = self
                 .set
                 .deleted
-                .get(self.start_index)
+                .get(self.end_index - 1)
                 .as_deref()
                 .copied()
                 .unwrap_or(true);

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::sync::Arc;
 
+use bitvec::vec::BitVec;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -23,15 +24,9 @@ pub struct ImmutableNumericIndex<T: Encodable + Numericable + Default> {
     point_to_values: ImmutablePointToValues<T>,
 }
 
-#[derive(Clone, PartialEq, Debug)]
-pub(super) struct NumericIndexKey<T> {
-    key: T,
-    idx: PointOffsetType,
-    deleted: bool,
-}
-
 struct NumericKeySortedVec<T: Encodable + Numericable> {
-    data: Vec<NumericIndexKey<T>>,
+    data: Vec<Point<T>>,
+    deleted: BitVec,
     deleted_count: usize,
 }
 
@@ -41,72 +36,17 @@ pub(super) struct NumericKeySortedVecIterator<'a, T: Encodable + Numericable> {
     end_index: usize,
 }
 
-impl<T: PartialEq + PartialOrd + Encodable + Numericable> NumericIndexKey<T> {
-    pub(super) fn new(key: T, idx: PointOffsetType) -> Self {
-        Self {
-            key,
-            idx,
-            deleted: false,
-        }
-    }
-
-    pub(super) fn encode(&self) -> Vec<u8> {
-        T::encode_key(&self.key, self.idx)
-    }
-
-    pub(super) fn decode(bytes: &[u8]) -> Self {
-        let (idx, key) = T::decode_key(bytes);
-        Self {
-            key,
-            idx,
-            deleted: false,
-        }
-    }
-}
-
-impl<T> From<NumericIndexKey<T>> for Point<T> {
-    fn from(key: NumericIndexKey<T>) -> Self {
-        Point {
-            val: key.key,
-            idx: key.idx as usize,
-        }
-    }
-}
-
-impl<T> From<Point<T>> for NumericIndexKey<T> {
-    fn from(key: Point<T>) -> Self {
-        NumericIndexKey {
-            key: key.val,
-            idx: key.idx as PointOffsetType,
-            deleted: false,
-        }
-    }
-}
-
-impl<T: PartialEq + PartialOrd + Encodable> PartialOrd for NumericIndexKey<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T: PartialEq + PartialOrd + Encodable> Ord for NumericIndexKey<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match self.key.cmp_encoded(&other.key) {
-            std::cmp::Ordering::Equal => self.idx.cmp(&other.idx),
-            ord => ord,
-        }
-    }
-}
-
-impl<T: PartialEq + PartialOrd + Encodable> Eq for NumericIndexKey<T> {}
-
 impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
     fn from_btree_map(map: BTreeMap<Vec<u8>, u32>) -> Self {
         Self {
+            deleted: BitVec::repeat(false, map.len()),
             data: map
                 .keys()
                 .cloned()
-                .map(|b| NumericIndexKey::<T>::decode(&b))
+                .map(|bytes| {
+                    let (idx, val) = T::decode_key(&bytes);
+                    Point::new(val, idx)
+                })
                 .collect(),
             deleted_count: 0,
         }
@@ -116,20 +56,23 @@ impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
         self.data.len() - self.deleted_count
     }
 
-    fn remove(&mut self, key: NumericIndexKey<T>) -> bool {
+    fn remove(&mut self, key: Point<T>) -> bool {
         if let Ok(index) = self.data.binary_search(&key) {
-            self.data[index].deleted = true;
-            self.deleted_count += 1;
-            true
-        } else {
-            false
+            if let Some(is_deleted) = self.deleted.get_mut(index).as_deref_mut() {
+                if !*is_deleted {
+                    self.deleted_count += 1;
+                    *is_deleted = true;
+                }
+                return true;
+            }
         }
+        false
     }
 
     fn values_range(
         &self,
-        start_bound: Bound<NumericIndexKey<T>>,
-        end_bound: Bound<NumericIndexKey<T>>,
+        start_bound: Bound<Point<T>>,
+        end_bound: Bound<Point<T>>,
     ) -> NumericKeySortedVecIterator<'_, T> {
         let start_index = self.find_start_index(start_bound);
         let end_index = self.find_end_index(start_index, end_bound);
@@ -140,7 +83,7 @@ impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
         }
     }
 
-    fn find_start_index(&self, bound: Bound<NumericIndexKey<T>>) -> usize {
+    fn find_start_index(&self, bound: Bound<Point<T>>) -> usize {
         match bound {
             Bound::Included(bound) => self.data.binary_search(&bound).unwrap_or_else(|idx| idx),
             Bound::Excluded(bound) => match self.data.binary_search(&bound) {
@@ -151,7 +94,7 @@ impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
         }
     }
 
-    fn find_end_index(&self, start: usize, bound: Bound<NumericIndexKey<T>>) -> usize {
+    fn find_end_index(&self, start: usize, bound: Bound<Point<T>>) -> usize {
         if start >= self.data.len() {
             // the range `end` should never be less than `start`
             return start;
@@ -171,13 +114,20 @@ impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
 }
 
 impl<'a, T: Encodable + Numericable> Iterator for NumericKeySortedVecIterator<'a, T> {
-    type Item = NumericIndexKey<T>;
+    type Item = Point<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.set.data[self.start_index].clone();
+            let deleted = self
+                .set
+                .deleted
+                .get(self.start_index)
+                .as_deref()
+                .copied()
+                .unwrap_or(true);
             self.start_index += 1;
-            if key.deleted {
+            if deleted {
                 continue;
             }
             return Some(key);
@@ -190,8 +140,15 @@ impl<'a, T: Encodable + Numericable> DoubleEndedIterator for NumericKeySortedVec
     fn next_back(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.set.data[self.end_index - 1].clone();
+            let deleted = self
+                .set
+                .deleted
+                .get(self.start_index)
+                .as_deref()
+                .copied()
+                .unwrap_or(true);
             self.end_index -= 1;
-            if key.deleted {
+            if deleted {
                 continue;
             }
             return Some(key);
@@ -210,6 +167,7 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
         Self {
             map: NumericKeySortedVec {
                 data: Default::default(),
+                deleted: BitVec::new(),
                 deleted_count: 0,
             },
             db_wrapper,
@@ -250,22 +208,22 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
 
     pub(super) fn values_range(
         &self,
-        start_bound: Bound<NumericIndexKey<T>>,
-        end_bound: Bound<NumericIndexKey<T>>,
+        start_bound: Bound<Point<T>>,
+        end_bound: Bound<Point<T>>,
     ) -> impl Iterator<Item = PointOffsetType> + '_ {
         self.map
             .values_range(start_bound, end_bound)
-            .map(|NumericIndexKey { idx, .. }| idx)
+            .map(|Point { idx, .. }| idx)
     }
 
     pub(super) fn orderable_values_range(
         &self,
-        start_bound: Bound<NumericIndexKey<T>>,
-        end_bound: Bound<NumericIndexKey<T>>,
+        start_bound: Bound<Point<T>>,
+        end_bound: Bound<Point<T>>,
     ) -> impl DoubleEndedIterator<Item = (T, PointOffsetType)> + '_ {
         self.map
             .values_range(start_bound, end_bound)
-            .map(|NumericIndexKey { key, idx, .. }| (key, idx))
+            .map(|Point { val, idx, .. }| (val, idx))
     }
 
     pub(super) fn load(&mut self) -> OperationResult<bool> {
@@ -301,7 +259,7 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
         if let Some(removed_values) = self.point_to_values.get_values(idx) {
             let mut removed_count = 0;
             for value in removed_values {
-                let key = NumericIndexKey::new(*value, idx);
+                let key = Point::new(*value, idx);
                 Self::remove_from_map(&mut self.map, &mut self.histogram, key);
 
                 // update db
@@ -321,11 +279,11 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
     fn remove_from_map(
         map: &mut NumericKeySortedVec<T>,
         histogram: &mut Histogram<T>,
-        key: NumericIndexKey<T>,
+        key: Point<T>,
     ) {
         if map.remove(key.clone()) {
             histogram.remove(
-                &key.into(),
+                &key,
                 |x| Self::get_histogram_left_neighbor(map, x),
                 |x| Self::get_histogram_right_neighbor(map, x),
             );
@@ -336,20 +294,16 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
         map: &NumericKeySortedVec<T>,
         point: &Point<T>,
     ) -> Option<Point<T>> {
-        let key: NumericIndexKey<T> = point.clone().into();
-        map.values_range(Bound::Unbounded, Bound::Excluded(key))
+        map.values_range(Bound::Unbounded, Bound::Excluded(point.clone()))
             .next_back()
-            .map(|key| key.into())
     }
 
     fn get_histogram_right_neighbor(
         map: &NumericKeySortedVec<T>,
         point: &Point<T>,
     ) -> Option<Point<T>> {
-        let key: NumericIndexKey<T> = point.clone().into();
-        map.values_range(Bound::Excluded(key), Bound::Unbounded)
+        map.values_range(Bound::Excluded(point.clone()), Bound::Unbounded)
             .next()
-            .map(|key| key.into())
     }
 }
 
@@ -365,30 +319,33 @@ mod tests {
     fn check_range(
         key_set: &NumericKeySortedVec<FloatPayloadType>,
         encoded_map: &BTreeMap<Vec<u8>, PointOffsetType>,
-        start_bound: Bound<NumericIndexKey<FloatPayloadType>>,
-        end_bound: Bound<NumericIndexKey<FloatPayloadType>>,
+        start_bound: Bound<Point<FloatPayloadType>>,
+        end_bound: Bound<Point<FloatPayloadType>>,
     ) {
         let set1 = key_set
             .values_range(start_bound.clone(), end_bound.clone())
             .collect::<Vec<_>>();
 
         let start_encoded_bound = match start_bound {
-            Included(k) => Included(k.encode()),
-            Excluded(k) => Excluded(k.encode()),
+            Included(k) => Included(k.val.encode_key(k.idx)),
+            Excluded(k) => Excluded(k.val.encode_key(k.idx)),
             Unbounded => Unbounded,
         };
         let end_encoded_bound = match end_bound {
-            Included(k) => Included(k.encode()),
-            Excluded(k) => Excluded(k.encode()),
+            Included(k) => Included(k.val.encode_key(k.idx)),
+            Excluded(k) => Excluded(k.val.encode_key(k.idx)),
             Unbounded => Unbounded,
         };
         let set2 = encoded_map
             .range((start_encoded_bound, end_encoded_bound))
-            .map(|(b, _)| NumericIndexKey::<FloatPayloadType>::decode(b))
+            .map(|(b, _)| {
+                let (idx, value) = FloatPayloadType::decode_key(b);
+                Point::new(value, idx)
+            })
             .collect::<Vec<_>>();
 
         for (k1, k2) in set1.iter().zip(set2.iter()) {
-            if k1.key.is_nan() && k2.key.is_nan() {
+            if k1.val.is_nan() && k2.val.is_nan() {
                 assert_eq!(k1.idx, k2.idx);
             } else {
                 assert_eq!(k1, k2);
@@ -405,93 +362,93 @@ mod tests {
             key_set,
             encoded_map,
             Bound::Unbounded,
-            Bound::Included(NumericIndexKey::new(0.4, 2)),
+            Bound::Included(Point::new(0.4, 2)),
         );
         check_range(
             key_set,
             encoded_map,
             Bound::Unbounded,
-            Bound::Excluded(NumericIndexKey::new(0.4, 2)),
+            Bound::Excluded(Point::new(0.4, 2)),
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Included(NumericIndexKey::new(0.4, 2)),
+            Bound::Included(Point::new(0.4, 2)),
             Bound::Unbounded,
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Excluded(NumericIndexKey::new(0.4, 2)),
+            Bound::Excluded(Point::new(0.4, 2)),
             Bound::Unbounded,
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Included(NumericIndexKey::new(-5.0, 1)),
-            Bound::Included(NumericIndexKey::new(5.0, 1)),
+            Bound::Included(Point::new(-5.0, 1)),
+            Bound::Included(Point::new(5.0, 1)),
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Included(NumericIndexKey::new(-5.0, 1)),
-            Bound::Excluded(NumericIndexKey::new(5.0, 1)),
+            Bound::Included(Point::new(-5.0, 1)),
+            Bound::Excluded(Point::new(5.0, 1)),
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Excluded(NumericIndexKey::new(-5.0, 1)),
-            Bound::Included(NumericIndexKey::new(5.0, 1)),
+            Bound::Excluded(Point::new(-5.0, 1)),
+            Bound::Included(Point::new(5.0, 1)),
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Excluded(NumericIndexKey::new(-5.0, 1)),
-            Bound::Excluded(NumericIndexKey::new(5.0, 1)),
+            Bound::Excluded(Point::new(-5.0, 1)),
+            Bound::Excluded(Point::new(5.0, 1)),
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Included(NumericIndexKey::new(-5.0, 1000)),
-            Bound::Included(NumericIndexKey::new(5.0, 1000)),
+            Bound::Included(Point::new(-5.0, 1000)),
+            Bound::Included(Point::new(5.0, 1000)),
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Excluded(NumericIndexKey::new(-5.0, 1000)),
-            Bound::Excluded(NumericIndexKey::new(5.0, 1000)),
+            Bound::Excluded(Point::new(-5.0, 1000)),
+            Bound::Excluded(Point::new(5.0, 1000)),
         );
         check_range(
             key_set,
             encoded_map,
-            Bound::Excluded(NumericIndexKey::new(-50000.0, 1000)),
-            Bound::Excluded(NumericIndexKey::new(50000.0, 1000)),
+            Bound::Excluded(Point::new(-50000.0, 1000)),
+            Bound::Excluded(Point::new(50000.0, 1000)),
         );
     }
 
     #[test]
     fn test_numeric_index_key_set() {
         let pairs = [
-            NumericIndexKey::new(0.0, 1),
-            NumericIndexKey::new(0.0, 3),
-            NumericIndexKey::new(-0.0, 2),
-            NumericIndexKey::new(-0.0, 4),
-            NumericIndexKey::new(0.4, 2),
-            NumericIndexKey::new(-0.4, 3),
-            NumericIndexKey::new(5.0, 1),
-            NumericIndexKey::new(-5.0, 1),
-            NumericIndexKey::new(f64::NAN, 0),
-            NumericIndexKey::new(f64::NAN, 2),
-            NumericIndexKey::new(f64::NAN, 3),
-            NumericIndexKey::new(f64::INFINITY, 0),
-            NumericIndexKey::new(f64::NEG_INFINITY, 1),
-            NumericIndexKey::new(f64::NEG_INFINITY, 2),
-            NumericIndexKey::new(f64::NEG_INFINITY, 3),
+            Point::new(0.0, 1),
+            Point::new(0.0, 3),
+            Point::new(-0.0, 2),
+            Point::new(-0.0, 4),
+            Point::new(0.4, 2),
+            Point::new(-0.4, 3),
+            Point::new(5.0, 1),
+            Point::new(-5.0, 1),
+            Point::new(f64::NAN, 0),
+            Point::new(f64::NAN, 2),
+            Point::new(f64::NAN, 3),
+            Point::new(f64::INFINITY, 0),
+            Point::new(f64::NEG_INFINITY, 1),
+            Point::new(f64::NEG_INFINITY, 2),
+            Point::new(f64::NEG_INFINITY, 3),
         ];
 
         let encoded: Vec<(Vec<u8>, PointOffsetType)> = pairs
             .iter()
-            .map(|k| (FloatPayloadType::encode_key(&k.key, k.idx), k.idx))
+            .map(|k| (k.val.encode_key(k.idx), k.idx))
             .collect();
 
         let mut set_byte: BTreeMap<Vec<u8>, PointOffsetType> = encoded.iter().cloned().collect();
@@ -501,16 +458,16 @@ mod tests {
         check_ranges(&set_keys, &set_byte);
 
         // test deletion and ranges after deletion
-        let deleted_key = NumericIndexKey::new(0.4, 2);
+        let deleted_key = Point::new(0.4, 2);
         set_keys.remove(deleted_key.clone());
-        set_byte.remove(&deleted_key.encode());
+        set_byte.remove(&deleted_key.val.encode_key(deleted_key.idx));
 
         check_ranges(&set_keys, &set_byte);
 
         // test deletion and ranges after deletion
-        let deleted_key = NumericIndexKey::new(-5.0, 1);
+        let deleted_key = Point::new(-5.0, 1);
         set_keys.remove(deleted_key.clone());
-        set_byte.remove(&deleted_key.encode());
+        set_byte.remove(&deleted_key.val.encode_key(deleted_key.idx));
 
         check_ranges(&set_keys, &set_byte);
     }
@@ -518,38 +475,32 @@ mod tests {
     #[test]
     fn test_numeric_index_key_sorting() {
         let pairs = [
-            NumericIndexKey::new(0.0, 1),
-            NumericIndexKey::new(0.0, 3),
-            NumericIndexKey::new(-0.0, 2),
-            NumericIndexKey::new(-0.0, 4),
-            NumericIndexKey::new(0.4, 2),
-            NumericIndexKey::new(-0.4, 3),
-            NumericIndexKey::new(5.0, 1),
-            NumericIndexKey::new(-5.0, 1),
-            NumericIndexKey::new(f64::NAN, 0),
-            NumericIndexKey::new(f64::NAN, 2),
-            NumericIndexKey::new(f64::NAN, 3),
-            NumericIndexKey::new(f64::INFINITY, 0),
-            NumericIndexKey::new(f64::NEG_INFINITY, 1),
-            NumericIndexKey::new(f64::NEG_INFINITY, 2),
-            NumericIndexKey::new(f64::NEG_INFINITY, 3),
+            Point::new(0.0, 1),
+            Point::new(0.0, 3),
+            Point::new(-0.0, 2),
+            Point::new(-0.0, 4),
+            Point::new(0.4, 2),
+            Point::new(-0.4, 3),
+            Point::new(5.0, 1),
+            Point::new(-5.0, 1),
+            Point::new(f64::INFINITY, 0),
+            Point::new(f64::NEG_INFINITY, 1),
+            Point::new(f64::NEG_INFINITY, 2),
+            Point::new(f64::NEG_INFINITY, 3),
         ];
 
-        let encoded: Vec<Vec<u8>> = pairs
-            .iter()
-            .map(|k| FloatPayloadType::encode_key(&k.key, k.idx))
-            .collect();
+        let encoded: Vec<Vec<u8>> = pairs.iter().map(|k| k.val.encode_key(k.idx)).collect();
 
         let set_byte: BTreeSet<Vec<u8>> = encoded.iter().cloned().collect();
-        let set_keys: BTreeSet<NumericIndexKey<FloatPayloadType>> = pairs.iter().cloned().collect();
+        let set_keys: BTreeSet<Point<FloatPayloadType>> = pairs.iter().cloned().collect();
 
         for (b, k) in set_byte.iter().zip(set_keys.iter()) {
             let (decoded_id, decoded_float) = FloatPayloadType::decode_key(b.as_slice());
-            if decoded_float.is_nan() && k.key.is_nan() {
+            if decoded_float.is_nan() && k.val.is_nan() {
                 assert_eq!(decoded_id, k.idx);
             } else {
                 assert_eq!(decoded_id, k.idx);
-                assert_eq!(decoded_float, k.key);
+                assert_eq!(decoded_float, k.val);
             }
         }
     }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -21,7 +21,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
 
-use self::immutable_numeric_index::{ImmutableNumericIndex, NumericIndexKey};
+use self::immutable_numeric_index::ImmutableNumericIndex;
+use super::histogram::Point;
 use super::utils::check_boundaries;
 use super::FieldIndexBuilderTrait;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -122,20 +123,16 @@ impl Encodable for DateTimePayloadType {
 impl<T: Encodable + Numericable> Range<T> {
     pub(in crate::index::field_index::numeric_index) fn as_index_key_bounds(
         &self,
-    ) -> (Bound<NumericIndexKey<T>>, Bound<NumericIndexKey<T>>) {
+    ) -> (Bound<Point<T>>, Bound<Point<T>>) {
         let start_bound = match self {
-            Range { gt: Some(gt), .. } => Excluded(NumericIndexKey::new(*gt, PointOffsetType::MAX)),
-            Range { gte: Some(gte), .. } => {
-                Included(NumericIndexKey::new(*gte, PointOffsetType::MIN))
-            }
+            Range { gt: Some(gt), .. } => Excluded(Point::new(*gt, PointOffsetType::MAX)),
+            Range { gte: Some(gte), .. } => Included(Point::new(*gte, PointOffsetType::MIN)),
             _ => Unbounded,
         };
 
         let end_bound = match self {
-            Range { lt: Some(lt), .. } => Excluded(NumericIndexKey::new(*lt, PointOffsetType::MIN)),
-            Range { lte: Some(lte), .. } => {
-                Included(NumericIndexKey::new(*lte, PointOffsetType::MAX))
-            }
+            Range { lt: Some(lt), .. } => Excluded(Point::new(*lt, PointOffsetType::MIN)),
+            Range { lte: Some(lte), .. } => Included(Point::new(*lte, PointOffsetType::MAX)),
             _ => Unbounded,
         };
 
@@ -436,8 +433,8 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndexInn
 
         Ok(match self {
             NumericIndexInner::Mutable(index) => {
-                let start_bound = start_bound.map(|k| k.encode());
-                let end_bound = end_bound.map(|k| k.encode());
+                let start_bound = start_bound.map(|k| k.val.encode_key(k.idx));
+                let end_bound = end_bound.map(|k| k.val.encode_key(k.idx));
                 Box::new(index.values_range(start_bound, end_bound))
             }
             NumericIndexInner::Immutable(index) => {
@@ -636,8 +633,8 @@ where
 
         match self {
             NumericIndexInner::Mutable(index) => {
-                let start_bound = start_bound.map(|k| k.encode());
-                let end_bound = end_bound.map(|k| k.encode());
+                let start_bound = start_bound.map(|k| k.val.encode_key(k.idx));
+                let end_bound = end_bound.map(|k| k.val.encode_key(k.idx));
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
             NumericIndexInner::Immutable(index) => {

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -202,7 +202,7 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
         let (decoded_idx, decoded_val) = T::decode_key(key);
         Point {
             val: decoded_val,
-            idx: decoded_idx as usize,
+            idx: decoded_idx,
         }
     }
 

--- a/lib/segment/src/index/field_index/tests/histogram_i64_tests.rs
+++ b/lib/segment/src/index/field_index/tests/histogram_i64_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::collections::Bound::Included;
 
+use common::types::PointOffsetType;
 use rand::prelude::SliceRandom;
 
 use crate::index::field_index::histogram::{Histogram, Point};
@@ -131,7 +132,7 @@ fn test_histogram() {
     let points: Vec<_> = points
         .into_iter()
         .enumerate()
-        .map(|(idx, val)| Point { val, idx })
+        .map(|(idx, val)| Point::new(val, idx as PointOffsetType))
         .collect();
 
     let (histogram, points_index) = build_histogram(max_bucket_size, precision, points);


### PR DESCRIPTION
This PR removes `NumericIndexKey` structure and replace it by `Point` from histogram. The main goal of this PR is to unify type of id+value pair and don't define such pair multiple times with conversions to each other. All indices (Mutable+Immutable+MMap) will use only one type of id+value pair