### PR TITLE
Filter update operations during resharding

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -80,19 +80,19 @@ pub enum BatchVectorStruct {
 }
 
 impl BatchVectorStruct {
-    pub fn swap_remove(&mut self, vector_index: usize) {
+    pub fn remove(&mut self, index: usize) {
         match self {
             Self::Single(vectors) => {
-                vectors.swap_remove(vector_index);
+                vectors.remove(index);
             }
 
             Self::MultiDense(vectors) => {
-                vectors.swap_remove(vector_index);
+                vectors.remove(index);
             }
 
             Self::Named(vector_batches) => {
                 for vector_batch in vector_batches.values_mut() {
-                    vector_batch.swap_remove(vector_index);
+                    vector_batch.remove(index);
                 }
             }
         }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -79,6 +79,26 @@ pub enum BatchVectorStruct {
     Named(HashMap<String, Vec<Vector>>),
 }
 
+impl BatchVectorStruct {
+    pub fn swap_remove(&mut self, vector_index: usize) {
+        match self {
+            Self::Single(vectors) => {
+                vectors.swap_remove(vector_index);
+            }
+
+            Self::MultiDense(vectors) => {
+                vectors.swap_remove(vector_index);
+            }
+
+            Self::Named(vector_batches) => {
+                for vector_batch in vector_batches.values_mut() {
+                    vector_batch.swap_remove(vector_index);
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(untagged)]
 pub enum ShardKeySelector {

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -5,6 +5,7 @@ pub mod payload_index_schema;
 mod point_ops;
 pub mod query;
 mod resharding;
+pub mod resharding_update_pre_filter;
 mod search;
 mod shard_transfer;
 mod sharding_keys;
@@ -515,7 +516,7 @@ impl Collection {
     pub async fn state(&self) -> State {
         let shards_holder = self.shards_holder.read().await;
         let transfers = shards_holder.shard_transfers.read().clone();
-        let resharding = shards_holder.resharding_state.read().clone();
+        let resharding = shards_holder.resharding_state();
         State {
             config: self.collection_config.read().await.clone(),
             shards: shards_holder

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -15,12 +15,7 @@ use crate::shards::transfer::ShardTransferConsensus;
 
 impl Collection {
     pub async fn resharding_state(&self) -> Option<ReshardState> {
-        self.shards_holder
-            .read()
-            .await
-            .resharding_state
-            .read()
-            .clone()
+        self.shards_holder.read().await.resharding_state()
     }
 
     /// Start a new resharding operation

--- a/lib/collection/src/collection/resharding_update_pre_filter.rs
+++ b/lib/collection/src/collection/resharding_update_pre_filter.rs
@@ -4,7 +4,7 @@ use segment::types::CustomIdCheckerCondition as _;
 
 use crate::hash_ring;
 use crate::operations::cluster_ops::ReshardingDirection;
-use crate::operations::types::{CollectionError, CollectionResult, PointRequestInternal};
+use crate::operations::types::{CollectionResult, PointRequestInternal};
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::resharding::ReshardStage;
 use crate::shards::shard::ShardId;

--- a/lib/collection/src/collection/resharding_update_pre_filter.rs
+++ b/lib/collection/src/collection/resharding_update_pre_filter.rs
@@ -13,11 +13,6 @@ use crate::shards::shard_trait::ShardOperation;
 
 #[derive(Clone, Debug)]
 pub struct ReshardingUpdatePreFilter {
-    /// Target shard of the resharding operation. This is the shard that:
-    /// - *created* during resharding *up*
-    /// - *deleted* during resharding *down*
-    is_target_shard: bool,
-
     /// Shard that will be *receiving* migrated points during resharding:
     /// - *target* shard during resharding *up*
     /// - *non* target shards during resharding *down*
@@ -85,7 +80,6 @@ impl ReshardingUpdatePreFilter {
             .expect("resharding filter is available when resharding is in progress");
 
         let pre_filter = Self {
-            is_target_shard,
             is_receiver_shard,
             filter,
         };

--- a/lib/collection/src/collection/resharding_update_pre_filter.rs
+++ b/lib/collection/src/collection/resharding_update_pre_filter.rs
@@ -1,0 +1,96 @@
+use std::collections::HashSet;
+
+use segment::types::CustomIdCheckerCondition as _;
+
+use crate::hash_ring;
+use crate::operations::types::{CollectionResult, PointRequestInternal};
+use crate::operations::CollectionUpdateOperations;
+use crate::shards::resharding::ReshardStage;
+use crate::shards::shard::ShardId;
+use crate::shards::shard_holder::ShardHolder;
+use crate::shards::shard_trait::ShardOperation;
+
+#[derive(Clone, Debug)]
+pub enum ReshardingUpdatePreFilter {
+    NewShard,
+    OldShard(hash_ring::HashRingFilter),
+}
+
+impl ReshardingUpdatePreFilter {
+    pub fn new(shard_holder: &ShardHolder, shard_id: ShardId) -> Option<Self> {
+        let state = shard_holder.resharding_state()?;
+
+        if state.shard_id == shard_id && state.stage == ReshardStage::MigratingPoints {
+            Some(Self::NewShard)
+        } else if state.shard_id != shard_id && state.stage >= ReshardStage::ReadHashRingCommitted {
+            shard_holder.resharding_filter().map(Self::OldShard)
+        } else {
+            None
+        }
+    }
+
+    pub async fn apply(
+        &self,
+        operation: &mut CollectionUpdateOperations,
+        local_shard: &(dyn ShardOperation + Sync),
+        runtime: &tokio::runtime::Handle,
+    ) -> CollectionResult<()> {
+        // There's no need to pre-filter point delete operations
+        if operation.is_delete_points() {
+            return Ok(());
+        }
+
+        let points_to_filter = match self {
+            Self::NewShard => {
+                // We must *not* pre-filter point upsert operations
+                if operation.is_upsert_points() {
+                    return Ok(());
+                }
+
+                // Select *all* points
+                operation.point_ids()
+            }
+
+            Self::OldShard(filter) => {
+                // Select points that are hashed into *new* shard
+                operation
+                    .point_ids()
+                    .into_iter()
+                    .filter(|&point_id| filter.check(point_id))
+                    .collect()
+            }
+        };
+
+        if points_to_filter.is_empty() {
+            return Ok(());
+        }
+
+        let retrieve = PointRequestInternal {
+            ids: points_to_filter.clone(),
+            with_payload: None,
+            with_vector: false.into(),
+        };
+
+        let retrieved_points = local_shard
+            .retrieve(
+                retrieve.into(),
+                &false.into(),
+                &false.into(),
+                runtime,
+                None, // TODO(resharding)?
+            )
+            .await?;
+
+        let retrieved_points: HashSet<_> =
+            retrieved_points.into_iter().map(|point| point.id).collect();
+
+        let missing_points: HashSet<_> = points_to_filter
+            .into_iter()
+            .filter(|point_id| !retrieved_points.contains(point_id))
+            .collect();
+
+        operation.remove_point_ids(&missing_points);
+
+        Ok(())
+    }
+}

--- a/lib/collection/src/collection/resharding_update_pre_filter.rs
+++ b/lib/collection/src/collection/resharding_update_pre_filter.rs
@@ -109,18 +109,12 @@ impl ReshardingUpdatePreFilter {
             return Ok(());
         }
 
-        let points_to_filter = if self.is_target_shard {
-            // When pre-filtering points on *target* shard, select *all* points for pre-filtering
-            operation.point_ids()
-        } else {
-            // When pre-filtering points on *non* target shard, only select points
-            // that are *hashed into target shard* for pre-filtering
-            operation
-                .point_ids()
-                .into_iter()
-                .filter(|&point_id| self.filter.check(point_id))
-                .collect()
-        };
+        // Only pre-filter points, that are *hashed into target shard*
+        let points_to_filter: Vec<_> = operation
+            .point_ids()
+            .into_iter()
+            .filter(|&point_id| self.filter.check(point_id))
+            .collect();
 
         if points_to_filter.is_empty() {
             return Ok(());

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -114,7 +114,7 @@ impl Collection {
                 );
 
                 replica_set
-                    .update_local(OperationWithClockTag::from(create_index_op), true) // TODO: Assign clock tag!? 🤔
+                    .update_local(OperationWithClockTag::from(create_index_op), true, None) // TODO: Assign clock tag!? 🤔
                     .await?;
             }
 

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -288,11 +288,18 @@ impl CollectionUpdateOperations {
         }
     }
 
+    pub fn is_upsert_points(&self) -> bool {
+        matches!(
+            self,
+            Self::PointOperation(point_ops::PointOperations::UpsertPoints(_))
+        )
+    }
+
     pub fn is_delete_points(&self) -> bool {
-        match self {
-            Self::PointOperation(op) => op.is_delete_points(),
-            _ => false,
-        }
+        matches!(
+            self,
+            Self::PointOperation(point_ops::PointOperations::DeletePoints { .. })
+        )
     }
 
     pub fn point_ids(&self) -> Vec<ExtendedPointId> {

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -17,7 +17,7 @@ pub mod validation;
 pub mod vector_ops;
 pub mod vector_params_builder;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use segment::json_path::JsonPath;
 use segment::types::{ExtendedPointId, PayloadFieldSchema};
@@ -285,6 +285,31 @@ impl CollectionUpdateOperations {
             CollectionUpdateOperations::FieldIndexOperation(operation) => {
                 operation.is_write_operation()
             }
+        }
+    }
+
+    pub fn is_delete_points(&self) -> bool {
+        match self {
+            Self::PointOperation(op) => op.is_delete_points(),
+            _ => false,
+        }
+    }
+
+    pub fn point_ids(&self) -> Vec<ExtendedPointId> {
+        match self {
+            Self::PointOperation(op) => op.point_ids(),
+            Self::VectorOperation(op) => op.point_ids(),
+            Self::PayloadOperation(op) => op.point_ids(),
+            Self::FieldIndexOperation(_) => Vec::new(),
+        }
+    }
+
+    pub fn remove_point_ids(&mut self, point_ids: &HashSet<ExtendedPointId>) {
+        match self {
+            Self::PointOperation(op) => op.remove_point_ids(point_ids),
+            Self::VectorOperation(op) => op.remove_point_ids(point_ids),
+            Self::PayloadOperation(op) => op.remove_point_ids(point_ids),
+            Self::FieldIndexOperation(_) => (),
         }
     }
 }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -229,11 +229,11 @@ impl PointInsertOperationsInternal {
             Self::PointsBatch(batch) => {
                 for index in (0..point_ids.len()).rev() {
                     if point_ids.contains(&batch.ids[index]) {
-                        batch.ids.swap_remove(index);
-                        batch.vectors.swap_remove(index);
+                        batch.ids.remove(index);
+                        batch.vectors.remove(index);
 
                         if let Some(payloads) = &mut batch.payloads {
-                            payloads.swap_remove(index);
+                            payloads.remove(index);
                         }
                     }
                 }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -379,13 +379,6 @@ impl PointOperations {
         }
     }
 
-    pub fn is_delete_points(&self) -> bool {
-        matches!(
-            self,
-            Self::DeletePoints { .. } | Self::DeletePointsByFilter(_)
-        )
-    }
-
     pub fn point_ids(&self) -> Vec<ExtendedPointId> {
         match self {
             Self::UpsertPoints(op) => op.point_ids(),

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -353,7 +353,7 @@ async fn drive_down(
             // Wait on all updates here, not just the last batch
             // If we don't wait on all updates it somehow results in inconsistent results
             target_replica_set
-                .update_with_consistency(operation, true, WriteOrdering::Weak)
+                .update_with_consistency(operation, true, WriteOrdering::Weak, None)
                 .await?;
 
             if offset.is_none() {

--- a/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
+++ b/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
@@ -95,7 +95,7 @@ pub(super) async fn drive(
             // Wait on all updates here, not just the last batch
             // If we don't wait on all updates it somehow results in inconsistent deletes
             replica_set
-                .update_with_consistency(operation, true, WriteOrdering::Weak)
+                .update_with_consistency(operation, true, WriteOrdering::Weak, None)
                 .await?;
 
             if offset.is_none() {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -470,11 +470,10 @@ impl ShardHolder {
                 for (&shard_id, shard) in self.shards.iter() {
                     // Ignore a new resharding shard until it completed point migration
                     // The shard will be marked as active at the end of the migration stage
-                    let resharding_migrating =
-                        self.resharding_state.read().clone().map_or(false, |state| {
-                            state.shard_id == shard_id
-                                && state.stage < ReshardStage::ReadHashRingCommitted
-                        });
+                    let resharding_migrating = self.resharding_state().map_or(false, |state| {
+                        state.shard_id == shard_id
+                            && state.stage < ReshardStage::ReadHashRingCommitted
+                    });
                     if resharding_migrating {
                         continue;
                     }

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -127,7 +127,7 @@ async fn fixture() -> Collection {
             ])),
         ));
         shard
-            .update_local(op, true)
+            .update_local(op, true, None)
             .await
             .expect("failed to insert points");
     }


### PR DESCRIPTION
This PR adds a pre-filter to update operations during resharding.

There are two different (but similar in implementation) filters introduced:

During `MigratingPoints` stage we forward relevant update operations to "new" shard. However, what if we forward, e.g., `SetPayload` operation for the point that was not yet migrated to the new shard? In such case, we can pre-filter update operation and remove modifications to points that does not (yet) exist in the shard.

Starting at `CommitReadHashRing` stage we want to apply pre-filter to update operations on "old" shards. We want to apply updates to points that are present both in old and new shards, but we don't want to *insert* new (or previously deleted) points that are hashed into new shard. This allows us to delete resharded points from old shards, but also keep the data consistent between old and new shards while we do these deletions.

**TODO:**
- [x] think through/handle resharding down?
- [ ] tests

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
3. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
4. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
