### PR TITLE
Remove vec u8 from mutable numeric index

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -486,8 +486,6 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndexInn
 
         Ok(match self {
             NumericIndexInner::Mutable(index) => {
-                let start_bound = start_bound.map(|k| k.val.encode_key(k.idx));
-                let end_bound = end_bound.map(|k| k.val.encode_key(k.idx));
                 Box::new(index.values_range(start_bound, end_bound))
             }
             NumericIndexInner::Immutable(index) => {
@@ -686,8 +684,6 @@ where
 
         match self {
             NumericIndexInner::Mutable(index) => {
-                let start_bound = start_bound.map(|k| k.val.encode_key(k.idx));
-                let end_bound = end_bound.map(|k| k.val.encode_key(k.idx));
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
             NumericIndexInner::Immutable(index) => {


### PR DESCRIPTION
This PR removes `Vec<u8>` as numeric type in `MutableNumericIndex`. It's a part of mmap index because mmap builder will use the mutable index as data collector. Use `Point<T>` as unified type for id+value in numeric index