### PR TITLE
Fix gen_storage_compat_data permissions

### DIFF
--- a/tests/storage-compat/gen_storage_compat_data.sh
+++ b/tests/storage-compat/gen_storage_compat_data.sh
@@ -81,6 +81,8 @@ gzip "${SCRIPT_DIR}/full-snapshot.snapshot"
 
 rm "${SCRIPT_DIR}/storage.tar.bz2" || true
 
+sudo chown -R $(whoami) ./storage
+
 # Save current storage folder
 tar -cjvf "${SCRIPT_DIR}/storage.tar.bz2" ./storage
 


### PR DESCRIPTION
Some files in the storage are created with 600 permissions

![image](https://github.com/user-attachments/assets/24a67727-797e-458d-a6d7-2d1079f94654)

To mitigate this, script will try do chown.

## Alternative

Use less restrictive file permissions