### PR TITLE
Rename payload storage operations for consistency

### DIFF
--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -53,7 +53,7 @@ fn range_filtering(c: &mut Criterion) {
         })
         .into();
         payload_storage
-            .assign(id as PointOffsetType, &payload)
+            .set(id as PointOffsetType, &payload)
             .unwrap();
     }
 

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -92,7 +92,7 @@ fn sparse_vector_index_search_benchmark_impl(
     let mut payload_index = sparse_vector_index.payload_index().borrow_mut();
     for idx in 0..NUM_VECTORS {
         payload_index
-            .assign(idx as PointOffsetType, &payload, &None)
+            .set_payload(idx as PointOffsetType, &payload, &None)
             .unwrap();
     }
     drop(payload_index);

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -191,7 +191,7 @@ pub fn create_payload_storage_fixture(num_points: usize, seed: u64) -> InMemoryP
     for id in 0..num_points {
         let payload = generate_diverse_payload(&mut rng);
         payload_storage
-            .assign(id as PointOffsetType, &payload)
+            .set(id as PointOffsetType, &payload)
             .unwrap();
     }
 

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -83,11 +83,15 @@ pub trait PayloadIndex {
         threshold: usize,
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_>;
 
-    /// Assign same payload to each given point
-    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
+    /// Overwrite payload for point_id. If payload already exists, replace it.
+    fn overwrite_payload(
+        &mut self,
+        point_id: PointOffsetType,
+        payload: &Payload,
+    ) -> OperationResult<()>;
 
     /// Assign payload to a concrete point with a concrete payload value
-    fn assign(
+    fn set_payload(
         &mut self,
         point_id: PointOffsetType,
         payload: &Payload,
@@ -95,17 +99,17 @@ pub trait PayloadIndex {
     ) -> OperationResult<()>;
 
     /// Get payload for point
-    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
+    fn get_payload(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
 
     /// Delete payload by key
-    fn delete(
+    fn delete_payload(
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
     ) -> OperationResult<Vec<Value>>;
 
     /// Drop all payload of the point
-    fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>>;
+    fn clear_payload(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>>;
 
     /// Return function that forces persistence of current storage state.
     fn flusher(&self) -> Flusher;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -166,7 +166,7 @@ impl PayloadIndex for PlainPayloadIndex {
         Box::new(vec![].into_iter())
     }
 
-    fn assign_all(
+    fn overwrite_payload(
         &mut self,
         _point_id: PointOffsetType,
         _payload: &Payload,
@@ -174,7 +174,7 @@ impl PayloadIndex for PlainPayloadIndex {
         unreachable!()
     }
 
-    fn assign(
+    fn set_payload(
         &mut self,
         _point_id: PointOffsetType,
         _payload: &Payload,
@@ -183,11 +183,11 @@ impl PayloadIndex for PlainPayloadIndex {
         unreachable!()
     }
 
-    fn payload(&self, _point_id: PointOffsetType) -> OperationResult<Payload> {
+    fn get_payload(&self, _point_id: PointOffsetType) -> OperationResult<Payload> {
         unreachable!()
     }
 
-    fn delete(
+    fn delete_payload(
         &mut self,
         _point_id: PointOffsetType,
         _key: PayloadKeyTypeRef,
@@ -195,7 +195,7 @@ impl PayloadIndex for PlainPayloadIndex {
         unreachable!()
     }
 
-    fn drop(&mut self, _point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
+    fn clear_payload(&mut self, _point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
         unreachable!()
     }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -524,8 +524,12 @@ impl PayloadIndex for StructPayloadIndex {
         }
     }
 
-    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
-        self.payload.borrow_mut().assign_all(point_id, payload)?;
+    fn overwrite_payload(
+        &mut self,
+        point_id: PointOffsetType,
+        payload: &Payload,
+    ) -> OperationResult<()> {
+        self.payload.borrow_mut().overwrite(point_id, payload)?;
 
         for (field, field_index) in &mut self.field_indexes {
             let field_value = payload.get_value(field);
@@ -542,7 +546,7 @@ impl PayloadIndex for StructPayloadIndex {
         Ok(())
     }
 
-    fn assign(
+    fn set_payload(
         &mut self,
         point_id: PointOffsetType,
         payload: &Payload,
@@ -551,12 +555,12 @@ impl PayloadIndex for StructPayloadIndex {
         if let Some(key) = key {
             self.payload
                 .borrow_mut()
-                .assign_by_key(point_id, payload, key)?;
+                .set_by_key(point_id, payload, key)?;
         } else {
-            self.payload.borrow_mut().assign(point_id, payload)?;
+            self.payload.borrow_mut().set(point_id, payload)?;
         };
 
-        let updated_payload = self.payload(point_id)?;
+        let updated_payload = self.get_payload(point_id)?;
         for (field, field_index) in &mut self.field_indexes {
             if !field.is_affected_by_value_set(&payload.0, key.as_ref()) {
                 continue;
@@ -575,11 +579,11 @@ impl PayloadIndex for StructPayloadIndex {
         Ok(())
     }
 
-    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
-        self.payload.borrow().payload(point_id)
+    fn get_payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
+        self.payload.borrow().get(point_id)
     }
 
-    fn delete(
+    fn delete_payload(
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
@@ -592,9 +596,9 @@ impl PayloadIndex for StructPayloadIndex {
         self.payload.borrow_mut().delete(point_id, key)
     }
 
-    fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
+    fn clear_payload(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
         self.clear_index_for_point(point_id)?;
-        self.payload.borrow_mut().drop(point_id)
+        self.payload.borrow_mut().clear(point_id)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -11,12 +11,12 @@ use crate::payload_storage::PayloadStorage;
 use crate::types::Payload;
 
 impl PayloadStorage for InMemoryPayloadStorage {
-    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+    fn overwrite(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         self.payload.insert(point_id, payload.to_owned());
         Ok(())
     }
 
-    fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+    fn set(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         match self.payload.get_mut(&point_id) {
             Some(point_payload) => point_payload.merge(payload),
             None => {
@@ -26,7 +26,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
         Ok(())
     }
 
-    fn assign_by_key(
+    fn set_by_key(
         &mut self,
         point_id: PointOffsetType,
         payload: &Payload,
@@ -43,7 +43,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
         }
     }
 
-    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
+    fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
         match self.payload.get(&point_id) {
             Some(payload) => Ok(payload.to_owned()),
             None => Ok(Default::default()),
@@ -60,7 +60,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
         }
     }
 
-    fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
+    fn clear(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
         let res = self.payload.remove(&point_id);
         Ok(res)
     }
@@ -142,14 +142,14 @@ mod tests {
     fn test_wipe() {
         let mut storage = InMemoryPayloadStorage::default();
         let payload: Payload = serde_json::from_str(r#"{"name": "John Doe"}"#).unwrap();
-        storage.assign(100, &payload).unwrap();
+        storage.set(100, &payload).unwrap();
         storage.wipe().unwrap();
-        storage.assign(100, &payload).unwrap();
+        storage.set(100, &payload).unwrap();
         storage.wipe().unwrap();
-        storage.assign(100, &payload).unwrap();
-        assert!(!storage.payload(100).unwrap().is_empty());
+        storage.set(100, &payload).unwrap();
+        assert!(!storage.get(100).unwrap().is_empty());
         storage.wipe().unwrap();
-        assert_eq!(storage.payload(100).unwrap(), Default::default());
+        assert_eq!(storage.get(100).unwrap(), Default::default());
     }
 
     #[test]
@@ -178,8 +178,8 @@ mod tests {
 
         let payload: Payload = serde_json::from_str(data).unwrap();
         let mut storage = InMemoryPayloadStorage::default();
-        storage.assign(100, &payload).unwrap();
-        let pload = storage.payload(100).unwrap();
+        storage.set(100, &payload).unwrap();
+        let pload = storage.get(100).unwrap();
         assert_eq!(pload, payload);
     }
 }

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -71,11 +71,11 @@ impl OnDiskPayloadStorage {
 }
 
 impl PayloadStorage for OnDiskPayloadStorage {
-    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+    fn overwrite(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         self.update_storage(point_id, payload)
     }
 
-    fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+    fn set(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         let stored_payload = self.read_payload(point_id)?;
         match stored_payload {
             Some(mut point_payload) => {
@@ -87,7 +87,7 @@ impl PayloadStorage for OnDiskPayloadStorage {
         Ok(())
     }
 
-    fn assign_by_key(
+    fn set_by_key(
         &mut self,
         point_id: PointOffsetType,
         payload: &Payload,
@@ -107,7 +107,7 @@ impl PayloadStorage for OnDiskPayloadStorage {
         }
     }
 
-    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
+    fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
         let payload = self.read_payload(point_id)?;
         match payload {
             Some(payload) => Ok(payload),
@@ -130,7 +130,7 @@ impl PayloadStorage for OnDiskPayloadStorage {
         }
     }
 
-    fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
+    fn clear(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
         let payload = self.read_payload(point_id)?;
         self.remove_from_storage(point_id)?;
         Ok(payload)

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -8,31 +8,30 @@ use crate::types::{Filter, Payload};
 
 /// Trait for payload data storage. Should allow filter checks
 pub trait PayloadStorage {
-    /// Assign same payload to each given point
-    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
+    /// Overwrite payload for point_id. If payload already exists, replace it
+    fn overwrite(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
 
-    /// Assign payload to a concrete point with a concrete payload value
-    fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
+    /// Set payload for point_id. If payload already exists, merge it with existing
+    fn set(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
 
-    /// Assign payload to a concrete point with a concrete payload value by path
-    fn assign_by_key(
+    /// Set payload to a point_id by key. If payload already exists, merge it with existing
+    fn set_by_key(
         &mut self,
         point_id: PointOffsetType,
         payload: &Payload,
         key: &JsonPath,
     ) -> OperationResult<()>;
 
-    /// Get payload for point
-    /// If no payload found, return empty payload
-    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
+    /// Get payload for point. If no payload found, return empty payload
+    fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
 
-    /// Delete payload by key
+    /// Delete payload by point_id and key
     fn delete(&mut self, point_id: PointOffsetType, key: &JsonPath) -> OperationResult<Vec<Value>>;
 
-    /// Drop all payload of the point
-    fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>>;
+    /// Clear all payload of the point
+    fn clear(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>>;
 
-    /// Completely drop payload. Pufff!
+    /// Completely delete payload storage. Pufff!
     fn wipe(&mut self) -> OperationResult<()>;
 
     /// Return function that forces persistence of current storage state.

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -333,7 +333,7 @@ mod tests {
         id_tracker.set_link(1.into(), 1).unwrap();
         id_tracker.set_link(2.into(), 2).unwrap();
         id_tracker.set_link(10.into(), 10).unwrap();
-        payload_storage.assign_all(0, &payload).unwrap();
+        payload_storage.overwrite(0, &payload).unwrap();
 
         let payload_checker = SimpleConditionChecker::new(
             Arc::new(AtomicRefCell::new(payload_storage)),

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -115,7 +115,10 @@ impl SegmentEntry for Segment {
             Some(internal_id) => {
                 self.handle_point_version_and_failure(op_num, Some(internal_id), |segment| {
                     // Mark point as deleted, drop mapping
-                    segment.payload_index.borrow_mut().drop(internal_id)?;
+                    segment
+                        .payload_index
+                        .borrow_mut()
+                        .clear_payload(internal_id)?;
                     segment.id_tracker.borrow_mut().drop(point_id)?;
 
                     // Before, we propagated point deletions to also delete its vectors. This turns
@@ -197,7 +200,7 @@ impl SegmentEntry for Segment {
                 segment
                     .payload_index
                     .borrow_mut()
-                    .assign_all(internal_id, full_payload)?;
+                    .overwrite_payload(internal_id, full_payload)?;
                 Ok((true, Some(internal_id)))
             }
             None => Err(OperationError::PointIdError {
@@ -219,7 +222,7 @@ impl SegmentEntry for Segment {
                 segment
                     .payload_index
                     .borrow_mut()
-                    .assign(internal_id, payload, key)?;
+                    .set_payload(internal_id, payload, key)?;
                 Ok((true, Some(internal_id)))
             }
             None => Err(OperationError::PointIdError {
@@ -240,7 +243,7 @@ impl SegmentEntry for Segment {
                 segment
                     .payload_index
                     .borrow_mut()
-                    .delete(internal_id, key)?;
+                    .delete_payload(internal_id, key)?;
                 Ok((true, Some(internal_id)))
             }
             None => Err(OperationError::PointIdError {
@@ -257,7 +260,10 @@ impl SegmentEntry for Segment {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
             Some(internal_id) => {
-                segment.payload_index.borrow_mut().drop(internal_id)?;
+                segment
+                    .payload_index
+                    .borrow_mut()
+                    .clear_payload(internal_id)?;
                 Ok((true, Some(internal_id)))
             }
             None => Err(OperationError::PointIdError {

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -409,7 +409,7 @@ impl Segment {
         &self,
         point_offset: PointOffsetType,
     ) -> OperationResult<Payload> {
-        self.payload_index.borrow().payload(point_offset)
+        self.payload_index.borrow().get_payload(point_offset)
     }
 
     pub fn save_current_state(&self) -> OperationResult<()> {
@@ -521,7 +521,9 @@ impl Segment {
 
             for internal_id in &internal_ids_to_delete {
                 // Drop removed points from payload index
-                self.payload_index.borrow_mut().drop(*internal_id)?;
+                self.payload_index
+                    .borrow_mut()
+                    .clear_payload(*internal_id)?;
 
                 // Drop removed points from vector storage
                 for vector_data in self.vector_data.values() {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -331,7 +331,8 @@ impl SegmentBuilder {
 
                 let old_internal_id = point_data.internal_id;
 
-                let other_payload = payloads[point_data.segment_index].payload(old_internal_id)?;
+                let other_payload =
+                    payloads[point_data.segment_index].get_payload(old_internal_id)?;
 
                 match self.id_tracker.internal_id(point_data.external_id) {
                     Some(existing_internal_id) => {
@@ -352,7 +353,7 @@ impl SegmentBuilder {
                                 .set_link(point_data.external_id, new_internal_id)?;
                             self.id_tracker
                                 .set_internal_version(new_internal_id, point_data.version)?;
-                            self.payload_storage.drop(existing_internal_id)?;
+                            self.payload_storage.clear(existing_internal_id)?;
 
                             existing_internal_id
                         } else {
@@ -374,8 +375,7 @@ impl SegmentBuilder {
 
                 // Propagate payload to new segment
                 if !other_payload.is_empty() {
-                    self.payload_storage
-                        .assign(new_internal_id, &other_payload)?;
+                    self.payload_storage.set(new_internal_id, &other_payload)?;
                 }
             }
         }

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -64,7 +64,7 @@ fn test_filtering_context_consistency() {
     for (idx, payload) in nested_payloads().into_iter().enumerate() {
         points.insert(idx, payload.clone());
         payload_storage
-            .assign(idx as PointOffsetType, &payload)
+            .set(idx as PointOffsetType, &payload)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1078,7 +1078,7 @@ fn test_update_payload_index_type() {
     for (idx, payload) in payloads.into_iter().enumerate() {
         points.insert(idx, payload.clone());
         payload_storage
-            .assign(idx as PointOffsetType, &payload)
+            .set(idx as PointOffsetType, &payload)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -409,7 +409,7 @@ fn sparse_vector_index_ram_filtered_search() {
     let mut payload_index = sparse_vector_index.payload_index().borrow_mut();
     for idx in 0..half_indexed_count {
         payload_index
-            .assign(idx as PointOffsetType, &payload, &None)
+            .set_payload(idx as PointOffsetType, &payload, &None)
             .unwrap();
     }
     drop(payload_index);
@@ -483,7 +483,7 @@ fn sparse_vector_index_plain_search() {
     let mut payload_index = sparse_vector_index.payload_index().borrow_mut();
     for idx in 0..NUM_VECTORS {
         payload_index
-            .assign(idx as PointOffsetType, &payload, &None)
+            .set_payload(idx as PointOffsetType, &payload, &None)
             .unwrap();
     }
     drop(payload_index);


### PR DESCRIPTION
In the context of working on a new payload storage, I realized our internal naming could be improved.

This PR renames the internal payload storage consistency for consistency with our documentation and ubiquitous language.


Namely:
- `assign` becomes `set`
- `assign_all` becomes `overwrite`
- `drop` becomes `clear`
- `payload` becomes `get`

The payload index interface gets updated as well with additional verbs where possible for clarity.