### PR TITLE
Cleanup `ClusterOperations` enum structure and ser/de implementation

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10723,40 +10723,99 @@
         }
       },
       "ClusterOperations": {
-        "anyOf": [
+        "oneOf": [
           {
-            "$ref": "#/components/schemas/MoveShardOperation"
+            "description": "Move shard to a different peer",
+            "type": "object",
+            "required": [
+              "move_shard"
+            ],
+            "properties": {
+              "move_shard": {
+                "$ref": "#/components/schemas/MoveShard"
+              }
+            },
+            "additionalProperties": false
           },
           {
-            "$ref": "#/components/schemas/ReplicateShardOperation"
+            "description": "Replicate shard to a different peer",
+            "type": "object",
+            "required": [
+              "replicate_shard"
+            ],
+            "properties": {
+              "replicate_shard": {
+                "$ref": "#/components/schemas/ReplicateShard"
+              }
+            },
+            "additionalProperties": false
           },
           {
-            "$ref": "#/components/schemas/AbortTransferOperation"
+            "description": "Abort currently running shard moving operation",
+            "type": "object",
+            "required": [
+              "abort_transfer"
+            ],
+            "properties": {
+              "abort_transfer": {
+                "$ref": "#/components/schemas/AbortShardTransfer"
+              }
+            },
+            "additionalProperties": false
           },
           {
-            "$ref": "#/components/schemas/DropReplicaOperation"
+            "description": "Restart transfer",
+            "type": "object",
+            "required": [
+              "restart_transfer"
+            ],
+            "properties": {
+              "restart_transfer": {
+                "$ref": "#/components/schemas/RestartTransfer"
+              }
+            },
+            "additionalProperties": false
           },
           {
-            "$ref": "#/components/schemas/CreateShardingKeyOperation"
+            "description": "Drop replica of a shard from a peer",
+            "type": "object",
+            "required": [
+              "drop_replica"
+            ],
+            "properties": {
+              "drop_replica": {
+                "$ref": "#/components/schemas/Replica"
+              }
+            },
+            "additionalProperties": false
           },
           {
-            "$ref": "#/components/schemas/DropShardingKeyOperation"
+            "description": "Create a custom shard partition for a given key",
+            "type": "object",
+            "required": [
+              "create_sharding_key"
+            ],
+            "properties": {
+              "create_sharding_key": {
+                "$ref": "#/components/schemas/CreateShardingKey"
+              }
+            },
+            "additionalProperties": false
           },
           {
-            "$ref": "#/components/schemas/RestartTransferOperation"
+            "description": "Drop a custom shard partition for a given key",
+            "type": "object",
+            "required": [
+              "drop_sharding_key"
+            ],
+            "properties": {
+              "drop_sharding_key": {
+                "$ref": "#/components/schemas/DropShardingKey"
+              }
+            },
+            "additionalProperties": false
           }
         ]
-      },
-      "MoveShardOperation": {
-        "type": "object",
-        "required": [
-          "move_shard"
-        ],
-        "properties": {
-          "move_shard": {
-            "$ref": "#/components/schemas/MoveShard"
-          }
-        }
       },
       "MoveShard": {
         "type": "object",
@@ -10791,17 +10850,6 @@
                 "nullable": true
               }
             ]
-          }
-        }
-      },
-      "ReplicateShardOperation": {
-        "type": "object",
-        "required": [
-          "replicate_shard"
-        ],
-        "properties": {
-          "replicate_shard": {
-            "$ref": "#/components/schemas/ReplicateShard"
           }
         }
       },
@@ -10841,17 +10889,6 @@
           }
         }
       },
-      "AbortTransferOperation": {
-        "type": "object",
-        "required": [
-          "abort_transfer"
-        ],
-        "properties": {
-          "abort_transfer": {
-            "$ref": "#/components/schemas/AbortShardTransfer"
-          }
-        }
-      },
       "AbortShardTransfer": {
         "type": "object",
         "required": [
@@ -10877,14 +10914,32 @@
           }
         }
       },
-      "DropReplicaOperation": {
+      "RestartTransfer": {
         "type": "object",
         "required": [
-          "drop_replica"
+          "from_peer_id",
+          "method",
+          "shard_id",
+          "to_peer_id"
         ],
         "properties": {
-          "drop_replica": {
-            "$ref": "#/components/schemas/Replica"
+          "shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "from_peer_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "to_peer_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "method": {
+            "$ref": "#/components/schemas/ShardTransferMethod"
           }
         }
       },
@@ -10904,17 +10959,6 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0
-          }
-        }
-      },
-      "CreateShardingKeyOperation": {
-        "type": "object",
-        "required": [
-          "create_sharding_key"
-        ],
-        "properties": {
-          "create_sharding_key": {
-            "$ref": "#/components/schemas/CreateShardingKey"
           }
         }
       },
@@ -10953,17 +10997,6 @@
           }
         }
       },
-      "DropShardingKeyOperation": {
-        "type": "object",
-        "required": [
-          "drop_sharding_key"
-        ],
-        "properties": {
-          "drop_sharding_key": {
-            "$ref": "#/components/schemas/DropShardingKey"
-          }
-        }
-      },
       "DropShardingKey": {
         "type": "object",
         "required": [
@@ -10972,46 +11005,6 @@
         "properties": {
           "shard_key": {
             "$ref": "#/components/schemas/ShardKey"
-          }
-        }
-      },
-      "RestartTransferOperation": {
-        "type": "object",
-        "required": [
-          "restart_transfer"
-        ],
-        "properties": {
-          "restart_transfer": {
-            "$ref": "#/components/schemas/RestartTransfer"
-          }
-        }
-      },
-      "RestartTransfer": {
-        "type": "object",
-        "required": [
-          "from_peer_id",
-          "method",
-          "shard_id",
-          "to_peer_id"
-        ],
-        "properties": {
-          "shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "from_peer_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "to_peer_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "method": {
-            "$ref": "#/components/schemas/ShardTransferMethod"
           }
         }
       },

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -37,10 +37,8 @@ use crate::config::{
 use crate::lookup::types::WithLookupInterface;
 use crate::lookup::WithLookup;
 use crate::operations::cluster_ops::{
-    AbortShardTransfer, AbortTransferOperation, ClusterOperations, CreateShardingKey,
-    CreateShardingKeyOperation, DropReplicaOperation, DropShardingKey, DropShardingKeyOperation,
-    MoveShard, MoveShardOperation, Replica, ReplicateShard, ReplicateShardOperation,
-    RestartTransfer, RestartTransferOperation,
+    AbortShardTransfer, ClusterOperations, CreateShardingKey, DropShardingKey, MoveShard, Replica,
+    ReplicateShard, RestartTransfer,
 };
 use crate::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
@@ -1733,50 +1731,26 @@ impl TryFrom<ClusterOperationsPb> for ClusterOperations {
 
     fn try_from(value: ClusterOperationsPb) -> Result<Self, Self::Error> {
         Ok(match value {
-            ClusterOperationsPb::MoveShard(op) => {
-                ClusterOperations::MoveShard(MoveShardOperation {
-                    move_shard: op.try_into()?,
-                })
-            }
+            ClusterOperationsPb::MoveShard(op) => ClusterOperations::MoveShard(op.try_into()?),
             ClusterOperationsPb::ReplicateShard(op) => {
-                ClusterOperations::ReplicateShard(ReplicateShardOperation {
-                    replicate_shard: op.try_into()?,
-                })
+                ClusterOperations::ReplicateShard(op.try_into()?)
             }
             ClusterOperationsPb::AbortTransfer(op) => {
-                ClusterOperations::AbortTransfer(AbortTransferOperation {
-                    abort_transfer: op.try_into()?,
-                })
+                ClusterOperations::AbortTransfer(op.try_into()?)
             }
-            ClusterOperationsPb::DropReplica(op) => {
-                ClusterOperations::DropReplica(DropReplicaOperation {
-                    drop_replica: Replica {
-                        shard_id: op.shard_id,
-                        peer_id: op.peer_id,
-                    },
-                })
-            }
-            Operation::CreateShardKey(op) => {
-                ClusterOperations::CreateShardingKey(CreateShardingKeyOperation {
-                    create_sharding_key: op.try_into()?,
-                })
-            }
-            Operation::DeleteShardKey(op) => {
-                ClusterOperations::DropShardingKey(DropShardingKeyOperation {
-                    drop_sharding_key: op.try_into()?,
-                })
-            }
-            Operation::RestartTransfer(op) => {
-                ClusterOperations::RestartTransfer(RestartTransferOperation {
-                    restart_transfer: RestartTransfer {
-                        shard_id: op.shard_id,
-                        to_shard_id: op.to_shard_id,
-                        from_peer_id: op.from_peer_id,
-                        to_peer_id: op.to_peer_id,
-                        method: op.method.try_into()?,
-                    },
-                })
-            }
+            ClusterOperationsPb::DropReplica(op) => ClusterOperations::DropReplica(Replica {
+                shard_id: op.shard_id,
+                peer_id: op.peer_id,
+            }),
+            Operation::CreateShardKey(op) => ClusterOperations::CreateShardingKey(op.try_into()?),
+            Operation::DeleteShardKey(op) => ClusterOperations::DropShardingKey(op.try_into()?),
+            Operation::RestartTransfer(op) => ClusterOperations::RestartTransfer(RestartTransfer {
+                shard_id: op.shard_id,
+                to_shard_id: op.to_shard_id,
+                from_peer_id: op.from_peer_id,
+                to_peer_id: op.to_peer_id,
+                method: op.method.try_into()?,
+            }),
         })
     }
 }

--- a/src/actix/api/shards_api.rs
+++ b/src/actix/api/shards_api.rs
@@ -1,9 +1,6 @@
 use actix_web::{post, put, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::operations::cluster_ops::{
-    ClusterOperations, CreateShardingKey, CreateShardingKeyOperation, DropShardingKey,
-    DropShardingKeyOperation,
-};
+use collection::operations::cluster_ops::{ClusterOperations, CreateShardingKey, DropShardingKey};
 use storage::dispatcher::Dispatcher;
 use tokio::time::Instant;
 
@@ -29,14 +26,10 @@ async fn create_shard_key(
 
     let request = request.into_inner();
 
-    let operation = ClusterOperations::CreateShardingKey(CreateShardingKeyOperation {
-        create_sharding_key: request,
-    });
-
     let response = do_update_collection_cluster(
         &dispatcher,
         collection.name.clone(),
-        operation,
+        ClusterOperations::CreateShardingKey(request),
         access,
         wait_timeout,
     )
@@ -59,14 +52,10 @@ async fn delete_shard_key(
     let dispatcher = dispatcher.into_inner();
     let request = request.into_inner();
 
-    let operation = ClusterOperations::DropShardingKey(DropShardingKeyOperation {
-        drop_sharding_key: request,
-    });
-
     let response = do_update_collection_cluster(
         &dispatcher,
         collection.name.clone(),
-        operation,
+        ClusterOperations::DropShardingKey(request),
         access,
         wait_timeout,
     )

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -6,9 +6,7 @@ use api::grpc::models::{CollectionDescription, CollectionsResponse};
 use api::grpc::qdrant::CollectionExists;
 use collection::config::ShardingMethod;
 use collection::operations::cluster_ops::{
-    AbortTransferOperation, ClusterOperations, DropReplicaOperation, MoveShardOperation,
-    ReplicateShardOperation, ReshardingDirection, RestartTransfer, RestartTransferOperation,
-    StartResharding,
+    ClusterOperations, ReshardingDirection, RestartTransfer, StartResharding,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::snapshot_ops::SnapshotDescription;
@@ -241,7 +239,7 @@ pub async fn do_update_collection_cluster(
         .await?;
 
     match operation {
-        ClusterOperations::MoveShard(MoveShardOperation { move_shard }) => {
+        ClusterOperations::MoveShard(move_shard) => {
             // validate shard to move
             if !collection.contains_shard(move_shard.shard_id).await {
                 return Err(StorageError::BadRequest {
@@ -275,7 +273,7 @@ pub async fn do_update_collection_cluster(
                 )
                 .await
         }
-        ClusterOperations::ReplicateShard(ReplicateShardOperation { replicate_shard }) => {
+        ClusterOperations::ReplicateShard(replicate_shard) => {
             // validate shard to move
             if !collection.contains_shard(replicate_shard.shard_id).await {
                 return Err(StorageError::BadRequest {
@@ -311,7 +309,7 @@ pub async fn do_update_collection_cluster(
                 )
                 .await
         }
-        ClusterOperations::AbortTransfer(AbortTransferOperation { abort_transfer }) => {
+        ClusterOperations::AbortTransfer(abort_transfer) => {
             let transfer = ShardTransferKey {
                 shard_id: abort_transfer.shard_id,
                 to_shard_id: abort_transfer.to_shard_id,
@@ -342,7 +340,7 @@ pub async fn do_update_collection_cluster(
                 )
                 .await
         }
-        ClusterOperations::DropReplica(DropReplicaOperation { drop_replica }) => {
+        ClusterOperations::DropReplica(drop_replica) => {
             if !collection.contains_shard(drop_replica.shard_id).await {
                 return Err(StorageError::BadRequest {
                     description: format!(
@@ -369,9 +367,7 @@ pub async fn do_update_collection_cluster(
                 )
                 .await
         }
-        ClusterOperations::CreateShardingKey(create_sharding_key_op) => {
-            let create_sharding_key = create_sharding_key_op.create_sharding_key;
-
+        ClusterOperations::CreateShardingKey(create_sharding_key) => {
             // Validate that:
             // - proper sharding method is used
             // - key does not exist yet
@@ -442,8 +438,7 @@ pub async fn do_update_collection_cluster(
                 )
                 .await
         }
-        ClusterOperations::DropShardingKey(drop_sharding_key_op) => {
-            let drop_sharding_key = drop_sharding_key_op.drop_sharding_key;
+        ClusterOperations::DropShardingKey(drop_sharding_key) => {
             // Validate that:
             // - proper sharding method is used
             // - key does exist
@@ -480,7 +475,7 @@ pub async fn do_update_collection_cluster(
                 )
                 .await
         }
-        ClusterOperations::RestartTransfer(RestartTransferOperation { restart_transfer }) => {
+        ClusterOperations::RestartTransfer(restart_transfer) => {
             // TODO(reshading): Deduplicate resharding operations handling?
 
             let RestartTransfer {
@@ -524,12 +519,12 @@ pub async fn do_update_collection_cluster(
                 )
                 .await
         }
-        ClusterOperations::StartResharding(op) => {
+        ClusterOperations::StartResharding(start_resharding) => {
             let StartResharding {
                 direction,
                 peer_id,
                 shard_key,
-            } = op.start_resharding;
+            } = start_resharding;
 
             let collection_state = collection.state().await;
 

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -11,9 +11,7 @@ use api::grpc::qdrant::{
     ListCollectionAliasesRequest, ListCollectionsRequest, ListCollectionsResponse,
     UpdateCollection, UpdateCollectionClusterSetupRequest, UpdateCollectionClusterSetupResponse,
 };
-use collection::operations::cluster_ops::{
-    ClusterOperations, CreateShardingKeyOperation, DropShardingKeyOperation,
-};
+use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::types::CollectionsAliasesResponse;
 use storage::content_manager::conversions::error_to_status;
 use storage::dispatcher::Dispatcher;
@@ -243,14 +241,10 @@ impl Collections for CollectionsService {
 
         let timeout = timeout.map(std::time::Duration::from_secs);
 
-        let operation = ClusterOperations::CreateShardingKey(CreateShardingKeyOperation {
-            create_sharding_key: request.try_into()?,
-        });
-
         let result = do_update_collection_cluster(
             self.dispatcher.as_ref(),
             collection_name,
-            operation,
+            ClusterOperations::CreateShardingKey(request.try_into()?),
             access,
             timeout,
         )
@@ -278,14 +272,10 @@ impl Collections for CollectionsService {
 
         let timeout = timeout.map(std::time::Duration::from_secs);
 
-        let operation = ClusterOperations::DropShardingKey(DropShardingKeyOperation {
-            drop_sharding_key: request.try_into()?,
-        });
-
         let result = do_update_collection_cluster(
             self.dispatcher.as_ref(),
             collection_name,
-            operation,
+            ClusterOperations::DropShardingKey(request.try_into()?),
             access,
             timeout,
         )

--- a/tests/consensus_tests/test_collection_shard_transfer.py
+++ b/tests/consensus_tests/test_collection_shard_transfer.py
@@ -121,7 +121,7 @@ def test_collection_shard_transfer(tmp_path: pathlib.Path):
         })
     assert not r.ok
     assert r.status_code == 422
-    assert r.json()["status"]["error"].__contains__("Validation error in JSON body: [move_shard.to_peer_id: cannot transfer shard to itself")
+    assert r.json()["status"]["error"].__contains__("Validation error in JSON body: [to_peer_id: cannot transfer shard to itself")
 
     # Move shard `shard_id` to peer `target_peer_id`
     r = requests.post(


### PR DESCRIPTION
`ClusterOperations` uses `#[serde(untagged)]` in a bit of nonsensical way: each variant defines a custom structure with a single field, and this field name is unique across all structures.

Basically, it's just serde's default externally-tagged enum representation with 1) extra steps, 2) worse deserialization performance and 3) terrible error messages.

I've simplified `ClusterOperations` enum back to externally-tagged representation and moved around declarations in `cluster_ops` module to be a bit more organized.

The only potential downside (stopper?) is that even if from Rust POV this new representation is exactly the same (i.e., it serializes to and deserializes from exactly the same JSON), it still changes OpenAPI spec slightly, and I'm not sure if this change would be backward compatible. 🤔

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
