### PR TITLE
Fix shard/collection status blinking

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -994,10 +994,14 @@ impl LocalShard {
 
         // If status looks green/ok but some optimizations are suboptimal
         if status == ShardStatus::Green && optimizer_status == OptimizersStatus::Ok {
-            let (has_triggered_any_optimizers, has_suboptimal_optimizers) =
-                self.update_handler.lock().await.pending_optimizations();
+            let (has_triggered_any_optimizers, has_suboptimal_optimizers) = self
+                .update_handler
+                .lock()
+                .await
+                .check_suboptimal_optimizations();
 
             if has_suboptimal_optimizers {
+                // Check if any optimizations were triggered after starting the node
                 if has_triggered_any_optimizers {
                     status = ShardStatus::Yellow;
                 } else {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -992,14 +992,20 @@ impl LocalShard {
             }
         }
 
-        // If status looks green/ok but optimizations can be triggered, mark as grey
-        if status == ShardStatus::Green
-            && optimizer_status == OptimizersStatus::Ok
-            && self.update_handler.lock().await.has_non_optimal_segments()
-        {
-            // This can happen when a node is restarted (crashed), because we don't
-            // automatically trigger optimizations on restart to avoid a crash loop
-            status = ShardStatus::Grey;
+        // If status looks green/ok but some optimizations are suboptimal
+        if status == ShardStatus::Green && optimizer_status == OptimizersStatus::Ok {
+            let (has_triggered_any_optimizers, has_suboptimal_optimizers) =
+                self.update_handler.lock().await.pending_optimizations();
+
+            if has_suboptimal_optimizers {
+                if has_triggered_any_optimizers {
+                    status = ShardStatus::Yellow;
+                } else {
+                    // This can happen when a node is restarted (crashed), because we don't
+                    // automatically trigger optimizations on restart to avoid a crash loop
+                    status = ShardStatus::Grey;
+                }
+            }
         }
 
         (status, optimizer_status)

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -998,7 +998,7 @@ impl LocalShard {
                 .update_handler
                 .lock()
                 .await
-                .check_suboptimal_optimizations();
+                .check_optimizer_conditions();
 
             if has_suboptimal_optimizers {
                 // Check if any optimizations were triggered after starting the node

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -433,7 +433,7 @@ impl UpdateHandler {
     /// Checks conditions for all optimizers and returns whether any is satisfied
     ///
     /// In other words, if this returns true we have pending optimizations.
-    pub(crate) fn pending_optimizations(&self) -> (bool, bool) {
+    pub(crate) fn check_suboptimal_optimizations(&self) -> (bool, bool) {
         // Check if Qdrant triggered any optimizations since starting at all
         let has_triggered_any_optimizers = self.has_triggered_optimizers.load(Ordering::Relaxed);
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -433,7 +433,7 @@ impl UpdateHandler {
     /// Checks conditions for all optimizers and returns whether any is satisfied
     ///
     /// In other words, if this returns true we have pending optimizations.
-    pub(crate) fn check_suboptimal_optimizations(&self) -> (bool, bool) {
+    pub(crate) fn check_optimizer_conditions(&self) -> (bool, bool) {
         // Check if Qdrant triggered any optimizations since starting at all
         let has_triggered_any_optimizers = self.has_triggered_optimizers.load(Ordering::Relaxed);
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -433,18 +433,18 @@ impl UpdateHandler {
     /// Checks conditions for all optimizers and returns whether any is satisfied
     ///
     /// In other words, if this returns true we have pending optimizations.
-    pub(crate) fn has_non_optimal_segments(&self) -> bool {
-        // If we did trigger optimizers at least once, we do not consider to be pending
-        if self.has_triggered_optimizers.load(Ordering::Relaxed) {
-            return false;
-        }
+    pub(crate) fn pending_optimizations(&self) -> (bool, bool) {
+        // Check if Qdrant triggered any optimizations since starting at all
+        let has_triggered_any_optimizers = self.has_triggered_optimizers.load(Ordering::Relaxed);
 
         let excluded_ids = HashSet::<_>::default();
-        self.optimizers.iter().any(|optimizer| {
+        let has_suboptimal_optimizers = self.optimizers.iter().any(|optimizer| {
             let nonoptimal_segment_ids =
                 optimizer.check_condition(self.segments.clone(), &excluded_ids);
             !nonoptimal_segment_ids.is_empty()
-        })
+        });
+
+        (has_triggered_any_optimizers, has_suboptimal_optimizers)
     }
 
     pub(crate) async fn process_optimization(

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -430,9 +430,11 @@ impl UpdateHandler {
         Ok(())
     }
 
-    /// Checks conditions for all optimizers and returns whether any is satisfied
+    /// Checks the optimizer conditions.
     ///
-    /// In other words, if this returns true we have pending optimizations.
+    /// This function returns a tuple of two booleans:
+    /// - The first indicates if any optimizers have been triggered since startup.
+    /// - The second indicates if there are any pending/suboptimal optimizers.
     pub(crate) fn check_optimizer_conditions(&self) -> (bool, bool) {
         // Check if Qdrant triggered any optimizations since starting at all
         let has_triggered_any_optimizers = self.has_triggered_optimizers.load(Ordering::Relaxed);


### PR DESCRIPTION
We should mark shard status as:
- Yellow if optimizers are suboptimal and we have run at least one since starting the node
- Grey if optimizers are suboptimal and we haven't run any since starting the node

This makes the status consistent

[Slack discussion](https://qdrant.slack.com/archives/C077CCW8NU8/p1725609571955249?thread_ts=1725568515.703859&cid=C077CCW8NU8)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

