### PR TITLE
Forbid aborting resharding after `ReadHashRingCommitted`

### DIFF
--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -317,7 +317,7 @@ impl ShardHolder {
                     None => {
                         log::warn!(
                             "aborting resharding {resharding_key}, \
-                         but peer {peer_id} does not exist in {shard_id} replica set"
+                             but peer {peer_id} does not exist in {shard_id} replica set"
                         );
                     }
                 }
@@ -343,7 +343,7 @@ impl ShardHolder {
             } else {
                 log::warn!(
                     "aborting resharding {resharding_key}, \
-                 but shard holder does not contain {shard_id} replica set",
+                     but shard holder does not contain {shard_id} replica set",
                 );
             }
         }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -227,14 +227,14 @@ impl ShardHolder {
         }
 
         // - it's safe to run, if write hash ring was not committed yet
-        if state.stage < ReshardStage::WriteHashRingCommitted {
+        if state.stage < ReshardStage::ReadHashRingCommitted {
             return Ok(());
         }
 
-        // - but resharding can't be aborted, after write hash ring has been committed
+        // - but resharding can't be aborted, after read hash ring has been committed
         Err(CollectionError::bad_request(format!(
             "can't abort resharding {resharding_key}, \
-             because write hash ring has been committed already, \
+             because read hash ring has been committed already, \
              resharding must be completed",
         )))
     }
@@ -253,10 +253,10 @@ impl ShardHolder {
 
         let is_in_progress = match self.resharding_state.read().deref() {
             Some(state) if state.matches(&resharding_key) => {
-                if !force && state.stage >= ReshardStage::WriteHashRingCommitted {
+                if !force && state.stage >= ReshardStage::ReadHashRingCommitted {
                     return Err(CollectionError::bad_request(format!(
                         "can't abort resharding {resharding_key}, \
-                         because write hash ring has been committed already, \
+                         because read hash ring has been committed already, \
                          resharding must be completed",
                     )));
                 }


### PR DESCRIPTION
Before, we were deleting migrated points (from "old" shards) during `WriteHashRingCommitted` stage. Current plan is to delete them during `ReadHashRingCommitted` stage, and so now we can't abort resharding once we switched to this stage.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~Have you written new tests for your core changes, as applicable?~~
* [ ] ~~Have you successfully ran tests with your changes locally?~~
