### PR TITLE
fix: Non-blocking payload index building

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -410,13 +410,15 @@ impl<'s> SegmentHolder {
 
     pub fn apply_segments<F>(&self, mut f: F) -> OperationResult<usize>
     where
-        F: FnMut(&mut RwLockWriteGuard<dyn SegmentEntry + 'static>) -> OperationResult<bool>,
+        F: FnMut(
+            &mut RwLockUpgradableReadGuard<dyn SegmentEntry + 'static>,
+        ) -> OperationResult<bool>,
     {
         let _update_guard = self.update_tracker.update();
 
         let mut processed_segments = 0;
         for (_id, segment) in self.iter() {
-            let is_applied = f(&mut segment.get().write())?;
+            let is_applied = f(&mut segment.get().upgradable_read())?;
             processed_segments += usize::from(is_applied);
         }
         Ok(processed_segments)

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -8,6 +8,7 @@ use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use parking_lot::Mutex;
 use schemars::_serde_json::Value;
 
+use super::field_index::FieldIndex;
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
@@ -83,17 +84,24 @@ impl PayloadIndex for PlainPayloadIndex {
         self.config.indexed_fields.clone()
     }
 
-    fn set_indexed(
-        &mut self,
-        field: PayloadKeyTypeRef,
-        payload_schema: impl Into<PayloadFieldSchema>,
-    ) -> OperationResult<()> {
-        let payload_schema = payload_schema.into();
+    fn build_index(
+        &self,
+        _field: PayloadKeyTypeRef,
+        _payload_schema: &PayloadFieldSchema,
+    ) -> OperationResult<Option<Vec<FieldIndex>>> {
+        Ok(Some(Vec::new()))
+    }
 
+    fn apply_index(
+        &mut self,
+        field: PayloadKeyType,
+        payload_schema: PayloadFieldSchema,
+        _field_index: Vec<FieldIndex>,
+    ) -> OperationResult<()> {
         if let Some(prev_schema) = self
             .config
             .indexed_fields
-            .insert(field.to_owned(), payload_schema.clone())
+            .insert(field, payload_schema.clone())
         {
             // the field is already present with the same schema, no need to save the config
             if prev_schema == payload_schema {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -641,10 +641,15 @@ impl SegmentEntry for Segment {
 
     fn build_field_index(
         &self,
-        _op_num: SeqNumberType,
+        op_num: SeqNumberType,
         key: PayloadKeyTypeRef,
         field_type: Option<&PayloadFieldSchema>,
     ) -> OperationResult<Option<(PayloadFieldSchema, Vec<FieldIndex>)>> {
+        // Check version without updating it
+        if self.version.unwrap_or(0) > op_num {
+            return Ok(None);
+        }
+
         match field_type {
             Some(schema) => {
                 let res = self

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -19,7 +19,7 @@ use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{QueryVector, Vector};
 use crate::entry::entry_point::SegmentEntry;
-use crate::index::field_index::CardinalityEstimation;
+use crate::index::field_index::{CardinalityEstimation, FieldIndex};
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::json_path::JsonPath;
 use crate::segment::{
@@ -639,32 +639,54 @@ impl SegmentEntry for Segment {
         })
     }
 
-    fn create_field_index(
-        &mut self,
-        op_num: u64,
+    fn build_field_index(
+        &self,
+        _op_num: SeqNumberType,
         key: PayloadKeyTypeRef,
         field_type: Option<&PayloadFieldSchema>,
-    ) -> OperationResult<bool> {
-        self.handle_segment_version_and_failure(op_num, |segment| match field_type {
+    ) -> OperationResult<Option<(PayloadFieldSchema, Vec<FieldIndex>)>> {
+        match field_type {
             Some(schema) => {
-                segment
+                let res = self
                     .payload_index
                     .borrow_mut()
-                    .set_indexed(key, schema.clone())?;
-                Ok(true)
+                    .build_index(key, schema)?
+                    .map(|field_index| (schema.to_owned(), field_index));
+
+                Ok(res)
             }
-            None => match segment.infer_from_payload_data(key)? {
+            None => match self.infer_from_payload_data(key)? {
                 None => Err(TypeInferenceError {
                     field_name: key.clone(),
                 }),
                 Some(schema_type) => {
-                    segment
+                    let schema = schema_type.into();
+
+                    let res = self
                         .payload_index
                         .borrow_mut()
-                        .set_indexed(key, schema_type)?;
-                    Ok(true)
+                        .build_index(key, &schema)?
+                        .map(|field_index| (schema, field_index));
+
+                    Ok(res)
                 }
             },
+        }
+    }
+
+    fn apply_field_index(
+        &mut self,
+        op_num: SeqNumberType,
+        key: PayloadKeyType,
+        schema: PayloadFieldSchema,
+        field_index: Vec<FieldIndex>,
+    ) -> OperationResult<bool> {
+        self.handle_segment_version_and_failure(op_num, |segment| {
+            segment
+                .payload_index
+                .borrow_mut()
+                .apply_index(key, schema, field_index)?;
+            Ok(true)
         })
     }
 

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -126,6 +126,7 @@ def create_field_index(
             "field_schema": field_schema,
         },
         headers=headers,
+        params={"wait": "true"}
     )
     assert_http_ok(r_batch)
 

--- a/tests/consensus_tests/test_issues_api.py
+++ b/tests/consensus_tests/test_issues_api.py
@@ -95,6 +95,8 @@ def test_unindexed_field_is_gone_when_indexing(setup_with_big_collection):
 
     # check the issue is now active
     issue_present = False
+    solution = None
+    timestamp = None
     for issue in issues:
         if issue["id"] == expected_issue_code:
             issue_present = True
@@ -102,7 +104,9 @@ def test_unindexed_field_is_gone_when_indexing(setup_with_big_collection):
             timestamp = issue["timestamp"]
             break
     assert issue_present
-
+    assert solution is not None
+    assert timestamp is not None
+    
     # search again
     search_with_city_filter(uri)
 
@@ -116,6 +120,8 @@ def test_unindexed_field_is_gone_when_indexing(setup_with_big_collection):
             assert timestamp == issue["timestamp"]
             break
     assert issue_present
+    assert solution is not None
+    assert timestamp is not None
 
     assert solution == {
         "method": "PUT",
@@ -128,6 +134,7 @@ def test_unindexed_field_is_gone_when_indexing(setup_with_big_collection):
     response = requests.request(
         method=solution["method"],
         url=uri + solution["uri"],
+        params={"wait": "true"},
         json=solution["body"],
     )
     assert response.ok


### PR DESCRIPTION
Fixes #4934 

Currently, when we build a payload index, we hold a write lock the entire time the index is being built. This might be acceptable for small collections, but on bigger ones this means that searches will be completely interrupted (and even make them timeout) during building.

With these changes I've separated the building and applying sections, so that we only need a read lock when building, and upgrades to a write lock when applying it to the segment.

I've tested this manually with bfb + dashboard, and now searches keep responding normally during index building, with only a really small hiccup at the end.