### PR TITLE
Refactor `FullTextIndex` as enum

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use super::binary_index::BinaryIndexBuilder;
 use super::facet_index::FacetIndex;
-use super::full_text_index::text_index::FullTextIndex;
+use super::full_text_index::text_index::{FullTextIndex, FullTextIndexBuilder};
 use super::geo_index::GeoMapIndexBuilder;
 use super::map_index::{MapIndex, MapIndexBuilder, MapIndexMmapBuilder};
 use super::numeric_index::{

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use super::binary_index::BinaryIndexBuilder;
 use super::facet_index::FacetIndex;
-use super::full_text_index::text_index::FullTextIndexBuilder;
+use super::full_text_index::text_index::FullTextIndex;
 use super::geo_index::GeoMapIndexBuilder;
 use super::map_index::{MapIndex, MapIndexBuilder, MapIndexMmapBuilder};
 use super::numeric_index::{
@@ -16,7 +16,6 @@ use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
 use crate::data_types::order_by::OrderValue;
 use crate::index::field_index::binary_index::BinaryIndex;
-use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::numeric_index::NumericIndexInner;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -2,13 +2,12 @@ use std::collections::HashMap;
 
 use common::types::PointOffsetType;
 
+use super::inverted_index::InvertedIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::full_text_index::compressed_posting::compressed_posting_list::CompressedPostingList;
 use crate::index::field_index::full_text_index::inverted_index::{ParsedQuery, TokenId};
 use crate::index::field_index::full_text_index::mutable_inverted_index::MutableInvertedIndex;
 use crate::index::field_index::full_text_index::postings_iterator::intersect_compressed_postings_iterator;
-
-use super::inverted_index::InvertedIndex;
 
 #[cfg_attr(test, derive(Clone))]
 #[derive(Default)]
@@ -116,7 +115,7 @@ impl InvertedIndex for ImmutableInvertedIndex {
         self.points_count
     }
 
-    fn get_token(&self, token: &str) -> Option<TokenId> {
+    fn get_token_id(&self, token: &str) -> Option<TokenId> {
         self.vocab.get(token).copied()
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -98,17 +98,16 @@ impl InvertedIndex for ImmutableInvertedIndex {
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        if self.point_to_tokens_count.len() <= point_id as usize {
-            return true;
-        }
-        self.point_to_tokens_count[point_id as usize].is_none()
+        self.point_to_tokens_count
+            .get(point_id as usize)
+            .map_or(true, |count| count.is_none())
     }
 
     fn values_count(&self, point_id: PointOffsetType) -> usize {
-        if self.point_to_tokens_count.len() <= point_id as usize {
-            return 0;
-        }
-        self.point_to_tokens_count[point_id as usize].unwrap_or(0)
+        self.point_to_tokens_count
+            .get(point_id as usize)
+            .and_then(|&count| count)
+            .unwrap_or(0)
     }
 
     fn points_count(&self) -> usize {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -1,0 +1,37 @@
+use common::types::PointOffsetType;
+
+use crate::{common::{operation_error::OperationResult, rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper}, data_types::index::TextIndexParams};
+
+use super::{immutable_inverted_index::ImmutableInvertedIndex, inverted_index::ParsedQuery};
+
+pub struct ImmutableFullTextIndex {
+    pub(super) inverted_index: ImmutableInvertedIndex,
+    pub(super) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
+    pub(super) config: TextIndexParams,
+}
+
+impl ImmutableFullTextIndex {
+    pub fn new(db_wrapper: DatabaseColumnScheduledDeleteWrapper, config: TextIndexParams) -> Self {
+        Self {
+            inverted_index: Default::default(),
+            db_wrapper,
+            config,
+        }
+    }
+    
+    pub fn init(&self) -> OperationResult<()> {
+        self.db_wrapper.recreate_column_family()
+    }
+
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        self.inverted_index.values_count(point_id)
+    }
+
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        self.inverted_index.values_is_empty(point_id)
+    }
+
+    pub fn check_match(&self, parsed_query: &ParsedQuery, point_id: PointOffsetType) -> bool {
+        self.inverted_index.check_match(parsed_query, point_id)
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mod.rs
@@ -1,5 +1,7 @@
+mod immutable_text_index;
 mod inverted_index;
 mod mmap_inverted_index;
+mod mutable_text_index;
 mod posting_list;
 mod postings_iterator;
 pub mod text_index;

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -3,11 +3,11 @@ use std::collections::{BTreeSet, HashMap};
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
-use crate::index::field_index::full_text_index::inverted_index::{
-    Document, InvertedIndex, ParsedQuery, TokenId,
-};
+use crate::index::field_index::full_text_index::inverted_index::{Document, ParsedQuery, TokenId};
 use crate::index::field_index::full_text_index::posting_list::PostingList;
 use crate::index::field_index::full_text_index::postings_iterator::intersect_postings_iterator;
+
+use super::inverted_index::InvertedIndex;
 
 #[cfg_attr(test, derive(Clone))]
 #[derive(Default)]
@@ -38,7 +38,7 @@ impl MutableInvertedIndex {
                     .resize_with(idx as usize + 1, Default::default);
             }
 
-            let document = InvertedIndex::document_from_tokens_impl(&mut self.vocab, &tokens);
+            let document = self.document_from_tokens(&tokens);
             self.point_to_docs[idx as usize] = Some(document);
         }
 
@@ -66,7 +66,17 @@ impl MutableInvertedIndex {
         Ok(())
     }
 
-    pub fn index_document(&mut self, idx: PointOffsetType, document: Document) {
+    fn get_doc(&self, idx: PointOffsetType) -> Option<&Document> {
+        self.point_to_docs.get(idx as usize)?.as_ref()
+    }
+}
+
+impl InvertedIndex for MutableInvertedIndex {
+    fn get_vocab_mut(&mut self) -> &mut HashMap<String, TokenId> {
+        &mut self.vocab
+    }
+
+    fn index_document(&mut self, idx: PointOffsetType, document: Document) -> OperationResult<()> {
         self.points_count += 1;
         if self.point_to_docs.len() <= idx as usize {
             self.point_to_docs
@@ -89,9 +99,11 @@ impl MutableInvertedIndex {
             }
         }
         self.point_to_docs[idx as usize] = Some(document);
+
+        Ok(())
     }
 
-    pub fn remove_document(&mut self, idx: PointOffsetType) -> bool {
+    fn remove_document(&mut self, idx: PointOffsetType) -> bool {
         if self.point_to_docs.len() <= idx as usize {
             return false; // Already removed or never actually existed
         }
@@ -112,7 +124,7 @@ impl MutableInvertedIndex {
         true
     }
 
-    pub fn filter(&self, query: &ParsedQuery) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+    fn filter(&self, query: &ParsedQuery) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
         let postings_opt: Option<Vec<_>> = query
             .tokens
             .iter()
@@ -135,28 +147,11 @@ impl MutableInvertedIndex {
         intersect_postings_iterator(postings)
     }
 
-    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
-        // Maybe we want number of documents in the future?
-        self.get_doc(point_id).map(|x| x.len()).unwrap_or(0)
+    fn get_posting_len(&self, token_id: TokenId) -> Option<usize> {
+        todo!()
     }
 
-    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        self.get_doc(point_id).map(|x| x.is_empty()).unwrap_or(true)
-    }
-
-    pub fn check_match(&self, parsed_query: &ParsedQuery, point_id: PointOffsetType) -> bool {
-        if let Some(doc) = self.get_doc(point_id) {
-            parsed_query.check_match(doc)
-        } else {
-            false
-        }
-    }
-
-    fn get_doc(&self, idx: PointOffsetType) -> Option<&Document> {
-        self.point_to_docs.get(idx as usize)?.as_ref()
-    }
-
-    pub fn vocab_with_postings_len_iter(&self) -> impl Iterator<Item = (&str, usize)> + '_ {
+    fn vocab_with_postings_len_iter(&self) -> impl Iterator<Item = (&str, usize)> + '_ {
         self.vocab.iter().filter_map(|(token, &posting_idx)| {
             if let Some(Some(postings)) = self.postings.get(posting_idx as usize) {
                 Some((token.as_str(), postings.len()))
@@ -164,5 +159,30 @@ impl MutableInvertedIndex {
                 None
             }
         })
+    }
+
+    fn check_match(&self, parsed_query: &ParsedQuery, point_id: PointOffsetType) -> bool {
+        if let Some(doc) = self.get_doc(point_id) {
+            parsed_query.check_match(doc)
+        } else {
+            false
+        }
+    }
+
+    fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        self.get_doc(point_id).map(|x| x.is_empty()).unwrap_or(true)
+    }
+
+    fn values_count(&self, point_id: PointOffsetType) -> usize {
+        // Maybe we want number of documents in the future?
+        self.get_doc(point_id).map(|x| x.len()).unwrap_or(0)
+    }
+
+    fn points_count(&self) -> usize {
+        self.points_count
+    }
+
+    fn get_token(&self, token: &str) -> Option<TokenId> {
+        self.vocab.get(token).copied()
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -2,12 +2,11 @@ use std::collections::{BTreeSet, HashMap};
 
 use common::types::PointOffsetType;
 
+use super::inverted_index::InvertedIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::full_text_index::inverted_index::{Document, ParsedQuery, TokenId};
 use crate::index::field_index::full_text_index::posting_list::PostingList;
 use crate::index::field_index::full_text_index::postings_iterator::intersect_postings_iterator;
-
-use super::inverted_index::InvertedIndex;
 
 #[cfg_attr(test, derive(Clone))]
 #[derive(Default)]
@@ -20,38 +19,36 @@ pub struct MutableInvertedIndex {
 
 impl MutableInvertedIndex {
     pub fn build_index(
-        &mut self,
         iter: impl Iterator<Item = OperationResult<(PointOffsetType, BTreeSet<String>)>>,
-    ) -> OperationResult<()> {
-        self.points_count = 0;
-        self.vocab.clear();
-        self.postings.clear();
-        self.point_to_docs.clear();
+    ) -> OperationResult<Self> {
+        let mut index = Self::default();
 
         // update point_to_docs
         for i in iter {
-            self.points_count += 1;
+            index.points_count += 1;
             let (idx, tokens) = i?;
 
-            if self.point_to_docs.len() <= idx as usize {
-                self.point_to_docs
+            if index.point_to_docs.len() <= idx as usize {
+                index
+                    .point_to_docs
                     .resize_with(idx as usize + 1, Default::default);
             }
 
-            let document = self.document_from_tokens(&tokens);
-            self.point_to_docs[idx as usize] = Some(document);
+            let document = index.document_from_tokens(&tokens);
+            index.point_to_docs[idx as usize] = Some(document);
         }
 
         // build postings from point_to_docs
         // build in order to increase document id
-        for (idx, doc) in self.point_to_docs.iter().enumerate() {
+        for (idx, doc) in index.point_to_docs.iter().enumerate() {
             if let Some(doc) = doc {
                 for token_idx in doc.tokens() {
-                    if self.postings.len() <= *token_idx as usize {
-                        self.postings
+                    if index.postings.len() <= *token_idx as usize {
+                        index
+                            .postings
                             .resize_with(*token_idx as usize + 1, Default::default);
                     }
-                    let posting = self
+                    let posting = index
                         .postings
                         .get_mut(*token_idx as usize)
                         .expect("posting must exist even if with None");
@@ -63,7 +60,7 @@ impl MutableInvertedIndex {
             }
         }
 
-        Ok(())
+        Ok(index)
     }
 
     fn get_doc(&self, idx: PointOffsetType) -> Option<&Document> {
@@ -148,7 +145,12 @@ impl InvertedIndex for MutableInvertedIndex {
     }
 
     fn get_posting_len(&self, token_id: TokenId) -> Option<usize> {
-        todo!()
+        self.postings
+            .get(token_id as usize)
+            // unwrap safety: token_id is a valid index. Same case as in `filter` method.
+            .unwrap()
+            .as_ref()
+            .map(|x| x.len())
     }
 
     fn vocab_with_postings_len_iter(&self) -> impl Iterator<Item = (&str, usize)> + '_ {
@@ -182,7 +184,7 @@ impl InvertedIndex for MutableInvertedIndex {
         self.points_count
     }
 
-    fn get_token(&self, token: &str) -> Option<TokenId> {
+    fn get_token_id(&self, token: &str) -> Option<TokenId> {
         self.vocab.get(token).copied()
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -147,8 +147,7 @@ impl InvertedIndex for MutableInvertedIndex {
     fn get_posting_len(&self, token_id: TokenId) -> Option<usize> {
         self.postings
             .get(token_id as usize)
-            // unwrap safety: token_id is a valid index. Same case as in `filter` method.
-            .unwrap()
+            .and_then(|posting| posting.as_ref())
             .as_ref()
             .map(|x| x.len())
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -1,0 +1,181 @@
+use std::collections::{BTreeSet, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use common::types::PointOffsetType;
+use parking_lot::RwLock;
+use rocksdb::DB;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::mutable_inverted_index::MutableInvertedIndex;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
+use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
+use crate::common::Flusher;
+use crate::data_types::index::TextIndexParams;
+use crate::index::field_index::full_text_index::inverted_index::{
+    Document, InvertedIndex, ParsedQuery,
+};
+use crate::index::field_index::full_text_index::tokenizers::Tokenizer;
+use crate::index::field_index::{
+    CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
+    ValueIndexer,
+};
+use crate::telemetry::PayloadIndexTelemetry;
+use crate::types::{FieldCondition, Match, PayloadKeyType};
+
+pub struct MutableFullTextIndex {
+    pub(super) inverted_index: MutableInvertedIndex,
+    pub(super) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
+    pub(super) config: TextIndexParams,
+}
+
+impl MutableFullTextIndex {
+    pub fn new(db_wrapper: DatabaseColumnScheduledDeleteWrapper, config: TextIndexParams) -> Self {
+        Self {
+            inverted_index: Default::default(),
+            db_wrapper,
+            config,
+        }
+    }
+    
+    pub fn init(&self) -> OperationResult<()> {
+        self.db_wrapper.recreate_column_family()
+    }
+
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        self.inverted_index.values_count(point_id)
+    }
+
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        self.inverted_index.values_is_empty(point_id)
+    }
+
+    pub fn check_match(&self, parsed_query: &ParsedQuery, point_id: PointOffsetType) -> bool {
+        self.inverted_index.check_match(parsed_query, point_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
+    use crate::data_types::index::{TextIndexType, TokenizerType};
+    use crate::json_path::JsonPath;
+
+    fn filter_request(text: &str) -> FieldCondition {
+        FieldCondition::new_match(JsonPath::new("text"), Match::new_text(text))
+    }
+
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    fn test_full_text_indexing(#[case] immutable: bool) {
+        let payloads: Vec<_> = vec![
+            serde_json::json!("The celebration had a long way to go and even in the silent depths of Multivac's underground chambers, it hung in the air."),
+            serde_json::json!("If nothing else, there was the mere fact of isolation and silence."),
+            serde_json::json!([
+                "For the first time in a decade, technicians were not scurrying about the vitals of the giant computer, ",
+                "the soft lights did not wink out their erratic patterns, the flow of information in and out had halted."
+            ]),
+            serde_json::json!("It would not be halted long, of course, for the needs of peace would be pressing."),
+            serde_json::json!("Yet now, for a day, perhaps for a week, even Multivac might celebrate the great time, and rest."),
+        ];
+
+        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let config = TextIndexParams {
+            r#type: TextIndexType::Text,
+            tokenizer: TokenizerType::Word,
+            min_token_len: None,
+            max_token_len: None,
+            lowercase: None,
+        };
+
+        {
+            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
+
+            let mut index = FullTextIndex::builder(db, config.clone(), "text")
+                .make_empty()
+                .unwrap();
+
+            for (idx, payload) in payloads.iter().enumerate() {
+                index.add_point(idx as PointOffsetType, &[payload]).unwrap();
+            }
+
+            assert_eq!(index.count_indexed_points(), payloads.len());
+
+            let filter_condition = filter_request("multivac");
+            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
+            assert_eq!(search_res, vec![0, 4]);
+
+            let filter_condition = filter_request("giant computer");
+            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
+            assert_eq!(search_res, vec![2]);
+
+            let filter_condition = filter_request("the great time");
+            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
+            assert_eq!(search_res, vec![4]);
+
+            index.remove_point(2).unwrap();
+            index.remove_point(3).unwrap();
+
+            let filter_condition = filter_request("giant computer");
+            assert!(index.filter(&filter_condition).unwrap().next().is_none());
+
+            assert_eq!(index.count_indexed_points(), payloads.len() - 2);
+
+            let payload = serde_json::json!([
+                "The last question was asked for the first time, half in jest, on May 21, 2061,",
+                "at a time when humanity first stepped into the light."
+            ]);
+            index.add_point(3, &[&payload]).unwrap();
+
+            let payload = serde_json::json!([
+                "The question came about as a result of a five dollar bet over highballs, and it happened this way: "
+            ]);
+            index.add_point(4, &[&payload]).unwrap();
+
+            assert_eq!(index.count_indexed_points(), payloads.len() - 1);
+
+            index.flusher()().unwrap();
+        }
+
+        {
+            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
+            let mut index = FullTextIndex::new(db, config, "text", immutable);
+            let loaded = index.load().unwrap();
+            assert!(loaded);
+
+            assert_eq!(index.count_indexed_points(), 4);
+
+            let filter_condition = filter_request("multivac");
+            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
+            assert_eq!(search_res, vec![0]);
+
+            let filter_condition = filter_request("the");
+            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
+            assert_eq!(search_res, vec![0, 1, 3, 4]);
+
+            // check deletion
+            index.remove_point(0).unwrap();
+            let filter_condition = filter_request("multivac");
+            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
+            assert!(search_res.is_empty());
+            assert_eq!(index.count_indexed_points(), 3);
+
+            index.remove_point(3).unwrap();
+            let filter_condition = filter_request("the");
+            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
+            assert_eq!(search_res, vec![1, 4]);
+            assert_eq!(index.count_indexed_points(), 2);
+
+            // check deletion of non-existing point
+            index.remove_point(3).unwrap();
+            assert_eq!(index.count_indexed_points(), 2);
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -8,15 +8,15 @@ use rocksdb::DB;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::immutable_text_index::ImmutableFullTextIndex;
+use super::inverted_index::{Document, InvertedIndex, ParsedQuery};
+use super::mutable_text_index::MutableFullTextIndex;
+use super::tokenizers::Tokenizer;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::data_types::index::TextIndexParams;
-use crate::index::field_index::full_text_index::inverted_index::{
-    Document, InvertedIndex, ParsedQuery,
-};
-use crate::index::field_index::full_text_index::tokenizers::Tokenizer;
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
     ValueIndexer,
@@ -24,13 +24,70 @@ use crate::index::field_index::{
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, PayloadKeyType};
 
-pub struct FullTextIndex {
-    inverted_index: InvertedIndex,
-    db_wrapper: DatabaseColumnScheduledDeleteWrapper,
-    config: TextIndexParams,
+pub enum FullTextIndex {
+    Mutable(MutableFullTextIndex),
+    Immutable(ImmutableFullTextIndex),
 }
 
 impl FullTextIndex {
+    pub fn new(
+        db: Arc<RwLock<DB>>,
+        config: TextIndexParams,
+        field: &str,
+        is_appendable: bool,
+    ) -> Self {
+        let store_cf_name = Self::storage_cf_name(field);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            &store_cf_name,
+        ));
+        if is_appendable {
+            Self::Mutable(MutableFullTextIndex::new(db_wrapper, config))
+        } else {
+            Self::Immutable(ImmutableTextIndex::new(db_wrapper, config))
+        }
+    }
+
+    pub fn init(&mut self) -> OperationResult<()> {
+        match self {
+            Self::Mutable(index) => index.init(),
+            Self::Immutable(index) => index.init(),
+        }
+    }
+
+    pub fn builder(
+        db: Arc<RwLock<DB>>,
+        config: TextIndexParams,
+        field: &str,
+    ) -> FullTextIndexBuilder {
+        FullTextIndexBuilder(Self::new(db, config, field, true))
+    }
+
+    fn storage_cf_name(field: &str) -> String {
+        format!("{field}_fts")
+    }
+
+    fn inverted_index(&self) -> InvertedIndex<'_> {
+        match self {
+            Self::Mutable(index) => InvertedIndex::Mutable(index.inverted_index),
+            Self::Immutable(index) => InvertedIndex::Immutable(index.inverted_index),
+        }
+    }
+
+    fn config(&self) -> &TextIndexParams {
+        match self {
+            Self::Mutable(index) => &index.config,
+            Self::Immutable(index) => &index.config,
+        }
+    }
+
+    fn db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
+        match self {
+            Self::Mutable(index) => &index.db_wrapper,
+            Self::Immutable(index) => &index.db_wrapper,
+        }
+    }
+
     fn store_key(id: &PointOffsetType) -> Vec<u8> {
         bincode::serialize(&id).unwrap()
     }
@@ -62,49 +119,19 @@ impl FullTextIndex {
             .map(|doc| doc.tokens)
     }
 
-    fn storage_cf_name(field: &str) -> String {
-        format!("{field}_fts")
-    }
-
-    pub fn new(
-        db: Arc<RwLock<DB>>,
-        config: TextIndexParams,
-        field: &str,
-        is_appendable: bool,
-    ) -> Self {
-        let store_cf_name = Self::storage_cf_name(field);
-        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
-            db,
-            &store_cf_name,
-        ));
-        FullTextIndex {
-            inverted_index: InvertedIndex::new(is_appendable),
-            db_wrapper,
-            config,
-        }
-    }
-
-    pub fn builder(
-        db: Arc<RwLock<DB>>,
-        config: TextIndexParams,
-        field: &str,
-    ) -> FullTextIndexBuilder {
-        FullTextIndexBuilder(Self::new(db, config, field, true))
-    }
-
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
         PayloadIndexTelemetry {
             field_name: None,
-            points_values_count: self.inverted_index.points_count(),
-            points_count: self.inverted_index.points_count(),
+            points_values_count: self.inverted_index().points_count(),
+            points_count: self.inverted_index().points_count(),
             histogram_bucket_size: None,
         }
     }
 
     pub fn parse_query(&self, text: &str) -> ParsedQuery {
         let mut tokens = HashSet::new();
-        Tokenizer::tokenize_query(text, &self.config, |token| {
-            tokens.insert(self.inverted_index.get_token(token));
+        Tokenizer::tokenize_query(text, &self.config(), |token| {
+            tokens.insert(self.inverted_index().get_token(token));
         });
         ParsedQuery {
             tokens: tokens.into_iter().collect(),
@@ -113,8 +140,8 @@ impl FullTextIndex {
 
     pub fn parse_document(&self, text: &str) -> Document {
         let mut document_tokens = vec![];
-        Tokenizer::tokenize_doc(text, &self.config, |token| {
-            if let Some(token_id) = self.inverted_index.get_token(token) {
+        Tokenizer::tokenize_doc(text, &self.config(), |token| {
+            if let Some(token_id) = self.inverted_index().get_token(token) {
                 document_tokens.push(token_id);
             }
         });
@@ -124,19 +151,7 @@ impl FullTextIndex {
     #[cfg(test)]
     pub fn query(&self, query: &str) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
         let parsed_query = self.parse_query(query);
-        self.inverted_index.filter(&parsed_query)
-    }
-
-    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
-        self.inverted_index.values_count(point_id)
-    }
-
-    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        self.inverted_index.values_is_empty(point_id)
-    }
-
-    pub fn check_match(&self, parsed_query: &ParsedQuery, point_id: PointOffsetType) -> bool {
-        self.inverted_index.check_match(parsed_query, point_id)
+        self.inverted_index().filter(&parsed_query)
     }
 }
 
@@ -146,7 +161,7 @@ impl FieldIndexBuilderTrait for FullTextIndexBuilder {
     type FieldIndexType = FullTextIndex;
 
     fn init(&mut self) -> OperationResult<()> {
-        self.0.db_wrapper.recreate_column_family()
+        self.0.init()
     }
 
     fn add_point(&mut self, id: PointOffsetType, payload: &[&Value]) -> OperationResult<()> {
@@ -169,18 +184,18 @@ impl ValueIndexer for FullTextIndex {
         let mut tokens: BTreeSet<String> = BTreeSet::new();
 
         for value in values {
-            Tokenizer::tokenize_doc(&value, &self.config, |token| {
+            Tokenizer::tokenize_doc(&value, &self.config(), |token| {
                 tokens.insert(token.to_owned());
             });
         }
 
-        let document = self.inverted_index.document_from_tokens(&tokens);
-        self.inverted_index.index_document(idx, document)?;
+        let document = self.inverted_index().document_from_tokens(&tokens);
+        self.inverted_index().index_document(idx, document)?;
 
         let db_idx = Self::store_key(&idx);
         let db_document = Self::serialize_document_tokens(tokens)?;
 
-        self.db_wrapper.put(db_idx, db_document)?;
+        self.db_wrapper().put(db_idx, db_document)?;
 
         Ok(())
     }
@@ -193,9 +208,9 @@ impl ValueIndexer for FullTextIndex {
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        if self.inverted_index.remove_document(id) {
+        if self.inverted_index().remove_document(id) {
             let db_doc_id = Self::store_key(&id);
-            self.db_wrapper.remove(db_doc_id)?;
+            self.db_wrapper().remove(db_doc_id)?;
         }
         Ok(())
     }
@@ -203,31 +218,31 @@ impl ValueIndexer for FullTextIndex {
 
 impl PayloadFieldIndex for FullTextIndex {
     fn count_indexed_points(&self) -> usize {
-        self.inverted_index.points_count()
+        self.inverted_index().points_count()
     }
 
     fn load(&mut self) -> OperationResult<bool> {
-        if !self.db_wrapper.has_column_family()? {
+        if !self.db_wrapper().has_column_family()? {
             return Ok(false);
         };
 
-        let db = self.db_wrapper.lock_db();
+        let db = self.db_wrapper().lock_db();
         let i = db.iter()?.map(|(key, value)| {
             let idx = Self::restore_key(&key);
             let tokens = Self::deserialize_document(&value)?;
             Ok((idx, tokens))
         });
-        self.inverted_index.build_index(i)?;
+        self.inverted_index().build_index(i)?;
 
         Ok(true)
     }
 
     fn clear(self) -> OperationResult<()> {
-        self.db_wrapper.remove_column_family()
+        self.db_wrapper().remove_column_family()
     }
 
     fn flusher(&self) -> Flusher {
-        self.db_wrapper.flusher()
+        self.db_wrapper().flusher()
     }
 
     fn files(&self) -> Vec<PathBuf> {
@@ -240,7 +255,7 @@ impl PayloadFieldIndex for FullTextIndex {
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
         if let Some(Match::Text(text_match)) = &condition.r#match {
             let parsed_query = self.parse_query(&text_match.text);
-            return Some(self.inverted_index.filter(&parsed_query));
+            return Some(self.inverted_index().filter(&parsed_query));
         }
         None
     }
@@ -262,128 +277,5 @@ impl PayloadFieldIndex for FullTextIndex {
         key: PayloadKeyType,
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
         self.inverted_index.payload_blocks(threshold, key)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use rstest::rstest;
-    use tempfile::Builder;
-
-    use super::*;
-    use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
-    use crate::data_types::index::{TextIndexType, TokenizerType};
-    use crate::json_path::JsonPath;
-
-    fn filter_request(text: &str) -> FieldCondition {
-        FieldCondition::new_match(JsonPath::new("text"), Match::new_text(text))
-    }
-
-    #[rstest]
-    #[case(true)]
-    #[case(false)]
-    fn test_full_text_indexing(#[case] immutable: bool) {
-        let payloads: Vec<_> = vec![
-            serde_json::json!("The celebration had a long way to go and even in the silent depths of Multivac's underground chambers, it hung in the air."),
-            serde_json::json!("If nothing else, there was the mere fact of isolation and silence."),
-            serde_json::json!([
-                "For the first time in a decade, technicians were not scurrying about the vitals of the giant computer, ",
-                "the soft lights did not wink out their erratic patterns, the flow of information in and out had halted."
-            ]),
-            serde_json::json!("It would not be halted long, of course, for the needs of peace would be pressing."),
-            serde_json::json!("Yet now, for a day, perhaps for a week, even Multivac might celebrate the great time, and rest."),
-        ];
-
-        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
-        let config = TextIndexParams {
-            r#type: TextIndexType::Text,
-            tokenizer: TokenizerType::Word,
-            min_token_len: None,
-            max_token_len: None,
-            lowercase: None,
-        };
-
-        {
-            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-
-            let mut index = FullTextIndex::builder(db, config.clone(), "text")
-                .make_empty()
-                .unwrap();
-
-            for (idx, payload) in payloads.iter().enumerate() {
-                index.add_point(idx as PointOffsetType, &[payload]).unwrap();
-            }
-
-            assert_eq!(index.count_indexed_points(), payloads.len());
-
-            let filter_condition = filter_request("multivac");
-            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
-            assert_eq!(search_res, vec![0, 4]);
-
-            let filter_condition = filter_request("giant computer");
-            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
-            assert_eq!(search_res, vec![2]);
-
-            let filter_condition = filter_request("the great time");
-            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
-            assert_eq!(search_res, vec![4]);
-
-            index.remove_point(2).unwrap();
-            index.remove_point(3).unwrap();
-
-            let filter_condition = filter_request("giant computer");
-            assert!(index.filter(&filter_condition).unwrap().next().is_none());
-
-            assert_eq!(index.count_indexed_points(), payloads.len() - 2);
-
-            let payload = serde_json::json!([
-                "The last question was asked for the first time, half in jest, on May 21, 2061,",
-                "at a time when humanity first stepped into the light."
-            ]);
-            index.add_point(3, &[&payload]).unwrap();
-
-            let payload = serde_json::json!([
-                "The question came about as a result of a five dollar bet over highballs, and it happened this way: "
-            ]);
-            index.add_point(4, &[&payload]).unwrap();
-
-            assert_eq!(index.count_indexed_points(), payloads.len() - 1);
-
-            index.flusher()().unwrap();
-        }
-
-        {
-            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-            let mut index = FullTextIndex::new(db, config, "text", immutable);
-            let loaded = index.load().unwrap();
-            assert!(loaded);
-
-            assert_eq!(index.count_indexed_points(), 4);
-
-            let filter_condition = filter_request("multivac");
-            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
-            assert_eq!(search_res, vec![0]);
-
-            let filter_condition = filter_request("the");
-            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
-            assert_eq!(search_res, vec![0, 1, 3, 4]);
-
-            // check deletion
-            index.remove_point(0).unwrap();
-            let filter_condition = filter_request("multivac");
-            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
-            assert!(search_res.is_empty());
-            assert_eq!(index.count_indexed_points(), 3);
-
-            index.remove_point(3).unwrap();
-            let filter_condition = filter_request("the");
-            let search_res: Vec<_> = index.filter(&filter_condition).unwrap().collect();
-            assert_eq!(search_res, vec![1, 4]);
-            assert_eq!(index.count_indexed_points(), 2);
-
-            // check deletion of non-existing point
-            index.remove_point(3).unwrap();
-            assert_eq!(index.count_indexed_points(), 2);
-        }
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -212,7 +212,7 @@ impl FullTextIndex {
 
     pub fn parse_query(&self, text: &str) -> ParsedQuery {
         let mut tokens = HashSet::new();
-        Tokenizer::tokenize_query(text, &self.config(), |token| {
+        Tokenizer::tokenize_query(text, self.config(), |token| {
             tokens.insert(self.get_token(token));
         });
         ParsedQuery {
@@ -222,7 +222,7 @@ impl FullTextIndex {
 
     pub fn parse_document(&self, text: &str) -> Document {
         let mut document_tokens = vec![];
-        Tokenizer::tokenize_doc(text, &self.config(), |token| {
+        Tokenizer::tokenize_doc(text, self.config(), |token| {
             if let Some(token_id) = self.get_token(token) {
                 document_tokens.push(token_id);
             }
@@ -266,7 +266,7 @@ impl ValueIndexer for FullTextIndex {
         let mut tokens: BTreeSet<String> = BTreeSet::new();
 
         for value in values {
-            Tokenizer::tokenize_doc(&value, &self.config(), |token| {
+            Tokenizer::tokenize_doc(&value, self.config(), |token| {
                 tokens.insert(token.to_owned());
             });
         }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -13,7 +13,7 @@ use super::numeric_index::{
 };
 use super::{FieldIndexBuilder, ValueIndexer};
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::field_index::full_text_index::text_index::FullTextIndex;
+use crate::index::field_index::full_text_index::mutable_text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::numeric_index::NumericIndex;
 use crate::index::field_index::FieldIndex;

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -13,7 +13,7 @@ use super::numeric_index::{
 };
 use super::{FieldIndexBuilder, ValueIndexer};
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::field_index::full_text_index::mutable_text_index::FullTextIndex;
+use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::numeric_index::NumericIndex;
 use crate::index::field_index::FieldIndex;


### PR DESCRIPTION
- Refactors `InvertedIndex` from an enum into a trait
- Changes `FullTextIndex` from a struct into an enum which now holds mutable and immutable versions, but soon will also hold Mmap version. This also follows same pattern as current map and numeric indices.

All of this is done just because mmap text index doesn't need a db associated to it. So this refactor is necessary for integrating it.