### PR TITLE
Fix Clippy 1.81

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -635,9 +635,8 @@ pub trait SegmentOptimizer {
 
         // ---- SLOW PART ENDS HERE -----
 
-        check_process_stopped(stopped).map_err(|error| {
+        check_process_stopped(stopped).inspect_err(|_error| {
             self.handle_cancellation(&segments, &proxy_ids, &tmp_segment);
-            error
         })?;
 
         {


### PR DESCRIPTION
Rust 1.81 is landing [soon](https://releases.rs/docs/1.81.0/).

This time the clippy lints change is minimal.