### PR TITLE
Refactor `local_shard_points::delete_points` API into `cleanup_shard` API

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -467,4 +467,12 @@ impl Collection {
 
         Ok(points)
     }
+
+    pub async fn cleanup_local_shard(&self, shard_id: ShardId) -> CollectionResult<UpdateResult> {
+        self.shards_holder
+            .read()
+            .await
+            .cleanup_local_shard(shard_id)
+            .await
+    }
 }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -525,7 +525,7 @@ impl ShardHolder {
         }
 
         let filter = self.hash_ring_filter(shard_id).expect("hash ring filter");
-        let filter = Filter::new_must(Condition::CustomIdChecker(Arc::new(filter)));
+        let filter = Filter::new_must_not(Condition::CustomIdChecker(Arc::new(filter)));
         shard.delete_local_points(filter).await
     }
 

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -8,7 +8,7 @@ use segment::types::{Condition, CustomIdCheckerCondition as _, Filter, ShardKey}
 use super::ShardHolder;
 use crate::hash_ring::{self, HashRingRouter};
 use crate::operations::cluster_ops::ReshardingDirection;
-use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::types::{CollectionError, CollectionResult, UpdateResult};
 use crate::operations::{point_ops, CollectionUpdateOperations};
 use crate::shards::replica_set::{ReplicaState, ShardReplicaSet};
 use crate::shards::resharding::{ReshardKey, ReshardStage, ReshardState};
@@ -511,6 +511,22 @@ impl ShardHolder {
 
             OperationsByMode::from(update_all).with_update_only_existing(update_only_existing)
         }
+    }
+
+    pub async fn cleanup_local_shard(&self, shard_id: ShardId) -> CollectionResult<UpdateResult> {
+        let shard = self.get_shard(&shard_id).ok_or_else(|| {
+            CollectionError::not_found(format!("shard {shard_id} does not exist"))
+        })?;
+
+        if !shard.is_local().await {
+            return Err(CollectionError::bad_shard_selection(format!(
+                "shard {shard_id} is not a local shard"
+            )))?;
+        }
+
+        let filter = self.hash_ring_filter(shard_id).expect("hash ring filter");
+        let filter = Filter::new_must(Condition::CustomIdChecker(Arc::new(filter)));
+        shard.delete_local_points(filter).await
     }
 
     pub fn resharding_filter(&self) -> Option<hash_ring::HashRingFilter> {


### PR DESCRIPTION
This PR refactors and simplifies `local_shard_points::delete_points` HTTP API into `cleanup_shard`, that reuses `ShardReplicaSet::delete_local_points` method added in #5021.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
