### PR TITLE
Bump dev version to 1.11.3-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "api"
-version = "1.11.2-dev"
+version = "1.11.3-dev"
 dependencies = [
  "chrono",
  "common",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.11.2-dev"
+version = "1.11.3-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.11.2-dev"
+version = "1.11.3-dev"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.11.2-dev"
+version = "1.11.3-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.11.2-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.11.3-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to `1.11.3-dev` with the release of <https://github.com/qdrant/qdrant/pull/4974>.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/4965>.