### PR TITLE
Drop DynamicMmapFlags file rotation logic

### DIFF
--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -24,16 +24,18 @@ const FLAGS_FILE_LEGACY: &str = "flags_b.dat";
 
 const STATUS_FILE_NAME: &str = "status.dat";
 
-pub fn status_file(directory: &Path) -> PathBuf {
+fn status_file(directory: &Path) -> PathBuf {
     directory.join(STATUS_FILE_NAME)
 }
 
 #[repr(C)]
-pub struct DynamicMmapStatus {
-    pub len: usize,
+struct DynamicMmapStatus {
+    /// Amount of flags (bits)
+    len: usize,
+
     /// Should be 0 in the current version.  Old versions used it to indicate which flags file
     /// (flags_a.dat or flags_b.dat) is currently in use.
-    pub current_file_id: usize,
+    current_file_id: usize,
 }
 
 fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
@@ -66,7 +68,7 @@ impl fmt::Debug for DynamicMmapFlags {
 
 /// Based on the number of flags determines the size of the mmap file.
 fn mmap_capacity_bytes(num_flags: usize) -> usize {
-    let number_of_bytes = num_flags.div_ceil(8);
+    let number_of_bytes = num_flags.div_ceil(u8::BITS as usize);
 
     max(MINIMAL_MMAP_SIZE, number_of_bytes.next_power_of_two())
 }
@@ -74,7 +76,7 @@ fn mmap_capacity_bytes(num_flags: usize) -> usize {
 /// Based on the current length determines how many flags can fit into the mmap file without resizing it.
 fn mmap_max_current_size(len: usize) -> usize {
     let mmap_capacity_bytes = mmap_capacity_bytes(len);
-    mmap_capacity_bytes * 8
+    mmap_capacity_bytes * u8::BITS as usize
 }
 
 impl DynamicMmapFlags {


### PR DESCRIPTION
`DynamicMmapFlags` is used to rotate the storage between `flags_a.dat` and `flags_b.dat` to extend its length. I find this is not necessary: we can extend the file without closing the existing mmap.

This PR drops this logic and makes Qdrant to always use `flags_a.dat`. The migration path is implemented.

---

New `set_len` sequence:

1. Open a file.
2. `file.set_len` (extend only, not shrink)
3. `mmap` it, `madvise`, create bit slice.
4. Put the new mmap into `self`, dropping the old `mmap`. 

In the worst-case scenario, we'll crash/bail out during step 3, resulting in a file twice as big. But it's not a big issue because:
1. It wouldn't affect data consistency.
2. The file will be truncated back during restart.
3. The rest of the file will be sparse, not affecting an on-disk size.
5. This PR still saves storage by not having an additional backup file.

---

Additionally, this change removes a potential race condition:

```rust
let mut flags = DynamicMmapFlags::open(…)?;
let files = flags.files(); // ["status.dat", "flags_a.dat"]
flags.set_len(…)?; // now flags_b.dat is used
flags.set(…, …);
flags.flusher()()?; // updates flags_b.dat

// now the value of `files` refers to a file with outdated data
```