### PR TITLE
Prevent overflow when updating timeouts

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -224,7 +224,7 @@ impl Collection {
         .await?;
 
         // update timeout
-        let timeout = timeout.map(|timeout| timeout - start.elapsed());
+        let timeout = timeout.map(|timeout| timeout.saturating_sub(start.elapsed()));
 
         // Check we actually fetched all referenced vectors from the resolver requests
         for (resolver_req, _) in &resolver_requests {

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -102,7 +102,7 @@ impl Collection {
                 )
                 .await?;
             // update timeout
-            let timeout = timeout.map(|t| t - start.elapsed());
+            let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
             let filled_results = without_payload_results
                 .into_iter()
                 .zip(request.clone().searches.into_iter())

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -198,7 +198,7 @@ where
     .await?;
 
     // update timeout
-    let timeout = timeout.map(|timeout| timeout - start.elapsed());
+    let timeout = timeout.map(|timeout| timeout.saturating_sub(start.elapsed()));
 
     let res = batch_requests::<
         (DiscoverRequestInternal, ShardSelectorInternal),

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -100,7 +100,9 @@ where
 
         if let Some(lookup) = with_lookup {
             // update timeout
-            let timeout = self.timeout.map(|timeout| timeout - start.elapsed());
+            let timeout = self
+                .timeout
+                .map(|timeout| timeout.saturating_sub(start.elapsed()));
             let mut lookups = {
                 let pseudo_ids = groups
                     .iter()

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -321,7 +321,7 @@ pub async fn group_by(
     let mut needs_filling = true;
     for _ in 0..MAX_GET_GROUPS_REQUESTS {
         // update timeout
-        let timeout = timeout.map(|t| t - start.elapsed());
+        let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
         let mut request = request.clone();
 
         let source = &mut request.source;
@@ -385,7 +385,7 @@ pub async fn group_by(
     if needs_filling {
         for _ in 0..MAX_GROUP_FILLING_REQUESTS {
             // update timeout
-            let timeout = timeout.map(|t| t - start.elapsed());
+            let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
             let mut request = request.clone();
 
             let source = &mut request.source;
@@ -453,7 +453,7 @@ pub async fn group_by(
         .collect();
 
     // update timeout
-    let timeout = timeout.map(|t| t - start.elapsed());
+    let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
 
     // enrich with payload and vector
     let enriched_points: HashMap<_, _> = collection

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -279,7 +279,7 @@ where
     .await?;
 
     // update timeout
-    let timeout = timeout.map(|timeout| timeout - start.elapsed());
+    let timeout = timeout.map(|timeout| timeout.saturating_sub(start.elapsed()));
 
     let res = batch_requests::<
         (RecommendRequestInternal, ShardSelectorInternal),


### PR DESCRIPTION
We have started to apply a more granular handling of timeouts by decreasing it for sequential operations.

However we need to be careful about overflow.