### PR TITLE
Add `Commit*HashRing` resharding operations to update collection cluster API

### DIFF
--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -26,14 +26,18 @@ pub enum ClusterOperations {
     DropShardingKey(DropShardingKeyOperation),
     /// Restart transfer
     RestartTransfer(RestartTransferOperation),
+
     /// Start resharding
-    // TODO(resharding): expose when releasing resharding
     #[schemars(skip)]
     StartResharding(StartReshardingOperation),
     /// Abort resharding
-    // TODO(resharding): expose when releasing resharding
     #[schemars(skip)]
     AbortResharding(AbortReshardingOperation),
+
+    #[schemars(skip)]
+    CommitReadHashRing(CommitReadHashRingOperation),
+    #[schemars(skip)]
+    CommitWriteHashRing(CommitWriteHashRingOperation),
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
@@ -100,6 +104,8 @@ impl Validate for ClusterOperations {
             ClusterOperations::RestartTransfer(op) => op.validate(),
             ClusterOperations::StartResharding(op) => op.validate(),
             ClusterOperations::AbortResharding(op) => op.validate(),
+            ClusterOperations::CommitReadHashRing(op) => op.validate(),
+            ClusterOperations::CommitWriteHashRing(op) => op.validate(),
         }
     }
 }
@@ -144,6 +150,18 @@ pub struct StartReshardingOperation {
 pub struct AbortReshardingOperation {
     #[validate]
     pub abort_resharding: AbortResharding,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
+pub struct CommitReadHashRingOperation {
+    pub commit_read_hash_ring: CommitReadHashRing,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
+pub struct CommitWriteHashRingOperation {
+    pub commit_write_hash_ring: CommitWriteHashRing,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -229,3 +247,11 @@ pub enum ReshardingDirection {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct AbortResharding {}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
+pub struct CommitReadHashRing {}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
+pub struct CommitWriteHashRing {}


### PR DESCRIPTION
This is required to be able to move resharding driver to a separate service.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
