### PR TITLE
Allow explicit populate of mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,8 +3512,7 @@ dependencies = [
 [[package]]
 name = "memmap2"
 version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+source = "git+https://github.com/RazrFalcon/memmap2-rs#34776c1f83b0ef17ecbc838a580c66e3d703b51d"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,3 +249,5 @@ codegen-units = 256 # restore default value for faster compilation
 [patch.crates-io]
 # Temporary patch until our PRs are merged.
 tar = { git = "https://github.com/qdrant/tar-rs", branch="main" }
+# Temporary patch until memmap2 0.9.5 is released.
+memmap2 = { git = "https://github.com/RazrFalcon/memmap2-rs" }

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -637,9 +637,8 @@ pub trait SegmentOptimizer {
 
         // ---- SLOW PART ENDS HERE -----
 
-        check_process_stopped(stopped).inspect_err(|_error| {
-            self.handle_cancellation(&segments, &proxy_ids, &tmp_segment);
-        })?;
+        check_process_stopped(stopped)
+            .inspect_err(|_| self.handle_cancellation(&segments, &proxy_ids, &tmp_segment))?;
 
         {
             // This block locks all operations with collection. It should be fast

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -359,7 +359,7 @@ impl CollectionParams {
                         storage_type: if params.on_disk.unwrap_or_default() {
                             VectorStorageType::ChunkedMmap
                         } else {
-                            VectorStorageType::Memory
+                            VectorStorageType::InRamChunkedMmap
                         },
                         multivector_config: params.multivector_config,
                         datatype: params.datatype.map(VectorStorageDatatype::from),

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -359,7 +359,7 @@ impl CollectionParams {
                         storage_type: if params.on_disk.unwrap_or_default() {
                             VectorStorageType::ChunkedMmap
                         } else {
-                            VectorStorageType::InRamChunkedMmap
+                            VectorStorageType::Memory
                         },
                         multivector_config: params.multivector_config,
                         datatype: params.datatype.map(VectorStorageDatatype::from),

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -114,9 +114,9 @@ impl Madviseable for memmap2::Mmap {
     }
 
     fn populate(&self) {
-        // #[cfg(unix)]
-        // self.advise(memmap2::Advice::PopulateRead)?;
-        // #[cfg(not(unix))]
+        #[cfg(unix)]
+        self.advise(memmap2::Advice::PopulateRead)?;
+        #[cfg(not(unix))]
         {
             // On non-Unix platforms, we just iterate over the memory to populate it.
             // This is not as efficient as `madvise(2)` with `PopulateRead` but it's better than nothing.
@@ -141,9 +141,9 @@ impl Madviseable for memmap2::MmapMut {
     }
 
     fn populate(&self) {
-        // #[cfg(unix)]
-        // self.advise(memmap2::Advice::PopulateRead)?;
-        // #[cfg(not(unix))]
+        #[cfg(unix)]
+        self.advise(memmap2::Advice::PopulateRead)?;
+        #[cfg(not(unix))]
         {
             // On non-Unix platforms, we just iterate over the memory to populate it.
             // This is not as efficient as `madvise(2)` with `PopulateRead` but it's better than nothing.

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -1,13 +1,13 @@
 //! Platform-independent abstractions over [`memmap2::Mmap::advise`]/[`memmap2::MmapMut::advise`]
 //! and [`memmap2::Advice`].
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 use std::hint::black_box;
 use std::io;
 
 use serde::Deserialize;
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 const PAGE_SIZE: usize = 4096;
 
 /// Global [`Advice`] value, to trivially set [`Advice`] value
@@ -116,9 +116,9 @@ impl Madviseable for memmap2::Mmap {
     }
 
     fn populate(&self) -> io::Result<()> {
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         self.advise(memmap2::Advice::PopulateRead)?;
-        #[cfg(not(unix))]
+        #[cfg(not(target_os = "linux"))]
         {
             // On non-Unix platforms, we just iterate over the memory to populate it.
             // This is not as efficient as `madvise(2)` with `PopulateRead` but it's better than nothing.
@@ -144,9 +144,9 @@ impl Madviseable for memmap2::MmapMut {
     }
 
     fn populate(&self) -> io::Result<()> {
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         self.advise(memmap2::Advice::PopulateRead)?;
-        #[cfg(not(unix))]
+        #[cfg(not(target_os = "linux"))]
         {
             // On non-Unix platforms, we just iterate over the memory to populate it.
             // This is not as efficient as `madvise(2)` with `PopulateRead` but it's better than nothing.

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -1,11 +1,13 @@
 //! Platform-independent abstractions over [`memmap2::Mmap::advise`]/[`memmap2::MmapMut::advise`]
 //! and [`memmap2::Advice`].
 
+#[cfg(not(unix))]
 use std::hint::black_box;
 use std::io;
 
 use serde::Deserialize;
 
+#[cfg(not(unix))]
 const PAGE_SIZE: usize = 4096;
 
 /// Global [`Advice`] value, to trivially set [`Advice`] value
@@ -101,7 +103,7 @@ pub trait Madviseable {
     /// Advise OS how given memory map will be accessed. On non-Unix platforms this is a no-op.
     fn madvise(&self, advice: Advice) -> io::Result<()>;
 
-    fn populate(&self);
+    fn populate(&self) -> io::Result<()>;
 }
 
 impl Madviseable for memmap2::Mmap {
@@ -113,7 +115,7 @@ impl Madviseable for memmap2::Mmap {
         Ok(())
     }
 
-    fn populate(&self) {
+    fn populate(&self) -> io::Result<()> {
         #[cfg(unix)]
         self.advise(memmap2::Advice::PopulateRead)?;
         #[cfg(not(unix))]
@@ -128,6 +130,7 @@ impl Madviseable for memmap2::Mmap {
 
             black_box(dst);
         }
+        Ok(())
     }
 }
 
@@ -140,7 +143,7 @@ impl Madviseable for memmap2::MmapMut {
         Ok(())
     }
 
-    fn populate(&self) {
+    fn populate(&self) -> io::Result<()> {
         #[cfg(unix)]
         self.advise(memmap2::Advice::PopulateRead)?;
         #[cfg(not(unix))]
@@ -155,5 +158,6 @@ impl Madviseable for memmap2::MmapMut {
 
             black_box(dst);
         }
+        Ok(())
     }
 }

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -48,7 +48,7 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<File> 
     }
 }
 
-pub fn open_read_mmap(path: &Path, advice: AdviceSetting) -> io::Result<Mmap> {
+pub fn open_read_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io::Result<Mmap> {
     let file = OpenOptions::new()
         .read(true)
         .write(false)
@@ -58,6 +58,13 @@ pub fn open_read_mmap(path: &Path, advice: AdviceSetting) -> io::Result<Mmap> {
         .open(path)?;
 
     let mmap = unsafe { Mmap::map(&file)? };
+
+    // Populate before advising
+    // Because we want to read data with normal advice
+    if populate {
+        mmap.populate();
+    }
+
     madvise::madvise(&mmap, advice.resolve())?;
 
     Ok(mmap)

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -62,7 +62,7 @@ pub fn open_read_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io:
     // Populate before advising
     // Because we want to read data with normal advice
     if populate {
-        mmap.populate();
+        mmap.populate()?;
     }
 
     madvise::madvise(&mmap, advice.resolve())?;
@@ -82,7 +82,7 @@ pub fn open_write_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io
     // Populate before advising
     // Because we want to read data with normal advice
     if populate {
-        mmap.populate();
+        mmap.populate()?;
     }
 
     madvise::madvise(&mmap, advice.resolve())?;
@@ -120,7 +120,14 @@ where
 
     let instant = time::Instant::now();
 
-    mmap.populate();
+    if let Err(err) = mmap.populate() {
+        log::warn!(
+            "Failed to populate mmap{separator}{path:?} to cache: {err}",
+            separator = separator,
+            path = path,
+            err = err
+        );
+    }
 
     log::trace!(
         "Reading mmap{separator}{path:?} to populate cache took {:?}",

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -565,7 +565,8 @@ mod tests {
     fn check_open_zero_type<T: Sized + PartialEq + Debug + 'static>(zero: T) {
         let bytes = mem::size_of::<T>();
         let tempfile = create_temp_mmap_file(bytes);
-        let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+        let mmap =
+            mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
 
         let mmap_type: MmapType<T> = unsafe { MmapType::from(mmap) };
         assert_eq!(mmap_type.deref(), &zero);
@@ -595,7 +596,8 @@ mod tests {
     fn check_open_zero_slice<T: Sized + PartialEq + Debug + 'static>(len: usize, zero: T) {
         let bytes = mem::size_of::<T>() * len;
         let tempfile = create_temp_mmap_file(bytes);
-        let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+        let mmap =
+            mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
 
         let mmap_slice: MmapSlice<T> = unsafe { MmapSlice::from(mmap) };
         assert_eq!(mmap_slice.len(), len);
@@ -629,7 +631,8 @@ mod tests {
 
         // Write random values from template into mmap
         {
-            let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+            let mmap =
+                mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
             let mut mmap_slice: MmapSlice<T> = unsafe { MmapSlice::from(mmap) };
             assert_eq!(mmap_slice.len(), len);
             mmap_slice.copy_from_slice(&template);
@@ -637,7 +640,8 @@ mod tests {
 
         // Reopen and assert values from template
         {
-            let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+            let mmap =
+                mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
             let mmap_slice: MmapSlice<T> = unsafe { MmapSlice::from(mmap) };
             assert_eq!(mmap_slice.as_ref(), template);
         }
@@ -659,7 +663,8 @@ mod tests {
         // Fill bitslice
         {
             let mut rng = StdRng::seed_from_u64(42);
-            let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+            let mmap =
+                mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
             let mut mmap_bitslice = MmapBitSlice::from(mmap, header_size);
             (0..bits).for_each(|i| mmap_bitslice.set(i, rng.gen()));
         }
@@ -667,7 +672,8 @@ mod tests {
         // Reopen and assert contents
         {
             let mut rng = StdRng::seed_from_u64(42);
-            let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+            let mmap =
+                mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
             let mmap_bitslice = MmapBitSlice::from(mmap, header_size);
             (0..bits).for_each(|i| assert_eq!(mmap_bitslice[i], rng.gen::<bool>()));
         }
@@ -677,14 +683,16 @@ mod tests {
     fn test_zero_sized_type() {
         {
             let tempfile = create_temp_mmap_file(0);
-            let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+            let mmap =
+                mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
             let result = unsafe { MmapType::<()>::try_from(mmap).unwrap() };
             assert_eq!(result.deref(), &());
         }
 
         {
             let tempfile = create_temp_mmap_file(0);
-            let mmap = mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global).unwrap();
+            let mmap =
+                mmap_ops::open_write_mmap(tempfile.path(), AdviceSetting::Global, false).unwrap();
             let result = unsafe { MmapSlice::<()>::try_from(mmap).unwrap() };
             assert_eq!(result.as_ref(), &[]);
             assert_alignment::<_, ()>(result.as_ref());

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -279,6 +279,7 @@ impl<T> MmapSlice<T> {
         let mmap = mmap_ops::open_write_mmap(
             path,
             AdviceSetting::Advice(Advice::Normal), // We only write sequentially
+            false,
         )?;
 
         let mut mmap_slice = unsafe { Self::try_from(mmap)? };
@@ -371,6 +372,7 @@ impl MmapBitSlice {
         let mmap = mmap_ops::open_write_mmap(
             path,
             AdviceSetting::Advice(Advice::Normal), // We only write sequentially
+            false,
         )?;
 
         let mut mmap_bitslice = MmapBitSlice::try_from(mmap, 0)?;

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -231,6 +231,7 @@ impl ImmutableIdTracker {
         let deleted_raw = open_write_mmap(
             &Self::deleted_file_path(segment_path),
             AdviceSetting::Global,
+            true,
         )?;
         let deleted_mmap = MmapBitSlice::try_from(deleted_raw, 0)?;
         let deleted_bitvec = deleted_mmap.to_bitvec();
@@ -239,6 +240,7 @@ impl ImmutableIdTracker {
         let internal_to_version_map = open_write_mmap(
             &Self::version_mapping_file_path(segment_path),
             AdviceSetting::Global,
+            true,
         )?;
         let internal_to_version_mapslice: MmapSlice<SeqNumberType> =
             unsafe { MmapSlice::try_from(internal_to_version_map)? };
@@ -272,7 +274,7 @@ impl ImmutableIdTracker {
 
         debug_assert!(mappings.deleted().len() <= mappings.total_point_count());
 
-        let deleted_mmap = open_write_mmap(&deleted_filepath, AdviceSetting::Global)?;
+        let deleted_mmap = open_write_mmap(&deleted_filepath, AdviceSetting::Global, false)?;
         let mut deleted_new = MmapBitSlice::try_from(deleted_mmap, 0)?;
         deleted_new[..mappings.deleted().len()].copy_from_bitslice(mappings.deleted());
 
@@ -298,7 +300,11 @@ impl ImmutableIdTracker {
             create_and_ensure_length(&version_filepath, version_size)?;
         }
         let mut internal_to_version_wrapper = unsafe {
-            MmapSlice::try_from(open_write_mmap(&version_filepath, AdviceSetting::Global)?)?
+            MmapSlice::try_from(open_write_mmap(
+                &version_filepath,
+                AdviceSetting::Global,
+                false,
+            )?)?
         };
 
         internal_to_version_wrapper[..internal_to_version.len()]

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -406,7 +406,7 @@ mod tests {
 
         MmapInvertedIndex::create(path.clone(), immutable.clone()).unwrap();
 
-        let mmap = MmapInvertedIndex::open(path).unwrap();
+        let mmap = MmapInvertedIndex::open(path, false).unwrap();
 
         // Check same vocabulary
         for (token, token_id) in immutable.vocab.iter() {
@@ -453,7 +453,7 @@ mod tests {
 
         MmapInvertedIndex::create(path.clone(), immutable.clone()).unwrap();
 
-        let mut mmap_index = MmapInvertedIndex::open(path).unwrap();
+        let mut mmap_index = MmapInvertedIndex::open(path, false).unwrap();
 
         let queries: Vec<_> = (0..100).map(|_| generate_query()).collect();
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -212,16 +212,9 @@ impl MmapPostings {
         Ok(())
     }
 
-    pub fn open(
-        path: impl Into<PathBuf>,
-        populate: bool
-    ) -> io::Result<Self> {
+    pub fn open(path: impl Into<PathBuf>, populate: bool) -> io::Result<Self> {
         let path = path.into();
-        let mmap = open_read_mmap(
-            &path,
-            AdviceSetting::Advice(Advice::Normal),
-            populate,
-        )?;
+        let mmap = open_read_mmap(&path, AdviceSetting::Advice(Advice::Normal), populate)?;
 
         let header_bytes = mmap.get(0..size_of::<PostingsHeader>()).ok_or_else(|| {
             io::Error::new(

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -212,9 +212,16 @@ impl MmapPostings {
         Ok(())
     }
 
-    pub fn open(path: impl Into<PathBuf>) -> io::Result<Self> {
+    pub fn open(
+        path: impl Into<PathBuf>,
+        populate: bool
+    ) -> io::Result<Self> {
         let path = path.into();
-        let mmap = open_read_mmap(&path, AdviceSetting::Advice(Advice::Normal))?;
+        let mmap = open_read_mmap(
+            &path,
+            AdviceSetting::Advice(Advice::Normal),
+            populate,
+        )?;
 
         let header_bytes = mmap.get(0..size_of::<PostingsHeader>()).ok_or_else(|| {
             io::Error::new(

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -78,23 +78,25 @@ impl MmapInvertedIndex {
         Ok(())
     }
 
-    pub fn open(path: PathBuf) -> OperationResult<Self> {
+    pub fn open(path: PathBuf, populate: bool) -> OperationResult<Self> {
         let postings_path = path.clone().join(POSTINGS_FILE);
         let vocab_path = path.clone().join(VOCAB_FILE);
         let point_to_tokens_count_path = path.clone().join(POINT_TO_TOKENS_COUNT_FILE);
         let deleted_points_path = path.clone().join(DELETED_POINTS_FILE);
 
-        let postings = MmapPostings::open(&postings_path)?;
+        let postings = MmapPostings::open(&postings_path, populate)?;
         let vocab = MmapHashMap::<str, TokenId>::open(&vocab_path)?;
 
         let point_to_tokens_count = unsafe {
             MmapSlice::try_from(mmap_ops::open_write_mmap(
                 &point_to_tokens_count_path,
                 AdviceSetting::Global,
+                populate,
             )?)?
         };
 
-        let deleted = mmap_ops::open_write_mmap(&deleted_points_path, AdviceSetting::Global)?;
+        let deleted =
+            mmap_ops::open_write_mmap(&deleted_points_path, AdviceSetting::Global, populate)?;
         let deleted = MmapBitSlice::from(deleted, 0);
 
         let num_deleted_points = deleted.count_ones();

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -50,7 +50,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         let hashmap = MmapHashMap::open(&hashmap_path)?;
         let point_to_values = MmapPointToValues::open(path)?;
 
-        let deleted = mmap_ops::open_write_mmap(&deleted_path, AdviceSetting::Global)?;
+        let deleted = mmap_ops::open_write_mmap(&deleted_path, AdviceSetting::Global, false)?;
         let deleted = MmapBitSlice::from(deleted, 0);
         let deleted_count = deleted.count_ones();
 

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -212,7 +212,7 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
         // create new file and mmap
         let file_name = path.join(POINT_TO_VALUES_PATH);
         create_and_ensure_length(&file_name, file_size)?;
-        let mut mmap = open_write_mmap(&file_name, AdviceSetting::Global)?;
+        let mut mmap = open_write_mmap(&file_name, AdviceSetting::Global, false)?;
 
         // fill mmap file data
         let header = Header {
@@ -262,7 +262,7 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
 
     pub fn open(path: &Path) -> OperationResult<Self> {
         let file_name = path.join(POINT_TO_VALUES_PATH);
-        let mmap = open_write_mmap(&file_name, AdviceSetting::Global)?;
+        let mmap = open_write_mmap(&file_name, AdviceSetting::Global, false)?;
         let header =
             Header::read_from_prefix(mmap.as_ref()).ok_or(OperationError::InconsistentStorage {
                 description: NOT_ENOUGHT_BYTES_ERROR_MESSAGE.to_owned(),

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -149,13 +149,14 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
 
         let histogram = Histogram::<T>::load(path)?;
         let config: MmapNumericIndexConfig = read_json(&config_path)?;
-        let deleted = mmap_ops::open_write_mmap(&deleted_path, AdviceSetting::Global)?;
+        let deleted = mmap_ops::open_write_mmap(&deleted_path, AdviceSetting::Global, false)?;
         let deleted = MmapBitSlice::from(deleted, 0);
         let deleted_count = deleted.count_ones();
         let map = unsafe {
             MmapSlice::try_from(mmap_ops::open_write_mmap(
                 &pairs_path,
                 AdviceSetting::Global,
+                false,
             )?)?
         };
         let point_to_values = MmapPointToValues::open(path)?;

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -206,8 +206,13 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
     let vectors_path = path.join(VECTORS_DIR_PATH);
     let deleted_path = path.join(DELETED_DIR_PATH);
 
-    let vectors =
-        ChunkedMmapVectors::<T>::open(&vectors_path, dim, Some(false), AdviceSetting::Global)?;
+    let vectors = ChunkedMmapVectors::<T>::open(
+        &vectors_path,
+        dim,
+        Some(false),
+        AdviceSetting::Global,
+        Some(false),
+    )?;
 
     let deleted: DynamicMmapFlags = DynamicMmapFlags::open(&deleted_path)?;
     let deleted_count = deleted.count_flags();

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -44,7 +44,7 @@ fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
         let length = std::mem::size_of::<DynamicMmapStatus>();
         create_and_ensure_length(&status_file, length)?;
     }
-    Ok(open_write_mmap(&status_file, AdviceSetting::Global)?)
+    Ok(open_write_mmap(&status_file, AdviceSetting::Global, false)?)
 }
 
 pub struct DynamicMmapFlags {

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -52,7 +52,7 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
         // Allocate/open vectors mmap
         ensure_mmap_file_size(vectors_path, VECTORS_HEADER, None)
             .describe("Create mmap data file")?;
-        let mmap = mmap_ops::open_read_mmap(vectors_path, AdviceSetting::Global)
+        let mmap = mmap_ops::open_read_mmap(vectors_path, AdviceSetting::Global, false)
             .describe("Open mmap for reading")?;
         let num_vectors = (mmap.len() - HEADER_SIZE) / dim / size_of::<T>();
 

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -60,7 +60,7 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
         let deleted_mmap_size = deleted_mmap_size(num_vectors);
         ensure_mmap_file_size(deleted_path, DELETED_HEADER, Some(deleted_mmap_size as u64))
             .describe("Create mmap deleted file")?;
-        let deleted_mmap = mmap_ops::open_write_mmap(deleted_path, AdviceSetting::Global)
+        let deleted_mmap = mmap_ops::open_write_mmap(deleted_path, AdviceSetting::Global, false)
             .describe("Open mmap deleted for writing")?;
 
         // Advise kernel that we'll need this page soon so the kernel can prepare

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -6,33 +6,22 @@ use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
-use crate::vector_storage::chunked_vectors::ChunkedVectors;
 
 #[derive(Debug)]
 pub struct InRamPersistedVectors<T: Sized + 'static> {
     mmap_storage: ChunkedMmapVectors<T>,
-    vectors: ChunkedVectors<T>,
 }
 
 impl<T: Sized + Copy + Clone + Default + 'static> InRamPersistedVectors<T> {
     pub fn open(directory: &Path, dim: usize) -> OperationResult<Self> {
-        let mut vectors = ChunkedVectors::new(dim);
-
-        let mut mmap_storage = ChunkedMmapVectors::open(
+        let mmap_storage = ChunkedMmapVectors::open(
             directory,
             dim,
             Some(false),
             AdviceSetting::from(Advice::Normal),
+            Some(true),
         )?;
-        mmap_storage.for_each_vector_then_discard_page_cache(|vector| {
-            vectors.push(vector)?;
-            Ok(())
-        })?;
-
-        Ok(Self {
-            mmap_storage,
-            vectors,
-        })
+        Ok(Self { mmap_storage })
     }
 }
 
@@ -41,7 +30,7 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
 {
     #[inline]
     fn len(&self) -> usize {
-        self.vectors.len()
+        self.mmap_storage.len()
     }
 
     #[inline]
@@ -51,7 +40,7 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
 
     #[inline]
     fn get(&self, key: VectorOffsetType) -> Option<&[T]> {
-        self.vectors.get_opt(key)
+        self.mmap_storage.get(key)
     }
 
     #[inline]
@@ -66,17 +55,12 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
 
     #[inline]
     fn push(&mut self, vector: &[T]) -> OperationResult<VectorOffsetType> {
-        let key = self.vectors.push(vector)?;
-        let key2 = self.mmap_storage.push(vector)?;
-        debug_assert_eq!(key, key2);
-        Ok(key)
+        self.mmap_storage.push(vector)
     }
 
     #[inline]
     fn insert(&mut self, key: VectorOffsetType, vector: &[T]) -> OperationResult<()> {
-        self.vectors.insert(key, vector)?;
-        self.mmap_storage.insert(key, vector)?;
-        Ok(())
+        self.mmap_storage.insert(key, vector)
     }
 
     #[inline]
@@ -86,19 +70,17 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
         vectors: &[T],
         count: usize,
     ) -> OperationResult<()> {
-        self.vectors.insert_many(start_key, vectors, count)?;
-        self.mmap_storage.insert_many(start_key, vectors, count)?;
-        Ok(())
+        self.mmap_storage.insert_many(start_key, vectors, count)
     }
 
     #[inline]
     fn get_many(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
-        self.vectors.get_many(key, count)
+        self.mmap_storage.get_many(key, count)
     }
 
     #[inline]
     fn get_remaining_chunk_keys(&self, start_key: VectorOffsetType) -> usize {
-        self.vectors.get_chunk_left_keys(start_key)
+        self.mmap_storage.get_remaining_chunk_keys(start_key)
     }
 
     fn max_vector_size_bytes(&self) -> usize {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -337,8 +337,20 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
     let offsets_path = path.join(OFFSETS_DIR_PATH);
     let deleted_path = path.join(DELETED_DIR_PATH);
 
-    let vectors = ChunkedMmapVectors::open(&vectors_path, dim, Some(false), AdviceSetting::Global)?;
-    let offsets = ChunkedMmapVectors::open(&offsets_path, 1, Some(false), AdviceSetting::Global)?;
+    let vectors = ChunkedMmapVectors::open(
+        &vectors_path,
+        dim,
+        Some(false),
+        AdviceSetting::Global,
+        Some(false),
+    )?;
+    let offsets = ChunkedMmapVectors::open(
+        &offsets_path,
+        1,
+        Some(false),
+        AdviceSetting::Global,
+        Some(false),
+    )?;
 
     let deleted: DynamicMmapFlags = DynamicMmapFlags::open(&deleted_path)?;
     let deleted_count = deleted.count_flags();

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -258,7 +258,11 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
 
         Ok(Self {
             path: path.as_ref().to_owned(),
-            mmap: Arc::new(open_read_mmap(file_path.as_ref(), AdviceSetting::Global)?),
+            mmap: Arc::new(open_read_mmap(
+                file_path.as_ref(),
+                AdviceSetting::Global,
+                false,
+            )?),
             file_header,
             _phantom: PhantomData,
         })
@@ -271,7 +275,11 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
         let file_header: InvertedIndexFileHeader = read_json(&config_file_path)?;
         // read index data into mmap
         let file_path = Self::index_file_path(path.as_ref());
-        let mmap = open_read_mmap(file_path.as_ref(), AdviceSetting::from(Advice::Normal))?;
+        let mmap = open_read_mmap(
+            file_path.as_ref(),
+            AdviceSetting::from(Advice::Normal),
+            false,
+        )?;
         Ok(Self {
             path: path.as_ref().to_owned(),
             mmap: Arc::new(mmap),

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -160,7 +160,11 @@ impl InvertedIndexMmap {
         let file_path = Self::index_file_path(path.as_ref());
         create_and_ensure_length(file_path.as_ref(), file_length)?;
 
-        let mut mmap = open_write_mmap(file_path.as_ref(), AdviceSetting::from(Advice::Normal))?;
+        let mut mmap = open_write_mmap(
+            file_path.as_ref(),
+            AdviceSetting::from(Advice::Normal),
+            false,
+        )?;
 
         // file index data
         Self::save_posting_headers(&mut mmap, inverted_index_ram, total_posting_headers_size);

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -199,7 +199,11 @@ impl InvertedIndexMmap {
         let file_header: InvertedIndexFileHeader = read_json(&config_file_path)?;
         // read index data into mmap
         let file_path = Self::index_file_path(path.as_ref());
-        let mmap = open_read_mmap(file_path.as_ref(), AdviceSetting::from(Advice::Normal))?;
+        let mmap = open_read_mmap(
+            file_path.as_ref(),
+            AdviceSetting::from(Advice::Normal),
+            false,
+        )?;
         Ok(Self {
             path: path.as_ref().to_owned(),
             mmap: Arc::new(mmap),

--- a/lib/sparse/src/index/loaders.rs
+++ b/lib/sparse/src/index/loaders.rs
@@ -38,6 +38,7 @@ impl Csr {
         Self::from_mmap(open_read_mmap(
             path.as_ref(),
             AdviceSetting::from(Advice::Normal),
+            false,
         )?)
     }
 


### PR DESCRIPTION
- Instead of in-ram + mmap we can just force mmap in ram with populate
- Should solve double memory usage of experimental vector storage along with cold start and OOM problems
- required benchmarks