### PR TITLE
Non blocking retrieve with timeout and cancellation support

### DIFF
--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -82,6 +82,7 @@ fn setup() -> (TempDir, LocalShard) {
             Default::default(),
             payload_index_schema,
             handle.clone(),
+            handle.clone(),
             CpuBudget::default(),
             optimizers_config,
         ))

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -101,6 +101,7 @@ fn batch_search_bench(c: &mut Criterion) {
             Default::default(),
             payload_index_schema,
             handle.clone(),
+            handle.clone(),
             CpuBudget::default(),
             optimizers_config,
         ))

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -104,6 +104,7 @@ impl Collection {
                     self.shared_storage_config.clone(),
                     self.payload_index_schema.clone(),
                     self.update_runtime.clone(),
+                    self.search_runtime.clone(),
                     self.optimizer_cpu_budget.clone(),
                     effective_optimizers_config,
                 )

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -104,6 +104,7 @@ impl ShardOperation for DummyShard {
         _: Arc<PointRequestInternal>,
         _: &WithPayload,
         _: &WithVector,
+        _: &Handle,
         _: Option<Duration>,
     ) -> CollectionResult<Vec<Record>> {
         self.dummy()

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -368,11 +368,18 @@ impl ShardOperation for ForwardProxyShard {
         request: Arc<PointRequestInternal>,
         with_payload: &WithPayload,
         with_vector: &WithVector,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Record>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .retrieve(request, with_payload, with_vector, timeout)
+            .retrieve(
+                request,
+                with_payload,
+                with_vector,
+                search_runtime_handle,
+                timeout,
+            )
             .await
     }
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -86,6 +86,7 @@ pub struct LocalShard {
     pub(super) optimizers: Arc<Vec<Arc<Optimizer>>>,
     pub(super) optimizers_log: Arc<ParkingMutex<TrackerLog>>,
     update_runtime: Handle,
+    search_runtime: Handle,
     disk_usage_watcher: DiskUsageWatcher,
 }
 
@@ -145,6 +146,7 @@ impl LocalShard {
         shard_path: &Path,
         clocks: LocalShardClocks,
         update_runtime: Handle,
+        search_runtime: Handle,
     ) -> Self {
         let segment_holder = Arc::new(RwLock::new(segment_holder));
         let config = collection_config.read().await;
@@ -195,6 +197,7 @@ impl LocalShard {
             update_tracker,
             path: shard_path.to_owned(),
             update_runtime,
+            search_runtime,
             optimizers,
             optimizers_log,
             disk_usage_watcher,
@@ -216,6 +219,7 @@ impl LocalShard {
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         update_runtime: Handle,
+        search_runtime: Handle,
         optimizer_cpu_budget: CpuBudget,
     ) -> CollectionResult<LocalShard> {
         let collection_config_read = collection_config.read().await;
@@ -351,6 +355,7 @@ impl LocalShard {
             shard_path,
             clocks,
             update_runtime,
+            search_runtime,
         )
         .await;
 
@@ -402,6 +407,7 @@ impl LocalShard {
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         update_runtime: Handle,
+        search_runtime: Handle,
         optimizer_cpu_budget: CpuBudget,
         effective_optimizers_config: OptimizersConfig,
     ) -> CollectionResult<LocalShard> {
@@ -415,6 +421,7 @@ impl LocalShard {
             shared_storage_config,
             payload_index_schema,
             update_runtime,
+            search_runtime,
             optimizer_cpu_budget,
             effective_optimizers_config,
         )
@@ -433,6 +440,7 @@ impl LocalShard {
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         update_runtime: Handle,
+        search_runtime: Handle,
         optimizer_cpu_budget: CpuBudget,
         effective_optimizers_config: OptimizersConfig,
     ) -> CollectionResult<LocalShard> {
@@ -521,6 +529,7 @@ impl LocalShard {
             shard_path,
             LocalShardClocks::default(),
             update_runtime,
+            search_runtime,
         )
         .await;
 

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -111,13 +111,16 @@ impl LocalShard {
             .map(|scored_point| scored_point.id)
             .collect();
 
+        // TODO tokio timeout
         // Collect retrieved records into a hashmap for fast lookup
         let records_map = SegmentsSearcher::retrieve(
-            self.segments(),
+            self.segments.clone(),
             &point_ids,
             &(&with_payload).into(),
             &with_vector,
-        )?;
+            &self.search_runtime,
+        )
+        .await?;
 
         // It might be possible, that we won't find all records,
         // so we need to re-collect the results

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -247,11 +247,18 @@ impl ShardOperation for ProxyShard {
         request: Arc<PointRequestInternal>,
         with_payload: &WithPayload,
         with_vector: &WithVector,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Record>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .retrieve(request, with_payload, with_vector, timeout)
+            .retrieve(
+                request,
+                with_payload,
+                with_vector,
+                search_runtime_handle,
+                timeout,
+            )
             .await
     }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -266,10 +266,17 @@ impl ShardOperation for QueueProxyShard {
         request: Arc<PointRequestInternal>,
         with_payload: &WithPayload,
         with_vector: &WithVector,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Record>> {
         self.inner_unchecked()
-            .retrieve(request, with_payload, with_vector, timeout)
+            .retrieve(
+                request,
+                with_payload,
+                with_vector,
+                search_runtime_handle,
+                timeout,
+            )
             .await
     }
 
@@ -569,11 +576,18 @@ impl ShardOperation for Inner {
         request: Arc<PointRequestInternal>,
         with_payload: &WithPayload,
         with_vector: &WithVector,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Record>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .retrieve(request, with_payload, with_vector, timeout)
+            .retrieve(
+                request,
+                with_payload,
+                with_vector,
+                search_runtime_handle,
+                timeout,
+            )
             .await
     }
 

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -822,6 +822,7 @@ impl ShardOperation for RemoteShard {
         request: Arc<PointRequestInternal>,
         with_payload: &WithPayload,
         with_vector: &WithVector,
+        _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Record>> {
         let get_points = GetPoints {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -144,6 +144,7 @@ impl ShardReplicaSet {
                 shared_storage_config.clone(),
                 payload_index_schema.clone(),
                 update_runtime.clone(),
+                search_runtime.clone(),
                 optimizer_cpu_budget.clone(),
                 effective_optimizers_config.clone(),
             )
@@ -264,6 +265,7 @@ impl ShardReplicaSet {
                     shared_storage_config.clone(),
                     payload_index_schema.clone(),
                     update_runtime.clone(),
+                    search_runtime.clone(),
                     optimizer_cpu_budget.clone(),
                 )
                 .await;
@@ -479,6 +481,7 @@ impl ShardReplicaSet {
             self.shared_storage_config.clone(),
             self.payload_index_schema.clone(),
             self.update_runtime.clone(),
+            self.search_runtime.clone(),
             self.optimizer_cpu_budget.clone(),
             self.optimizers_config.clone(),
         )
@@ -664,6 +667,7 @@ impl ShardReplicaSet {
                     self.shared_storage_config.clone(),
                     self.payload_index_schema.clone(),
                     self.update_runtime.clone(),
+                    self.search_runtime.clone(),
                     self.optimizer_cpu_budget.clone(),
                     self.optimizers_config.clone(),
                 )

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -115,10 +115,17 @@ impl ShardReplicaSet {
                 let request = request.clone();
                 let with_payload = with_payload.clone();
                 let with_vector = with_vector.clone();
+                let search_runtime = self.search_runtime.clone();
 
                 async move {
                     shard
-                        .retrieve(request, &with_payload, &with_vector, timeout)
+                        .retrieve(
+                            request,
+                            &with_payload,
+                            &with_vector,
+                            &search_runtime,
+                            timeout,
+                        )
                         .await
                 }
                 .boxed()

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -115,6 +115,7 @@ impl ShardReplicaSet {
                 self.shared_storage_config.clone(),
                 self.payload_index_schema.clone(),
                 self.update_runtime.clone(),
+                self.search_runtime.clone(),
                 self.optimizer_cpu_budget.clone(),
             )
             .await

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -600,6 +600,7 @@ impl ShardHolder {
                             shared_storage_config.clone(),
                             payload_index_schema.clone(),
                             update_runtime.clone(),
+                            search_runtime.clone(),
                             optimizer_cpu_budget.clone(),
                         )
                         .await
@@ -627,6 +628,7 @@ impl ShardHolder {
                             shared_storage_config.clone(),
                             payload_index_schema.clone(),
                             update_runtime.clone(),
+                            search_runtime.clone(),
                             optimizer_cpu_budget.clone(),
                         )
                         .await

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -52,6 +52,7 @@ pub trait ShardOperation {
         request: Arc<PointRequestInternal>,
         with_payload: &WithPayload,
         with_vector: &WithVector,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Record>>;
 

--- a/lib/collection/src/tests/fix_payload_indices.rs
+++ b/lib/collection/src/tests/fix_payload_indices.rs
@@ -34,6 +34,7 @@ async fn test_fix_payload_indices() {
         Arc::new(Default::default()),
         payload_index_schema.clone(),
         current_runtime.clone(),
+        current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),
     )
@@ -75,6 +76,7 @@ async fn test_fix_payload_indices() {
         config.optimizer_config.clone(),
         Arc::new(Default::default()),
         payload_index_schema,
+        current_runtime.clone(),
         current_runtime,
         CpuBudget::default(),
     )

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -40,6 +40,7 @@ async fn test_shard_query_rrf_rescoring() {
         Arc::new(Default::default()),
         payload_index_schema,
         current_runtime.clone(),
+        current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),
     )
@@ -224,6 +225,7 @@ async fn test_shard_query_vector_rescoring() {
         Arc::new(Default::default()),
         payload_index_schema,
         current_runtime.clone(),
+        current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),
     )
@@ -354,6 +356,7 @@ async fn test_shard_query_payload_vector() {
         Arc::new(RwLock::new(config.clone())),
         Arc::new(Default::default()),
         payload_index_schema,
+        current_runtime.clone(),
         current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -34,6 +34,7 @@ async fn test_delete_from_indexed_payload() {
         Arc::new(Default::default()),
         payload_index_schema.clone(),
         current_runtime.clone(),
+        current_runtime.clone(),
         CpuBudget::default(),
         config.optimizer_config.clone(),
     )
@@ -78,6 +79,7 @@ async fn test_delete_from_indexed_payload() {
         Arc::new(Default::default()),
         payload_index_schema.clone(),
         current_runtime.clone(),
+        current_runtime.clone(),
         CpuBudget::default(),
     )
     .await
@@ -99,6 +101,7 @@ async fn test_delete_from_indexed_payload() {
         config.optimizer_config.clone(),
         Arc::new(Default::default()),
         payload_index_schema,
+        current_runtime.clone(),
         current_runtime,
         CpuBudget::default(),
     )


### PR DESCRIPTION
Performing a retrieve operation at the segment level is a blocking operation:
- the segment's read lock needs to be acquired
- the vectors are fetched from storage
- the payload are fetched from storage

This PR makes retrieving asynchronous & multithreaded so it does not block anymore Tokio threads which can cause various responsiveness issues.

It also applies additional measures to:
- honor user timeout where possible
- ensure cancellation of tasks