### PR TITLE
Fix race condition getting optimizers stuck, leaving collection in yellow state

### DIFF
--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -508,7 +508,7 @@ impl UpdateHandler {
                 .collect::<Vec<_>>()
                 .into_iter()
                 .rev()
-                .map(|i| handles.remove(i))
+                .map(|i| handles.swap_remove(i))
                 .collect()
         };
 


### PR DESCRIPTION
This PR fixes a race condition which would allow the optimizers for a collection to get stuck. The result is a collection that remains in yellow state forever, unless a new update operation is send to trigger the remaining optimizations.

The PR has two changes:
1. patch race condition (with an extra branch)
2. remove a level of nesting in the match statement. The bulk of the logic now happens after the match rather than inside it, other branches use `continue`/`break`.

The data race is caused by an ordering problem between three things:
1. condition that checks max allowed handles (max 1 in this case)
2. clean up of handles that are finished
3. signal at the end of optimization to trigger new optimizations

Basically, we trigger the optimizers again before cleaning the finished handle up (through a callback). If checking the maximum allowed handles on a new run, we'd still be at the maximum, cancelling the new optimization. There are no other ongoing optimizations to trigger the optimizer loop once again, getting it stuck. In other words, the problem is that we retrigger optimizations before cleaning up the handles. Sadly that's not an easy thing to fix.

This PR patches the problem by triggering optimizations even if we clean up any finished handles. This means we pass the handle limit condition, which prevents it getting stuck. We have tested this patch on our benchmark server. It has shown to solve the problem.

I'm not super satisfied with the way the optimization loops works right now. I suggest to merge this PR, and attempt to refactor it separately to make this data race impossible.

<details>
<summary>Details</summary>

We did not catch this before because we have no optimization handle limit by default. In case of our benchmark server we have a limit of 1 set however.

Detailed scenario, in order:
1. Thread 1: one optimization is running
2. Thread 1: optimization is at the end, sends optimizer signal
3. Thread 2: optimization worker triggered, received signal
4. Thread 2: optimization worker fails condition, already at max of 1 handle
5. Thread 1: optimization is finished
6. _some time passes_
7. Thread 2: optimization worker triggered by clean interval
8. Thread 2: optimization worker cleans finished handle
9. _now we're stuck, we won't receive new signals_

This PR patches point 8.

</details>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?