### PR TITLE
Reduce collection name length limit

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -116,7 +116,7 @@ fn configure_validation(builder: Builder) -> Builder {
         .validates(&[
             ("GetCollectionInfoRequest.collection_name", "length(min = 1, max = 255)"),
             ("CollectionExistsRequest.collection_name", "length(min = 1, max = 255)"),
-            ("CreateCollection.collection_name", "length(min = 1, max = 255), custom = \"common::validation::validate_collection_name\""),
+            ("CreateCollection.collection_name", "length(min = 1, max = 218), custom = \"common::validation::validate_collection_name\""),
             ("CreateCollection.hnsw_config", ""),
             ("CreateCollection.wal_config", ""),
             ("CreateCollection.optimizers_config", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -435,7 +435,7 @@ pub struct CreateCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
     #[validate(
-        length(min = 1, max = 255),
+        length(min = 1, max = 218),
         custom = "common::validation::validate_collection_name"
     )]
     pub collection_name: ::prost::alloc::string::String,

--- a/src/actix/api/mod.rs
+++ b/src/actix/api/mod.rs
@@ -25,7 +25,7 @@ use validator::Validate;
 /// collections. Basic validation is enforced everywhere else.
 #[derive(Deserialize, Validate)]
 struct StrictCollectionPath {
-    #[validate(length(min = 1, max = 255), custom = "validate_collection_name")]
+    #[validate(length(min = 1, max = 218), custom = "validate_collection_name")]
     name: String,
 }
 


### PR DESCRIPTION
Fixes #4568 

We can't limit the length of other collection name request parameters as this might make some existing collections not work at all.
To prevent issues in future, we only limit the collection name length to 218