### PR TITLE
Configure properly column families when using open_db_with_existing_cf

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -89,7 +89,13 @@ pub fn open_db_with_existing_cf(path: &Path) -> Result<Arc<RwLock<DB>>, rocksdb:
     } else {
         vec![]
     };
-    let db = DB::open_cf(&db_options(), path, existing_column_families)?;
+    let options = db_options();
+    // Make sure that all column families have the same options
+    let column_with_options = existing_column_families
+        .into_iter()
+        .map(|cf| (cf, options.clone()))
+        .collect::<Vec<_>>();
+    let db = DB::open_cf_with_opts(&db_options(), path, column_with_options)?;
     Ok(Arc::new(RwLock::new(db)))
 }
 


### PR DESCRIPTION
We have configured RocksDB to create missing column families opened.

```rust
 options.create_missing_column_families(true);
```

There are two ways to open a column family, first `open_cf`:

```rust
    /// Opens a database with the given database options and column family names.
    ///
    /// Column families opened using this function will be created with default `Options`.
    pub fn open_cf<P, I, N>(opts: &Options, path: P, cfs: I) -> Result<Self, Error>
```

Which only configure the database using the `Options`

Whereas  `open_cf_with_opts`:

```rust
    /// Opens a database with the given database options and column family names.
    ///
    /// Column families opened using given `Options`.
    pub fn open_cf_with_opts<P, I, N>(opts: &Options, path: P, cfs: I) -> Result<Self, Error>
```

which also applies the `Options` to the column family.

This means all column families created with `open_db_with_existing_cf` are not configured.

This is visible with `payload_index` CFs not using `lz4` for compression. 