### PR TITLE
Facets: Support for `bool` payload 

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2509,6 +2509,7 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | string_value | [string](#string) |  | String value from the facet |
 | integer_value | [int64](#int64) |  | Integer value from the facet |
+| bool_value | [bool](#bool) |  | Boolean value from the facet |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -13234,6 +13234,9 @@
           {
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "type": "boolean"
           }
         ]
       }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2291,6 +2291,7 @@ impl TryFrom<FacetValueInternal> for segment_facets::FacetValue {
                 })?;
                 segment_facets::FacetValue::Uuid(Uuid::from_bytes(uuid_bytes).as_u128())
             }
+            Variant::BoolValue(value) => segment_facets::FacetValue::Bool(value),
         })
     }
 }
@@ -2307,6 +2308,7 @@ impl From<segment_facets::FacetValue> for FacetValueInternal {
                     let uuid = Uuid::from_u128(value);
                     Variant::UuidValue(uuid.as_bytes().to_vec())
                 }
+                segment_facets::FacetValue::Bool(value) => Variant::BoolValue(value),
             }),
         }
     }
@@ -2323,6 +2325,7 @@ impl From<segment_facets::FacetValue> for FacetValue {
                 segment_facets::FacetValue::Uuid(value) => {
                     Variant::StringValue(Uuid::from_u128(value).to_string())
                 }
+                segment_facets::FacetValue::Bool(value) => Variant::BoolValue(value),
             }),
         }
     }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -604,6 +604,7 @@ message FacetValue {
     oneof variant {
         string string_value = 1; // String value from the facet
         int64 integer_value = 2; // Integer value from the facet
+        bool bool_value = 3; // Boolean value from the facet
     }
 }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -304,6 +304,7 @@ message FacetValueInternal {
         string keyword_value = 1;
         int64 integer_value = 2;
         bytes uuid_value = 3;
+        bool bool_value = 4;
     }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5099,7 +5099,7 @@ pub struct FacetCounts {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FacetValue {
-    #[prost(oneof = "facet_value::Variant", tags = "1, 2")]
+    #[prost(oneof = "facet_value::Variant", tags = "1, 2, 3")]
     pub variant: ::core::option::Option<facet_value::Variant>,
 }
 /// Nested message and enum types in `FacetValue`.
@@ -5114,6 +5114,9 @@ pub mod facet_value {
         /// Integer value from the facet
         #[prost(int64, tag = "2")]
         IntegerValue(i64),
+        /// Boolean value from the facet
+        #[prost(bool, tag = "3")]
+        BoolValue(bool),
     }
 }
 #[derive(serde::Serialize)]
@@ -9263,7 +9266,7 @@ pub struct FacetCountsInternal {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FacetValueInternal {
-    #[prost(oneof = "facet_value_internal::Variant", tags = "1, 2, 3")]
+    #[prost(oneof = "facet_value_internal::Variant", tags = "1, 2, 3, 4")]
     pub variant: ::core::option::Option<facet_value_internal::Variant>,
 }
 /// Nested message and enum types in `FacetValueInternal`.
@@ -9278,6 +9281,8 @@ pub mod facet_value_internal {
         IntegerValue(i64),
         #[prost(bytes, tag = "3")]
         UuidValue(::prost::alloc::vec::Vec<u8>),
+        #[prost(bool, tag = "4")]
+        BoolValue(bool),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -260,6 +260,7 @@ impl From<segment::data_types::facets::FacetValue> for FacetValue {
             segment::data_types::facets::FacetValue::Uuid(uuid_int) => {
                 Self::String(Uuid::from_u128(uuid_int).to_string())
             }
+            segment::data_types::facets::FacetValue::Bool(b) => Self::Bool(b),
         }
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -769,6 +769,7 @@ pub struct FacetRequest {
 pub enum FacetValue {
     String(String),
     Integer(IntPayloadType),
+    Bool(bool)
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -769,7 +769,7 @@ pub struct FacetRequest {
 pub enum FacetValue {
     String(String),
     Integer(IntPayloadType),
-    Bool(bool)
+    Bool(bool),
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -31,6 +31,7 @@ pub enum FacetValueRef<'a> {
     Keyword(&'a str),
     Int(&'a IntPayloadType),
     Uuid(&'a u128),
+    Bool(bool),
 }
 
 impl<'a> FacetValueRef<'a> {
@@ -39,6 +40,7 @@ impl<'a> FacetValueRef<'a> {
             FacetValueRef::Keyword(s) => FacetValue::Keyword((*s).to_string()),
             FacetValueRef::Int(i) => FacetValue::Int(**i),
             FacetValueRef::Uuid(uuid) => FacetValue::Uuid(**uuid),
+            FacetValueRef::Bool(b) => FacetValue::Bool(*b),
         }
     }
 }
@@ -48,6 +50,7 @@ pub enum FacetValue {
     Keyword(String),
     Int(IntPayloadType),
     Uuid(UuidIntType),
+    Bool(bool),
     // other types to add?
     // Bool(bool),
     // FloatRange(FloatRange),
@@ -101,6 +104,7 @@ impl From<FacetValue> for ValueVariants {
             FacetValue::Keyword(s) => ValueVariants::String(s),
             FacetValue::Int(i) => ValueVariants::Integer(i),
             FacetValue::Uuid(uuid) => ValueVariants::String(Uuid::from_u128(uuid).to_string()),
+            FacetValue::Bool(b) => ValueVariants::Bool(b),
         }
     }
 }

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -227,9 +227,13 @@ impl BinaryIndex {
         ]
         .into_iter()
     }
-    
+
     pub fn iter_counts_per_value(&self) -> impl Iterator<Item = (bool, usize)> + '_ {
-        vec![(false, self.memory.falses_count()), (true, self.memory.trues_count())].into_iter()
+        vec![
+            (false, self.memory.falses_count()),
+            (true, self.memory.trues_count()),
+        ]
+        .into_iter()
     }
 }
 

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -7,6 +7,7 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use self::memory::{BinaryItem, BinaryMemory};
+use super::map_index::IdIter;
 use super::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndex, PrimaryCondition,
     ValueIndexer,
@@ -217,6 +218,18 @@ impl BinaryIndex {
     /// Check if the point has a false value
     pub fn values_has_false(&self, point_id: PointOffsetType) -> bool {
         self.memory.get(point_id).has_false()
+    }
+
+    pub fn iter_values_map(&self) -> impl Iterator<Item = (bool, IdIter<'_>)> + '_ {
+        vec![
+            (false, Box::new(self.memory.iter_has_false()) as IdIter),
+            (true, Box::new(self.memory.iter_has_true()) as IdIter),
+        ]
+        .into_iter()
+    }
+    
+    pub fn iter_counts_per_value(&self) -> impl Iterator<Item = (bool, usize)> + '_ {
+        vec![(false, self.memory.falses_count()), (true, self.memory.trues_count())].into_iter()
     }
 }
 

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -1,6 +1,7 @@
 use common::types::PointOffsetType;
 use itertools::Itertools;
 
+use super::binary_index::BinaryIndex;
 use super::map_index::MapIndex;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::struct_filter_context::StructFilterContext;
@@ -11,6 +12,7 @@ pub enum FacetIndex<'a> {
     Keyword(&'a MapIndex<str>),
     Int(&'a MapIndex<IntPayloadType>),
     Uuid(&'a MapIndex<UuidIntType>),
+    Bool(&'a BinaryIndex),
 }
 
 impl<'a> FacetIndex<'a> {
@@ -46,6 +48,17 @@ impl<'a> FacetIndex<'a> {
 
                 Box::new(iter)
             }
+            FacetIndex::Bool(index) => {
+                let iter = vec![
+                    index.values_has_true(point_id).then(|| true),
+                    index.values_has_false(point_id).then(|| false),
+                ]
+                .into_iter()
+                .filter_map(|x| x)
+                .map(FacetValueRef::Bool);
+
+                Box::new(iter)
+            }
         }
     }
 
@@ -61,6 +74,10 @@ impl<'a> FacetIndex<'a> {
             }
             FacetIndex::Uuid(index) => {
                 let iter = index.iter_values().map(FacetValueRef::Uuid);
+                Box::new(iter)
+            }
+            FacetIndex::Bool(_index) => {
+                let iter = vec![true, false].into_iter().map(FacetValueRef::Bool);
                 Box::new(iter)
             }
         }
@@ -89,13 +106,19 @@ impl<'a> FacetIndex<'a> {
                     .map(|(value, ids_iter)| (FacetValueRef::Uuid(value), ids_iter));
                 Box::new(iter)
             }
+            FacetIndex::Bool(index) => {
+                let iter = index
+                    .iter_values_map()
+                    .map(|(value, ids_iter)| (FacetValueRef::Bool(value), ids_iter));
+                Box::new(iter)
+            }
         };
 
         iter.map(|(value, internal_ids_iter)| FacetHit {
             value,
             count: internal_ids_iter
                 .unique()
-                .filter(|point_id| context.check(**point_id))
+                .filter(|&point_id| context.check(point_id))
                 .count(),
         })
     }
@@ -119,6 +142,12 @@ impl<'a> FacetIndex<'a> {
                 let iter = index
                     .iter_counts_per_value()
                     .map(|(value, count)| (FacetValueRef::Uuid(value), count));
+                Box::new(iter)
+            }
+            FacetIndex::Bool(index) => {
+                let iter = index
+                    .iter_counts_per_value()
+                    .map(|(value, count)| (FacetValueRef::Bool(value), count));
                 Box::new(iter)
             }
         };

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -50,11 +50,11 @@ impl<'a> FacetIndex<'a> {
             }
             FacetIndex::Bool(index) => {
                 let iter = vec![
-                    index.values_has_true(point_id).then(|| true),
-                    index.values_has_false(point_id).then(|| false),
+                    index.values_has_true(point_id).then_some(true),
+                    index.values_has_false(point_id).then_some(false),
                 ]
                 .into_iter()
-                .filter_map(|x| x)
+                .flatten()
                 .map(FacetValueRef::Bool);
 
                 Box::new(iter)

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -373,12 +373,12 @@ impl FieldIndex {
             FieldIndex::KeywordIndex(index) => Some(FacetIndex::Keyword(index)),
             FieldIndex::IntMapIndex(index) => Some(FacetIndex::Int(index)),
             FieldIndex::UuidMapIndex(index) => Some(FacetIndex::Uuid(index)),
+            FieldIndex::BinaryIndex(index) => Some(FacetIndex::Bool(index)),
             FieldIndex::UuidIndex(_)
             | FieldIndex::IntIndex(_)
             | FieldIndex::DatetimeIndex(_)
             | FieldIndex::FloatIndex(_)
             | FieldIndex::GeoIndex(_)
-            | FieldIndex::BinaryIndex(_)
             | FieldIndex::FullTextIndex(_) => None,
         }
     }

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 
 use super::mutable_map_index::MutableMapIndex;
-use super::{IdRefIter, MapIndex, MapIndexKey};
+use super::{IdIter, IdRefIter, MapIndex, MapIndexKey};
 use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
@@ -273,12 +273,11 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
             .map(|(k, entry)| (k.borrow(), entry.count as usize))
     }
 
-    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdRefIter<'_>)> + '_ {
+    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> + '_ {
         self.value_to_points.keys().map(|k| {
             (
                 k.borrow(),
-                Box::new(self.get_iterator(k.borrow()))
-                    as Box<dyn Iterator<Item = &PointOffsetType>>,
+                Box::new(self.get_iterator(k.borrow()).copied()) as IdIter,
             )
         })
     }

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -247,11 +247,8 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     }
 
     pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> + '_ {
-        self.value_to_points.iter().map(|(k, v)| {
-            (
-                k,
-                Box::new(v.iter().copied()) as IdIter,
-            )
-        })
+        self.value_to_points
+            .iter()
+            .map(|(k, v)| (k, Box::new(v.iter().copied()) as IdIter))
     }
 }

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -15,7 +15,7 @@ use memory::mmap_ops::{self, create_and_ensure_length};
 use memory::mmap_type::MmapBitSlice;
 use serde::{Deserialize, Serialize};
 
-use super::{IdRefIter, MapIndexKey};
+use super::{IdIter, MapIndexKey};
 use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
@@ -246,11 +246,11 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         })
     }
 
-    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdRefIter<'_>)> + '_ {
+    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> + '_ {
         self.value_to_points.iter().map(|(k, v)| {
             (
                 k,
-                Box::new(v.iter()) as Box<dyn Iterator<Item = &PointOffsetType>>,
+                Box::new(v.iter().copied()) as IdIter,
             )
         })
     }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -40,6 +40,7 @@ pub mod mmap_map_index;
 pub mod mutable_map_index;
 
 pub type IdRefIter<'a> = Box<dyn Iterator<Item = &'a PointOffsetType> + 'a>;
+pub type IdIter<'a> = Box<dyn Iterator<Item = PointOffsetType> + 'a>;
 
 pub trait MapIndexKey: Key + MmapValue + Eq + Display + Debug {
     type Owned: Borrow<Self> + Hash + Eq + Clone + FromStr + Default;
@@ -198,7 +199,7 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
         }
     }
 
-    pub fn iter_values_map(&self) -> Box<dyn Iterator<Item = (&N, IdRefIter<'_>)> + '_> {
+    pub fn iter_values_map(&self) -> Box<dyn Iterator<Item = (&N, IdIter<'_>)> + '_> {
         match self {
             MapIndex::Mutable(index) => Box::new(index.iter_values_map()),
             MapIndex::Immutable(index) => Box::new(index.iter_values_map()),

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -161,12 +161,9 @@ impl<N: MapIndexKey + ?Sized> MutableMapIndex<N> {
     }
 
     pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> + '_ {
-        self.map.iter().map(|(k, v)| {
-            (
-                k.borrow(),
-                Box::new(v.iter().copied()) as IdIter,
-            )
-        })
+        self.map
+            .iter()
+            .map(|(k, v)| (k.borrow(), Box::new(v.iter().copied()) as IdIter))
     }
 
     pub fn get_iterator(&self, value: &N) -> IdRefIter<'_> {

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -7,7 +7,7 @@ use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
-use super::{IdRefIter, MapIndex, MapIndexKey};
+use super::{IdIter, IdRefIter, MapIndex, MapIndexKey};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
@@ -160,11 +160,11 @@ impl<N: MapIndexKey + ?Sized> MutableMapIndex<N> {
         self.map.iter().map(|(k, v)| (k.borrow(), v.len()))
     }
 
-    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdRefIter<'_>)> + '_ {
+    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> + '_ {
         self.map.iter().map(|(k, v)| {
             (
                 k.borrow(),
-                Box::new(v.iter()) as Box<dyn Iterator<Item = &PointOffsetType>>,
+                Box::new(v.iter().copied()) as IdIter,
             )
         })
     }

--- a/tests/openapi/test_facets.py
+++ b/tests/openapi/test_facets.py
@@ -10,6 +10,26 @@ collection_name = "test_facets"
 def setup(on_disk_vectors):
     basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
 
+    # add extra fields with other datatypes
+    request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "points": [
+                {"id": 100, "vector": {}, "payload": {"integer": 3, "boolean": True}},
+                {"id": 101, "vector": {}, "payload": {"integer": 3, "boolean": True}},
+                {"id": 102, "vector": {}, "payload": {"integer": 3, "boolean": False}},
+                {"id": 103, "vector": {}, "payload": {"integer": 0, "boolean": True}},
+                {"id": 104, "vector": {}, "payload": {"integer": 3, "boolean": True}},
+                {"id": 105, "vector": {}, "payload": {"integer": 1, "boolean": False}},
+                {"id": 106, "vector": {}, "payload": {"integer": 2, "boolean": False}},
+                {"id": 107, "vector": {}, "payload": {"integer": 0, "boolean": True}},
+            ]
+        }
+    ).raise_for_status()
+    
     request_with_validation(
         api="/collections/{collection_name}/index",
         method="PUT",
@@ -18,6 +38,28 @@ def setup(on_disk_vectors):
         body={
             "field_name": "city",
             "field_schema": "keyword",
+        }
+    ).raise_for_status()
+    
+    request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "field_name": "integer",
+            "field_schema": "integer",
+        }
+    ).raise_for_status()
+    
+    request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "field_name": "boolean",
+            "field_schema": "bool",
         }
     ).raise_for_status()
 
@@ -45,5 +87,49 @@ def test_basic_facet():
             {"value": "Berlin", "count": 3 },
             {"value": "London", "count": 2 },
             {"value": "Moscow", "count": 2 },
+        ]
+    }
+
+def test_integer_facet():
+    response = request_with_validation(
+        api="/collections/{collection_name}/facet",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "key": "integer",
+        }
+    )
+
+    assert response.ok, response.json()
+
+    city_facet = response.json()["result"]
+    assert city_facet == {
+        "hits": [
+            # Sorted by count, then by value
+            {"value": 3, "count": 4 },
+            {"value": 0, "count": 2 },
+            {"value": 1, "count": 1 },
+            {"value": 2, "count": 1 },
+        ]
+    }
+    
+def test_boolean_facet():
+    response = request_with_validation(
+        api="/collections/{collection_name}/facet",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "key": "boolean",
+        }
+    )
+
+    assert response.ok, response.json()
+
+    city_facet = response.json()["result"]
+    assert city_facet == {
+        "hits": [
+            # Sorted by count, then by value
+            {"value": True, "count": 5 },
+            {"value": False, "count": 3 },
         ]
     }

--- a/tests/openapi/test_facets.py
+++ b/tests/openapi/test_facets.py
@@ -18,18 +18,82 @@ def setup(on_disk_vectors):
         query_params={"wait": "true"},
         body={
             "points": [
-                {"id": 100, "vector": {}, "payload": {"integer": 3, "boolean": True}},
-                {"id": 101, "vector": {}, "payload": {"integer": 3, "boolean": True}},
-                {"id": 102, "vector": {}, "payload": {"integer": 3, "boolean": False}},
-                {"id": 103, "vector": {}, "payload": {"integer": 0, "boolean": True}},
-                {"id": 104, "vector": {}, "payload": {"integer": 3, "boolean": True}},
-                {"id": 105, "vector": {}, "payload": {"integer": 1, "boolean": False}},
-                {"id": 106, "vector": {}, "payload": {"integer": 2, "boolean": False}},
-                {"id": 107, "vector": {}, "payload": {"integer": 0, "boolean": True}},
+                {
+                    "id": 100,
+                    "vector": {},
+                    "payload": {
+                        "integer": 3,
+                        "uuid": "a64a8051-3ee7-4881-8bc6-691d25c70d54",
+                        "boolean": True,
+                    },
+                },
+                {
+                    "id": 101,
+                    "vector": {},
+                    "payload": {
+                        "integer": 3,
+                        "uuid": "a64a8051-3ee7-4881-8bc6-691d25c70d54",
+                        "boolean": True,
+                    },
+                },
+                {
+                    "id": 102,
+                    "vector": {},
+                    "payload": {
+                        "integer": 3,
+                        "uuid": "7cb46fb3-e348-4762-93ad-7fb983d2b85e",
+                        "boolean": False,
+                    },
+                },
+                {
+                    "id": 103,
+                    "vector": {},
+                    "payload": {
+                        "integer": 0,
+                        "uuid": "2b016c50-282c-4d80-b784-cefead291180",
+                        "boolean": True,
+                    },
+                },
+                {
+                    "id": 104,
+                    "vector": {},
+                    "payload": {
+                        "integer": 3,
+                        "uuid": "a64a8051-3ee7-4881-8bc6-691d25c70d54",
+                        "boolean": True,
+                    },
+                },
+                {
+                    "id": 105,
+                    "vector": {},
+                    "payload": {
+                        "integer": 1,
+                        "uuid": "a64a8051-3ee7-4881-8bc6-691d25c70d54",
+                        "boolean": False,
+                    },
+                },
+                {
+                    "id": 106,
+                    "vector": {},
+                    "payload": {
+                        "integer": 2,
+                        "uuid": "7cb46fb3-e348-4762-93ad-7fb983d2b85e",
+                        "boolean": False,
+                    },
+                },
+                {
+                    "id": 107,
+                    "vector": {},
+                    "payload": {
+                        "integer": 0,
+                        "uuid": "a64a8051-3ee7-4881-8bc6-691d25c70d54",
+                        "boolean": True,
+                    },
+                },
             ]
-        }
+        },
     ).raise_for_status()
-    
+
     request_with_validation(
         api="/collections/{collection_name}/index",
         method="PUT",
@@ -38,9 +102,9 @@ def setup(on_disk_vectors):
         body={
             "field_name": "city",
             "field_schema": "keyword",
-        }
+        },
     ).raise_for_status()
-    
+
     request_with_validation(
         api="/collections/{collection_name}/index",
         method="PUT",
@@ -49,9 +113,20 @@ def setup(on_disk_vectors):
         body={
             "field_name": "integer",
             "field_schema": "integer",
-        }
+        },
     ).raise_for_status()
-    
+
+    request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "field_name": "uuid",
+            "field_schema": "uuid",
+        },
+    ).raise_for_status()
+
     request_with_validation(
         api="/collections/{collection_name}/index",
         method="PUT",
@@ -60,7 +135,7 @@ def setup(on_disk_vectors):
         body={
             "field_name": "boolean",
             "field_schema": "bool",
-        }
+        },
     ).raise_for_status()
 
     yield
@@ -75,7 +150,7 @@ def test_basic_facet():
         body={
             "key": "city",
             # limit is optional
-        }
+        },
     )
 
     assert response.ok, response.json()
@@ -84,11 +159,12 @@ def test_basic_facet():
     assert city_facet == {
         "hits": [
             # Sorted by count, then by value
-            {"value": "Berlin", "count": 3 },
-            {"value": "London", "count": 2 },
-            {"value": "Moscow", "count": 2 },
+            {"value": "Berlin", "count": 3},
+            {"value": "London", "count": 2},
+            {"value": "Moscow", "count": 2},
         ]
     }
+
 
 def test_integer_facet():
     response = request_with_validation(
@@ -97,7 +173,7 @@ def test_integer_facet():
         path_params={"collection_name": collection_name},
         body={
             "key": "integer",
-        }
+        },
     )
 
     assert response.ok, response.json()
@@ -106,13 +182,36 @@ def test_integer_facet():
     assert city_facet == {
         "hits": [
             # Sorted by count, then by value
-            {"value": 3, "count": 4 },
-            {"value": 0, "count": 2 },
-            {"value": 1, "count": 1 },
-            {"value": 2, "count": 1 },
+            {"value": 3, "count": 4},
+            {"value": 0, "count": 2},
+            {"value": 1, "count": 1},
+            {"value": 2, "count": 1},
         ]
     }
-    
+
+
+def test_uuid_facet():
+    response = request_with_validation(
+        api="/collections/{collection_name}/facet",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "key": "uuid",
+        },
+    )
+
+    assert response.ok, response.json()
+
+    city_facet = response.json()["result"]
+    assert city_facet == {
+        "hits": [
+            {"value": "a64a8051-3ee7-4881-8bc6-691d25c70d54", "count": 5},
+            {"value": "7cb46fb3-e348-4762-93ad-7fb983d2b85e", "count": 2},
+            {"value": "2b016c50-282c-4d80-b784-cefead291180", "count": 1},
+        ]
+    }
+
+
 def test_boolean_facet():
     response = request_with_validation(
         api="/collections/{collection_name}/facet",
@@ -120,7 +219,7 @@ def test_boolean_facet():
         path_params={"collection_name": collection_name},
         body={
             "key": "boolean",
-        }
+        },
     )
 
     assert response.ok, response.json()
@@ -129,7 +228,7 @@ def test_boolean_facet():
     assert city_facet == {
         "hits": [
             # Sorted by count, then by value
-            {"value": True, "count": 5 },
-            {"value": False, "count": 3 },
+            {"value": True, "count": 5},
+            {"value": False, "count": 3},
         ]
     }


### PR DESCRIPTION
Adds support for boolean payloads with `bool` index in Facet API. It is a small change to fill a missing hole. 

Now it makes sense to say that any index which supports `MatchValue` conditions can be used for faceting.

cc @joein 