### PR TITLE
Cleanup shards when aborting scale-down resharding

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -795,11 +795,13 @@ impl ShardReplicaSet {
         let mut ids = Vec::new();
 
         while let Some(current_offset) = next_offset {
+            const BATCH_SIZE: usize = 1000;
+
             let mut points = local_shard
                 .get()
                 .scroll_by(
                     Some(current_offset),
-                    1001,
+                    BATCH_SIZE + 1,
                     &false.into(),
                     &false.into(),
                     Some(&filter),
@@ -809,7 +811,7 @@ impl ShardReplicaSet {
                 )
                 .await?;
 
-            if points.len() > 100 {
+            if points.len() > BATCH_SIZE {
                 next_offset = points.pop().map(|points| points.id);
             } else {
                 next_offset = None;

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use common::cpu::CpuBudget;
 use common::types::TelemetryDetail;
 use schemars::JsonSchema;
+use segment::types::{ExtendedPointId, Filter};
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
@@ -27,8 +28,10 @@ use super::CollectionId;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::common::snapshots_manager::SnapshotStorageManager;
 use crate::config::CollectionConfig;
+use crate::operations::point_ops::{self};
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
+use crate::operations::CollectionUpdateOperations;
 use crate::optimizers_builder::OptimizersConfig;
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
@@ -779,6 +782,61 @@ impl ShardReplicaSet {
         remote.health_check().await?;
 
         Ok(())
+    }
+
+    pub async fn cleanup_local_shard(&self, filter: Filter) -> CollectionResult<UpdateResult> {
+        let local_shard_guard = self.local.read().await;
+
+        let Some(local_shard) = local_shard_guard.deref() else {
+            return Err(CollectionError::bad_request("TODO"));
+        };
+
+        let mut next_offset = Some(ExtendedPointId::NumId(0));
+        let mut ids = Vec::new();
+
+        while let Some(current_offset) = next_offset {
+            let mut points = local_shard
+                .get()
+                .scroll_by(
+                    Some(current_offset),
+                    1001,
+                    &false.into(),
+                    &false.into(),
+                    Some(&filter),
+                    &self.search_runtime,
+                    None,
+                    None,
+                )
+                .await?;
+
+            if points.len() > 100 {
+                next_offset = points.pop().map(|points| points.id);
+            } else {
+                next_offset = None;
+            }
+
+            ids.extend(points.into_iter().map(|points| points.id));
+        }
+
+        if ids.is_empty() {
+            return Ok(UpdateResult {
+                operation_id: None,
+                status: UpdateStatus::Completed,
+                clock_tag: None,
+            });
+        }
+
+        drop(local_shard_guard);
+
+        let op =
+            CollectionUpdateOperations::PointOperation(point_ops::PointOperations::DeletePoints {
+                ids,
+            });
+
+        // TODO(resharding): Assign clock tag to the operation!? 🤔
+        self.update_local(op.into(), false)
+            .await?
+            .ok_or_else(|| CollectionError::bad_request("TODO"))
     }
 
     fn init_remote_shards(

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -784,7 +784,7 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub async fn cleanup_local_shard(&self, filter: Filter) -> CollectionResult<UpdateResult> {
+    pub async fn delete_local_points(&self, filter: Filter) -> CollectionResult<UpdateResult> {
         let local_shard_guard = self.local.read().await;
 
         let Some(local_shard) = local_shard_guard.deref() else {

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -317,7 +317,7 @@ impl ShardHolder {
 
                 // Remove any points that might have been transferred from target shard
                 let filter = self.hash_ring_filter(id).expect("hash ring filter");
-                let filter = Filter::new_must(Condition::CustomIdChecker(Arc::new(filter)));
+                let filter = Filter::new_must_not(Condition::CustomIdChecker(Arc::new(filter)));
                 shard.cleanup_local_shard(filter).await?;
             }
         }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -318,7 +318,7 @@ impl ShardHolder {
                 // Remove any points that might have been transferred from target shard
                 let filter = self.hash_ring_filter(id).expect("hash ring filter");
                 let filter = Filter::new_must_not(Condition::CustomIdChecker(Arc::new(filter)));
-                shard.cleanup_local_shard(filter).await?;
+                shard.delete_local_points(filter).await?;
             }
         }
 


### PR DESCRIPTION
Error handling for scale-up resharding is rather trivial: when resharding is aborted, we simply delete "new" shard. However, in case of scale-down resharding, we transfer points into already existing shards, and so when resharding is aborted, we need to remove all points that might have already been transferred into existing shards.

This PR executes filtered delete when aborting scale-down resharding.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
