### PR TITLE
Issues: Accept UUID index

### DIFF
--- a/lib/segment/src/problems/unindexed_field.rs
+++ b/lib/segment/src/problems/unindexed_field.rs
@@ -8,7 +8,6 @@ use http::{HeaderMap, HeaderValue, Method, Uri};
 use issues::{Action, Code, ImmediateSolution, Issue, Solution};
 use itertools::Itertools;
 use strum::IntoEnumIterator as _;
-use uuid::Uuid;
 
 use crate::common::operation_error::OperationError;
 use crate::data_types::index::{TextIndexParams, TextIndexType, TokenizerType};

--- a/lib/segment/src/problems/unindexed_field.rs
+++ b/lib/segment/src/problems/unindexed_field.rs
@@ -271,7 +271,15 @@ impl<'a> Extractor<'a> {
         self.unindexed_schema
             .into_iter()
             .filter_map(|(key, field_schemas)| {
-                let field_schemas = HashSet::from_iter(field_schemas);
+                let field_schemas: HashSet<_> = field_schemas
+                    .iter()
+                    .map(PayloadFieldSchema::kind)
+                    .filter(|kind| {
+                        let is_advanced = matches!(kind, PayloadSchemaType::Uuid);
+                        !is_advanced
+                    })
+                    .map(PayloadFieldSchema::from)
+                    .collect();
 
                 UnindexedField::try_new(key, field_schemas, self.collection_name.clone()).ok()
             })

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1253,6 +1253,13 @@ impl PayloadFieldSchema {
             PayloadFieldSchema::FieldParams(params) => params.is_on_disk(),
         }
     }
+
+    pub fn kind(&self) -> PayloadSchemaType {
+        match self {
+            PayloadFieldSchema::FieldType(t) => *t,
+            PayloadFieldSchema::FieldParams(p) => p.kind(),
+        }
+    }
 }
 
 impl From<PayloadSchemaType> for PayloadFieldSchema {


### PR DESCRIPTION
Fixes two things:

- When checking MatchValue conditions, the extractor will now report a UUID index as an alternative, not only keyword index.

- Parametrized indices are much more common now with `on_disk` and related stuff. So now we need to make better checks if a field is already indexed. For this I am am changing it to compare only unparametrized versions of schemas.
 
  This fixes false-positives, but it is still possible to make a false-negative. I added a TODO comment for strict-mode to resolve this 😄 