### PR TITLE
Add `UpdateClusterMetadata` consensus operation

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::collections::HashMap;
 use std::fs::{create_dir_all, File};
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
@@ -42,6 +43,8 @@ pub struct Persistent {
     pub peer_address_by_id: Arc<RwLock<PeerAddressById>>,
     #[serde(default)]
     pub peer_metadata_by_id: Arc<RwLock<PeerMetadataById>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub cluster_metadata: HashMap<String, serde_json::Value>,
     pub this_peer_id: PeerId,
     #[serde(skip)]
     pub path: PathBuf,
@@ -174,6 +177,14 @@ impl Persistent {
         self.save()
     }
 
+    pub fn update_cluster_metadata(&mut self, key: String, value: serde_json::Value) {
+        if !value.is_null() {
+            self.cluster_metadata.insert(key, value);
+        } else {
+            self.cluster_metadata.remove(&key);
+        }
+    }
+
     pub fn last_applied_entry(&self) -> Option<u64> {
         self.apply_progress_queue.get_last_applied()
     }
@@ -224,6 +235,7 @@ impl Persistent {
             apply_progress_queue: Default::default(),
             peer_address_by_id: Default::default(),
             peer_metadata_by_id: Default::default(),
+            cluster_metadata: Default::default(),
             this_peer_id,
             path,
             latest_snapshot_meta: Default::default(),

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -177,7 +177,18 @@ impl Persistent {
         self.save()
     }
 
-    pub fn update_cluster_metadata(&mut self, key: String, value: serde_json::Value) {
+    pub fn get_cluster_metadata_keys(&self) -> Vec<String> {
+        self.cluster_metadata.keys().cloned().collect()
+    }
+
+    pub fn get_cluster_metadata_key(&self, key: &str) -> serde_json::Value {
+        self.cluster_metadata
+            .get(key)
+            .cloned()
+            .unwrap_or(serde_json::Value::Null)
+    }
+
+    pub fn update_cluster_metadata_key(&mut self, key: String, value: serde_json::Value) {
         if !value.is_null() {
             self.cluster_metadata.insert(key, value);
         } else {

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -473,7 +473,9 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             }
 
             ConsensusOperations::UpdateClusterMetadata { key, value } => {
-                self.persistent.write().update_cluster_metadata(key, value);
+                self.persistent
+                    .write()
+                    .update_cluster_metadata_key(key, value);
                 Ok(true)
             }
 

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -472,6 +472,11 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 Ok(true)
             }
 
+            ConsensusOperations::UpdateClusterMetadata { key, value } => {
+                self.persistent.write().update_cluster_metadata(key, value);
+                Ok(true)
+            }
+
             ConsensusOperations::RequestSnapshot | ConsensusOperations::ReportSnapshot { .. } => {
                 unreachable!()
             }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -282,10 +282,10 @@ mod test {
 
     fn serde_json_value_compatible_with_cbor(input: serde_json::Value) {
         let cbor = serde_cbor::to_vec(&input)
-            .expect(&format!("JSON value {input} can be serialized to CBOR"));
+            .unwrap_or_else(|_| panic!("JSON value {input} can be serialized to CBOR"));
 
         let output: serde_json::Value = serde_cbor::from_slice(&cbor)
-            .expect(&format!("JSON value {input} can be deserialized from CBOR"));
+            .unwrap_or_else(|_| panic!("JSON value {input} can be deserialized from CBOR"));
 
         assert_eq!(input, output);
     }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -46,6 +46,10 @@ pub mod consensus_ops {
             peer_id: PeerId,
             metadata: PeerMetadata,
         },
+        UpdateClusterMetadata {
+            key: String,
+            value: serde_json::Value,
+        },
         RequestSnapshot,
         ReportSnapshot {
             peer_id: PeerId,
@@ -214,4 +218,88 @@ pub trait CollectionContainer {
     fn remove_peer(&self, peer_id: PeerId) -> Result<(), StorageError>;
 
     fn sync_local_state(&self) -> Result<(), StorageError>;
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    // Consensus messages are serialized to CBOR when sent over network and written into WAL.
+    //
+    // We are using `serde_json::Value` in `ConsensusOperations::UpdateClusterMetadata`,
+    // but the way `serde` works, it is not *strictly* guaranteed that all possible JSON values
+    // can be serialized to CBOR, there might be some minor inconsistencies between formats.
+    //
+    // These tests check that `serde_json::Value` can be serialized to (and deserialized from) CBOR.
+
+    #[test]
+    fn serde_json_null_combatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json!(null));
+    }
+
+    #[test]
+    fn serde_json_integer_combatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json!(1337));
+    }
+
+    #[test]
+    fn serde_json_float_combatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json!(42.69));
+    }
+
+    #[test]
+    fn serde_json_string_compatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json!(
+            "Qdrant is the best vector search engine on the market 💪😎👍"
+        ));
+    }
+
+    #[test]
+    fn serde_json_basic_array_compatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json_array());
+    }
+
+    #[test]
+    fn serde_json_basic_object_compatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json_object());
+    }
+
+    #[test]
+    fn serde_json_nested_array_compatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json!([
+            json!([json_array(), json_object()]),
+            json!({ "array": json_array(), "object": json_object() }),
+        ]));
+    }
+
+    #[test]
+    fn serde_json_nested_object_compatible_with_cbor() {
+        serde_json_value_compatible_with_cbor(json!({
+            "array": json!([ json_array(), json_object() ]),
+            "object": json!({ "array": json_array(), "object": json_object() }),
+        }))
+    }
+
+    fn serde_json_value_compatible_with_cbor(input: serde_json::Value) {
+        let cbor = serde_cbor::to_vec(&input)
+            .expect(&format!("JSON value {input} can be serialized to CBOR"));
+
+        let output: serde_json::Value = serde_cbor::from_slice(&cbor)
+            .expect(&format!("JSON value {input} can be deserialized from CBOR"));
+
+        assert_eq!(input, output);
+    }
+
+    fn json_array() -> serde_json::Value {
+        json!([null, 1337, 42.69, "string"])
+    }
+
+    fn json_object() -> serde_json::Value {
+        json!({
+            "null": null,
+            "integer": 1337,
+            "float": 42.69,
+            "string": "string",
+        })
+    }
 }

--- a/tests/consensus_tests/test_cluster_metadata.py
+++ b/tests/consensus_tests/test_cluster_metadata.py
@@ -1,0 +1,63 @@
+import pathlib
+from time import sleep
+from typing import Any
+
+from .utils import *
+
+CONSENSUS_WAIT_SECONDS = 0.5
+
+def test_cluster_metadata(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3, None)
+
+    # Get (empty) metadata key list
+    get_metadata_keys(peer_api_uris, [])
+
+    # Put some metadata keys
+    put_metadata_key(peer_api_uris, 'string', 'string')
+
+    put_metadata_key(peer_api_uris, 'array', [
+        None,
+        1337,
+        42.69,
+        "string",
+    ])
+
+    put_metadata_key(peer_api_uris, 'object', {
+        'null': None,
+        'integer': 1337,
+        'float': 42.69,
+        'string': 'string',
+    })
+
+    # Get metadata key list
+    get_metadata_keys(peer_api_uris, ['string', 'array', 'object'])
+
+    # Delete metadata keys
+    for key in ['string', 'array', 'object']:
+        resp = requests.delete(f"{peer_api_uris[0]}/cluster/metadata/keys/{key}")
+        assert_http_ok(resp)
+        sleep(CONSENSUS_WAIT_SECONDS)
+        get_metadata_key(peer_api_uris, key, None)
+
+    # Get (empty) metadata key list
+    get_metadata_keys(peer_api_uris, [])
+
+def get_metadata_keys(peer_uris: list[str], keys: list[str]):
+    for peer_uri in peer_uris:
+        resp = requests.get(f"{peer_uri}/cluster/metadata/keys")
+        assert_http_ok(resp)
+        assert set(resp.json()['result']) == set(keys)
+
+def put_metadata_key(peer_uris: list[str], key: str, value: Any):
+    resp = requests.put(f"{peer_uris[0]}/cluster/metadata/keys/{key}", json=value)
+    assert_http_ok(resp)
+    sleep(CONSENSUS_WAIT_SECONDS)
+    get_metadata_key(peer_uris, key, value)
+
+def get_metadata_key(peer_uris: list[str], key: str, expected_value: Any):
+    for peer_uri in peer_uris:
+        resp = requests.get(f"{peer_uri}/cluster/metadata/keys/{key}")
+        assert_http_ok(resp)
+        assert resp.json()['result'] == expected_value


### PR DESCRIPTION
This PR adds `UpdateClusterMetadata` operation that allows to store arbitrary JSON values (under string keys) into Qdrant. These values are propagated to cluster nodes through consensus and stored as part of persistent consensus state.

**TODO:**
* [x] API endpoint(s) to store and retrieve metadata
* [x] tests

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
