### PR TITLE
Approximate facets if filter has big cardinality

### DIFF
--- a/lib/common/common/src/math.rs
+++ b/lib/common/common/src/math.rs
@@ -17,7 +17,11 @@ pub fn scaled_fast_sigmoid(x: ScoreType) -> ScoreType {
     0.5 * (fast_sigmoid(x) + 1.0)
 }
 
-/// Calculates the ideal sample size for a given population size and proportion at confidence level 0.99.
+/// Sample size for an unlimited population, confidence level 0.99 and margin of error 0.01.
+pub const SAMPLE_SIZE_CL99_ME01: usize = 16641;
+
+/// Calculates the ideal sample size for a given population size and proportion
+/// at confidence level 0.99 and margin of error 0.01.
 ///
 /// If population is `None`, considers an unlimited population.
 pub fn ideal_sample_size(population_size: Option<usize>) -> usize {
@@ -47,7 +51,7 @@ pub fn ideal_sample_size(population_size: Option<usize>) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use crate::math::ideal_sample_size;
+    use crate::math::{ideal_sample_size, SAMPLE_SIZE_CL99_ME01};
 
     /// Tests equivalence against https://www.calculator.net/sample-size-calculator.html
     #[test]
@@ -57,6 +61,6 @@ mod tests {
         assert_eq!(ideal_sample_size(Some(100000)), 14267);
         assert_eq!(ideal_sample_size(Some(1000000)), 16369);
         assert_eq!(ideal_sample_size(Some(10000000)), 16614);
-        assert_eq!(ideal_sample_size(None), 16641);
+        assert_eq!(ideal_sample_size(None), SAMPLE_SIZE_CL99_ME01);
     }
 }

--- a/lib/common/common/src/math.rs
+++ b/lib/common/common/src/math.rs
@@ -16,3 +16,47 @@ pub fn fast_sigmoid(x: ScoreType) -> ScoreType {
 pub fn scaled_fast_sigmoid(x: ScoreType) -> ScoreType {
     0.5 * (fast_sigmoid(x) + 1.0)
 }
+
+/// Calculates the ideal sample size for a given population size and proportion at confidence level 0.99.
+///
+/// If population is `None`, considers an unlimited population.
+pub fn ideal_sample_size(population_size: Option<usize>) -> usize {
+    // z-score for confidence level 0.99
+    const Z_SCORE: f32 = 2.58;
+
+    // Margin of error for confidence level 0.99
+    const MARGIN_OF_ERROR: f32 = 0.01;
+
+    // We don't know the population proportion, so we use 0.5 as a conservative estimate
+    const POPULATION_PROPORTION: f32 = 0.5;
+
+    let unlimited_sample_size =
+        ((Z_SCORE * Z_SCORE * POPULATION_PROPORTION * (1.0 - POPULATION_PROPORTION))
+            / (MARGIN_OF_ERROR * MARGIN_OF_ERROR))
+            .ceil();
+
+    let Some(population_size) = population_size else {
+        return unlimited_sample_size as usize;
+    };
+
+    let sample_size = (unlimited_sample_size * population_size as f32)
+        / (unlimited_sample_size + population_size as f32 - 1.0);
+
+    sample_size.ceil() as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::math::ideal_sample_size;
+
+    /// Tests equivalence against https://www.calculator.net/sample-size-calculator.html
+    #[test]
+    fn test_ideal_sample_size() {
+        assert_eq!(ideal_sample_size(Some(1000)), 944);
+        assert_eq!(ideal_sample_size(Some(10000)), 6247);
+        assert_eq!(ideal_sample_size(Some(100000)), 14267);
+        assert_eq!(ideal_sample_size(Some(1000000)), 16369);
+        assert_eq!(ideal_sample_size(Some(10000000)), 16614);
+        assert_eq!(ideal_sample_size(None), 16641);
+    }
+}


### PR DESCRIPTION
Currently each segment produces a very accurate response, even at high filter cardinalities. But this is at the cost of slow responses.

To mitigate this, this PR actually takes advantage of doing approximate faceting. When the cardinality is above ~16k points, it switches from counting exactly, to providing estimations based on the filter and the amount of points for each value.

This will keep low counts accurate, while high counts will be approximate but fast.