### PR TITLE
Packed geohash

### DIFF
--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -153,6 +153,12 @@ impl From<fs_extra::error::Error> for OperationError {
     }
 }
 
+impl From<geohash::GeohashError> for OperationError {
+    fn from(err: geohash::GeohashError) -> Self {
+        OperationError::service_error(format!("Geohash error: {err}"))
+    }
+}
+
 impl From<quantization::EncodingError> for OperationError {
     fn from(err: quantization::EncodingError) -> Self {
         match err {

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::ops::{Index, Range};
 
 use geo::algorithm::haversine_distance::HaversineDistance;
 use geo::{Coord, Intersects, LineString, Point, Polygon};
@@ -9,7 +9,20 @@ use smol_str::SmolStr;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::types::{GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius};
 
-pub type GeoHash = SmolStr;
+#[derive(Default, Clone, Copy, Debug, PartialEq, Hash, Ord, PartialOrd, Eq)]
+pub struct GeoHash {
+    packed: u64,
+}
+
+// code from geohash crate
+// the alphabet for the base32 encoding used in geohashing
+#[rustfmt::skip]
+const BASE32_CODES: [char; 32] = [
+    '0', '1', '2', '3', '4', '5', '6', '7',
+    '8', '9', 'b', 'c', 'd', 'e', 'f', 'g',
+    'h', 'j', 'k', 'm', 'n', 'p', 'q', 'r',
+    's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+];
 
 /// Max size of geo-hash used for indexing. size=12 is about 6cm2
 const GEOHASH_MAX_LENGTH: usize = 12;
@@ -17,6 +30,90 @@ const GEOHASH_MAX_LENGTH: usize = 12;
 const LON_RANGE: Range<f64> = -180.0..180.0;
 const LAT_RANGE: Range<f64> = -90.0..90.0;
 const COORD_EPS: f64 = 1e-12;
+
+impl Index<usize> for GeoHash {
+    type Output = char;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        assert!(i < self.len());
+        let index = (self.packed >> (5 * (GEOHASH_MAX_LENGTH - 1 - i) + 4)) & 0b11111;
+        &BASE32_CODES[index as usize]
+    }
+}
+
+impl From<SmolStr> for GeoHash {
+    fn from(hash: SmolStr) -> Self {
+        Self::new(hash.as_str())
+    }
+}
+
+impl From<GeoHash> for SmolStr {
+    fn from(hash: GeoHash) -> Self {
+        hash.iter().collect()
+    }
+}
+
+pub struct GeoHashIterator {
+    hash: GeoHash,
+    index: usize,
+    len: usize,
+}
+
+impl Iterator for GeoHashIterator {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.len {
+            let result = Some(self.hash[self.index]);
+            self.index += 1;
+            result
+        } else {
+            None
+        }
+    }
+}
+
+impl GeoHash {
+    pub fn new(s: &str) -> Self {
+        let mut packed: u64 = 0;
+        for (i, c) in s.chars().enumerate() {
+            let index = BASE32_CODES.iter().position(|&x| x == c).unwrap() as u64;
+            packed |= index << (5 * (GEOHASH_MAX_LENGTH - 1 - i) + 4);
+        }
+        packed |= s.len() as u64;
+        Self { packed }
+    }
+
+    pub fn iter(&self) -> GeoHashIterator {
+        GeoHashIterator {
+            hash: *self,
+            index: 0,
+            len: self.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        (self.packed & 0b1111) as usize
+    }
+
+    pub fn cut(&self, new_len: usize) -> Self {
+        let mut packed = self.packed;
+        for i in new_len..self.len() {
+            packed &= !(0b11111 << (5 * (GEOHASH_MAX_LENGTH - 1 - i) + 4));
+        }
+        packed &= !(0b1111);
+        packed |= new_len as u64;
+        Self { packed }
+    }
+
+    pub fn starts_with(&self, other: GeoHash) -> bool {
+        self.cut(other.len()) == other
+    }
+}
 
 impl From<GeoPoint> for Coord<f64> {
     fn from(point: GeoPoint) -> Self {
@@ -32,13 +129,13 @@ pub fn common_hash_prefix(geo_hashes: &[GeoHash]) -> GeoHash {
     let mut prefix: usize = first.len();
     for geo_hash in geo_hashes.iter().skip(1) {
         for i in 0..prefix {
-            if first.as_bytes()[i] != geo_hash.as_bytes()[i] {
+            if first[i] != geo_hash[i] {
                 prefix = i;
                 break;
             }
         }
     }
-    first[0..prefix].into()
+    first.cut(prefix)
 }
 
 /// Fix longitude for spherical overflow
@@ -67,22 +164,27 @@ fn sphere_lat(lat: f64) -> f64 {
 }
 
 /// Get neighbour geohash even from the other side of coordinates
-fn sphere_neighbor(hash_str: &str, direction: Direction) -> Result<GeoHash, GeohashError> {
-    let (coord, lon_err, lat_err) = decode(hash_str)?;
+fn sphere_neighbor(hash: GeoHash, direction: Direction) -> Result<GeoHash, GeohashError> {
+    let hash_str = SmolStr::from(hash);
+    let (coord, lon_err, lat_err) = decode(hash_str.as_str())?;
     let (dlat, dlng) = direction.to_tuple();
     let lon = sphere_lon(coord.x + 2f64 * lon_err.abs() * dlng);
     let lat = sphere_lat(coord.y + 2f64 * lat_err.abs() * dlat);
 
     let neighbor_coord = Coord { x: lon, y: lat };
-    encode(neighbor_coord, hash_str.len()).map(Into::into)
+    encode(neighbor_coord, hash_str.len())
+        .map(Into::<SmolStr>::into)
+        .map(Into::into)
 }
 
 pub fn encode_max_precision(lon: f64, lat: f64) -> Result<GeoHash, GeohashError> {
-    encode((lon, lat).into(), GEOHASH_MAX_LENGTH).map(Into::into)
+    encode((lon, lat).into(), GEOHASH_MAX_LENGTH)
+        .map(Into::<SmolStr>::into)
+        .map(Into::into)
 }
 
-pub fn geo_hash_to_box(geo_hash: &GeoHash) -> GeoBoundingBox {
-    let rectangle = decode_bbox(geo_hash).unwrap();
+pub fn geo_hash_to_box(geo_hash: GeoHash) -> GeoBoundingBox {
+    let rectangle = decode_bbox(SmolStr::from(geo_hash).as_str()).unwrap();
     let top_left = GeoPoint {
         lon: rectangle.min().x,
         lat: rectangle.max().y,
@@ -123,15 +225,15 @@ impl GeohashBoundingBox {
     fn geohash_regions(&self, precision: usize, max_regions: usize) -> Option<Vec<GeoHash>> {
         let mut seen: Vec<GeoHash> = Vec::new();
 
-        let mut from_row: GeoHash = self.north_west[..precision].into();
-        let mut to_row: GeoHash = self.north_east[..precision].into();
+        let mut from_row: GeoHash = self.north_west.cut(precision);
+        let mut to_row: GeoHash = self.north_east.cut(precision);
 
-        let to_column = self.south_west[..precision].to_owned();
+        let to_column = self.south_west.cut(precision);
 
         loop {
-            let mut current = from_row.clone();
+            let mut current = from_row;
             loop {
-                seen.push(current.clone());
+                seen.push(current);
 
                 if seen.len() > max_regions {
                     return None;
@@ -140,14 +242,14 @@ impl GeohashBoundingBox {
                 if current == to_row {
                     break;
                 }
-                current = sphere_neighbor(current.as_str(), Direction::E).unwrap();
+                current = sphere_neighbor(current, Direction::E).unwrap();
             }
             if from_row == to_column {
                 break;
             }
 
-            from_row = sphere_neighbor(&from_row, Direction::S).unwrap();
-            to_row = sphere_neighbor(&to_row, Direction::S).unwrap();
+            from_row = sphere_neighbor(from_row, Direction::S).unwrap();
+            to_row = sphere_neighbor(to_row, Direction::S).unwrap();
         }
 
         Some(seen)
@@ -244,7 +346,7 @@ pub fn circle_hashes(circle: &GeoRadius, max_regions: usize) -> OperationResult<
             .map(|hashes| {
                 hashes
                     .into_iter()
-                    .filter(|hash| check_circle_intersection(hash, circle))
+                    .filter(|hash| check_circle_intersection(SmolStr::from(*hash).as_str(), circle))
                     .collect_vec()
             })
     };
@@ -281,7 +383,9 @@ fn boundary_hashes(boundary: &LineString, max_regions: usize) -> OperationResult
             .map(|hashes| {
                 hashes
                     .into_iter()
-                    .filter(|hash| check_polygon_intersection(hash, &polygon))
+                    .filter(|hash| {
+                        check_polygon_intersection(SmolStr::from(*hash).as_str(), &polygon)
+                    })
                     .collect_vec()
             })
     };
@@ -327,7 +431,9 @@ pub fn polygon_hashes(polygon: &GeoPolygon, max_regions: usize) -> OperationResu
             .map(|hashes| {
                 hashes
                     .into_iter()
-                    .filter(|hash| check_polygon_intersection(hash, &polygon_wrapper))
+                    .filter(|hash| {
+                        check_polygon_intersection(SmolStr::from(*hash).as_str(), &polygon_wrapper)
+                    })
                     .collect_vec()
             })
     };
@@ -439,15 +545,37 @@ mod tests {
     };
 
     #[test]
+    fn geohash_ordering() {
+        let mut v = vec![
+            "dr5ru",
+            "uft56",
+            "hhbcd",
+            "h",
+            "hbcd",
+            "887hh1234567",
+            "",
+            "hwx98",
+            "hbc",
+            "dr5rukz",
+        ];
+        let mut hashes = v.iter().map(|s| GeoHash::new(s)).collect_vec();
+        hashes.sort_unstable();
+        v.sort_unstable();
+        assert_eq!(hashes.iter().map(|h| SmolStr::from(*h)).collect_vec(), v);
+    }
+
+    #[test]
     fn geohash_encode_longitude_first() {
-        let center_hash = encode((NYC.lon, NYC.lat).into(), GEOHASH_MAX_LENGTH).unwrap();
-        assert_eq!(center_hash, "dr5ru7c02wnv");
-        let center_hash = encode((NYC.lon, NYC.lat).into(), 6).unwrap();
-        assert_eq!(center_hash, "dr5ru7");
-        let center_hash = encode((BERLIN.lon, BERLIN.lat).into(), GEOHASH_MAX_LENGTH).unwrap();
-        assert_eq!(center_hash, "u33dc1v0xupz");
-        let center_hash = encode((BERLIN.lon, BERLIN.lat).into(), 6).unwrap();
-        assert_eq!(center_hash, "u33dc1");
+        let center_hash =
+            GeoHash::new(&encode((NYC.lon, NYC.lat).into(), GEOHASH_MAX_LENGTH).unwrap());
+        assert_eq!(center_hash, GeoHash::new("dr5ru7c02wnv"));
+        let center_hash = GeoHash::new(&encode((NYC.lon, NYC.lat).into(), 6).unwrap());
+        assert_eq!(center_hash, GeoHash::new("dr5ru7"));
+        let center_hash =
+            GeoHash::new(&encode((BERLIN.lon, BERLIN.lat).into(), GEOHASH_MAX_LENGTH).unwrap());
+        assert_eq!(center_hash, GeoHash::new("u33dc1v0xupz"));
+        let center_hash = GeoHash::new(&encode((BERLIN.lon, BERLIN.lat).into(), 6).unwrap());
+        assert_eq!(center_hash, GeoHash::new("u33dc1"));
     }
 
     #[test]
@@ -460,22 +588,27 @@ mod tests {
 
         let bounding_box = minimum_bounding_rectangle_for_circle(&near_nyc_circle);
         let rectangle: GeohashBoundingBox = bounding_box.into();
-        assert_eq!(rectangle.north_west, "dr5ruj4477kd");
-        assert_eq!(rectangle.south_west, "dr5ru46ne2ux");
-        assert_eq!(rectangle.south_east, "dr5ru6ryw0cp");
-        assert_eq!(rectangle.north_east, "dr5rumpfq534");
+        assert_eq!(rectangle.north_west, GeoHash::new("dr5ruj4477kd"));
+        assert_eq!(rectangle.south_west, GeoHash::new("dr5ru46ne2ux"));
+        assert_eq!(rectangle.south_east, GeoHash::new("dr5ru6ryw0cp"));
+        assert_eq!(rectangle.north_east, GeoHash::new("dr5rumpfq534"));
     }
 
     #[test]
     fn top_level_rectangle_geo_area() {
         let rect = GeohashBoundingBox {
-            north_west: "u".into(),
-            south_west: "s".into(),
-            south_east: "t".into(),
-            north_east: "v".into(),
+            north_west: GeoHash::new("u"),
+            south_west: GeoHash::new("s"),
+            south_east: GeoHash::new("t"),
+            north_east: GeoHash::new("v"),
         };
         let mut geo_area = rect.geohash_regions(1, 100).unwrap();
-        let mut expected = vec!["u", "s", "v", "t"];
+        let mut expected = vec![
+            GeoHash::new("u"),
+            GeoHash::new("s"),
+            GeoHash::new("v"),
+            GeoHash::new("t"),
+        ];
 
         geo_area.sort_unstable();
         expected.sort_unstable();
@@ -485,10 +618,10 @@ mod tests {
     #[test]
     fn nyc_rectangle_geo_area_high_precision() {
         let rect = GeohashBoundingBox {
-            north_west: "dr5ruj4477kd".into(),
-            south_west: "dr5ru46ne2ux".into(),
-            south_east: "dr5ru6ryw0cp".into(),
-            north_east: "dr5rumpfq534".into(),
+            north_west: GeoHash::new("dr5ruj4477kd"),
+            south_west: GeoHash::new("dr5ru46ne2ux"),
+            south_east: GeoHash::new("dr5ru6ryw0cp"),
+            north_east: GeoHash::new("dr5rumpfq534"),
         };
 
         // calling `rect.geohash_regions()` is too expensive
@@ -498,10 +631,10 @@ mod tests {
     #[test]
     fn nyc_rectangle_geo_area_medium_precision() {
         let rect = GeohashBoundingBox {
-            north_west: "dr5ruj4".into(),
-            south_west: "dr5ru46".into(),
-            south_east: "dr5ru6r".into(),
-            north_east: "dr5rump".into(),
+            north_west: GeoHash::new("dr5ruj4"),
+            south_west: GeoHash::new("dr5ru46"),
+            south_east: GeoHash::new("dr5ru6r"),
+            north_east: GeoHash::new("dr5rump"),
         };
 
         let geo_area = rect.geohash_regions(7, 1000).unwrap();
@@ -511,15 +644,22 @@ mod tests {
     #[test]
     fn nyc_rectangle_geo_area_low_precision() {
         let rect = GeohashBoundingBox {
-            north_west: "dr5ruj".into(),
-            south_west: "dr5ru4".into(),
-            south_east: "dr5ru6".into(),
-            north_east: "dr5rum".into(),
+            north_west: GeoHash::new("dr5ruj"),
+            south_west: GeoHash::new("dr5ru4"),
+            south_east: GeoHash::new("dr5ru6"),
+            north_east: GeoHash::new("dr5rum"),
         };
 
         let mut geo_area = rect.geohash_regions(6, 100).unwrap();
         let mut expected = vec![
-            "dr5ru4", "dr5ru5", "dr5ru6", "dr5ru7", "dr5ruh", "dr5ruj", "dr5rum", "dr5ruk",
+            GeoHash::new("dr5ru4"),
+            GeoHash::new("dr5ru5"),
+            GeoHash::new("dr5ru6"),
+            GeoHash::new("dr5ru7"),
+            GeoHash::new("dr5ruh"),
+            GeoHash::new("dr5ruj"),
+            GeoHash::new("dr5rum"),
+            GeoHash::new("dr5ruk"),
         ];
 
         expected.sort_unstable();
@@ -555,7 +695,14 @@ mod tests {
         let mut nyc_hashes_result = rectangle_hashes(&near_nyc_rectangle, 10);
         nyc_hashes_result.as_mut().unwrap().sort_unstable();
         let mut expected = vec![
-            "dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6",
+            GeoHash::new("dr5ruj"),
+            GeoHash::new("dr5ruh"),
+            GeoHash::new("dr5ru5"),
+            GeoHash::new("dr5ru4"),
+            GeoHash::new("dr5rum"),
+            GeoHash::new("dr5ruk"),
+            GeoHash::new("dr5ru7"),
+            GeoHash::new("dr5ru6"),
         ];
         expected.sort_unstable();
 
@@ -579,7 +726,7 @@ mod tests {
 
         // falls back to finest region that encompasses the whole area
         let nyc_hashes_result = rectangle_hashes(&near_nyc_rectangle, 7);
-        assert_eq!(nyc_hashes_result.unwrap(), ["dr5ru"]);
+        assert_eq!(nyc_hashes_result.unwrap(), [GeoHash::new("dr5ru")]);
     }
 
     #[test]
@@ -609,7 +756,16 @@ mod tests {
 
         let mut usa_hashes_result = rectangle_hashes(&crossing_usa_rectangle, 10);
         usa_hashes_result.as_mut().unwrap().sort_unstable();
-        let mut expected = vec!["8", "9", "b", "c", "d", "f", "x", "z"];
+        let mut expected = vec![
+            GeoHash::new("8"),
+            GeoHash::new("9"),
+            GeoHash::new("b"),
+            GeoHash::new("c"),
+            GeoHash::new("d"),
+            GeoHash::new("f"),
+            GeoHash::new("x"),
+            GeoHash::new("z"),
+        ];
         expected.sort_unstable();
 
         assert_eq!(usa_hashes_result.unwrap(), expected);
@@ -647,7 +803,14 @@ mod tests {
         let mut nyc_hashes_result = polygon_hashes(&near_nyc_polygon, 10);
         nyc_hashes_result.as_mut().unwrap().sort_unstable();
         let mut expected = vec![
-            "dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6",
+            GeoHash::new("dr5ruj"),
+            GeoHash::new("dr5ruh"),
+            GeoHash::new("dr5ru5"),
+            GeoHash::new("dr5ru4"),
+            GeoHash::new("dr5rum"),
+            GeoHash::new("dr5ruk"),
+            GeoHash::new("dr5ru7"),
+            GeoHash::new("dr5ru6"),
         ];
         expected.sort_unstable();
 
@@ -655,7 +818,7 @@ mod tests {
 
         // falls back to finest region that encompasses the whole area
         let nyc_hashes_result = polygon_hashes(&near_nyc_polygon, 7);
-        assert_eq!(nyc_hashes_result.unwrap(), ["dr5ru"]);
+        assert_eq!(nyc_hashes_result.unwrap(), [GeoHash::new("dr5ru"),]);
     }
 
     #[test]
@@ -799,7 +962,15 @@ mod tests {
 
         let max_hashes = 10;
         let hashes = circle_hashes(&query, max_hashes);
-        assert_eq!(hashes.unwrap(), vec!["zbp", "b00", "xzz", "8pb"]);
+        assert_eq!(
+            hashes.unwrap(),
+            vec![
+                GeoHash::new("zbp"),
+                GeoHash::new("b00"),
+                GeoHash::new("xzz"),
+                GeoHash::new("8pb"),
+            ]
+        );
     }
 
     #[test]
@@ -816,7 +987,19 @@ mod tests {
         let hashes = circle_hashes(&query, max_hashes);
         let vec = hashes.unwrap();
         assert!(vec.len() <= max_hashes);
-        assert_eq!(vec, ["b", "c", "f", "g", "u", "v", "y", "z"]);
+        assert_eq!(
+            vec,
+            [
+                GeoHash::new("b"),
+                GeoHash::new("c"),
+                GeoHash::new("f"),
+                GeoHash::new("g"),
+                GeoHash::new("u"),
+                GeoHash::new("v"),
+                GeoHash::new("y"),
+                GeoHash::new("z"),
+            ]
+        );
     }
 
     #[test]
@@ -833,7 +1016,17 @@ mod tests {
         let hashes_result = circle_hashes(&query, max_hashes);
         let hashes = hashes_result.unwrap();
         assert!(hashes.len() <= max_hashes);
-        assert_eq!(hashes, ["fz", "gp", "gr", "gx", "gz", "up"]);
+        assert_eq!(
+            hashes,
+            [
+                GeoHash::new("fz"),
+                GeoHash::new("gp"),
+                GeoHash::new("gr"),
+                GeoHash::new("gx"),
+                GeoHash::new("gz"),
+                GeoHash::new("up"),
+            ]
+        );
     }
 
     #[test]
@@ -849,7 +1042,15 @@ mod tests {
         let hashes_result = circle_hashes(&query, max_hashes);
         let hashes = hashes_result.unwrap();
         assert!(hashes.len() <= max_hashes);
-        assert_eq!(hashes, ["p6yd", "p6yf", "p6y9", "p6yc"]);
+        assert_eq!(
+            hashes,
+            [
+                GeoHash::new("p6yd"),
+                GeoHash::new("p6yf"),
+                GeoHash::new("p6y9"),
+                GeoHash::new("p6yc"),
+            ]
+        );
     }
 
     #[test]
@@ -865,7 +1066,14 @@ mod tests {
         let hashes_result = circle_hashes(&query, max_hashes);
         let hashes = hashes_result.unwrap();
         assert!(hashes.len() <= max_hashes);
-        assert_eq!(hashes, ["p6ycc", "p6ycf", "p6ycg"]);
+        assert_eq!(
+            hashes,
+            [
+                GeoHash::new("p6ycc"),
+                GeoHash::new("p6ycf"),
+                GeoHash::new("p6ycg"),
+            ]
+        );
     }
 
     #[test]
@@ -881,31 +1089,38 @@ mod tests {
         let mut nyc_hashes_result = circle_hashes(&near_nyc_circle, 10);
         nyc_hashes_result.as_mut().unwrap().sort_unstable();
         let mut expected = [
-            "dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6",
+            GeoHash::new("dr5ruj"),
+            GeoHash::new("dr5ruh"),
+            GeoHash::new("dr5ru5"),
+            GeoHash::new("dr5ru4"),
+            GeoHash::new("dr5rum"),
+            GeoHash::new("dr5ruk"),
+            GeoHash::new("dr5ru7"),
+            GeoHash::new("dr5ru6"),
         ];
         expected.sort_unstable();
         assert_eq!(nyc_hashes_result.unwrap(), expected);
 
         // falls back to finest region that encompasses the whole area
         let nyc_hashes_result = circle_hashes(&near_nyc_circle, 7);
-        assert_eq!(nyc_hashes_result.unwrap(), ["dr5ru"]);
+        assert_eq!(nyc_hashes_result.unwrap(), [GeoHash::new("dr5ru")]);
     }
 
     #[test]
     fn go_north() {
-        let mut geohash = sphere_neighbor("ww8p", Direction::N).unwrap();
+        let mut geohash = sphere_neighbor(GeoHash::new("ww8p"), Direction::N).unwrap();
         for _ in 0..1000 {
-            geohash = sphere_neighbor(&geohash, Direction::N).unwrap();
+            geohash = sphere_neighbor(geohash, Direction::N).unwrap();
         }
     }
 
     #[test]
     fn go_west() {
-        let starting_hash = "ww8";
+        let starting_hash = GeoHash::new("ww8");
         let mut geohash = sphere_neighbor(starting_hash, Direction::W).unwrap();
         let mut is_earth_round = false;
         for _ in 0..1000 {
-            geohash = sphere_neighbor(&geohash, Direction::W).unwrap();
+            geohash = sphere_neighbor(geohash, Direction::W).unwrap();
             if geohash == starting_hash {
                 is_earth_round = true;
             }
@@ -915,19 +1130,43 @@ mod tests {
 
     #[test]
     fn sphere_neighbor_corner_cases() {
-        assert_eq!(&sphere_neighbor("z", Direction::NE).unwrap(), "b");
-        assert_eq!(&sphere_neighbor("zz", Direction::NE).unwrap(), "bp");
-        assert_eq!(&sphere_neighbor("0", Direction::SW).unwrap(), "p");
-        assert_eq!(&sphere_neighbor("00", Direction::SW).unwrap(), "pb");
-
-        assert_eq!(&sphere_neighbor("8", Direction::W).unwrap(), "x");
-        assert_eq!(&sphere_neighbor("8h", Direction::W).unwrap(), "xu");
-        assert_eq!(&sphere_neighbor("r", Direction::E).unwrap(), "2");
-        assert_eq!(&sphere_neighbor("ru", Direction::E).unwrap(), "2h");
+        assert_eq!(
+            &SmolStr::from(sphere_neighbor(GeoHash::new("z"), Direction::NE).unwrap()),
+            "b"
+        );
+        assert_eq!(
+            &SmolStr::from(sphere_neighbor(GeoHash::new("zz"), Direction::NE).unwrap()),
+            "bp"
+        );
+        assert_eq!(
+            &SmolStr::from(sphere_neighbor(GeoHash::new("0"), Direction::SW).unwrap()),
+            "p"
+        );
+        assert_eq!(
+            &SmolStr::from(sphere_neighbor(GeoHash::new("00"), Direction::SW).unwrap()),
+            "pb"
+        );
 
         assert_eq!(
-            sphere_neighbor("ww8p1r4t8", Direction::SE).unwrap(),
-            geohash::neighbor("ww8p1r4t8", Direction::SE).unwrap()
+            &SmolStr::from(sphere_neighbor(GeoHash::new("8"), Direction::W).unwrap()),
+            "x"
+        );
+        assert_eq!(
+            &SmolStr::from(sphere_neighbor(GeoHash::new("8h"), Direction::W).unwrap()),
+            "xu"
+        );
+        assert_eq!(
+            &SmolStr::from(sphere_neighbor(GeoHash::new("r"), Direction::E).unwrap()),
+            "2"
+        );
+        assert_eq!(
+            &SmolStr::from(sphere_neighbor(GeoHash::new("ru"), Direction::E).unwrap()),
+            "2h"
+        );
+
+        assert_eq!(
+            SmolStr::from(sphere_neighbor(GeoHash::new("ww8p1r4t8"), Direction::SE).unwrap()),
+            SmolStr::from(&geohash::neighbor("ww8p1r4t8", Direction::SE).unwrap())
         );
     }
 
@@ -942,7 +1181,7 @@ mod tests {
 
     #[test]
     fn turn_geo_hash_to_box() {
-        let geo_box = geo_hash_to_box(&"dr5ruj4477kd".into());
+        let geo_box = geo_hash_to_box(GeoHash::new("dr5ruj4477kd"));
         let center = GeoPoint {
             lat: 40.76517460,
             lon: -74.00101399,
@@ -953,26 +1192,26 @@ mod tests {
     #[test]
     fn common_prefix() {
         let geo_hashes = vec![
-            "abcd123".into(),
-            "abcd2233".into(),
-            "abcd3213".into(),
-            "abcd533".into(),
+            GeoHash::new("zbcd123"),
+            GeoHash::new("zbcd2233"),
+            GeoHash::new("zbcd3213"),
+            GeoHash::new("zbcd533"),
         ];
 
         let common_prefix = common_hash_prefix(&geo_hashes);
 
-        assert_eq!(&common_prefix, "abcd");
+        assert_eq!(common_prefix, GeoHash::new("zbcd"));
 
         let geo_hashes = vec![
-            "abcd123".into(),
-            "bbcd2233".into(),
-            "cbcd3213".into(),
-            "dbcd533".into(),
+            GeoHash::new("zbcd123"),
+            GeoHash::new("bbcd2233"),
+            GeoHash::new("cbcd3213"),
+            GeoHash::new("dbcd533"),
         ];
 
         let common_prefix = common_hash_prefix(&geo_hashes);
 
-        assert_eq!(&common_prefix, "");
+        assert_eq!(common_prefix, GeoHash::new(""));
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -127,7 +127,7 @@ impl GeoHash {
     }
 
     fn shift_value(i: usize) -> usize {
-        // first 4 bits is size, then 5 bits per character in reverse order (for lexigraphical order)
+        // first 4 bits is size, then 5 bits per character in reverse order (for lexicographical order)
         5 * (GEOHASH_MAX_LENGTH - 1 - i) + 4
     }
 }

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -644,18 +644,31 @@ mod tests {
 
     #[test]
     fn geohash_starts_with() {
-        assert!(GeoHash::new("uft560000000")
-            .unwrap()
-            .starts_with(GeoHash::new("uft5600").unwrap()));
-        assert!(GeoHash::new("uft5600")
-            .unwrap()
-            .starts_with(GeoHash::new("").unwrap()));
-        assert!(GeoHash::new("")
-            .unwrap()
-            .starts_with(GeoHash::new("").unwrap()));
-        assert!(GeoHash::new("uft56000000r")
-            .unwrap()
-            .starts_with(GeoHash::new("uft56000000r").unwrap()));
+        let samples = [
+            "",
+            "uft5601",
+            "uft560100000",
+            "uft56010000r",
+            "uft5602",
+            "uft560200000",
+        ];
+        for a_str in samples.iter() {
+            let a_hash = GeoHash::new(a_str).unwrap();
+            for b_str in samples.iter() {
+                let b_hash = GeoHash::new(b_str).unwrap();
+                if a_str.starts_with(b_str) {
+                    assert!(
+                        a_hash.starts_with(b_hash),
+                        "{a_str:?} expected to start with {b_str:?}",
+                    );
+                } else {
+                    assert!(
+                        !a_hash.starts_with(b_hash),
+                        "{a_str:?} expected to not start with {b_str:?}",
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
+use smol_str::SmolStr;
 
 use super::mutable_geo_index::MutableGeoMapIndex;
 use super::GeoMapIndex;
@@ -109,7 +110,7 @@ impl ImmutableGeoMapIndex {
         let mut counts_per_hash: BTreeMap<GeoHash, Counts> = Default::default();
         for (hash, points) in points_per_hash {
             counts_per_hash.insert(
-                hash.clone(),
+                hash,
                 Counts {
                     hash,
                     points: points as u32,
@@ -122,7 +123,7 @@ impl ImmutableGeoMapIndex {
                 counts.values = values as u32;
             } else {
                 counts_per_hash.insert(
-                    hash.clone(),
+                    hash,
                     Counts {
                         hash,
                         points: 0,
@@ -133,10 +134,7 @@ impl ImmutableGeoMapIndex {
         }
 
         self.counts_per_hash = counts_per_hash.values().cloned().collect();
-        self.points_map = points_map
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        self.points_map = points_map.iter().map(|(k, v)| (*k, v.clone())).collect();
         self.point_to_values = ImmutablePointToValues::new(point_to_values);
         self.points_count = points_count;
         self.points_values_count = points_values_count;
@@ -158,9 +156,9 @@ impl ImmutableGeoMapIndex {
         for removed_geo_point in removed_geo_points {
             let removed_geo_hash: GeoHash =
                 encode_max_precision(removed_geo_point.lon, removed_geo_point.lat).unwrap();
-            removed_geo_hashes.push(removed_geo_hash.clone());
+            removed_geo_hashes.push(removed_geo_hash);
 
-            let key = GeoMapIndex::encode_db_key(&removed_geo_hash, idx);
+            let key = GeoMapIndex::encode_db_key(removed_geo_hash, idx);
             self.db_wrapper.remove(key)?;
 
             if let Ok(index) = self
@@ -171,7 +169,7 @@ impl ImmutableGeoMapIndex {
             } else {
                 log::warn!(
                     "Geo index error: no points for hash {} was found",
-                    removed_geo_hash
+                    SmolStr::from(removed_geo_hash),
                 );
             };
 
@@ -186,61 +184,71 @@ impl ImmutableGeoMapIndex {
         &self,
         geo: &GeoHash,
     ) -> impl Iterator<Item = &(GeoHash, HashSet<PointOffsetType>)> + '_ {
-        let geo_clone = geo.clone();
+        let geo_clone = *geo;
         let start_index = self
             .points_map
             .binary_search_by(|(p, _h)| p.cmp(geo))
             .unwrap_or_else(|index| index);
         self.points_map[start_index..]
             .iter()
-            .take_while(move |(p, _h)| p.starts_with(geo_clone.as_str()))
+            .take_while(move |(p, _h)| p.starts_with(geo_clone))
     }
 
     fn decrement_hash_value_counts(&mut self, geo_hash: &GeoHash) {
         for i in 0..=geo_hash.len() {
-            let sub_geo_hash = &geo_hash[0..i];
+            let sub_geo_hash = geo_hash.cut(i);
             if let Ok(index) = self
                 .counts_per_hash
-                .binary_search_by(|x| x.hash.as_str().cmp(sub_geo_hash))
+                .binary_search_by(|x| x.hash.cmp(&sub_geo_hash))
             {
                 let values_count = self.counts_per_hash[index].values;
                 if values_count > 0 {
                     self.counts_per_hash[index].values = values_count - 1;
                 } else {
-                    debug_assert!(false, "Hash value count is already empty: {sub_geo_hash}",);
+                    debug_assert!(
+                        false,
+                        "Hash value count is already empty: {}",
+                        SmolStr::from(sub_geo_hash),
+                    );
                 }
             } else {
                 debug_assert!(
                     false,
-                    "Hash value count is not found for hash: {sub_geo_hash}",
+                    "Hash value count is not found for hash: {}",
+                    SmolStr::from(sub_geo_hash),
                 );
             }
         }
     }
 
     fn decrement_hash_point_counts(&mut self, geo_hashes: &[GeoHash]) {
-        let mut seen_hashes: HashSet<&str> = Default::default();
+        let mut seen_hashes: HashSet<GeoHash> = Default::default();
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
-                let sub_geo_hash = &geo_hash[0..i];
-                if seen_hashes.contains(sub_geo_hash) {
+                let sub_geo_hash = geo_hash.cut(i);
+                if seen_hashes.contains(&sub_geo_hash) {
                     continue;
                 }
                 seen_hashes.insert(sub_geo_hash);
                 if let Ok(index) = self
                     .counts_per_hash
-                    .binary_search_by(|x| x.hash.as_str().cmp(sub_geo_hash))
+                    .binary_search_by(|x| x.hash.cmp(&sub_geo_hash))
                 {
                     let points_count = self.counts_per_hash[index].points;
                     if points_count > 0 {
                         self.counts_per_hash[index].points = points_count - 1;
                     } else {
-                        debug_assert!(false, "Hash point count is already empty: {sub_geo_hash}",);
+                        debug_assert!(
+                            false,
+                            "Hash point count is already empty: {}",
+                            SmolStr::from(sub_geo_hash),
+                        );
                     }
                 } else {
                     debug_assert!(
                         false,
-                        "Hash point count is not found for hash: {sub_geo_hash}",
+                        "Hash point count is not found for hash: {}",
+                        SmolStr::from(sub_geo_hash),
                     );
                 };
             }

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -159,7 +159,7 @@ impl ImmutableGeoMapIndex {
             removed_geo_hashes.push(removed_geo_hash);
 
             let key = GeoMapIndex::encode_db_key(removed_geo_hash, idx);
-            self.db_wrapper.remove(key)?;
+            self.db_wrapper.remove(key.as_bytes())?;
 
             if let Ok(index) = self
                 .points_map

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -196,7 +196,7 @@ impl ImmutableGeoMapIndex {
 
     fn decrement_hash_value_counts(&mut self, geo_hash: &GeoHash) {
         for i in 0..=geo_hash.len() {
-            let sub_geo_hash = geo_hash.cut(i);
+            let sub_geo_hash = geo_hash.truncate(i);
             if let Ok(index) = self
                 .counts_per_hash
                 .binary_search_by(|x| x.hash.cmp(&sub_geo_hash))
@@ -225,7 +225,7 @@ impl ImmutableGeoMapIndex {
         let mut seen_hashes: HashSet<GeoHash> = Default::default();
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
-                let sub_geo_hash = geo_hash.cut(i);
+                let sub_geo_hash = geo_hash.truncate(i);
                 if seen_hashes.contains(&sub_geo_hash) {
                     continue;
                 }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -121,7 +121,10 @@ impl GeoMapIndex {
         let idx_str = &s[separator_pos + 1..];
         let idx = PointOffsetType::from_str(idx_str)
             .map_err(|_| OperationError::service_error(DECODE_ERR))?;
-        Ok((GeoHash::new(geohash_str), idx))
+        Ok((
+            GeoHash::new(geohash_str).map_err(OperationError::from)?,
+            idx,
+        ))
     }
 
     fn decode_db_value<T: AsRef<[u8]>>(value: T) -> OperationResult<GeoPoint> {

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -117,11 +117,11 @@ impl GeoMapIndex {
         if separator_pos == s.len() - 1 {
             return Err(OperationError::service_error(DECODE_ERR));
         }
-        let geohash_str: SmolStr = s[..separator_pos].into();
+        let geohash_str = &s[..separator_pos];
         let idx_str = &s[separator_pos + 1..];
         let idx = PointOffsetType::from_str(idx_str)
             .map_err(|_| OperationError::service_error(DECODE_ERR))?;
-        Ok((GeoHash::from(geohash_str), idx))
+        Ok((GeoHash::new(geohash_str), idx))
     }
 
     fn decode_db_value<T: AsRef<[u8]>>(value: T) -> OperationResult<GeoPoint> {
@@ -275,7 +275,7 @@ impl GeoMapIndex {
         let mut current_region = GeoHash::default();
 
         for (&region, size) in large_regions {
-            if current_region.cut(region.len()) != region {
+            if !current_region.starts_with(region) {
                 current_region = region;
                 edge_region.push((region, size));
             }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
-use smol_str::SmolStr;
+use smol_str::{format_smolstr, SmolStr};
 
 use self::immutable_geo_index::ImmutableGeoMapIndex;
 use self::mutable_geo_index::MutableGeoMapIndex;
@@ -104,9 +104,9 @@ impl GeoMapIndex {
         format!("{field}_geo")
     }
 
-    fn encode_db_key(value: GeoHash, idx: PointOffsetType) -> String {
+    fn encode_db_key(value: GeoHash, idx: PointOffsetType) -> SmolStr {
         let value_str = SmolStr::from(value);
-        format!("{value_str}/{idx}")
+        format_smolstr!("{value_str}/{idx}")
     }
 
     fn decode_db_key(s: &str) -> OperationResult<(GeoHash, PointOffsetType)> {

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -159,7 +159,7 @@ impl MutableGeoMapIndex {
             removed_geo_hashes.push(removed_geo_hash);
 
             let key = GeoMapIndex::encode_db_key(removed_geo_hash, idx);
-            self.db_wrapper.remove(key)?;
+            self.db_wrapper.remove(key.as_bytes())?;
 
             let is_last = if let Some(hash_ids) = self.points_map.get_mut(&removed_geo_hash) {
                 hash_ids.remove(&idx);
@@ -210,7 +210,7 @@ impl MutableGeoMapIndex {
 
             geo_hashes.push(added_geo_hash);
 
-            self.db_wrapper.put(key, value)?;
+            self.db_wrapper.put(key.as_bytes(), value)?;
         }
 
         for geo_hash in &geo_hashes {

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
+use smol_str::SmolStr;
 
 use super::GeoMapIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -119,16 +120,10 @@ impl MutableGeoMapIndex {
                 self.points_count += 1;
             }
 
-            points_to_hashes
-                .entry(idx)
-                .or_default()
-                .push(geo_hash.clone());
+            points_to_hashes.entry(idx).or_default().push(geo_hash);
 
             self.point_to_values[idx as usize].push(geo_point);
-            self.points_map
-                .entry(geo_hash.clone())
-                .or_default()
-                .insert(idx);
+            self.points_map.entry(geo_hash).or_default().insert(idx);
 
             self.points_values_count += 1;
         }
@@ -161,9 +156,9 @@ impl MutableGeoMapIndex {
         for removed_geo_point in removed_geo_points {
             let removed_geo_hash: GeoHash =
                 encode_max_precision(removed_geo_point.lon, removed_geo_point.lat).unwrap();
-            removed_geo_hashes.push(removed_geo_hash.clone());
+            removed_geo_hashes.push(removed_geo_hash);
 
-            let key = GeoMapIndex::encode_db_key(&removed_geo_hash, idx);
+            let key = GeoMapIndex::encode_db_key(removed_geo_hash, idx);
             self.db_wrapper.remove(key)?;
 
             let is_last = if let Some(hash_ids) = self.points_map.get_mut(&removed_geo_hash) {
@@ -172,7 +167,7 @@ impl MutableGeoMapIndex {
             } else {
                 log::warn!(
                     "Geo index error: no points for hash {} was found",
-                    removed_geo_hash
+                    SmolStr::from(removed_geo_hash),
                 );
                 false
             };
@@ -210,7 +205,7 @@ impl MutableGeoMapIndex {
             let added_geo_hash: GeoHash = encode_max_precision(added_point.lon, added_point.lat)
                 .map_err(|e| OperationError::service_error(format!("Malformed geo points: {e}")))?;
 
-            let key = GeoMapIndex::encode_db_key(&added_geo_hash, idx);
+            let key = GeoMapIndex::encode_db_key(added_geo_hash, idx);
             let value = GeoMapIndex::encode_db_value(added_point);
 
             geo_hashes.push(added_geo_hash);
@@ -239,18 +234,18 @@ impl MutableGeoMapIndex {
         &self,
         geo: &GeoHash,
     ) -> impl Iterator<Item = (&GeoHash, &HashSet<PointOffsetType>)> + '_ {
-        let geo_clone = geo.clone();
+        let geo_clone = *geo;
         self.points_map
-            .range(geo.clone()..)
-            .take_while(move |(p, _h)| p.starts_with(geo_clone.as_str()))
+            .range(*geo..)
+            .take_while(move |(p, _h)| p.cut(geo_clone.len()) == geo_clone)
     }
 
     fn increment_hash_value_counts(&mut self, geo_hash: &GeoHash) {
         for i in 0..=geo_hash.len() {
-            let sub_geo_hash = &geo_hash[0..i];
-            match self.values_per_hash.get_mut(sub_geo_hash) {
+            let sub_geo_hash = geo_hash.cut(i);
+            match self.values_per_hash.get_mut(&sub_geo_hash) {
                 None => {
-                    self.values_per_hash.insert(sub_geo_hash.into(), 1);
+                    self.values_per_hash.insert(sub_geo_hash, 1);
                 }
                 Some(count) => {
                     *count += 1;
@@ -260,18 +255,18 @@ impl MutableGeoMapIndex {
     }
 
     fn increment_hash_point_counts(&mut self, geo_hashes: &[GeoHash]) {
-        let mut seen_hashes: HashSet<&str> = Default::default();
+        let mut seen_hashes: HashSet<GeoHash> = Default::default();
 
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
-                let sub_geo_hash = &geo_hash[0..i];
-                if seen_hashes.contains(sub_geo_hash) {
+                let sub_geo_hash = geo_hash.cut(i);
+                if seen_hashes.contains(&sub_geo_hash) {
                     continue;
                 }
                 seen_hashes.insert(sub_geo_hash);
-                match self.points_per_hash.get_mut(sub_geo_hash) {
+                match self.points_per_hash.get_mut(&sub_geo_hash) {
                     None => {
-                        self.points_per_hash.insert(sub_geo_hash.into(), 1);
+                        self.points_per_hash.insert(sub_geo_hash, 1);
                     }
                     Some(count) => {
                         *count += 1;
@@ -283,14 +278,15 @@ impl MutableGeoMapIndex {
 
     fn decrement_hash_value_counts(&mut self, geo_hash: &GeoHash) {
         for i in 0..=geo_hash.len() {
-            let sub_geo_hash = &geo_hash[0..i];
-            match self.values_per_hash.get_mut(sub_geo_hash) {
+            let sub_geo_hash = geo_hash.cut(i);
+            match self.values_per_hash.get_mut(&sub_geo_hash) {
                 None => {
                     debug_assert!(
                         false,
-                        "Hash value count is not found for hash: {sub_geo_hash}"
+                        "Hash value count is not found for hash: {}",
+                        SmolStr::from(sub_geo_hash),
                     );
-                    self.values_per_hash.insert(sub_geo_hash.into(), 0);
+                    self.values_per_hash.insert(sub_geo_hash, 0);
                 }
                 Some(count) => {
                     *count -= 1;
@@ -300,21 +296,22 @@ impl MutableGeoMapIndex {
     }
 
     fn decrement_hash_point_counts(&mut self, geo_hashes: &[GeoHash]) {
-        let mut seen_hashes: HashSet<&str> = Default::default();
+        let mut seen_hashes: HashSet<GeoHash> = Default::default();
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
-                let sub_geo_hash = &geo_hash[0..i];
-                if seen_hashes.contains(sub_geo_hash) {
+                let sub_geo_hash = geo_hash.cut(i);
+                if seen_hashes.contains(&sub_geo_hash) {
                     continue;
                 }
                 seen_hashes.insert(sub_geo_hash);
-                match self.points_per_hash.get_mut(sub_geo_hash) {
+                match self.points_per_hash.get_mut(&sub_geo_hash) {
                     None => {
                         debug_assert!(
                             false,
-                            "Hash point count is not found for hash: {sub_geo_hash}"
+                            "Hash point count is not found for hash: {}",
+                            SmolStr::from(sub_geo_hash),
                         );
-                        self.points_per_hash.insert(sub_geo_hash.into(), 0);
+                        self.points_per_hash.insert(sub_geo_hash, 0);
                     }
                     Some(count) => {
                         *count -= 1;

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -237,7 +237,7 @@ impl MutableGeoMapIndex {
         let geo_clone = *geo;
         self.points_map
             .range(*geo..)
-            .take_while(move |(p, _h)| p.cut(geo_clone.len()) == geo_clone)
+            .take_while(move |(p, _h)| p.starts_with(geo_clone))
     }
 
     fn increment_hash_value_counts(&mut self, geo_hash: &GeoHash) {

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -242,7 +242,7 @@ impl MutableGeoMapIndex {
 
     fn increment_hash_value_counts(&mut self, geo_hash: &GeoHash) {
         for i in 0..=geo_hash.len() {
-            let sub_geo_hash = geo_hash.cut(i);
+            let sub_geo_hash = geo_hash.truncate(i);
             match self.values_per_hash.get_mut(&sub_geo_hash) {
                 None => {
                     self.values_per_hash.insert(sub_geo_hash, 1);
@@ -259,7 +259,7 @@ impl MutableGeoMapIndex {
 
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
-                let sub_geo_hash = geo_hash.cut(i);
+                let sub_geo_hash = geo_hash.truncate(i);
                 if seen_hashes.contains(&sub_geo_hash) {
                     continue;
                 }
@@ -278,7 +278,7 @@ impl MutableGeoMapIndex {
 
     fn decrement_hash_value_counts(&mut self, geo_hash: &GeoHash) {
         for i in 0..=geo_hash.len() {
-            let sub_geo_hash = geo_hash.cut(i);
+            let sub_geo_hash = geo_hash.truncate(i);
             match self.values_per_hash.get_mut(&sub_geo_hash) {
                 None => {
                     debug_assert!(
@@ -299,7 +299,7 @@ impl MutableGeoMapIndex {
         let mut seen_hashes: HashSet<GeoHash> = Default::default();
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
-                let sub_geo_hash = geo_hash.cut(i);
+                let sub_geo_hash = geo_hash.truncate(i);
                 if seen_hashes.contains(&sub_geo_hash) {
                     continue;
                 }


### PR DESCRIPTION
This PR replaces `GeoHash` implementation from `SmolStr` into `u64`. It's possible because each string char can be one of 32 values (5bits), max chars 12 (5*12=60bits) and size 4 bit.