### PR TITLE
Non blocking exact count with timeout and cancellation support

### DIFF
--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -94,6 +94,7 @@ impl ShardOperation for DummyShard {
     async fn count(
         &self,
         _: Arc<CountRequestInternal>,
+        _: &Handle,
         _: Option<Duration>,
     ) -> CollectionResult<CountResult> {
         self.dummy()

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -357,10 +357,13 @@ impl ShardOperation for ForwardProxyShard {
     async fn count(
         &self,
         request: Arc<CountRequestInternal>,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<CountResult> {
         let local_shard = &self.wrapped_shard;
-        local_shard.count(request, timeout).await
+        local_shard
+            .count(request, search_runtime_handle, timeout)
+            .await
     }
 
     async fn retrieve(

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -255,9 +255,12 @@ impl ShardOperation for QueueProxyShard {
     async fn count(
         &self,
         request: Arc<CountRequestInternal>,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<CountResult> {
-        self.inner_unchecked().count(request, timeout).await
+        self.inner_unchecked()
+            .count(request, search_runtime_handle, timeout)
+            .await
     }
 
     /// Forward read-only `retrieve` to `wrapped_shard`
@@ -564,10 +567,13 @@ impl ShardOperation for Inner {
     async fn count(
         &self,
         request: Arc<CountRequestInternal>,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<CountResult> {
         let local_shard = &self.wrapped_shard;
-        local_shard.count(request, timeout).await
+        local_shard
+            .count(request, search_runtime_handle, timeout)
+            .await
     }
 
     /// Forward read-only `retrieve` to `wrapped_shard`

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -782,6 +782,7 @@ impl ShardOperation for RemoteShard {
     async fn count(
         &self,
         request: Arc<CountRequestInternal>,
+        _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<CountResult> {
         let count_points = CountPoints {

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -44,6 +44,7 @@ pub trait ShardOperation {
     async fn count(
         &self,
         request: Arc<CountRequestInternal>,
+        search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<CountResult>;
 


### PR DESCRIPTION
Similar to https://github.com/qdrant/qdrant/pull/4844 for exact counts.

Exact counts can be very expensive, this PR make those non-blocking with the regular benefits on the Tokio runtime.