### PR TITLE
[StrictMode, review refactor]: decouple extractor from issues

### DIFF
--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -72,10 +72,10 @@ pub trait StrictModeVerification {
             |filter: Option<&Filter>, allow_unindexed_filter: Option<bool>| -> Result<(), String> {
                 if let Some(read_filter) = filter {
                     if allow_unindexed_filter == Some(false) {
-                        if let Some(key) = collection.filter_without_index(read_filter) {
+                        if let Some(key) = collection.one_unindexed_key(read_filter) {
                             return Err(new_error_msg(
                                 format!("Index required but not found for \"{key}\""),
-                                "Create an index or use a different filter.",
+                                "Create an index for this key or use a different filter.",
                             ));
                         }
                     }

--- a/lib/collection/src/tests/payload.rs
+++ b/lib/collection/src/tests/payload.rs
@@ -65,7 +65,7 @@ async fn test_payload_missing_index_check() {
         shard
             .payload_index_schema
             .read()
-            .filter_without_index(&geo_filter, &collection_name),
+            .one_unindexed_key(&geo_filter),
         Some(JsonPath::from_str("location").unwrap())
     );
 
@@ -83,7 +83,7 @@ async fn test_payload_missing_index_check() {
         shard
             .payload_index_schema
             .read()
-            .filter_without_index(&geo_filter, &collection_name),
+            .one_unindexed_key(&geo_filter),
         None
     );
 
@@ -106,7 +106,7 @@ async fn test_payload_missing_index_check() {
         shard
             .payload_index_schema
             .read()
-            .filter_without_index(&num_filter, &collection_name),
+            .one_unindexed_key(&num_filter),
         Some("location.lat".parse().unwrap())
     );
 
@@ -124,7 +124,7 @@ async fn test_payload_missing_index_check() {
         shard
             .payload_index_schema
             .read()
-            .filter_without_index(&num_filter, &collection_name),
+            .one_unindexed_key(&num_filter),
         None,
     );
 
@@ -134,7 +134,7 @@ async fn test_payload_missing_index_check() {
         shard
             .payload_index_schema
             .read()
-            .filter_without_index(&combined_filter, &collection_name),
+            .one_unindexed_key(&combined_filter),
         None,
     );
 }


### PR DESCRIPTION
I think the current extractor is too coupled with the issues API when it shouldn't be. 

This fixes it and renames some methods.