### PR TITLE
Dynamic numeric index without persistence

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -618,7 +618,7 @@ impl ValueIndexer for NumericIndex<IntPayloadType, DateTimePayloadType> {
     ) -> OperationResult<()> {
         match &mut self.inner {
             NumericIndexInner::Mutable(index) => {
-                index.add_many_to_list(id, values.into_iter().map(|x| x.timestamp()))
+                index.add_many_to_list(id, values.into_iter().map(|x| x.timestamp()).collect())
             }
             NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -171,14 +171,14 @@ impl<T: Encodable + Numericable + Default> NumericIndexInner<T> {
 
     fn get_histogram(&self) -> &Histogram<T> {
         match self {
-            NumericIndexInner::Mutable(index) => &index.histogram,
+            NumericIndexInner::Mutable(index) => index.get_histogram(),
             NumericIndexInner::Immutable(index) => &index.histogram,
         }
     }
 
     fn get_points_count(&self) -> usize {
         match self {
-            NumericIndexInner::Mutable(index) => index.points_count,
+            NumericIndexInner::Mutable(index) => index.get_points_count(),
             NumericIndexInner::Immutable(index) => index.points_count,
         }
     }
@@ -240,7 +240,7 @@ impl<T: Encodable + Numericable + Default> NumericIndexInner<T> {
     /// Zero if the index is empty.
     pub fn max_values_per_point(&self) -> usize {
         match self {
-            NumericIndexInner::Mutable(index) => index.max_values_per_point,
+            NumericIndexInner::Mutable(index) => index.get_max_values_per_point(),
             NumericIndexInner::Immutable(index) => index.max_values_per_point,
         }
     }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -4,6 +4,7 @@ use std::ops::Bound::{Excluded, Unbounded};
 use std::sync::Arc;
 
 use common::types::PointOffsetType;
+use delegate::delegate;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
@@ -14,33 +15,57 @@ use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 
 pub struct MutableNumericIndex<T: Encodable + Numericable> {
-    pub(super) map: BTreeSet<Point<T>>,
-    pub(super) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
-    pub(super) histogram: Histogram<T>,
-    pub(super) points_count: usize,
-    pub(super) max_values_per_point: usize,
-    pub(super) point_to_values: Vec<Vec<T>>,
+    db_wrapper: DatabaseColumnScheduledDeleteWrapper,
+    dynamic_index: DynamicNumericIndex<T>,
 }
 
-impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
-    pub fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
-        let store_cf_name = NumericIndexInner::<T>::storage_cf_name(field);
-        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
-            db,
-            &store_cf_name,
-        ));
+// Numeric Index with insertions and deletions without persistence
+pub struct DynamicNumericIndex<T: Encodable + Numericable> {
+    pub map: BTreeSet<Point<T>>,
+    pub histogram: Histogram<T>,
+    pub points_count: usize,
+    pub max_values_per_point: usize,
+    pub point_to_values: Vec<Vec<T>>,
+}
+
+impl<T: Encodable + Numericable> Default for DynamicNumericIndex<T> {
+    fn default() -> Self {
         Self {
             map: BTreeSet::new(),
-            db_wrapper,
             histogram: Histogram::new(HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION),
             points_count: 0,
             max_values_per_point: 0,
             point_to_values: Default::default(),
         }
     }
+}
 
-    pub fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
-        &self.db_wrapper
+impl<T: Encodable + Numericable + Default> DynamicNumericIndex<T> {
+    pub fn from_iter(
+        iter: impl Iterator<Item = OperationResult<(PointOffsetType, T)>>,
+    ) -> OperationResult<Self> {
+        let mut index = DynamicNumericIndex::default();
+        for pair in iter {
+            let (idx, value) = pair?;
+
+            if index.point_to_values.len() <= idx as usize {
+                index
+                    .point_to_values
+                    .resize_with(idx as usize + 1, Vec::new)
+            }
+
+            index.point_to_values[idx as usize].push(value);
+
+            let key = Point::new(value, idx);
+            DynamicNumericIndex::add_to_map(&mut index.map, &mut index.histogram, key);
+        }
+        for values in &index.point_to_values {
+            if !values.is_empty() {
+                index.points_count += 1;
+                index.max_values_per_point = index.max_values_per_point.max(values.len());
+            }
+        }
+        Ok(index)
     }
 
     pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&T) -> bool) -> bool {
@@ -86,81 +111,32 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
             .map(|point| (point.val, point.idx))
     }
 
-    fn add_value(&mut self, id: PointOffsetType, value: T) -> OperationResult<()> {
-        let key = value.encode_key(id);
-        self.db_wrapper.put(key, id.to_be_bytes())?;
-        Self::add_to_map(&mut self.map, &mut self.histogram, Point::new(value, id));
-        Ok(())
-    }
-
-    pub fn add_many_to_list(
-        &mut self,
-        idx: PointOffsetType,
-        values: impl IntoIterator<Item = T>,
-    ) -> OperationResult<()> {
+    pub fn add_many_to_list(&mut self, idx: PointOffsetType, values: Vec<T>) {
         if self.point_to_values.len() <= idx as usize {
             self.point_to_values.resize_with(idx as usize + 1, Vec::new)
         }
-        let values: Vec<T> = values.into_iter().collect();
         for value in &values {
-            self.add_value(idx, *value)?;
+            let key = Point::new(*value, idx);
+            Self::add_to_map(&mut self.map, &mut self.histogram, key);
         }
         if !values.is_empty() {
             self.points_count += 1;
             self.max_values_per_point = self.max_values_per_point.max(values.len());
         }
         self.point_to_values[idx as usize] = values;
-        Ok(())
     }
 
-    pub fn load(&mut self) -> OperationResult<bool> {
-        if !self.db_wrapper.has_column_family()? {
-            return Ok(false);
-        };
-
-        for (key, value) in self.db_wrapper.lock_db().iter()? {
-            let value_idx = u32::from_be_bytes(value.as_ref().try_into().unwrap());
-            let (idx, value) = T::decode_key(&key);
-
-            if idx != value_idx {
-                return Err(OperationError::service_error("incorrect key value"));
-            }
-
-            if self.point_to_values.len() <= idx as usize {
-                self.point_to_values.resize_with(idx as usize + 1, Vec::new)
-            }
-
-            self.point_to_values[idx as usize].push(value);
-
-            Self::add_to_map(&mut self.map, &mut self.histogram, Point::new(value, idx));
-        }
-        for values in &self.point_to_values {
+    pub fn remove_point(&mut self, idx: PointOffsetType) {
+        if let Some(values) = self.point_to_values.get_mut(idx as usize) {
             if !values.is_empty() {
-                self.points_count += 1;
-                self.max_values_per_point = self.max_values_per_point.max(values.len());
+                self.points_count = self.points_count.checked_sub(1).unwrap_or_default();
             }
+            for value in values.iter() {
+                let key = Point::new(*value, idx);
+                Self::remove_from_map(&mut self.map, &mut self.histogram, key);
+            }
+            *values = Default::default();
         }
-        Ok(true)
-    }
-
-    pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
-        if self.point_to_values.len() <= idx as usize {
-            return Ok(());
-        }
-
-        let removed_values = std::mem::take(&mut self.point_to_values[idx as usize]);
-
-        for value in &removed_values {
-            let key = value.encode_key(idx);
-            self.db_wrapper.remove(&key)?;
-            Self::remove_from_map(&mut self.map, &mut self.histogram, Point::new(*value, idx));
-        }
-
-        if !removed_values.is_empty() {
-            self.points_count -= 1;
-        }
-
-        Ok(())
     }
 
     fn add_to_map(map: &mut BTreeSet<Point<T>>, histogram: &mut Histogram<T>, key: Point<T>) {
@@ -194,5 +170,115 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
 
     fn get_histogram_right_neighbor(map: &BTreeSet<Point<T>>, key: Point<T>) -> Option<Point<T>> {
         map.range((Excluded(key), Unbounded)).next().cloned()
+    }
+
+    pub fn get_histogram(&self) -> &Histogram<T> {
+        &self.histogram
+    }
+
+    pub fn get_points_count(&self) -> usize {
+        self.points_count
+    }
+
+    pub fn get_max_values_per_point(&self) -> usize {
+        self.max_values_per_point
+    }
+}
+
+impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
+    pub fn new_from_db_wrapper(db_wrapper: DatabaseColumnScheduledDeleteWrapper) -> Self {
+        Self {
+            db_wrapper,
+            dynamic_index: DynamicNumericIndex::default(),
+        }
+    }
+
+    pub fn into_dynamic_index(self) -> DynamicNumericIndex<T> {
+        self.dynamic_index
+    }
+
+    pub fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
+        &self.db_wrapper
+    }
+
+    pub fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
+        let store_cf_name = NumericIndexInner::<T>::storage_cf_name(field);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            &store_cf_name,
+        ));
+        Self {
+            db_wrapper,
+            dynamic_index: DynamicNumericIndex::default(),
+        }
+    }
+
+    pub fn load(&mut self) -> OperationResult<bool> {
+        if !self.db_wrapper.has_column_family()? {
+            return Ok(false);
+        };
+
+        self.dynamic_index = DynamicNumericIndex::from_iter(
+            self.db_wrapper.lock_db().iter()?.map(|(key, value)| {
+                let value_idx = u32::from_be_bytes(value.as_ref().try_into().unwrap());
+                let (idx, value) = T::decode_key(&key);
+                if idx != value_idx {
+                    return Err(OperationError::service_error("incorrect key value"));
+                }
+                Ok((idx, value))
+            }),
+        )?;
+
+        Ok(true)
+    }
+
+    pub fn add_many_to_list(
+        &mut self,
+        idx: PointOffsetType,
+        values: impl IntoIterator<Item = T>,
+    ) -> OperationResult<()> {
+        let values: Vec<T> = values.into_iter().collect();
+        for value in &values {
+            let key = value.encode_key(idx);
+            self.db_wrapper.put(&key, idx.to_be_bytes())?;
+        }
+        self.dynamic_index.add_many_to_list(idx, values);
+        Ok(())
+    }
+
+    pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
+        self.dynamic_index
+            .get_values(idx)
+            .map(|mut values| {
+                values.try_for_each(|value| {
+                    let key = value.encode_key(idx);
+                    self.db_wrapper.remove(key)
+                })
+            })
+            .transpose()?;
+        self.dynamic_index.remove_point(idx);
+        Ok(())
+    }
+
+    delegate! {
+        to self.dynamic_index {
+            pub fn total_unique_values_count(&self) -> usize;
+            pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&T) -> bool) -> bool;
+            pub fn get_points_count(&self) -> usize;
+            pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>>;
+            pub fn values_count(&self, idx: PointOffsetType) -> Option<usize>;
+            pub fn values_range(
+                &self,
+                start_bound: Bound<Point<T>>,
+                end_bound: Bound<Point<T>>,
+            ) -> impl Iterator<Item = PointOffsetType> + '_;
+            pub fn orderable_values_range(
+                &self,
+                start_bound: Bound<Point<T>>,
+                end_bound: Bound<Point<T>>,
+            ) -> impl DoubleEndedIterator<Item = (T, PointOffsetType)> + '_ ;
+            pub fn get_histogram(&self) -> &Histogram<T>;
+            pub fn get_max_values_per_point(&self) -> usize;
+        }
     }
 }


### PR DESCRIPTION
This PR splits `MutableNumericIndex` into `MutableNumericIndex` and `DynamicNumericIndex`. `DynamicNumericIndex` is an index with insertions and deletions but without persistence. It's required for future mmap builder where we need `DynamicNumericIndex` to construct all collections but without writing into RocksDB.