### PR TITLE
Fix point deletions on mmap segment optimization

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -86,7 +86,7 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
 
     fn update_from<'a>(
         &mut self,
-        _other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        _other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         _stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         todo!()

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -306,7 +306,7 @@ impl SegmentBuilder {
                 let other_vector_storage = &other_vector_storages[point_data.segment_index];
                 let vec = other_vector_storage.get_vector(point_data.internal_id);
                 let vector_deleted = other_vector_storage.is_deleted_vector(point_data.internal_id);
-                (point_data.internal_id, vec, vector_deleted)
+                (vec, vector_deleted)
             });
 
             let internal_range = vector_storage.update_from(&mut iter, stopped)?;

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -111,11 +111,11 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
-        for (_, other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_ids {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -175,7 +175,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let dim = self.vector_dim();
@@ -191,7 +191,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         // Extend vectors file, write other vectors into it
         let mut vectors_file = open_append(&self.vectors_path)?;
         let mut deleted_ids = vec![];
-        for (offset, (_, other_vector, other_deleted)) in other_ids.enumerate() {
+        for (offset, (other_vector, other_deleted)) in other_ids.enumerate() {
             check_process_stopped(stopped)?;
             let vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
             let raw_bites = mmap_ops::transmute_to_u8_slice(vector.as_ref());
@@ -338,7 +338,7 @@ mod tests {
                 let i = i as PointOffsetType;
                 let vector = storage2.get_vector(i);
                 let deleted = storage2.is_deleted_vector(i);
-                (i, vector, deleted)
+                (vector, deleted)
             });
             storage.update_from(&mut iter, &Default::default()).unwrap();
         }
@@ -375,7 +375,7 @@ mod tests {
                 let i = i as PointOffsetType;
                 let vector = storage2.get_vector(i);
                 let deleted = storage2.is_deleted_vector(i);
-                (i, vector, deleted)
+                (vector, deleted)
             });
             storage.update_from(&mut iter, &Default::default()).unwrap();
         }
@@ -442,7 +442,7 @@ mod tests {
                 let i = i as PointOffsetType;
                 let vector = storage2.get_vector(i);
                 let deleted = storage2.is_deleted_vector(i);
-                (i, vector, deleted)
+                (vector, deleted)
             });
             storage.update_from(&mut iter, &Default::default()).unwrap();
         }
@@ -564,7 +564,7 @@ mod tests {
                 let i = i as PointOffsetType;
                 let vector = storage2.get_vector(i);
                 let deleted = storage2.is_deleted_vector(i);
-                (i, vector, deleted)
+                (vector, deleted)
             });
             storage.update_from(&mut iter, &Default::default()).unwrap();
         }
@@ -637,7 +637,7 @@ mod tests {
                 let i = i as PointOffsetType;
                 let vector = storage2.get_vector(i);
                 let deleted = storage2.is_deleted_vector(i);
-                (i, vector, deleted)
+                (vector, deleted)
             });
             storage.update_from(&mut iter, &Default::default()).unwrap();
         }
@@ -721,7 +721,7 @@ mod tests {
                 let i = i as PointOffsetType;
                 let vector = storage2.get_vector(i);
                 let deleted = storage2.is_deleted_vector(i);
-                (i, vector, deleted)
+                (vector, deleted)
             });
             storage.update_from(&mut iter, &Default::default()).unwrap();
         }

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -191,7 +191,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         // Extend vectors file, write other vectors into it
         let mut vectors_file = open_append(&self.vectors_path)?;
         let mut deleted_ids = vec![];
-        for (id, other_vector, other_deleted) in other_ids {
+        for (offset, (_, other_vector, other_deleted)) in other_ids.enumerate() {
             check_process_stopped(stopped)?;
             let vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
             let raw_bites = mmap_ops::transmute_to_u8_slice(vector.as_ref());
@@ -200,7 +200,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
 
             // Remember deleted IDs so we can propagate deletions later
             if other_deleted {
-                deleted_ids.push((start_index + id) as PointOffsetType);
+                deleted_ids.push(start_index as PointOffsetType + offset as PointOffsetType);
             }
         }
         vectors_file.flush()?;

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -236,11 +236,11 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
-        for (_, other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_ids {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -219,11 +219,11 @@ impl<
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.offsets.len() as PointOffsetType;
-        for (_, other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_ids {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector: VectorRef = other_vector.as_vec_ref();

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -357,11 +357,11 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors_metadata.len() as PointOffsetType;
-        for (_, other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_ids {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector: VectorRef = other_vector.as_vec_ref();

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -177,11 +177,11 @@ impl VectorStorage for SimpleSparseVectorStorage {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.total_vector_count as PointOffsetType;
-        for (_, other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_ids {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = other_vector.as_vec_ref().try_into()?;

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -81,7 +81,7 @@ fn test_async_raw_scorer(
             let i = i as PointOffsetType;
             let vec = mutable_storage.get_vector(i);
             let deleted = mutable_storage.is_deleted_vector(i);
-            (i, vec, deleted)
+            (vec, deleted)
         });
         storage.update_from(&mut iter, &Default::default())?;
     }

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -221,7 +221,7 @@ fn scoring_equivalency(
         let i = i as PointOffsetType;
         let vec = raw_storage.get_vector(i);
         let deleted = raw_storage.is_deleted_vector(i);
-        (i, vec, deleted)
+        (vec, deleted)
     });
     other_storage.update_from(&mut iter, &Default::default())?;
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -132,7 +132,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
             let i = i as PointOffsetType;
             let vec = storage2.get_vector(i);
             let deleted = storage2.is_deleted_vector(i);
-            (i, vec, deleted)
+            (vec, deleted)
         });
         storage.update_from(&mut iter, &Default::default()).unwrap();
     }

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -200,7 +200,7 @@ fn do_test_update_from_delete_points(
             let i = i as PointOffsetType;
             let vec = storage2.get_vector(i);
             let deleted = storage2.is_deleted_vector(i);
-            (i, vec, deleted)
+            (vec, deleted)
         });
         storage.update_from(&mut iter, &Default::default()).unwrap();
     }

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -139,7 +139,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
             let i = i as PointOffsetType;
             let vec = storage2.get_vector(i);
             let deleted = storage2.is_deleted_vector(i);
-            (i, vec, deleted)
+            (vec, deleted)
         });
         storage.update_from(&mut iter, &Default::default()).unwrap();
     }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -65,7 +65,7 @@ pub trait VectorStorage {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>>;
 
@@ -538,7 +538,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (PointOffsetType, CowVector<'a>, bool)>,
+        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         match self {


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/4949>.

Fix `memmap_dense_vector_storage` incorrectly taking over vector deletions on segment optimization. This resulted in deleted vectors suddenly appearing again once segments get optimized.

This problem has existed for a long time but only came to light recently. Our input data on `update_from` may now contain points for multiple segments, in which case the previous logic breaks.

All other storage types implemented it correctly. This implementation has now been updated to match the others, fixing the problem.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?