### PR TITLE
More filtering of points without preallocating

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -431,9 +431,10 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
         let deleted_bitslice = vector_storage.deleted_vector_bitslice();
 
+        let cardinality_estimation = payload_index.estimate_cardinality(&filter);
+
         let points_to_index: Vec<_> = payload_index
-            .query_points(&filter)
-            .into_iter()
+            .iter_filtered_points(&filter, id_tracker, &cardinality_estimation)
             .filter(|&point_id| {
                 !deleted_bitslice
                     .get(point_id as usize)

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -289,12 +289,7 @@ impl VectorIndex for PlainIndex {
                 let id_tracker = self.id_tracker.borrow();
                 let payload_index = self.payload_index.borrow();
                 let vector_storage = self.vector_storage.borrow();
-                let cardinality_estimation = payload_index.estimate_cardinality(filter);
-                let mut filtered_ids_iter = payload_index.iter_filtered_points(
-                    filter,
-                    &*id_tracker,
-                    &cardinality_estimation,
-                );
+                let filtered_ids_vec = payload_index.query_points(filter);
                 let deleted_points = query_context
                     .deleted_points()
                     .unwrap_or(id_tracker.deleted_point_bitslice());
@@ -307,7 +302,9 @@ impl VectorIndex for PlainIndex {
                             deleted_points,
                             &is_stopped,
                         )
-                        .map(|scorer| scorer.peek_top_iter(&mut filtered_ids_iter, top))
+                        .map(|scorer| {
+                            scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top)
+                        })
                     })
                     .collect()
             }


### PR DESCRIPTION
Needs #4753 

In #4753 we added `iter_filtered_points` to the payload index struct, which allows us to return the filtered iterator.

This PR switches the use of `query_points` to the new `iter_filterd_points` when possible, to avoid an early filtered points allocation.
