### PR TITLE
Make computing snapshot checksums faster in debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,14 @@ lto = false
 opt-level = 3
 codegen-units = 256 # restore default value for faster compilation
 
+# Override for fast sha256 hashing in dev builds
+[profile.dev.package.sha2]
+opt-level = 3
+
+# Override for fast sha256 hashing in ci builds
+[profile.ci.package.sha2]
+opt-level = 3
+
 [patch.crates-io]
 # Temporary patch until our PRs are merged.
 tar = { git = "https://github.com/qdrant/tar-rs", branch="main" }

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -5,25 +5,10 @@ use bytes::BytesMut;
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 
-const SHA256_HASH_LENGTH: usize = 64;
-
 /// Compute sha256 hash for the given file
 pub async fn hash_file(file_path: &Path) -> io::Result<String> {
     log::debug!("Computing checksum for file: {file_path:?}");
 
-    // On Linux in debug builds, get hash through sha256sum because it's significantly faster
-    #[cfg(all(debug_assertions, target_os = "linux"))]
-    match hash_file_bin(file_path).await {
-        Ok(hash) => return Ok(hash),
-        Err(err) => log::warn!(
-            "Failed to compute checksum with sha256sum, falling back to built-in hasher: {err}",
-        ),
-    };
-
-    hash_file_builtin(file_path).await
-}
-
-async fn hash_file_builtin(file_path: &Path) -> io::Result<String> {
     const ONE_MB: usize = 1024 * 1024;
     let input_file = tokio::fs::File::open(file_path).await?;
     let mut reader = tokio::io::BufReader::new(input_file);
@@ -39,50 +24,6 @@ async fn hash_file_builtin(file_path: &Path) -> io::Result<String> {
     }
     let hash = sha.finalize();
     Ok(format!("{hash:x}"))
-}
-
-/// Compute sha256 hash for the given file using the `sha256sum` binary
-///
-/// May fail if the binary does not exist on the system.
-#[cfg(all(debug_assertions, target_os = "linux"))]
-async fn hash_file_bin(file_path: &Path) -> io::Result<String> {
-    use tokio::process::Command;
-
-    let output = match Command::new("sha256sum")
-        .arg("-b")
-        .arg(file_path)
-        .output()
-        .await
-    {
-        Ok(command) if command.status.success() => command,
-        Ok(command) => {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!(
-                    "Failed to compute checksum with sha256sum: {}",
-                    String::from_utf8(command.stderr).unwrap(),
-                ),
-            ));
-        }
-        Err(err) => {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Failed to compute checksum with sha256sum: {err}"),
-            ));
-        }
-    };
-
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    let hash = stdout.split_whitespace().next().unwrap();
-
-    if hash.len() != SHA256_HASH_LENGTH {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("Failed to compute checksum with sha256sum, malformed output: {stdout}"),
-        ));
-    }
-
-    Ok(hash.to_string())
 }
 
 /// Compare two hashes, ignoring whitespace and case
@@ -107,38 +48,5 @@ mod tests {
         assert!(hashes_equal("0123abc", "0123ABC"));
         assert!(hashes_equal("0123abc", "0123abc "));
         assert!(!hashes_equal("0123abc", "0123abd"));
-    }
-
-    /// Test consistency between built-in sha256 hasher and sha256sum binary
-    #[tokio::test]
-    #[cfg(all(debug_assertions, target_os = "linux"))]
-    async fn test_hash_file_bin() {
-        use std::io::Write;
-
-        use rand::{thread_rng, Rng};
-
-        // Create a temporary file with random data
-        let mut temp_file = tempfile::Builder::new()
-            .prefix("test-sha256sum")
-            .tempfile()
-            .unwrap();
-        let mut buf = [0u8; 128];
-        thread_rng().fill(&mut buf[..]);
-        temp_file.write_all(&buf).unwrap();
-
-        let hash_builtin = hash_file_builtin(temp_file.path()).await.unwrap();
-        let hash_bin = match hash_file_bin(temp_file.path()).await {
-            Ok(hash) => hash,
-            // May error if the sha256bin binary is not available on this system
-            Err(err) => {
-                log::warn!("Failed to compute checksum with sha256sum, skipping test: {err}");
-                return;
-            }
-        };
-
-        assert_eq!(
-            hash_builtin, hash_bin,
-            "built-in hasher and sha256sum binary must produce the same hash",
-        );
     }
 }

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -5,9 +5,25 @@ use bytes::BytesMut;
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 
+const SHA256_HASH_LENGTH: usize = 64;
+
+/// Compute sha256 hash for the given file
 pub async fn hash_file(file_path: &Path) -> io::Result<String> {
     log::debug!("Computing checksum for file: {file_path:?}");
 
+    // On unix in debug builds, get hash through sha256sum because it's significantly faster
+    #[cfg(all(debug_assertions, unix))]
+    match hash_file_bin(file_path).await {
+        Ok(hash) => return Ok(hash),
+        Err(err) => log::warn!(
+            "Failed to compute checksum with sha256sum, falling back to built-in hasher: {err}",
+        ),
+    };
+
+    hash_file_builtin(file_path).await
+}
+
+async fn hash_file_builtin(file_path: &Path) -> io::Result<String> {
     const ONE_MB: usize = 1024 * 1024;
     let input_file = tokio::fs::File::open(file_path).await?;
     let mut reader = tokio::io::BufReader::new(input_file);
@@ -23,6 +39,52 @@ pub async fn hash_file(file_path: &Path) -> io::Result<String> {
     }
     let hash = sha.finalize();
     Ok(format!("{hash:x}"))
+}
+
+/// Compute sha256 hash for the given file using the `sha256sum` binary
+///
+/// May fail if the binary does not exist on the system.
+#[cfg(all(debug_assertions, unix))]
+async fn hash_file_bin(file_path: &Path) -> io::Result<String> {
+    use tokio::process::Command;
+
+    let output = match Command::new("sha256sum")
+        .arg("-b")
+        .arg(file_path.as_os_str())
+        .output()
+        .await
+    {
+        // Binary must have success exit code
+        Ok(command) if !command.status.success() => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "Failed to compute checksum with sha256sum: {}",
+                    String::from_utf8(command.stderr).unwrap(),
+                ),
+            ));
+        }
+        // Binary must have been called successfully
+        Err(err) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to compute checksum with sha256sum: {err}"),
+            ));
+        }
+        Ok(command) => command,
+    };
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let hash = stdout.split_whitespace().next().unwrap();
+
+    if hash.len() != SHA256_HASH_LENGTH {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Failed to compute checksum with sha256sum, malformed output: {stdout}"),
+        ));
+    }
+
+    Ok(hash.to_string())
 }
 
 /// Compare two hashes, ignoring whitespace and case

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -11,8 +11,8 @@ const SHA256_HASH_LENGTH: usize = 64;
 pub async fn hash_file(file_path: &Path) -> io::Result<String> {
     log::debug!("Computing checksum for file: {file_path:?}");
 
-    // On unix in debug builds, get hash through sha256sum because it's significantly faster
-    #[cfg(all(debug_assertions, unix))]
+    // On Linux in debug builds, get hash through sha256sum because it's significantly faster
+    #[cfg(all(debug_assertions, target_os = "linux"))]
     match hash_file_bin(file_path).await {
         Ok(hash) => return Ok(hash),
         Err(err) => log::warn!(
@@ -44,7 +44,7 @@ async fn hash_file_builtin(file_path: &Path) -> io::Result<String> {
 /// Compute sha256 hash for the given file using the `sha256sum` binary
 ///
 /// May fail if the binary does not exist on the system.
-#[cfg(all(debug_assertions, unix))]
+#[cfg(all(debug_assertions, target_os = "linux"))]
 async fn hash_file_bin(file_path: &Path) -> io::Result<String> {
     use tokio::process::Command;
 
@@ -111,7 +111,7 @@ mod tests {
 
     /// Test consistency between built-in sha256 hasher and sha256sum binary
     #[tokio::test]
-    #[cfg(all(debug_assertions, unix))]
+    #[cfg(all(debug_assertions, target_os = "linux"))]
     async fn test_hash_file_bin() {
         use std::io::Write;
 

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -50,12 +50,12 @@ async fn hash_file_bin(file_path: &Path) -> io::Result<String> {
 
     let output = match Command::new("sha256sum")
         .arg("-b")
-        .arg(file_path.as_os_str())
+        .arg(file_path)
         .output()
         .await
     {
-        // Binary must have success exit code
-        Ok(command) if !command.status.success() => {
+        Ok(command) if command.status.success() => command,
+        Ok(command) => {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!(
@@ -64,14 +64,12 @@ async fn hash_file_bin(file_path: &Path) -> io::Result<String> {
                 ),
             ));
         }
-        // Binary must have been called successfully
         Err(err) => {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!("Failed to compute checksum with sha256sum: {err}"),
             ));
         }
-        Ok(command) => command,
     };
 
     let stdout = String::from_utf8(output.stdout).unwrap();

--- a/lib/collection/src/tests/sha_256_test.rs
+++ b/lib/collection/src/tests/sha_256_test.rs
@@ -11,7 +11,7 @@ async fn test_sha_256_digest() -> std::io::Result<()> {
     let result_hash = hash_file(file.path()).await?;
     assert_eq!(
         result_hash,
-        "735e3ec1b05d901d07e84b1504518442aba2395fe3f945a1c962e81a8e152b2d"
+        "735e3ec1b05d901d07e84b1504518442aba2395fe3f945a1c962e81a8e152b2d",
     );
     Ok(())
 }


### PR DESCRIPTION
Computing file checksums is extremely slow in our debug builds. I was experimenting with snapshots again today and decided to fix this because it was quite annoying.

This enables the release optimizations in all profiles for the sha2 sub crate to always benefit from the faster implementation.

Before: checksum takes 15.6s
After: checksum takes 0.4s

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?