### PR TITLE
Fix distance matrix min samples found

### DIFF
--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -204,6 +204,11 @@ impl Collection {
             sampled_points.extend(filtered);
         }
 
+        // if we have less than 2 points, we can't build a matrix
+        if sampled_points.len() < 2 {
+            return Ok(CollectionSearchMatrixResponse::default());
+        }
+
         sampled_points.truncate(sample_size);
         // sort by id for a deterministic order
         sampled_points.sort_unstable_by(|(id1, _), (id2, _)| id1.cmp(id2));


### PR DESCRIPTION
This issue surfaced while working on the congruence tests in https://github.com/qdrant/qdrant-client/pull/769

It is not possible to build a matrix if less than 2 results are found.