### PR TITLE
Check that peer still exist, when applying set shard replica set operation

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -372,16 +372,30 @@ impl Collection {
         let current_state = replica_set.peer_state(&peer_id);
 
         // Validation:
-        // 0. Check that `from_state` matches current state
+        //
+        // 1. Check that peer exists in the cluster (peer might *not* exist, if it was removed from
+        //    the cluster right before `SetShardReplicaSet` was proposed)
+        let peer_exists = self
+            .channel_service
+            .id_to_address
+            .read()
+            .contains_key(&peer_id);
 
+        if !peer_exists {
+            return Err(CollectionError::bad_input(format!(
+                "Can't set replica {peer_id}:{shard_id} state to {state:?}, \
+                 because peer {peer_id} is not part of the cluster"
+            )));
+        }
+
+        // 2. Check that `from_state` matches current state
         if from_state.is_some() && current_state != from_state {
             return Err(CollectionError::bad_input(format!(
                 "Replica {peer_id} of shard {shard_id} has state {current_state:?}, but expected {from_state:?}"
             )));
         }
 
-        // 1. Do not deactivate the last active replica
-
+        // 3. Do not deactivate the last active replica
         if state != ReplicaState::Active {
             let active_replicas: HashSet<_> = replica_set
                 .peers()

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -381,10 +381,13 @@ impl Collection {
             .read()
             .contains_key(&peer_id);
 
-        if !peer_exists {
+        let replica_exists = replica_set.peer_state(&peer_id).is_some();
+
+        if !peer_exists && !replica_exists {
             return Err(CollectionError::bad_input(format!(
                 "Can't set replica {peer_id}:{shard_id} state to {state:?}, \
-                 because peer {peer_id} is not part of the cluster"
+                 because replica {peer_id}:{shard_id} does not exist \
+                 and peer {peer_id} is not part of the cluster"
             )));
         }
 


### PR DESCRIPTION
Similar to #4968, this PR fixes a potential bug, when peer is removed right before state of a replica on removed peer is changes, which may create an "orphan" shard.

Fix is conceptually the same as in #4968: check that peer still exists in the cluster before applying `SetShardReplicaSet` operation.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~Have you written new tests for your core changes, as applicable?~~
* [ ] ~~Have you successfully ran tests with your changes locally?~~
