### PR TITLE
Pass is_appendable to index_builder_selector()

### DIFF
--- a/lib/segment/benches/boolean_filtering.rs
+++ b/lib/segment/benches/boolean_filtering.rs
@@ -95,7 +95,7 @@ pub fn keyword_index_boolean_query_points(c: &mut Criterion) {
         StructPayloadIndex::open(payload_storage, id_tracker, dir.path(), true).unwrap();
 
     index
-        .set_indexed(&BOOL_KEY.parse().unwrap(), PayloadSchemaType::Keyword)
+        .set_indexed(&BOOL_KEY.parse().unwrap(), PayloadSchemaType::Keyword, true)
         .unwrap();
 
     let mut group = c.benchmark_group("boolean-query-points");

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -68,14 +68,24 @@ fn range_filtering(c: &mut Criterion) {
     )
     .unwrap();
 
+    let is_appendable = true;
+
     // add numeric float index
     index
-        .set_indexed(&FLT_KEY.parse().unwrap(), PayloadSchemaType::Float)
+        .set_indexed(
+            &FLT_KEY.parse().unwrap(),
+            PayloadSchemaType::Float,
+            is_appendable,
+        )
         .unwrap();
 
     // add numeric integer index
     index
-        .set_indexed(&INT_KEY.parse().unwrap(), PayloadSchemaType::Integer)
+        .set_indexed(
+            &INT_KEY.parse().unwrap(),
+            PayloadSchemaType::Integer,
+            is_appendable,
+        )
         .unwrap();
 
     // make sure all points are indexed

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -182,7 +182,7 @@ fn sparse_vector_index_search_benchmark_impl(
 
     // create payload field index
     payload_index
-        .set_indexed(&field_name.parse().unwrap(), Keyword)
+        .set_indexed(&field_name.parse().unwrap(), Keyword, true)
         .unwrap();
 
     drop(payload_index);

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -238,30 +238,57 @@ pub fn create_struct_payload_index(
     num_points: usize,
     seed: u64,
 ) -> StructPayloadIndex {
+    let is_appendable = true;
+
     let payload_storage = Arc::new(AtomicRefCell::new(
         create_payload_storage_fixture(num_points, seed).into(),
     ));
     let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(num_points)));
 
-    let mut index = StructPayloadIndex::open(payload_storage, id_tracker, path, true).unwrap();
+    let mut index =
+        StructPayloadIndex::open(payload_storage, id_tracker, path, is_appendable).unwrap();
 
     index
-        .set_indexed(&STR_KEY.parse().unwrap(), PayloadSchemaType::Keyword)
+        .set_indexed(
+            &STR_KEY.parse().unwrap(),
+            PayloadSchemaType::Keyword,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&INT_KEY.parse().unwrap(), PayloadSchemaType::Integer)
+        .set_indexed(
+            &INT_KEY.parse().unwrap(),
+            PayloadSchemaType::Integer,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&FLT_KEY.parse().unwrap(), PayloadSchemaType::Float)
+        .set_indexed(
+            &FLT_KEY.parse().unwrap(),
+            PayloadSchemaType::Float,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&GEO_KEY.parse().unwrap(), PayloadSchemaType::Geo)
+        .set_indexed(
+            &GEO_KEY.parse().unwrap(),
+            PayloadSchemaType::Geo,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&TEXT_KEY.parse().unwrap(), PayloadSchemaType::Text)
+        .set_indexed(
+            &TEXT_KEY.parse().unwrap(),
+            PayloadSchemaType::Text,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&BOOL_KEY.parse().unwrap(), PayloadSchemaType::Bool)
+        .set_indexed(
+            &BOOL_KEY.parse().unwrap(),
+            PayloadSchemaType::Bool,
+            is_appendable,
+        )
         .unwrap();
 
     index

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -71,6 +71,7 @@ pub fn index_builder_selector(
     field: &JsonPath,
     payload_schema: &PayloadFieldSchema,
     db: Arc<RwLock<DB>>,
+    _is_appendable: bool,
 ) -> Vec<FieldIndexBuilder> {
     let field: String = field.to_string();
     let field = field.as_str();

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -22,6 +22,7 @@ pub trait PayloadIndex {
         &mut self,
         field: PayloadKeyTypeRef,
         payload_schema: impl Into<PayloadFieldSchema>,
+        is_appendable: bool,
     ) -> OperationResult<()>;
 
     /// Remove index

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -87,6 +87,7 @@ impl PayloadIndex for PlainPayloadIndex {
         &mut self,
         field: PayloadKeyTypeRef,
         payload_schema: impl Into<PayloadFieldSchema>,
+        _is_appendable: bool,
     ) -> OperationResult<()> {
         let payload_schema = payload_schema.into();
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1721,12 +1721,14 @@ impl SegmentEntry for Segment {
         key: PayloadKeyTypeRef,
         field_type: Option<&PayloadFieldSchema>,
     ) -> OperationResult<bool> {
+        let appendable_flag = self.appendable_flag;
         self.handle_segment_version_and_failure(op_num, |segment| match field_type {
             Some(schema) => {
-                segment
-                    .payload_index
-                    .borrow_mut()
-                    .set_indexed(key, schema.clone())?;
+                segment.payload_index.borrow_mut().set_indexed(
+                    key,
+                    schema.clone(),
+                    appendable_flag,
+                )?;
                 Ok(true)
             }
             None => match segment.infer_from_payload_data(key)? {
@@ -1734,10 +1736,11 @@ impl SegmentEntry for Segment {
                     field_name: key.clone(),
                 }),
                 Some(schema_type) => {
-                    segment
-                        .payload_index
-                        .borrow_mut()
-                        .set_indexed(key, schema_type)?;
+                    segment.payload_index.borrow_mut().set_indexed(
+                        key,
+                        schema_type,
+                        appendable_flag,
+                    )?;
                     Ok(true)
                 }
             },

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -417,7 +417,7 @@ impl SegmentBuilder {
             )?;
 
             for (field, payload_schema) in indexed_fields {
-                payload_index.set_indexed(&field, payload_schema)?;
+                payload_index.set_indexed(&field, payload_schema, appendable_flag)?;
                 check_process_stopped(stopped)?;
             }
 

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -192,12 +192,12 @@ fn test_byte_storage_hnsw(
     segment_float
         .payload_index
         .borrow_mut()
-        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer)
+        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer, true)
         .unwrap();
     segment_byte
         .payload_index
         .borrow_mut()
-        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer)
+        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer, true)
         .unwrap();
 
     let hnsw_config = HnswConfig {

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -293,7 +293,7 @@ fn test_byte_storage_binary_quantization_hnsw(
     segment_byte
         .payload_index
         .borrow_mut()
-        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer)
+        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer, true)
         .unwrap();
 
     let quantization_config = match quantization_variant {

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -90,7 +90,7 @@ fn exact_search_test() {
 
     payload_index_ptr
         .borrow_mut()
-        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer)
+        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer, true)
         .unwrap();
     let borrowed_payload_index = payload_index_ptr.borrow();
     let blocks = borrowed_payload_index

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -154,7 +154,7 @@ fn _test_filterable_hnsw(
 
     payload_index_ptr
         .borrow_mut()
-        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer)
+        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer, true)
         .unwrap();
     let borrowed_payload_index = payload_index_ptr.borrow();
     let blocks = borrowed_payload_index

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -216,7 +216,11 @@ fn filtered_hnsw_discover_precision() {
     let payload_index_ptr = segment.payload_index.clone();
     payload_index_ptr
         .borrow_mut()
-        .set_indexed(&JsonPath::new(keyword_key), PayloadSchemaType::Keyword)
+        .set_indexed(
+            &JsonPath::new(keyword_key),
+            PayloadSchemaType::Keyword,
+            true,
+        )
         .unwrap();
 
     let hnsw_config = HnswConfig {

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -167,7 +167,7 @@ fn test_multi_filterable_hnsw(
     let payload_index_ptr = segment.payload_index.clone();
     payload_index_ptr
         .borrow_mut()
-        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer)
+        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer, true)
         .unwrap();
 
     let hnsw_config = HnswConfig {

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -257,7 +257,7 @@ fn test_multivector_quantization_hnsw(
     segment
         .payload_index
         .borrow_mut()
-        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer)
+        .set_indexed(&JsonPath::new(int_key), PayloadSchemaType::Integer, true)
         .unwrap();
 
     let quantization_config = match quantization_variant {

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -71,26 +71,57 @@ fn test_filtering_context_consistency() {
     let wrapped_payload_storage = Arc::new(AtomicRefCell::new(payload_storage.into()));
     let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(NUM_POINTS)));
 
-    let mut index =
-        StructPayloadIndex::open(wrapped_payload_storage, id_tracker, dir.path(), true).unwrap();
+    let is_appendable = true;
+
+    let mut index = StructPayloadIndex::open(
+        wrapped_payload_storage,
+        id_tracker,
+        dir.path(),
+        is_appendable,
+    )
+    .unwrap();
 
     index
-        .set_indexed(&JsonPath::new("f"), PayloadSchemaType::Integer)
+        .set_indexed(
+            &JsonPath::new("f"),
+            PayloadSchemaType::Integer,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&JsonPath::new("arr1[].a"), PayloadSchemaType::Integer)
+        .set_indexed(
+            &JsonPath::new("arr1[].a"),
+            PayloadSchemaType::Integer,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&JsonPath::new("arr1[].b"), PayloadSchemaType::Integer)
+        .set_indexed(
+            &JsonPath::new("arr1[].b"),
+            PayloadSchemaType::Integer,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&JsonPath::new("arr1[].c"), PayloadSchemaType::Integer)
+        .set_indexed(
+            &JsonPath::new("arr1[].c"),
+            PayloadSchemaType::Integer,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&JsonPath::new("arr1[].d"), PayloadSchemaType::Integer)
+        .set_indexed(
+            &JsonPath::new("arr1[].d"),
+            PayloadSchemaType::Integer,
+            is_appendable,
+        )
         .unwrap();
     index
-        .set_indexed(&JsonPath::new("arr1[].text"), PayloadSchemaType::Text)
+        .set_indexed(
+            &JsonPath::new("arr1[].text"),
+            PayloadSchemaType::Text,
+            is_appendable,
+        )
         .unwrap();
 
     {

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -853,7 +853,7 @@ fn test_update_payload_index_type() {
     let field = JsonPath::new("field");
 
     // set field to Integer type
-    index.set_indexed(&field, Integer).unwrap();
+    index.set_indexed(&field, Integer, true).unwrap();
     assert_eq!(
         *index.indexed_fields().get(&field).unwrap(),
         FieldType(Integer)
@@ -863,7 +863,7 @@ fn test_update_payload_index_type() {
     assert_eq!(field_index[1].count_indexed_points(), point_num);
 
     // update field to Keyword type
-    index.set_indexed(&field, Keyword).unwrap();
+    index.set_indexed(&field, Keyword, true).unwrap();
     assert_eq!(
         *index.indexed_fields().get(&field).unwrap(),
         FieldType(Keyword)
@@ -872,7 +872,7 @@ fn test_update_payload_index_type() {
     assert_eq!(field_index[0].count_indexed_points(), 0); // only one field index for Keyword
 
     // set field to Integer type (again)
-    index.set_indexed(&field, Integer).unwrap();
+    index.set_indexed(&field, Integer, true).unwrap();
     assert_eq!(
         *index.indexed_fields().get(&field).unwrap(),
         FieldType(Integer)

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -383,7 +383,7 @@ fn sparse_vector_index_ram_filtered_search() {
     // create payload field index
     let mut payload_index = sparse_vector_index.payload_index().borrow_mut();
     payload_index
-        .set_indexed(&JsonPath::new(field_name), Keyword)
+        .set_indexed(&JsonPath::new(field_name), Keyword, true)
         .unwrap();
     drop(payload_index);
 


### PR DESCRIPTION
This PR adds `is_appendable` to `index_builder_selector()`. Currently unused, but it will be used in subsequent PRs: the `on_disk` parameter should be ignored for appendable indices.