### PR TITLE
Refactor local-only `Condition::Resharding` into serializable `Condition::HashRing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5305,7 +5305,6 @@ version = "0.0.0"
 dependencies = [
  "hashring",
  "rstest",
- "schemars",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "prost-build 0.12.6",
  "prost-wkt-types",
  "rand 0.8.5",
+ "scaled-hashring",
  "schemars",
  "segment",
  "serde",
@@ -1103,7 +1104,6 @@ dependencies = [
  "fs4",
  "fs_extra",
  "futures",
- "hashring",
  "indexmap 2.2.6",
  "indicatif",
  "io",
@@ -1121,6 +1121,7 @@ dependencies = [
  "ringbuffer",
  "rmp-serde",
  "rstest",
+ "scaled-hashring",
  "schemars",
  "segment",
  "semver",
@@ -5299,6 +5300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scaled-hashring"
+version = "0.0.0"
+dependencies = [
+ "hashring",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "scc"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5484,6 +5494,7 @@ dependencies = [
  "rmp-serde",
  "rocksdb",
  "rstest",
+ "scaled-hashring",
  "schemars",
  "seahash",
  "segment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,8 +5304,10 @@ name = "scaled-hashring"
 version = "0.0.0"
 dependencies = [
  "hashring",
+ "rstest",
  "schemars",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -150,6 +150,8 @@
     - [GroupId](#qdrant-GroupId)
     - [GroupsResult](#qdrant-GroupsResult)
     - [HasIdCondition](#qdrant-HasIdCondition)
+    - [HashRing](#qdrant-HashRing)
+    - [HashRingCondition](#qdrant-HashRingCondition)
     - [IsEmptyCondition](#qdrant-IsEmptyCondition)
     - [IsNullCondition](#qdrant-IsNullCondition)
     - [LookupLocation](#qdrant-LookupLocation)
@@ -2080,6 +2082,7 @@ The JSON representation for `Value` is a JSON value.
 | filter | [Filter](#qdrant-Filter) |  |  |
 | is_null | [IsNullCondition](#qdrant-IsNullCondition) |  |  |
 | nested | [NestedCondition](#qdrant-NestedCondition) |  |  |
+| hash_ring | [HashRingCondition](#qdrant-HashRingCondition) |  |  |
 
 
 
@@ -2604,6 +2607,38 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | has_id | [PointId](#qdrant-PointId) | repeated |  |
+
+
+
+
+
+
+<a name="qdrant-HashRing"></a>
+
+### HashRing
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| scale | [uint32](#uint32) |  |  |
+| nodes | [uint32](#uint32) | repeated |  |
+
+
+
+
+
+
+<a name="qdrant-HashRingCondition"></a>
+
+### HashRingCondition
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ring | [HashRing](#qdrant-HashRing) |  |  |
+| match_shard_ids | [uint32](#uint32) | repeated |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7209,6 +7209,9 @@
             "$ref": "#/components/schemas/HasIdCondition"
           },
           {
+            "$ref": "#/components/schemas/HashRingCondition"
+          },
+          {
             "$ref": "#/components/schemas/NestedCondition"
           },
           {
@@ -7636,6 +7639,70 @@
             "uniqueItems": true
           }
         }
+      },
+      "HashRingCondition": {
+        "type": "object",
+        "required": [
+          "match_shard_ids",
+          "ring"
+        ],
+        "properties": {
+          "ring": {
+            "$ref": "#/components/schemas/ScaledHashRing"
+          },
+          "match_shard_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "uniqueItems": true
+          }
+        }
+      },
+      "ScaledHashRing": {
+        "type": "object",
+        "required": [
+          "nodes"
+        ],
+        "properties": {
+          "scale": {
+            "$ref": "#/components/schemas/Scale"
+          },
+          "nodes": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          }
+        }
+      },
+      "Scale": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "raw"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "fair"
+            ],
+            "properties": {
+              "fair": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "NestedCondition": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7209,9 +7209,6 @@
             "$ref": "#/components/schemas/HasIdCondition"
           },
           {
-            "$ref": "#/components/schemas/HashRingCondition"
-          },
-          {
             "$ref": "#/components/schemas/NestedCondition"
           },
           {
@@ -7639,70 +7636,6 @@
             "uniqueItems": true
           }
         }
-      },
-      "HashRingCondition": {
-        "type": "object",
-        "required": [
-          "match_shard_ids",
-          "ring"
-        ],
-        "properties": {
-          "ring": {
-            "$ref": "#/components/schemas/ScaledHashRing"
-          },
-          "match_shard_ids": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            },
-            "uniqueItems": true
-          }
-        }
-      },
-      "ScaledHashRing": {
-        "type": "object",
-        "required": [
-          "nodes"
-        ],
-        "properties": {
-          "scale": {
-            "$ref": "#/components/schemas/Scale"
-          },
-          "nodes": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            }
-          }
-        }
-      },
-      "Scale": {
-        "oneOf": [
-          {
-            "type": "string",
-            "enum": [
-              "raw"
-            ]
-          },
-          {
-            "type": "object",
-            "required": [
-              "fair"
-            ],
-            "properties": {
-              "fair": {
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
       },
       "NestedCondition": {
         "type": "object",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -31,6 +31,7 @@ validator = { workspace = true }
 itertools = { workspace = true }
 
 common = { path = "../common/common" }
+scaled-hashring = { path = "../common/scaled_hashring" }
 segment = { path = "../segment" }
 sparse = { path = "../sparse" }
 

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1412,11 +1412,11 @@ impl TryFrom<HashRingCondition> for segment::types::HashRingCondition {
             .ok_or_else(|| Status::invalid_argument("HashRingCondition::ring is None"))?
             .into();
 
-        let shard_ids = cond.shard_ids.into_iter().collect();
+        let shard_ids = cond.match_shard_ids.into_iter().collect();
 
         Ok(Self {
             ring,
-            shard_ids,
+            match_shard_ids: shard_ids,
             is_local_only: false,
         })
     }
@@ -1428,7 +1428,7 @@ impl From<segment::types::HashRingCondition> for HashRingCondition {
 
         Self {
             ring: Some(cond.ring.into()),
-            shard_ids: cond.shard_ids.into_iter().collect(),
+            match_shard_ids: cond.match_shard_ids.into_iter().collect(),
         }
     }
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -858,7 +858,7 @@ message FieldCondition {
 
 message HashRingCondition {
   HashRing ring = 1;
-  repeated uint32 shard_ids = 2;
+  repeated uint32 match_shard_ids = 2;
 }
 
 message HashRing {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -824,6 +824,7 @@ message Condition {
     Filter filter = 4;
     IsNullCondition is_null = 5;
     NestedCondition nested = 6;
+    HashRingCondition hash_ring = 7;
   }
 }
 
@@ -853,6 +854,16 @@ message FieldCondition {
   ValuesCount values_count = 6; // Check number of values for a specific field
   GeoPolygon geo_polygon = 7; // Check if geo point is within a given polygon
   DatetimeRange datetime_range = 8; // Check if datetime is within a given range
+}
+
+message HashRingCondition {
+  HashRing ring = 1;
+  repeated uint32 shard_ids = 2;
+}
+
+message HashRing {
+  uint32 scale = 1;
+  repeated uint32 nodes = 2;
 }
 
 message Match {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5606,7 +5606,7 @@ pub struct HashRingCondition {
     #[prost(message, optional, tag = "1")]
     pub ring: ::core::option::Option<HashRing>,
     #[prost(uint32, repeated, tag = "2")]
-    pub shard_ids: ::prost::alloc::vec::Vec<u32>,
+    pub match_shard_ids: ::prost::alloc::vec::Vec<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5511,7 +5511,7 @@ pub struct MinShould {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Condition {
-    #[prost(oneof = "condition::ConditionOneOf", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "condition::ConditionOneOf", tags = "1, 2, 3, 4, 5, 6, 7")]
     #[validate]
     pub condition_one_of: ::core::option::Option<condition::ConditionOneOf>,
 }
@@ -5533,6 +5533,8 @@ pub mod condition {
         IsNull(super::IsNullCondition),
         #[prost(message, tag = "6")]
         Nested(super::NestedCondition),
+        #[prost(message, tag = "7")]
+        HashRing(super::HashRingCondition),
     }
 }
 #[derive(serde::Serialize)]
@@ -5596,6 +5598,24 @@ pub struct FieldCondition {
     /// Check if datetime is within a given range
     #[prost(message, optional, tag = "8")]
     pub datetime_range: ::core::option::Option<DatetimeRange>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HashRingCondition {
+    #[prost(message, optional, tag = "1")]
+    pub ring: ::core::option::Option<HashRing>,
+    #[prost(uint32, repeated, tag = "2")]
+    pub shard_ids: ::prost::alloc::vec::Vec<u32>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HashRing {
+    #[prost(uint32, tag = "1")]
+    pub scale: u32,
+    #[prost(uint32, repeated, tag = "2")]
+    pub nodes: ::prost::alloc::vec::Vec<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -241,7 +241,7 @@ impl Validate for grpc::HashRingCondition {
         // it would be way too easy to, e.g., wipe your whole shard with a faulty filter.
         //
         // There's no point checking that hash ring contains all `match_shard_ids`, if there are
-        // no nodes in the hash ring. Return immideately.
+        // no nodes in the hash ring. Return immediately.
         ValidationErrors::merge(Ok(()), "ring", ring.validate())?;
 
         // Hash ring in `HashRingCondition` *must* contain all `match_shard_ids`, because otherwise

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -40,7 +40,6 @@ serde_variant = { workspace = true }
 rmp-serde = "~1.3"
 wal = { workspace = true }
 ordered-float = "4.2"
-hashring = "0.3.5"
 tinyvec = { version = "1.8.0", features = ["alloc"] }
 bitvec = "1.0.1"
 lazy_static = "1.5.0"
@@ -67,6 +66,7 @@ common = { path = "../common/common" }
 cancel = { path = "../common/cancel" }
 io = { path = "../common/io" }
 issues = { path = "../common/issues" }
+scaled-hashring = { path = "../common/scaled_hashring" }
 segment = { path = "../segment" }
 sparse = { path = "../sparse" }
 api = { path = "../api" }

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -425,7 +425,7 @@ impl Collection {
             let target_shards = shard_holder.select_shards(shard_selection)?;
 
             // Resharding filter to apply when resharding is active
-            let resharding_filter = shard_holder.resharding_filter_impl();
+            let resharding_filter = shard_holder.resharding_hash_ring_condition();
             let reshard_shard_id = shard_holder
                 .resharding_state
                 .read()

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,16 +1,12 @@
 use std::collections::HashSet;
+use std::fmt;
 use std::hash::Hash;
-use std::{any, fmt};
 
 use itertools::Itertools as _;
-use segment::index::field_index::CardinalityEstimation;
-use segment::types::{PointIdType, ReshardingCondition};
 use smallvec::SmallVec;
 
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::shards::shard::ShardId;
-
-const HASH_RING_SHARD_SCALE: u32 = 100;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum HashRing<T = ShardId> {
@@ -25,18 +21,18 @@ pub enum HashRing<T = ShardId> {
 impl<T: Hash + Copy + PartialEq> HashRing<T> {
     /// Create a new single hashring.
     ///
-    /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.
+    /// The hashring is created with a fair distribution of points and `FAIR_HASH_RING_SCALE` scale.
     pub fn single() -> Self {
-        Self::Single(Inner::fair(HASH_RING_SHARD_SCALE))
+        Self::Single(Inner::fair(common::defaults::FAIR_HASH_RING_SCALE))
     }
 
     /// Create a new resharding hashring, with resharding shard already added into `new` hashring.
     ///
-    /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.
+    /// The hashring is created with a fair distribution of points and `FAIR_HASH_RING_SCALE` scale.
     pub fn resharding(shard: T, direction: ReshardingDirection) -> Self {
         let mut ring = Self::Resharding {
-            old: Inner::fair(HASH_RING_SHARD_SCALE),
-            new: Inner::fair(HASH_RING_SHARD_SCALE),
+            old: Inner::fair(common::defaults::FAIR_HASH_RING_SCALE),
+            new: Inner::fair(common::defaults::FAIR_HASH_RING_SCALE),
         };
 
         ring.start_resharding(shard, direction);
@@ -205,196 +201,10 @@ impl<T: Hash + Copy + PartialEq + Eq> HashRing<T> {
     }
 }
 
+pub type Inner<T> = scaled_hashring::ScaledHashRing<T>;
+
 /// List type for shard IDs
 ///
 /// Uses a `SmallVec` putting two IDs on the stack. That's the maximum number of shards we expect
 /// with the current resharding implementation.
 pub type ShardIds<T = ShardId> = SmallVec<[T; 2]>;
-
-#[derive(Clone, PartialEq, Debug)]
-pub enum Inner<T> {
-    Raw(hashring::HashRing<T>),
-
-    Fair {
-        ring: hashring::HashRing<(T, u32)>,
-        scale: u32,
-    },
-}
-
-impl<T: Hash + Copy> Inner<T> {
-    pub fn raw() -> Self {
-        Self::Raw(hashring::HashRing::new())
-    }
-
-    /// Constructs a HashRing that tries to give all shards equal space on the ring.
-    /// The higher the `scale` - the more equal the distribution of points on the shards will be,
-    /// but shard search might be slower.
-    pub fn fair(scale: u32) -> Self {
-        Self::Fair {
-            ring: hashring::HashRing::new(),
-            scale,
-        }
-    }
-
-    pub fn add(&mut self, shard: T) {
-        match self {
-            Inner::Raw(ring) => ring.add(shard),
-            Inner::Fair { ring, scale } => {
-                for i in 0..*scale {
-                    ring.add((shard, i))
-                }
-            }
-        }
-    }
-
-    pub fn remove(&mut self, shard: &T) -> bool {
-        match self {
-            Inner::Raw(ring) => ring.remove(shard).is_some(),
-            Inner::Fair { ring, scale } => {
-                let mut removed = false;
-                for i in 0..*scale {
-                    if ring.remove(&(*shard, i)).is_some() {
-                        removed = true;
-                    }
-                }
-                removed
-            }
-        }
-    }
-
-    pub fn get<U: Hash>(&self, key: &U) -> Option<&T> {
-        match self {
-            Inner::Raw(ring) => ring.get(key),
-            Inner::Fair { ring, .. } => ring.get(key).map(|(shard, _)| shard),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Inner::Raw(ring) => ring.is_empty(),
-            Inner::Fair { ring, .. } => ring.is_empty(),
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        match self {
-            Inner::Raw(ring) => ring.len(),
-            Inner::Fair { ring, scale } => ring.len() / *scale as usize,
-        }
-    }
-}
-
-impl<T: Hash + Copy + PartialEq + Eq> Inner<T> {
-    /// Get unique nodes from the hashring
-    pub fn unique_nodes(&self) -> HashSet<T> {
-        match self {
-            Inner::Raw(ring) => ring.clone().into_iter().collect(),
-            Inner::Fair { ring, .. } => ring.clone().into_iter().map(|(node, _)| node).collect(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Filter<T = ShardId> {
-    ring: Inner<T>,
-    filter: T,
-}
-
-impl<T> Filter<T> {
-    pub fn new(ring: Inner<T>, filter: T) -> Self {
-        Self { ring, filter }
-    }
-
-    pub fn check(&self, point_id: PointIdType) -> bool
-    where
-        T: Hash + PartialEq + Copy,
-    {
-        self.ring.get(&point_id) == Some(&self.filter)
-    }
-}
-
-impl<T> ReshardingCondition for Filter<T>
-where
-    T: fmt::Debug + Hash + PartialEq + Copy + 'static,
-{
-    fn check(&self, point_id: PointIdType) -> bool {
-        self.check(point_id)
-    }
-
-    fn estimate_cardinality(&self, points: usize) -> CardinalityEstimation {
-        CardinalityEstimation {
-            primary_clauses: vec![],
-            min: 0,
-            exp: points / self.ring.len(),
-            max: points,
-        }
-    }
-
-    fn eq(&self, other: &dyn ReshardingCondition) -> bool {
-        match other.as_any().downcast_ref::<Self>() {
-            Some(other) => self == other,
-            None => false,
-        }
-    }
-
-    fn as_any(&self) -> &dyn any::Any {
-        self
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_non_seq_keys() {
-        let mut ring = Inner::fair(100);
-        ring.add(5);
-        ring.add(7);
-        ring.add(8);
-        ring.add(20);
-
-        for i in 0..20 {
-            match ring.get(&i) {
-                None => panic!("Key {i} has no shard"),
-                Some(x) => assert!([5, 7, 8, 20].contains(x)),
-            }
-        }
-    }
-
-    #[test]
-    fn test_repartition() {
-        let mut ring = Inner::fair(100);
-
-        ring.add(1);
-        ring.add(2);
-        ring.add(3);
-
-        let mut pre_split = Vec::new();
-        let mut post_split = Vec::new();
-
-        for i in 0..100 {
-            match ring.get(&i) {
-                None => panic!("Key {i} has no shard"),
-                Some(x) => pre_split.push(*x),
-            }
-        }
-
-        ring.add(4);
-
-        for i in 0..100 {
-            match ring.get(&i) {
-                None => panic!("Key {i} has no shard"),
-                Some(x) => post_split.push(*x),
-            }
-        }
-
-        assert_ne!(pre_split, post_split);
-
-        for (x, y) in pre_split.iter().zip(post_split.iter()) {
-            if x != y {
-                assert_eq!(*y, 4);
-            }
-        }
-    }
-}

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -23,7 +23,7 @@ impl<T: Hash + Copy + PartialEq> HashRing<T> {
     ///
     /// The hashring is created with a fair distribution of points and `FAIR_HASH_RING_SCALE` scale.
     pub fn single() -> Self {
-        Self::Single(Inner::fair(common::defaults::FAIR_HASH_RING_SCALE))
+        Self::Single(Inner::fair(scaled_hashring::DEFAULT_FAIR_HASH_RING_SCALE))
     }
 
     /// Create a new resharding hashring, with resharding shard already added into `new` hashring.
@@ -31,8 +31,8 @@ impl<T: Hash + Copy + PartialEq> HashRing<T> {
     /// The hashring is created with a fair distribution of points and `FAIR_HASH_RING_SCALE` scale.
     pub fn resharding(shard: T, direction: ReshardingDirection) -> Self {
         let mut ring = Self::Resharding {
-            old: Inner::fair(common::defaults::FAIR_HASH_RING_SCALE),
-            new: Inner::fair(common::defaults::FAIR_HASH_RING_SCALE),
+            old: Inner::fair(scaled_hashring::DEFAULT_FAIR_HASH_RING_SCALE),
+            new: Inner::fair(scaled_hashring::DEFAULT_FAIR_HASH_RING_SCALE),
         };
 
         ring.start_resharding(shard, direction);

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -367,7 +367,7 @@ impl ShardHolder {
     ///
     /// `None` if resharding is not active or if the read hash ring is not committed yet.
     pub fn resharding_filter(&self) -> Option<Filter> {
-        let cond = self.resharding_hash_ring_condition()?.local_only();
+        let cond = self.resharding_hash_ring_condition()?;
         let filter = Filter::new_must_not(Condition::HashRing(cond));
         Some(filter)
     }
@@ -393,7 +393,7 @@ impl ShardHolder {
             HashRing::Single(ring) => ring,
         };
 
-        Some(HashRingCondition::new(ring.clone(), state.shard_id))
+        Some(HashRingCondition::new(ring.clone(), state.shard_id).local_only())
     }
 }
 

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -25,9 +25,6 @@ lazy_static! {
     pub static ref POOL_KEEP_LIMIT: usize = cpu::get_num_cpus().clamp(16, 128);
 }
 
-/// Default number of virtual nodes for the `ScaledHashRing::Fair` used in Qdrant code.
-pub const FAIR_HASH_RING_SCALE: u32 = 100;
-
 /// Default value of CPU budget parameter.
 ///
 /// Dynamic based on CPU size.

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -25,6 +25,9 @@ lazy_static! {
     pub static ref POOL_KEEP_LIMIT: usize = cpu::get_num_cpus().clamp(16, 128);
 }
 
+/// Default number of virtual nodes for the `ScaledHashRing::Fair` used in Qdrant code.
+pub const FAIR_HASH_RING_SCALE: u32 = 100;
+
 /// Default value of CPU budget parameter.
 ///
 /// Dynamic based on CPU size.

--- a/lib/common/scaled_hashring/Cargo.toml
+++ b/lib/common/scaled_hashring/Cargo.toml
@@ -16,3 +16,7 @@ workspace = true
 hashring = "0.3"
 schemars = { workspace = true }
 serde = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.21.0"
+serde_json = { workspace = true }

--- a/lib/common/scaled_hashring/Cargo.toml
+++ b/lib/common/scaled_hashring/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 hashring = "0.3"
-schemars = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/lib/common/scaled_hashring/Cargo.toml
+++ b/lib/common/scaled_hashring/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "scaled-hashring"
+version = "0.0.0"
+authors = [
+    "Andrey Vasnetsov <vasnetsov93@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+hashring = "0.3"
+schemars = { workspace = true }
+serde = { workspace = true }

--- a/lib/common/scaled_hashring/src/lib.rs
+++ b/lib/common/scaled_hashring/src/lib.rs
@@ -256,10 +256,13 @@ mod tests {
         let mut serialized_json =
             serde_json::to_value(hashring).expect("ScaledHashRing can be serialized to JSON");
 
-        serialized_json
+        let nodes = serialized_json
             .get_mut("nodes")
-            .and_then(|nodes| nodes.as_array_mut())
-            .map(|nodes| nodes.sort_unstable_by_key(|node| node.as_u64()));
+            .and_then(|nodes| nodes.as_array_mut());
+
+        if let Some(nodes) = nodes {
+            nodes.sort_unstable_by_key(|node| node.as_u64());
+        }
 
         assert_eq!(&serialized_json, expected_json);
     }

--- a/lib/common/scaled_hashring/src/lib.rs
+++ b/lib/common/scaled_hashring/src/lib.rs
@@ -1,0 +1,216 @@
+use std::collections::HashSet;
+use std::hash;
+
+pub const DEFAULT_FAIR_HASH_RING_SCALE: u32 = 100;
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(from = "SerdeHelper<T>", into = "SerdeHelper<T>")]
+#[serde(bound(deserialize = "T: Copy + hash::Hash + serde::Deserialize<'de>"))]
+#[serde(bound(serialize = "T: Copy + Eq + hash::Hash + serde::Serialize"))]
+pub enum ScaledHashRing<T> {
+    Raw(hashring::HashRing<T>),
+
+    Fair {
+        ring: hashring::HashRing<(T, u32)>,
+        scale: u32,
+    },
+}
+
+impl<T: Copy + hash::Hash> ScaledHashRing<T> {
+    pub fn raw() -> Self {
+        Self::Raw(hashring::HashRing::new())
+    }
+
+    /// Constructs a HashRing that tries to give all shards equal space on the ring.
+    /// The higher the `scale` - the more equal the distribution of points on the shards will be,
+    /// but shard search might be slower.
+    pub fn fair(scale: u32) -> Self {
+        Self::Fair {
+            ring: hashring::HashRing::new(),
+            scale,
+        }
+    }
+
+    pub fn add(&mut self, shard: T) {
+        match self {
+            Self::Raw(ring) => ring.add(shard),
+            Self::Fair { ring, scale } => {
+                for i in 0..*scale {
+                    ring.add((shard, i))
+                }
+            }
+        }
+    }
+
+    pub fn remove(&mut self, shard: &T) -> bool {
+        match self {
+            Self::Raw(ring) => ring.remove(shard).is_some(),
+            Self::Fair { ring, scale } => {
+                let mut removed = false;
+                for i in 0..*scale {
+                    if ring.remove(&(*shard, i)).is_some() {
+                        removed = true;
+                    }
+                }
+                removed
+            }
+        }
+    }
+
+    pub fn get<U: hash::Hash>(&self, key: &U) -> Option<&T> {
+        match self {
+            Self::Raw(ring) => ring.get(key),
+            Self::Fair { ring, .. } => ring.get(key).map(|(shard, _)| shard),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Raw(ring) => ring.is_empty(),
+            Self::Fair { ring, .. } => ring.is_empty(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Raw(ring) => ring.len(),
+            Self::Fair { ring, scale } => ring.len() / *scale as usize,
+        }
+    }
+
+    /// Get unique nodes from the hashring
+    pub fn unique_nodes(&self) -> HashSet<T>
+    where
+        T: Eq,
+    {
+        match self {
+            Self::Raw(ring) => ring.clone().into_iter().collect(),
+            Self::Fair { ring, .. } => ring.clone().into_iter().map(|(node, _)| node).collect(),
+        }
+    }
+}
+
+impl<T: schemars::JsonSchema> schemars::JsonSchema for ScaledHashRing<T> {
+    fn schema_name() -> String {
+        "ScaledHashRing".into()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        SerdeHelper::<T>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        SerdeHelper::<T>::is_referenceable()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        SerdeHelper::<T>::schema_id()
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+struct SerdeHelper<T> {
+    #[serde(default)]
+    scale: Scale,
+    nodes: Vec<T>,
+}
+
+impl<T: Copy + Eq + hash::Hash> From<ScaledHashRing<T>> for SerdeHelper<T> {
+    fn from(ring: ScaledHashRing<T>) -> Self {
+        let scale = match ring {
+            ScaledHashRing::Raw(_) => Scale::Raw,
+            ScaledHashRing::Fair { scale, .. } => Scale::Fair(scale),
+        };
+
+        let nodes = ring.unique_nodes().into_iter().collect();
+
+        Self { scale, nodes }
+    }
+}
+
+impl<T: Copy + hash::Hash> From<SerdeHelper<T>> for ScaledHashRing<T> {
+    fn from(helper: SerdeHelper<T>) -> Self {
+        let mut ring = match helper.scale {
+            Scale::Raw | Scale::Fair(0) => Self::raw(),
+            Scale::Fair(scale) => Self::fair(scale),
+        };
+
+        for node in helper.nodes {
+            ring.add(node);
+        }
+
+        ring
+    }
+}
+
+#[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum Scale {
+    Raw,
+
+    #[serde(untagged)]
+    Fair(u32),
+}
+
+impl Default for Scale {
+    fn default() -> Self {
+        Self::Fair(DEFAULT_FAIR_HASH_RING_SCALE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_non_seq_keys() {
+        let mut ring = ScaledHashRing::fair(100);
+        ring.add(5);
+        ring.add(7);
+        ring.add(8);
+        ring.add(20);
+
+        for i in 0..20 {
+            match ring.get(&i) {
+                None => panic!("Key {i} has no shard"),
+                Some(x) => assert!([5, 7, 8, 20].contains(x)),
+            }
+        }
+    }
+
+    #[test]
+    fn test_repartition() {
+        let mut ring = ScaledHashRing::fair(100);
+
+        ring.add(1);
+        ring.add(2);
+        ring.add(3);
+
+        let mut pre_split = Vec::new();
+        let mut post_split = Vec::new();
+
+        for i in 0..100 {
+            match ring.get(&i) {
+                None => panic!("Key {i} has no shard"),
+                Some(x) => pre_split.push(*x),
+            }
+        }
+
+        ring.add(4);
+
+        for i in 0..100 {
+            match ring.get(&i) {
+                None => panic!("Key {i} has no shard"),
+                Some(x) => post_split.push(*x),
+            }
+        }
+
+        assert_ne!(pre_split, post_split);
+
+        for (x, y) in pre_split.iter().zip(post_split.iter()) {
+            if x != y {
+                assert_eq!(*y, 4);
+            }
+        }
+    }
+}

--- a/lib/common/scaled_hashring/src/lib.rs
+++ b/lib/common/scaled_hashring/src/lib.rs
@@ -91,25 +91,7 @@ impl<T: Copy + hash::Hash> ScaledHashRing<T> {
     }
 }
 
-impl<T: schemars::JsonSchema> schemars::JsonSchema for ScaledHashRing<T> {
-    fn schema_name() -> String {
-        "ScaledHashRing".into()
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        SerdeHelper::<T>::json_schema(gen)
-    }
-
-    fn is_referenceable() -> bool {
-        SerdeHelper::<T>::is_referenceable()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        SerdeHelper::<T>::schema_id()
-    }
-}
-
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 struct SerdeHelper<T> {
     #[serde(default)]
     scale: Scale,
@@ -144,7 +126,7 @@ impl<T: Copy + hash::Hash> From<SerdeHelper<T>> for ScaledHashRing<T> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 enum Scale {
     Raw,

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -92,6 +92,7 @@ common = { path = "../common/common" }
 io = { path = "../common/io" }
 issues = { path = "../common/issues" }
 memory = { path = "../common/memory" }
+scaled-hashring = { path = "../common/scaled_hashring" }
 sparse = { path = "../sparse" }
 
 tracing = { workspace = true, optional = true }

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -292,6 +292,7 @@ mod tests {
             Condition::Filter(_) => panic!("unexpected Filter"),
             Condition::Nested(_) => panic!("unexpected Nested"),
             Condition::Resharding(_) => panic!("unexpected Resharding"),
+            Condition::HashRing(_) => panic!("unexpected HashRing"),
             Condition::Field(field) => match field.key.to_string().as_str() {
                 "color" => CardinalityEstimation {
                     primary_clauses: vec![PrimaryCondition::Condition(field.clone())],

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -291,7 +291,6 @@ mod tests {
         match condition {
             Condition::Filter(_) => panic!("unexpected Filter"),
             Condition::Nested(_) => panic!("unexpected Nested"),
-            Condition::Resharding(_) => panic!("unexpected Resharding"),
             Condition::HashRing(_) => panic!("unexpected HashRing"),
             Condition::Field(field) => match field.key.to_string().as_str() {
                 "color" => CardinalityEstimation {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -121,7 +121,8 @@ pub fn condition_converter<'a>(
                 })
             })
         }
-        Condition::Resharding(cond) => {
+
+        Condition::HashRing(cond) => {
             let segment_ids: HashSet<_> = id_tracker
                 .iter_external()
                 .filter(|&point_id| cond.check(point_id))
@@ -130,6 +131,7 @@ pub fn condition_converter<'a>(
 
             Box::new(move |internal_id| segment_ids.contains(&internal_id))
         }
+
         Condition::Filter(_) => unreachable!(),
     }
 }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -315,7 +315,7 @@ impl StructPayloadIndex {
                 .estimate_field_condition(field_condition, nested_path)
                 .unwrap_or_else(|| CardinalityEstimation::unknown(self.available_point_count())),
 
-            Condition::Resharding(cond) => {
+            Condition::HashRing(cond) => {
                 cond.estimate_cardinality(self.id_tracker.borrow().available_point_count())
             }
         }

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -147,7 +147,7 @@ where
                 })
         }
 
-        Condition::Resharding(cond) => id_tracker
+        Condition::HashRing(cond) => id_tracker
             .and_then(|id_tracker| id_tracker.external_id(point_id))
             .map_or(false, |point_id| cond.check(point_id)),
 

--- a/lib/segment/src/problems/unindexed_field.rs
+++ b/lib/segment/src/problems/unindexed_field.rs
@@ -323,7 +323,7 @@ impl<'a> Extractor<'a> {
             }
             // No index needed
             Condition::HasId(_) => return,
-            Condition::Resharding(_) => return,
+            Condition::HashRing(_) => return,
         };
 
         let full_key = JsonPath::extend_or_new(nested_prefix, key);

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1970,7 +1970,7 @@ impl NestedCondition {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct HashRingCondition {
     pub ring: scaled_hashring::ScaledHashRing<ShardId>,
     pub match_shard_ids: HashSet<ShardId>,
@@ -2070,12 +2070,14 @@ pub enum Condition {
     IsNull(IsNullCondition),
     /// Check if points id is in a given set
     HasId(HasIdCondition),
-    /// Check if point ID is hashed into particular shards
-    HashRing(HashRingCondition),
     /// Nested filters
     Nested(NestedCondition),
     /// Nested filter
     Filter(Filter),
+
+    /// Check if point ID is hashed into particular shard(s)
+    #[schemars(skip)]
+    HashRing(HashRingCondition),
 }
 
 impl Condition {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1970,10 +1970,17 @@ impl NestedCondition {
     }
 }
 
+/// Selects points that are hashed into particular shards
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct HashRingCondition {
+    /// Hash ring to hash point IDs with
     pub ring: scaled_hashring::ScaledHashRing<ShardId>,
+
+    /// Shard IDs that hashed point IDs should match
     pub match_shard_ids: HashSet<ShardId>,
+
+    /// Marks if this condition should *not* be transferred to remote shards when applying queries
+    // or operations to replica set
     #[serde(skip)]
     pub is_local_only: bool,
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2020,7 +2020,7 @@ impl Validate for HashRingCondition {
         // it would be way too easy to, e.g., wipe your whole shard with a faulty filter.
         if self.ring.is_empty() {
             // There's no point checking that hash ring contains all `match_shard_ids`,
-            // if there are no nodes in the hash ring. Return immideately.
+            // if there are no nodes in the hash ring. Return immediately.
             errors.add("ring", ValidationError::new("hash ring must contain nodes"));
             return Err(errors);
         }


### PR DESCRIPTION
This PR refactor local-only `hash_ring::Filter` and `Condition::Resharding` into a generic, serializable `Condition::HashRing`. This _(or some specialized API)_ is required to move resharding driver into external service.

`Condition::HashRing` seems like a generally useful API to test/debug resharding correctness, so it was decided to implement it, instead of a simpler/specialized solution.

__TODO:__
- [x] ~~documentation~~
  - we're keeping it hush-hush 🤫
  - [ ] ~~Document fields of `HashRingCondition`~~
  - [ ] ~~OpenAPI~~
  - [ ] ~~gRPC~~
- [x] unit-tests
- [ ] ~~intergraiton tests~~
  - integration tests would be added in a follow up PR, *once we expose `Commit*HashRing` API*, because it would be trivial to *setup* `HashRingCondition` tests once `Commit*HashRing` API is available

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
