### PR TITLE
Facets: add consistency param to openapi

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5297,6 +5297,15 @@
               "type": "integer",
               "minimum": 1
             }
+          },
+          {
+            "name": "consistency",
+            "in": "query",
+            "description": "Define read consistency guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReadConsistency"
+            }
           }
         ],
         "responses": {

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -373,8 +373,8 @@ impl FieldIndex {
         match self {
             FieldIndex::KeywordIndex(index) => Some(FacetIndex::Keyword(index)),
             FieldIndex::IntMapIndex(index) => Some(FacetIndex::Int(index)),
-            | FieldIndex::UuidMapIndex(_) // TODO(facets): use uuid index too
-            | FieldIndex::UuidIndex(_)
+            FieldIndex::UuidMapIndex(index) => Some(FacetIndex::Uuid(index)),
+            FieldIndex::UuidIndex(_)
             | FieldIndex::IntIndex(_)
             | FieldIndex::DatetimeIndex(_)
             | FieldIndex::FloatIndex(_)

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -642,6 +642,12 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - name: consistency
+          in: query
+          description: Define read consistency guarantees for the operation
+          required: false
+          schema:
+            $ref: "#/components/schemas/ReadConsistency"
       responses: #@ response(reference("FacetResponse"))
       
   /collections/{collection_name}/points/query:


### PR DESCRIPTION
Adds the missing read consistency query parameter to the openapi spec for the facets endpoint