### PR TITLE
Add missing timeout query params in openapi specs

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3345,6 +3345,16 @@
             "schema": {
               "$ref": "#/components/schemas/ReadConsistency"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "If set, overrides global timeout for this request. Unit is seconds.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4298,6 +4298,16 @@
             "schema": {
               "$ref": "#/components/schemas/ReadConsistency"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "If set, overrides global timeout for this request. Unit is seconds.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {
@@ -5178,6 +5188,16 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "If set, overrides global timeout for this request. Unit is seconds.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -272,6 +272,13 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/ReadConsistency"
+        - name: timeout
+          in: query
+          description: If set, overrides global timeout for this request. Unit is seconds.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses: #@ response(reference("ScrollResult"))
 
   /collections/{collection_name}/points/search:
@@ -598,6 +605,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: timeout
+          in: query
+          description: If set, overrides global timeout for this request. Unit is seconds.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses: #@ response(reference("CountResult"))
 
   /collections/{collection_name}/points/query:

--- a/openapi/openapi-points.ytt.yaml
+++ b/openapi/openapi-points.ytt.yaml
@@ -56,6 +56,13 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/ReadConsistency"
+        - name: timeout
+          in: query
+          description: If set, overrides global timeout for this request. Unit is seconds.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses: #@ response(array(reference("Record")))
 
     put:


### PR DESCRIPTION
The PR https://github.com/qdrant/qdrant/pull/4842 fixed the timeout implementation for the retrieve APIs:
- GetPoints
- CountPoints
- ScrollPoints

The timeout were already accepted but not fully used.

Now that the implementation has been fixed, we can advertise those to the clients.