### PR TITLE
Bump latest WAL and fs4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version",
 ]
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+checksum = "e8c6b3bd49c37d2aa3f3f2220233b29a7cd23f79d1fe70e5337d25fb390793de"
 dependencies = [
  "rustix 0.38.31",
  "windows-sys 0.52.0",
@@ -7005,7 +7005,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=a7870900f29811a24e20882887d60e6a2febf945#a7870900f29811a24e20882887d60e6a2febf945"
+source = "git+https://github.com/qdrant/wal.git?rev=7c9202d0874b719212e6eacedaa795bfdf43199c#7c9202d0874b719212e6eacedaa795bfdf43199c"
 dependencies = [
  "byteorder",
  "crc32c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ tonic-reflection = "0.11.0"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.10", features = ["v4", "serde"] }
 validator = { version = "0.18.1", features = ["derive"] }
-wal = { git = "https://github.com/qdrant/wal.git", rev = "a7870900f29811a24e20882887d60e6a2febf945" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "7c9202d0874b719212e6eacedaa795bfdf43199c" }
 zerocopy = { version = "0.7.34", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -87,7 +87,7 @@ ringbuffer = "0.15.0"
 strum = { workspace = true }
 
 tracing = { workspace = true, optional = true }
-fs4 = "0.8.4"
+fs4 = "0.9.1"
 
 # AWS S3 support
 object_store = { version = "0.10.2", features = ["aws"] }


### PR DESCRIPTION
Follow up on https://github.com/qdrant/wal/pull/76 to keep the WAL up to date.

I updated `fs4` manually here as well so that we depend on and build a single version.