### PR TITLE
Disable resharding driver and intergration tests

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -28,9 +28,9 @@ impl Collection {
     pub async fn start_resharding<T, F>(
         &self,
         resharding_key: ReshardKey,
-        consensus: Box<dyn ShardTransferConsensus>,
-        on_finish: T,
-        on_error: F,
+        _consensus: Box<dyn ShardTransferConsensus>,
+        _on_finish: T,
+        _on_error: F,
     ) -> CollectionResult<()>
     where
         T: Future<Output = ()> + Send + 'static,
@@ -83,8 +83,8 @@ impl Collection {
         }
 
         // Drive resharding
-        self.drive_resharding(resharding_key, consensus, false, on_finish, on_error)
-            .await?;
+        // self.drive_resharding(resharding_key, consensus, false, on_finish, on_error)
+        //     .await?;
 
         Ok(())
     }

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -121,7 +121,7 @@ pub enum ShardTransferMethod {
     WalDelta,
     /// Shard transfer for resharding: stream all records in batches until all points are
     /// transferred.
-    #[schemars(skip)] // TODO(resharding): expose once we release resharding
+    #[schemars(skip)]
     ReshardingStreamRecords,
 }
 

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -18,6 +18,7 @@ COLLECTION_NAME = "test_collection"
 #
 # More specifically this starts at 1 shard, reshards 3 times to 4 shards, and
 # reshards 3 times back to 1 shard.
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -138,6 +139,7 @@ def test_resharding(tmp_path: pathlib.Path):
 #
 # In this case the replicas are balanced on the second and third node. The first
 # node has all shards because we explicitly set it as shard target all the time.
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding_balance(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -221,6 +223,7 @@ def test_resharding_balance(tmp_path: pathlib.Path):
 # - 3 threads upserting new points on all peers
 # - 1 threads updating existing points on the first peer
 # - 2 threads deleting points on the first two peers
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -318,6 +321,7 @@ def test_resharding_concurrent_updates(tmp_path: pathlib.Path):
 #
 # On a static collection, this performs resharding a few times and asserts the
 # exact point count remains stable on all peers during the whole process.
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding_stable_point_count(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -401,6 +405,7 @@ def test_resharding_stable_point_count(tmp_path: pathlib.Path):
 # On a static collection, this performs resharding and indexing a few times and
 # asserts the exact point count remains stable on all peers during the whole
 # process.
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding_indexing_stable_point_count(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -487,6 +492,7 @@ def test_resharding_indexing_stable_point_count(tmp_path: pathlib.Path):
 #
 # On a static collection, this performs resharding a few times and asserts
 # scrolling remains stable on all peers during the whole process.
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding_stable_scroll(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -577,6 +583,7 @@ def test_resharding_stable_scroll(tmp_path: pathlib.Path):
 #
 # On a static collection, this performs resharding a few times and asserts
 # query remains stable on all peers during the whole process.
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding_stable_query(tmp_path: pathlib.Path):
     assert_project_root()
 
@@ -668,6 +675,7 @@ def test_resharding_stable_query(tmp_path: pathlib.Path):
 # On a static collection, this performs resharding. It kills and restarts the
 # driving peer at various stages. On restart, it should finish resharding as if
 # nothing happened.
+@pytest.mark.skip(reason="moving resharding driver to external service")
 def test_resharding_resume_on_restart(tmp_path: pathlib.Path):
     assert_project_root()
 


### PR DESCRIPTION
This should allow us to test bit and pieces we implemented recently (and will implement shortly) to move resharding driver to external service.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~Have you written new tests for your core changes, as applicable?~~
* [ ] Have you successfully ran tests with your changes locally?
