### PR TITLE
numeric index remove direct db usage

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -8,7 +8,9 @@ use delegate::delegate;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
-use super::{Encodable, NumericIndexInner, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
+use super::{
+    numeric_index_storage_cf_name, Encodable, HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION,
+};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
@@ -202,7 +204,7 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
     }
 
     pub fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
-        let store_cf_name = NumericIndexInner::<T>::storage_cf_name(field);
+        let store_cf_name = numeric_index_storage_cf_name(field);
         let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
             db,
             &store_cf_name,


### PR DESCRIPTION
This PR a preparation step before opening https://github.com/qdrant/qdrant/pull/4721

It includes:
1. Remove direct usage of DB. Mmap numeric index does not have rocksdb
2. Remove usage of `NumericIndex` inside `MutableNumericIndex` and `ImmutableNumericIndex`. `NumericIndex` generic will have more generic restrictions then `MutableNumericIndex` and `ImmutableNumericIndex`.
3. Small refactor like remove `pub` from immutable index fields