### PR TITLE
Improve logging

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -139,7 +139,6 @@ impl SegmentOptimizer for MergeOptimizer {
         if candidates.len() < 3 {
             return vec![];
         }
-        log::trace!("Possible merge candidates: {:?}", candidates);
         candidates
     }
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -139,7 +139,7 @@ impl SegmentOptimizer for MergeOptimizer {
         if candidates.len() < 3 {
             return vec![];
         }
-        log::debug!("Possible merge candidates: {:?}", candidates);
+        log::trace!("Possible merge candidates: {:?}", candidates);
         candidates
     }
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -139,7 +139,7 @@ impl SegmentOptimizer for MergeOptimizer {
         if candidates.len() < 3 {
             return vec![];
         }
-        log::debug!("Merge candidates: {:?}", candidates);
+        log::debug!("Possible merge candidates: {:?}", candidates);
         candidates
     }
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -281,6 +281,8 @@ impl UpdateHandler {
                     break;
                 }
 
+                debug!("Optimizing segments: {:?}", &nonoptimal_segment_ids);
+
                 // Determine how many CPUs we prefer for optimization task, acquire permit for it
                 let max_indexing_threads = optimizer.hnsw_config().max_indexing_threads;
                 let desired_cpus = num_rayon_threads(max_indexing_threads);


### PR DESCRIPTION
Calling telemetry API now checks for pending optimizations while fetching shard status. So it looks like Qdrant is now repeatedly logging `Merge candidates: [...]` which gives a false appearance that Qdrant merge optimizer is stuck 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

