### PR TITLE
debug asserts for malformed hashmmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ dependencies = [
  "common",
  "criterion",
  "lazy_static",
+ "log",
  "memmap2 0.9.4",
  "num_cpus",
  "ordered-float 4.2.2",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -28,6 +28,7 @@ lazy_static = "1.5.0"
 memmap2 = { workspace = true }
 semver = { workspace = true }
 zerocopy = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
 common = { path = ".", features = ["testing"] }

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -194,18 +194,34 @@ impl<K: Key + ?Sized> MmapHashMap<K> {
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &K> {
-        (0..self.keys_count()).filter_map(|i| {
-            let entry = self.get_entry(i).ok()?;
-            K::from_bytes(entry)
+        (0..self.keys_count()).filter_map(|i| match self.get_entry(i) {
+            Ok(entry) => K::from_bytes(entry),
+            Err(err) => {
+                debug_assert!(false, "Error reading entry for key {i}: {err}");
+                log::error!("Error reading entry for key {i}: {err}");
+                None
+            }
         })
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&K, &[PointOffsetType])> {
-        (0..self.keys_count()).filter_map(|i| {
-            let entry = self.get_entry(i).ok()?;
-            let key = K::from_bytes(entry)?;
-            let values = Self::get_values_from_entry(entry, key).ok()?;
-            Some((key, values))
+        (0..self.keys_count()).filter_map(|i| match self.get_entry(i) {
+            Ok(entry) => {
+                let key = K::from_bytes(entry)?;
+                match Self::get_values_from_entry(entry, key) {
+                    Ok(values) => Some((key, values)),
+                    Err(err) => {
+                        debug_assert!(false, "Error reading values for key {i}: {err}");
+                        log::error!("Error reading values for key {i}: {err}");
+                        None
+                    }
+                }
+            }
+            Err(err) => {
+                debug_assert!(false, "Error reading entry for key {i}: {err}");
+                log::error!("Error reading entry for key {i}: {err}");
+                None
+            }
         })
     }
 
@@ -232,14 +248,25 @@ impl<K: Key + ?Sized> MmapHashMap<K> {
             let pos = entry.as_ptr() as usize - entry_start;
             pos.next_multiple_of(4) - pos
         };
-        let entry = entry.get(padding..).ok_or(io::ErrorKind::InvalidData)?;
+        let Some(entry) = entry.get(padding..) else {
+            let error_message = format!(
+                "Invalid padding {:?} in entry, entry len: {:?}",
+                padding,
+                entry.len()
+            );
+            return Err(io::Error::new(io::ErrorKind::InvalidData, error_message));
+        };
 
-        let values_len =
-            PointOffsetType::read_from_prefix(entry).ok_or(io::ErrorKind::InvalidData)? as usize;
+        let Some(values_len) = PointOffsetType::read_from_prefix(entry) else {
+            let error_message = format!("Can't read values_len, entry len: {:?}", entry.len());
+            return Err(io::Error::new(io::ErrorKind::InvalidData, error_message));
+        };
+
         let entry = entry
             .get(
                 size_of::<PointOffsetType>()
-                    ..size_of::<PointOffsetType>() + values_len * size_of::<PointOffsetType>(),
+                    ..size_of::<PointOffsetType>()
+                        + values_len as usize * size_of::<PointOffsetType>(),
             )
             .ok_or(io::ErrorKind::InvalidData)?;
         let result = PointOffsetType::slice_from(entry).ok_or(io::ErrorKind::InvalidData)?;
@@ -247,25 +274,41 @@ impl<K: Key + ?Sized> MmapHashMap<K> {
     }
 
     fn get_entry(&self, index: usize) -> io::Result<&[u8]> {
+        let mmap_offset_from = self.header.buckets_pos as usize;
+        let mmap_offset_to = self.header.buckets_pos as usize
+            + self.header.buckets_count as usize * size_of::<BucketOffset>();
+
         let bucket_val = self
             .mmap
-            .get(
-                self.header.buckets_pos as usize
-                    ..self.header.buckets_pos as usize
-                        + self.header.buckets_count as usize * size_of::<BucketOffset>(),
-            )
+            .get(mmap_offset_from..mmap_offset_to)
             .and_then(BucketOffset::slice_from)
-            .and_then(|buckets| buckets.get(index).copied())
-            .ok_or(io::ErrorKind::InvalidData)?;
+            .and_then(|buckets| buckets.get(index).copied());
 
-        Ok(self
-            .mmap
-            .get(
-                self.header.buckets_pos as usize
-                    + self.header.buckets_count as usize * size_of::<BucketOffset>()
-                    + bucket_val as usize..,
-            )
-            .ok_or(io::ErrorKind::InvalidData)?)
+        let Some(bucket_val) = bucket_val else {
+            let error_message =
+                format!(
+                "Can't read entry for mmap hash map for index {}, mmap offset: {}:{}, mmap len: {}",
+                index, mmap_offset_from, mmap_offset_to, self.mmap.len()
+            );
+            return Err(io::Error::new(io::ErrorKind::InvalidData, error_message));
+        };
+
+        let mmap_value_offset = self.header.buckets_pos as usize
+            + self.header.buckets_count as usize * size_of::<BucketOffset>()
+            + bucket_val as usize;
+
+        let entry_opt = self.mmap.get(mmap_value_offset..);
+
+        let Some(entry) = entry_opt else {
+            let error_message =
+                format!(
+                "Can't read entry for mmap hash map for index {}, mmap offset: {:?}, mmap len: {}",
+                index, mmap_value_offset, self.mmap.len()
+            );
+            return Err(io::Error::new(io::ErrorKind::InvalidData, error_message));
+        };
+
+        Ok(entry)
     }
 }
 

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -250,9 +250,8 @@ impl<K: Key + ?Sized> MmapHashMap<K> {
         };
         let Some(entry) = entry.get(padding..) else {
             let error_message = format!(
-                "Invalid padding {:?} in entry, entry len: {:?}",
-                padding,
-                entry.len()
+                "Invalid padding {padding:?} in entry, entry len: {:?}",
+                entry.len(),
             );
             return Err(io::Error::new(io::ErrorKind::InvalidData, error_message));
         };
@@ -287,8 +286,8 @@ impl<K: Key + ?Sized> MmapHashMap<K> {
         let Some(bucket_val) = bucket_val else {
             let error_message =
                 format!(
-                "Can't read entry for mmap hash map for index {}, mmap offset: {}:{}, mmap len: {}",
-                index, mmap_offset_from, mmap_offset_to, self.mmap.len()
+                "Can't read entry for mmap hash map for index {index}, mmap offset: {mmap_offset_from}:{mmap_offset_to}, mmap len: {}",
+                self.mmap.len(),
             );
             return Err(io::Error::new(io::ErrorKind::InvalidData, error_message));
         };
@@ -302,8 +301,8 @@ impl<K: Key + ?Sized> MmapHashMap<K> {
         let Some(entry) = entry_opt else {
             let error_message =
                 format!(
-                "Can't read entry for mmap hash map for index {}, mmap offset: {:?}, mmap len: {}",
-                index, mmap_value_offset, self.mmap.len()
+                "Can't read entry for mmap hash map for index {index}, mmap offset: {mmap_value_offset:?}, mmap len: {}",
+                self.mmap.len(),
             );
             return Err(io::Error::new(io::ErrorKind::InvalidData, error_message));
         };

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -202,9 +202,8 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             Ok(Some(points)) => Some(points.len()),
             Ok(None) => None,
             Err(err) => {
-                let error = format!("Error while getting count for value {value:?}: {err:?}");
-                debug_assert!(false, "{}", error);
-                log::error!("{}", error);
+                debug_assert!(false, "Error while getting count for value {value:?}: {err:?}");
+                log::error!("Error while getting count for value {value:?}: {err:?}");
                 None
             }
         }
@@ -215,9 +214,8 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             Ok(Some(slice)) => Box::new(slice.iter()),
             Ok(None) => Box::new(iter::empty()),
             Err(err) => {
-                let error = format!("Error while getting iterator for value {value:?}: {err:?}");
-                debug_assert!(false, "{}", error);
-                log::error!("{}", error);
+                debug_assert!(false, "Error while getting iterator for value {value:?}: {err:?}");
+                log::error!("Error while getting iterator for value {value:?}: {err:?}");
                 Box::new(iter::empty())
             }
         }

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -202,7 +202,10 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             Ok(Some(points)) => Some(points.len()),
             Ok(None) => None,
             Err(err) => {
-                debug_assert!(false, "Error while getting count for value {value:?}: {err:?}");
+                debug_assert!(
+                    false,
+                    "Error while getting count for value {value:?}: {err:?}",
+                );
                 log::error!("Error while getting count for value {value:?}: {err:?}");
                 None
             }
@@ -214,7 +217,10 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             Ok(Some(slice)) => Box::new(slice.iter()),
             Ok(None) => Box::new(iter::empty()),
             Err(err) => {
-                debug_assert!(false, "Error while getting iterator for value {value:?}: {err:?}");
+                debug_assert!(
+                    false,
+                    "Error while getting iterator for value {value:?}: {err:?}",
+                );
                 log::error!("Error while getting iterator for value {value:?}: {err:?}");
                 Box::new(iter::empty())
             }

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -198,18 +198,28 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     }
 
     pub fn get_count_for_value(&self, value: &N) -> Option<usize> {
-        self.value_to_points
-            .get(value)
-            .ok()
-            .flatten()
-            .map(|p| p.len())
+        match self.value_to_points.get(value) {
+            Ok(Some(points)) => Some(points.len()),
+            Ok(None) => None,
+            Err(err) => {
+                let error = format!("Error while getting count for value {value:?}: {err:?}");
+                debug_assert!(false, "{}", error);
+                log::error!("{}", error);
+                None
+            }
+        }
     }
 
     pub fn get_iterator(&self, value: &N) -> Box<dyn Iterator<Item = &PointOffsetType> + '_> {
-        if let Some(slice) = self.value_to_points.get(value).ok().flatten() {
-            Box::new(slice.iter())
-        } else {
-            Box::new(iter::empty())
+        match self.value_to_points.get(value) {
+            Ok(Some(slice)) => Box::new(slice.iter()),
+            Ok(None) => Box::new(iter::empty()),
+            Err(err) => {
+                let error = format!("Error while getting iterator for value {value:?}: {err:?}");
+                debug_assert!(false, "{}", error);
+                log::error!("{}", error);
+                Box::new(iter::empty())
+            }
         }
     }
 


### PR DESCRIPTION
Current version of Mmap HashMap silently ignores errors if storage is malformed.

This PR proposes to do:

- better error messages, with captured important pieces of context
- debug asserts to potentially spot errors early in tests
- log errors to be able to detect problems in production


