### PR TITLE
Facets in REST

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5267,7 +5267,7 @@
         ],
         "summary": "Facet a payload key with a given filter.",
         "description": "Count points that satisfy the given filter for each unique value of a payload key.",
-        "operationId": "facet_points",
+        "operationId": "facet",
         "requestBody": {
           "description": "Request counts of points for each unique value of a payload key",
           "content": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -13056,8 +13056,7 @@
       "FacetRequest": {
         "type": "object",
         "required": [
-          "key",
-          "limit"
+          "key"
         ],
         "properties": {
           "shard_key": {
@@ -13076,7 +13075,8 @@
           "limit": {
             "type": "integer",
             "format": "uint",
-            "minimum": 1
+            "minimum": 1,
+            "nullable": true
           },
           "filter": {
             "anyOf": [

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5260,7 +5260,7 @@
         }
       }
     },
-    "/collections/{collection_name}/points/facet": {
+    "/collections/{collection_name}/facet": {
       "post": {
         "tags": [
           "points"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12964,6 +12964,43 @@
             "format": "float"
           }
         }
+      },
+      "FacetRequest": {
+        "type": "object",
+        "required": [
+          "key",
+          "limit"
+        ],
+        "properties": {
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
       }
     }
   }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5260,6 +5260,94 @@
         }
       }
     },
+    "/collections/{collection_name}/points/facet": {
+      "post": {
+        "tags": [
+          "points"
+        ],
+        "summary": "Facet a payload key with a given filter.",
+        "description": "Count points that satisfy the given filter for each unique value of a payload key.",
+        "operationId": "facet_points",
+        "requestBody": {
+          "description": "Request counts of points for each unique value of a payload key",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FacetRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection to facet in",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "If set, overrides global timeout for this request. Unit is seconds.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/FacetResponse"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collection_name}/points/query": {
       "post": {
         "tags": [
@@ -13001,6 +13089,44 @@
             ]
           }
         }
+      },
+      "FacetResponse": {
+        "type": "object",
+        "required": [
+          "hits"
+        ],
+        "properties": {
+          "hits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FacetValueHit"
+            }
+          }
+        }
+      },
+      "FacetValueHit": {
+        "type": "object",
+        "required": [
+          "count",
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/FacetValue"
+          },
+          "count": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        }
+      },
+      "FacetValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          }
+        ]
       }
     }
   }

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -2,7 +2,9 @@ use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 
 use super::schema::{BatchVectorStruct, ScoredPoint, Vector, VectorStruct};
-use super::{NearestQuery, OrderByInterface, Query, QueryInterface};
+use super::{
+    FacetResponse, FacetValue, FacetValueHit, NearestQuery, OrderByInterface, Query, QueryInterface,
+};
 use crate::rest::{DenseVector, NamedVectorStruct};
 
 impl From<segment::data_types::vectors::Vector> for Vector {
@@ -228,6 +230,31 @@ impl From<QueryInterface> for Query {
         match value {
             QueryInterface::Nearest(vector) => Query::Nearest(NearestQuery { nearest: vector }),
             QueryInterface::Query(query) => query,
+        }
+    }
+}
+
+impl From<segment::data_types::facets::FacetValue> for FacetValue {
+    fn from(value: segment::data_types::facets::FacetValue) -> Self {
+        match value {
+            segment::data_types::facets::FacetValue::Keyword(keyword) => Self::Keyword(keyword),
+        }
+    }
+}
+
+impl From<segment::data_types::facets::FacetValueHit> for FacetValueHit {
+    fn from(value: segment::data_types::facets::FacetValueHit) -> Self {
+        Self {
+            value: From::from(value.value),
+            count: value.count,
+        }
+    }
+}
+
+impl From<segment::data_types::facets::FacetResponse> for FacetResponse {
+    fn from(value: segment::data_types::facets::FacetResponse) -> Self {
+        Self {
+            hits: value.hits.into_iter().map(From::from).collect(),
         }
     }
 }

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -3,7 +3,8 @@ use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 
 use super::schema::{BatchVectorStruct, ScoredPoint, Vector, VectorStruct};
 use super::{
-    FacetResponse, FacetValue, FacetValueHit, NearestQuery, OrderByInterface, Query, QueryInterface,
+    FacetRequestInternal, FacetResponse, FacetValue, FacetValueHit, NearestQuery, OrderByInterface,
+    Query, QueryInterface,
 };
 use crate::rest::{DenseVector, NamedVectorStruct};
 
@@ -255,6 +256,16 @@ impl From<segment::data_types::facets::FacetResponse> for FacetResponse {
     fn from(value: segment::data_types::facets::FacetResponse) -> Self {
         Self {
             hits: value.hits.into_iter().map(From::from).collect(),
+        }
+    }
+}
+
+impl From<FacetRequestInternal> for segment::data_types::facets::FacetParams {
+    fn from(value: FacetRequestInternal) -> Self {
+        Self {
+            key: value.key,
+            limit: value.limit.unwrap_or(Self::DEFAULT_LIMIT),
+            filter: value.filter,
         }
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use common::types::ScoreType;
 use schemars::JsonSchema;
 use segment::common::utils::MaybeOneOrMany;
-use segment::data_types::facets::FacetRequestInternal;
 use segment::data_types::order_by::OrderBy;
 use segment::json_path::JsonPath;
 use segment::types::{
@@ -719,6 +718,16 @@ impl SearchMatrixPair {
 pub struct SearchMatrixPairsResponse {
     /// List of pairs of points with scores
     pub pairs: Vec<SearchMatrixPair>,
+}
+
+#[derive(Debug, JsonSchema, Serialize, Deserialize, Validate)]
+pub struct FacetRequestInternal {
+    pub key: JsonPath,
+
+    #[validate(range(min = 1))]
+    pub limit: Option<usize>,
+
+    pub filter: Option<Filter>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use common::types::ScoreType;
 use schemars::JsonSchema;
 use segment::common::utils::MaybeOneOrMany;
+use segment::data_types::facets::FacetRequestInternal;
 use segment::data_types::order_by::OrderBy;
 use segment::json_path::JsonPath;
 use segment::types::{
@@ -718,4 +719,30 @@ impl SearchMatrixPair {
 pub struct SearchMatrixPairsResponse {
     /// List of pairs of points with scores
     pub pairs: Vec<SearchMatrixPair>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
+pub struct FacetRequest {
+    #[validate(nested)]
+    #[serde(flatten)]
+    pub facet_request: FacetRequestInternal,
+
+    pub shard_key: Option<ShardKeySelector>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum FacetValue {
+    Keyword(String),
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct FacetValueHit {
+    pub value: FacetValue,
+    pub count: usize,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct FacetResponse {
+    pub hits: Vec<FacetValueHit>,
 }

--- a/lib/collection/src/collection/facet.rs
+++ b/lib/collection/src/collection/facet.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures::future;
 use itertools::Itertools;
 use segment::data_types::facets::{
-    aggregate_facet_hits, FacetRequest, FacetResponse, FacetValueHit,
+    aggregate_facet_hits, FacetRequestInternal, FacetResponse, FacetValueHit,
 };
 
 use super::Collection;
@@ -15,7 +15,7 @@ use crate::operations::types::CollectionResult;
 impl Collection {
     pub async fn facet(
         &self,
-        request: FacetRequest,
+        request: FacetRequestInternal,
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,

--- a/lib/collection/src/collection/facet.rs
+++ b/lib/collection/src/collection/facet.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures::future;
 use itertools::Itertools;
 use segment::data_types::facets::{
-    aggregate_facet_hits, FacetRequestInternal, FacetResponse, FacetValueHit,
+    aggregate_facet_hits, FacetParams, FacetResponse, FacetValueHit,
 };
 
 use super::Collection;
@@ -15,7 +15,7 @@ use crate::operations::types::CollectionResult;
 impl Collection {
     pub async fn facet(
         &self,
-        request: FacetRequestInternal,
+        request: FacetParams,
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -8,9 +8,7 @@ use bitvec::prelude::BitVec;
 use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
-use segment::data_types::facets::{
-    aggregate_facet_hits, FacetHit, FacetRequestInternal, FacetValueHit,
-};
+use segment::data_types::facets::{FacetRequestInternal, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -18,7 +16,6 @@ use segment::data_types::vectors::{QueryVector, Vector};
 use segment::entry::entry_point::SegmentEntry;
 use segment::index::field_index::CardinalityEstimation;
 use segment::json_path::JsonPath;
-use segment::spaces::tools::peek_top_largest_iterable;
 use segment::telemetry::SegmentTelemetry;
 use segment::types::{
     Condition, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PointIdType,
@@ -719,9 +716,9 @@ impl SegmentEntry for ProxySegment {
         &self,
         request: &FacetRequestInternal,
         is_stopped: &AtomicBool,
-    ) -> OperationResult<Vec<FacetValueHit>> {
+    ) -> OperationResult<HashMap<FacetValue, usize>> {
         let deleted_points = self.deleted_points.read();
-        let read_segment_hits = if deleted_points.is_empty() {
+        let mut segment_hits = if deleted_points.is_empty() {
             self.wrapped_segment
                 .get()
                 .read()
@@ -741,14 +738,12 @@ impl SegmentEntry for ProxySegment {
                 .read()
                 .facet(&new_request, is_stopped)?
         };
+
         let write_segment_hits = self.write_segment.get().read().facet(request, is_stopped)?;
 
-        let hits_iter =
-            aggregate_facet_hits(read_segment_hits.into_iter().chain(write_segment_hits))
-                .into_iter()
-                .map(|(value, count)| FacetHit { value, count });
-        let hits = peek_top_largest_iterable(hits_iter, request.limit);
-        Ok(hits)
+        segment_hits.extend(write_segment_hits);
+
+        Ok(segment_hits)
     }
 
     fn has_point(&self, point_id: PointIdType) -> bool {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -8,7 +8,9 @@ use bitvec::prelude::BitVec;
 use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
-use segment::data_types::facets::{aggregate_facet_hits, FacetHit, FacetRequest, FacetValueHit};
+use segment::data_types::facets::{
+    aggregate_facet_hits, FacetHit, FacetRequestInternal, FacetValueHit,
+};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -715,7 +717,7 @@ impl SegmentEntry for ProxySegment {
 
     fn facet(
         &self,
-        request: &FacetRequest,
+        request: &FacetRequestInternal,
         is_stopped: &AtomicBool,
     ) -> OperationResult<Vec<FacetValueHit>> {
         let deleted_points = self.deleted_points.read();
@@ -729,7 +731,7 @@ impl SegmentEntry for ProxySegment {
                 request.filter.as_ref(),
                 &deleted_points,
             );
-            let new_request = FacetRequest {
+            let new_request = FacetRequestInternal {
                 key: request.key.clone(),
                 limit: request.limit,
                 filter: Some(wrapped_filter),

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -8,7 +8,7 @@ use bitvec::prelude::BitVec;
 use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
-use segment::data_types::facets::{FacetRequestInternal, FacetValue};
+use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -714,7 +714,7 @@ impl SegmentEntry for ProxySegment {
 
     fn facet(
         &self,
-        request: &FacetRequestInternal,
+        request: &FacetParams,
         is_stopped: &AtomicBool,
     ) -> OperationResult<HashMap<FacetValue, usize>> {
         let deleted_points = self.deleted_points.read();
@@ -728,7 +728,7 @@ impl SegmentEntry for ProxySegment {
                 request.filter.as_ref(),
                 &deleted_points,
             );
-            let new_request = FacetRequestInternal {
+            let new_request = FacetParams {
                 key: request.key.clone(),
                 limit: request.limit,
                 filter: Some(wrapped_filter),

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -122,7 +122,7 @@ impl ShardOperation for DummyShard {
 
     async fn facet(
         &self,
-        _: Arc<FacetRequest>,
+        _: Arc<FacetRequestInternal>,
         _search_runtime_handle: &Handle,
         _: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -122,7 +122,7 @@ impl ShardOperation for DummyShard {
 
     async fn facet(
         &self,
-        _: Arc<FacetRequestInternal>,
+        _: Arc<FacetParams>,
         _search_runtime_handle: &Handle,
         _: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::types::TelemetryDetail;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
@@ -400,7 +400,7 @@ impl ShardOperation for ForwardProxyShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::types::TelemetryDetail;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
@@ -400,7 +400,7 @@ impl ShardOperation for ForwardProxyShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/local_shard/facet.rs
+++ b/lib/collection/src/shards/local_shard/facet.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use futures::future::try_join_all;
 use itertools::{process_results, Itertools};
-use segment::data_types::facets::{aggregate_facet_hits, FacetRequest, FacetValueHit};
+use segment::data_types::facets::{aggregate_facet_hits, FacetRequestInternal, FacetValueHit};
 use tokio::runtime::Handle;
 use tokio::time::error::Elapsed;
 
@@ -15,7 +15,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 impl LocalShard {
     pub async fn do_facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<FacetValueHit>> {

--- a/lib/collection/src/shards/local_shard/facet.rs
+++ b/lib/collection/src/shards/local_shard/facet.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use futures::future::try_join_all;
 use itertools::process_results;
-use segment::data_types::facets::{FacetRequestInternal, FacetValueHit};
+use segment::data_types::facets::{FacetParams, FacetValueHit};
 use tokio::runtime::Handle;
 use tokio::time::error::Elapsed;
 
@@ -15,7 +15,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 impl LocalShard {
     pub async fn do_facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<FacetValueHit>> {

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -241,7 +241,7 @@ impl ShardOperation for LocalShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -241,7 +241,7 @@ impl ShardOperation for LocalShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::types::TelemetryDetail;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
@@ -283,7 +283,7 @@ impl ShardOperation for ProxyShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::types::TelemetryDetail;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
@@ -283,7 +283,7 @@ impl ShardOperation for ProxyShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex as ParkingMutex;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -298,7 +298,7 @@ impl ShardOperation for QueueProxyShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {
@@ -612,7 +612,7 @@ impl ShardOperation for Inner {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex as ParkingMutex;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -298,7 +298,7 @@ impl ShardOperation for QueueProxyShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {
@@ -612,7 +612,7 @@ impl ShardOperation for Inner {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -24,7 +24,7 @@ use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
-use segment::data_types::facets::{FacetRequest, FacetResponse, FacetValueHit};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse, FacetValueHit};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -924,14 +924,14 @@ impl ShardOperation for RemoteShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);
         timer.set_success(false);
 
-        let FacetRequest { key, limit, filter } = request.as_ref();
+        let FacetRequestInternal { key, limit, filter } = request.as_ref();
 
         let response = self
             .with_points_client(|mut client| async move {

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -24,7 +24,7 @@ use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse, FacetValueHit};
+use segment::data_types::facets::{FacetParams, FacetResponse, FacetValueHit};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -924,14 +924,14 @@ impl ShardOperation for RemoteShard {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);
         timer.set_success(false);
 
-        let FacetRequestInternal { key, limit, filter } = request.as_ref();
+        let FacetParams { key, limit, filter } = request.as_ref();
 
         let response = self
             .with_points_client(|mut client| async move {

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::FutureExt as _;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::*;
 
@@ -185,7 +185,7 @@ impl ShardReplicaSet {
 
     pub async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         read_consistency: Option<ReadConsistency>,
         local_only: bool,
         timeout: Option<Duration>,

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::FutureExt as _;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::*;
 
@@ -185,7 +185,7 @@ impl ShardReplicaSet {
 
     pub async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         read_consistency: Option<ReadConsistency>,
         local_only: bool,
         timeout: Option<Duration>,

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::*;
 use tokio::runtime::Handle;
@@ -66,7 +66,7 @@ pub trait ShardOperation {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequest>,
+        request: Arc<FacetRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse>;

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::*;
 use tokio::runtime::Handle;
@@ -66,7 +66,7 @@ pub trait ShardOperation {
 
     async fn facet(
         &self,
-        request: Arc<FacetRequestInternal>,
+        request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse>;

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use crate::json_path::JsonPath;
 use crate::types::Filter;
 
-pub struct FacetRequest {
+pub struct FacetRequestInternal {
     pub key: JsonPath,
     pub limit: usize,
     pub filter: Option<Filter>,

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -2,11 +2,18 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::hash::Hash;
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
 use crate::json_path::JsonPath;
 use crate::types::Filter;
 
+#[derive(Debug, JsonSchema, Serialize, Deserialize, Validate)]
 pub struct FacetRequestInternal {
     pub key: JsonPath,
+
+    #[validate(range(min = 1))]
     pub limit: usize,
     pub filter: Option<Filter>,
 }

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -10,12 +10,16 @@ use crate::json_path::JsonPath;
 use crate::types::Filter;
 
 #[derive(Debug, JsonSchema, Serialize, Deserialize, Validate)]
-pub struct FacetRequestInternal {
+pub struct FacetParams {
     pub key: JsonPath,
 
     #[validate(range(min = 1))]
     pub limit: usize,
     pub filter: Option<Filter>,
+}
+
+impl FacetParams {
+    pub const DEFAULT_LIMIT: usize = 10;
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicBool;
 use common::types::TelemetryDetail;
 
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
-use crate::data_types::facets::{FacetHit, FacetRequest, FacetValue};
+use crate::data_types::facets::{FacetHit, FacetRequestInternal, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -149,7 +149,7 @@ pub trait SegmentEntry {
     /// Return the largest counts for the given facet request.
     fn facet(
         &self,
-        request: &FacetRequest,
+        request: &FacetRequestInternal,
         is_stopped: &AtomicBool,
     ) -> OperationResult<Vec<FacetHit<FacetValue>>>;
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicBool;
 use common::types::TelemetryDetail;
 
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
-use crate::data_types::facets::{FacetHit, FacetRequestInternal, FacetValue};
+use crate::data_types::facets::{FacetRequestInternal, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -151,7 +151,7 @@ pub trait SegmentEntry {
         &self,
         request: &FacetRequestInternal,
         is_stopped: &AtomicBool,
-    ) -> OperationResult<Vec<FacetHit<FacetValue>>>;
+    ) -> OperationResult<HashMap<FacetValue, usize>>;
 
     /// Check if there is point with `point_id` in this segment.
     fn has_point(&self, point_id: PointIdType) -> bool;

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicBool;
 use common::types::TelemetryDetail;
 
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
-use crate::data_types::facets::{FacetRequestInternal, FacetValue};
+use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -149,7 +149,7 @@ pub trait SegmentEntry {
     /// Return the largest counts for the given facet request.
     fn facet(
         &self,
-        request: &FacetRequestInternal,
+        request: &FacetParams,
         is_stopped: &AtomicBool,
     ) -> OperationResult<HashMap<FacetValue, usize>>;
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -27,7 +27,7 @@ use crate::common::operation_error::{
 };
 use crate::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
-use crate::data_types::facets::{FacetHit, FacetRequest, FacetValueHit};
+use crate::data_types::facets::{FacetHit, FacetRequestInternal, FacetValueHit};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{Direction, OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -1517,7 +1517,7 @@ impl SegmentEntry for Segment {
 
     fn facet(
         &self,
-        request: &FacetRequest,
+        request: &FacetRequestInternal,
         is_stopped: &AtomicBool,
     ) -> OperationResult<Vec<FacetValueHit>> {
         let payload_index = self.payload_index.borrow();

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -27,7 +27,7 @@ use crate::common::operation_error::{
 };
 use crate::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
-use crate::data_types::facets::{FacetHit, FacetRequestInternal, FacetValueHit};
+use crate::data_types::facets::{FacetHit, FacetRequestInternal, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{Direction, OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -1519,7 +1519,7 @@ impl SegmentEntry for Segment {
         &self,
         request: &FacetRequestInternal,
         is_stopped: &AtomicBool,
-    ) -> OperationResult<Vec<FacetValueHit>> {
+    ) -> OperationResult<HashMap<FacetValue, usize>> {
         let payload_index = self.payload_index.borrow();
 
         let facet_index = payload_index
@@ -1560,10 +1560,7 @@ impl SegmentEntry for Segment {
         //
         // We need all values to be able to aggregate correctly across segments
         let hits = hits_iter
-            .map(|hit| FacetHit {
-                value: hit.value.to_owned(),
-                count: hit.count,
-            })
+            .map(|hit| (hit.value.to_owned(), hit.count))
             .collect();
 
         Ok(hits)

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -27,7 +27,7 @@ use crate::common::operation_error::{
 };
 use crate::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
-use crate::data_types::facets::{FacetHit, FacetRequestInternal, FacetValue};
+use crate::data_types::facets::{FacetHit, FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{Direction, OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
@@ -1517,7 +1517,7 @@ impl SegmentEntry for Segment {
 
     fn facet(
         &self,
-        request: &FacetRequestInternal,
+        request: &FacetParams,
         is_stopped: &AtomicBool,
     ) -> OperationResult<HashMap<FacetValue, usize>> {
         let payload_index = self.payload_index.borrow();

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -13,7 +13,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use segment::data_types::facets::{FacetRequest, FacetValue, FacetValueHit};
+use segment::data_types::facets::{FacetRequestInternal, FacetValue, FacetValueHit};
 use segment::data_types::index::{
     FloatIndexParams, FloatIndexType, IntegerIndexParams, IntegerIndexType, KeywordIndexParams,
     KeywordIndexType,
@@ -1210,7 +1210,7 @@ fn test_keyword_facet() {
     let key: JsonPath = STR_KEY.try_into().unwrap();
 
     // *** No filter ***
-    let request = FacetRequest {
+    let request = FacetRequestInternal {
         key: key.clone(),
         limit,
         filter: None,
@@ -1232,7 +1232,7 @@ fn test_keyword_facet() {
     // *** With filter ***
     let mut rng = rand::thread_rng();
     let filter = random_filter(&mut rng, 3);
-    let request = FacetRequest {
+    let request = FacetRequestInternal {
         key,
         limit,
         filter: Some(filter.clone()),

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -12,7 +12,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use segment::data_types::facets::{FacetRequestInternal, FacetValue, FacetValueHit};
+use segment::data_types::facets::{FacetRequestInternal, FacetValue};
 use segment::data_types::index::{
     FloatIndexParams, FloatIndexType, IntegerIndexParams, IntegerIndexType, KeywordIndexParams,
     KeywordIndexType,
@@ -1175,17 +1175,12 @@ fn test_any_matcher_cardinality_estimation() {
 /// each value exactly.
 fn validate_facet_result(
     segment: &Segment,
-    facet_hits: Vec<FacetValueHit>,
+    facet_hits: HashMap<FacetValue, usize>,
     filter: Option<Filter>,
 ) {
-    // TODO(facets): Re-enable this check?
-    // let mut expected = facet_hits.clone();
-    // expected.sort_by_key(|hit| Reverse(hit.clone()));
-    // assert_eq!(facet_hits, expected);
-
-    for hit in facet_hits {
+    for (value, count) in facet_hits {
         // Compare against exact count
-        let FacetValue::Keyword(value) = hit.value;
+        let FacetValue::Keyword(value) = value;
 
         let count_filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
             JsonPath::new(STR_KEY),
@@ -1197,7 +1192,7 @@ fn validate_facet_result(
             .read_filtered(None, None, count_filter.as_ref(), &Default::default())
             .len();
 
-        assert_eq!(hit.count, exact);
+        assert_eq!(count, exact);
     }
 }
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1238,7 +1238,7 @@ fn test_keyword_facet() {
         .unwrap();
 
     validate_facet_result(
-        &test_segments.mmap_segment.as_ref().unwrap(),
+        test_segments.mmap_segment.as_ref().unwrap(),
         facet_hits,
         None,
     );
@@ -1273,7 +1273,7 @@ fn test_keyword_facet() {
         .unwrap();
 
     validate_facet_result(
-        &test_segments.mmap_segment.as_ref().unwrap(),
+        test_segments.mmap_segment.as_ref().unwrap(),
         facet_hits,
         Some(filter),
     );

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1,4 +1,3 @@
-use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::fs::create_dir;
 use std::path::Path;

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -12,7 +12,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use segment::data_types::facets::{FacetRequestInternal, FacetValue};
+use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::index::{
     FloatIndexParams, FloatIndexType, IntegerIndexParams, IntegerIndexType, KeywordIndexParams,
     KeywordIndexType,
@@ -1204,7 +1204,7 @@ fn test_keyword_facet() {
     let key: JsonPath = STR_KEY.try_into().unwrap();
 
     // *** Without filter ***
-    let request = FacetRequestInternal {
+    let request = FacetParams {
         key: key.clone(),
         limit,
         filter: None,
@@ -1241,7 +1241,7 @@ fn test_keyword_facet() {
     // *** With filter ***
     let mut rng = rand::thread_rng();
     let filter = random_filter(&mut rng, 3);
-    let request = FacetRequestInternal {
+    let request = FacetParams {
         key,
         limit,
         filter: Some(filter.clone()),

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -15,7 +15,7 @@ use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use collection::{discovery, recommendations};
 use futures::stream::FuturesUnordered;
 use futures::TryStreamExt as _;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::types::{ScoredPoint, ShardKey};
 
 use super::TableOfContent;
@@ -335,7 +335,7 @@ impl TableOfContent {
     pub async fn facet(
         &self,
         collection_name: &str,
-        mut request: FacetRequest,
+        mut request: FacetRequestInternal,
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         access: Access,

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -15,7 +15,7 @@ use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use collection::{discovery, recommendations};
 use futures::stream::FuturesUnordered;
 use futures::TryStreamExt as _;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::types::{ScoredPoint, ShardKey};
 
 use super::TableOfContent;
@@ -335,7 +335,7 @@ impl TableOfContent {
     pub async fn facet(
         &self,
         collection_name: &str,
-        mut request: FacetRequestInternal,
+        mut request: FacetParams,
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         access: Access,

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 
 use super::TableOfContent;
 use crate::content_manager::errors::StorageResult;
@@ -29,7 +29,7 @@ impl TableOfContent {
     pub async fn facet_internal(
         &self,
         collection_name: &str,
-        request: FacetRequest,
+        request: FacetRequestInternal,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
     ) -> StorageResult<FacetResponse> {

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 
 use super::TableOfContent;
 use crate::content_manager::errors::StorageResult;
@@ -29,7 +29,7 @@ impl TableOfContent {
     pub async fn facet_internal(
         &self,
         collection_name: &str,
-        request: FacetRequestInternal,
+        request: FacetParams,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
     ) -> StorageResult<FacetResponse> {

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -17,7 +17,7 @@ use collection::operations::universal_query::collection_query::{
 };
 use collection::operations::vector_ops::VectorOperations;
 use collection::operations::CollectionUpdateOperations;
-use segment::data_types::facets::FacetRequestInternal;
+use segment::data_types::facets::FacetParams;
 use segment::types::{Condition, ExtendedPointId, FieldCondition, Filter, Match, Payload};
 
 use super::{
@@ -367,7 +367,7 @@ fn check_access_for_prefetch(
     Ok(())
 }
 
-impl CheckableCollectionOperation for FacetRequestInternal {
+impl CheckableCollectionOperation for FacetParams {
     fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -17,7 +17,7 @@ use collection::operations::universal_query::collection_query::{
 };
 use collection::operations::vector_ops::VectorOperations;
 use collection::operations::CollectionUpdateOperations;
-use segment::data_types::facets::FacetRequest;
+use segment::data_types::facets::FacetRequestInternal;
 use segment::types::{Condition, ExtendedPointId, FieldCondition, Filter, Match, Payload};
 
 use super::{
@@ -367,7 +367,7 @@ fn check_access_for_prefetch(
     Ok(())
 }
 
-impl CheckableCollectionOperation for FacetRequest {
+impl CheckableCollectionOperation for FacetRequestInternal {
     fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -620,7 +620,7 @@ paths:
         - points
       summary: Facet a payload key with a given filter.
       description: Count points that satisfy the given filter for each unique value of a payload key.
-      operationId: facet_points
+      operationId: facet
       requestBody:
         description: Request counts of points for each unique value of a payload key
         content:

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -614,6 +614,36 @@ paths:
             minimum: 1
       responses: #@ response(reference("CountResult"))
 
+  /collections/{collection_name}/points/facet:
+    post:
+      tags:
+        - points
+      summary: Facet a payload key with a given filter.
+      description: Count points that satisfy the given filter for each unique value of a payload key.
+      operationId: facet_points
+      requestBody:
+        description: Request counts of points for each unique value of a payload key
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FacetRequest"
+
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection to facet in
+          required: true
+          schema:
+            type: string
+        - name: timeout
+          in: query
+          description: If set, overrides global timeout for this request. Unit is seconds.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+      responses: #@ response(reference("FacetResponse"))
+      
   /collections/{collection_name}/points/query:
     post:
       tags:

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -614,7 +614,7 @@ paths:
             minimum: 1
       responses: #@ response(reference("CountResult"))
 
-  /collections/{collection_name}/points/facet:
+  /collections/{collection_name}/facet:
     post:
       tags:
         - points

--- a/src/actix/api/facet_api.rs
+++ b/src/actix/api/facet_api.rs
@@ -1,0 +1,51 @@
+use actix_web::{post, web, Responder};
+use actix_web_validator::{Json, Path, Query};
+use api::rest::{FacetRequest, FacetResponse};
+use collection::operations::shard_selector_internal::ShardSelectorInternal;
+use storage::dispatcher::Dispatcher;
+use tokio::time::Instant;
+
+use crate::actix::api::read_params::ReadParams;
+use crate::actix::api::CollectionPath;
+use crate::actix::auth::ActixAccess;
+use crate::actix::helpers::process_response;
+
+#[post("/collections/{name}/points/facet")]
+async fn facet(
+    dispatcher: web::Data<Dispatcher>,
+    collection: Path<CollectionPath>,
+    request: Json<FacetRequest>,
+    params: Query<ReadParams>,
+    ActixAccess(access): ActixAccess,
+) -> impl Responder {
+    let timing = Instant::now();
+
+    let FacetRequest {
+        facet_request,
+        shard_key,
+    } = request.into_inner();
+
+    let shard_selection = match shard_key {
+        None => ShardSelectorInternal::All,
+        Some(shard_keys) => shard_keys.into(),
+    };
+
+    let response = dispatcher
+        .toc(&access)
+        .facet(
+            &collection.name,
+            facet_request,
+            shard_selection,
+            params.consistency,
+            access,
+            params.timeout(),
+        )
+        .await
+        .map(FacetResponse::from);
+
+    process_response(response, timing)
+}
+
+pub fn config_facet_api(cfg: &mut web::ServiceConfig) {
+    cfg.service(facet);
+}

--- a/src/actix/api/facet_api.rs
+++ b/src/actix/api/facet_api.rs
@@ -10,7 +10,7 @@ use crate::actix::api::CollectionPath;
 use crate::actix::auth::ActixAccess;
 use crate::actix::helpers::process_response;
 
-#[post("/collections/{name}/points/facet")]
+#[post("/collections/{name}/facet")]
 async fn facet(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,

--- a/src/actix/api/facet_api.rs
+++ b/src/actix/api/facet_api.rs
@@ -25,6 +25,8 @@ async fn facet(
         shard_key,
     } = request.into_inner();
 
+    let facet_params = From::from(facet_request);
+
     let shard_selection = match shard_key {
         None => ShardSelectorInternal::All,
         Some(shard_keys) => shard_keys.into(),
@@ -34,7 +36,7 @@ async fn facet(
         .toc(&access)
         .facet(
             &collection.name,
-            facet_request,
+            facet_params,
             shard_selection,
             params.consistency,
             access,

--- a/src/actix/api/mod.rs
+++ b/src/actix/api/mod.rs
@@ -3,6 +3,7 @@ pub mod collections_api;
 pub mod count_api;
 pub mod debug_api;
 pub mod discovery_api;
+pub mod facet_api;
 pub mod issues_api;
 pub mod query_api;
 pub mod read_params;

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -17,6 +17,7 @@ use actix_multipart::form::MultipartFormConfig;
 use actix_web::middleware::{Compress, Condition, Logger};
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use actix_web_extras::middleware::Condition as ConditionEx;
+use api::facet_api::config_facet_api;
 use collection::operations::validation;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::Access;
@@ -145,6 +146,7 @@ pub fn init(
                 .configure(config_recommend_api)
                 .configure(config_discovery_api)
                 .configure(config_query_api)
+                .configure(config_facet_api)
                 .configure(config_shards_api)
                 .configure(config_issues_api)
                 .configure(config_debugger_api)

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -25,6 +25,7 @@ const REST_ENDPOINT_WHITELIST: &[&str] = &[
     "/collections/{name}/points/delete",
     "/collections/{name}/points/discover",
     "/collections/{name}/points/discover/batch",
+    "/collections/{name}/points/facet",
     "/collections/{name}/points/payload",
     "/collections/{name}/points/payload/clear",
     "/collections/{name}/points/payload/delete",
@@ -56,6 +57,7 @@ const GRPC_ENDPOINT_WHITELIST: &[&str] = &[
     "/qdrant.Points/DeletePayload",
     "/qdrant.Points/Discover",
     "/qdrant.Points/DiscoverBatch",
+    // TODO(facet): add GRPC endpoint for facets here
     "/qdrant.Points/Get",
     "/qdrant.Points/OverwritePayload",
     "/qdrant.Points/Query",

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,7 +1,7 @@
 use api::grpc::models::{CollectionsResponse, VersionInfo};
 use api::rest::{
-    QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse, Record, ScoredPoint,
-    SearchMatrixOffsetsResponse, SearchMatrixPairsResponse, SearchMatrixRequest,
+    FacetRequest, QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse, Record,
+    ScoredPoint, SearchMatrixOffsetsResponse, SearchMatrixPairsResponse, SearchMatrixRequest,
 };
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
@@ -91,6 +91,7 @@ struct AllDefinitions {
     bi: SearchMatrixRequest,
     bj: SearchMatrixOffsetsResponse,
     bk: SearchMatrixPairsResponse,
+    bl: FacetRequest,
 }
 
 fn save_schema<T: JsonSchema>() {

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,7 +1,8 @@
 use api::grpc::models::{CollectionsResponse, VersionInfo};
 use api::rest::{
-    FacetRequest, QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse, Record,
-    ScoredPoint, SearchMatrixOffsetsResponse, SearchMatrixPairsResponse, SearchMatrixRequest,
+    FacetRequest, FacetResponse, QueryGroupsRequest, QueryRequest, QueryRequestBatch,
+    QueryResponse, Record, ScoredPoint, SearchMatrixOffsetsResponse, SearchMatrixPairsResponse,
+    SearchMatrixRequest,
 };
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
@@ -92,6 +93,7 @@ struct AllDefinitions {
     bj: SearchMatrixOffsetsResponse,
     bk: SearchMatrixPairsResponse,
     bl: FacetRequest,
+    bm: FacetResponse,
 }
 
 fn save_schema<T: JsonSchema>() {

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -17,7 +17,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use collection::shards::shard::ShardId;
 use itertools::Itertools;
-use segment::data_types::facets::{FacetRequest, FacetResponse};
+use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
 use segment::json_path::JsonPath;
 use segment::types::Filter;
 use storage::content_manager::toc::TableOfContent;
@@ -108,7 +108,7 @@ async fn facet_counts_internal(
 
     let shard_selection = ShardSelectorInternal::ShardId(shard_id);
 
-    let request = FacetRequest {
+    let request = FacetRequestInternal {
         key: JsonPath::from_str(&key)
             .map_err(|_| Status::invalid_argument("Failed to parse facet key"))?,
         limit: limit as usize,

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -17,7 +17,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use collection::shards::shard::ShardId;
 use itertools::Itertools;
-use segment::data_types::facets::{FacetRequestInternal, FacetResponse};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::json_path::JsonPath;
 use segment::types::Filter;
 use storage::content_manager::toc::TableOfContent;
@@ -108,7 +108,7 @@ async fn facet_counts_internal(
 
     let shard_selection = ShardSelectorInternal::ShardId(shard_id);
 
-    let request = FacetRequestInternal {
+    let request = FacetParams {
         key: JsonPath::from_str(&key)
             .map_err(|_| Status::invalid_argument("Failed to parse facet key"))?,
         limit: limit as usize,

--- a/tests/consensus_tests/auth_tests/test_jwt_access.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_access.py
@@ -557,7 +557,7 @@ ACTION_ACCESS = {
         "POST /collections/{collection_name}/points/search/matrix/pairs"
     ),
     "facet": EndpointAccess(
-        True, True, True, "POST /collections/{collection_name}/points/facet", # TODO(facet): enable grpc "qdrant.Points/Facet"
+        True, True, True, "POST /collections/{collection_name}/facet", # TODO(facet): enable grpc "qdrant.Points/Facet"
     ),
     ### Service ###
     "root": EndpointAccess(True, True, True, "GET /", "qdrant.Qdrant/HealthCheck"),

--- a/tests/consensus_tests/auth_tests/test_jwt_access.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_access.py
@@ -54,6 +54,7 @@ POINT_ID = 0
 FIELD_NAME = "test_field"
 PEER_ID = 0
 SHARD_KEY = "existing_shard_key"
+FACET_KEY = "a"
 
 _cached_grpc_clients = None
 
@@ -554,6 +555,9 @@ ACTION_ACCESS = {
         True,
         True,
         "POST /collections/{collection_name}/points/search/matrix/pairs"
+    ),
+    "facet": EndpointAccess(
+        True, True, True, "POST /collections/{collection_name}/points/facet", # TODO(facet): enable grpc "qdrant.Points/Facet"
     ),
     ### Service ###
     "root": EndpointAccess(True, True, True, "GET /", "qdrant.Qdrant/HealthCheck"),
@@ -1802,6 +1806,7 @@ def test_query_points_groups():
         },
     )
 
+
 def test_search_points_matrix_offsets():
     check_access(
         "search_points_matrix_offsets",
@@ -1809,6 +1814,7 @@ def test_search_points_matrix_offsets():
         path_params={"collection_name": COLL_NAME},
         grpc_request={"collection_name": COLL_NAME, "sample": 10, "limit": 2},
     )
+
 
 def test_search_points_matrix_rows():
     check_access(
@@ -1818,6 +1824,7 @@ def test_search_points_matrix_rows():
         grpc_request={"collection_name": COLL_NAME, "sample": 10, "limit": 2},
     )
 
+
 def test_search_points_matrix_pairs():
     check_access(
         "search_points_matrix_pairs",
@@ -1825,6 +1832,18 @@ def test_search_points_matrix_pairs():
         path_params={"collection_name": COLL_NAME},
         grpc_request={"collection_name": COLL_NAME, "sample": 10, "limit": 2},
     )
+
+
+def test_facet():
+    check_access(
+        "facet",
+        path_params={"collection_name": COLL_NAME},
+        rest_request={
+            "key": FACET_KEY,
+        },
+        # TODO(facet): grpc request
+    )
+
 
 def test_root():
     check_access("root")

--- a/tests/openapi/test_facets.py
+++ b/tests/openapi/test_facets.py
@@ -1,0 +1,49 @@
+import pytest
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = "test_facets"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(on_disk_vectors):
+    basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
+
+    request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "field_name": "city",
+            "field_schema": "keyword",
+        }
+    ).raise_for_status()
+
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_basic_facet():
+    response = request_with_validation(
+        api="/collections/{collection_name}/facet",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "key": "city",
+            # limit is optional
+        }
+    )
+
+    assert response.ok, response.json()
+
+    city_facet = response.json()["result"]
+    assert city_facet == {
+        "hits": [
+            # Sorted by count, then by value
+            {"value": "Berlin", "count": 3 },
+            {"value": "London", "count": 2 },
+            {"value": "Moscow", "count": 2 },
+        ]
+    }

--- a/tests/openapi_consistency_check.sh
+++ b/tests/openapi_consistency_check.sh
@@ -36,7 +36,8 @@ fi
 rm -f ./docs/redoc/master/.diff.openapi.json
 
 NUMBER_OF_APIS=$(cat ./docs/redoc/master/openapi.json | jq '[.paths[] | length] | add')
-EXPECTED_NUMBER_OF_APIS=70
+
+EXPECTED_NUMBER_OF_APIS=71
 
 if [ "$NUMBER_OF_APIS" -ne "$EXPECTED_NUMBER_OF_APIS" ]; then
     echo "ERROR: It looks like the total number of APIs has changed."


### PR DESCRIPTION
Adds faceting to REST interface at `/collections/{collection_name}/points/facet`. 

But also fixes and tests a few bugs regarding mmap indexes and overall counts.

An exact facet mode will be part of a separate PR to prevent saturating this one.

Note: Openapi tests are still missing because I want to validate the interface first. I will write some as soon as this PR gets greenlighted.
