### PR TITLE
Add {Integer,Float,Datetime}IndexParams::on_disk to the API

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -688,6 +688,11 @@
 
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| on_disk | [bool](#bool) | optional | If true - store index on disk. |
+
+
 
 
 
@@ -786,6 +791,11 @@
 
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| on_disk | [bool](#bool) | optional | If true - store index on disk. |
+
+
 
 
 
@@ -862,6 +872,7 @@
 | lookup | [bool](#bool) |  | If true - support direct lookups. |
 | range | [bool](#bool) |  | If true - support ranges filters. |
 | is_tenant | [bool](#bool) | optional | If true - used for tenant optimization. |
+| on_disk | [bool](#bool) | optional | If true - store index on disk. |
 
 
 
@@ -877,6 +888,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | is_tenant | [bool](#bool) | optional | If true - used for tenant optimization. |
+| on_disk | [bool](#bool) | optional | If true - store index on disk. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6421,6 +6421,11 @@
             "description": "If true - used for tenant optimization. Default: false.",
             "type": "boolean",
             "nullable": true
+          },
+          "on_disk": {
+            "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -6453,6 +6458,11 @@
             "description": "If true - used for tenant optimization.",
             "type": "boolean",
             "nullable": true
+          },
+          "on_disk": {
+            "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -6470,6 +6480,11 @@
         "properties": {
           "type": {
             "$ref": "#/components/schemas/FloatIndexType"
+          },
+          "on_disk": {
+            "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -6567,6 +6582,11 @@
         "properties": {
           "type": {
             "$ref": "#/components/schemas/DatetimeIndexType"
+          },
+          "on_disk": {
+            "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -225,6 +225,7 @@ impl From<segment::data_types::index::KeywordIndexParams> for PayloadIndexParams
         PayloadIndexParams {
             index_params: Some(IndexParams::KeywordIndexParams(KeywordIndexParams {
                 is_tenant: params.is_tenant,
+                on_disk: params.on_disk,
             })),
         }
     }
@@ -237,15 +238,18 @@ impl From<segment::data_types::index::IntegerIndexParams> for PayloadIndexParams
                 lookup: params.lookup,
                 range: params.range,
                 is_tenant: params.is_tenant,
+                on_disk: params.on_disk,
             })),
         }
     }
 }
 
 impl From<segment::data_types::index::FloatIndexParams> for PayloadIndexParams {
-    fn from(_params: segment::data_types::index::FloatIndexParams) -> Self {
+    fn from(params: segment::data_types::index::FloatIndexParams) -> Self {
         PayloadIndexParams {
-            index_params: Some(IndexParams::FloatIndexParams(FloatIndexParams {})),
+            index_params: Some(IndexParams::FloatIndexParams(FloatIndexParams {
+                on_disk: params.on_disk,
+            })),
         }
     }
 }
@@ -281,9 +285,11 @@ impl From<segment::data_types::index::BoolIndexParams> for PayloadIndexParams {
 }
 
 impl From<segment::data_types::index::DatetimeIndexParams> for PayloadIndexParams {
-    fn from(_params: segment::data_types::index::DatetimeIndexParams) -> Self {
+    fn from(params: segment::data_types::index::DatetimeIndexParams) -> Self {
         PayloadIndexParams {
-            index_params: Some(IndexParams::DatetimeIndexParams(DatetimeIndexParams {})),
+            index_params: Some(IndexParams::DatetimeIndexParams(DatetimeIndexParams {
+                on_disk: params.on_disk,
+            })),
         }
     }
 }
@@ -361,6 +367,7 @@ impl TryFrom<KeywordIndexParams> for segment::data_types::index::KeywordIndexPar
         Ok(segment::data_types::index::KeywordIndexParams {
             r#type: KeywordIndexType::Keyword,
             is_tenant: params.is_tenant,
+            on_disk: params.on_disk,
         })
     }
 }
@@ -373,15 +380,17 @@ impl TryFrom<IntegerIndexParams> for segment::data_types::index::IntegerIndexPar
             lookup: params.lookup,
             range: params.range,
             is_tenant: params.is_tenant,
+            on_disk: params.on_disk,
         })
     }
 }
 
 impl TryFrom<FloatIndexParams> for segment::data_types::index::FloatIndexParams {
     type Error = Status;
-    fn try_from(_params: FloatIndexParams) -> Result<Self, Self::Error> {
+    fn try_from(params: FloatIndexParams) -> Result<Self, Self::Error> {
         Ok(segment::data_types::index::FloatIndexParams {
             r#type: FloatIndexType::Float,
+            on_disk: params.on_disk,
         })
     }
 }
@@ -421,9 +430,10 @@ impl TryFrom<BoolIndexParams> for segment::data_types::index::BoolIndexParams {
 
 impl TryFrom<DatetimeIndexParams> for segment::data_types::index::DatetimeIndexParams {
     type Error = Status;
-    fn try_from(_params: DatetimeIndexParams) -> Result<Self, Self::Error> {
+    fn try_from(params: DatetimeIndexParams) -> Result<Self, Self::Error> {
         Ok(segment::data_types::index::DatetimeIndexParams {
             r#type: DatetimeIndexType::Datetime,
+            on_disk: params.on_disk,
         })
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -387,15 +387,18 @@ enum TokenizerType {
 
 message KeywordIndexParams {
     optional bool is_tenant = 3; // If true - used for tenant optimization.
+    optional bool on_disk = 4; // If true - store index on disk.
 }
 
 message IntegerIndexParams {
   bool lookup = 1; // If true - support direct lookups.
   bool range = 2; // If true - support ranges filters.
   optional bool is_tenant = 3; // If true - used for tenant optimization.
+  optional bool on_disk = 4; // If true - store index on disk.
 }
 
 message FloatIndexParams {
+  optional bool on_disk = 1; // If true - store index on disk.
 }
 
 message GeoIndexParams {
@@ -412,6 +415,7 @@ message BoolIndexParams {
 }
 
 message DatetimeIndexParams {
+  optional bool on_disk = 1; // If true - store index on disk.
 }
 
 message PayloadIndexParams {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -626,6 +626,9 @@ pub struct KeywordIndexParams {
     /// If true - used for tenant optimization.
     #[prost(bool, optional, tag = "3")]
     pub is_tenant: ::core::option::Option<bool>,
+    /// If true - store index on disk.
+    #[prost(bool, optional, tag = "4")]
+    pub on_disk: ::core::option::Option<bool>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -640,11 +643,18 @@ pub struct IntegerIndexParams {
     /// If true - used for tenant optimization.
     #[prost(bool, optional, tag = "3")]
     pub is_tenant: ::core::option::Option<bool>,
+    /// If true - store index on disk.
+    #[prost(bool, optional, tag = "4")]
+    pub on_disk: ::core::option::Option<bool>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FloatIndexParams {}
+pub struct FloatIndexParams {
+    /// If true - store index on disk.
+    #[prost(bool, optional, tag = "1")]
+    pub on_disk: ::core::option::Option<bool>,
+}
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -673,7 +683,11 @@ pub struct BoolIndexParams {}
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DatetimeIndexParams {}
+pub struct DatetimeIndexParams {
+    /// If true - store index on disk.
+    #[prost(bool, optional, tag = "1")]
+    pub on_disk: ::core::option::Option<bool>,
+}
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -21,7 +21,6 @@ pub struct KeywordIndexParams {
     pub is_tenant: Option<bool>,
 
     /// If true, store the index on disk. Default: false.
-    #[cfg(any())]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_disk: Option<bool>,
 }
@@ -52,7 +51,6 @@ pub struct IntegerIndexParams {
 
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg(any())]
     pub on_disk: Option<bool>,
 }
 
@@ -63,6 +61,7 @@ impl Default for IntegerIndexParams {
             lookup: true,
             range: true,
             is_tenant: None,
+            on_disk: None,
         }
     }
 }
@@ -84,7 +83,6 @@ pub struct FloatIndexParams {
 
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg(any())]
     pub on_disk: Option<bool>,
 }
 
@@ -186,6 +184,5 @@ pub struct DatetimeIndexParams {
 
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg(any())]
     pub on_disk: Option<bool>,
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1184,6 +1184,16 @@ impl PayloadSchemaParams {
             _ => false,
         }
     }
+
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            PayloadSchemaParams::Keyword(i) => i.on_disk.unwrap_or_default(),
+            PayloadSchemaParams::Integer(i) => i.on_disk.unwrap_or_default(),
+            PayloadSchemaParams::Float(i) => i.on_disk.unwrap_or_default(),
+            PayloadSchemaParams::Datetime(i) => i.on_disk.unwrap_or_default(),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
@@ -1213,6 +1223,13 @@ impl PayloadFieldSchema {
         match self {
             PayloadFieldSchema::FieldType(_) => false,
             PayloadFieldSchema::FieldParams(params) => params.is_tenant(),
+        }
+    }
+
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            PayloadFieldSchema::FieldType(_) => false,
+            PayloadFieldSchema::FieldParams(params) => params.is_on_disk(),
         }
     }
 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -111,6 +111,7 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
                     lookup: true,
                     range: false,
                     is_tenant: None,
+                    on_disk: None,
                 },
             ))),
         )
@@ -125,6 +126,7 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
                     lookup: false,
                     range: true,
                     is_tenant: None,
+                    on_disk: None,
                 },
             ))),
         )


### PR DESCRIPTION
This PR enables `on_disk` boolean parameter for the payload types affected by map and numeric indices. Namely, for Keyword, Integer, Float, Datetime.

Additionally, this PR adds `PayloadFieldSchema::is_on_disk()` method to get this value regardless of field schema type.