### PR TITLE
Switch to sparse tar implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6232,8 +6232,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tar"
 version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+source = "git+https://github.com/qdrant/tar-rs?branch=main#856dbd090eede1736604f23cfe99a104b5639734"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,3 +245,7 @@ inherits = "release"
 lto = false
 opt-level = 3
 codegen-units = 256 # restore default value for faster compilation
+
+[patch.crates-io]
+# Temporary patch until our PRs are merged.
+tar = { git = "https://github.com/qdrant/tar-rs", branch="main" }

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -155,6 +155,7 @@ impl Collection {
         log::debug!("Archiving snapshot {snapshot_temp_target_dir_path:?}");
         let archiving = tokio::task::spawn_blocking(move || -> CollectionResult<_> {
             let mut builder = tar::Builder::new(snapshot_temp_arc_file.as_file_mut());
+            builder.sparse(true);
             // archive recursively collection directory `snapshot_path_with_arc_extension` into `snapshot_path`
             builder.append_dir_all(".", &snapshot_temp_target_dir_path)?;
             builder.finish()?;

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -877,6 +877,7 @@ impl ShardHolder {
 
             cancel::blocking::spawn_cancel_on_drop(move |cancel| -> CollectionResult<_> {
                 let mut tar = TarBuilder::new(temp_file.as_file_mut());
+                tar.sparse(true);
 
                 if cancel.is_cancelled() {
                     return Err(cancel::Error::Cancelled.into());

--- a/lib/segment/src/common/validate_snapshot_archive.rs
+++ b/lib/segment/src/common/validate_snapshot_archive.rs
@@ -31,7 +31,7 @@ pub fn open_snapshot_archive_with_validation<P: AsRef<Path>>(
             };
             if !matches!(
                 entry_type,
-                tar::EntryType::Regular | tar::EntryType::Directory,
+                tar::EntryType::Regular | tar::EntryType::Directory | tar::EntryType::GNUSparse
             ) {
                 return Err(OperationError::ValidationError {
                     description: format!(

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -776,6 +776,7 @@ impl SegmentEntry for Segment {
         })?;
 
         let mut builder = Builder::new(file);
+        builder.sparse(true);
 
         builder
             .append_dir_all(SNAPSHOT_PATH, &temp_path)

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -180,6 +180,7 @@ async fn _do_create_full_snapshot(
         // have to use std here, cause TarBuilder is not async
         let file = std::fs::File::create(&full_snapshot_path_clone)?;
         let mut builder = TarBuilder::new(file);
+        builder.sparse(true);
         for (temp_file, snapshot_name) in temp_collection_snapshots {
             builder.append_path_with_name(&temp_file, &snapshot_name)?;
         }


### PR DESCRIPTION
This PR enables sparse tar implementation from our `tar-rs` fork.

It provides two main benefits:
- Snapshots archives become smaller, especially for newly created collections.
- Collection restored from snapshots would also take less on-disk size.

## How it works

When you create an empty file and set it size, but do not explicitly write bytes into it, the file will be filled with zeroes. The modern filesystems do not store these zeroes. Instead, they efficiently store ranges of zeroed blocks as "holes".

Qdrant uses sparse files extensively. In particular, empty collections have a high sparse-to-dense ratio. For example, WAL[^1] files by default are 32MiB filled with zeroes. Or any storage file created by [`create_and_ensure_length()`] is sparse.

If we naively copy these files bytewise, we'll lose their sparseness, blowing their size. In my branch of `tar-rs` I've made `tar::Builder` to properly store the sparseness of files. Upstream PR: https://github.com/alexcrichton/tar-rs/pull/375

[^1]: Arguably, we don't even need to put the whole WAL into a snapshot. As @generall explained, we need to story only the last sequence ID, an could potentially optimize it away. But it's out of the scope of this PR.

[`create_and_ensure_length()`]: https://github.com/qdrant/qdrant/blob/v1.11.0/lib/common/memory/src/mmap_ops.rs#L15


## Comparison for empty collection

<table>
    <tr>
        <th>
        <th>current dev
        <th>this PR
    <tr>
        <td>On-disk collection size (<code>du -sh</code>)
        <td colspan=2 align=center>1.3MiB
    <tr>
        <td>Apparent collection size (<code>du -sh --apparent-size</code>)
        <td colspan=2 align=center>65MiB
    <tr>
        <td>Collection snapshot size
        <td align=right>65MiB
        <td align=right>📉16KiB
    <tr>
        <td>Snapshot creation time
        <td align=right>2.07s
        <td align=right>📉0.73s
    <tr>
        <td>Snapshot restore time
        <td align=right>0.79s
        <td align=right>0.78s
    <tr>
        <td>On-disk collection size (after restore)
        <td align=right>66MiB
        <td align=right>📉1.6MiB
    <tr>
        <td>Apparent collection size (after restore)
        <td align=right>66MiB
        <td align=right>66MiB
</table>