### PR TITLE
Fix optimizations stopped early being counted as failure

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -545,6 +545,7 @@ pub trait SegmentOptimizer {
 
         if !all_segments_ok {
             // Cancel the optimization
+            timer.set_success(true);
             return Ok(0);
         }
 


### PR DESCRIPTION
In the optimizer we have a special condition that quits early if we fail to grab all segments for optimization. Then, we return with an okay status noting zero changes.

However, in telemetry we count this as optimization failure because the timer still has an unsuccessful status.

This patches it to set the success status, in the same way we do at the end of optimization.

In other words, this PR fixes optimizations count as failure in telemetry if we hit the above branch.

Before:

```json
  "optimizations": {
    "count": 2,
    "fail_count": 2,
    "avg_duration_micros": 3557455.5,
    "min_duration_micros": 133971.0,
    "max_duration_micros": 20389912.0,
    "total_duration_micros": 35562396,
    "last_responded": "2024-09-18T08:19:27.410Z"
  },
```

After:

```json
  "optimizations": {
    "count": 4,
    "avg_duration_micros": 3557455.5,
    "min_duration_micros": 133971.0,
    "max_duration_micros": 20389912.0,
    "total_duration_micros": 35562396,
    "last_responded": "2024-09-18T08:19:27.410Z"
  },
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?