### PR TITLE
Make BitVec portable, set fixed bit layout in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,6 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "atomicwrites",
- "bitvec",
  "bytes",
  "cancel",
  "chrono",
@@ -1232,6 +1231,7 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
+ "bitvec",
  "common",
  "criterion",
  "lazy_static",
@@ -3534,7 +3534,7 @@ dependencies = [
 name = "memory"
 version = "0.0.0"
 dependencies = [
- "bitvec",
+ "common",
  "log",
  "memmap2 0.9.5",
  "parking_lot",
@@ -5595,7 +5595,6 @@ dependencies = [
  "atomicwrites",
  "bincode",
  "bitpacking",
- "bitvec",
  "byteorder",
  "cc",
  "cgroups-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,6 @@ zerocopy = { version = "0.7.34", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"
 thiserror = "1.0.64"
-bitvec = "1.0.1"
 merge = "0.1.0"
 
 [[bin]]

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -42,7 +42,6 @@ wal = { workspace = true }
 ordered-float = "4.3"
 hashring = "0.3.6"
 tinyvec = { version = "1.8.0", features = ["alloc"] }
-bitvec = { workspace = true }
 lazy_static = "1.5.0"
 smallvec = "1.13.2"
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use bitvec::prelude::BitVec;
 use common::tar_ext;
 use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
@@ -25,6 +24,7 @@ use segment::types::{
 };
 
 use crate::collection_manager::holders::segment_holder::LockedSegment;
+use crate::BitVec;
 
 type LockedRmSet = Arc<RwLock<HashSet<PointIdType>>>;
 type LockedFieldsSet = Arc<RwLock<HashSet<PayloadKeyType>>>;

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::bitvec::BitVec;
 use common::tar_ext;
 use common::types::{PointOffsetType, TelemetryDetail};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
@@ -24,7 +25,6 @@ use segment::types::{
 };
 
 use crate::collection_manager::holders::segment_holder::LockedSegment;
-use crate::BitVec;
 
 type LockedRmSet = Arc<RwLock<HashSet<PointIdType>>>;
 type LockedFieldsSet = Arc<RwLock<HashSet<PayloadKeyType>>>;

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -20,3 +20,8 @@ pub mod wal_delta;
 pub mod events;
 #[cfg(test)]
 mod tests;
+
+// TODO: move this somewhere else?
+pub type BitSliceElement = u64;
+pub type BitSlice = bitvec::slice::BitSlice<BitSliceElement, bitvec::order::Lsb0>;
+pub type BitVec = bitvec::vec::BitVec<BitSliceElement, bitvec::order::Lsb0>;

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -21,7 +21,7 @@ pub mod events;
 #[cfg(test)]
 mod tests;
 
-// TODO: move this somewhere else?
-pub type BitSliceElement = u64;
-pub type BitSlice = bitvec::slice::BitSlice<BitSliceElement, bitvec::order::Lsb0>;
-pub type BitVec = bitvec::vec::BitVec<BitSliceElement, bitvec::order::Lsb0>;
+// TODO: remove this!
+pub type BitSliceElement = ::common::bitvec::BitSliceElement;
+pub type BitSlice = ::common::bitvec::BitSlice;
+pub type BitVec = ::common::bitvec::BitVec;

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -20,8 +20,3 @@ pub mod wal_delta;
 pub mod events;
 #[cfg(test)]
 mod tests;
-
-// TODO: remove this!
-pub type BitSliceElement = ::common::bitvec::BitSliceElement;
-pub type BitSlice = ::common::bitvec::BitSlice;
-pub type BitVec = ::common::bitvec::BitVec;

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 testing = []
 
 [dependencies]
+bitvec = "1.0.1"
 num_cpus = "1.16"
 ordered-float = "4.3"
 ph = { workspace = true }

--- a/lib/common/common/src/bitvec.rs
+++ b/lib/common/common/src/bitvec.rs
@@ -1,0 +1,11 @@
+use bitvec::slice::BitSlice as RawBitSlice;
+pub use bitvec::store::BitStore;
+pub use bitvec::vec::BitVec as RawBitVec;
+
+// BitVec type we use across the codebase. Has consistent bit layout, suitable for persisting.
+pub type BitSliceElement = u64;
+pub type BitSlice = RawBitSlice<BitSliceElement, bitvec::order::Lsb0>;
+pub type BitVec = RawBitVec<BitSliceElement, bitvec::order::Lsb0>;
+
+// BitVec type we use for in-memory bit vectors. Can be more efficient than BitVec.
+pub type MemoryBitVec = bitvec::vec::BitVec;

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bitvec;
 pub mod cpu;
 pub mod defaults;
 pub mod disk;

--- a/lib/common/memory/Cargo.toml
+++ b/lib/common/memory/Cargo.toml
@@ -13,11 +13,11 @@ publish = false
 workspace = true
 
 [dependencies]
-memmap2 = { workspace = true }
+common = { path = "../common" }
 log = { workspace = true }
+memmap2 = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
-bitvec = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -37,9 +37,10 @@ type Result<T> = std::result::Result<T, Error>;
 
 pub type MmapFlusher = Box<dyn FnOnce() -> Result<()> + Send>;
 
-pub type BitSliceElement = u64;
-pub type BitSlice = bitvec::slice::BitSlice<BitSliceElement, bitvec::order::Lsb0>;
-pub type BitVec = bitvec::vec::BitVec<BitSliceElement, bitvec::order::Lsb0>;
+// TODO: remove this!
+pub type BitSliceElement = common::bitvec::BitSliceElement;
+pub type BitSlice = common::bitvec::BitSlice;
+pub type BitVec = common::bitvec::BitVec;
 
 /// Type `T` on a memory mapped file
 ///

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -27,7 +27,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::{fmt, mem, slice};
 
-use bitvec::slice::BitSlice;
 use memmap2::MmapMut;
 
 use crate::madvise::{Advice, AdviceSetting};
@@ -37,6 +36,10 @@ use crate::mmap_ops;
 type Result<T> = std::result::Result<T, Error>;
 
 pub type MmapFlusher = Box<dyn FnOnce() -> Result<()> + Send>;
+
+pub type BitSliceElement = u64;
+pub type BitSlice = bitvec::slice::BitSlice<BitSliceElement, bitvec::order::Lsb0>;
+pub type BitVec = bitvec::vec::BitVec<BitSliceElement, bitvec::order::Lsb0>;
 
 /// Type `T` on a memory mapped file
 ///

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -27,6 +27,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::{fmt, mem, slice};
 
+use common::bitvec::BitSlice;
 use memmap2::MmapMut;
 
 use crate::madvise::{Advice, AdviceSetting};
@@ -36,11 +37,6 @@ use crate::mmap_ops;
 type Result<T> = std::result::Result<T, Error>;
 
 pub type MmapFlusher = Box<dyn FnOnce() -> Result<()> + Send>;
-
-// TODO: remove this!
-pub type BitSliceElement = common::bitvec::BitSliceElement;
-pub type BitSlice = common::bitvec::BitSlice;
-pub type BitVec = common::bitvec::BitVec;
 
 /// Type `T` on a memory mapped file
 ///

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -64,7 +64,6 @@ num-traits = { workspace = true }
 num-derive = "0.4.2"
 num-cmp = "0.1.0"
 rand = { workspace = true }
-bitvec = { workspace = true }
 seahash = "4.1.0"
 semver = { workspace = true }
 tar = { workspace = true }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use memory::mmap_type::BitSlice;
+use common::bitvec::BitSlice;
 use sparse::common::types::{DimId, DimWeight};
 
 use crate::data_types::tiny_map;

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use bitvec::prelude::BitSlice;
+use memory::mmap_type::BitSlice;
 use sparse::common::types::{DimId, DimWeight};
 
 use crate::data_types::tiny_map;

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -3,8 +3,8 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
-use bitvec::prelude::{BitSlice, BitVec};
 use common::types::PointOffsetType;
+use memory::mmap_type::{BitSlice, BitVec};
 use rand::Rng;
 
 use crate::common::operation_error::OperationResult;

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -3,8 +3,8 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
-use memory::mmap_type::{BitSlice, BitVec};
 use rand::Rng;
 
 use crate::common::operation_error::OperationResult;

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
-use memory::mmap_type::{BitSlice, BitVec};
 use rand::prelude::StdRng;
 use rand::SeedableRng;
 

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use bitvec::prelude::{BitSlice, BitVec};
 use common::types::PointOffsetType;
+use memory::mmap_type::{BitSlice, BitVec};
 use rand::prelude::StdRng;
 use rand::SeedableRng;
 

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
-use memory::mmap_type::BitSlice;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
+use memory::mmap_type::BitSlice;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -5,10 +5,11 @@ use std::mem::{size_of, size_of_val};
 use std::path::{Path, PathBuf};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
-use memory::mmap_type::{BitSlice, BitVec, MmapBitSlice, MmapSlice};
+use memory::mmap_type::{MmapBitSlice, MmapSlice};
 use uuid::Uuid;
 
 use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -4,13 +4,11 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::mem::{size_of, size_of_val};
 use std::path::{Path, PathBuf};
 
-use bitvec::prelude::BitSlice;
-use bitvec::vec::BitVec;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
-use memory::mmap_type::{MmapBitSlice, MmapSlice};
+use memory::mmap_type::{BitSlice, BitVec, MmapBitSlice, MmapSlice};
 use uuid::Uuid;
 
 use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
-use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
+use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 use std::iter;
 
-use bitvec::prelude::{BitSlice, BitVec};
 use byteorder::LittleEndian;
 use common::types::PointOffsetType;
 use itertools::Itertools;
+use memory::mmap_type::{BitSlice, BitVec};
 use rand::distributions::Distribution;
 use uuid::Uuid;
 

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 use std::iter;
 
 use byteorder::LittleEndian;
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
 use itertools::Itertools;
-use memory::mmap_type::{BitSlice, BitVec};
 use rand::distributions::Distribution;
 use uuid::Uuid;
 

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use bincode;
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
-use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 use serde::{Deserialize, Serialize};

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use bincode;
-use bitvec::prelude::{BitSlice, BitVec};
 use common::types::PointOffsetType;
+use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 use serde::{Deserialize, Serialize};

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -19,7 +19,8 @@ use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, MatchValue, PayloadKeyType, ValueVariants};
 
 mod memory {
-    use common::{bitvec::MemoryBitVec, types::PointOffsetType};
+    use common::bitvec::MemoryBitVec;
+    use common::types::PointOffsetType;
 
     pub struct BinaryItem {
         value: u8,

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -19,8 +19,7 @@ use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, MatchValue, PayloadKeyType, ValueVariants};
 
 mod memory {
-    use bitvec::vec::BitVec;
-    use common::types::PointOffsetType;
+    use common::{bitvec::MemoryBitVec, types::PointOffsetType};
 
     pub struct BinaryItem {
         value: u8,
@@ -69,8 +68,8 @@ mod memory {
     }
 
     pub struct BinaryMemory {
-        trues: BitVec,
-        falses: BitVec,
+        trues: MemoryBitVec,
+        falses: MemoryBitVec,
         trues_count: usize,
         falses_count: usize,
         indexed_count: usize,
@@ -79,8 +78,8 @@ mod memory {
     impl BinaryMemory {
         pub fn new() -> Self {
             Self {
-                trues: BitVec::new(),
-                falses: BitVec::new(),
+                trues: Default::default(),
+                falses: Default::default(),
                 trues_count: 0,
                 falses_count: 0,
                 indexed_count: 0,

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -3,12 +3,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use bitvec::vec::BitVec;
 use common::mmap_hashmap::MmapHashMap;
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops;
-use memory::mmap_type::{MmapBitSlice, MmapSlice};
+use memory::mmap_type::{BitVec, MmapBitSlice, MmapSlice};
 use mmap_postings::MmapPostings;
 
 use super::inverted_index::{InvertedIndex, ParsedQuery};

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -3,11 +3,12 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use common::bitvec::BitVec;
 use common::mmap_hashmap::MmapHashMap;
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops;
-use memory::mmap_type::{BitVec, MmapBitSlice, MmapSlice};
+use memory::mmap_type::{MmapBitSlice, MmapSlice};
 use mmap_postings::MmapPostings;
 
 use super::inverted_index::{InvertedIndex, ParsedQuery};

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::ops::Range;
 use std::sync::Arc;
 
-use bitvec::vec::BitVec;
+use common::bitvec::MemoryBitVec;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -21,7 +21,7 @@ pub struct ImmutableMapIndex<N: MapIndexKey + ?Sized> {
     /// Container holding a slice of point IDs per value. `value_to_point` holds the range per value.
     /// Each slice MUST be sorted so that we can binary search over it.
     value_to_points_container: Vec<PointOffsetType>,
-    deleted_value_to_points_container: BitVec,
+    deleted_value_to_points_container: MemoryBitVec,
     point_to_values: ImmutablePointToValues<N::Owned>,
     /// Amount of point which have at least one indexed payload value
     indexed_points: usize,
@@ -115,7 +115,7 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
     fn remove_idx_from_value_list(
         value_to_points: &mut HashMap<N::Owned, ContainerSegment>,
         value_to_points_container: &mut [PointOffsetType],
-        deleted_value_to_points_container: &mut BitVec,
+        deleted_value_to_points_container: &mut MemoryBitVec,
         value: &N,
         idx: PointOffsetType,
     ) {

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::ops::Bound;
 use std::sync::Arc;
 
-use bitvec::vec::BitVec;
+use common::bitvec::MemoryBitVec;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -28,7 +28,7 @@ pub struct ImmutableNumericIndex<T: Encodable + Numericable + Default> {
 
 pub(super) struct NumericKeySortedVec<T: Encodable + Numericable> {
     data: Vec<Point<T>>,
-    deleted: BitVec,
+    deleted: MemoryBitVec,
     deleted_count: usize,
 }
 
@@ -41,7 +41,7 @@ pub(super) struct NumericKeySortedVecIterator<'a, T: Encodable + Numericable> {
 impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
     fn from_btree_set(map: BTreeSet<Point<T>>) -> Self {
         Self {
-            deleted: BitVec::repeat(false, map.len()),
+            deleted: MemoryBitVec::repeat(false, map.len()),
             data: map.into_iter().collect(),
             deleted_count: 0,
         }
@@ -162,7 +162,7 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
         Self {
             map: NumericKeySortedVec {
                 data: Default::default(),
-                deleted: BitVec::new(),
+                deleted: Default::default(),
                 deleted_count: 0,
             },
             db_wrapper,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -3,7 +3,7 @@ use std::collections::BinaryHeap;
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 
-use bitvec::prelude::BitVec;
+use common::bitvec::MemoryBitVec;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 use parking_lot::{Mutex, MutexGuard, RwLock};
@@ -40,7 +40,7 @@ pub struct GraphLayersBuilder {
     visited_pool: VisitedPool,
 
     // List of bool flags, which defines if the point is already indexed or not
-    ready_list: RwLock<BitVec>,
+    ready_list: RwLock<MemoryBitVec>,
 }
 
 impl GraphLayersBase for GraphLayersBuilder {
@@ -120,7 +120,7 @@ impl GraphLayersBuilder {
         .take(num_vectors)
         .collect();
 
-        let ready_list = RwLock::new(BitVec::repeat(false, num_vectors));
+        let ready_list = RwLock::new(MemoryBitVec::repeat(false, num_vectors));
 
         Self {
             max_level: AtomicUsize::new(0),

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -6,13 +6,13 @@ use std::sync::Arc;
 use std::thread;
 
 use atomic_refcell::AtomicRefCell;
+use common::bitvec::BitSlice;
 #[cfg(target_os = "linux")]
 use common::cpu::linux_low_thread_priority;
 use common::cpu::{get_num_cpus, CpuPermit};
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use log::debug;
 use memory::mmap_ops;
-use memory::mmap_type::BitSlice;
 use parking_lot::Mutex;
 use rand::thread_rng;
 use rayon::prelude::*;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -6,13 +6,13 @@ use std::sync::Arc;
 use std::thread;
 
 use atomic_refcell::AtomicRefCell;
-use bitvec::prelude::BitSlice;
 #[cfg(target_os = "linux")]
 use common::cpu::linux_low_thread_priority;
 use common::cpu::{get_num_cpus, CpuPermit};
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use log::debug;
 use memory::mmap_ops;
+use memory::mmap_type::BitSlice;
 use parking_lot::Mutex;
 use rand::thread_rng;
 use rayon::prelude::*;

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -4,10 +4,10 @@ use std::fs::{self};
 use std::path::Path;
 use std::thread::{self, JoinHandle};
 
+use common::bitvec::BitVec;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use memory::mmap_ops;
-use memory::mmap_type::BitVec;
 
 use super::{
     Segment, DB_BACKUP_PATH, PAYLOAD_DB_BACKUP_PATH, SEGMENT_STATE_FILE, SNAPSHOT_FILES_PATH,

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -4,10 +4,10 @@ use std::fs::{self};
 use std::path::Path;
 use std::thread::{self, JoinHandle};
 
-use bitvec::prelude::BitVec;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use memory::mmap_ops;
+use memory::mmap_type::BitVec;
 
 use super::{
     Segment, DB_BACKUP_PATH, PAYLOAD_DB_BACKUP_PATH, SEGMENT_STATE_FILE, SNAPSHOT_FILES_PATH,

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use ahash::AHasher;
 use atomic_refcell::AtomicRefCell;
-use bitvec::macros::internal::funty::Integral;
 use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use io::storage_version::StorageVersion;
@@ -142,7 +141,7 @@ impl SegmentBuilder {
     /// Note: This value doesn't guarantee strict ordering in ambiguous cases.
     ///       It should only be used in optimization purposes, not for correctness.
     fn _get_ordering_value(internal_id: PointOffsetType, indices: &[FieldIndex]) -> u64 {
-        let mut ordering = 0;
+        let mut ordering = 0u64;
         for payload_index in indices {
             match payload_index {
                 FieldIndex::IntMapIndex(index) => {

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use common::bitvec::BitSlice;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
-use memory::mmap_type::BitSlice;
 
 use super::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use bitvec::prelude::BitSlice;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use memory::mmap_type::BitSlice;
 
 use super::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;

--- a/lib/segment/src/vector_storage/bitvec.rs
+++ b/lib/segment/src/vector_storage/bitvec.rs
@@ -1,4 +1,4 @@
-use bitvec::{store::BitStore, vec::BitVec};
+use common::bitvec::{BitStore, RawBitVec};
 use common::types::PointOffsetType;
 
 /// Set deleted state in given bitvec.
@@ -8,7 +8,7 @@ use common::types::PointOffsetType;
 /// Returns previous deleted state of the given point.
 #[inline]
 pub fn bitvec_set_deleted<T: BitStore>(
-    bitvec: &mut BitVec<T>,
+    bitvec: &mut RawBitVec<T>,
     point_id: PointOffsetType,
     deleted: bool,
 ) -> bool {

--- a/lib/segment/src/vector_storage/bitvec.rs
+++ b/lib/segment/src/vector_storage/bitvec.rs
@@ -1,4 +1,4 @@
-use bitvec::vec::BitVec;
+use bitvec::{store::BitStore, vec::BitVec};
 use common::types::PointOffsetType;
 
 /// Set deleted state in given bitvec.
@@ -7,7 +7,11 @@ use common::types::PointOffsetType;
 ///
 /// Returns previous deleted state of the given point.
 #[inline]
-pub fn bitvec_set_deleted(bitvec: &mut BitVec, point_id: PointOffsetType, deleted: bool) -> bool {
+pub fn bitvec_set_deleted<T: BitStore>(
+    bitvec: &mut BitVec<T>,
+    point_id: PointOffsetType,
+    deleted: bool,
+) -> bool {
     // Set deleted flag if bitvec is large enough, no need to check bounds
     if (point_id as usize) < bitvec.len() {
         return unsafe { bitvec.replace_unchecked(point_id as usize, deleted) };

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
-use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::{check_process_stopped, OperationResult};
 use crate::common::Flusher;

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
+use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::{check_process_stopped, OperationResult};
 use crate::common::Flusher;

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -4,11 +4,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, fs};
 
+use common::bitvec::{BitSlice, BitSliceElement};
 use memmap2::MmapMut;
 use memory::madvise::{self, AdviceSetting, Madviseable as _};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
-use memory::mmap_type::BitSlice;
-use memory::mmap_type::{BitSliceElement, MmapBitSlice, MmapFlusher, MmapType};
+use memory::mmap_type::{MmapBitSlice, MmapFlusher, MmapType};
 use parking_lot::Mutex;
 
 use crate::common::operation_error::{OperationError, OperationResult};

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -5,9 +5,9 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
 use memory::mmap_ops;
+use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::Flusher;

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -5,9 +5,9 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use memory::mmap_ops;
-use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::Flusher;

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -4,11 +4,11 @@ use std::mem::{self, size_of, transmute};
 use std::path::Path;
 use std::sync::Arc;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use memmap2::Mmap;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops;
-use memory::mmap_type::BitSlice;
 use memory::mmap_type::{MmapBitSlice, MmapFlusher};
 use parking_lot::Mutex;
 

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -4,11 +4,11 @@ use std::mem::{self, size_of, transmute};
 use std::path::Path;
 use std::sync::Arc;
 
-use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
 use memmap2::Mmap;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops;
+use memory::mmap_type::BitSlice;
 use memory::mmap_type::{MmapBitSlice, MmapFlusher};
 use parking_lot::Mutex;
 

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
 use log::debug;
-use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use bitvec::prelude::{BitSlice, BitVec};
 use common::types::PointOffsetType;
 use log::debug;
+use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
-use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::Flusher;

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
+use memory::mmap_type::BitSlice;
 
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::Flusher;

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -3,8 +3,8 @@ use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use bitvec::prelude::{BitSlice, BitVec};
 use common::types::PointOffsetType;
+use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -3,8 +3,8 @@ use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
-use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
-use bitvec::slice::BitSlice;
+use memory::mmap_type::BitSlice;
 use quantization::EncodedVectors;
 
 use super::quantized_custom_query_scorer::QuantizedCustomQueryScorer;

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
-use memory::mmap_type::BitSlice;
+use common::bitvec::BitSlice;
 use quantization::EncodedVectors;
 
 use super::quantized_custom_query_scorer::QuantizedCustomQueryScorer;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -2,9 +2,9 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
-use memory::mmap_type::BitSlice;
 use quantization::encoded_vectors_binary::{EncodedBinVector, EncodedVectorsBin};
 use quantization::{
     EncodedQueryPQ, EncodedQueryU8, EncodedVectors, EncodedVectorsPQ, EncodedVectorsU8,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -2,9 +2,9 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use bitvec::slice::BitSlice;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
+use memory::mmap_type::BitSlice;
 use quantization::encoded_vectors_binary::{EncodedBinVector, EncodedVectorsBin};
 use quantization::{
     EncodedQueryPQ, EncodedQueryU8, EncodedVectors, EncodedVectorsPQ, EncodedVectorsU8,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use common::bitvec::BitSlice;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
-use memory::mmap_type::BitSlice;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use bitvec::prelude::BitSlice;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use memory::mmap_type::BitSlice;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -2,8 +2,8 @@ use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
-use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 use sparse::common::sparse_vector::SparseVector;

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -2,8 +2,8 @@ use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use bitvec::prelude::{BitSlice, BitVec};
 use common::types::PointOffsetType;
+use memory::mmap_type::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 use sparse::common::sparse_vector::SparseVector;

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::AtomicBool;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use itertools::Itertools;
-use memory::mmap_type::BitSlice;
 use rand::seq::IteratorRandom as _;
 use rand::SeedableRng as _;
 

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::AtomicBool;
 
-use bitvec::slice::BitSlice;
 use common::types::PointOffsetType;
 use itertools::Itertools;
+use memory::mmap_type::BitSlice;
 use rand::seq::IteratorRandom as _;
 use rand::SeedableRng as _;
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -2,8 +2,8 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
-use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
+use memory::mmap_type::BitSlice;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::memmap_dense_vector_storage::MemmapDenseVectorStorage;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -2,8 +2,8 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
+use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
-use memory::mmap_type::BitSlice;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::memmap_dense_vector_storage::MemmapDenseVectorStorage;


### PR DESCRIPTION
We make use of [`BitVec`](https://docs.rs/bitvec/latest/bitvec/vec/struct.BitVec.html) and its default parameters in many places throughout our code base.

The problem is that this definition is not portable. The container type and bit order are system dependent. Because we persist these bit vectors on disk and potentially transfer them to other machines, this may be problematic.

To resolve this, we now explicitly set our container type and bit order. That way we're sure the persisted data is consistent across all system configurations. To simplify usage of this, I've defined these explicit types centrally. See the review comment below.

Note that this assumes we've only been used on little endian systems thus far. Big endian systems, having different byte order, will break with this update. The idea is that we better patch and use a fixed configuration now, versus letting this escalate further beyond control.

One interesting performance quirk is that using the native bit/byte ordering on the platform likely will be faster at runtime. Because of this I've also exposed `MemoryBitVec`. It is intended to use in places where we never persist the bit vector, as portability is not needed there. My plan is to apply this type in more places where it seems fit, but in a separate PR.

<https://github.com/qdrant/qdrant/pull/5180> goes along with this one to potentially help debugging remote systems.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?