### PR TITLE
Integer and UUID facets

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2476,6 +2476,7 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | string_value | [string](#string) |  | String value from the facet |
+| integer_value | [int64](#int64) |  | Integer value from the facet |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2477,6 +2477,7 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | string_value | [string](#string) |  | String value from the facet |
 | integer_value | [int64](#int64) |  | Integer value from the facet |
+| uuid_value | [string](#string) |  | UUID value from the facet |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2477,7 +2477,6 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | string_value | [string](#string) |  | String value from the facet |
 | integer_value | [int64](#int64) |  | Integer value from the facet |
-| uuid_value | [string](#string) |  | UUID value from the facet |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -13180,6 +13180,10 @@
         "anyOf": [
           {
             "type": "string"
+          },
+          {
+            "type": "integer",
+            "format": "int64"
           }
         ]
       }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2273,6 +2273,11 @@ impl TryFrom<FacetValue> for segment_facets::FacetValue {
         Ok(match variant {
             Variant::StringValue(value) => segment_facets::FacetValue::Keyword(value),
             Variant::IntegerValue(value) => segment_facets::FacetValue::Int(value),
+            Variant::UuidValue(value) => segment_facets::FacetValue::Uuid(
+                Uuid::parse_str(&value)
+                    .map_err(|_| Status::invalid_argument("Invalid UUID"))?
+                    .as_u128(),
+            ),
         })
     }
 }
@@ -2285,6 +2290,9 @@ impl From<segment_facets::FacetValue> for FacetValue {
             variant: Some(match value {
                 segment_facets::FacetValue::Keyword(value) => Variant::StringValue(value),
                 segment_facets::FacetValue::Int(value) => Variant::IntegerValue(value),
+                segment_facets::FacetValue::Uuid(value) => {
+                    Variant::UuidValue(Uuid::from_u128(value).to_string())
+                }
             }),
         }
     }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2272,6 +2272,7 @@ impl TryFrom<FacetValue> for segment_facets::FacetValue {
 
         Ok(match variant {
             Variant::StringValue(value) => segment_facets::FacetValue::Keyword(value),
+            Variant::IntegerValue(value) => segment_facets::FacetValue::Int(value),
         })
     }
 }
@@ -2283,6 +2284,7 @@ impl From<segment_facets::FacetValue> for FacetValue {
         Self {
             variant: Some(match value {
                 segment_facets::FacetValue::Keyword(value) => Variant::StringValue(value),
+                segment_facets::FacetValue::Int(value) => Variant::IntegerValue(value),
             }),
         }
     }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -19,11 +19,11 @@ use uuid::Uuid;
 use super::qdrant::raw_query::RawContextPair;
 use super::qdrant::{
     raw_query, start_from, BinaryQuantization, BoolIndexParams, CompressionRatio,
-    DatetimeIndexParams, DatetimeRange, Direction, FacetHit, FacetValue, FieldType,
-    FloatIndexParams, GeoIndexParams, GeoLineString, GroupId, KeywordIndexParams, LookupLocation,
-    MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range, RawVector,
-    RecommendStrategy, SearchPointGroups, SearchPoints, ShardKeySelector, SparseIndices, StartFrom,
-    UuidIndexParams, WithLookup,
+    DatetimeIndexParams, DatetimeRange, Direction, FacetHit, FacetHitInternal, FacetValue,
+    FacetValueInternal, FieldType, FloatIndexParams, GeoIndexParams, GeoLineString, GroupId,
+    KeywordIndexParams, LookupLocation, MultiVectorComparator, MultiVectorConfig, OrderBy,
+    OrderValue, Range, RawVector, RecommendStrategy, SearchPointGroups, SearchPoints,
+    ShardKeySelector, SparseIndices, StartFrom, UuidIndexParams, WithLookup,
 };
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
@@ -2236,10 +2236,10 @@ impl From<LookupLocation> for rest::LookupLocation {
     }
 }
 
-impl TryFrom<FacetHit> for segment_facets::FacetValueHit {
+impl TryFrom<FacetHitInternal> for segment_facets::FacetValueHit {
     type Error = Status;
 
-    fn try_from(hit: FacetHit) -> Result<Self, Self::Error> {
+    fn try_from(hit: FacetHitInternal) -> Result<Self, Self::Error> {
         let value = hit
             .value
             .ok_or_else(|| Status::internal("expected FacetHit to have a value"))?;
@@ -2248,6 +2248,15 @@ impl TryFrom<FacetHit> for segment_facets::FacetValueHit {
             value: segment_facets::FacetValue::try_from(value)?,
             count: hit.count as usize,
         })
+    }
+}
+
+impl From<segment_facets::FacetValueHit> for FacetHitInternal {
+    fn from(hit: segment_facets::FacetValueHit) -> Self {
+        Self {
+            value: Some(From::from(hit.value)),
+            count: hit.count as u64,
+        }
     }
 }
 
@@ -2260,25 +2269,43 @@ impl From<segment_facets::FacetValueHit> for FacetHit {
     }
 }
 
-impl TryFrom<FacetValue> for segment_facets::FacetValue {
+impl TryFrom<FacetValueInternal> for segment_facets::FacetValue {
     type Error = Status;
 
-    fn try_from(value: FacetValue) -> Result<Self, Self::Error> {
-        use super::qdrant::facet_value::Variant;
+    fn try_from(value: FacetValueInternal) -> Result<Self, Self::Error> {
+        use super::qdrant::facet_value_internal::Variant;
 
         let variant = value
             .variant
-            .ok_or_else(|| Status::internal("expected FacetValue to have a value"))?;
+            .ok_or_else(|| Status::internal("expected FacetValueInternal to have a value"))?;
 
         Ok(match variant {
-            Variant::StringValue(value) => segment_facets::FacetValue::Keyword(value),
+            Variant::KeywordValue(value) => segment_facets::FacetValue::Keyword(value),
             Variant::IntegerValue(value) => segment_facets::FacetValue::Int(value),
-            Variant::UuidValue(value) => segment_facets::FacetValue::Uuid(
-                Uuid::parse_str(&value)
-                    .map_err(|_| Status::invalid_argument("Invalid UUID"))?
-                    .as_u128(),
-            ),
+            Variant::UuidValue(value) => {
+                let uuid_bytes: [u8; 16] = value.try_into().map_err(|_| {
+                    Status::invalid_argument("Unable to parse UUID: expected 16 bytes")
+                })?;
+                segment_facets::FacetValue::Uuid(Uuid::from_bytes(uuid_bytes).as_u128())
+            }
         })
+    }
+}
+
+impl From<segment_facets::FacetValue> for FacetValueInternal {
+    fn from(value: segment_facets::FacetValue) -> Self {
+        use super::qdrant::facet_value_internal::Variant;
+
+        Self {
+            variant: Some(match value {
+                segment_facets::FacetValue::Keyword(value) => Variant::KeywordValue(value),
+                segment_facets::FacetValue::Int(value) => Variant::IntegerValue(value),
+                segment_facets::FacetValue::Uuid(value) => {
+                    let uuid = Uuid::from_u128(value);
+                    Variant::UuidValue(uuid.as_bytes().to_vec())
+                }
+            }),
+        }
     }
 }
 
@@ -2291,7 +2318,7 @@ impl From<segment_facets::FacetValue> for FacetValue {
                 segment_facets::FacetValue::Keyword(value) => Variant::StringValue(value),
                 segment_facets::FacetValue::Int(value) => Variant::IntegerValue(value),
                 segment_facets::FacetValue::Uuid(value) => {
-                    Variant::UuidValue(Uuid::from_u128(value).to_string())
+                    Variant::StringValue(Uuid::from_u128(value).to_string())
                 }
             }),
         }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -603,6 +603,7 @@ message FacetCounts {
 message FacetValue {
     oneof variant {
         string string_value = 1; // String value from the facet
+        int64 integer_value = 2; // Integer value from the facet
     }
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -604,7 +604,6 @@ message FacetValue {
     oneof variant {
         string string_value = 1; // String value from the facet
         int64 integer_value = 2; // Integer value from the facet
-        string uuid_value = 3; // UUID value from the facet
     }
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -604,6 +604,7 @@ message FacetValue {
     oneof variant {
         string string_value = 1; // String value from the facet
         int64 integer_value = 2; // Integer value from the facet
+        string uuid_value = 3; // UUID value from the facet
     }
 }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -299,7 +299,20 @@ message FacetCountsInternal {
     optional uint64 timeout = 7;
 }
 
+message FacetValueInternal {
+    oneof variant {
+        string keyword_value = 1;
+        int64 integer_value = 2;
+        bytes uuid_value = 3;
+    }
+}
+
+message FacetHitInternal {
+    FacetValueInternal value = 1;
+    uint64 count = 2;
+}
+
 message FacetResponseInternal {
-    repeated FacetHit hits = 1;
+    repeated FacetHitInternal hits = 1;
     double time = 2; // Time spent to process
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5065,7 +5065,7 @@ pub struct FacetCounts {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FacetValue {
-    #[prost(oneof = "facet_value::Variant", tags = "1")]
+    #[prost(oneof = "facet_value::Variant", tags = "1, 2")]
     pub variant: ::core::option::Option<facet_value::Variant>,
 }
 /// Nested message and enum types in `FacetValue`.
@@ -5077,6 +5077,9 @@ pub mod facet_value {
         /// String value from the facet
         #[prost(string, tag = "1")]
         StringValue(::prost::alloc::string::String),
+        /// Integer value from the facet
+        #[prost(int64, tag = "2")]
+        IntegerValue(i64),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5065,7 +5065,7 @@ pub struct FacetCounts {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FacetValue {
-    #[prost(oneof = "facet_value::Variant", tags = "1, 2, 3")]
+    #[prost(oneof = "facet_value::Variant", tags = "1, 2")]
     pub variant: ::core::option::Option<facet_value::Variant>,
 }
 /// Nested message and enum types in `FacetValue`.
@@ -5080,9 +5080,6 @@ pub mod facet_value {
         /// Integer value from the facet
         #[prost(int64, tag = "2")]
         IntegerValue(i64),
-        /// UUID value from the facet
-        #[prost(string, tag = "3")]
-        UuidValue(::prost::alloc::string::String),
     }
 }
 #[derive(serde::Serialize)]
@@ -8977,9 +8974,39 @@ pub struct FacetCountsInternal {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FacetValueInternal {
+    #[prost(oneof = "facet_value_internal::Variant", tags = "1, 2, 3")]
+    pub variant: ::core::option::Option<facet_value_internal::Variant>,
+}
+/// Nested message and enum types in `FacetValueInternal`.
+pub mod facet_value_internal {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(string, tag = "1")]
+        KeywordValue(::prost::alloc::string::String),
+        #[prost(int64, tag = "2")]
+        IntegerValue(i64),
+        #[prost(bytes, tag = "3")]
+        UuidValue(::prost::alloc::vec::Vec<u8>),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FacetHitInternal {
+    #[prost(message, optional, tag = "1")]
+    pub value: ::core::option::Option<FacetValueInternal>,
+    #[prost(uint64, tag = "2")]
+    pub count: u64,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FacetResponseInternal {
     #[prost(message, repeated, tag = "1")]
-    pub hits: ::prost::alloc::vec::Vec<FacetHit>,
+    pub hits: ::prost::alloc::vec::Vec<FacetHitInternal>,
     /// Time spent to process
     #[prost(double, tag = "2")]
     pub time: f64,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5065,7 +5065,7 @@ pub struct FacetCounts {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FacetValue {
-    #[prost(oneof = "facet_value::Variant", tags = "1, 2")]
+    #[prost(oneof = "facet_value::Variant", tags = "1, 2, 3")]
     pub variant: ::core::option::Option<facet_value::Variant>,
 }
 /// Nested message and enum types in `FacetValue`.
@@ -5080,6 +5080,9 @@ pub mod facet_value {
         /// Integer value from the facet
         #[prost(int64, tag = "2")]
         IntegerValue(i64),
+        /// UUID value from the facet
+        #[prost(string, tag = "3")]
+        UuidValue(::prost::alloc::string::String),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -255,10 +255,10 @@ impl From<QueryInterface> for Query {
 impl From<segment::data_types::facets::FacetValue> for FacetValue {
     fn from(value: segment::data_types::facets::FacetValue) -> Self {
         match value {
-            segment::data_types::facets::FacetValue::Keyword(keyword) => Self::Keyword(keyword),
+            segment::data_types::facets::FacetValue::Keyword(keyword) => Self::String(keyword),
             segment::data_types::facets::FacetValue::Int(integer) => Self::Integer(integer),
             segment::data_types::facets::FacetValue::Uuid(uuid_int) => {
-                Self::Keyword(Uuid::from_u128(uuid_int).to_string())
+                Self::String(Uuid::from_u128(uuid_int).to_string())
             }
         }
     }

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -255,6 +255,7 @@ impl From<segment::data_types::facets::FacetValue> for FacetValue {
     fn from(value: segment::data_types::facets::FacetValue) -> Self {
         match value {
             segment::data_types::facets::FacetValue::Keyword(keyword) => Self::Keyword(keyword),
+            segment::data_types::facets::FacetValue::Int(integer) => Self::Integer(integer),
         }
     }
 }

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -1,5 +1,6 @@
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
+use uuid::Uuid;
 
 use super::schema::{BatchVectorStruct, ScoredPoint, Vector, VectorStruct};
 use super::{
@@ -256,6 +257,9 @@ impl From<segment::data_types::facets::FacetValue> for FacetValue {
         match value {
             segment::data_types::facets::FacetValue::Keyword(keyword) => Self::Keyword(keyword),
             segment::data_types::facets::FacetValue::Int(integer) => Self::Integer(integer),
+            segment::data_types::facets::FacetValue::Uuid(uuid_int) => {
+                Self::Keyword(Uuid::from_u128(uuid_int).to_string())
+            }
         }
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -767,7 +767,7 @@ pub struct FacetRequest {
 #[derive(Debug, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum FacetValue {
-    Keyword(String),
+    String(String),
     Integer(IntPayloadType),
 }
 

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -6,7 +6,7 @@ use segment::common::utils::MaybeOneOrMany;
 use segment::data_types::order_by::OrderBy;
 use segment::json_path::JsonPath;
 use segment::types::{
-    Filter, PointIdType, SearchParams, ShardKey, WithPayloadInterface, WithVector,
+    Filter, IntPayloadType, PointIdType, SearchParams, ShardKey, WithPayloadInterface, WithVector,
 };
 use serde::{Deserialize, Serialize};
 use sparse::common::sparse_vector::SparseVector;
@@ -768,6 +768,7 @@ pub struct FacetRequest {
 #[serde(untagged)]
 pub enum FacetValue {
     Keyword(String),
+    Integer(IntPayloadType),
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -101,7 +101,7 @@ impl From<FacetValue> for ValueVariants {
         match value {
             FacetValue::Keyword(s) => ValueVariants::String(s),
             FacetValue::Int(i) => ValueVariants::Integer(i),
-            FacetValue::Uuid(uuid) => ValueVariants::Keyword(Uuid::from_u128(uuid).to_string()),
+            FacetValue::Uuid(uuid) => ValueVariants::String(Uuid::from_u128(uuid).to_string()),
         }
     }
 }

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -4,10 +4,11 @@ use std::hash::Hash;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use validator::Validate;
 
 use crate::json_path::JsonPath;
-use crate::types::{Filter, IntPayloadType, ValueVariants};
+use crate::types::{Filter, IntPayloadType, UuidIntType, ValueVariants};
 
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize, Validate)]
 pub struct FacetParams {
@@ -29,6 +30,7 @@ impl FacetParams {
 pub enum FacetValueRef<'a> {
     Keyword(&'a str),
     Int(&'a IntPayloadType),
+    Uuid(&'a u128),
 }
 
 impl<'a> FacetValueRef<'a> {
@@ -36,6 +38,7 @@ impl<'a> FacetValueRef<'a> {
         match self {
             FacetValueRef::Keyword(s) => FacetValue::Keyword((*s).to_string()),
             FacetValueRef::Int(i) => FacetValue::Int(**i),
+            FacetValueRef::Uuid(uuid) => FacetValue::Uuid(**uuid),
         }
     }
 }
@@ -44,6 +47,7 @@ impl<'a> FacetValueRef<'a> {
 pub enum FacetValue {
     Keyword(String),
     Int(IntPayloadType),
+    Uuid(UuidIntType),
     // other types to add?
     // Bool(bool),
     // Integer(IntPayloadType),
@@ -97,6 +101,7 @@ impl From<FacetValue> for ValueVariants {
         match value {
             FacetValue::Keyword(s) => ValueVariants::String(s),
             FacetValue::Int(i) => ValueVariants::Integer(i),
+            FacetValue::Uuid(uuid) => ValueVariants::Keyword(Uuid::from_u128(uuid).to_string()),
         }
     }
 }

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::json_path::JsonPath;
-use crate::types::{Filter, ValueVariants};
+use crate::types::{Filter, IntPayloadType, ValueVariants};
 
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize, Validate)]
 pub struct FacetParams {
@@ -28,12 +28,14 @@ impl FacetParams {
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum FacetValueRef<'a> {
     Keyword(&'a str),
+    Int(&'a IntPayloadType),
 }
 
 impl<'a> FacetValueRef<'a> {
     pub fn to_owned(&self) -> FacetValue {
         match self {
             FacetValueRef::Keyword(s) => FacetValue::Keyword((*s).to_string()),
+            FacetValueRef::Int(i) => FacetValue::Int(**i),
         }
     }
 }
@@ -41,6 +43,7 @@ impl<'a> FacetValueRef<'a> {
 #[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Debug)]
 pub enum FacetValue {
     Keyword(String),
+    Int(IntPayloadType),
     // other types to add?
     // Bool(bool),
     // Integer(IntPayloadType),
@@ -93,6 +96,7 @@ impl From<FacetValue> for ValueVariants {
     fn from(value: FacetValue) -> Self {
         match value {
             FacetValue::Keyword(s) => ValueVariants::String(s),
+            FacetValue::Int(i) => ValueVariants::Integer(i),
         }
     }
 }

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -5,9 +5,11 @@ use super::map_index::MapIndex;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::payload_storage::FilterContext;
+use crate::types::IntPayloadType;
 
 pub enum FacetIndex<'a> {
     KeywordIndex(&'a MapIndex<str>),
+    IntIndex(&'a MapIndex<IntPayloadType>),
 }
 
 impl<'a> FacetIndex<'a> {
@@ -25,6 +27,15 @@ impl<'a> FacetIndex<'a> {
 
                 Box::new(iter)
             }
+            FacetIndex::IntIndex(index) => {
+                let iter = index
+                    .get_values(point_id)
+                    .into_iter()
+                    .flatten() // flatten the Option
+                    .map(FacetValueRef::Int);
+
+                Box::new(iter)
+            }
         }
     }
 
@@ -34,41 +45,58 @@ impl<'a> FacetIndex<'a> {
                 let iter = index.iter_values().map(FacetValueRef::Keyword);
                 Box::new(iter)
             }
+            FacetIndex::IntIndex(index) => {
+                let iter = index.iter_values().map(FacetValueRef::Int);
+                Box::new(iter)
+            }
         }
     }
 
     pub fn iter_filtered_counts_per_value(
         &self,
         context: &'a StructFilterContext,
-    ) -> Box<dyn Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a> {
-        match self {
+    ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a {
+        let iter: Box<dyn Iterator<Item = _>> = match self {
             FacetIndex::KeywordIndex(index) => {
                 let iter = index
                     .iter_values_map()
-                    .map(|(value, internal_ids_iter)| FacetHit {
-                        value: FacetValueRef::Keyword(value),
-                        count: internal_ids_iter
-                            .unique()
-                            .filter(|point_id| context.check(**point_id))
-                            .count(),
-                    });
+                    .map(|(value, ids_iter)| (FacetValueRef::Keyword(value), ids_iter));
                 Box::new(iter)
             }
-        }
+            FacetIndex::IntIndex(index) => {
+                let iter = index
+                    .iter_values_map()
+                    .map(|(value, ids_iter)| (FacetValueRef::Int(value), ids_iter));
+                Box::new(iter)
+            }
+        };
+
+        iter.map(|(value, internal_ids_iter)| FacetHit {
+            value,
+            count: internal_ids_iter
+                .unique()
+                .filter(|point_id| context.check(**point_id))
+                .count(),
+        })
     }
     pub fn iter_counts_per_value(
         &'a self,
-    ) -> Box<dyn Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a> {
-        match self {
+    ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a {
+        let iter: Box<dyn Iterator<Item = _>> = match self {
             FacetIndex::KeywordIndex(index) => {
                 let iter = index
                     .iter_counts_per_value()
-                    .map(|(value, count)| FacetHit {
-                        value: FacetValueRef::Keyword(value),
-                        count,
-                    });
+                    .map(|(value, count)| (FacetValueRef::Keyword(value), count));
                 Box::new(iter)
             }
-        }
+            FacetIndex::IntIndex(index) => {
+                let iter = index
+                    .iter_counts_per_value()
+                    .map(|(value, count)| (FacetValueRef::Int(value), count));
+                Box::new(iter)
+            }
+        };
+
+        iter.map(|(value, count)| FacetHit { value, count })
     }
 }

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -1,0 +1,74 @@
+use common::types::PointOffsetType;
+use itertools::Itertools;
+
+use super::map_index::MapIndex;
+use crate::data_types::facets::{FacetHit, FacetValueRef};
+use crate::index::struct_filter_context::StructFilterContext;
+use crate::payload_storage::FilterContext;
+
+pub enum FacetIndex<'a> {
+    KeywordIndex(&'a MapIndex<str>),
+}
+
+impl<'a> FacetIndex<'a> {
+    pub fn get_values(
+        &self,
+        point_id: PointOffsetType,
+    ) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
+        match self {
+            FacetIndex::KeywordIndex(index) => {
+                let iter = index
+                    .get_values(point_id)
+                    .into_iter()
+                    .flatten() // flatten the Option
+                    .map(FacetValueRef::Keyword);
+
+                Box::new(iter)
+            }
+        }
+    }
+
+    pub fn iter_values(&self) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
+        match self {
+            FacetIndex::KeywordIndex(index) => {
+                let iter = index.iter_values().map(FacetValueRef::Keyword);
+                Box::new(iter)
+            }
+        }
+    }
+
+    pub fn iter_filtered_counts_per_value(
+        &self,
+        context: &'a StructFilterContext,
+    ) -> Box<dyn Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a> {
+        match self {
+            FacetIndex::KeywordIndex(index) => {
+                let iter = index
+                    .iter_values_map()
+                    .map(|(value, internal_ids_iter)| FacetHit {
+                        value: FacetValueRef::Keyword(value),
+                        count: internal_ids_iter
+                            .unique()
+                            .filter(|point_id| context.check(**point_id))
+                            .count(),
+                    });
+                Box::new(iter)
+            }
+        }
+    }
+    pub fn iter_counts_per_value(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a> {
+        match self {
+            FacetIndex::KeywordIndex(index) => {
+                let iter = index
+                    .iter_counts_per_value()
+                    .map(|(value, count)| FacetHit {
+                        value: FacetValueRef::Keyword(value),
+                        count,
+                    });
+                Box::new(iter)
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -5,11 +5,12 @@ use super::map_index::MapIndex;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::payload_storage::FilterContext;
-use crate::types::IntPayloadType;
+use crate::types::{IntPayloadType, UuidIntType};
 
 pub enum FacetIndex<'a> {
-    KeywordIndex(&'a MapIndex<str>),
-    IntIndex(&'a MapIndex<IntPayloadType>),
+    Keyword(&'a MapIndex<str>),
+    Int(&'a MapIndex<IntPayloadType>),
+    Uuid(&'a MapIndex<UuidIntType>),
 }
 
 impl<'a> FacetIndex<'a> {
@@ -18,7 +19,7 @@ impl<'a> FacetIndex<'a> {
         point_id: PointOffsetType,
     ) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
         match self {
-            FacetIndex::KeywordIndex(index) => {
+            FacetIndex::Keyword(index) => {
                 let iter = index
                     .get_values(point_id)
                     .into_iter()
@@ -27,7 +28,7 @@ impl<'a> FacetIndex<'a> {
 
                 Box::new(iter)
             }
-            FacetIndex::IntIndex(index) => {
+            FacetIndex::Int(index) => {
                 let iter = index
                     .get_values(point_id)
                     .into_iter()
@@ -36,17 +37,30 @@ impl<'a> FacetIndex<'a> {
 
                 Box::new(iter)
             }
+            FacetIndex::Uuid(index) => {
+                let iter = index
+                    .get_values(point_id)
+                    .into_iter()
+                    .flatten() // flatten the Option
+                    .map(FacetValueRef::Uuid);
+
+                Box::new(iter)
+            }
         }
     }
 
     pub fn iter_values(&self) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
         match self {
-            FacetIndex::KeywordIndex(index) => {
+            FacetIndex::Keyword(index) => {
                 let iter = index.iter_values().map(FacetValueRef::Keyword);
                 Box::new(iter)
             }
-            FacetIndex::IntIndex(index) => {
+            FacetIndex::Int(index) => {
                 let iter = index.iter_values().map(FacetValueRef::Int);
+                Box::new(iter)
+            }
+            FacetIndex::Uuid(index) => {
+                let iter = index.iter_values().map(FacetValueRef::Uuid);
                 Box::new(iter)
             }
         }
@@ -57,16 +71,22 @@ impl<'a> FacetIndex<'a> {
         context: &'a StructFilterContext,
     ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a {
         let iter: Box<dyn Iterator<Item = _>> = match self {
-            FacetIndex::KeywordIndex(index) => {
+            FacetIndex::Keyword(index) => {
                 let iter = index
                     .iter_values_map()
                     .map(|(value, ids_iter)| (FacetValueRef::Keyword(value), ids_iter));
                 Box::new(iter)
             }
-            FacetIndex::IntIndex(index) => {
+            FacetIndex::Int(index) => {
                 let iter = index
                     .iter_values_map()
                     .map(|(value, ids_iter)| (FacetValueRef::Int(value), ids_iter));
+                Box::new(iter)
+            }
+            FacetIndex::Uuid(index) => {
+                let iter = index
+                    .iter_values_map()
+                    .map(|(value, ids_iter)| (FacetValueRef::Uuid(value), ids_iter));
                 Box::new(iter)
             }
         };
@@ -83,16 +103,22 @@ impl<'a> FacetIndex<'a> {
         &'a self,
     ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a {
         let iter: Box<dyn Iterator<Item = _>> = match self {
-            FacetIndex::KeywordIndex(index) => {
+            FacetIndex::Keyword(index) => {
                 let iter = index
                     .iter_counts_per_value()
                     .map(|(value, count)| (FacetValueRef::Keyword(value), count));
                 Box::new(iter)
             }
-            FacetIndex::IntIndex(index) => {
+            FacetIndex::Int(index) => {
                 let iter = index
                     .iter_counts_per_value()
                     .map(|(value, count)| (FacetValueRef::Int(value), count));
+                Box::new(iter)
+            }
+            FacetIndex::Uuid(index) => {
+                let iter = index
+                    .iter_counts_per_value()
+                    .map(|(value, count)| (FacetValueRef::Uuid(value), count));
                 Box::new(iter)
             }
         };

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -372,7 +372,7 @@ impl FieldIndex {
     pub fn as_facet_index(&self) -> Option<FacetIndex> {
         match self {
             FieldIndex::KeywordIndex(index) => Some(FacetIndex::KeywordIndex(index)),
-            FieldIndex::IntMapIndex(_) // TODO(facets): use int map index too
+            FieldIndex::IntMapIndex(index) => Some(FacetIndex::IntIndex(index)),
             | FieldIndex::UuidMapIndex(_) // TODO(facets): use uuid index too
             | FieldIndex::UuidIndex(_)
             | FieldIndex::IntIndex(_)

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -3,10 +3,10 @@ use std::path::PathBuf;
 
 use common::types::PointOffsetType;
 use delegate::delegate;
-use itertools::Itertools;
 use serde_json::Value;
 
 use super::binary_index::BinaryIndexBuilder;
+use super::facet_index::FacetIndex;
 use super::full_text_index::text_index::FullTextIndexBuilder;
 use super::geo_index::GeoMapIndexBuilder;
 use super::map_index::{MapIndex, MapIndexBuilder, MapIndexMmapBuilder};
@@ -15,15 +15,12 @@ use super::numeric_index::{
 };
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
-use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::data_types::order_by::OrderValue;
 use crate::index::field_index::binary_index::BinaryIndex;
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::numeric_index::NumericIndexInner;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::struct_filter_context::StructFilterContext;
-use crate::payload_storage::FilterContext;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchText,
@@ -523,73 +520,6 @@ impl<'a> NumericFieldIndex<'a> {
                     .flatten()
                     .map(OrderValue::Float),
             ),
-        }
-    }
-}
-
-pub enum FacetIndex<'a> {
-    KeywordIndex(&'a MapIndex<str>),
-}
-
-impl<'a> FacetIndex<'a> {
-    pub fn get_values(
-        &self,
-        point_id: PointOffsetType,
-    ) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
-        match self {
-            FacetIndex::KeywordIndex(index) => {
-                let iter = index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten() // flatten the Option
-                    .map(FacetValueRef::Keyword);
-
-                Box::new(iter)
-            }
-        }
-    }
-
-    pub fn iter_values(&self) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
-        match self {
-            FacetIndex::KeywordIndex(index) => {
-                let iter = index.iter_values().map(FacetValueRef::Keyword);
-                Box::new(iter)
-            }
-        }
-    }
-
-    pub fn iter_filtered_counts_per_value(
-        &self,
-        context: &'a StructFilterContext,
-    ) -> Box<dyn Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a> {
-        match self {
-            FacetIndex::KeywordIndex(index) => {
-                let iter = index
-                    .iter_values_map()
-                    .map(|(value, internal_ids_iter)| FacetHit {
-                        value: FacetValueRef::Keyword(value),
-                        count: internal_ids_iter
-                            .unique()
-                            .filter(|point_id| context.check(**point_id))
-                            .count(),
-                    });
-                Box::new(iter)
-            }
-        }
-    }
-    pub fn iter_counts_per_value(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a> {
-        match self {
-            FacetIndex::KeywordIndex(index) => {
-                let iter = index
-                    .iter_counts_per_value()
-                    .map(|(value, count)| FacetHit {
-                        value: FacetValueRef::Keyword(value),
-                        count,
-                    });
-                Box::new(iter)
-            }
         }
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -371,8 +371,8 @@ impl FieldIndex {
 
     pub fn as_facet_index(&self) -> Option<FacetIndex> {
         match self {
-            FieldIndex::KeywordIndex(index) => Some(FacetIndex::KeywordIndex(index)),
-            FieldIndex::IntMapIndex(index) => Some(FacetIndex::IntIndex(index)),
+            FieldIndex::KeywordIndex(index) => Some(FacetIndex::Keyword(index)),
+            FieldIndex::IntMapIndex(index) => Some(FacetIndex::Int(index)),
             | FieldIndex::UuidMapIndex(_) // TODO(facets): use uuid index too
             | FieldIndex::UuidIndex(_)
             | FieldIndex::IntIndex(_)

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -94,9 +94,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             point_to_values.iter().enumerate().map(|(idx, values)| {
                 (
                     idx as PointOffsetType,
-                    values
-                        .iter()
-                        .map(|value| N::into_referenced(value.borrow())),
+                    values.iter().map(|value| N::as_referenced(value.borrow())),
                 )
             }),
         )?;

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -1129,7 +1129,7 @@ mod tests {
             let res: Vec<_> = index
                 .get_values(idx as u32)
                 .unwrap()
-                .map(|i| i as i32)
+                .map(|i| *i as i32)
                 .collect();
             assert_eq!(res, *values);
         }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -125,10 +125,10 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
     ) -> Option<Box<dyn Iterator<Item = N::Referenced<'_>> + '_>> {
         match self {
             MapIndex::Mutable(index) => Some(Box::new(
-                index.get_values(idx)?.map(|v| N::into_referenced(v)),
+                index.get_values(idx)?.map(|v| N::as_referenced(v)),
             )),
             MapIndex::Immutable(index) => Some(Box::new(
-                index.get_values(idx)?.map(|v| N::into_referenced(v)),
+                index.get_values(idx)?.map(|v| N::as_referenced(v)),
             )),
             MapIndex::Mmap(index) => Some(Box::new(index.get_values(idx)?)),
         }

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -27,7 +27,7 @@ pub trait MmapValue {
 
     fn from_referenced<'a>(value: &'a Self::Referenced<'_>) -> &'a Self;
 
-    fn into_referenced(&self) -> Self::Referenced<'_>;
+    fn as_referenced(&self) -> Self::Referenced<'_>;
 }
 
 impl MmapValue for IntPayloadType {
@@ -49,7 +49,7 @@ impl MmapValue for IntPayloadType {
         value
     }
 
-    fn into_referenced(&self) -> Self::Referenced<'_> {
+    fn as_referenced(&self) -> Self::Referenced<'_> {
         self
     }
 }
@@ -73,23 +73,23 @@ impl MmapValue for FloatPayloadType {
         value
     }
 
-    fn into_referenced(&self) -> Self::Referenced<'_> {
+    fn as_referenced(&self) -> Self::Referenced<'_> {
         *self
     }
 }
 
 impl MmapValue for UuidIntType {
-    type Referenced<'a> = Self;
+    type Referenced<'a> = &'a Self;
 
-    fn mmaped_size(_value: Self) -> usize {
+    fn mmaped_size(_value: Self::Referenced<'_>) -> usize {
         std::mem::size_of::<Self>()
     }
 
-    fn read_from_mmap(bytes: &[u8]) -> Option<Self> {
-        Self::read_from_prefix(bytes)
+    fn read_from_mmap(bytes: &[u8]) -> Option<Self::Referenced<'_>> {
+        Self::ref_from_prefix(bytes)
     }
 
-    fn write_to_mmap(value: Self, bytes: &mut [u8]) -> Option<()> {
+    fn write_to_mmap(value: Self::Referenced<'_>, bytes: &mut [u8]) -> Option<()> {
         value.write_to_prefix(bytes)
     }
 
@@ -97,8 +97,8 @@ impl MmapValue for UuidIntType {
         value
     }
 
-    fn into_referenced(&self) -> Self::Referenced<'_> {
-        *self
+    fn as_referenced(&self) -> Self::Referenced<'_> {
+        self
     }
 }
 
@@ -129,7 +129,7 @@ impl MmapValue for GeoPoint {
         value
     }
 
-    fn into_referenced(&self) -> Self::Referenced<'_> {
+    fn as_referenced(&self) -> Self::Referenced<'_> {
         self.clone()
     }
 }
@@ -160,7 +160,7 @@ impl MmapValue for str {
         value
     }
 
-    fn into_referenced(&self) -> Self::Referenced<'_> {
+    fn as_referenced(&self) -> Self::Referenced<'_> {
         self
     }
 }

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -27,21 +27,21 @@ pub trait MmapValue {
 
     fn from_referenced<'a>(value: &'a Self::Referenced<'_>) -> &'a Self;
 
-    fn into_referenced(value: &Self) -> Self::Referenced<'_>;
+    fn into_referenced(&self) -> Self::Referenced<'_>;
 }
 
 impl MmapValue for IntPayloadType {
-    type Referenced<'a> = Self;
+    type Referenced<'a> = &'a Self;
 
-    fn mmaped_size(_value: Self) -> usize {
+    fn mmaped_size(_value: Self::Referenced<'_>) -> usize {
         std::mem::size_of::<Self>()
     }
 
-    fn read_from_mmap(bytes: &[u8]) -> Option<Self> {
-        Self::read_from_prefix(bytes)
+    fn read_from_mmap(bytes: &[u8]) -> Option<Self::Referenced<'_>> {
+        Self::ref_from_prefix(bytes)
     }
 
-    fn write_to_mmap(value: Self, bytes: &mut [u8]) -> Option<()> {
+    fn write_to_mmap(value: Self::Referenced<'_>, bytes: &mut [u8]) -> Option<()> {
         value.write_to_prefix(bytes)
     }
 
@@ -49,8 +49,8 @@ impl MmapValue for IntPayloadType {
         value
     }
 
-    fn into_referenced(value: &Self) -> Self::Referenced<'_> {
-        *value
+    fn into_referenced(&self) -> Self::Referenced<'_> {
+        self
     }
 }
 
@@ -73,8 +73,8 @@ impl MmapValue for FloatPayloadType {
         value
     }
 
-    fn into_referenced(value: &Self) -> Self::Referenced<'_> {
-        *value
+    fn into_referenced(&self) -> Self::Referenced<'_> {
+        *self
     }
 }
 
@@ -97,8 +97,8 @@ impl MmapValue for UuidIntType {
         value
     }
 
-    fn into_referenced(value: &Self) -> Self::Referenced<'_> {
-        *value
+    fn into_referenced(&self) -> Self::Referenced<'_> {
+        *self
     }
 }
 
@@ -129,8 +129,8 @@ impl MmapValue for GeoPoint {
         value
     }
 
-    fn into_referenced(value: &Self) -> Self::Referenced<'_> {
-        value.clone()
+    fn into_referenced(&self) -> Self::Referenced<'_> {
+        self.clone()
     }
 }
 
@@ -160,8 +160,8 @@ impl MmapValue for str {
         value
     }
 
-    fn into_referenced(value: &Self) -> Self::Referenced<'_> {
-        value
+    fn into_referenced(&self) -> Self::Referenced<'_> {
+        self
     }
 }
 

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -4,6 +4,7 @@ use common::types::PointOffsetType;
 
 use crate::types::{FieldCondition, IsEmptyCondition, IsNullCondition};
 
+pub(super) mod facet_index;
 mod field_index_base;
 pub mod full_text_index;
 pub mod geo_hash;

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -103,7 +103,7 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
                 .map(|(idx, values)| {
                     (
                         idx as PointOffsetType,
-                        values.iter().map(|v| T::into_referenced(v)),
+                        values.iter().map(|v| T::as_referenced(v)),
                     )
                 }),
         )?;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -12,10 +12,11 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
+use super::field_index::facet_index::FacetIndex;
 use super::field_index::index_selector::{
     IndexSelector, IndexSelectorOnDisk, IndexSelectorRocksDb,
 };
-use super::field_index::{FacetIndex, FieldIndexBuilderTrait as _};
+use super::field_index::FieldIndexBuilderTrait as _;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::common::utils::IndexesMap;

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -198,7 +198,7 @@ impl SegmentBuilder {
                 }
                 FieldIndex::UuidMapIndex(index) => {
                     if let Some(ids) = index.get_values(internal_id) {
-                        uuid_hash(&mut ordering, ids);
+                        uuid_hash(&mut ordering, ids.copied());
                     }
                     break;
                 }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -147,7 +147,7 @@ impl SegmentBuilder {
                 FieldIndex::IntMapIndex(index) => {
                     if let Some(numbers) = index.get_values(internal_id) {
                         for number in numbers {
-                            ordering = ordering.wrapping_add(number as u64);
+                            ordering = ordering.wrapping_add(*number as u64);
                         }
                     }
                     break;

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1488,6 +1488,12 @@ impl From<Vec<String>> for Match {
     }
 }
 
+impl From<ValueVariants> for Match {
+    fn from(value: ValueVariants) -> Self {
+        Self::Value(MatchValue { value })
+    }
+}
+
 impl From<Vec<String>> for MatchExcept {
     fn from(keywords: Vec<String>) -> Self {
         let keywords: IndexSet<String, FnvBuildHasher> = keywords.into_iter().collect();

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -39,8 +39,8 @@ use segment::types::PayloadSchemaType::{Integer, Keyword};
 use segment::types::{
     AnyVariants, Condition, Distance, FieldCondition, Filter, GeoBoundingBox, GeoLineString,
     GeoPoint, GeoPolygon, GeoRadius, HnswConfig, Indexes, IsEmptyCondition, Match, Payload,
-    PayloadField, PayloadSchemaParams, PayloadSchemaType, Range, SegmentConfig, VectorDataConfig,
-    VectorStorageType, WithPayload,
+    PayloadField, PayloadSchemaParams, PayloadSchemaType, Range, SegmentConfig, ValueVariants,
+    VectorDataConfig, VectorStorageType, WithPayload,
 };
 use segment::utils::scored_point_ties::ScoredPointTies;
 use serde_json::json;
@@ -1179,7 +1179,7 @@ fn validate_facet_result(
 ) {
     for (value, count) in facet_hits.iter() {
         // Compare against exact count
-        let FacetValue::Keyword(value) = value.to_owned();
+        let value = ValueVariants::from(value.clone());
 
         let count_filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
             JsonPath::new(STR_KEY),


### PR DESCRIPTION
Enables faceting with the other existing map indexes: integer and uuid

Note: I decided to not add a special case for UUID in REST, and just use Keyword variant as output. This should be transparent when serializing, and we do not consume it in any form.

Note2: I edited the trait and implementations of `MmapValue` to allow references of `i64` and `u128`
