### PR TITLE
fix mismatch of index parametrization and type

### DIFF
--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -155,6 +155,13 @@ $docker_grpcurl -d '{
   ]
 }' $QDRANT_HOST qdrant.Collections/UpdateAliases
 
+# create bool index
+$docker_grpcurl -d '{
+  "collection_name": "test_collection",
+  "field_name": "bool_field",
+  "field_type": 5,
+  "field_index_params": { "bool_index_params": {} }
+}' $QDRANT_HOST qdrant.Points/CreateFieldIndex
 
 $docker_grpcurl -d '{
   "collection_name": "test_collection",


### PR DESCRIPTION
We had a bug where selecting `field_type: Bool` and `field_index_params: { bool_index_params: {} }` would result in a mismatch error, and same for Geo type. 

With these changes we fix it and also we make sure to not forget it in the future via a compiler error.