### PR TITLE
Bump version to v1.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "api"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "chrono",
  "common",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.11.1"
+version = "1.11.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.11.1"
+version = "1.11.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.11.1";
+pub const QDRANT_VERSION_STRING: &str = "1.11.2";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=a1ab6d36d2ddc6564b08e64eab28ae0ce7e48425
+IGNORE_UPTO=6f11e748c3d878342ef45d07f867d1360dadcdda
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
PR to release Qdrant 1.11.2.

Most importantly, this fixes a potential panic during payload index building (<https://github.com/qdrant/qdrant/pull/4973>).

Follows the pattern of <https://github.com/qdrant/qdrant/pull/4962>.

---

# Change log

## Bug fixes

- https://github.com/qdrant/qdrant/pull/4973 - Fix potential panic during payload index building