### PR TITLE
[Strict-mode] Verification check in API

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -244,6 +244,14 @@ impl Collection {
         Ok(())
     }
 
+    pub async fn strict_mode_config(&self) -> Option<StrictModeConfig> {
+        self.collection_config
+            .read()
+            .await
+            .strict_mode_config
+            .clone()
+    }
+
     pub async fn info(
         &self,
         shard_selection: &ShardSelectorInternal,

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -8,6 +8,19 @@ use super::config_diff::StrictModeConfig;
 use super::types::CollectionError;
 use crate::collection::Collection;
 
+// Creates a new `VerificationPass` for successful verifications.
+// Don't use this, unless you know what you're doing!
+pub fn new_pass() -> VerificationPass {
+    VerificationPass { inner: () }
+}
+
+/// A pass, created on successful verification.
+pub struct VerificationPass {
+    // Private field, so we can't instantiate it from somewhere else.
+    #[allow(dead_code)]
+    inner: (),
+}
+
 /// Trait to verify strict mode for requests.
 /// This trait ignores the `enabled` parameter in `StrictModeConfig`.
 pub trait StrictModeVerification {
@@ -32,7 +45,7 @@ pub trait StrictModeVerification {
     fn indexed_filter_read(&self) -> Option<&Filter>;
 
     /// Verifies that all keys in the given filter have an index available. Only implement this
-    /// if the filter is used for FILTERED-updates like delete by payload.
+    /// if the filter is used for filtered-UPDATES like delete by payload.
     /// For read only filters implement `request_indexed_filter_read`!
     fn indexed_filter_write(&self) -> Option<&Filter>;
 

--- a/lib/storage/src/content_manager/collection_verification.rs
+++ b/lib/storage/src/content_manager/collection_verification.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use collection::collection::Collection;
-use collection::operations::config_diff::StrictModeConfig;
-use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::verification::{new_pass, StrictModeVerification, VerificationPass};
 
 use super::errors::StorageError;
@@ -10,51 +7,28 @@ use super::toc::TableOfContent;
 use crate::dispatcher::Dispatcher;
 use crate::rbac::{Access, AccessRequirements};
 
-/// Trait for verification checks of collection operation requests.
-pub trait CollectionRequestVerification {
-    #[allow(async_fn_in_trait)]
-    async fn check(
-        &self,
-        dispatcher: &Dispatcher,
-        access: &Access,
-        collection_name: &str,
-    ) -> Result<VerificationPass, StorageError> {
-        let toc = get_toc_without_verification_pass(dispatcher, access);
+pub async fn check_strict_mode(
+    request: &impl StrictModeVerification,
+    collection_name: &str,
+    dispatcher: &Dispatcher,
+    access: &Access,
+) -> Result<VerificationPass, StorageError> {
+    let toc = get_toc_without_verification_pass(dispatcher, access);
 
-        self.check_strict_mode(toc, access, collection_name).await?;
+    // Check access here first since strict-mode gets checked before `access`.
+    // If we simply bypassed here, requests to a collection a user doesn't has access to could leak
+    // information, like existence, strict mode config, payload indices, ...
+    let collection_pass =
+        access.check_collection_access(collection_name, AccessRequirements::new())?;
+    let collection = toc.get_collection(&collection_pass).await?;
 
-        Ok(new_pass())
-    }
-
-    #[allow(async_fn_in_trait)]
-    async fn check_strict_mode(
-        &self,
-        toc: &Arc<TableOfContent>,
-        access: &Access,
-        collection: &str,
-    ) -> Result<(), StorageError> {
-        // Check access here first since strict-mode gets checked before `access`.
-        // If we simply bypassed here, requests to a collection a user doesn't has access to could leak
-        // information, like existence, strict mode config, payload indices, ...
-        let collection_pass =
-            access.check_collection_access(collection, AccessRequirements::new())?;
-        let collection = toc.get_collection(&collection_pass).await?;
-        let collection_info = collection.info(&ShardSelectorInternal::All).await?;
-
-        if let Some(strict_mode_config) = &collection_info.config.strict_mode_config {
-            if strict_mode_config.enabled.unwrap_or_default() {
-                self.check_strict_mode_inner(&collection, strict_mode_config)?;
-            }
+    if let Some(strict_mode_config) = &collection.strict_mode_config().await {
+        if strict_mode_config.enabled.unwrap_or_default() {
+            request.check_strict_mode(&collection, strict_mode_config)?;
         }
-
-        Ok(())
     }
 
-    fn check_strict_mode_inner(
-        &self,
-        collection: &Collection,
-        strict_mode_config: &StrictModeConfig,
-    ) -> Result<(), StorageError>;
+    Ok(new_pass())
 }
 
 /// Returns the `TableOfContents` from `dispatcher` without needing a validity check.
@@ -66,18 +40,4 @@ fn get_toc_without_verification_pass<'a>(
 ) -> &'a Arc<TableOfContent> {
     let pass = new_pass();
     dispatcher.toc_new(access, &pass)
-}
-
-impl<T> CollectionRequestVerification for T
-where
-    T: StrictModeVerification + Sync,
-{
-    fn check_strict_mode_inner(
-        &self,
-        collection: &Collection,
-        strict_mode_config: &StrictModeConfig,
-    ) -> Result<(), StorageError> {
-        StrictModeVerification::check_strict_mode(self, collection, strict_mode_config)
-            .map_err(From::from)
-    }
 }

--- a/lib/storage/src/content_manager/collection_verification.rs
+++ b/lib/storage/src/content_manager/collection_verification.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use collection::collection::Collection;
+use collection::operations::config_diff::StrictModeConfig;
+use collection::operations::shard_selector_internal::ShardSelectorInternal;
+use collection::operations::verification::{new_pass, StrictModeVerification, VerificationPass};
+
+use super::errors::StorageError;
+use super::toc::TableOfContent;
+use crate::dispatcher::Dispatcher;
+use crate::rbac::{Access, AccessRequirements};
+
+/// Trait for verification checks of collection operation requests.
+pub trait CollectionRequestVerification {
+    #[allow(async_fn_in_trait)]
+    async fn check(
+        &self,
+        dispatcher: &Dispatcher,
+        access: &Access,
+        collection_name: &str,
+    ) -> Result<VerificationPass, StorageError> {
+        let toc = get_toc_without_verification_pass(dispatcher, access);
+
+        self.check_strict_mode(toc, access, collection_name).await?;
+
+        Ok(new_pass())
+    }
+
+    #[allow(async_fn_in_trait)]
+    async fn check_strict_mode(
+        &self,
+        toc: &Arc<TableOfContent>,
+        access: &Access,
+        collection: &str,
+    ) -> Result<(), StorageError> {
+        // Check access here first since strict-mode gets checked before `access`.
+        // If we simply bypassed here, requests to a collection a user doesn't has access to could leak
+        // information, like existence, strict mode config, payload indices, ...
+        let collection_pass =
+            access.check_collection_access(collection, AccessRequirements::new())?;
+        let collection = toc.get_collection(&collection_pass).await?;
+        let collection_info = collection.info(&ShardSelectorInternal::All).await?;
+
+        if let Some(strict_mode_config) = &collection_info.config.strict_mode_config {
+            if strict_mode_config.enabled.unwrap_or_default() {
+                self.check_strict_mode_inner(&collection, strict_mode_config)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_strict_mode_inner(
+        &self,
+        collection: &Collection,
+        strict_mode_config: &StrictModeConfig,
+    ) -> Result<(), StorageError>;
+}
+
+/// Returns the `TableOfContents` from `dispatcher` without needing a validity check.
+/// Caution: Do only use this to obtain a `VerificationPass`!
+/// Don't make public!
+fn get_toc_without_verification_pass<'a>(
+    dispatcher: &'a Dispatcher,
+    access: &Access,
+) -> &'a Arc<TableOfContent> {
+    let pass = new_pass();
+    dispatcher.toc_new(access, &pass)
+}
+
+impl<T> CollectionRequestVerification for T
+where
+    T: StrictModeVerification + Sync,
+{
+    fn check_strict_mode_inner(
+        &self,
+        collection: &Collection,
+        strict_mode_config: &StrictModeConfig,
+    ) -> Result<(), StorageError> {
+        StrictModeVerification::check_strict_mode(self, collection, strict_mode_config)
+            .map_err(From::from)
+    }
+}

--- a/lib/storage/src/content_manager/collection_verification.rs
+++ b/lib/storage/src/content_manager/collection_verification.rs
@@ -21,7 +21,6 @@ pub async fn check_strict_mode(
     let collection_pass =
         access.check_collection_access(collection_name, AccessRequirements::new())?;
     let collection = toc.get_collection(&collection_pass).await?;
-
     if let Some(strict_mode_config) = &collection.strict_mode_config().await {
         if strict_mode_config.enabled.unwrap_or_default() {
             request.check_strict_mode(&collection, strict_mode_config)?;

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -6,6 +6,7 @@ use self::errors::StorageError;
 
 pub mod alias_mapping;
 pub mod collection_meta_ops;
+pub mod collection_verification;
 mod collections_ops;
 pub mod consensus;
 pub mod consensus_manager;

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use collection::config::ShardingMethod;
+use collection::operations::verification::VerificationPass;
 use common::defaults::CONSENSUS_META_OP_WAIT;
 use segment::types::default_shard_number_per_node_const;
 
@@ -38,7 +39,19 @@ impl Dispatcher {
     /// Get the table of content.
     /// The `_access` parameter is not used, but it's required to verify caller's possession
     /// of the [Access] object.
+    /// TODO: replace with `toc_new`
     pub fn toc(&self, _access: &Access) -> &Arc<TableOfContent> {
+        &self.toc
+    }
+
+    /// Get the table of content.
+    /// The `_access` and `_verification_pass` parameter are not used, but it's required to verify caller's possession
+    /// of both objects.
+    pub fn toc_new(
+        &self,
+        _access: &Access,
+        _verification_pass: &VerificationPass,
+    ) -> &Arc<TableOfContent> {
         &self.toc
     }
 

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -28,15 +28,18 @@ async fn search_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    let pass = match check_strict_mode(&request.0, &collection.name, &dispatcher, &access).await {
-        Ok(pass) => pass,
-        Err(err) => return process_response_error(err, Instant::now()),
-    };
+    let search_request = request.into_inner();
+
+    let pass =
+        match check_strict_mode(&search_request, &collection.name, &dispatcher, &access).await {
+            Ok(pass) => pass,
+            Err(err) => return process_response_error(err, Instant::now()),
+        };
 
     let SearchRequest {
         search_request,
         shard_key,
-    } = request.into_inner();
+    } = search_request;
 
     let shard_selection = match shard_key {
         None => ShardSelectorInternal::All,
@@ -71,12 +74,13 @@ async fn batch_search_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    let pass = match check_strict_mode(&request.0, &collection.name, &dispatcher, &access).await {
+    let request = request.into_inner();
+
+    let pass = match check_strict_mode(&request, &collection.name, &dispatcher, &access).await {
         Ok(pass) => pass,
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let request = request.into_inner();
     let requests = request
         .searches
         .into_iter()

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -8,7 +8,7 @@ use collection::operations::types::{
 };
 use futures::TryFutureExt;
 use itertools::Itertools;
-use storage::content_manager::collection_verification::CollectionRequestVerification;
+use storage::content_manager::collection_verification::check_strict_mode;
 use storage::dispatcher::Dispatcher;
 use tokio::time::Instant;
 
@@ -28,7 +28,7 @@ async fn search_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    let pass = match request.check(&dispatcher, &access, &collection.name).await {
+    let pass = match check_strict_mode(&request.0, &collection.name, &dispatcher, &access).await {
         Ok(pass) => pass,
         Err(err) => return process_response_error(err, Instant::now()),
     };
@@ -71,7 +71,7 @@ async fn batch_search_points(
     params: Query<ReadParams>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    let pass = match request.check(&dispatcher, &access, &collection.name).await {
+    let pass = match check_strict_mode(&request.0, &collection.name, &dispatcher, &access).await {
         Ok(pass) => pass,
         Err(err) => return process_response_error(err, Instant::now()),
     };


### PR DESCRIPTION
Adds a trait for request verification and implements it for the search REST API.

To ensure we don't forget to implement checks for future endpoints, a new `toc_new` function gets introduced that requires a new, empty type created when verification was successful. 

We also need to check for access rights in strict mode, since it gets executed before the operation, which usually does the check. An alternative would be to combine `Access` and `Verification`, let `CollectionRequestVerification` do the access check and use only `Verification` as parameter for `toc(..)`.