### PR TITLE
Properly preserve full error chain, when `handle_committed_entries` returns an error

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -799,7 +799,7 @@ impl Consensus {
         // Should be done after Hard State is saved, so that `applied` index is never bigger than `commit`.
         let stop_consensus =
             handle_committed_entries(ready.take_committed_entries(), &store, &mut self.node)
-                .map_err(|err| anyhow!("Failed to handle committed entries: {}", err))?;
+                .context("Failed to handle committed entries")?;
         if stop_consensus {
             return Ok((None, None));
         }
@@ -828,7 +828,7 @@ impl Consensus {
         // Apply all committed entries.
         let stop_consensus =
             handle_committed_entries(light_rd.take_committed_entries(), &store, &mut self.node)
-                .map_err(|err| anyhow!("Failed to apply committed entries: {}", err))?;
+                .context("Failed to apply committed entries")?;
         // Advance the apply index.
         self.node.advance_apply();
         Ok(stop_consensus)


### PR DESCRIPTION
Continuation of #5066.

As it turned out, we made some "lossy" error conversions in `consensus` module, and so at the point where we were logging consensus error, the error did not contain the cause of the error.

This PR fixes error conversions, so that we preserve error cause.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
