### PR TITLE
Use Jemalloc for RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,21 +3030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "glob",
- "libc",
- "libz-sys",
- "lz4-sys",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3445,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
 dependencies = [
  "cc",
  "libc",
@@ -5118,16 +5103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
-name = "rocksdb"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,6 +5190,32 @@ checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust-librocksdb-sys"
+version = "0.26.0+9.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4508cf0cb12feb8185556cebc1bf2e53925b415e7b5cb3bcaaff5d90f57eae4e"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "rust-rocksdb"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98735c6ebacc6796c0f74814de76d99dd379df7afa7389c801ed11bba5782884"
+dependencies = [
+ "libc",
+ "rust-librocksdb-sys",
 ]
 
 [[package]]
@@ -5612,8 +5613,8 @@ dependencies = [
  "rand_distr",
  "rayon",
  "rmp-serde",
- "rocksdb",
  "rstest",
+ "rust-rocksdb",
  "schemars",
  "seahash",
  "segment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ pyroscope_pprofrs = "0.2.7"
 rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 
 [workspace.lints.clippy]
 cast_lossless = "warn"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -42,7 +42,6 @@ tempfile = { workspace = true }
 parking_lot = { workspace = true }
 rayon = "1.10.0"
 itertools = { workspace = true }
-rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "lz4"] }
 uuid = { workspace = true }
 bincode = "1.3"
 serde = { workspace = true }
@@ -104,6 +103,12 @@ half = { workspace = true }
 cgroups-rs = "0.3"
 procfs = { version = "0.16", default-features = false }
 io-uring = "0.6.4"
+
+[target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+rocksdb = { version = "0.30.0", default-features = false, features = ["snappy", "lz4", "jemalloc"], package = "rust-rocksdb" }
+
+[target.'cfg(target_env = "msvc")'.dependencies]
+rocksdb = { version = "0.30.0", default-features = false, features = ["snappy", "lz4"], package = "rust-rocksdb" }
 
 [[bench]]
 name = "vector_search"

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use rocksdb::statistics::StatsLevel;
 //use atomic_refcell::{AtomicRef, AtomicRefCell};
 use rocksdb::{ColumnFamily, DBRecoveryMode, LogLevel, Options, WriteOptions, DB};
 
@@ -42,7 +43,7 @@ pub fn db_options() -> Options {
     let mut options: Options = Options::default();
     options.set_write_buffer_size(DB_CACHE_SIZE); // write_buffer_size is enforced per column family.
     options.create_if_missing(true);
-    options.set_log_level(LogLevel::Error);
+    options.set_log_level(LogLevel::Info);
     options.set_recycle_log_file_num(1);
     options.set_keep_log_file_num(1); // must be greater than zero
     options.set_max_log_file_size(DB_MAX_LOG_SIZE);
@@ -50,6 +51,9 @@ pub fn db_options() -> Options {
     options.create_missing_column_families(true);
     options.set_max_open_files(DB_MAX_OPEN_FILES as i32);
     options.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    options.set_dump_malloc_stats(true);
+    options.enable_statistics();
+    options.set_statistics_level(StatsLevel::All);
 
     // Qdrant relies on it's own WAL for durability
     options.set_wal_recovery_mode(DBRecoveryMode::TolerateCorruptedTailRecords);


### PR DESCRIPTION
Enabling Jemalloc on RocksDB to tackle the growing RSS.