### PR TITLE
Bump version to 1.11.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "api"
-version = "1.11.3"
+version = "1.11.4"
 dependencies = [
  "chrono",
  "common",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.11.3"
+version = "1.11.4"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.11.3"
+version = "1.11.4"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.11.3"
+version = "1.11.4"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.11.3";
+pub const QDRANT_VERSION_STRING: &str = "1.11.4";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=2eff2c722752e3f92cc684f04f65794328fc99e7
+IGNORE_UPTO=6f8dd8176afb2097be3aca6274f97eb872c735be
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
PR to release Qdrant 1.11.4.

Follows the pattern of https://github.com/qdrant/qdrant/pull/4984.

---

# Change log

## Improvements

- https://github.com/qdrant/qdrant/pull/4940 - Add grey collection status if optimizations are pending after restart
- https://github.com/qdrant/qdrant/pull/5073 - Parallelize deduplication of points on start, making startups faster
- https://github.com/qdrant/qdrant/pull/5072 - Significantly improve performance of lookup/delete in keyword index, making startups faster
- https://github.com/qdrant/qdrant/pull/5091 - Buffer reads when loading quantized vectors, making startups faster
- https://github.com/qdrant/qdrant/pull/5061, https://github.com/qdrant/qdrant/pull/4943 - Create snapshots without intermediate files, making it faster and requiring less disk space
- https://github.com/qdrant/qdrant/pull/4997 - Save shard configuration only once when creating snapshot
- https://github.com/qdrant/qdrant/pull/4923 - On Linux, warm up memory for mmap files with madvice populate
- https://github.com/qdrant/qdrant/pull/5041 - Add template in configuration to configure logging to disk
- https://github.com/qdrant/qdrant/pull/5066 - Report more detailed error if consensus stops due to an error
- https://github.com/qdrant/qdrant/pull/5035 - Improve error reporting for malformed JSON path strings
- https://github.com/qdrant/qdrant/pull/4992 - Reuse HTTP client for telemetry reporting
- https://github.com/qdrant/qdrant/pull/4581 - Print warning in log if JWT RBAC key has low entropy
- https://github.com/qdrant/qdrant/pull/5058 - Remove mention of max_segment_number from OpenAPI definition, because we don't use this anymore

## Fixes

- https://github.com/qdrant/qdrant/pull/5039 - Fix potential data race in collection aliases file leaving corrupted state
- https://github.com/qdrant/qdrant/pull/5043 - Fix shard/collection status blinking green between optimizations
- https://github.com/qdrant/qdrant/pull/5075 - Fsync files to physical storage when restoring snapshot, fixing inconsistencies in volume based snapshots
- https://github.com/qdrant/qdrant/pull/4994 - Fix potential out of memory error when uploading large snapshot to S3
- https://github.com/qdrant/qdrant/pull/5089 - Fix keyword index not excluding deleted points properly
- https://github.com/qdrant/qdrant/pull/5088 - Fix panic on start if mmap metadata file is grown by misbehaving file systems, ignore and continue instead
- https://github.com/qdrant/qdrant/pull/5090 - Clean temporary segments if optimization is cancelled