### PR TITLE
Refactor condition converter, use uuid index there too

### DIFF
--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -50,7 +50,6 @@ pub enum FacetValue {
     Uuid(UuidIntType),
     // other types to add?
     // Bool(bool),
-    // Integer(IntPayloadType),
     // FloatRange(FloatRange),
 }
 

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -1,6 +1,9 @@
+mod match_converter;
+
 use std::collections::HashSet;
 
 use common::types::PointOffsetType;
+use match_converter::get_match_checkers;
 use serde_json::Value;
 
 use crate::common::utils::IndexesMap;
@@ -8,15 +11,14 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::FieldIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
-use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::payload_storage::query_checker::{
     check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
     select_nested_indexes,
 };
 use crate::types::{
-    AnyVariants, Condition, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox,
-    GeoPolygon, GeoRadius, IntPayloadType, Match, MatchAny, MatchExcept, MatchText, MatchValue,
-    OwnedPayloadRef, PayloadContainer, Range, RangeInterface, ValueVariants,
+    Condition, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPolygon,
+    GeoRadius, IntPayloadType, OwnedPayloadRef, PayloadContainer, Range, RangeInterface,
+    ValuesCount,
 };
 
 pub fn condition_converter<'a>(
@@ -164,13 +166,18 @@ pub fn field_condition_index<'a>(
         } => get_geo_polygon_checkers(index, geo_polygon.clone()),
 
         FieldCondition {
+            values_count: Some(values_count),
+            ..
+        } => Some(get_values_count_checkers(*values_count, index)),
+
+        FieldCondition {
             key: _,
             r#match: None,
             range: None,
             geo_radius: None,
             geo_bounding_box: None,
             geo_polygon: None,
-            values_count: _, // No applicable index for values_count
+            values_count: None,
         } => None,
     }
 }
@@ -184,7 +191,15 @@ pub fn get_geo_polygon_checkers(
         FieldIndex::GeoIndex(geo_index) => Some(Box::new(move |point_id: PointOffsetType| {
             geo_index.check_values_any(point_id, |value| polygon_wrapper.check_point(value))
         })),
-        _ => None,
+        FieldIndex::BinaryIndex(_)
+        | FieldIndex::DatetimeIndex(_)
+        | FieldIndex::FloatIndex(_)
+        | FieldIndex::FullTextIndex(_)
+        | FieldIndex::IntIndex(_)
+        | FieldIndex::IntMapIndex(_)
+        | FieldIndex::KeywordIndex(_)
+        | FieldIndex::UuidIndex(_)
+        | FieldIndex::UuidMapIndex(_) => None,
     }
 }
 
@@ -196,7 +211,15 @@ pub fn get_geo_radius_checkers(
         FieldIndex::GeoIndex(geo_index) => Some(Box::new(move |point_id: PointOffsetType| {
             geo_index.check_values_any(point_id, |value| geo_radius.check_point(value))
         })),
-        _ => None,
+        FieldIndex::BinaryIndex(_)
+        | FieldIndex::DatetimeIndex(_)
+        | FieldIndex::FloatIndex(_)
+        | FieldIndex::FullTextIndex(_)
+        | FieldIndex::IntIndex(_)
+        | FieldIndex::IntMapIndex(_)
+        | FieldIndex::KeywordIndex(_)
+        | FieldIndex::UuidIndex(_)
+        | FieldIndex::UuidMapIndex(_) => None,
     }
 }
 
@@ -208,7 +231,15 @@ pub fn get_geo_bounding_box_checkers(
         FieldIndex::GeoIndex(geo_index) => Some(Box::new(move |point_id: PointOffsetType| {
             geo_index.check_values_any(point_id, |value| geo_bounding_box.check_point(value))
         })),
-        _ => None,
+        FieldIndex::BinaryIndex(_)
+        | FieldIndex::DatetimeIndex(_)
+        | FieldIndex::FloatIndex(_)
+        | FieldIndex::FullTextIndex(_)
+        | FieldIndex::IntIndex(_)
+        | FieldIndex::IntMapIndex(_)
+        | FieldIndex::KeywordIndex(_)
+        | FieldIndex::UuidIndex(_)
+        | FieldIndex::UuidMapIndex(_) => None,
     }
 }
 
@@ -233,7 +264,14 @@ pub fn get_float_range_checkers(
         FieldIndex::FloatIndex(num_index) => Some(Box::new(move |point_id: PointOffsetType| {
             num_index.check_values_any(point_id, |value| range.check_range(*value))
         })),
-        _ => None,
+        FieldIndex::BinaryIndex(_)
+        | FieldIndex::DatetimeIndex(_)
+        | FieldIndex::FullTextIndex(_)
+        | FieldIndex::GeoIndex(_)
+        | FieldIndex::IntMapIndex(_)
+        | FieldIndex::KeywordIndex(_)
+        | FieldIndex::UuidIndex(_)
+        | FieldIndex::UuidMapIndex(_) => None,
     }
 }
 
@@ -248,102 +286,15 @@ pub fn get_datetime_range_checkers(
                 num_index.check_values_any(point_id, |value| range.check_range(*value))
             }))
         }
-        _ => None,
-    }
-}
-
-pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<ConditionCheckerFn> {
-    match cond_match {
-        Match::Value(MatchValue {
-            value: value_variant,
-        }) => match (value_variant, index) {
-            (ValueVariants::String(keyword), FieldIndex::KeywordIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index.check_values_any(point_id, |k| k == keyword)
-                }))
-            }
-            (ValueVariants::Integer(value), FieldIndex::IntMapIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index.check_values_any(point_id, |i| *i == value)
-                }))
-            }
-            (ValueVariants::Bool(is_true), FieldIndex::BinaryIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    if is_true {
-                        index.values_has_true(point_id)
-                    } else {
-                        index.values_has_false(point_id)
-                    }
-                }))
-            }
-            _ => None,
-        },
-        Match::Text(MatchText { text }) => match index {
-            FieldIndex::FullTextIndex(full_text_index) => {
-                let parsed_query = full_text_index.parse_query(&text);
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    full_text_index.check_match(&parsed_query, point_id)
-                }))
-            }
-            _ => None,
-        },
-        Match::Any(MatchAny { any }) => match (any, index) {
-            (AnyVariants::Strings(list), FieldIndex::KeywordIndex(index)) => {
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| {
-                            list.iter().any(|s| s.as_str() == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| list.contains(value))
-                    }))
-                }
-            }
-            (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| list.iter().any(|i| *i == *value))
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| list.contains(value))
-                    }))
-                }
-            }
-            _ => None,
-        },
-        Match::Except(MatchExcept { except }) => match (except, index) {
-            (AnyVariants::Strings(list), FieldIndex::KeywordIndex(index)) => {
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| {
-                            !list.iter().any(|s| s.as_str() == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| !list.contains(value))
-                    }))
-                }
-            }
-            (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| !list.iter().any(|i| *i == *value))
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        index.check_values_any(point_id, |value| !list.contains(value))
-                    }))
-                }
-            }
-            (_, index) => Some(Box::new(|point_id: PointOffsetType| {
-                // If there is any other value of any other index, then it's a match
-                index.values_count(point_id) > 0
-            })),
-        },
+        FieldIndex::BinaryIndex(_)
+        | FieldIndex::FloatIndex(_)
+        | FieldIndex::FullTextIndex(_)
+        | FieldIndex::GeoIndex(_)
+        | FieldIndex::IntIndex(_)
+        | FieldIndex::IntMapIndex(_)
+        | FieldIndex::KeywordIndex(_)
+        | FieldIndex::UuidIndex(_)
+        | FieldIndex::UuidMapIndex(_) => None,
     }
 }
 
@@ -360,5 +311,12 @@ fn get_is_empty_checker<'a>(
         // Counting on the short-circuit of the `&&` operator
         // Only check the fallback if the index seems to be empty
         index.values_is_empty(point_id) && fallback(point_id)
+    })
+}
+
+fn get_values_count_checkers(values_count: ValuesCount, index: &FieldIndex) -> ConditionCheckerFn {
+    Box::new(move |point_id: PointOffsetType| {
+        let count = index.values_count(point_id);
+        values_count.check_count(count)
     })
 }

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -18,7 +18,6 @@ use crate::payload_storage::query_checker::{
 use crate::types::{
     Condition, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPolygon,
     GeoRadius, IntPayloadType, OwnedPayloadRef, PayloadContainer, Range, RangeInterface,
-    ValuesCount,
 };
 
 pub fn condition_converter<'a>(

--- a/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
@@ -1,0 +1,234 @@
+use common::types::PointOffsetType;
+use indexmap::IndexSet;
+use uuid::Uuid;
+
+use crate::index::field_index::FieldIndex;
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
+use crate::types::{
+    AnyVariants, Match, MatchAny, MatchExcept, MatchText, MatchValue, ValueVariants,
+};
+
+pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<ConditionCheckerFn> {
+    match cond_match {
+        Match::Value(MatchValue { value }) => get_match_value_checker(value, index),
+        Match::Text(MatchText { text }) => get_match_text_checker(text, index),
+        Match::Any(MatchAny { any }) => get_match_any_checker(any, index),
+        Match::Except(MatchExcept { except }) => get_match_except_checker(except, index),
+    }
+}
+
+fn get_match_value_checker(
+    value_variant: ValueVariants,
+    index: &FieldIndex,
+) -> Option<ConditionCheckerFn> {
+    match (value_variant, index) {
+        (ValueVariants::String(keyword), FieldIndex::KeywordIndex(index)) => {
+            Some(Box::new(move |point_id: PointOffsetType| {
+                index.check_values_any(point_id, |k| k == keyword)
+            }))
+        }
+        (ValueVariants::String(value), FieldIndex::UuidMapIndex(index)) => {
+            let uuid = Uuid::parse_str(&value).map(|uuid| uuid.as_u128()).ok()?;
+            Some(Box::new(move |point_id: PointOffsetType| {
+                index.check_values_any(point_id, |i| i == &uuid)
+            }))
+        }
+        (ValueVariants::Integer(value), FieldIndex::IntMapIndex(index)) => {
+            Some(Box::new(move |point_id: PointOffsetType| {
+                index.check_values_any(point_id, |i| *i == value)
+            }))
+        }
+        (ValueVariants::Bool(is_true), FieldIndex::BinaryIndex(index)) => {
+            Some(Box::new(move |point_id: PointOffsetType| {
+                if is_true {
+                    index.values_has_true(point_id)
+                } else {
+                    index.values_has_false(point_id)
+                }
+            }))
+        }
+        (ValueVariants::Bool(_), FieldIndex::DatetimeIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::FloatIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::FullTextIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::GeoIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::IntIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::IntMapIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::KeywordIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::UuidIndex(_))
+        | (ValueVariants::Bool(_), FieldIndex::UuidMapIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::BinaryIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::DatetimeIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::FloatIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::FullTextIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::GeoIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::IntIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::KeywordIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::UuidIndex(_))
+        | (ValueVariants::Integer(_), FieldIndex::UuidMapIndex(_))
+        | (ValueVariants::String(_), FieldIndex::BinaryIndex(_))
+        | (ValueVariants::String(_), FieldIndex::DatetimeIndex(_))
+        | (ValueVariants::String(_), FieldIndex::FloatIndex(_))
+        | (ValueVariants::String(_), FieldIndex::FullTextIndex(_))
+        | (ValueVariants::String(_), FieldIndex::GeoIndex(_))
+        | (ValueVariants::String(_), FieldIndex::IntIndex(_))
+        | (ValueVariants::String(_), FieldIndex::IntMapIndex(_))
+        | (ValueVariants::String(_), FieldIndex::UuidIndex(_)) => None,
+    }
+}
+
+fn get_match_any_checker(
+    any_variant: AnyVariants,
+    index: &FieldIndex,
+) -> Option<ConditionCheckerFn> {
+    match (any_variant, index) {
+        (AnyVariants::Strings(list), FieldIndex::KeywordIndex(index)) => {
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| {
+                        list.iter().any(|s| s.as_str() == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| list.contains(value))
+                }))
+            }
+        }
+        (AnyVariants::Strings(list), FieldIndex::UuidMapIndex(index)) => {
+            let list = list
+                .iter()
+                .map(|s| Uuid::parse_str(s).map(|uuid| uuid.as_u128()).ok())
+                .collect::<Option<IndexSet<_>>>()?;
+
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| list.iter().any(|i| i == value))
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| list.contains(value))
+                }))
+            }
+        }
+        (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| list.iter().any(|i| i == value))
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| list.contains(value))
+                }))
+            }
+        }
+        (AnyVariants::Integers(_), FieldIndex::BinaryIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::DatetimeIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::FloatIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::FullTextIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::GeoIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::IntIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::KeywordIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::UuidIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::UuidMapIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::BinaryIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::DatetimeIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::FloatIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::FullTextIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::GeoIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::IntIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::IntMapIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::UuidIndex(_)) => None,
+    }
+}
+
+fn get_match_except_checker(except: AnyVariants, index: &FieldIndex) -> Option<ConditionCheckerFn> {
+    let checker: Option<ConditionCheckerFn> = match (except, index) {
+        (AnyVariants::Strings(list), FieldIndex::KeywordIndex(index)) => {
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| {
+                        !list.iter().any(|s| s.as_str() == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| !list.contains(value))
+                }))
+            }
+        }
+        (AnyVariants::Strings(list), FieldIndex::UuidMapIndex(index)) => {
+            let list = list
+                .iter()
+                .map(|s| Uuid::parse_str(s).map(|uuid| uuid.as_u128()).ok())
+                .collect::<Option<IndexSet<_>>>()?;
+
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| !list.iter().any(|i| i == value))
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| !list.contains(value))
+                }))
+            }
+        }
+        (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| !list.iter().any(|i| i == value))
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, |value| !list.contains(value))
+                }))
+            }
+        }
+        (AnyVariants::Strings(_), FieldIndex::IntIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::DatetimeIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::IntMapIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::FloatIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::GeoIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::FullTextIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::BinaryIndex(_))
+        | (AnyVariants::Strings(_), FieldIndex::UuidIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::IntIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::DatetimeIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::KeywordIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::FloatIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::GeoIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::FullTextIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::BinaryIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::UuidIndex(_))
+        | (AnyVariants::Integers(_), FieldIndex::UuidMapIndex(_)) => None,
+    };
+
+    if checker.is_none() {
+        return Some(Box::new(|point_id: PointOffsetType| {
+            // If there is any other value of any other index, then it's a match
+            index.values_count(point_id) > 0
+        }));
+    };
+
+    checker
+}
+
+fn get_match_text_checker(text: String, index: &FieldIndex) -> Option<ConditionCheckerFn> {
+    match index {
+        FieldIndex::FullTextIndex(full_text_index) => {
+            let parsed_query = full_text_index.parse_query(&text);
+            Some(Box::new(move |point_id: PointOffsetType| {
+                full_text_index.check_match(&parsed_query, point_id)
+            }))
+        }
+        FieldIndex::BinaryIndex(_)
+        | FieldIndex::DatetimeIndex(_)
+        | FieldIndex::FloatIndex(_)
+        | FieldIndex::GeoIndex(_)
+        | FieldIndex::IntIndex(_)
+        | FieldIndex::IntMapIndex(_)
+        | FieldIndex::KeywordIndex(_)
+        | FieldIndex::UuidIndex(_)
+        | FieldIndex::UuidMapIndex(_) => None,
+    }
+}

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -357,18 +357,17 @@ impl StructPayloadIndex {
         id_tracker: &'a IdTrackerSS,
         query_cardinality: &'a CardinalityEstimation,
     ) -> impl Iterator<Item = PointOffsetType> + 'a {
+        let struct_filtered_context = self.struct_filtered_context(filter);
+
         if query_cardinality.primary_clauses.is_empty() {
             let full_scan_iterator = id_tracker.iter_ids();
 
-            let struct_filtered_context = self.struct_filtered_context(filter);
             // Worst case: query expected to return few matches, but index can't be used
             let matched_points =
                 full_scan_iterator.filter(move |i| struct_filtered_context.check(*i));
 
             Either::Left(matched_points)
         } else {
-            let struct_filtered_context = self.struct_filtered_context(filter);
-
             // CPU-optimized strategy here: points are made unique before applying other filters.
             let mut visited_list = self.visited_pool.get(id_tracker.total_point_count());
 

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -69,7 +69,10 @@ impl ValueChecker for FieldCondition {
 
     fn check(&self, payload: &Value) -> bool {
         if self.values_count.is_some() {
-            self.values_count.as_ref().unwrap().check_count(payload)
+            self.values_count
+                .as_ref()
+                .unwrap()
+                .check_count_from(payload)
         } else {
             self._check(payload)
         }
@@ -214,11 +217,11 @@ impl ValueChecker for GeoPolygon {
 
 impl ValueChecker for ValuesCount {
     fn check_match(&self, payload: &Value) -> bool {
-        self.check_count(payload)
+        self.check_count_from(payload)
     }
 
     fn check(&self, payload: &Value) -> bool {
-        self.check_count(payload)
+        self.check_count_from(payload)
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1612,17 +1612,21 @@ pub struct ValuesCount {
 }
 
 impl ValuesCount {
-    pub fn check_count(&self, value: &Value) -> bool {
+    pub fn check_count(&self, count: usize) -> bool {
+        self.lt.map_or(true, |x| count < x)
+            && self.gt.map_or(true, |x| count > x)
+            && self.lte.map_or(true, |x| count <= x)
+            && self.gte.map_or(true, |x| count >= x)
+    }
+
+    pub fn check_count_from(&self, value: &Value) -> bool {
         let count = match value {
             Value::Null => 0,
             Value::Array(array) => array.len(),
             _ => 1,
         };
 
-        self.lt.map_or(true, |x| count < x)
-            && self.gt.map_or(true, |x| count > x)
-            && self.lte.map_or(true, |x| count <= x)
-            && self.gte.map_or(true, |x| count >= x)
+        self.check_count(count)
     }
 }
 


### PR DESCRIPTION
Refactors `condition_converter.rs` to make exhaustive matches on all combinations of index + condition, so we don't forget these in the future.

Also adds correct handling for:
- MatchValue of string with uuid map index
- MatchAny of string with uuid map index
- MatchExcept of string with uuid map index
- ~ValuesCount with any index~ Edit: This wasn't used intentionally
