### PR TITLE
Tiny improvements in map index

### DIFF
--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -176,6 +176,7 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
         self.values_count = values_count;
         self.value_to_points.clear();
         self.value_to_points_container.clear();
+        self.value_to_points_container.reserve_exact(values_count);
 
         // flatten values-to-points map
         for (value, points) in map {
@@ -186,9 +187,7 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
             self.value_to_points_container.extend(points);
         }
 
-        // Shrink vectors because we won't be adding any new points or values
         self.value_to_points.shrink_to_fit();
-        self.value_to_points_container.shrink_to_fit();
 
         self.point_to_values = ImmutablePointToValues::new(point_to_values);
 

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -186,6 +186,10 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
             self.value_to_points_container.extend(points);
         }
 
+        // Shrink vectors because we won't be adding any new points or values
+        self.value_to_points.shrink_to_fit();
+        self.value_to_points_container.shrink_to_fit();
+
         self.point_to_values = ImmutablePointToValues::new(point_to_values);
 
         Ok(result)

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -103,17 +103,19 @@ impl<N: MapIndexKey + ?Sized> MutableMapIndex<N> {
                 OperationError::service_error("Index load error: UTF8 error while DB parsing")
             })?;
             let (value, idx) = MapIndex::<N>::decode_db_record(record)?;
+
             if self.point_to_values.len() <= idx as usize {
                 self.point_to_values.resize_with(idx as usize + 1, Vec::new)
             }
-            if self.point_to_values[idx as usize].is_empty() {
+            let point_values = &mut self.point_to_values[idx as usize];
+
+            if point_values.is_empty() {
                 self.indexed_points += 1;
             }
             self.values_count += 1;
 
-            let entry = self.map.entry(value);
-            self.point_to_values[idx as usize].push(entry.key().clone());
-            entry.or_default().insert(idx);
+            point_values.push(value.clone());
+            self.map.entry(value).or_default().insert(idx);
         }
         Ok(true)
     }


### PR DESCRIPTION
Some tiny improvements in the map indices. I collected these when working on #5072 and #5073.

This does not show a clear measurable difference in loading time while testing locally. But it may be nice to apply anyway.

- Restructure mutable map index loading a bit
- Preallocate container in immutable map index
- Shrink value to points in immutable map index after construction

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?