### PR TITLE
Parallelize duplicate point deletions across segments

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1194,7 +1194,7 @@ impl<'s> SegmentHolder {
     pub async fn deduplicate_points(&self) -> OperationResult<usize> {
         let points_to_remove = self.find_duplicated_points();
 
-        // Create (blocking) task per segment for points to delete so we can paralellize
+        // Create (blocking) task per segment for points to delete so we can parallelize
         let tasks = points_to_remove
             .into_iter()
             .map(|(segment_id, points)| {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use common::iterator_ext::IteratorExt;
 use common::tar_ext;
+use futures::future::try_join_all;
 use io::storage_version::StorageVersion;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use rand::seq::SliceRandom;
@@ -1190,21 +1191,40 @@ impl<'s> SegmentHolder {
     /// If two points have the same id and version, one of them is kept.
     ///
     /// Deduplication works with plain segments only.
-    pub fn deduplicate_points(&self) -> OperationResult<usize> {
+    pub async fn deduplicate_points(&self) -> OperationResult<usize> {
         let points_to_remove = self.find_duplicated_points();
 
-        let mut removed_points = 0;
-        for (segment_id, points) in points_to_remove {
-            let locked_segment = self.get(segment_id).unwrap();
-            let segment_arc = locked_segment.get();
-            let mut write_segment = segment_arc.write();
-            for point_id in points {
-                if let Some(point_version) = write_segment.point_version(point_id) {
-                    removed_points += 1;
-                    write_segment.delete_point(point_version, point_id)?;
-                }
-            }
-        }
+        // Create (blocking) task per segment for points to delete so we can paralellize
+        let tasks = points_to_remove
+            .into_iter()
+            .map(|(segment_id, points)| {
+                let locked_segment = self.get(segment_id).unwrap().clone();
+                tokio::task::spawn_blocking(move || {
+                    let mut removed_points = 0;
+                    let segment_arc = locked_segment.get();
+                    let mut write_segment = segment_arc.write();
+                    for point_id in points {
+                        if let Some(point_version) = write_segment.point_version(point_id) {
+                            removed_points += 1;
+                            write_segment.delete_point(point_version, point_id)?;
+                        }
+                    }
+                    OperationResult::Ok(removed_points)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // Join and sum results in parallel
+        let removed_points = try_join_all(tasks)
+            .await
+            .map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to join task that removes duplicate points from segment: {err}"
+                ))
+            })?
+            .into_iter()
+            .sum::<Result<_, _>>()?;
+
         Ok(removed_points)
     }
 
@@ -1562,8 +1582,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_points_deduplication() {
+    #[tokio::test]
+    async fn test_points_deduplication() {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let mut segment1 = build_segment_1(dir.path());
@@ -1588,7 +1608,7 @@ mod tests {
         let sid1 = holder.add_new(segment1);
         let sid2 = holder.add_new(segment2);
 
-        let res = holder.deduplicate_points().unwrap();
+        let res = holder.deduplicate_points().await.unwrap();
 
         assert_eq!(5, res);
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -318,7 +318,7 @@ impl LocalShard {
             segment_holder.add_new(segment);
         }
 
-        let res = segment_holder.deduplicate_points()?;
+        let res = segment_holder.deduplicate_points().await?;
         if res > 0 {
             log::debug!("Deduplicated {} points", res);
         }


### PR DESCRIPTION
Improve performance of dropping duplicate points on start in case there is a lot of them.

This parallelizes the deletions across segments, rather than doing them in sequence.

My test collection has a segment of about 750k points with 5 keyword indices having just 2 distinct values. This segment is duplicated to get 750k duplicates.

This is how long it takes when loading:
- Before PR: 149 seconds
- After PR: 44 seconds

A more extreme case with 5 copies of the above mentioned segment rather than just 2:
- Before PR: 277 seconds
- After PR: 259 seconds
- After PR with [#5072](https://github.com/qdrant/qdrant/pull/5072): 65 seconds

This obviously is an very unlikely scenario, but it's a good way to show the potential benefit.


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?