### PR TITLE
Fix: allow to specify shard_key in `with_lookup`

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11491,6 +11491,17 @@
                 "nullable": true
               }
             ]
+          },
+          "shard_key": {
+            "description": "Shard key for lookup. If not specified, all shards would be searched",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2220,6 +2220,7 @@ impl TryFrom<WithLookup> for rest::WithLookup {
                 .transpose()?
                 .or_else(with_default_payload),
             with_vectors: value.with_vectors.map(|wv| wv.into()),
+            shard_key: value.shard_key_selector.map(Into::into),
         })
     }
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -308,6 +308,7 @@ message WithLookup {
   string collection = 1; // Name of the collection to use for points lookup
   optional WithPayloadSelector with_payload = 2; // Options for specifying which payload to include (or not)
   optional WithVectorsSelector with_vectors = 3; // Options for specifying which vectors to include (or not)
+  optional ShardKeySelector shard_key_selector = 4; // Specify in which shards to look for the ids, if not specified - look in all shards
 }
 
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4332,6 +4332,9 @@ pub struct WithLookup {
     /// Options for specifying which vectors to include (or not)
     #[prost(message, optional, tag = "3")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
+    /// Specify in which shards to look for the ids, if not specified - look in all shards
+    #[prost(message, optional, tag = "4")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -463,6 +463,10 @@ pub struct WithLookup {
     #[serde(alias = "with_vector")]
     #[serde(default)]
     pub with_vectors: Option<WithVector>,
+
+    /// Shard key for lookup. If not specified, all shards would be searched
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard_key: Option<ShardKeySelector>,
 }
 
 #[allow(clippy::unnecessary_wraps)] // Used as serde default

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -115,7 +115,6 @@ where
                     pseudo_ids,
                     self.collection_by_name,
                     self.read_consistency,
-                    &self.shard_selection,
                     timeout,
                 )
                 .await?

--- a/lib/collection/src/lookup/mod.rs
+++ b/lib/collection/src/lookup/mod.rs
@@ -24,6 +24,9 @@ pub struct WithLookup {
 
     /// Options for specifying which vectors to include (or not)
     pub with_vectors: Option<WithVector>,
+
+    /// Options for shard selection
+    pub shard_selection: ShardSelectorInternal,
 }
 
 pub async fn lookup_ids<'a, F, Fut>(
@@ -31,7 +34,6 @@ pub async fn lookup_ids<'a, F, Fut>(
     values: Vec<PseudoId>,
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
-    shard_selection: &ShardSelectorInternal,
     timeout: Option<Duration>,
 ) -> CollectionResult<HashMap<PseudoId, Record>>
 where
@@ -60,7 +62,12 @@ where
     };
 
     let result = collection
-        .retrieve(point_request, read_consistency, shard_selection, timeout)
+        .retrieve(
+            point_request,
+            read_consistency,
+            &request.shard_selection,
+            timeout,
+        )
         .await?
         .into_iter()
         .map(|point| (PseudoId::from(point.id), point))

--- a/lib/collection/src/lookup/types.rs
+++ b/lib/collection/src/lookup/types.rs
@@ -5,6 +5,7 @@ use segment::types::PointIdType;
 use uuid::Uuid;
 
 use super::WithLookup;
+use crate::operations::shard_selector_internal::ShardSelectorInternal;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum WithLookupInterface {
@@ -32,6 +33,7 @@ impl From<api::rest::WithLookupInterface> for WithLookup {
                 collection_name,
                 with_payload: Some(true.into()),
                 with_vectors: Some(false.into()),
+                shard_selection: ShardSelectorInternal::All,
             },
             api::rest::WithLookupInterface::WithLookup(with_lookup) => {
                 WithLookup::from(with_lookup)
@@ -46,6 +48,10 @@ impl From<api::rest::WithLookup> for WithLookup {
             collection_name: with_lookup.collection_name,
             with_payload: with_lookup.with_payload.map(Into::into),
             with_vectors: with_lookup.with_vectors.map(Into::into),
+            shard_selection: with_lookup
+                .shard_key
+                .map(Into::into)
+                .unwrap_or(ShardSelectorInternal::All),
         }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1134,6 +1134,10 @@ impl TryFrom<api::grpc::qdrant::WithLookup> for WithLookup {
                 .transpose()?
                 .or_else(with_default_payload),
             with_vectors: value.with_vectors.map(|wv| wv.into()),
+            shard_selection: value
+                .shard_key_selector
+                .map(Into::into)
+                .unwrap_or(ShardSelectorInternal::All),
         })
     }
 }

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -438,6 +438,7 @@ mod group_by_builder {
     use collection::grouping::GroupBy;
     use collection::lookup::types::PseudoId;
     use collection::lookup::WithLookup;
+    use collection::operations::shard_selector_internal::ShardSelectorInternal;
     use segment::data_types::vectors::BatchVectorStructInternal;
     use segment::json_path::JsonPath;
     use tokio::sync::RwLock;
@@ -584,6 +585,7 @@ mod group_by_builder {
             collection_name: "test".to_string(),
             with_payload: Some(true.into()),
             with_vectors: Some(true.into()),
+            shard_selection: ShardSelectorInternal::All,
         });
 
         let collection_by_name = |_: String| async { Some(lookup_collection.read().await) };

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -643,6 +643,7 @@ mod tests_ops {
         PointOperationsDiscriminants, PointStruct, PointSyncOperation,
     };
     use collection::operations::query_enum::QueryEnum;
+    use collection::operations::shard_selector_internal::ShardSelectorInternal;
     use collection::operations::types::UsingVector;
     use collection::operations::vector_ops::{
         PointVectors, UpdateVectorsOp, VectorOperationsDiscriminants,
@@ -905,6 +906,7 @@ mod tests_ops {
                 collection_name: "col2".to_string(),
                 with_payload: Some(WithPayloadInterface::Bool(true)),
                 with_vectors: Some(WithVector::Bool(true)),
+                shard_selection: ShardSelectorInternal::All,
             }),
         };
 

--- a/tests/consensus_tests/test_custom_sharding.py
+++ b/tests/consensus_tests/test_custom_sharding.py
@@ -8,69 +8,12 @@ N_REPLICAS = 1
 
 COLLECTION_NAME = "test_collection"
 
-
-def create_collection_with_custom_sharding(
-        peer_url,
-        collection=COLLECTION_NAME,
-        shard_number=1,
-        replication_factor=1,
-        write_consistency_factor=1,
-        timeout=10
-):
-    # Create collection in peer_url
-    r_batch = requests.put(
-        f"{peer_url}/collections/{collection}?timeout={timeout}", json={
-            "vectors": {
-                "size": 4,
-                "distance": "Dot"
-            },
-            "shard_number": shard_number,
-            "replication_factor": replication_factor,
-            "write_consistency_factor": write_consistency_factor,
-            "sharding_method": "custom",
-        })
-    assert_http_ok(r_batch)
-
-
-def create_shard(
-        peer_url,
-        collection,
-        shard_key,
-        shard_number=1,
-        replication_factor=1,
-        placement=None,
-        timeout=10
-):
-    r_batch = requests.put(
-        f"{peer_url}/collections/{collection}/shards?timeout={timeout}", json={
-            "shard_key": shard_key,
-            "shards_number": shard_number,
-            "replication_factor": replication_factor,
-            "placement": placement,
-        })
-    assert_http_ok(r_batch)
-
-
-def delete_shard(
-        peer_url,
-        collection,
-        shard_key,
-        timeout=10
-):
-    r_batch = requests.post(
-        f"{peer_url}/collections/{collection}/shards/delete?timeout={timeout}",
-        json={
-            "shard_key": shard_key,
-        }
-    )
-    assert_http_ok(r_batch)
-
 def test_shard_consistency(tmp_path: pathlib.Path):
     assert_project_root()
 
     peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
 
-    create_collection_with_custom_sharding(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICAS)
+    create_collection_with_custom_sharding(peer_api_uris[0], collection=COLLECTION_NAME, shard_number=N_SHARDS, replication_factor=N_REPLICAS)
     wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris)
 
     # Create shards

--- a/tests/consensus_tests/test_custom_sharding_group_by_with_lookup.py
+++ b/tests/consensus_tests/test_custom_sharding_group_by_with_lookup.py
@@ -1,0 +1,142 @@
+import pathlib
+
+from .utils import *
+
+N_PEERS = 3
+N_SHARDS = 1
+N_REPLICAS = 1
+
+COLLECTION_NAME = "test_collection"
+LOOKUP_COLLECTION_NAME = "test_lookup_collection"
+
+# https://github.com/qdrant/qdrant/issues/4425
+def test_shard_group_by_with_lookup(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection_with_custom_sharding(
+        peer_api_uris[0],
+        collection=COLLECTION_NAME,
+        size=1,
+        shard_number=N_SHARDS,
+        replication_factor=N_REPLICAS
+    )
+    create_collection_with_custom_sharding(
+        peer_api_uris[0],
+        collection=LOOKUP_COLLECTION_NAME,
+        size=1,
+        shard_number=N_SHARDS,
+        replication_factor=N_REPLICAS
+    )
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris)
+    wait_collection_exists_and_active_on_all_peers(collection_name=LOOKUP_COLLECTION_NAME, peer_api_uris=peer_api_uris)
+
+    # Create shards
+    create_shard(
+        peer_api_uris[0],
+        COLLECTION_NAME,
+        shard_key="first",
+        shard_number=1,
+        replication_factor=1
+    )
+
+    create_shard(
+        peer_api_uris[0],
+        LOOKUP_COLLECTION_NAME,
+        shard_key="second",
+        shard_number=1,
+        replication_factor=1
+    )
+
+    create_shard(
+        peer_api_uris[0],
+        LOOKUP_COLLECTION_NAME,
+        shard_key="third",
+        shard_number=1,
+        replication_factor=1
+    )
+
+
+    # Insert data
+
+    # Create points in first peer's collection
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points?wait=true", json={
+            "shard_key": "first",
+            "points": [
+                {"id": 1, "vector": [1.0], "payload": {"document_id": 1}},
+                {"id": 2, "vector": [2.0], "payload": {"document_id": 2}},
+                {"id": 3, "vector": [3.0], "payload": {"document_id": 2}},
+                {"id": 4, "vector": [4.0], "payload": {"document_id": 1}},
+                {"id": 5, "vector": [5.0], "payload": {"document_id": 3}},
+            ]
+        })
+    assert_http_ok(r)
+
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/{LOOKUP_COLLECTION_NAME}/points?wait=true", json={
+            "shard_key": "second",
+            "points": [
+                {"id": 1, "vector": [0.0], "payload": {"document_title": "I am number one"}},
+                {"id": 2, "vector": [0.0], "payload": {"document_title": "Second"}},
+            ]
+    })
+    assert_http_ok(r)
+
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/{LOOKUP_COLLECTION_NAME}/points?wait=true", json={
+            "shard_key": "third",
+            "points": [
+                {"id": 3, "vector": [0.0], "payload": {"document_title": "On a different shard"}},
+            ]
+    })
+    assert_http_ok(r)
+
+    # Search points within the shard without explicit shard key for lookup
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points/search/groups",
+        json={
+            "vector": [2.5],
+            "shard_key": "first",
+            "group_by": "document_id",
+            "group_size": 2,
+            "limit": 10,
+            "with_lookup": {
+                "collection": LOOKUP_COLLECTION_NAME,
+                "with_payload": True,
+            },
+        }
+    )
+    assert_http_ok(r)
+    groups = r.json()["result"]["groups"]
+    assert(len(groups) == 3)
+    for group in groups:
+        assert group["lookup"]
+        assert group["lookup"]["payload"]
+        assert group["lookup"]["payload"]["document_title"] in ["I am number one", "Second", "On a different shard"]
+
+    # Search points within the shard with explicit shard key for lookup
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points/search/groups",
+        json={
+            "vector": [2.5],
+            "shard_key": "first",
+            "group_by": "document_id",
+            "group_size": 2,
+            "limit": 10,
+            "with_lookup": {
+                "shard_key": "second",
+                "collection": LOOKUP_COLLECTION_NAME,
+                "with_payload": True,
+            },
+        }
+    )
+    assert_http_ok(r)
+    groups = r.json()["result"]["groups"]
+    assert(len(groups) == 3)
+    groups_with_lookup = [group for group in groups if "lookup" in group]
+    assert(len(groups_with_lookup) == 2)
+    for group in groups_with_lookup:
+        assert group["lookup"]["payload"]
+        assert group["lookup"]["payload"]["document_title"] in ["I am number one", "Second"]

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -663,3 +663,60 @@ def wait_collection_exists_and_active_on_all_peers(collection_name: str, peer_ap
     for peer_uri in peer_api_uris:
         # Collection is active on all peers
         wait_for_all_replicas_active(collection_name=collection_name, peer_api_uri=peer_uri, headers=headers)
+
+def create_collection_with_custom_sharding(
+        peer_url,
+        collection,
+        shard_number=1,
+        size=4,
+        replication_factor=1,
+        write_consistency_factor=1,
+        timeout=10
+):
+    # Create collection in peer_url
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}?timeout={timeout}", json={
+            "vectors": {
+                "size": size,
+                "distance": "Dot"
+            },
+            "shard_number": shard_number,
+            "replication_factor": replication_factor,
+            "write_consistency_factor": write_consistency_factor,
+            "sharding_method": "custom",
+        })
+    assert_http_ok(r_batch)
+
+
+def create_shard(
+        peer_url,
+        collection,
+        shard_key,
+        shard_number=1,
+        replication_factor=1,
+        placement=None,
+        timeout=10
+):
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}/shards?timeout={timeout}", json={
+            "shard_key": shard_key,
+            "shards_number": shard_number,
+            "replication_factor": replication_factor,
+            "placement": placement,
+        })
+    assert_http_ok(r_batch)
+
+
+def delete_shard(
+        peer_url,
+        collection,
+        shard_key,
+        timeout=10
+):
+    r_batch = requests.post(
+        f"{peer_url}/collections/{collection}/shards/delete?timeout={timeout}",
+        json={
+            "shard_key": shard_key,
+        }
+    )
+    assert_http_ok(r_batch)


### PR DESCRIPTION
This PR introduces following changes to group by endpoint:

1. Stop re-using outer collection `shard_key` for lookup of the nested collection. Lookup will now default to searching on all shards.
2. Allows to specify `shard_key` in `with_lookup` parameter of group by to perform the lookup only within specific shard(s).

Adds python integration tests that verifies that both parts work as expected.

Fix #4425

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
