### PR TITLE
Remove resharding read filtering logic

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -8,7 +8,7 @@ use itertools::{Either, Itertools};
 use rand::Rng;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
 use segment::common::score_fusion::{score_fusion, ScoreFusion};
-use segment::types::{Filter, Order, ScoredPoint};
+use segment::types::{Order, ScoredPoint};
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tokio::sync::RwLockReadGuard;
 use tokio::time::Instant;
@@ -64,31 +64,11 @@ impl Collection {
         let shard_holder = self.shards_holder.read().await;
         let target_shards = shard_holder.select_shards(shard_selection)?;
 
-        // Resharding filter to apply when resharding is active
-        let resharding_filter = shard_holder.resharding_filter();
-        let reshard_shard_id = shard_holder
-            .resharding_state
-            .read()
-            .as_ref()
-            .map(|state| state.shard_id);
-
-        // Create a batch with resharding filtering a normal and resharding filter
-        // Should be used on all shards, except the new resharding shard
-        let (normal_batch, reshard_batch) =
-            normal_and_resharding_query_batch(batch_request, resharding_filter);
-
         let all_searches = target_shards.iter().map(|(shard, shard_key)| {
-            // Take resharding request if available on existing shards, otherwise take normal request
-            let batch = reshard_batch
-                .as_ref()
-                .filter(|_| Some(shard.shard_id) != reshard_shard_id)
-                .unwrap_or(&normal_batch)
-                .clone();
-
             let shard_key = shard_key.cloned();
             shard
                 .query_batch(
-                    batch,
+                    Arc::clone(&batch_request),
                     read_consistency,
                     shard_selection.is_shard_id(),
                     timeout,
@@ -414,36 +394,5 @@ fn intermediate_query_infos(request: &ShardQueryRequest) -> Vec<IntermediateQuer
             scoring_query: request.query.as_ref(),
             take: request.offset + request.limit,
         }]
-    }
-}
-
-/// Merge a regular and resharding query batch
-///
-/// The first element is always the given `batch`.
-///
-/// The second element is the `batch` with `resharding_filter` merged into it. It's None if no
-/// resharding filter was given.
-///
-/// This function minimizes cloning of the batch to when it's strictly necessary.
-#[inline]
-fn normal_and_resharding_query_batch(
-    batch: Arc<Vec<ShardQueryRequest>>,
-    resharding_filter: Option<Filter>,
-) -> (
-    Arc<Vec<ShardQueryRequest>>,
-    Option<Arc<Vec<ShardQueryRequest>>>,
-) {
-    match resharding_filter {
-        None => (batch, None),
-        Some(resharding_filter) => {
-            let mut requests = batch.as_ref().clone();
-            requests.iter_mut().for_each(|request| {
-                super::resharding::merge_filters(
-                    &mut request.filter,
-                    Some(resharding_filter.clone()),
-                );
-            });
-            (batch, Some(Arc::new(requests)))
-        }
     }
 }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use futures::Future;
 use parking_lot::Mutex;
-use segment::types::Filter;
 
 use super::Collection;
 use crate::config::ShardingMethod;
@@ -284,15 +283,5 @@ impl Collection {
             .await
             .stop_task(resharding_key)
             .await
-    }
-}
-
-#[inline]
-pub(super) fn merge_filters(filter: &mut Option<Filter>, resharding_filter: Option<Filter>) {
-    if let Some(resharding_filter) = resharding_filter {
-        *filter = Some(match filter.take() {
-            Some(filter) => filter.merge_owned(resharding_filter),
-            None => resharding_filter,
-        });
     }
 }

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -132,35 +132,7 @@ impl Collection {
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        // Resharding filter to apply when resharding is active
-        let (resharding_filter, reshard_shard_id) = {
-            let shards_holder = self.shards_holder.read().await;
-            let resharding_filter = shards_holder.resharding_filter();
-            let reshard_shard_id = shards_holder
-                .resharding_state
-                .read()
-                .as_ref()
-                .map(|state| state.shard_id);
-            (resharding_filter, reshard_shard_id)
-        };
-
-        // Create filtered request, which has resharding filter applied
-        // Should be used on all shards, except the new resharding shard
-        let mut filtered_request = request.clone();
-        if let Some(resharding_filter) = resharding_filter {
-            for search in &mut filtered_request.searches {
-                match &mut search.filter {
-                    Some(filter) => {
-                        *filter = filter.merge(&resharding_filter);
-                    }
-
-                    None => {
-                        search.filter = Some(resharding_filter.clone());
-                    }
-                }
-            }
-        }
-        let filtered_request = Arc::new(filtered_request);
+        let request = Arc::new(request);
 
         let instant = Instant::now();
 
@@ -169,17 +141,10 @@ impl Collection {
             let shard_holder = self.shards_holder.read().await;
             let target_shards = shard_holder.select_shards(shard_selection)?;
             let all_searches = target_shards.iter().map(|(shard, shard_key)| {
-                // Take the filtered request, or the original request for the resharding shard
-                let request = if Some(shard.shard_id) == reshard_shard_id {
-                    Arc::new(request.clone())
-                } else {
-                    filtered_request.clone()
-                };
-
                 let shard_key = shard_key.cloned();
                 shard
                     .core_search(
-                        request,
+                        Arc::clone(&request),
                         read_consistency,
                         shard_selection.is_shard_id(),
                         timeout,
@@ -202,7 +167,7 @@ impl Collection {
         let result = self
             .merge_from_shards(
                 all_searches_res,
-                Arc::clone(&filtered_request),
+                Arc::clone(&request),
                 !shard_selection.is_shard_id(),
             )
             .await;


### PR DESCRIPTION
Strip out the read filtering logic we implemented for resharding. It was implemented in <https://github.com/qdrant/qdrant/pull/4617> and <https://github.com/qdrant/qdrant/pull/4681>.

It is unnecessary because we'll be switching to a different mechanism for resharding. Removing this also makes our read request handling simpler.

Though not strictly required for the upcoming release, I think it'd be nice to include it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?