### PR TITLE
Support shard transfers within same peer if from/to shard are different

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -113,19 +113,34 @@ impl Validate for grpc::update_collection_cluster_setup_request::Operation {
 
 impl Validate for grpc::MoveShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(
+            self.from_peer_id,
+            self.to_peer_id,
+            self.shard_id,
+            self.to_shard_id,
+        )
     }
 }
 
 impl Validate for grpc::ReplicateShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(
+            self.from_peer_id,
+            self.to_peer_id,
+            self.shard_id,
+            self.to_shard_id,
+        )
     }
 }
 
 impl Validate for crate::grpc::qdrant::AbortShardTransfer {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(
+            self.from_peer_id,
+            self.to_peer_id,
+            self.shard_id,
+            self.to_shard_id,
+        )
     }
 }
 

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -200,7 +200,12 @@ pub struct ReplicateShard {
 
 impl Validate for ReplicateShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(
+            self.from_peer_id,
+            self.to_peer_id,
+            self.shard_id,
+            self.to_shard_id,
+        )
     }
 }
 
@@ -219,13 +224,23 @@ pub struct MoveShard {
 
 impl Validate for MoveShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(
+            self.from_peer_id,
+            self.to_peer_id,
+            self.shard_id,
+            self.to_shard_id,
+        )
     }
 }
 
 impl Validate for AbortShardTransfer {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(
+            self.from_peer_id,
+            self.to_peer_id,
+            self.shard_id,
+            self.to_shard_id,
+        )
     }
 }
 

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -99,12 +99,22 @@ where
     Ok(())
 }
 
-/// Validate that shard request has two different peers.
+/// Validate that shard request has two different peers
+///
+/// We do allow transferring from/to the same peer if the source and target shard are different.
+/// This may be used during resharding shard transfers.
 pub fn validate_shard_different_peers(
     from_peer_id: u64,
     to_peer_id: u64,
+    shard_id: u32,
+    to_shard_id: Option<u32>,
 ) -> Result<(), ValidationErrors> {
     if to_peer_id != from_peer_id {
+        return Ok(());
+    }
+
+    // If source and target shard is different, we do allow transferring from/to the same peer
+    if to_shard_id.map_or(false, |to_shard_id| to_shard_id != shard_id) {
         return Ok(());
     }
 


### PR DESCRIPTION
Tracked in #4213

Allow a shard transfer from and to the same peer if the source and target shard is different.

Previously there was no use case for this. With resharding transfers we do want to support this though. A resharding shard transfer may need to happen on a single peer because replicas may be on a single peer.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?