### PR TITLE
Fix openapi operationId inconsistency

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5464,7 +5464,7 @@
         ],
         "summary": "Query points, grouped by a given payload field",
         "description": "Universally query points, grouped by a given payload field",
-        "operationId": "query_points_groups",
+        "operationId": "query_point_groups",
         "requestBody": {
           "description": "Describes the query to make to the collection",
           "content": {

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -696,7 +696,7 @@ paths:
         - points
       summary: Query points, grouped by a given payload field
       description: Universally query points, grouped by a given payload field
-      operationId: query_points_groups
+      operationId: query_point_groups
       requestBody:
         description: Describes the query to make to the collection
         content:


### PR DESCRIPTION
The proper naming scheme is `*_point_groups`.

Do not merge before 1.12.0.