### PR TITLE
Direct snapshot creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "rand 0.8.5",
  "semver",
  "serde",
+ "tar",
  "tempfile",
  "thiserror",
  "thread-priority",

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use bitvec::prelude::BitVec;
+use common::tar_ext;
 use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
@@ -1069,25 +1070,23 @@ impl SegmentEntry for ProxySegment {
     fn take_snapshot(
         &self,
         temp_path: &Path,
-        snapshot_dir_path: &Path,
+        tar: &tar_ext::BuilderExt,
         snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()> {
-        log::info!(
-            "Taking a snapshot of a proxy segment into {:?}",
-            snapshot_dir_path
-        );
+        log::info!("Taking a snapshot of a proxy segment");
 
-        self.wrapped_segment.get().read().take_snapshot(
-            temp_path,
-            snapshot_dir_path,
-            snapshotted_segments,
-        )?;
+        // snapshot wrapped segment data into the temporary dir
+        self.wrapped_segment
+            .get()
+            .read()
+            .take_snapshot(temp_path, tar, snapshotted_segments)?;
 
-        self.write_segment.get().read().take_snapshot(
-            temp_path,
-            snapshot_dir_path,
-            snapshotted_segments,
-        )?;
+        // snapshot write_segment
+        // Write segment is not unique to the proxy segment, therefore it might overwrite an existing snapshot.
+        self.write_segment
+            .get()
+            .read()
+            .take_snapshot(temp_path, tar, snapshotted_segments)?;
 
         Ok(())
     }
@@ -1107,7 +1106,7 @@ impl SegmentEntry for ProxySegment {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::read_dir;
+    use std::fs::File;
 
     use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
     use segment::types::{FieldCondition, PayloadSchemaType};
@@ -1559,35 +1558,30 @@ mod tests {
             .upsert_point(201, 11.into(), only_default_vector(&vec6))
             .unwrap();
 
-        let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
-        eprintln!("Snapshot into {:?}", snapshot_dir.path());
-
+        let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
+        eprintln!("Snapshot into {:?}", snapshot_file.path());
+        let tar = tar_ext::BuilderExt::new(File::create(&snapshot_file).unwrap());
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let temp_dir2 = Builder::new().prefix("temp_dir").tempdir().unwrap();
-
         let mut snapshotted_segments = HashSet::new();
         proxy_segment
-            .take_snapshot(
-                temp_dir.path(),
-                snapshot_dir.path(),
-                &mut snapshotted_segments,
-            )
+            .take_snapshot(temp_dir.path(), &tar, &mut snapshotted_segments)
             .unwrap();
         proxy_segment2
-            .take_snapshot(
-                temp_dir2.path(),
-                snapshot_dir.path(),
-                &mut snapshotted_segments,
-            )
+            .take_snapshot(temp_dir2.path(), &tar, &mut snapshotted_segments)
             .unwrap();
+        tar.blocking_finish().unwrap();
 
         // validate that 3 archives were created:
         // wrapped_segment1, wrapped_segment2 & shared write_segment
-        let archive_count = read_dir(&snapshot_dir).unwrap().count();
+        let mut tar = tar::Archive::new(File::open(&snapshot_file).unwrap());
+        let archive_count = tar.entries_with_seek().unwrap().count();
         assert_eq!(archive_count, 3);
+        assert_eq!(snapshotted_segments.len(), 3);
 
-        for archive in read_dir(&snapshot_dir).unwrap() {
-            let archive_path = archive.unwrap().path();
+        let mut tar = tar::Archive::new(File::open(&snapshot_file).unwrap());
+        for entry in tar.entries_with_seek().unwrap() {
+            let archive_path = entry.unwrap().path().unwrap().into_owned();
             let archive_extension = archive_path.extension().unwrap();
             // correct file extension
             assert_eq!(archive_extension, "tar");

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -8,6 +8,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use common::iterator_ext::IteratorExt;
+use common::tar_ext;
 use io::storage_version::StorageVersion;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use rand::seq::SliceRandom;
@@ -1153,7 +1154,7 @@ impl<'s> SegmentHolder {
         collection_params: Option<&CollectionParams>,
         payload_index_schema: &PayloadIndexSchema,
         temp_dir: &Path,
-        snapshot_dir_path: &Path,
+        tar: &tar_ext::BuilderExt,
     ) -> OperationResult<()> {
         // Snapshotting may take long-running read locks on segments blocking incoming writes, do
         // this through proxied segments to allow writes to continue.
@@ -1166,11 +1167,7 @@ impl<'s> SegmentHolder {
             payload_index_schema,
             |segment| {
                 let read_segment = segment.read();
-                read_segment.take_snapshot(
-                    temp_dir,
-                    snapshot_dir_path,
-                    &mut snapshotted_segments,
-                )?;
+                read_segment.take_snapshot(temp_dir, tar, &mut snapshotted_segments)?;
                 Ok(())
             },
         )
@@ -1291,7 +1288,7 @@ impl<'s> SegmentHolder {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::read_dir;
+    use std::fs::File;
     use std::str::FromStr;
 
     use segment::data_types::vectors::Vector;
@@ -1628,14 +1625,15 @@ mod tests {
 
         let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
-        let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
+        let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
+        let tar = tar_ext::BuilderExt::new(File::create(&snapshot_file).unwrap());
         SegmentHolder::snapshot_all_segments(
             holder.clone(),
             segments_dir.path(),
             None,
             &PayloadIndexSchema::default(),
             temp_dir.path(),
-            snapshot_dir.path(),
+            &tar,
         )
         .unwrap();
 
@@ -1650,7 +1648,8 @@ mod tests {
             "segment holder IDs before and after snapshotting must be equal",
         );
 
-        let archive_count = read_dir(&snapshot_dir).unwrap().count();
+        let mut tar = tar::Archive::new(File::open(&snapshot_file).unwrap());
+        let archive_count = tar.entries_with_seek().unwrap().count();
         // one archive produced per concrete segment in the SegmentHolder
         assert_eq!(archive_count, 2);
     }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -168,6 +168,10 @@ pub struct CollectionConfig {
 }
 
 impl CollectionConfig {
+    pub fn to_bytes(&self) -> CollectionResult<Vec<u8>> {
+        serde_json::to_vec(self).map_err(|err| CollectionError::service_error(err.to_string()))
+    }
+
     pub fn save(&self, path: &Path) -> CollectionResult<()> {
         let config_path = path.join(COLLECTION_CONFIG_FILE);
         let af = AtomicFile::new(&config_path, AllowOverwrite);

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::tar_ext;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
@@ -34,7 +35,7 @@ impl DummyShard {
     pub async fn create_snapshot(
         &self,
         _temp_path: &Path,
-        _target_path: &Path,
+        _tar: &tar_ext::BuilderExt,
         _save_wal: bool,
     ) -> CollectionResult<()> {
         self.dummy()

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
@@ -190,11 +191,11 @@ impl ForwardProxyShard {
     pub async fn create_snapshot(
         &self,
         temp_path: &Path,
-        target_path: &Path,
+        tar: &tar_ext::BuilderExt,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.wrapped_shard
-            .create_snapshot(temp_path, target_path, save_wal)
+            .create_snapshot(temp_path, tar, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -69,6 +69,10 @@ use crate::wal_delta::{LockedWal, RecoverableWal};
 /// If rendering WAL load progression in basic text form, report progression every 60 seconds.
 const WAL_LOAD_REPORT_EVERY: Duration = Duration::from_secs(60);
 
+const WAL_PATH: &str = "wal";
+
+const SEGMENTS_PATH: &str = "segments";
+
 /// LocalShard
 ///
 /// LocalShard is an entity that can be moved between peers and contains some part of one collections data.
@@ -396,11 +400,11 @@ impl LocalShard {
     }
 
     pub fn wal_path(shard_path: &Path) -> PathBuf {
-        shard_path.join("wal")
+        shard_path.join(WAL_PATH)
     }
 
     pub fn segments_path(shard_path: &Path) -> PathBuf {
-        shard_path.join("segments")
+        shard_path.join(SEGMENTS_PATH)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -451,7 +455,7 @@ impl LocalShard {
     ) -> CollectionResult<LocalShard> {
         let config = collection_config.read().await;
 
-        let wal_path = shard_path.join("wal");
+        let wal_path = Self::wal_path(shard_path);
 
         create_dir_all(&wal_path).await.map_err(|err| {
             CollectionError::service_error(format!(
@@ -459,7 +463,7 @@ impl LocalShard {
             ))
         })?;
 
-        let segments_path = shard_path.join("segments");
+        let segments_path = Self::segments_path(shard_path);
 
         create_dir_all(&segments_path).await.map_err(|err| {
             CollectionError::service_error(format!(
@@ -1097,6 +1101,10 @@ impl Drop for LocalShard {
     }
 }
 
+const NEWEST_CLOCKS_PATH: &str = "newest_clocks.json";
+
+const OLDEST_CLOCKS_PATH: &str = "oldest_clocks.json";
+
 /// Convenience struct for combining clock maps belonging to a shard
 ///
 /// Holds a clock map for tracking the highest clocks and the cutoff clocks.
@@ -1191,10 +1199,10 @@ impl LocalShardClocks {
     }
 
     fn newest_clocks_path(shard_path: &Path) -> PathBuf {
-        shard_path.join("newest_clocks.json")
+        shard_path.join(NEWEST_CLOCKS_PATH)
     }
 
     fn oldest_clocks_path(shard_path: &Path) -> PathBuf {
-        shard_path.join("oldest_clocks.json")
+        shard_path.join(OLDEST_CLOCKS_PATH)
     }
 }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -17,8 +17,8 @@ use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use common::cpu::CpuBudget;
-use common::panic;
 use common::types::TelemetryDetail;
+use common::{panic, tar_ext};
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use parking_lot::{Mutex as ParkingMutex, RwLock};
@@ -32,7 +32,7 @@ use segment::types::{
     QuantizationConfig, SegmentConfig, SegmentType,
 };
 use segment::utils::mem::Mem;
-use tokio::fs::{copy, create_dir_all, remove_dir_all, remove_file};
+use tokio::fs::{create_dir_all, remove_dir_all, remove_file};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock as TokioRwLock};
@@ -772,18 +772,11 @@ impl LocalShard {
     pub async fn create_snapshot(
         &self,
         temp_path: &Path,
-        target_path: &Path,
+        tar: &tar_ext::BuilderExt,
         save_wal: bool,
     ) -> CollectionResult<()> {
-        let snapshot_shard_path = target_path;
-
-        // snapshot all shard's segment
-        let snapshot_segments_shard_path = snapshot_shard_path.join("segments");
-        create_dir_all(&snapshot_segments_shard_path).await?;
-
         let segments = self.segments.clone();
         let wal = self.wal.wal.clone();
-        let snapshot_shard_path_owned = snapshot_shard_path.to_owned();
 
         if !save_wal {
             // If we are not saving WAL, we still need to make sure that all submitted by this point
@@ -800,6 +793,7 @@ impl LocalShard {
         let temp_path = temp_path.to_owned();
         let payload_index_schema = self.payload_index_schema.clone();
 
+        let tar_c = tar.clone();
         tokio::task::spawn_blocking(move || {
             // Do not change segments while snapshotting
             SegmentHolder::snapshot_all_segments(
@@ -808,43 +802,42 @@ impl LocalShard {
                 Some(&collection_params),
                 &payload_index_schema.read().clone(),
                 &temp_path,
-                &snapshot_segments_shard_path,
+                &tar_c.descend(Path::new(SEGMENTS_PATH))?,
             )?;
 
             if save_wal {
                 // snapshot all shard's WAL
-                Self::snapshot_wal(wal, &snapshot_shard_path_owned)
+                Self::snapshot_wal(wal, &tar_c)
             } else {
-                Self::snapshot_empty_wal(wal, &snapshot_shard_path_owned)
+                Self::snapshot_empty_wal(wal, &temp_path, &tar_c)
             }
         })
         .await??;
 
-        LocalShardClocks::copy_data(&self.path, snapshot_shard_path).await?;
+        LocalShardClocks::archive_data(&self.path, tar).await?;
 
         Ok(())
     }
 
     /// Create empty WAL which is compatible with currently stored data
-    pub fn snapshot_empty_wal(wal: LockedWal, snapshot_shard_path: &Path) -> CollectionResult<()> {
+    pub fn snapshot_empty_wal(
+        wal: LockedWal,
+        temp_path: &Path,
+        tar: &tar_ext::BuilderExt,
+    ) -> CollectionResult<()> {
         let (segment_capacity, latest_op_num) = {
             let wal_guard = wal.lock();
             (wal_guard.segment_capacity(), wal_guard.last_index())
         };
 
-        let target_path = Self::wal_path(snapshot_shard_path);
-
-        // Create directory if it does not exist
-        std::fs::create_dir_all(&target_path).map_err(|err| {
+        let temp_dir = tempfile::tempdir_in(temp_path).map_err(|err| {
             CollectionError::service_error(format!(
-                "Can not crate directory {}: {}",
-                target_path.display(),
-                err
+                "Can not create temporary directory for WAL: {err}",
             ))
         })?;
 
         Wal::generate_empty_wal_starting_at_index(
-            target_path,
+            temp_dir.path(),
             &WalOptions {
                 segment_capacity,
                 segment_queue_len: 0,
@@ -853,24 +846,24 @@ impl LocalShard {
         )
         .map_err(|err| {
             CollectionError::service_error(format!("Error while create empty WAL: {err}"))
-        })
+        })?;
+
+        tar.blocking_append_dir_all(temp_dir.path(), Path::new(WAL_PATH))
+            .map_err(|err| {
+                CollectionError::service_error(format!("Error while archiving WAL: {err}"))
+            })
     }
 
     /// snapshot WAL
-    ///
-    /// copies all WAL files into `snapshot_shard_path/wal`
-    pub fn snapshot_wal(wal: LockedWal, snapshot_shard_path: &Path) -> CollectionResult<()> {
+    pub fn snapshot_wal(wal: LockedWal, tar: &tar_ext::BuilderExt) -> CollectionResult<()> {
         // lock wal during snapshot
         let mut wal_guard = wal.lock();
         wal_guard.flush()?;
         let source_wal_path = wal_guard.path();
-        let options = fs_extra::dir::CopyOptions::new();
-        fs_extra::dir::copy(source_wal_path, snapshot_shard_path, &options).map_err(|err| {
-            CollectionError::service_error(format!(
-                "Error while copy WAL {snapshot_shard_path:?} {err}"
-            ))
-        })?;
-        Ok(())
+        tar.blocking_append_dir_all(source_wal_path, Path::new(WAL_PATH))
+            .map_err(|err| {
+                CollectionError::service_error(format!("Error while archiving WAL: {err}"))
+            })
     }
 
     pub fn estimate_cardinality<'a>(
@@ -1146,19 +1139,19 @@ impl LocalShardClocks {
         Ok(())
     }
 
-    /// Copy clock data on disk from one shard path to another.
-    pub async fn copy_data(from: &Path, to: &Path) -> CollectionResult<()> {
+    /// Put clock data from the disk into an archive.
+    pub async fn archive_data(from: &Path, tar: &tar_ext::BuilderExt) -> CollectionResult<()> {
         let newest_clocks_from = Self::newest_clocks_path(from);
         let oldest_clocks_from = Self::oldest_clocks_path(from);
 
         if newest_clocks_from.exists() {
-            let newest_clocks_to = Self::newest_clocks_path(to);
-            copy(newest_clocks_from, newest_clocks_to).await?;
+            tar.append_file(&newest_clocks_from, Path::new(NEWEST_CLOCKS_PATH))
+                .await?;
         }
 
         if oldest_clocks_from.exists() {
-            let oldest_clocks_to = Self::oldest_clocks_path(to);
-            copy(oldest_clocks_from, oldest_clocks_to).await?;
+            tar.append_file(&oldest_clocks_from, Path::new(OLDEST_CLOCKS_PATH))
+                .await?;
         }
 
         Ok(())

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
@@ -70,11 +71,11 @@ impl ProxyShard {
     pub async fn create_snapshot(
         &self,
         temp_path: &Path,
-        target_path: &Path,
+        tar: &tar_ext::BuilderExt,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.wrapped_shard
-            .create_snapshot(temp_path, target_path, save_wal)
+            .create_snapshot(temp_path, tar, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::tar_ext;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
@@ -123,12 +124,12 @@ impl QueueProxyShard {
     pub async fn create_snapshot(
         &self,
         temp_path: &Path,
-        target_path: &Path,
+        tar: &tar_ext::BuilderExt,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.inner_unchecked()
             .wrapped_shard
-            .create_snapshot(temp_path, target_path, save_wal)
+            .create_snapshot(temp_path, tar, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -2,6 +2,7 @@ use core::marker::{Send, Sync};
 use std::future::{self, Future};
 use std::path::Path;
 
+use common::tar_ext;
 use common::types::TelemetryDetail;
 
 use super::local_shard::clock_map::RecoveryPoint;
@@ -84,34 +85,24 @@ impl Shard {
     pub async fn create_snapshot(
         &self,
         temp_path: &Path,
-        target_path: &Path,
+        tar: &tar_ext::BuilderExt,
         save_wal: bool,
     ) -> CollectionResult<()> {
         match self {
             Shard::Local(local_shard) => {
-                local_shard
-                    .create_snapshot(temp_path, target_path, save_wal)
-                    .await
+                local_shard.create_snapshot(temp_path, tar, save_wal).await
             }
             Shard::Proxy(proxy_shard) => {
-                proxy_shard
-                    .create_snapshot(temp_path, target_path, save_wal)
-                    .await
+                proxy_shard.create_snapshot(temp_path, tar, save_wal).await
             }
             Shard::ForwardProxy(proxy_shard) => {
-                proxy_shard
-                    .create_snapshot(temp_path, target_path, save_wal)
-                    .await
+                proxy_shard.create_snapshot(temp_path, tar, save_wal).await
             }
             Shard::QueueProxy(proxy_shard) => {
-                proxy_shard
-                    .create_snapshot(temp_path, target_path, save_wal)
-                    .await
+                proxy_shard.create_snapshot(temp_path, tar, save_wal).await
             }
             Shard::Dummy(dummy_shard) => {
-                dummy_shard
-                    .create_snapshot(temp_path, target_path, save_wal)
-                    .await
+                dummy_shard.create_snapshot(temp_path, tar, save_wal).await
             }
         }
     }

--- a/lib/collection/src/shards/shard_config.rs
+++ b/lib/collection/src/shards/shard_config.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use common::tar_ext;
 use io::file_operations::{atomic_save_json, read_json};
 use serde::{Deserialize, Serialize};
 
@@ -44,5 +45,13 @@ impl ShardConfig {
     pub fn save(&self, shard_path: &Path) -> CollectionResult<()> {
         let config_path = Self::get_config_path(shard_path);
         Ok(atomic_save_json(&config_path, self)?)
+    }
+
+    pub async fn save_to_tar(&self, tar: &tar_ext::BuilderExt) -> CollectionResult<()> {
+        tar.write_fn(Path::new(SHARD_CONFIG_FILE), |writer| {
+            serde_json::to_writer(writer, self)?;
+            Ok(())
+        })
+        .await
     }
 }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1,16 +1,17 @@
 mod resharding;
 
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
 use std::ops::Deref as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use common::cpu::CpuBudget;
+use common::tar_ext::BuilderExt;
 use futures::Future;
 use itertools::Itertools;
 use segment::types::ShardKey;
-use tar::Builder as TarBuilder;
 use tokio::runtime::Handle;
 use tokio::sync::{broadcast, RwLock};
 
@@ -94,9 +95,13 @@ impl ShardHolder {
         })
     }
 
-    pub fn save_key_mapping_to_dir(&self, dir: &Path) -> CollectionResult<()> {
-        let path = dir.join(SHARD_KEY_MAPPING_FILE);
-        self.key_mapping.save_to(path)?;
+    pub async fn save_key_mapping_to_tar(
+        &self,
+        tar: &common::tar_ext::BuilderExt,
+    ) -> CollectionResult<()> {
+        self.key_mapping
+            .save_to_tar(tar, Path::new(SHARD_KEY_MAPPING_FILE))
+            .await?;
         Ok(())
     }
 
@@ -830,7 +835,7 @@ impl ShardHolder {
         shard_id: ShardId,
         temp_dir: &Path,
     ) -> CollectionResult<SnapshotDescription> {
-        // - `snapshot_temp_dir`, `snapshot_target_dir` and `temp_file` are handled by `tempfile`
+        // - `snapshot_temp_dir` and `temp_file` are handled by `tempfile`
         //   and would be deleted, if future is cancelled
 
         let shard = self
@@ -852,12 +857,15 @@ impl ShardHolder {
             .prefix(&format!("{snapshot_file_name}-temp-"))
             .tempdir_in(temp_dir)?;
 
-        let snapshot_target_dir = tempfile::Builder::new()
-            .prefix(&format!("{snapshot_file_name}-target-"))
-            .tempdir_in(temp_dir)?;
+        let temp_file = tempfile::Builder::new()
+            .prefix(&format!("{snapshot_file_name}-"))
+            .suffix(".tar")
+            .tempfile_in(temp_dir)?;
+
+        let tar = BuilderExt::new(File::create(temp_file.path())?);
 
         shard
-            .create_snapshot(snapshot_temp_dir.path(), snapshot_target_dir.path(), false)
+            .create_snapshot(snapshot_temp_dir.path(), &tar, false)
             .await?;
 
         let snapshot_temp_dir_path = snapshot_temp_dir.path().to_path_buf();
@@ -868,45 +876,7 @@ impl ShardHolder {
             );
         }
 
-        let mut temp_file = tempfile::Builder::new()
-            .prefix(&format!("{snapshot_file_name}-"))
-            .tempfile_in(temp_dir)?;
-
-        let task = {
-            let snapshot_target_dir = snapshot_target_dir.path().to_path_buf();
-
-            cancel::blocking::spawn_cancel_on_drop(move |cancel| -> CollectionResult<_> {
-                let mut tar = TarBuilder::new(temp_file.as_file_mut());
-                tar.sparse(true);
-
-                if cancel.is_cancelled() {
-                    return Err(cancel::Error::Cancelled.into());
-                }
-
-                tar.append_dir_all(".", &snapshot_target_dir)?;
-
-                if cancel.is_cancelled() {
-                    return Err(cancel::Error::Cancelled.into());
-                }
-
-                tar.finish()?;
-                drop(tar);
-
-                Ok(temp_file)
-            })
-        };
-
-        let task_result = task.await;
-
-        let snapshot_target_dir_path = snapshot_target_dir.path().to_path_buf();
-        if let Err(err) = snapshot_target_dir.close() {
-            log::error!(
-                "Failed to remove temporary directory {}: {err}",
-                snapshot_target_dir_path.display(),
-            );
-        }
-
-        let temp_file = task_result??;
+        tar.finish().await?;
 
         let snapshot_path =
             Self::shard_snapshot_path_unchecked(snapshots_path, shard_id, snapshot_file_name)?;

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -21,6 +21,7 @@ ordered-float = "4.2"
 ph = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+tar = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 validator = { workspace = true }

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod iterator_ext;
 pub mod math;
 pub mod mmap_hashmap;
 pub mod panic;
+pub mod tar_ext;
 pub mod top_k;
 pub mod types;
 pub mod validation;

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -82,6 +82,17 @@ impl BuilderExt {
     }
 
     /// Append a file to the tar archive.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution context.
+    /// Use [`BuilderExt::append_file`] instead.
+    pub fn blocking_append_file(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
+        let dst = join_relative(&self.path, dst)?;
+        self.tar.blocking_lock().append_path_with_name(src, dst)
+    }
+
+    /// Append a file to the tar archive.
     pub async fn append_file(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
         let src = src.to_path_buf();
         let dst = join_relative(&self.path, dst)?;

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -1,0 +1,158 @@
+//! Extensions for the `tar` crate.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tokio::task::JoinError;
+
+/// A wrapper around [`tar::Builder`] that:
+/// 1. Usable in async contexts.
+/// 2. Provides the [`BuilderExt::descend`] method.
+#[derive(Clone)]
+pub struct BuilderExt {
+    tar: Arc<Mutex<tar::Builder<File>>>,
+    path: PathBuf,
+}
+
+impl BuilderExt {
+    pub fn new(tar_file: File) -> Self {
+        let mut tar = tar::Builder::new(tar_file);
+        tar.sparse(true);
+        Self {
+            tar: Arc::new(Mutex::new(tar)),
+            path: PathBuf::new(),
+        }
+    }
+
+    /// Create a new [`BuilderExt`] that writes to a subdirectory of the current
+    /// path. I.e. the following two lines are equivalent:
+    /// ```rust,ignore
+    /// builder.append_data(data, Path::new("foo/bar/baz")).await?;
+    /// builder.descend(Path::new("foo/bar"))?.append_data(data, Path::new("baz")).await?;
+    /// ```
+    pub fn descend(&self, subdir: &Path) -> std::io::Result<Self> {
+        Ok(BuilderExt {
+            tar: Arc::clone(&self.tar),
+            path: join_relative(&self.path, subdir)?,
+        })
+    }
+
+    /// Write an entry to the tar archive. Takes a closure that takes an
+    /// `impl Write` and writes the entry contents into it.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution context.
+    /// Use [`BuilderExt::write_fn`] instead.
+    pub fn blocking_write_fn<E>(
+        &self,
+        dst: &Path,
+        f: impl FnOnce(tar::EntryWriter) -> Result<(), E>,
+    ) -> Result<(), E>
+    where
+        E: std::error::Error + From<std::io::Error>,
+    {
+        let dst = join_relative(&self.path, dst)?;
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        let mut tar = self.tar.blocking_lock();
+        let writer = tar.append_writer(&mut header, dst)?;
+        f(writer)
+    }
+
+    /// Write an entry to the tar archive. Takes a closure that takes an
+    /// `impl Write` and writes the entry contents into it.
+    pub async fn write_fn<E>(
+        &self,
+        dst: &Path,
+        f: impl FnOnce(tar::EntryWriter) -> Result<(), E>,
+    ) -> Result<(), E>
+    where
+        E: std::error::Error + From<std::io::Error>,
+    {
+        let dst = join_relative(&self.path, dst)?;
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        let mut tar = self.tar.lock().await;
+        let writer = tar.append_writer(&mut header, dst)?;
+        f(writer)
+    }
+
+    /// Append a file to the tar archive.
+    pub async fn append_file(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
+        let src = src.to_path_buf();
+        let dst = join_relative(&self.path, dst)?;
+        self.run_async(move |tar| tar.append_path_with_name(src, dst))
+            .await
+    }
+
+    /// Append a directory to the tar archive.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution context.
+    pub fn blocking_append_dir_all(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
+        let dst = join_relative(&self.path, dst)?;
+        self.tar.blocking_lock().append_dir_all(dst, src)
+    }
+
+    /// Append a new entry to the tar archive with the given file contents.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution context.
+    pub async fn append_data(&self, src: Vec<u8>, dst: &Path) -> std::io::Result<()> {
+        let dst = join_relative(&self.path, dst)?;
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(src.len() as u64);
+        self.run_async(move |tar| tar.append_data(&mut header, dst, src.as_slice()))
+            .await
+    }
+
+    /// Finish writing the tar archive. For async counterpart, see
+    /// [`BuilderExt::finish`].
+    pub fn blocking_finish(self) -> std::io::Result<()> {
+        Arc::try_unwrap(self.tar)
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "finish called with multiple references to the tar builder",
+                )
+            })?
+            .into_inner()
+            .into_inner()?
+            .flush()
+    }
+
+    /// Finish writing the tar archive.
+    pub async fn finish(self) -> std::io::Result<()> {
+        tokio::task::spawn_blocking(move || self.blocking_finish()).await?
+    }
+
+    async fn run_async<T, E>(
+        &self,
+        f: impl FnOnce(&mut tar::Builder<File>) -> Result<T, E> + Send + 'static,
+    ) -> Result<T, E>
+    where
+        T: Send + 'static,
+        E: Send + 'static + From<JoinError>,
+    {
+        let tar = Arc::clone(&self.tar);
+        tokio::task::spawn_blocking(move || f(&mut tar.blocking_lock())).await?
+    }
+}
+
+fn join_relative(base: &Path, rel_path: &Path) -> std::io::Result<PathBuf> {
+    if rel_path.is_absolute() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("path must be relative, but got {rel_path:?}"),
+        ));
+    }
+
+    Ok(base.join(rel_path))
+}

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -268,8 +268,13 @@ pub trait SegmentEntry {
     ///
     /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
     /// Uses `temp_path` to prepare files to archive.
-    fn take_snapshot(&self, temp_path: &Path, snapshot_dir_path: &Path)
-        -> OperationResult<PathBuf>;
+    /// The `snapshotted_segments` set is used to avoid writing the same snapshot twice.
+    fn take_snapshot(
+        &self,
+        temp_path: &Path,
+        snapshot_dir_path: &Path,
+        snapshotted_segments: &mut HashSet<String>,
+    ) -> OperationResult<()>;
 
     // Get collected telemetry data of segment
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry;

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use common::tar_ext;
 use common::types::TelemetryDetail;
 
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
@@ -272,7 +273,7 @@ pub trait SegmentEntry {
     fn take_snapshot(
         &self,
         temp_path: &Path,
-        snapshot_dir_path: &Path,
+        tar: &tar_ext::BuilderExt,
         snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()>;
 

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -424,6 +424,9 @@ impl Segment {
         payload_index.infer_payload_type(key)
     }
 
+    /// Unpacks segment snapshot archive.
+    /// A call `restore_snapshot("foo/bar/baz/snapshot.tar", "segment-id")`
+    /// will result in a directory `foo/bar/baz/segment-id/`.
     pub fn restore_snapshot(snapshot_path: &Path, segment_id: &str) -> OperationResult<()> {
         let segment_path = snapshot_path.parent().unwrap().join(segment_id);
 

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
+use std::fs::File;
 use std::sync::atomic::AtomicBool;
 
-use itertools::Itertools as _;
+use common::tar_ext;
 use tempfile::Builder;
 
 use super::*;
@@ -215,35 +216,43 @@ fn test_snapshot() {
 
     let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+    let snapshot_name = snapshot_dir.path().join("snapshot.tar");
 
     // snapshotting!
+    let tar = tar_ext::BuilderExt::new(File::create(&snapshot_name).unwrap());
     segment
-        .take_snapshot(temp_dir.path(), snapshot_dir.path(), &mut HashSet::new())
+        .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
         .unwrap();
-    let archive = snapshot_dir
-        .path()
-        .read_dir()
-        .unwrap()
-        .exactly_one()
-        .unwrap()
-        .unwrap()
-        .path();
-    let archive_extension = archive.extension().unwrap();
-    let archive_name = archive.file_name().unwrap().to_str().unwrap().to_string();
+    tar.blocking_finish().unwrap();
 
-    // correct file extension
-    assert_eq!(archive_extension, "tar");
+    let mut tar = tar::Archive::new(File::open(&snapshot_name).unwrap());
+    let mut entries = tar.entries().unwrap();
+    let mut entry = entries.next().unwrap().unwrap();
 
-    // archive name contains segment id
+    // The archive entry should have a proper name.
     let segment_id = segment
         .current_path
         .file_stem()
         .and_then(|f| f.to_str())
         .unwrap();
-    assert!(archive_name.starts_with(segment_id));
+    assert_eq!(
+        entry.path().unwrap(),
+        PathBuf::from(format!("{segment_id}.tar"))
+    );
+
+    entry
+        .unpack(snapshot_dir.path().join("segment-snapshot.tar"))
+        .unwrap();
+
+    // Should be exactly only entry in the archive.
+    assert!(entries.next().is_none());
 
     // restore snapshot
-    Segment::restore_snapshot(&archive, segment_id).unwrap();
+    Segment::restore_snapshot(
+        &snapshot_dir.path().join("segment-snapshot.tar"),
+        segment_id,
+    )
+    .unwrap();
 
     let restored_segment = load_segment(
         &snapshot_dir.path().join(segment_id),

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
 
+use itertools::Itertools as _;
 use tempfile::Builder;
 
 use super::*;
@@ -215,9 +217,17 @@ fn test_snapshot() {
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
 
     // snapshotting!
-    let archive = segment
-        .take_snapshot(temp_dir.path(), snapshot_dir.path())
+    segment
+        .take_snapshot(temp_dir.path(), snapshot_dir.path(), &mut HashSet::new())
         .unwrap();
+    let archive = snapshot_dir
+        .path()
+        .read_dir()
+        .unwrap()
+        .exactly_one()
+        .unwrap()
+        .unwrap()
+        .path();
     let archive_extension = archive.extension().unwrap();
     let archive_name = archive.file_name().unwrap().to_str().unwrap().to_string();
 

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicBool;
 
 use common::cpu::CpuPermit;
+use itertools::Itertools as _;
 use segment::data_types::index::{IntegerIndexParams, KeywordIndexParams};
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
@@ -133,9 +134,17 @@ fn test_on_disk_segment_snapshot() {
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
 
     // take snapshot
-    let archive = segment
-        .take_snapshot(temp_dir.path(), snapshot_dir.path())
+    segment
+        .take_snapshot(temp_dir.path(), snapshot_dir.path(), &mut HashSet::new())
         .unwrap();
+    let archive = snapshot_dir
+        .path()
+        .read_dir()
+        .unwrap()
+        .exactly_one()
+        .unwrap()
+        .unwrap()
+        .path();
     let archive_extension = archive.extension().unwrap();
     let archive_name = archive.file_name().unwrap().to_str().unwrap().to_string();
 

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
 use common::cpu::CpuPermit;
-use itertools::Itertools as _;
+use common::tar_ext;
 use segment::data_types::index::{IntegerIndexParams, KeywordIndexParams};
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
@@ -132,35 +134,40 @@ fn test_on_disk_segment_snapshot() {
 
     let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+    let snapshot_name = snapshot_dir.path().join("snapshot.tar");
 
     // take snapshot
+    let tar = tar_ext::BuilderExt::new(File::create(&snapshot_name).unwrap());
     segment
-        .take_snapshot(temp_dir.path(), snapshot_dir.path(), &mut HashSet::new())
+        .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
         .unwrap();
-    let archive = snapshot_dir
-        .path()
-        .read_dir()
-        .unwrap()
-        .exactly_one()
-        .unwrap()
-        .unwrap()
-        .path();
-    let archive_extension = archive.extension().unwrap();
-    let archive_name = archive.file_name().unwrap().to_str().unwrap().to_string();
+    tar.blocking_finish().unwrap();
 
-    // correct file extension
-    assert_eq!(archive_extension, "tar");
+    let mut tar = tar::Archive::new(File::open(&snapshot_name).unwrap());
+    let mut entries = tar.entries().unwrap();
+    let mut entry = entries.next().unwrap().unwrap();
 
-    // archive name contains segment id
+    // The archive entry should have a proper name.
     let segment_id = segment
         .current_path
         .file_stem()
         .and_then(|f| f.to_str())
         .unwrap();
-    assert!(archive_name.starts_with(segment_id));
+    assert_eq!(
+        entry.path().unwrap(),
+        PathBuf::from(format!("{segment_id}.tar")),
+    );
+
+    entry
+        .unpack(snapshot_dir.path().join("segment-snapshot.tar"))
+        .unwrap();
 
     // restore snapshot
-    Segment::restore_snapshot(&archive, segment_id).unwrap();
+    Segment::restore_snapshot(
+        &snapshot_dir.path().join("segment-snapshot.tar"),
+        segment_id,
+    )
+    .unwrap();
 
     let restored_segment = load_segment(
         &snapshot_dir.path().join(segment_id),


### PR DESCRIPTION
This PR updates the snapshot creation logic.

Previously, the snapshot were created in two steps: (1) put files into a temporary directory, then (2) put this directory contents into an archive.

In this PR, the snapshot is written directly into an archive without an intermediate step.

Follow-up for #4943.