### PR TITLE
Use option in `filter` and `estimate_cardinality`

### DIFF
--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -265,18 +265,18 @@ impl PayloadFieldIndex for BinaryIndex {
     fn filter<'a>(
         &'a self,
         condition: &'a crate::types::FieldCondition,
-    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match &condition.r#match {
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Bool(value),
             })) => {
                 if *value {
-                    Ok(Box::new(self.memory.iter_has_true()))
+                    Some(Box::new(self.memory.iter_has_true()))
                 } else {
-                    Ok(Box::new(self.memory.iter_has_false()))
+                    Some(Box::new(self.memory.iter_has_false()))
                 }
             }
-            _ => Err(OperationError::service_error("failed to filter")),
+            _ => None,
         }
     }
 

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -10,7 +10,7 @@ use super::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndex, PrimaryCondition,
     ValueIndexer,
 };
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::telemetry::PayloadIndexTelemetry;
@@ -280,10 +280,7 @@ impl PayloadFieldIndex for BinaryIndex {
         }
     }
 
-    fn estimate_cardinality(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<CardinalityEstimation> {
+    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
         match &condition.r#match {
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Bool(value),
@@ -297,11 +294,9 @@ impl PayloadFieldIndex for BinaryIndex {
                 let estimation = CardinalityEstimation::exact(count)
                     .with_primary_clause(PrimaryCondition::Condition(condition.clone()));
 
-                Ok(estimation)
+                Some(estimation)
             }
-            _ => Err(OperationError::service_error(
-                "failed to estimate cardinality",
-            )),
+            _ => None,
         }
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -41,7 +41,7 @@ pub trait PayloadFieldIndex {
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
-    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
 
     /// Return estimation of points amount which satisfy given condition
     fn estimate_cardinality(
@@ -218,7 +218,7 @@ impl FieldIndex {
     pub fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
-    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         self.get_payload_field_index().filter(condition)
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -44,10 +44,7 @@ pub trait PayloadFieldIndex {
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
 
     /// Return estimation of points amount which satisfy given condition
-    fn estimate_cardinality(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<CardinalityEstimation>;
+    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
 
     /// Iterate conditions for payload blocks with minimum size of `threshold`
     /// Required for building HNSW index
@@ -225,7 +222,7 @@ impl FieldIndex {
     pub fn estimate_cardinality(
         &self,
         condition: &FieldCondition,
-    ) -> OperationResult<CardinalityEstimation> {
+    ) -> Option<CardinalityEstimation> {
         self.get_payload_field_index()
             .estimate_cardinality(condition)
     }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -43,7 +43,8 @@ pub trait PayloadFieldIndex {
         condition: &'a FieldCondition,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
 
-    /// Return estimation of points amount which satisfy given condition
+    /// Return estimation of amount of points which satisfy given condition.
+    /// Returns `None` if the condition does not match the index type
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
 
     /// Iterate conditions for payload blocks with minimum size of `threshold`

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -240,19 +240,15 @@ impl PayloadFieldIndex for FullTextIndex {
         None
     }
 
-    fn estimate_cardinality(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<CardinalityEstimation> {
+    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
         if let Some(Match::Text(text_match)) = &condition.r#match {
             let parsed_query = self.parse_query(&text_match.text);
-            return Ok(self
-                .inverted_index
-                .estimate_cardinality(&parsed_query, condition));
+            return Some(
+                self.inverted_index
+                    .estimate_cardinality(&parsed_query, condition),
+            );
         }
-        Err(OperationError::service_error(
-            "failed to estimate cardinality",
-        ))
+        None
     }
 
     fn payload_blocks(

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -232,12 +232,12 @@ impl PayloadFieldIndex for FullTextIndex {
     fn filter(
         &self,
         condition: &FieldCondition,
-    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
         if let Some(Match::Text(text_match)) = &condition.r#match {
             let parsed_query = self.parse_query(&text_match.text);
-            return Ok(self.inverted_index.filter(&parsed_query));
+            return Some(self.inverted_index.filter(&parsed_query));
         }
-        Err(OperationError::service_error("failed to filter"))
+        None
     }
 
     fn estimate_cardinality(

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -491,21 +491,14 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndexInn
         })
     }
 
-    fn estimate_cardinality(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<CardinalityEstimation> {
-        condition
-            .range
-            .as_ref()
-            .map(|range| {
-                let mut cardinality = self.range_cardinality(range);
-                cardinality
-                    .primary_clauses
-                    .push(PrimaryCondition::Condition(condition.clone()));
-                cardinality
-            })
-            .ok_or_else(|| OperationError::service_error("failed to estimate cardinality"))
+    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
+        condition.range.as_ref().map(|range| {
+            let mut cardinality = self.range_cardinality(range);
+            cardinality
+                .primary_clauses
+                .push(PrimaryCondition::Condition(condition.clone()));
+            cardinality
+        })
     }
 
     fn payload_blocks(

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -464,11 +464,8 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndexInn
     fn filter(
         &self,
         condition: &FieldCondition,
-    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
-        let range_cond = condition
-            .range
-            .as_ref()
-            .ok_or_else(|| OperationError::service_error("failed to get range condition"))?;
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
+        let range_cond = condition.range.as_ref()?;
 
         let (start_bound, end_bound) = match range_cond {
             RangeInterface::Float(float_range) => float_range.map(T::from_f64),
@@ -481,10 +478,10 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndexInn
         // map.range
         // Panics if range start > end. Panics if range start == end and both bounds are Excluded.
         if !check_boundaries(&start_bound, &end_bound) {
-            return Ok(Box::new(vec![].into_iter()));
+            return Some(Box::new(vec![].into_iter()));
         }
 
-        Ok(match self {
+        Some(match self {
             NumericIndexInner::Mutable(index) => {
                 Box::new(index.values_range(start_bound, end_bound))
             }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -85,7 +85,7 @@ impl StructPayloadIndex {
             .and_then(|indexes| {
                 indexes
                     .iter()
-                    .find_map(|field_index| field_index.filter(field_condition).ok())
+                    .find_map(|field_index| field_index.filter(field_condition))
             });
         indexes
     }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -71,7 +71,7 @@ impl StructPayloadIndex {
 
             indexes
                 .iter()
-                .find_map(|index| index.estimate_cardinality(&full_path_condition).ok())
+                .find_map(|index| index.estimate_cardinality(&full_path_condition))
         })
     }
 


### PR DESCRIPTION
In a [previous PR](https://github.com/qdrant/qdrant/commit/1611deaf034a8ec219b4aab80abe31200bb8fc15), we changed the output of `PayloadFieldIndex::filter` and `PayloadFieldIndex::estimate_cardinality` to an `OperationResult`. Apparently the reason was that it was better to propagate the error from geo `*_hashes` functions up to their respective usages. But in practice the two methods from the trait were designed to be used with an `Option`, as mismatched condition/index would just return `None` and become ignored.

This PR removes this level of propagation that was ignored anyway.

Main change:
```diff
- fn filter<'a>(&'a self, condition: &'a FieldCondition) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
+ fn filter<'a>(&'a self, condition: &'a FieldCondition) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;

- fn estimate_cardinality(&self, condition: &FieldCondition) -> OperationResult<CardinalityEstimation>;
+ fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
```