### PR TITLE
perf: Limit bad performance of filtered faceting

### DIFF
--- a/lib/collection/src/shards/local_shard/facet.rs
+++ b/lib/collection/src/shards/local_shard/facet.rs
@@ -4,16 +4,18 @@ use std::time::Duration;
 
 use futures::future;
 use futures::future::try_join_all;
-use itertools::{process_results, Itertools};
-use segment::data_types::facets::{FacetParams, FacetValue, FacetValueHit};
-use segment::types::{Condition, FieldCondition, Filter, Match};
+use itertools::{Itertools, process_results};
 use tokio::runtime::Handle;
 use tokio::time::error::Elapsed;
 
-use super::LocalShard;
+use segment::data_types::facets::{FacetParams, FacetValue, FacetValueHit};
+use segment::types::{Condition, FieldCondition, Filter, Match};
+
 use crate::collection_manager::holders::segment_holder::LockedSegment;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::types::{CollectionError, CollectionResult};
+
+use super::LocalShard;
 
 impl LocalShard {
     /// Returns values with approximate counts for the given facet request.

--- a/lib/collection/src/shards/local_shard/facet.rs
+++ b/lib/collection/src/shards/local_shard/facet.rs
@@ -4,18 +4,16 @@ use std::time::Duration;
 
 use futures::future;
 use futures::future::try_join_all;
-use itertools::{Itertools, process_results};
+use itertools::{process_results, Itertools};
+use segment::data_types::facets::{FacetParams, FacetValue, FacetValueHit};
+use segment::types::{Condition, FieldCondition, Filter, Match};
 use tokio::runtime::Handle;
 use tokio::time::error::Elapsed;
 
-use segment::data_types::facets::{FacetParams, FacetValue, FacetValueHit};
-use segment::types::{Condition, FieldCondition, Filter, Match};
-
+use super::LocalShard;
 use crate::collection_manager::holders::segment_holder::LockedSegment;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::types::{CollectionError, CollectionResult};
-
-use super::LocalShard;
 
 impl LocalShard {
     /// Returns values with approximate counts for the given facet request.

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -532,12 +532,6 @@ pub enum FacetIndex<'a> {
 }
 
 impl<'a> FacetIndex<'a> {
-    // pub fn get_unique_values_count(&self) -> usize {
-    //     match self {
-    //         FacetIndex::KeywordIndex(index) => index.get_unique_values_count(),
-    //     }
-    // }
-
     pub fn get_values(
         &self,
         point_id: PointOffsetType,

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -158,7 +158,7 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
         }
     }
 
-    fn get_unique_values_count(&self) -> usize {
+    pub fn get_unique_values_count(&self) -> usize {
         match self {
             MapIndex::Mutable(index) => index.get_unique_values_count(),
             MapIndex::Immutable(index) => index.get_unique_values_count(),

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1559,39 +1559,70 @@ impl SegmentEntry for Segment {
         let payload_index = self.payload_index.borrow();
 
         let facet_index = payload_index.get_facet_index(&request.key)?;
+        let context;
 
         let hits_iter = if let Some(filter) = &request.filter {
             let id_tracker = self.id_tracker.borrow();
             let filter_cardinality = payload_index.estimate_cardinality(filter);
 
-            let iter = payload_index
-                .iter_filtered_points(filter, &*id_tracker, &filter_cardinality)
-                .check_stop(|| is_stopped.load(Ordering::Relaxed))
-                .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
-                .fold(HashMap::new(), |mut map, point_id| {
-                    facet_index.get_values(point_id).unique().for_each(|value| {
-                        *map.entry(value).or_insert(0) += 1;
-                    });
-                    map
-                })
-                .into_iter()
-                .map(|(value, count)| FacetHit { value, count });
+            let available = self.available_point_count();
+            let percentage_filtered = filter_cardinality.exp as f64 / available as f64;
 
+            // TODO(facets): define a better estimate for this decision, the question is:
+            // What is more expensive, to hash the same value excessively or to check with filter too many times?
+            //
+            // For now this is defined from some rudimentary benchmarking
+            // a collection with few keys and a collection with almost unique key per point
+            let use_iterative_approach = percentage_filtered < 0.3;
+
+            let iter = if use_iterative_approach {
+                // go over the filtered points and aggregate the values
+                // aka. read from other indexes
+                let iter = payload_index
+                    .iter_filtered_points(filter, &*id_tracker, &filter_cardinality)
+                    .check_stop(|| is_stopped.load(Ordering::Relaxed))
+                    .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
+                    .fold(HashMap::new(), |mut map, point_id| {
+                        facet_index.get_values(point_id).unique().for_each(|value| {
+                            *map.entry(value).or_insert(0) += 1;
+                        });
+                        map
+                    })
+                    .into_iter()
+                    .map(|(value, count)| FacetHit { value, count });
+
+                Either::Left(iter)
+            } else {
+                // go over the values and filter the points
+                // aka. read from facet index
+                //
+                // This is more similar to a full-scan, but we won't be hashing so many times.
+                context = payload_index.struct_filtered_context(filter);
+
+                let iter = facet_index
+                    .iter_filtered_counts_per_value(&context)
+                    .check_stop(|| is_stopped.load(Ordering::Relaxed));
+
+                Either::Right(iter)
+            };
             Either::Left(iter)
         } else {
+            // just count how many points each value has
             let iter = facet_index
                 .iter_counts_per_value()
                 .check_stop(|| is_stopped.load(Ordering::Relaxed));
+
             Either::Right(iter)
         };
 
-        // TODO(luis): We can't just select top values, because we need to aggregate across segments,
+        // We can't just select top values, because we need to aggregate across segments,
         // which we can't assume to select the same best top.
         //
         // We need all values to be able to aggregate correctly across segments
-        let hits = hits_iter
-            .map(|hit| (hit.value.to_owned(), hit.count))
-            .collect();
+        let hits = hits_iter.fold(HashMap::new(), |mut acc, hit| {
+            acc.insert(hit.value.to_owned(), hit.count);
+            acc
+        });
 
         Ok(hits)
     }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1177,9 +1177,9 @@ fn validate_facet_result(
     facet_hits: HashMap<FacetValue, usize>,
     filter: Option<Filter>,
 ) {
-    for (value, count) in facet_hits {
+    for (value, count) in facet_hits.iter() {
         // Compare against exact count
-        let FacetValue::Keyword(value) = value;
+        let FacetValue::Keyword(value) = value.to_owned();
 
         let count_filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
             JsonPath::new(STR_KEY),
@@ -1191,7 +1191,7 @@ fn validate_facet_result(
             .read_filtered(None, None, count_filter.as_ref(), &Default::default())
             .len();
 
-        assert_eq!(count, exact);
+        assert_eq!(*count, exact);
     }
 }
 


### PR DESCRIPTION
Currently the filtered iterator works great if the cardinality of the filter is small enough, but its performance slows linearly as the cardinality increases.

Here I introduce a second approach of going through the values->points map and filtering the points. This is essentially a full-scan always, independently of the filter cardinality, but it is faster than the existing approach after some threshold.

TODO:
- define a dynamic threshold based on the amount of unique values, cardinality and amount of available points?

Rudimentary experiments:
https://docs.google.com/spreadsheets/d/1CtdaBIGRVH1bzu_JuKmyNBnLX9GUh1LACbpswjdNiDs/edit?usp=sharing
