### PR TITLE
Add local shard points get/scroll/count/delete HTTP API

### DIFF
--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::shards::shard::ShardId;
 
-const HASH_RING_SHARD_SCALE: u32 = 100;
+pub const HASH_RING_SHARD_SCALE: u32 = 100;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum HashRingRouter<T = ShardId> {

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref as _;
-use std::sync::Arc;
 
-use segment::types::{Condition, Filter, ShardKey};
+use segment::types::ShardKey;
 
 use super::ShardHolder;
 use crate::hash_ring::{self, HashRingRouter};
@@ -11,6 +10,7 @@ use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::{ReplicaState, ShardReplicaSet};
 use crate::shards::resharding::{ReshardKey, ReshardStage, ReshardState};
+use crate::shards::shard::ShardId;
 
 impl ShardHolder {
     pub fn check_start_resharding(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
@@ -364,37 +364,30 @@ impl ShardHolder {
         Ok(())
     }
 
-    /// A filter that excludes points migrated to a different shard, as part of resharding.
-    ///
-    /// `None` if resharding is not active or if the read hash ring is not committed yet.
-    pub fn resharding_filter(&self) -> Option<Filter> {
-        let filter = self.resharding_filter_impl()?;
-        let filter = Filter::new_must_not(Condition::CustomIdChecker(Arc::new(filter)));
-        Some(filter)
+    pub fn resharding_filter(&self) -> Option<hash_ring::HashRingFilter> {
+        let shard_id = self.resharding_state.read().as_ref()?.shard_id;
+        self.hash_ring_filter(shard_id)
     }
 
-    #[inline]
-    pub fn resharding_filter_impl(&self) -> Option<hash_ring::HashRingFilter> {
-        let state = self.resharding_state.read();
-
-        let Some(state) = state.deref() else {
-            return None;
-        };
-
-        if state.stage < ReshardStage::ReadHashRingCommitted {
+    pub fn hash_ring_filter(&self, shard_id: ShardId) -> Option<hash_ring::HashRingFilter> {
+        if !self.contains_shard(&shard_id) {
             return None;
         }
 
-        let Some(ring) = self.rings.get(&state.shard_key) else {
-            return None; // TODO(resharding): Return error?
-        };
-
-        let ring = match ring {
-            HashRingRouter::Resharding { new, .. } => new,
+        let shard_key = self.shard_id_to_key_mapping.get(&shard_id).cloned();
+        let router = self.rings.get(&shard_key).expect("hashring exists");
+        let ring = match router {
             HashRingRouter::Single(ring) => ring,
+            HashRingRouter::Resharding { old, new } => {
+                if new.len() > old.len() {
+                    new
+                } else {
+                    old
+                }
+            }
         };
 
-        Some(hash_ring::HashRingFilter::new(ring.clone(), state.shard_id))
+        Some(hash_ring::HashRingFilter::new(ring.clone(), shard_id))
     }
 }
 

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -1,8 +1,6 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use actix_web::{post, web, Responder};
-use collection::hash_ring::{self, HashRing, HashRingFilter};
 use collection::operations::point_ops::{PointIdsList, PointsSelector};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
@@ -10,8 +8,9 @@ use collection::operations::types::{
 };
 use collection::shards::shard::ShardId;
 use segment::types::{Condition, ExtendedPointId, Filter};
+use storage::content_manager::errors::{StorageError, StorageResult};
 use storage::dispatcher::Dispatcher;
-use validator::Validate;
+use storage::rbac::{Access, AccessRequirements};
 
 use super::update_api::UpdateParam;
 use crate::actix::api::read_params::ReadParams;
@@ -67,6 +66,20 @@ async fn scroll_points(
             hash_ring_filter,
         } = request.into_inner();
 
+        let hash_ring_filter = match hash_ring_filter {
+            Some(filter) => get_hash_ring_filter(
+                &dispatcher,
+                &access,
+                &path.collection,
+                AccessRequirements::new(),
+                filter.expected_shard_id,
+            )
+            .await?
+            .into(),
+
+            None => None,
+        };
+
         request.filter = merge_with_optional_filter(request.filter.take(), hash_ring_filter);
 
         dispatcher
@@ -98,6 +111,20 @@ async fn count_points(
             hash_ring_filter,
         } = request.into_inner();
 
+        let hash_ring_filter = match hash_ring_filter {
+            Some(filter) => get_hash_ring_filter(
+                &dispatcher,
+                &access,
+                &path.collection,
+                AccessRequirements::new(),
+                filter.expected_shard_id,
+            )
+            .await?
+            .into(),
+
+            None => None,
+        };
+
         request.filter = merge_with_optional_filter(request.filter.take(), hash_ring_filter);
 
         points::do_count_points(
@@ -126,6 +153,15 @@ async fn delete_points(
         let path = path.into_inner();
         let selector = selector.into_inner();
 
+        let filter = get_hash_ring_filter(
+            &dispatcher,
+            &access,
+            &path.collection,
+            AccessRequirements::new().write().whole(),
+            selector.hash_ring_filter.expected_shard_id,
+        )
+        .await?;
+
         let mut points = Vec::new();
         let mut next_offset = Some(ExtendedPointId::NumId(0));
 
@@ -133,7 +169,7 @@ async fn delete_points(
             let scroll = ScrollRequestInternal {
                 limit: Some(1000),
                 offset: Some(current_offset),
-                filter: Some(selector.filter.clone()),
+                filter: Some(filter.clone()),
                 ..Default::default()
             };
 
@@ -188,126 +224,60 @@ struct CollectionShard {
     shard: ShardId,
 }
 
+#[derive(Clone, Debug, serde::Deserialize)]
+struct WithFilter<T> {
+    #[serde(flatten)]
+    request: T,
+    #[serde(default)]
+    hash_ring_filter: Option<SerdeHelper>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+struct Selector {
+    hash_ring_filter: SerdeHelper,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+struct SerdeHelper {
+    expected_shard_id: ShardId,
+}
+
+async fn get_hash_ring_filter(
+    dispatcher: &Dispatcher,
+    access: &Access,
+    collection: &str,
+    reqs: AccessRequirements,
+    expected_shard_id: ShardId,
+) -> StorageResult<Filter> {
+    let pass = access.check_collection_access(collection, reqs)?;
+
+    let shard_holder = dispatcher
+        .toc(access)
+        .get_collection(&pass)
+        .await?
+        .shards_holder();
+
+    let hash_ring_filter = shard_holder
+        .read()
+        .await
+        .hash_ring_filter(expected_shard_id)
+        .ok_or_else(|| {
+            StorageError::bad_request(format!(
+                "shard {expected_shard_id} does not exist in collection {collection}"
+            ))
+        })?;
+
+    let condition = Condition::CustomIdChecker(Arc::new(hash_ring_filter));
+    let filter = Filter::new_must(condition);
+
+    Ok(filter)
+}
+
 fn merge_with_optional_filter(filter: Option<Filter>, hash_ring: Option<Filter>) -> Option<Filter> {
     match (filter, hash_ring) {
         (Some(filter), Some(hash_ring)) => hash_ring.merge_owned(filter).into(),
         (Some(filter), None) => filter.into(),
         (None, Some(hash_ring)) => hash_ring.into(),
         _ => None,
-    }
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-struct WithFilter<T> {
-    #[serde(flatten)]
-    request: T,
-    #[serde(default, deserialize_with = "deserialize_optional_filter")]
-    hash_ring_filter: Option<Filter>,
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-struct Selector {
-    #[serde(default, deserialize_with = "deserialize_filter")]
-    filter: Filter,
-}
-
-fn deserialize_optional_filter<'de, D>(deserializer: D) -> Result<Option<Filter>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let helper: Option<SerdeHelper> = serde::Deserialize::deserialize(deserializer)?;
-
-    let Some(helper) = helper else {
-        return Ok(None);
-    };
-
-    helper.validate().map_err(serde::de::Error::custom)?;
-    Ok(Some(helper.into()))
-}
-
-fn deserialize_filter<'de, D>(deserializer: D) -> Result<Filter, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let helper: SerdeHelper = serde::Deserialize::deserialize(deserializer)?;
-    helper.validate().map_err(serde::de::Error::custom)?;
-    Ok(helper.into())
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-struct SerdeHelper {
-    #[serde(default)]
-    scale: Scale,
-    shard_ids: HashSet<ShardId>,
-    expected_shard_id: ShardId,
-}
-
-impl validator::Validate for SerdeHelper {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        use validator::{ValidationError, ValidationErrors};
-
-        let mut errors = ValidationErrors::new();
-
-        if let Scale::Fair(0) = self.scale {
-            errors.add("scale", ValidationError::new("fair scale can't be 0"));
-        }
-
-        let Some(&max_shard_id) = self.shard_ids.iter().max() else {
-            errors.add("shard_ids", ValidationError::new("can't be empty"));
-            return Err(errors);
-        };
-
-        if (0..max_shard_id).any(|shard_id| !self.shard_ids.contains(&shard_id)) {
-            // TODO(resharding): Is this true for custom sharding? 🤔
-            errors.add(
-                "shard_ids",
-                ValidationError::new("all shard ids must be sequential"),
-            );
-        }
-
-        if !self.shard_ids.contains(&self.expected_shard_id) {
-            errors.add("expected_shard_id", ValidationError::new(""));
-        }
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
-}
-
-impl From<SerdeHelper> for Filter {
-    fn from(helper: SerdeHelper) -> Self {
-        Filter::new_must(Condition::CustomIdChecker(Arc::new(HashRingFilter::from(
-            helper,
-        ))))
-    }
-}
-
-impl From<SerdeHelper> for HashRingFilter {
-    fn from(helper: SerdeHelper) -> Self {
-        let mut ring = match helper.scale {
-            Scale::Raw => HashRing::raw(),
-            Scale::Fair(scale) => HashRing::fair(scale),
-        };
-
-        for shard_id in helper.shard_ids {
-            ring.add(shard_id);
-        }
-
-        HashRingFilter::new(ring, helper.expected_shard_id)
-    }
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-enum Scale {
-    Raw,
-    Fair(u32),
-}
-
-impl Default for Scale {
-    fn default() -> Self {
-        Self::Fair(hash_ring::HASH_RING_SHARD_SCALE)
     }
 }

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -1,0 +1,313 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use actix_web::{post, web, Responder};
+use collection::hash_ring::{self, HashRing, HashRingFilter};
+use collection::operations::point_ops::{PointIdsList, PointsSelector};
+use collection::operations::shard_selector_internal::ShardSelectorInternal;
+use collection::operations::types::{
+    CountRequestInternal, PointRequestInternal, ScrollRequestInternal, UpdateResult, UpdateStatus,
+};
+use collection::shards::shard::ShardId;
+use segment::types::{Condition, ExtendedPointId, Filter};
+use storage::dispatcher::Dispatcher;
+use validator::Validate;
+
+use super::update_api::UpdateParam;
+use crate::actix::api::read_params::ReadParams;
+use crate::actix::auth::ActixAccess;
+use crate::actix::helpers;
+use crate::common::points;
+
+// Configure services
+pub fn config_local_shard_api(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_points)
+        .service(scroll_points)
+        .service(count_points)
+        .service(delete_points);
+}
+
+#[post("/collections/{collection}/shards/{shard}/points")]
+async fn get_points(
+    dispatcher: web::Data<Dispatcher>,
+    ActixAccess(access): ActixAccess,
+    path: web::Path<CollectionShard>,
+    request: web::Json<PointRequestInternal>,
+    params: web::Query<ReadParams>,
+) -> impl Responder {
+    helpers::time(async move {
+        let records = points::do_get_points(
+            dispatcher.toc(&access),
+            &path.collection,
+            request.into_inner(),
+            params.consistency,
+            params.timeout(),
+            ShardSelectorInternal::ShardId(path.shard),
+            access,
+        )
+        .await?;
+
+        let records: Vec<_> = records.into_iter().map(api::rest::Record::from).collect();
+        Ok(records)
+    })
+    .await
+}
+
+#[post("/collections/{collection}/shards/{shard}/points/scroll")]
+async fn scroll_points(
+    dispatcher: web::Data<Dispatcher>,
+    ActixAccess(access): ActixAccess,
+    path: web::Path<CollectionShard>,
+    request: web::Json<WithFilter<ScrollRequestInternal>>,
+    params: web::Query<ReadParams>,
+) -> impl Responder {
+    helpers::time(async move {
+        let WithFilter {
+            mut request,
+            hash_ring_filter,
+        } = request.into_inner();
+
+        request.filter = merge_with_optional_filter(request.filter.take(), hash_ring_filter);
+
+        dispatcher
+            .toc(&access)
+            .scroll(
+                &path.collection,
+                request,
+                params.consistency,
+                params.timeout(),
+                ShardSelectorInternal::ShardId(path.shard),
+                access,
+            )
+            .await
+    })
+    .await
+}
+
+#[post("/collections/{collection}/shards/{shard}/points/count")]
+async fn count_points(
+    dispatcher: web::Data<Dispatcher>,
+    ActixAccess(access): ActixAccess,
+    path: web::Path<CollectionShard>,
+    request: web::Json<WithFilter<CountRequestInternal>>,
+    params: web::Query<ReadParams>,
+) -> impl Responder {
+    helpers::time(async move {
+        let WithFilter {
+            mut request,
+            hash_ring_filter,
+        } = request.into_inner();
+
+        request.filter = merge_with_optional_filter(request.filter.take(), hash_ring_filter);
+
+        points::do_count_points(
+            dispatcher.toc(&access),
+            &path.collection,
+            request,
+            params.consistency,
+            params.timeout(),
+            ShardSelectorInternal::ShardId(path.shard),
+            access,
+        )
+        .await
+    })
+    .await
+}
+
+#[post("/collections/{collection}/shards/{shard}/points/delete")]
+async fn delete_points(
+    dispatcher: web::Data<Dispatcher>,
+    ActixAccess(access): ActixAccess,
+    path: web::Path<CollectionShard>,
+    selector: web::Json<Selector>,
+    params: web::Query<UpdateParam>,
+) -> impl Responder {
+    helpers::time(async move {
+        let path = path.into_inner();
+        let selector = selector.into_inner();
+
+        let mut points = Vec::new();
+        let mut next_offset = Some(ExtendedPointId::NumId(0));
+
+        while let Some(current_offset) = next_offset {
+            let scroll = ScrollRequestInternal {
+                limit: Some(1000),
+                offset: Some(current_offset),
+                filter: Some(selector.filter.clone()),
+                ..Default::default()
+            };
+
+            let resp = dispatcher
+                .toc(&access)
+                .scroll(
+                    &path.collection,
+                    scroll,
+                    None,
+                    None,
+                    ShardSelectorInternal::ShardId(path.shard),
+                    access.clone(),
+                )
+                .await?;
+
+            points.extend(resp.points.into_iter().map(|record| record.id));
+            next_offset = resp.next_page_offset;
+        }
+
+        if points.is_empty() {
+            return Ok(UpdateResult {
+                operation_id: None,
+                status: UpdateStatus::Completed,
+                clock_tag: None,
+            });
+        }
+
+        let delete = PointsSelector::PointIdsSelector(PointIdsList {
+            points,
+            shard_key: None,
+        });
+
+        points::do_delete_points(
+            dispatcher.toc(&access).clone(),
+            path.collection,
+            delete,
+            None,
+            Some(path.shard),
+            params.wait.unwrap_or(false),
+            Default::default(),
+            access,
+        )
+        .await
+    })
+    .await
+}
+
+#[derive(serde::Deserialize, validator::Validate)]
+struct CollectionShard {
+    #[validate(length(min = 1, max = 255))]
+    collection: String,
+    shard: ShardId,
+}
+
+fn merge_with_optional_filter(filter: Option<Filter>, hash_ring: Option<Filter>) -> Option<Filter> {
+    match (filter, hash_ring) {
+        (Some(filter), Some(hash_ring)) => hash_ring.merge_owned(filter).into(),
+        (Some(filter), None) => filter.into(),
+        (None, Some(hash_ring)) => hash_ring.into(),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+struct WithFilter<T> {
+    #[serde(flatten)]
+    request: T,
+    #[serde(default, deserialize_with = "deserialize_optional_filter")]
+    hash_ring_filter: Option<Filter>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+struct Selector {
+    #[serde(default, deserialize_with = "deserialize_filter")]
+    filter: Filter,
+}
+
+fn deserialize_optional_filter<'de, D>(deserializer: D) -> Result<Option<Filter>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let helper: Option<SerdeHelper> = serde::Deserialize::deserialize(deserializer)?;
+
+    let Some(helper) = helper else {
+        return Ok(None);
+    };
+
+    helper.validate().map_err(serde::de::Error::custom)?;
+    Ok(Some(helper.into()))
+}
+
+fn deserialize_filter<'de, D>(deserializer: D) -> Result<Filter, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let helper: SerdeHelper = serde::Deserialize::deserialize(deserializer)?;
+    helper.validate().map_err(serde::de::Error::custom)?;
+    Ok(helper.into())
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+struct SerdeHelper {
+    #[serde(default)]
+    scale: Scale,
+    shard_ids: HashSet<ShardId>,
+    expected_shard_id: ShardId,
+}
+
+impl validator::Validate for SerdeHelper {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        use validator::{ValidationError, ValidationErrors};
+
+        let mut errors = ValidationErrors::new();
+
+        if let Scale::Fair(0) = self.scale {
+            errors.add("scale", ValidationError::new("fair scale can't be 0"));
+        }
+
+        let Some(&max_shard_id) = self.shard_ids.iter().max() else {
+            errors.add("shard_ids", ValidationError::new("can't be empty"));
+            return Err(errors);
+        };
+
+        if (0..max_shard_id).any(|shard_id| !self.shard_ids.contains(&shard_id)) {
+            // TODO(resharding): Is this true for custom sharding? 🤔
+            errors.add(
+                "shard_ids",
+                ValidationError::new("all shard ids must be sequential"),
+            );
+        }
+
+        if !self.shard_ids.contains(&self.expected_shard_id) {
+            errors.add("expected_shard_id", ValidationError::new(""));
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+impl From<SerdeHelper> for Filter {
+    fn from(helper: SerdeHelper) -> Self {
+        Filter::new_must(Condition::CustomIdChecker(Arc::new(HashRingFilter::from(
+            helper,
+        ))))
+    }
+}
+
+impl From<SerdeHelper> for HashRingFilter {
+    fn from(helper: SerdeHelper) -> Self {
+        let mut ring = match helper.scale {
+            Scale::Raw => HashRing::raw(),
+            Scale::Fair(scale) => HashRing::fair(scale),
+        };
+
+        for shard_id in helper.shard_ids {
+            ring.add(shard_id);
+        }
+
+        HashRingFilter::new(ring, helper.expected_shard_id)
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+enum Scale {
+    Raw,
+    Fair(u32),
+}
+
+impl Default for Scale {
+    fn default() -> Self {
+        Self::Fair(hash_ring::HASH_RING_SHARD_SCALE)
+    }
+}

--- a/src/actix/api/mod.rs
+++ b/src/actix/api/mod.rs
@@ -5,6 +5,7 @@ pub mod debug_api;
 pub mod discovery_api;
 pub mod facet_api;
 pub mod issues_api;
+pub mod local_shard_api;
 pub mod query_api;
 pub mod read_params;
 pub mod recommend_api;

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -28,6 +28,7 @@ use crate::actix::api::count_api::count_points;
 use crate::actix::api::debug_api::config_debugger_api;
 use crate::actix::api::discovery_api::config_discovery_api;
 use crate::actix::api::issues_api::config_issues_api;
+use crate::actix::api::local_shard_api::config_local_shard_api;
 use crate::actix::api::query_api::config_query_api;
 use crate::actix::api::recommend_api::config_recommend_api;
 use crate::actix::api::retrieve_api::{get_point, get_points, scroll_points};
@@ -150,6 +151,7 @@ pub fn init(
                 .configure(config_shards_api)
                 .configure(config_issues_api)
                 .configure(config_debugger_api)
+                .configure(config_local_shard_api)
                 // Ordering of services is important for correct path pattern matching
                 // See: <https://github.com/qdrant/qdrant/issues/3543>
                 .service(scroll_points)


### PR DESCRIPTION
`delete` API is required to move resharding driver to external service. `get`/`scroll`/`count` are not strictly required, but seems useful for future debugging and troubleshouting.

__TODO:__
- disable automatic resharding filter for local shard points APIs
	- currently, after read hash ring was committed, resharding filter is automatically applied to all read requests
	- e.g., `get`/`scroll`/`count` start return empty/zero results...
	- and `delete` stops working, because it relies on `scroll` requests internally
	- it is still possible to test the API (just don't commit read hash ring), so this fix will be done in a follow-up PR
- integration tests
	- I'd prefer to add tests in a follow-up PR as well, once everything is fixed and fully ready

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
