### PR TITLE
Alternative for: Filter update operations during resharding

### DIFF
--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -324,6 +324,34 @@ impl CustomIdCheckerCondition for HashRingFilter {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct HashRingMovedFilter {
+    old_ring: HashRing<ShardId>,
+    new_ring: HashRing<ShardId>,
+}
+
+impl HashRingMovedFilter {
+    pub fn new(old_ring: HashRing<ShardId>, new_ring: HashRing<ShardId>) -> Self {
+        Self { old_ring, new_ring }
+    }
+}
+
+impl CustomIdCheckerCondition for HashRingMovedFilter {
+    fn estimate_cardinality(&self, points: usize) -> CardinalityEstimation {
+        CardinalityEstimation {
+            primary_clauses: vec![],
+            min: 0,
+            exp: points / self.new_ring.len(),
+            max: points,
+        }
+    }
+
+    /// Returns true if a point ID is moved according to resharding hash rings.
+    fn check(&self, point_id: PointIdType) -> bool {
+        self.old_ring.get(&point_id) != self.new_ring.get(&point_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Alternative resharding pre filter implementation on top of the current PR (<https://github.com/qdrant/qdrant/pull/4867>).

Reimplements the resharding pre filter.

This functions more as a request for comment, rather than a direct replacement.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?