### PR TITLE
Don't save shard config in `LocalShard::create_snapshot`

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -59,7 +59,7 @@ use crate::operations::OperationWithClockTag;
 use crate::optimizers_builder::{build_optimizers, clear_temp_segments, OptimizersConfig};
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_config::{ShardConfig, SHARD_CONFIG_FILE};
+use crate::shards::shard_config::ShardConfig;
 use crate::shards::telemetry::{LocalShardTelemetry, OptimizerTelemetry};
 use crate::shards::CollectionId;
 use crate::update_handler::{Optimizer, UpdateHandler, UpdateSignal};
@@ -813,11 +813,6 @@ impl LocalShard {
         .await??;
 
         LocalShardClocks::copy_data(&self.path, snapshot_shard_path).await?;
-
-        // copy shard's config
-        let shard_config_path = ShardConfig::get_config_path(&self.path);
-        let target_shard_config_path = snapshot_shard_path.join(SHARD_CONFIG_FILE);
-        copy(&shard_config_path, &target_shard_config_path).await?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR removes code to save shard config in `LocalShard::create_snapshot`.

Reason: this file is getting overwritten in the only code path in which this method is called. So, no need to write it in the first place. Here is the call graph:

```mermaid
graph TD
    Collection::create_snapshot --> ShardReplicaSet::create_snapshot
    ForwardProxyShard::create_snapshot --> LocalShard::create_snapshot
    ProxyShard::create_snapshot --> LocalShard::create_snapshot
    QueueProxyShard::create_snapshot --> LocalShard::create_snapshot
    ShardReplicaSet::create_snapshot --> Shard::create_snapshot
    Shard::create_snapshot --> LocalShard::create_snapshot
    Shard::create_snapshot --> ProxyShard::create_snapshot
    Shard::create_snapshot --> ForwardProxyShard::create_snapshot
    Shard::create_snapshot --> QueueProxyShard::create_snapshot
    Shard::create_snapshot --> DummyShard::create_snapshot
    ShardHolder::creste_shard_snapshot --> ShardReplicaSet::create_snapshot
    _do_create_full_snapshot --> TableOfContent::create_snapshot
    TableOfContent::create_snapshot --> Collection::create_snapshot
    do_create_snapshot --> TableOfContent::create_snapshot

    class ShardReplicaSet::create_snapshot highlight1
    class LocalShard::create_snapshot highlight2

    classDef highlight1 color:#77FF77,fill:#222222
    classDef highlight2 color:#FF7777,fill:#222222
```

$${\texttt{\color{#ff7777}Red node}},$$ `LocalShard::create_snapshot`: removed code (this PR).
$${\texttt{\color{#77ff00}Green node}},$$ [`ShardReplicaSet::create_snapshot`](https://github.com/qdrant/qdrant/blob/v1.11.3/lib/collection/src/shards/replica_set/snapshots.rs#L30-L32): overwrites this file with `{"type":"ReplicaSet"}`.

I've stumbled into this when updating the code to build a snapshot archive without copying files to a temporary directory. Adding two files with the same name to an archive is problematic.