### PR TITLE
Add `scroll` endpoints to metrics whitelist

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -14,7 +14,7 @@ use crate::common::telemetry_ops::requests_telemetry::{
 
 /// Whitelist for REST endpoints in metrics output.
 ///
-/// Contains selection of search, recommend and upsert endpoints.
+/// Contains selection of search, recommend, scroll and upsert endpoints.
 ///
 /// This array *must* be sorted.
 const REST_ENDPOINT_WHITELIST: &[&str] = &[
@@ -27,6 +27,7 @@ const REST_ENDPOINT_WHITELIST: &[&str] = &[
     "/collections/{name}/points/query/batch",
     "/collections/{name}/points/recommend",
     "/collections/{name}/points/recommend/batch",
+    "/collections/{name}/points/scroll",
     "/collections/{name}/points/search",
     "/collections/{name}/points/search/batch",
 ];
@@ -44,6 +45,7 @@ const GRPC_ENDPOINT_WHITELIST: &[&str] = &[
     "/qdrant.Points/QueryBatch",
     "/qdrant.Points/Recommend",
     "/qdrant.Points/RecommendBatch",
+    "/qdrant.Points/Scroll",
     "/qdrant.Points/Search",
     "/qdrant.Points/SearchBatch",
     "/qdrant.Points/SetPayload",

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -34,7 +34,7 @@ const REST_ENDPOINT_WHITELIST: &[&str] = &[
 
 /// Whitelist for GRPC endpoints in metrics output.
 ///
-/// Contains selection of search, recommend and upsert endpoints.
+/// Contains selection of search, recommend, scroll and upsert endpoints.
 ///
 /// This array *must* be sorted.
 const GRPC_ENDPOINT_WHITELIST: &[&str] = &[


### PR DESCRIPTION
## Summary
Adds `scroll` endpoint to `GRPC_ENDPOINT_WHITELIST` and `REST_ENDPOINT_WHITELIST`.

This is my first PR on `qdrant`, let me know if I am missing any steps. 

To check whether additional configuration or edits were required for adding metrics endpoints I had a look at some previous PRs that expanded the whitelists ( such as: https://github.com/qdrant/qdrant/pull/4497 ) but found no specific implementation, so I'm presuming expansion is as straightforward as this PR. Will post further thoughts in related issue.

Relates to: https://github.com/qdrant/qdrant/issues/4805 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
