### PR TITLE
Bump version to 1.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "api"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "chrono",
  "common",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.11.2"
+version = "1.11.3"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.11.2"
+version = "1.11.3"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.11.2";
+pub const QDRANT_VERSION_STRING: &str = "1.11.3";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=6f11e748c3d878342ef45d07f867d1360dadcdda
+IGNORE_UPTO=2eff2c722752e3f92cc684f04f65794328fc99e7
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
PR to release Qdrant 1.11.3.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/4974>.