### PR TITLE
Expose cluster metadata in telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10904,8 +10904,7 @@
       "ClusterTelemetry": {
         "type": "object",
         "required": [
-          "enabled",
-          "metadata"
+          "enabled"
         ],
         "properties": {
           "enabled": {
@@ -10940,7 +10939,8 @@
           },
           "metadata": {
             "type": "object",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9974,6 +9974,7 @@
           "cluster",
           "collections",
           "id",
+          "metadata",
           "requests"
         ],
         "properties": {
@@ -9991,6 +9992,10 @@
           },
           "requests": {
             "$ref": "#/components/schemas/RequestsTelemetry"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9974,7 +9974,6 @@
           "cluster",
           "collections",
           "id",
-          "metadata",
           "requests"
         ],
         "properties": {
@@ -9992,10 +9991,6 @@
           },
           "requests": {
             "$ref": "#/components/schemas/RequestsTelemetry"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": true
           }
         }
       },
@@ -10909,7 +10904,8 @@
       "ClusterTelemetry": {
         "type": "object",
         "required": [
-          "enabled"
+          "enabled",
+          "metadata"
         ],
         "properties": {
           "enabled": {
@@ -10941,6 +10937,10 @@
               "$ref": "#/components/schemas/PeerInfo"
             },
             "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
           }
         }
       },

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -171,6 +171,7 @@ impl MetricsProvider for ClusterTelemetry {
             status,
             config: _,
             peers: _,
+            metadata: _,
         } = self;
 
         metrics.push(metric_family(

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common::types::TelemetryDetail;
+use common::types::{DetailsLevel, TelemetryDetail};
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
@@ -76,9 +76,11 @@ impl TelemetryCollector {
     }
 
     pub async fn prepare_data(&self, access: &Access, detail: TelemetryDetail) -> TelemetryData {
+        // Cluster metadata for details level 1 and up
         let metadata = self
             .dispatcher
             .consensus_state()
+            .filter(|_| detail.level >= DetailsLevel::Level1)
             .map(|state| state.persistent.read().cluster_metadata.clone())
             .unwrap_or_default();
 

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -66,8 +66,8 @@ pub struct ClusterTelemetry {
     pub config: Option<ClusterConfigTelemetry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peers: Option<HashMap<PeerId, PeerInfo>>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub metadata: HashMap<String, serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl ClusterTelemetry {
@@ -106,9 +106,9 @@ impl ClusterTelemetry {
                     dispatcher
                         .consensus_state()
                         .map(|state| state.persistent.read().cluster_metadata.clone())
-                        .unwrap_or_default()
+                        .filter(|metadata| !metadata.is_empty())
                 })
-                .unwrap_or_default(),
+                .flatten(),
         }
     }
 }
@@ -120,7 +120,7 @@ impl Anonymize for ClusterTelemetry {
             status: self.status.clone().map(|x| x.anonymize()),
             config: self.config.clone().map(|x| x.anonymize()),
             peers: None,
-            metadata: HashMap::default(),
+            metadata: None,
         }
     }
 }

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -66,6 +66,8 @@ pub struct ClusterTelemetry {
     pub config: Option<ClusterConfigTelemetry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peers: Option<HashMap<PeerId, PeerInfo>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, serde_json::Value>,
 }
 
 impl ClusterTelemetry {
@@ -99,6 +101,14 @@ impl ClusterTelemetry {
                     ClusterStatus::Enabled(cluster_info) => Some(cluster_info.peers.clone()),
                 })
                 .flatten(),
+            metadata: (detail.level >= DetailsLevel::Level1)
+                .then(|| {
+                    dispatcher
+                        .consensus_state()
+                        .map(|state| state.persistent.read().cluster_metadata.clone())
+                        .unwrap_or_default()
+                })
+                .unwrap_or_default(),
         }
     }
 }
@@ -110,6 +120,7 @@ impl Anonymize for ClusterTelemetry {
             status: self.status.clone().map(|x| x.anonymize()),
             config: self.config.clone().map(|x| x.anonymize()),
             peers: None,
+            metadata: HashMap::default(),
         }
     }
 }


### PR DESCRIPTION
Tracked in: #4213 

Expose cluster metadata in telemetry with details level 1 and up:

```json
{
  "id": "709a6909-3f61-45b4-a6fb-f541909bca95",
  // -- snip --
  "metadata": {
    "_cluster_manager/resharding/collections/benchmark": {
      "direction": "up",
      "shard_id": 1,
      "peer_id": 377010536499172,
      "stage": "migrate_points",
      "relevant_shards": [0],
      "shards_migrating": [0],
      "shards_migrated": [],
      "replicas_migrating": [],
      "replicas_migrated": [],
      "replicas_deleting": [],
      "replicas_deleted": []
    }
  }
}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?