### PR TITLE
Abort resharding when aborting resharding shard transfer

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -432,11 +432,6 @@ impl Collection {
         // If resharding reached `ReshardingStage::WriteHashRingCommitted`, and this branch is
         // triggered *somehow*, then `Collection::abort_resharding` call should return an error,
         // so no special handling is needed for `ReshardingStage::WriteHashRingCommitted`.
-        //
-        // TODO(resharding):
-        //
-        // Abort resharding, if resharding shard is (being) marked as `Dead` and resharding is at
-        // `ReshardingStage::ReadHashRingCommitted` stage!? 🤔
         if current_state == Some(ReplicaState::Resharding) && state == ReplicaState::Dead {
             let shard_key = shard_holder
                 .get_shard_id_to_key_mapping()
@@ -471,9 +466,12 @@ impl Collection {
 
             // Terminate transfer if source or target replicas are now dead
             let related_transfers = shard_holder.get_related_transfers(&shard_id, &peer_id);
+
+            // `abort_shard_transfer` locks `shard_holder`!
+            drop(shard_holder);
+
             for transfer in related_transfers {
-                self.abort_shard_transfer(transfer.key(), Some(&shard_holder))
-                    .await?;
+                self.abort_shard_transfer(transfer.key()).await?;
             }
         }
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -275,7 +275,6 @@ impl Collection {
     pub async fn abort_shard_transfer(
         &self,
         transfer_key: ShardTransferKey,
-        shard_holder: Option<&ShardHolder>,
     ) -> CollectionResult<()> {
         // TODO: Ensure cancel safety!
 
@@ -286,22 +285,34 @@ impl Collection {
             .stop_task(&transfer_key)
             .await;
 
-        let mut shard_holder_guard = None;
-
-        let shard_holder = match shard_holder {
-            Some(shard_holder) => shard_holder,
-            None => shard_holder_guard.insert(self.shards_holder.read().await),
-        };
+        let shard_holder = self.shards_holder.read().await;
 
         let Some(transfer) = shard_holder.get_transfer(&transfer_key) else {
             return Ok(());
         };
 
+        let is_resharding_transfer = transfer
+            .method
+            .map_or(false, |method| method.is_resharding());
+
         let shard_id = transfer_key.to_shard_id.unwrap_or(transfer_key.shard_id);
 
         if let Some(replica_set) = shard_holder.get_shard(&shard_id) {
             if replica_set.peer_state(&transfer.to).is_some() {
-                if transfer.sync {
+                if is_resharding_transfer {
+                    // If *resharding* shard transfer failed, we don't need/want to change replica state:
+                    // - on transfer failure, the whole resharding would be aborted (see below),
+                    //   and so all changes to replicas would be discarded/rolled-back anyway
+                    // - during resharding *up*, we transfer points to a single new shard replica;
+                    //   it is expected that this node is initially empty/incomplete, and so failed
+                    //   transfer should not strictly introduce inconcistency (it just means the node
+                    //   is *still* empty/incomplete); marking this new replica as `Dead` would only
+                    //   make requests to return explicit errors
+                    // - during resharding *down*, we transfer points from shard-to-be-removed
+                    //   to all other shards; all other shards are expected to be `Active`,
+                    //   and so failed transfer does not introduce any inconsistencies to points
+                    //   that are not affected by resharding in all other shards
+                } else if transfer.sync {
                     replica_set.set_replica_state(&transfer.to, ReplicaState::Dead)?;
                 } else {
                     replica_set.remove_peer(transfer.to).await?;
@@ -314,10 +325,21 @@ impl Collection {
         }
 
         if transfer.from == self.this_peer_id {
-            transfer::driver::revert_proxy_shard_to_local(shard_holder, transfer.shard_id).await?;
+            transfer::driver::revert_proxy_shard_to_local(&shard_holder, transfer.shard_id).await?;
         }
 
         shard_holder.register_abort_transfer(&transfer_key)?;
+
+        if is_resharding_transfer {
+            let resharding_state = shard_holder.resharding_state.read().clone();
+
+            // `abort_resharding` locks `shard_holder`!
+            drop(shard_holder);
+
+            if let Some(state) = resharding_state {
+                self.abort_resharding(state.key(), false).await?;
+            }
+        }
 
         Ok(())
     }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -305,7 +305,7 @@ impl Collection {
                     //   and so all changes to replicas would be discarded/rolled-back anyway
                     // - during resharding *up*, we transfer points to a single new shard replica;
                     //   it is expected that this node is initially empty/incomplete, and so failed
-                    //   transfer should not strictly introduce inconcistency (it just means the node
+                    //   transfer should not strictly introduce inconsistency (it just means the node
                     //   is *still* empty/incomplete); marking this new replica as `Dead` would only
                     //   make requests to return explicit errors
                     // - during resharding *down*, we transfer points from shard-to-be-removed

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -649,7 +649,7 @@ impl TableOfContent {
                     &collection.state().await.transfers,
                 )?;
                 log::warn!("Aborting shard transfer: {reason}");
-                collection.abort_shard_transfer(transfer, None).await?;
+                collection.abort_shard_transfer(transfer).await?;
             }
         };
         Ok(())


### PR DESCRIPTION
This PR aborts resharding, when *resharding* shard transfer is aborted.

This is the most basic error handling strategy possible, but it's trivial to implement and we will revisit it later if required/desired.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
