### PR TITLE
Fix panic during payload index building

### DIFF
--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -654,7 +654,7 @@ impl SegmentEntry for Segment {
             Some(schema) => {
                 let res = self
                     .payload_index
-                    .borrow_mut()
+                    .borrow()
                     .build_index(key, schema)?
                     .map(|field_index| (schema.to_owned(), field_index));
 
@@ -669,7 +669,7 @@ impl SegmentEntry for Segment {
 
                     let res = self
                         .payload_index
-                        .borrow_mut()
+                        .borrow()
                         .build_index(key, &schema)?
                         .map(|field_index| (schema, field_index));
 


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/4970>

Fix a panic during payload index building.

We took a [`payload_index.borrow_mut()`](https://github.com/qdrant/qdrant/blob/8a46eb12478b6f535ac08a45228a2c17fd8d1730/lib/segment/src/segment/entry.rs#L657) while not having exclusive access to the parameter (`&self`). Other actors accessing the payload index at the same time trigger a panic.

We recently implemented non-blocking payload indexing in <https://github.com/qdrant/qdrant/pull/4941> which is where this problem was introduced. It didn't happen before because the function taking the mutable borrow enforced exclusive access on its own (with `&mut self`).

It turns out the `borrow_mut()` is obsolete now because we don't need mutability on the value anymore.

Changing the `borrow_mut()` to `borrow()` patches the problem and guarantees this cannot happen anymore.

### Reproduce

This panic can be reproduced in Qdrant v1.11.1 with `cargo run -r -- --drills-to-run collections_churn` using [coach](https://github.com/qdrant/coach).

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?