### PR TITLE
Check that peer still exist, when applying finish transfer operation

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use futures::{future, TryStreamExt as _};
@@ -168,6 +169,7 @@ impl Collection {
     pub async fn handle_replica_changes(
         &self,
         replica_changes: Vec<Change>,
+        all_peers: &HashSet<PeerId>,
     ) -> CollectionResult<()> {
         if replica_changes.is_empty() {
             return Ok(());
@@ -212,7 +214,7 @@ impl Collection {
 
                 // ...and cancel transfer tasks and remove transfers from internal state
                 for transfer in transfers {
-                    self.finish_shard_transfer(transfer, Some(&shard_holder))
+                    self.finish_shard_transfer(transfer, all_peers, Some(&shard_holder))
                         .await?;
                 }
             }

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -1,5 +1,4 @@
 use std::cmp;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use futures::{future, TryStreamExt as _};
@@ -169,7 +168,6 @@ impl Collection {
     pub async fn handle_replica_changes(
         &self,
         replica_changes: Vec<Change>,
-        all_peers: &HashSet<PeerId>,
     ) -> CollectionResult<()> {
         if replica_changes.is_empty() {
             return Ok(());
@@ -214,7 +212,7 @@ impl Collection {
 
                 // ...and cancel transfer tasks and remove transfers from internal state
                 for transfer in transfers {
-                    self.finish_shard_transfer(transfer, all_peers, Some(&shard_holder))
+                    self.finish_shard_transfer(transfer, Some(&shard_holder))
                         .await?;
                 }
             }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -14,9 +14,7 @@ use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_holder::ShardHolder;
 use crate::shards::transfer;
-use crate::shards::transfer::transfer_tasks_pool::{
-    TaskResult, TransferTaskItem, TransferTaskProgress,
-};
+use crate::shards::transfer::transfer_tasks_pool::{TransferTaskItem, TransferTaskProgress};
 use crate::shards::transfer::{
     ShardTransfer, ShardTransferConsensus, ShardTransferKey, ShardTransferMethod,
 };
@@ -193,9 +191,7 @@ impl Collection {
             .stop_task(&transfer.key())
             .await;
 
-        let transfer_finished = transfer_result == Some(TaskResult::Finished);
-
-        log::debug!("transfer_finished: {transfer_finished}");
+        log::debug!("Transfer result: {transfer_result:?}");
 
         let mut shard_holder_guard = None;
 
@@ -204,85 +200,60 @@ impl Collection {
             None => shard_holder_guard.insert(self.shards_holder.read().await),
         };
 
-        // Should happen on transfer side
-        // Unwrap forward proxy into local shard, or replace it with remote shard
-        // depending on the `sync` flag.
-        if self.this_peer_id == transfer.from {
-            // Normally we promote the shard to become active, in case of resharding we do not.
-            // For resharding we have multiple transfers in sequence, during which the shard should
-            // remain in the resharding state. Once all are done, the shard is manually promoted to active.
-            let dst_peer_exists = all_peers.contains(&transfer.to);
+        let is_resharding_transfer = transfer
+            .method
+            .map_or(false, |method| method.is_resharding());
 
-            let is_resharding_transfer = transfer
-                .method
-                .map_or(false, |method| method.is_resharding());
+        // Handle *source* replica/shard
+        let src_replica_set = shard_holder.get_shard(&transfer.shard_id);
 
-            let activate_shard = dst_peer_exists && !is_resharding_transfer;
+        if let Some(replica_set) = src_replica_set {
+            if transfer.sync || is_resharding_transfer {
+                // If transfer is *sync* (or *resharding*), we *keep* source replica/shard
 
-            let proxy_promoted = transfer::driver::handle_transferred_shard_proxy(
-                shard_holder,
-                transfer.shard_id,
-                transfer.to,
-                activate_shard,
-                transfer.sync,
-            )
-            .await?;
+                if transfer.from == self.this_peer_id {
+                    // If current peer is *transfer-sender*, we need to unproxify local shard
 
-            log::debug!("proxy_promoted: {proxy_promoted}");
-        }
-
-        // Should happen on receiving side
-        // Promote partial shard to active shard
-        // In case of resharding we manually promote the shard, and there are no partial shards
-        if self.this_peer_id == transfer.to
-            && !transfer
-                .method
-                .map_or(false, |method| method.is_resharding())
-        {
-            let shard_promoted =
-                transfer::driver::finalize_partial_shard(shard_holder, transfer.shard_id).await?;
-            log::debug!(
-                "shard_promoted: {shard_promoted}, shard_id: {}, peer_id: {}",
-                transfer.shard_id,
-                self.this_peer_id,
-            );
-        }
-
-        // Should happen on a third-party side
-        // Change direction of the remote shards or add a new remote shard
-        if self.this_peer_id != transfer.from {
-            // Normally we promote the shard to become active, in case of resharding we do not.
-            // For resharding we have multiple transfers in sequence, during which the shard should
-            // remain in the resharding state. Once all are done, the shard is manually promoted to active.
-            let state = if transfer
-                .method
-                .map_or(false, |method| method.is_resharding())
-            {
-                ReplicaState::Resharding
+                    replica_set.un_proxify_local().await?;
+                }
             } else {
-                ReplicaState::Active
-            };
+                // If transfer is *not* sync, we *remove* source replica/shard
 
-            let state = if all_peers.contains(&transfer.to) {
-                Some(state)
-            } else {
-                None
-            };
-
-            let remote_shard_rerouted = transfer::driver::change_remote_shard_route(
-                shard_holder,
-                transfer.shard_id,
-                transfer.to_shard_id.unwrap_or(transfer.shard_id),
-                transfer.from,
-                transfer.to,
-                state,
-                transfer.sync,
-            )
-            .await?;
-            log::debug!("remote_shard_rerouted: {remote_shard_rerouted}");
+                if transfer.from == self.this_peer_id {
+                    replica_set.remove_local().await?;
+                } else {
+                    replica_set.remove_remote(transfer.from).await?;
+                }
+            }
         }
-        let finish_was_registered = shard_holder.register_finish_transfer(&transfer.key())?;
-        log::debug!("finish_was_registered: {finish_was_registered}");
+
+        // Handle *destination* replica/shard
+        let dest_replica_set =
+            shard_holder.get_shard(&transfer.to_shard_id.unwrap_or(transfer.shard_id));
+
+        if let Some(replica_set) = dest_replica_set {
+            let does_dest_peer_exist = all_peers.contains(&transfer.to);
+
+            if does_dest_peer_exist && !is_resharding_transfer {
+                // Promote *destination* shard/replica to `Active` if:
+                //
+                // - destination *peer* exists
+                //   - destination peer might *not* exist, if peer is removed right before transfer
+                //     is finished
+                // - transfer is *not* resharding
+                //   - resharding requires multiple transfers, so destination shard is promoted
+                //     *explicitly* when all transfers are finished
+
+                // We expect that replica already exists in the replica set
+                debug_assert!(replica_set.peer_state(&transfer.to).is_some());
+
+                replica_set.set_replica_state(&transfer.to, ReplicaState::Active)?;
+            }
+        }
+
+        let is_finish_registered = shard_holder.register_finish_transfer(&transfer.key())?;
+        log::debug!("Transfer finish registered: {is_finish_registered}");
+
         Ok(())
     }
 

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -187,7 +187,7 @@ pub async fn change_remote_shard_route(
     to_shard_id: ShardId,
     old_peer_id: PeerId,
     new_peer_id: PeerId,
-    state: ReplicaState,
+    state: Option<ReplicaState>,
     sync: bool,
 ) -> CollectionResult<bool> {
     let from_replica_set = match shard_holder.get_shard(&from_shard_id) {
@@ -199,8 +199,10 @@ pub async fn change_remote_shard_route(
         Some(replica_set) => replica_set,
     };
 
-    if to_replica_set.this_peer_id() != new_peer_id {
-        to_replica_set.add_remote(new_peer_id, state).await?;
+    if let Some(state) = state {
+        if to_replica_set.this_peer_id() != new_peer_id {
+            to_replica_set.add_remote(new_peer_id, state).await?;
+        }
     }
 
     if !sync {

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -16,8 +16,7 @@ use crate::common::stoppable_task_async::{spawn_async_cancellable, CancellableAs
 use crate::operations::types::CollectionResult;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
-use crate::shards::replica_set::ReplicaState;
-use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::{LockedShardHolder, ShardHolder};
 use crate::shards::CollectionId;
 
@@ -177,91 +176,6 @@ pub async fn revert_proxy_shard_to_local(
 
     // Un-proxify local shard
     replica_set.un_proxify_local().await?;
-
-    Ok(true)
-}
-
-pub async fn change_remote_shard_route(
-    shard_holder: &ShardHolder,
-    from_shard_id: ShardId,
-    to_shard_id: ShardId,
-    old_peer_id: PeerId,
-    new_peer_id: PeerId,
-    state: Option<ReplicaState>,
-    sync: bool,
-) -> CollectionResult<bool> {
-    let from_replica_set = match shard_holder.get_shard(&from_shard_id) {
-        None => return Ok(false),
-        Some(replica_set) => replica_set,
-    };
-    let to_replica_set = match shard_holder.get_shard(&to_shard_id) {
-        None => return Ok(false),
-        Some(replica_set) => replica_set,
-    };
-
-    if let Some(state) = state {
-        if to_replica_set.this_peer_id() != new_peer_id {
-            to_replica_set.add_remote(new_peer_id, state).await?;
-        }
-    }
-
-    if !sync {
-        // Transfer was a move, we need to remove the old peer
-        from_replica_set.remove_remote(old_peer_id).await?;
-    }
-    Ok(true)
-}
-
-/// Mark partial shard as ready
-///
-/// Returns `true` if the shard was promoted, `false` if the shard was not found.
-pub async fn finalize_partial_shard(
-    shard_holder: &ShardHolder,
-    shard_id: ShardId,
-) -> CollectionResult<bool> {
-    let replica_set = match shard_holder.get_shard(&shard_id) {
-        None => return Ok(false),
-        Some(replica_set) => replica_set,
-    };
-
-    if !replica_set.has_local_shard().await {
-        return Ok(false);
-    }
-
-    replica_set.set_replica_state(&replica_set.this_peer_id(), ReplicaState::Active)?;
-    Ok(true)
-}
-
-/// Promotes wrapped local shard to remote shard
-///
-/// Returns true if the shard was promoted, false if it was already handled
-pub async fn handle_transferred_shard_proxy(
-    shard_holder: &ShardHolder,
-    shard_id: ShardId,
-    to: PeerId,
-    activate_shard: bool,
-    sync: bool,
-) -> CollectionResult<bool> {
-    // TODO: Ensure cancel safety!
-
-    let replica_set = match shard_holder.get_shard(&shard_id) {
-        None => return Ok(false),
-        Some(replica_set) => replica_set,
-    };
-
-    if activate_shard {
-        replica_set.add_remote(to, ReplicaState::Active).await?;
-    }
-
-    if sync {
-        // Keep local shard in the replica set
-        replica_set.un_proxify_local().await?;
-    } else {
-        // Remove local proxy
-        //
-        // TODO: Ensure cancel safety!
-        replica_set.remove_local().await?;
-    }
 
     Ok(true)
 }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -159,17 +159,7 @@ impl TableOfContent {
             recreate_optimizers = true;
         }
         if let Some(changes) = replica_changes {
-            let all_peers = self
-                .channel_service
-                .id_to_address
-                .read()
-                .keys()
-                .copied()
-                .collect();
-
-            collection
-                .handle_replica_changes(changes, &all_peers)
-                .await?;
+            collection.handle_replica_changes(changes).await?;
         }
 
         // Recreate optimizers
@@ -597,17 +587,7 @@ impl TableOfContent {
                     &collection.state().await.transfers,
                 )?;
 
-                let all_peers: HashSet<_> = self
-                    .channel_service
-                    .id_to_address
-                    .read()
-                    .keys()
-                    .cloned()
-                    .collect();
-
-                collection
-                    .finish_shard_transfer(transfer, &all_peers, None)
-                    .await?;
+                collection.finish_shard_transfer(transfer, None).await?;
             }
             ShardTransferOperations::RecoveryToPartial(transfer)
             | ShardTransferOperations::SnapshotRecovered(transfer) => {


### PR DESCRIPTION
This PR fixes a possible bug, when peer is removed right before shard transfer **to** removed peer is finished, which may create an "orphan" shard: a shard, that exists in shard replica state, but the **peer** this shard should belong to is already removed from cluster.

The fix is rather simple: when applying `ShardTransfer::Finish` conensus message, only mark replica as `Active`, if *peer* still exists in the cluster.

This PR also restructures/simplifies `Collection::finish_shard_transfer`, cause it was too hard to work with before.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~Have you written new tests for your core changes, as applicable?~~
* [ ] ~~Have you successfully ran tests with your changes locally?~~
