### PR TITLE
Wrap handler body in helpers::time

### DIFF
--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -43,10 +43,8 @@ fn get_collections(
 async fn get_aliases(
     dispatcher: web::Data<Dispatcher>,
     ActixAccess(access): ActixAccess,
-) -> impl Responder {
-    let timing = Instant::now();
-    let response = do_list_aliases(dispatcher.toc(&access), access).await;
-    process_response(response, timing)
+) -> HttpResponse {
+    helpers::time(async { do_list_aliases(dispatcher.toc(&access), access).await }).await
 }
 
 #[get("/collections/{name}")]
@@ -54,10 +52,11 @@ async fn get_collection(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
-) -> impl Responder {
-    let timing = Instant::now();
-    let response = do_get_collection(dispatcher.toc(&access), access, &collection.name, None).await;
-    process_response(response, timing)
+) -> HttpResponse {
+    helpers::time(async {
+        do_get_collection(dispatcher.toc(&access), access, &collection.name, None).await
+    })
+    .await
 }
 
 #[get("/collections/{name}/exists")]
@@ -65,10 +64,11 @@ async fn get_collection_existence(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
-) -> impl Responder {
-    let timing = Instant::now();
-    let response = do_collection_exists(dispatcher.toc(&access), access, &collection.name).await;
-    process_response(response, timing)
+) -> HttpResponse {
+    helpers::time(async {
+        do_collection_exists(dispatcher.toc(&access), access, &collection.name).await
+    })
+    .await
 }
 
 #[get("/collections/{name}/aliases")]
@@ -76,11 +76,11 @@ async fn get_collection_aliases(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
-) -> impl Responder {
-    let timing = Instant::now();
-    let response =
-        do_list_collection_aliases(dispatcher.toc(&access), access, &collection.name).await;
-    process_response(response, timing)
+) -> HttpResponse {
+    helpers::time(async {
+        do_list_collection_aliases(dispatcher.toc(&access), access, &collection.name).await
+    })
+    .await
 }
 
 #[put("/collections/{name}")]
@@ -90,19 +90,20 @@ async fn create_collection(
     operation: Json<CreateCollection>,
     Query(query): Query<WaitTimeout>,
     ActixAccess(access): ActixAccess,
-) -> impl Responder {
-    let timing = Instant::now();
-    let response = dispatcher
-        .submit_collection_meta_op(
-            CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
-                collection.name.clone(),
-                operation.into_inner(),
-            )),
-            access,
-            query.timeout(),
-        )
-        .await;
-    process_response(response, timing)
+) -> HttpResponse {
+    helpers::time(async {
+        dispatcher
+            .submit_collection_meta_op(
+                CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
+                    collection.name.clone(),
+                    operation.into_inner(),
+                )),
+                access,
+                query.timeout(),
+            )
+            .await
+    })
+    .await
 }
 
 #[patch("/collections/{name}")]
@@ -172,10 +173,10 @@ async fn get_cluster_info(
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let response =
-        do_get_collection_cluster(dispatcher.toc(&access), access, &collection.name).await;
-    process_response(response, timing)
+    helpers::time(async {
+        do_get_collection_cluster(dispatcher.toc(&access), access, &collection.name).await
+    })
+    .await
 }
 
 #[post("/collections/{name}/cluster")]

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -1,4 +1,3 @@
-use std::future::Future;
 use std::time::Duration;
 
 use actix_web::rt::time::Instant;
@@ -32,11 +31,11 @@ impl WaitTimeout {
 }
 
 #[get("/collections")]
-fn get_collections(
+async fn get_collections(
     dispatcher: web::Data<Dispatcher>,
     ActixAccess(access): ActixAccess,
-) -> impl Future<Output = HttpResponse> {
-    helpers::time(async move { do_list_collections(dispatcher.toc(&access), access).await })
+) -> HttpResponse {
+    helpers::time(do_list_collections(dispatcher.toc(&access), access)).await
 }
 
 #[get("/aliases")]
@@ -44,7 +43,7 @@ async fn get_aliases(
     dispatcher: web::Data<Dispatcher>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    helpers::time(async { do_list_aliases(dispatcher.toc(&access), access).await }).await
+    helpers::time(do_list_aliases(dispatcher.toc(&access), access)).await
 }
 
 #[get("/collections/{name}")]
@@ -53,9 +52,12 @@ async fn get_collection(
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    helpers::time(async {
-        do_get_collection(dispatcher.toc(&access), access, &collection.name, None).await
-    })
+    helpers::time(do_get_collection(
+        dispatcher.toc(&access),
+        access,
+        &collection.name,
+        None,
+    ))
     .await
 }
 
@@ -65,9 +67,11 @@ async fn get_collection_existence(
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    helpers::time(async {
-        do_collection_exists(dispatcher.toc(&access), access, &collection.name).await
-    })
+    helpers::time(do_collection_exists(
+        dispatcher.toc(&access),
+        access,
+        &collection.name,
+    ))
     .await
 }
 
@@ -77,9 +81,11 @@ async fn get_collection_aliases(
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    helpers::time(async {
-        do_list_collection_aliases(dispatcher.toc(&access), access, &collection.name).await
-    })
+    helpers::time(do_list_collection_aliases(
+        dispatcher.toc(&access),
+        access,
+        &collection.name,
+    ))
     .await
 }
 
@@ -91,18 +97,14 @@ async fn create_collection(
     Query(query): Query<WaitTimeout>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    helpers::time(async {
-        dispatcher
-            .submit_collection_meta_op(
-                CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
-                    collection.name.clone(),
-                    operation.into_inner(),
-                )),
-                access,
-                query.timeout(),
-            )
-            .await
-    })
+    helpers::time(dispatcher.submit_collection_meta_op(
+        CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
+            collection.name.clone(),
+            operation.into_inner(),
+        )),
+        access,
+        query.timeout(),
+    ))
     .await
 }
 
@@ -173,9 +175,11 @@ async fn get_cluster_info(
     collection: Path<CollectionPath>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        do_get_collection_cluster(dispatcher.toc(&access), access, &collection.name).await
-    })
+    helpers::time(do_get_collection_cluster(
+        dispatcher.toc(&access),
+        access,
+        &collection.name,
+    ))
     .await
 }
 

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -1,4 +1,3 @@
-use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
@@ -8,7 +7,7 @@ use storage::dispatcher::Dispatcher;
 use super::CollectionPath;
 use crate::actix::api::read_params::ReadParams;
 use crate::actix::auth::ActixAccess;
-use crate::actix::helpers::process_response;
+use crate::actix::helpers;
 use crate::common::points::do_count_points;
 
 #[post("/collections/{name}/points/count")]
@@ -19,28 +18,27 @@ async fn count_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
+    helpers::time(async {
+        let CountRequest {
+            count_request,
+            shard_key,
+        } = request.into_inner();
 
-    let CountRequest {
-        count_request,
-        shard_key,
-    } = request.into_inner();
+        let shard_selector = match shard_key {
+            None => ShardSelectorInternal::All,
+            Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
+        };
 
-    let shard_selector = match shard_key {
-        None => ShardSelectorInternal::All,
-        Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
-    };
-
-    let response = do_count_points(
-        dispatcher.toc(&access),
-        &collection.name,
-        count_request,
-        params.consistency,
-        params.timeout(),
-        shard_selector,
-        access,
-    )
-    .await;
-
-    process_response(response, timing)
+        do_count_points(
+            dispatcher.toc(&access),
+            &collection.name,
+            count_request,
+            params.consistency,
+            params.timeout(),
+            shard_selector,
+            access,
+        )
+        .await
+    })
+    .await
 }

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -18,27 +18,24 @@ async fn count_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let CountRequest {
-            count_request,
-            shard_key,
-        } = request.into_inner();
+    let CountRequest {
+        count_request,
+        shard_key,
+    } = request.into_inner();
 
-        let shard_selector = match shard_key {
-            None => ShardSelectorInternal::All,
-            Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
-        };
+    let shard_selector = match shard_key {
+        None => ShardSelectorInternal::All,
+        Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
+    };
 
-        do_count_points(
-            dispatcher.toc(&access),
-            &collection.name,
-            count_request,
-            params.consistency,
-            params.timeout(),
-            shard_selector,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_count_points(
+        dispatcher.toc(&access),
+        &collection.name,
+        count_request,
+        params.consistency,
+        params.timeout(),
+        shard_selector,
+        access,
+    ))
     .await
 }

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -4,12 +4,11 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{DiscoverRequest, DiscoverRequestBatch};
 use itertools::Itertools;
 use storage::dispatcher::Dispatcher;
-use tokio::time::Instant;
 
 use crate::actix::api::read_params::ReadParams;
 use crate::actix::api::CollectionPath;
 use crate::actix::auth::ActixAccess;
-use crate::actix::helpers::process_response;
+use crate::actix::helpers;
 use crate::common::points::do_discover_batch_points;
 
 #[post("/collections/{name}/points/discover")]
@@ -20,37 +19,36 @@ async fn discover_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-
-    let DiscoverRequest {
-        discover_request,
-        shard_key,
-    } = request.into_inner();
-
-    let shard_selection = match shard_key {
-        None => ShardSelectorInternal::All,
-        Some(shard_keys) => shard_keys.into(),
-    };
-
-    let response = dispatcher
-        .toc(&access)
-        .discover(
-            &collection.name,
+    helpers::time(async {
+        let DiscoverRequest {
             discover_request,
-            params.consistency,
-            shard_selection,
-            access,
-            params.timeout(),
-        )
-        .await
-        .map(|scored_points| {
-            scored_points
-                .into_iter()
-                .map(api::rest::ScoredPoint::from)
-                .collect_vec()
-        });
+            shard_key,
+        } = request.into_inner();
 
-    process_response(response, timing)
+        let shard_selection = match shard_key {
+            None => ShardSelectorInternal::All,
+            Some(shard_keys) => shard_keys.into(),
+        };
+
+        dispatcher
+            .toc(&access)
+            .discover(
+                &collection.name,
+                discover_request,
+                params.consistency,
+                shard_selection,
+                access,
+                params.timeout(),
+            )
+            .await
+            .map(|scored_points| {
+                scored_points
+                    .into_iter()
+                    .map(api::rest::ScoredPoint::from)
+                    .collect_vec()
+            })
+    })
+    .await
 }
 
 #[post("/collections/{name}/points/discover/batch")]
@@ -61,30 +59,29 @@ async fn discover_batch_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-
-    let response = do_discover_batch_points(
-        dispatcher.toc(&access),
-        &collection.name,
-        request.into_inner(),
-        params.consistency,
-        access,
-        params.timeout(),
-    )
+    helpers::time(async {
+        do_discover_batch_points(
+            dispatcher.toc(&access),
+            &collection.name,
+            request.into_inner(),
+            params.consistency,
+            access,
+            params.timeout(),
+        )
+        .await
+        .map(|batch_scored_points| {
+            batch_scored_points
+                .into_iter()
+                .map(|scored_points| {
+                    scored_points
+                        .into_iter()
+                        .map(api::rest::ScoredPoint::from)
+                        .collect_vec()
+                })
+                .collect_vec()
+        })
+    })
     .await
-    .map(|batch_scored_points| {
-        batch_scored_points
-            .into_iter()
-            .map(|scored_points| {
-                scored_points
-                    .into_iter()
-                    .map(api::rest::ScoredPoint::from)
-                    .collect_vec()
-            })
-            .collect_vec()
-    });
-
-    process_response(response, timing)
 }
 
 pub fn config_discovery_api(cfg: &mut web::ServiceConfig) {

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -7,6 +7,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     RecommendGroupsRequest, RecommendRequest, RecommendRequestBatch,
 };
+use futures_util::TryFutureExt;
 use itertools::Itertools;
 use segment::types::ScoredPoint;
 use storage::content_manager::errors::StorageError;
@@ -92,7 +93,7 @@ async fn recommend_batch_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
+    helpers::time(
         do_recommend_batch_points(
             dispatcher.toc(&access),
             &collection.name,
@@ -101,8 +102,7 @@ async fn recommend_batch_points(
             access,
             params.timeout(),
         )
-        .await
-        .map(|batch_scored_points| {
+        .map_ok(|batch_scored_points| {
             batch_scored_points
                 .into_iter()
                 .map(|scored_points| {
@@ -112,8 +112,8 @@ async fn recommend_batch_points(
                         .collect_vec()
                 })
                 .collect_vec()
-        })
-    })
+        }),
+    )
     .await
 }
 

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -28,17 +28,17 @@ async fn recommend_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let RecommendRequest {
-            recommend_request,
-            shard_key,
-        } = request.into_inner();
+    let RecommendRequest {
+        recommend_request,
+        shard_key,
+    } = request.into_inner();
 
-        let shard_selection = match shard_key {
-            None => ShardSelectorInternal::All,
-            Some(shard_keys) => shard_keys.into(),
-        };
+    let shard_selection = match shard_key {
+        None => ShardSelectorInternal::All,
+        Some(shard_keys) => shard_keys.into(),
+    };
 
+    helpers::time(
         dispatcher
             .toc(&access)
             .recommend(
@@ -49,14 +49,13 @@ async fn recommend_points(
                 access,
                 params.timeout(),
             )
-            .await
-            .map(|scored_points| {
+            .map_ok(|scored_points| {
                 scored_points
                     .into_iter()
                     .map(api::rest::ScoredPoint::from)
                     .collect_vec()
-            })
-    })
+            }),
+    )
     .await
 }
 
@@ -125,28 +124,25 @@ async fn recommend_point_groups(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let RecommendGroupsRequest {
-            recommend_group_request,
-            shard_key,
-        } = request.into_inner();
+    let RecommendGroupsRequest {
+        recommend_group_request,
+        shard_key,
+    } = request.into_inner();
 
-        let shard_selection = match shard_key {
-            None => ShardSelectorInternal::All,
-            Some(shard_keys) => shard_keys.into(),
-        };
+    let shard_selection = match shard_key {
+        None => ShardSelectorInternal::All,
+        Some(shard_keys) => shard_keys.into(),
+    };
 
-        crate::common::points::do_recommend_point_groups(
-            dispatcher.toc(&access),
-            &collection.name,
-            recommend_group_request,
-            params.consistency,
-            shard_selection,
-            access,
-            params.timeout(),
-        )
-        .await
-    })
+    helpers::time(crate::common::points::do_recommend_point_groups(
+        dispatcher.toc(&access),
+        &collection.name,
+        recommend_group_request,
+        params.consistency,
+        shard_selection,
+        access,
+        params.timeout(),
+    ))
     .await
 }
 // Configure services

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -1,4 +1,4 @@
-use actix_web::{post, web, HttpResponse};
+use actix_web::{post, web, HttpResponse, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{SearchMatrixOffsetsResponse, SearchMatrixPairsResponse, SearchMatrixRequest};
 use collection::collection::distance_matrix::CollectionSearchMatrixRequest;
@@ -8,11 +8,12 @@ use collection::operations::types::{
 };
 use itertools::Itertools;
 use storage::dispatcher::Dispatcher;
+use tokio::time::Instant;
 
 use super::read_params::ReadParams;
 use super::CollectionPath;
 use crate::actix::auth::ActixAccess;
-use crate::actix::helpers;
+use crate::actix::helpers::{self, process_response};
 use crate::common::points::{
     do_core_search_points, do_search_batch_points, do_search_point_groups, do_search_points_matrix,
 };

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use actix_multipart::form::tempfile::TempFile;
 use actix_multipart::form::MultipartForm;
-use actix_web::rt::time::Instant;
 use actix_web::{delete, get, post, put, web, HttpRequest, Responder, Result};
 use actix_web_validator as valid;
 use collection::common::file_utils::move_file;
@@ -30,7 +29,7 @@ use validator::Validate;
 
 use super::{CollectionPath, StrictCollectionPath};
 use crate::actix::auth::ActixAccess;
-use crate::actix::helpers::{self, process_response, HttpError};
+use crate::actix::helpers::{self, HttpError};
 use crate::common;
 use crate::common::collections::*;
 use crate::common::http_client::HttpClient;
@@ -144,11 +143,7 @@ async fn list_snapshots(
     path: web::Path<String>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let collection_name = path.into_inner();
-    let timing = Instant::now();
-
-    let response = do_list_snapshots(dispatcher.toc(&access), access, &collection_name).await;
-    process_response(response, timing)
+    helpers::time(async { do_list_snapshots(dispatcher.toc(&access), access, &path).await }).await
 }
 
 #[post("/collections/{name}/snapshots")]
@@ -256,9 +251,7 @@ async fn list_full_snapshots(
     dispatcher: web::Data<Dispatcher>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let response = do_list_full_snapshots(dispatcher.toc(&access), access).await;
-    process_response(response, timing)
+    helpers::time(async { do_list_full_snapshots(dispatcher.toc(&access), access).await }).await
 }
 
 #[post("/snapshots")]

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -143,7 +143,7 @@ async fn list_snapshots(
     path: web::Path<String>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async { do_list_snapshots(dispatcher.toc(&access), access, &path).await }).await
+    helpers::time(do_list_snapshots(dispatcher.toc(&access), access, &path)).await
 }
 
 #[post("/collections/{name}/snapshots")]
@@ -251,7 +251,7 @@ async fn list_full_snapshots(
     dispatcher: web::Data<Dispatcher>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async { do_list_full_snapshots(dispatcher.toc(&access), access).await }).await
+    helpers::time(do_list_full_snapshots(dispatcher.toc(&access), access)).await
 }
 
 #[post("/snapshots")]

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -39,23 +39,20 @@ async fn upsert_points(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let operation = operation.into_inner();
-        let wait = params.wait.unwrap_or(false);
-        let ordering = params.ordering.unwrap_or_default();
+    let operation = operation.into_inner();
+    let wait = params.wait.unwrap_or(false);
+    let ordering = params.ordering.unwrap_or_default();
 
-        do_upsert_points(
-            dispatcher.toc(&access).clone(),
-            collection.into_inner().name,
-            operation,
-            None,
-            None,
-            wait,
-            ordering,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_upsert_points(
+        dispatcher.toc(&access).clone(),
+        collection.into_inner().name,
+        operation,
+        None,
+        None,
+        wait,
+        ordering,
+        access,
+    ))
     .await
 }
 
@@ -67,23 +64,20 @@ async fn delete_points(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let operation = operation.into_inner();
-        let wait = params.wait.unwrap_or(false);
-        let ordering = params.ordering.unwrap_or_default();
+    let operation = operation.into_inner();
+    let wait = params.wait.unwrap_or(false);
+    let ordering = params.ordering.unwrap_or_default();
 
-        do_delete_points(
-            dispatcher.toc(&access).clone(),
-            collection.into_inner().name,
-            operation,
-            None,
-            None,
-            wait,
-            ordering,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_delete_points(
+        dispatcher.toc(&access).clone(),
+        collection.into_inner().name,
+        operation,
+        None,
+        None,
+        wait,
+        ordering,
+        access,
+    ))
     .await
 }
 
@@ -95,23 +89,20 @@ async fn update_vectors(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let operation = operation.into_inner();
-        let wait = params.wait.unwrap_or(false);
-        let ordering = params.ordering.unwrap_or_default();
+    let operation = operation.into_inner();
+    let wait = params.wait.unwrap_or(false);
+    let ordering = params.ordering.unwrap_or_default();
 
-        do_update_vectors(
-            dispatcher.toc(&access).clone(),
-            collection.into_inner().name,
-            operation,
-            None,
-            None,
-            wait,
-            ordering,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_update_vectors(
+        dispatcher.toc(&access).clone(),
+        collection.into_inner().name,
+        operation,
+        None,
+        None,
+        wait,
+        ordering,
+        access,
+    ))
     .await
 }
 
@@ -150,23 +141,20 @@ async fn set_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let operation = operation.into_inner();
-        let wait = params.wait.unwrap_or(false);
-        let ordering = params.ordering.unwrap_or_default();
+    let operation = operation.into_inner();
+    let wait = params.wait.unwrap_or(false);
+    let ordering = params.ordering.unwrap_or_default();
 
-        do_set_payload(
-            dispatcher.toc(&access).clone(),
-            collection.into_inner().name,
-            operation,
-            None,
-            None,
-            wait,
-            ordering,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_set_payload(
+        dispatcher.toc(&access).clone(),
+        collection.into_inner().name,
+        operation,
+        None,
+        None,
+        wait,
+        ordering,
+        access,
+    ))
     .await
 }
 
@@ -178,23 +166,20 @@ async fn overwrite_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let operation = operation.into_inner();
-        let wait = params.wait.unwrap_or(false);
-        let ordering = params.ordering.unwrap_or_default();
+    let operation = operation.into_inner();
+    let wait = params.wait.unwrap_or(false);
+    let ordering = params.ordering.unwrap_or_default();
 
-        do_overwrite_payload(
-            dispatcher.toc(&access).clone(),
-            collection.into_inner().name,
-            operation,
-            None,
-            None,
-            wait,
-            ordering,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_overwrite_payload(
+        dispatcher.toc(&access).clone(),
+        collection.into_inner().name,
+        operation,
+        None,
+        None,
+        wait,
+        ordering,
+        access,
+    ))
     .await
 }
 
@@ -206,23 +191,20 @@ async fn delete_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let operation = operation.into_inner();
-        let wait = params.wait.unwrap_or(false);
-        let ordering = params.ordering.unwrap_or_default();
+    let operation = operation.into_inner();
+    let wait = params.wait.unwrap_or(false);
+    let ordering = params.ordering.unwrap_or_default();
 
-        do_delete_payload(
-            dispatcher.toc(&access).clone(),
-            collection.into_inner().name,
-            operation,
-            None,
-            None,
-            wait,
-            ordering,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_delete_payload(
+        dispatcher.toc(&access).clone(),
+        collection.into_inner().name,
+        operation,
+        None,
+        None,
+        wait,
+        ordering,
+        access,
+    ))
     .await
 }
 
@@ -234,23 +216,20 @@ async fn clear_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    helpers::time(async {
-        let operation = operation.into_inner();
-        let wait = params.wait.unwrap_or(false);
-        let ordering = params.ordering.unwrap_or_default();
+    let operation = operation.into_inner();
+    let wait = params.wait.unwrap_or(false);
+    let ordering = params.ordering.unwrap_or_default();
 
-        do_clear_payload(
-            dispatcher.toc(&access).clone(),
-            collection.into_inner().name,
-            operation,
-            None,
-            None,
-            wait,
-            ordering,
-            access,
-        )
-        .await
-    })
+    helpers::time(do_clear_payload(
+        dispatcher.toc(&access).clone(),
+        collection.into_inner().name,
+        operation,
+        None,
+        None,
+        wait,
+        ordering,
+        access,
+    ))
     .await
 }
 

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -12,7 +12,7 @@ use validator::Validate;
 
 use super::CollectionPath;
 use crate::actix::auth::ActixAccess;
-use crate::actix::helpers::process_response;
+use crate::actix::helpers::{self, process_response};
 use crate::common::points::{
     do_batch_update_points, do_clear_payload, do_create_index, do_delete_index, do_delete_payload,
     do_delete_points, do_delete_vectors, do_overwrite_payload, do_set_payload, do_update_vectors,
@@ -39,23 +39,24 @@ async fn upsert_points(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    helpers::time(async {
+        let operation = operation.into_inner();
+        let wait = params.wait.unwrap_or(false);
+        let ordering = params.ordering.unwrap_or_default();
 
-    let response = do_upsert_points(
-        dispatcher.toc(&access).clone(),
-        collection.into_inner().name,
-        operation,
-        None,
-        None,
-        wait,
-        ordering,
-        access,
-    )
-    .await;
-    process_response(response, timing)
+        do_upsert_points(
+            dispatcher.toc(&access).clone(),
+            collection.into_inner().name,
+            operation,
+            None,
+            None,
+            wait,
+            ordering,
+            access,
+        )
+        .await
+    })
+    .await
 }
 
 #[post("/collections/{name}/points/delete")]
@@ -66,23 +67,24 @@ async fn delete_points(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    helpers::time(async {
+        let operation = operation.into_inner();
+        let wait = params.wait.unwrap_or(false);
+        let ordering = params.ordering.unwrap_or_default();
 
-    let response = do_delete_points(
-        dispatcher.toc(&access).clone(),
-        collection.into_inner().name,
-        operation,
-        None,
-        None,
-        wait,
-        ordering,
-        access,
-    )
-    .await;
-    process_response(response, timing)
+        do_delete_points(
+            dispatcher.toc(&access).clone(),
+            collection.into_inner().name,
+            operation,
+            None,
+            None,
+            wait,
+            ordering,
+            access,
+        )
+        .await
+    })
+    .await
 }
 
 #[put("/collections/{name}/points/vectors")]
@@ -93,23 +95,24 @@ async fn update_vectors(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    helpers::time(async {
+        let operation = operation.into_inner();
+        let wait = params.wait.unwrap_or(false);
+        let ordering = params.ordering.unwrap_or_default();
 
-    let response = do_update_vectors(
-        dispatcher.toc(&access).clone(),
-        collection.into_inner().name,
-        operation,
-        None,
-        None,
-        wait,
-        ordering,
-        access,
-    )
-    .await;
-    process_response(response, timing)
+        do_update_vectors(
+            dispatcher.toc(&access).clone(),
+            collection.into_inner().name,
+            operation,
+            None,
+            None,
+            wait,
+            ordering,
+            access,
+        )
+        .await
+    })
+    .await
 }
 
 #[post("/collections/{name}/points/vectors/delete")]
@@ -147,23 +150,24 @@ async fn set_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    helpers::time(async {
+        let operation = operation.into_inner();
+        let wait = params.wait.unwrap_or(false);
+        let ordering = params.ordering.unwrap_or_default();
 
-    let response = do_set_payload(
-        dispatcher.toc(&access).clone(),
-        collection.into_inner().name,
-        operation,
-        None,
-        None,
-        wait,
-        ordering,
-        access,
-    )
-    .await;
-    process_response(response, timing)
+        do_set_payload(
+            dispatcher.toc(&access).clone(),
+            collection.into_inner().name,
+            operation,
+            None,
+            None,
+            wait,
+            ordering,
+            access,
+        )
+        .await
+    })
+    .await
 }
 
 #[put("/collections/{name}/points/payload")]
@@ -174,23 +178,24 @@ async fn overwrite_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    helpers::time(async {
+        let operation = operation.into_inner();
+        let wait = params.wait.unwrap_or(false);
+        let ordering = params.ordering.unwrap_or_default();
 
-    let response = do_overwrite_payload(
-        dispatcher.toc(&access).clone(),
-        collection.into_inner().name,
-        operation,
-        None,
-        None,
-        wait,
-        ordering,
-        access,
-    )
-    .await;
-    process_response(response, timing)
+        do_overwrite_payload(
+            dispatcher.toc(&access).clone(),
+            collection.into_inner().name,
+            operation,
+            None,
+            None,
+            wait,
+            ordering,
+            access,
+        )
+        .await
+    })
+    .await
 }
 
 #[post("/collections/{name}/points/payload/delete")]
@@ -201,23 +206,24 @@ async fn delete_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    helpers::time(async {
+        let operation = operation.into_inner();
+        let wait = params.wait.unwrap_or(false);
+        let ordering = params.ordering.unwrap_or_default();
 
-    let response = do_delete_payload(
-        dispatcher.toc(&access).clone(),
-        collection.into_inner().name,
-        operation,
-        None,
-        None,
-        wait,
-        ordering,
-        access,
-    )
-    .await;
-    process_response(response, timing)
+        do_delete_payload(
+            dispatcher.toc(&access).clone(),
+            collection.into_inner().name,
+            operation,
+            None,
+            None,
+            wait,
+            ordering,
+            access,
+        )
+        .await
+    })
+    .await
 }
 
 #[post("/collections/{name}/points/payload/clear")]
@@ -228,23 +234,24 @@ async fn clear_payload(
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let timing = Instant::now();
-    let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    helpers::time(async {
+        let operation = operation.into_inner();
+        let wait = params.wait.unwrap_or(false);
+        let ordering = params.ordering.unwrap_or_default();
 
-    let response = do_clear_payload(
-        dispatcher.toc(&access).clone(),
-        collection.into_inner().name,
-        operation,
-        None,
-        None,
-        wait,
-        ordering,
-        access,
-    )
-    .await;
-    process_response(response, timing)
+        do_clear_payload(
+            dispatcher.toc(&access).clone(),
+            collection.into_inner().name,
+            operation,
+            None,
+            None,
+            wait,
+            ordering,
+            access,
+        )
+        .await
+    })
+    .await
 }
 
 #[post("/collections/{name}/points/batch")]


### PR DESCRIPTION
Wraps all cancel-safe operations in actix handlers in helpers::time.
This allows early-returning using `?` and makes the code cleaner.