### PR TITLE
refactor: Abstract away automatic resharding filter on reads

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -269,12 +269,10 @@ impl Collection {
                         )
                         .await?;
 
-                    if shard_key.is_none() {
-                        return Ok(records);
-                    }
-
-                    for point in &mut records {
-                        common::clone_from_opt(&mut point.shard_key, *shard_key);
+                    if shard_key.is_some() {
+                        for point in &mut records {
+                            point.shard_key = shard_key.cloned();
+                        }
                     }
 
                     CollectionResult::Ok(records)
@@ -428,12 +426,10 @@ impl Collection {
                         records.retain(|record| !filter.check(record.id));
                     }
 
-                    if shard_key.is_none() {
-                        return Ok(records);
-                    }
-
-                    for point in &mut records {
-                        common::clone_from_opt(&mut point.shard_key, *shard_key);
+                    if shard_key.is_some() {
+                        for point in &mut records {
+                            point.shard_key = shard_key.cloned();
+                        }
                     }
 
                     CollectionResult::Ok(records)

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -80,12 +80,10 @@ impl Collection {
                     )
                     .await?;
 
-                if shard_key.is_none() {
-                    return Ok(responses);
-                }
-
-                for point in responses.iter_mut().flatten().flatten() {
-                    common::clone_from_opt(&mut point.shard_key, *shard_key);
+                if shard_key.is_some() {
+                    for point in responses.iter_mut().flatten().flatten() {
+                        point.shard_key = shard_key.cloned();
+                    }
                 }
 
                 CollectionResult::Ok(responses)

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -8,7 +8,7 @@ use itertools::{Either, Itertools};
 use rand::Rng;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
 use segment::common::score_fusion::{score_fusion, ScoreFusion};
-use segment::types::{Filter, Order, ScoredPoint};
+use segment::types::{Order, ScoredPoint};
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tokio::sync::RwLockReadGuard;
 use tokio::time::Instant;
@@ -64,26 +64,11 @@ impl Collection {
         let shard_holder = self.shards_holder.read().await;
         let target_shards = shard_holder.select_shards(shard_selection)?;
 
-        // Resharding filter to apply when resharding is active
-        let resharding_filter = shard_holder.resharding_filter();
-        let reshard_shard_id = shard_holder
-            .resharding_state
-            .read()
-            .as_ref()
-            .map(|state| state.shard_id);
-
-        // Create a batch with resharding filtering a normal and resharding filter
-        // Should be used on all shards, except the new resharding shard
-        let (normal_batch, reshard_batch) =
-            normal_and_resharding_query_batch(batch_request, resharding_filter);
+        let reshardable_request = shard_holder.reshardable_request(batch_request);
 
         let all_searches = target_shards.iter().map(|(shard, shard_key)| {
             // Take resharding request if available on existing shards, otherwise take normal request
-            let batch = reshard_batch
-                .as_ref()
-                .filter(|_| Some(shard.shard_id) != reshard_shard_id)
-                .unwrap_or(&normal_batch)
-                .clone();
+            let batch = reshardable_request.get_request(shard.shard_id);
 
             let shard_key = shard_key.cloned();
             shard
@@ -414,36 +399,5 @@ fn intermediate_query_infos(request: &ShardQueryRequest) -> Vec<IntermediateQuer
             scoring_query: request.query.as_ref(),
             take: request.offset + request.limit,
         }]
-    }
-}
-
-/// Merge a regular and resharding query batch
-///
-/// The first element is always the given `batch`.
-///
-/// The second element is the `batch` with `resharding_filter` merged into it. It's None if no
-/// resharding filter was given.
-///
-/// This function minimizes cloning of the batch to when it's strictly necessary.
-#[inline]
-fn normal_and_resharding_query_batch(
-    batch: Arc<Vec<ShardQueryRequest>>,
-    resharding_filter: Option<Filter>,
-) -> (
-    Arc<Vec<ShardQueryRequest>>,
-    Option<Arc<Vec<ShardQueryRequest>>>,
-) {
-    match resharding_filter {
-        None => (batch, None),
-        Some(resharding_filter) => {
-            let mut requests = batch.as_ref().clone();
-            requests.iter_mut().for_each(|request| {
-                super::resharding::merge_filters(
-                    &mut request.filter,
-                    Some(resharding_filter.clone()),
-                );
-            });
-            (batch, Some(Arc::new(requests)))
-        }
     }
 }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use futures::Future;
 use parking_lot::Mutex;
-use segment::types::Filter;
 
 use super::Collection;
 use crate::config::ShardingMethod;
@@ -284,15 +283,5 @@ impl Collection {
             .await
             .stop_task(resharding_key)
             .await
-    }
-}
-
-#[inline]
-pub(super) fn merge_filters(filter: &mut Option<Filter>, resharding_filter: Option<Filter>) {
-    if let Some(resharding_filter) = resharding_filter {
-        *filter = Some(match filter.take() {
-            Some(filter) => filter.merge_owned(resharding_filter),
-            None => resharding_filter,
-        });
     }
 }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -15,12 +15,7 @@ use crate::shards::transfer::ShardTransferConsensus;
 
 impl Collection {
     pub async fn resharding_state(&self) -> Option<ReshardState> {
-        self.shards_holder
-            .read()
-            .await
-            .resharding_state
-            .read()
-            .clone()
+        self.shards_holder.read().await.resharding_state()
     }
 
     /// Start a new resharding operation

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -182,7 +182,7 @@ impl Collection {
         let result = self
             .merge_from_shards(
                 all_searches_res,
-                Arc::clone(&request),
+                request.clone(),
                 !shard_selection.is_shard_id(),
             )
             .await;

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -162,13 +162,9 @@ impl Collection {
                         )
                         .await?;
 
-                    if shard_key.is_none() {
-                        return Ok(records);
-                    }
-
-                    for batch in &mut records {
-                        for point in batch {
-                            common::clone_from_opt(&mut point.shard_key, *shard_key);
+                    if shard_key.is_some() {
+                        for point in &mut records.iter_mut().flatten() {
+                            point.shard_key = shard_key.cloned();
                         }
                     }
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1,3 +1,4 @@
+mod reshardable_read_request;
 mod resharding;
 
 use std::collections::{HashMap, HashSet};

--- a/lib/collection/src/shards/shard_holder/reshardable_read_request.rs
+++ b/lib/collection/src/shards/shard_holder/reshardable_read_request.rs
@@ -63,12 +63,6 @@ pub trait MergeFilter {
     fn merge_filter(&mut self, filter: Filter);
 }
 
-impl MergeFilter for CoreSearchRequestBatch {
-    fn merge_filter(&mut self, filter: Filter) {
-        self.searches.merge_filter(filter);
-    }
-}
-
 macro_rules! impl_merge_filter {
     ($type:ty) => {
         impl MergeFilter for $type {
@@ -92,6 +86,12 @@ where
         for item in self {
             item.merge_filter(filter.clone());
         }
+    }
+}
+
+impl MergeFilter for CoreSearchRequestBatch {
+    fn merge_filter(&mut self, filter: Filter) {
+        self.searches.merge_filter(filter);
     }
 }
 

--- a/lib/collection/src/shards/shard_holder/reshardable_read_request.rs
+++ b/lib/collection/src/shards/shard_holder/reshardable_read_request.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use segment::data_types::facets::FacetRequest;
+use segment::types::Filter;
+
+use crate::operations::types::{CoreSearchRequest, CoreSearchRequestBatch, CountRequestInternal};
+use crate::operations::universal_query::shard_query::ShardQueryRequest;
+use crate::shards::shard::ShardId;
+
+pub trait EditFilter {
+    fn edit_filter<E>(&mut self, edit: E)
+    where
+        E: Clone + FnMut(Option<Filter>) -> Option<Filter>;
+}
+
+// Preserves original request, and optionally holds an edited one with the resharding filter.
+//
+// The edited request should be used on all shards, except the new resharding shard
+pub struct ReshardableReadRequest<T> {
+    /// Original request
+    pub original: Arc<T>,
+
+    /// Tuple of edited request and resharding shard id
+    pub edited: Option<(Arc<T>, u32)>,
+}
+
+impl<T: EditFilter + Clone> ReshardableReadRequest<T> {
+    pub fn new(request: Arc<T>, resharding_id_and_filter: Option<(u32, Filter)>) -> Self {
+        let Some((resharding_id, resharding_filter)) = resharding_id_and_filter else {
+            return Self {
+                original: request,
+                edited: None,
+            };
+        };
+
+        let mut edited = request.as_ref().clone();
+
+        edited.edit_filter(|filter| {
+            Some(match filter {
+                Some(filter) => filter.merge_owned(resharding_filter.clone()),
+                None => resharding_filter.clone(),
+            })
+        });
+
+        Self {
+            original: request,
+            edited: Some((Arc::new(edited), resharding_id)),
+        }
+    }
+
+    /// If available, use edited request on all shards, except the new resharding shard
+    pub fn get_request(&self, shard_id: ShardId) -> Arc<T> {
+        if let Some((edited, resharding_id)) = self.edited.clone() {
+            // Use edited request on all shards, except the new resharding shard
+            if resharding_id != shard_id {
+                return edited;
+            }
+        }
+        self.original.clone()
+    }
+}
+
+macro_rules! impl_edit_filter {
+    ($($type:ty),+ $(,)?) => {
+        $(impl EditFilter for $type {
+            fn edit_filter<E>(&mut self, mut edit: E)
+            where
+                E: Clone + FnMut(Option<Filter>) -> Option<Filter>
+            {
+                self.filter = edit(self.filter.take());
+            }
+        })*
+    };
+}
+
+impl_edit_filter!(
+    CoreSearchRequest,
+    CountRequestInternal,
+    FacetRequest,
+    ShardQueryRequest,
+);
+
+impl<T: EditFilter> EditFilter for Vec<T> {
+    fn edit_filter<E>(&mut self, edit: E)
+    where
+        E: Clone + FnMut(Option<Filter>) -> Option<Filter>,
+    {
+        self.iter_mut()
+            .for_each(|req| req.edit_filter(edit.clone()));
+    }
+}
+
+impl EditFilter for CoreSearchRequestBatch {
+    fn edit_filter<E>(&mut self, edit: E)
+    where
+        E: Clone + FnMut(Option<Filter>) -> Option<Filter>,
+    {
+        self.searches.edit_filter(edit);
+    }
+}
+
+impl EditFilter for Option<Filter> {
+    fn edit_filter<E>(&mut self, mut edit: E)
+    where
+        E: Clone + FnMut(Option<Filter>) -> Option<Filter>,
+    {
+        *self = edit(self.take());
+    }
+}

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -374,11 +374,11 @@ impl ShardHolder {
         T: Clone + MergeFilter,
     {
         let Some(state) = self.resharding_state() else {
-            return request.into();
+            return From::from(request);
         };
 
         let Some(filter) = self.resharding_filter() else {
-            return request.into();
+            return From::from(request);
         };
 
         ReshardableReadRequest::new(state.shard_id, filter, request)

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -371,7 +371,7 @@ impl ShardHolder {
 
     pub fn reshardable_request<T>(&self, request: T) -> ReshardableReadRequest<T>
     where
-        T: Clone + MergeFilter<Filter>,
+        T: Clone + MergeFilter,
     {
         let Some(state) = self.resharding_state() else {
             return request.into();

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -9,10 +9,3 @@ pub mod panic;
 pub mod top_k;
 pub mod types;
 pub mod validation;
-
-pub fn clone_from_opt<T: Clone>(this: &mut Option<T>, other: Option<&T>) {
-    match (this, other) {
-        (Some(this), Some(other)) => this.clone_from(other),
-        (this, other) => *this = other.cloned(),
-    }
-}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -9,3 +9,10 @@ pub mod panic;
 pub mod top_k;
 pub mod types;
 pub mod validation;
+
+pub fn clone_from_opt<T: Clone>(this: &mut Option<T>, other: Option<&T>) {
+    match (this, other) {
+        (Some(this), Some(other)) => this.clone_from(other),
+        (this, other) => *this = other.cloned(),
+    }
+}


### PR DESCRIPTION
Introduces a `ReshardableReadRequest` type to use on every read request which implement a new `EditFilter` trait. This reduces the cognitive complexity of internal read apis like:

- batch query
- scroll
- count
- batch search

And prepares for easy integration with facets, which will use this as soon as this is merged