### PR TITLE
Log underlying error, when consensus is stopped due to one

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -104,7 +104,7 @@ impl Consensus {
                 }
 
                 if let Err(err) = consensus.start() {
-                    log::error!("Consensus stopped with error: {err}");
+                    log::error!("Consensus stopped with error: {err:#}");
                     state_ref_clone.on_consensus_thread_err(err);
                 } else {
                     log::info!("Consensus stopped");


### PR DESCRIPTION
Currently, [when consensus is stopped][consensus-stop] due to `ServiceError` during consensus entry application, we only log ["context" message][service-error-context], without the actual underlying error itself.

When formatting `anyhow::Error` without any modifiers, it will only print top-most error or *context* message. To print the whole error stack (e.g., all context messages and all `std::error::Error::source` errors in `most recent: less recent: oldest` format) we can use "alternative" formatting.

[consensus-stop]: https://github.com/qdrant/qdrant/blob/dev/src/consensus.rs#L106-L109
[service-error-context]: https://github.com/qdrant/qdrant/blob/dev/lib/storage/src/content_manager/consensus_manager.rs#L330-L331

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
