### PR TITLE
Switch to camelcase in `Sample` proto enum

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -4243,7 +4243,7 @@ Sample points from the collection
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| RANDOM | 0 |  |
+| Random | 0 |  |
 
 
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -515,7 +515,7 @@ enum Fusion {
 ///
 /// * `random` - Random sampling
 enum Sample {
-    RANDOM = 0;
+    Random = 0;
 }
 
 message Query {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6002,13 +6002,13 @@ impl Sample {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Sample::Random => "RANDOM",
+            Sample::Random => "Random",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "RANDOM" => Some(Self::Random),
+            "Random" => Some(Self::Random),
             _ => None,
         }
     }


### PR DESCRIPTION
This was inconsistent with other enums, which causes to be inconsistent in python client too
