### PR TITLE
Tidy up integration tests

### DIFF
--- a/lib/collection/tests/integration/main.rs
+++ b/lib/collection/tests/integration/main.rs
@@ -1,16 +1,8 @@
-#[cfg(test)]
-pub mod collection_restore_test;
-#[cfg(test)]
-pub mod collection_test;
-#[cfg(test)]
-pub mod common;
-#[cfg(test)]
-pub mod grouping_test;
-#[cfg(test)]
-pub mod lookup_test;
-#[cfg(test)]
-pub mod multi_vec_test;
-#[cfg(test)]
-pub mod pagination_test;
-#[cfg(test)]
-pub mod snapshot_recovery_test;
+mod collection_restore_test;
+mod collection_test;
+mod common;
+mod grouping_test;
+mod lookup_test;
+mod multi_vec_test;
+mod pagination_test;
+mod snapshot_recovery_test;

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -1,23 +1,21 @@
-#![cfg(test)]
-
-pub mod batch_search_test;
+mod batch_search_test;
 mod byte_storage_hnsw_test;
-pub mod byte_storage_quantization_test;
-pub mod disbalanced_vectors_test;
-pub mod exact_search_test;
-pub mod fail_recovery_test;
-pub mod filtering_context_check;
-pub mod filtrable_hnsw_test;
-pub mod fixtures;
-pub mod hnsw_discover_test;
-pub mod hnsw_quantized_search_test;
+mod byte_storage_quantization_test;
+mod disbalanced_vectors_test;
+mod exact_search_test;
+mod fail_recovery_test;
+mod filtering_context_check;
+mod filtrable_hnsw_test;
+mod fixtures;
+mod hnsw_discover_test;
+mod hnsw_quantized_search_test;
 mod multivector_filtrable_hnsw_test;
 mod multivector_hnsw_test;
 mod multivector_quantization_test;
-pub mod nested_filtering_test;
-pub mod payload_index_test;
-pub mod scroll_filtering_test;
-pub mod segment_builder_test;
-pub mod segment_tests;
+mod nested_filtering_test;
+mod payload_index_test;
+mod scroll_filtering_test;
+mod segment_builder_test;
+mod segment_tests;
 mod sparse_discover_test;
 mod sparse_vector_index_search_tests;

--- a/lib/storage/tests/integration/main.rs
+++ b/lib/storage/tests/integration/main.rs
@@ -1,2 +1,1 @@
-#[cfg(test)]
-pub mod alias_tests;
+mod alias_tests;


### PR DESCRIPTION
This PR makes `main.rs` of integration tests more uniform.