### PR TITLE
Use `ReshardingDirection::Up` if `direction` field is missing when deserializing `ReshardKey`

### DIFF
--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -270,10 +270,11 @@ pub struct StartResharding {
 }
 
 /// Resharding direction, scale up or down in number of shards
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReshardingDirection {
     /// Scale up, add a new shard
+    #[default]
     Up,
     /// Scale down, remove a shard
     Down,

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -96,6 +96,7 @@ pub enum ReshardStage {
 /// Unique identifier of a resharding task
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema)]
 pub struct ReshardKey {
+    #[serde(default)]
     pub direction: ReshardingDirection,
     pub peer_id: PeerId,
     pub shard_id: ShardId,


### PR DESCRIPTION
Someone was trying to trigger (officially unreleased) resharding some time ago, before we even added `direction` field (for scale-up/scale-down) resharding. Now this operation is stuck in their WAL, and if you try to replay this WAL on a never version of Qdrant (e.g., if you add a new node to the cluster) deserialization of consensus operation fails, because `direction` field is mandatory. 🙄

This PR "defaults" `ReshardKey::direction` to `ReshardingDirection::Up` if the field is missing.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
