### PR TITLE
Bump memmap2 to latest upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
  "criterion",
  "lazy_static",
  "log",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "num_cpus",
  "ordered-float 4.2.2",
  "ph",
@@ -3512,8 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
-source = "git+https://github.com/RazrFalcon/memmap2-rs#34776c1f83b0ef17ecbc838a580c66e3d703b51d"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -3533,7 +3534,7 @@ version = "0.0.0"
 dependencies = [
  "bitvec",
  "log",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "parking_lot",
  "rand 0.8.5",
  "serde",
@@ -5596,7 +5597,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "macro_rules_attribute",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "memory",
  "nom",
  "num-cmp",
@@ -5989,7 +5990,7 @@ dependencies = [
  "indicatif",
  "io",
  "itertools 0.13.0",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "memory",
  "ordered-float 4.2.2",
  "parking_lot",
@@ -7033,7 +7034,7 @@ dependencies = [
  "env_logger",
  "fs4",
  "log",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "rand 0.8.5",
  "rand_distr",
  "rustix 0.38.31",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ indexmap = { version = "2", features = ["serde"] }
 indicatif = "0.17.8"
 itertools = "0.13.0"
 log = "0.4.22"
-memmap2 = "0.9.4"
+memmap2 = "0.9.5"
 nix = { version = "0.29", features = ["fs"]}
 num-traits = "0.2.19"
 parking_lot = { version = "0.12.3", features = ["deadlock_detection", "serde"] }
@@ -257,5 +257,3 @@ opt-level = 3
 [patch.crates-io]
 # Temporary patch until our PRs are merged.
 tar = { git = "https://github.com/qdrant/tar-rs", branch="main" }
-# Temporary patch until memmap2 0.9.5 is released.
-memmap2 = { git = "https://github.com/RazrFalcon/memmap2-rs" }


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/4923> we switched to a temporary new version because a new change wasn't released yet.

It has been now, so this switches back to the upstream release.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?