### PR TITLE
Update `tar_ext::BuilderExt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "rand 0.8.5",
  "semver",
  "serde",
+ "tap",
  "tar",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ serde_variant = "0.1.3"
 sha2 = "0.10.8"
 serde_json = {version = "~1.0", features = ["preserve_order"]}
 strum = { version = "0.26.3", features = ["derive"] }
+tap = "1.0.1"
 tar = "0.4.41"
 tempfile = "3.12.0"
 tokio = { version = "1.40.0", features = ["full"] }

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -76,7 +76,7 @@ impl Collection {
                 ))
             })?;
 
-        let tar = BuilderExt::new_seekable(File::create(snapshot_temp_arc_file.path())?);
+        let tar = BuilderExt::new_seekable_owned(File::create(snapshot_temp_arc_file.path())?);
 
         // Create snapshot of each shard
         {

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -76,7 +76,7 @@ impl Collection {
                 ))
             })?;
 
-        let tar = BuilderExt::new(File::create(snapshot_temp_arc_file.path())?);
+        let tar = BuilderExt::new_seekable(File::create(snapshot_temp_arc_file.path())?);
 
         // Create snapshot of each shard
         {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1560,7 +1560,7 @@ mod tests {
 
         let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
         eprintln!("Snapshot into {:?}", snapshot_file.path());
-        let tar = tar_ext::BuilderExt::new(File::create(&snapshot_file).unwrap());
+        let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_file).unwrap());
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let temp_dir2 = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let mut snapshotted_segments = HashSet::new();

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1560,7 +1560,7 @@ mod tests {
 
         let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
         eprintln!("Snapshot into {:?}", snapshot_file.path());
-        let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_file).unwrap());
+        let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(&snapshot_file).unwrap());
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let temp_dir2 = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let mut snapshotted_segments = HashSet::new();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1646,7 +1646,7 @@ mod tests {
         let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
-        let tar = tar_ext::BuilderExt::new(File::create(&snapshot_file).unwrap());
+        let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_file).unwrap());
         SegmentHolder::snapshot_all_segments(
             holder.clone(),
             segments_dir.path(),

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1646,7 +1646,7 @@ mod tests {
         let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
-        let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_file).unwrap());
+        let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(&snapshot_file).unwrap());
         SegmentHolder::snapshot_all_segments(
             holder.clone(),
             segments_dir.path(),

--- a/lib/collection/src/shards/shard_config.rs
+++ b/lib/collection/src/shards/shard_config.rs
@@ -48,10 +48,8 @@ impl ShardConfig {
     }
 
     pub async fn save_to_tar(&self, tar: &tar_ext::BuilderExt) -> CollectionResult<()> {
-        tar.write_fn(Path::new(SHARD_CONFIG_FILE), |writer| {
-            serde_json::to_writer(writer, self)?;
-            Ok(())
-        })
-        .await
+        let bytes = serde_json::to_vec(self)?;
+        tar.append_data(bytes, Path::new(SHARD_CONFIG_FILE)).await?;
+        Ok(())
     }
 }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -870,7 +870,7 @@ impl ShardHolder {
             .suffix(".tar")
             .tempfile_in(temp_dir)?;
 
-        let tar = BuilderExt::new(File::create(temp_file.path())?);
+        let tar = BuilderExt::new_seekable(File::create(temp_file.path())?);
 
         shard
             .create_snapshot(snapshot_temp_dir.path(), &tar, false)

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -870,7 +870,7 @@ impl ShardHolder {
             .suffix(".tar")
             .tempfile_in(temp_dir)?;
 
-        let tar = BuilderExt::new_seekable(File::create(temp_file.path())?);
+        let tar = BuilderExt::new_seekable_owned(File::create(temp_file.path())?);
 
         shard
             .create_snapshot(snapshot_temp_dir.path(), &tar, false)

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -21,6 +21,7 @@ ordered-float = "4.2"
 ph = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+tap = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -1,10 +1,11 @@
 //! Extensions for the `tar` crate.
 
-use std::fs::File;
-use std::io::Write;
+use std::io::{Seek, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use tap::Tap;
 use tokio::sync::Mutex;
 use tokio::task::JoinError;
 
@@ -13,16 +14,92 @@ use tokio::task::JoinError;
 /// 2. Provides the [`BuilderExt::descend`] method.
 #[derive(Clone)]
 pub struct BuilderExt {
-    tar: Arc<Mutex<tar::Builder<File>>>,
+    tar: Arc<Mutex<BuilderBox>>,
     path: PathBuf,
 }
 
+/// A wrapper around [`tar::Builder<WriteBox>`] that disables [`WriteBox`] when
+/// it is dropped.
+///
+/// Disabling the [`WriteBox`] is a workaround for the inconvenient
+/// [`tar::Builder`] behavior: dropping a [`tar::Builder`] might cause a final
+/// write of archive footer.
+/// This behavior is problematic for [`Write`] implementations that could panic
+/// when used in an async context, such as [`SyncIoBridge`].
+///
+/// [`SyncIoBridge`]: https://docs.rs/tokio-util/0.7.12/tokio_util/io/struct.SyncIoBridge.html#method.new
+struct BuilderBox {
+    tar: Option<tar::Builder<WriteBox>>,
+    enabled: Arc<AtomicBool>,
+}
+
+/// A wrapper around [`Write`] that could be disabled by [`BuilderBox`].
+struct WriteBox {
+    inner: Box<dyn Send + WriteSeek>,
+    enabled: Arc<AtomicBool>,
+}
+
+/// TODO: This trait will be replaced with just [`Write`] once we get rid of
+/// nested tar archives.
+trait WriteSeek: Write + Seek {}
+impl<T: Write + Seek> WriteSeek for T {}
+
+impl BuilderBox {
+    fn tar(&mut self) -> &mut tar::Builder<WriteBox> {
+        self.tar.as_mut().unwrap()
+    }
+}
+
+impl Drop for BuilderBox {
+    fn drop(&mut self) {
+        self.enabled.store(false, Ordering::Release);
+    }
+}
+
+impl Write for WriteBox {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if !self.enabled.load(Ordering::Acquire) {
+            // This error shouldn't be observable. It might appear only in
+            // `tar::Builder::drop`, and will be ignored there.
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Using WriteBox after it is disabled",
+            ));
+        }
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // This method is never called by `tar::Builder`.
+        self.inner.flush()
+    }
+}
+
+impl Seek for WriteBox {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
 impl BuilderExt {
-    pub fn new(tar_file: File) -> Self {
-        let mut tar = tar::Builder::new(tar_file);
-        tar.sparse(false);
+    #[inline]
+    pub fn new(output: impl Send + Write + Seek + 'static) -> Self {
+        Self::from_box(Box::new(output))
+    }
+
+    fn from_box(output: Box<dyn Send + WriteSeek>) -> Self {
+        let enabled = Arc::new(AtomicBool::new(true));
         Self {
-            tar: Arc::new(Mutex::new(tar)),
+            tar: Arc::new(Mutex::new(BuilderBox {
+                tar: Some(
+                    tar::Builder::new(WriteBox {
+                        inner: output,
+                        enabled: Arc::clone(&enabled),
+                    })
+                    .tap_mut(|tar| tar.sparse(false)),
+                ),
+                enabled,
+            })),
             path: PathBuf::new(),
         }
     }
@@ -59,7 +136,7 @@ impl BuilderExt {
         let mut header = tar::Header::new_gnu();
         header.set_mode(0o644);
         let mut tar = self.tar.blocking_lock();
-        let writer = tar.append_writer(&mut header, dst)?;
+        let writer = tar.tar().append_writer(&mut header, dst)?;
         f(writer)
     }
 
@@ -77,7 +154,7 @@ impl BuilderExt {
         let mut header = tar::Header::new_gnu();
         header.set_mode(0o644);
         let mut tar = self.tar.lock().await;
-        let writer = tar.append_writer(&mut header, dst)?;
+        let writer = tar.tar().append_writer(&mut header, dst)?;
         f(writer)
     }
 
@@ -89,7 +166,10 @@ impl BuilderExt {
     /// Use [`BuilderExt::append_file`] instead.
     pub fn blocking_append_file(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
         let dst = join_relative(&self.path, dst)?;
-        self.tar.blocking_lock().append_path_with_name(src, dst)
+        self.tar
+            .blocking_lock()
+            .tar()
+            .append_path_with_name(src, dst)
     }
 
     /// Append a file to the tar archive.
@@ -107,7 +187,7 @@ impl BuilderExt {
     /// This function panics if called within an asynchronous execution context.
     pub fn blocking_append_dir_all(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
         let dst = join_relative(&self.path, dst)?;
-        self.tar.blocking_lock().append_dir_all(dst, src)
+        self.tar.blocking_lock().tar().append_dir_all(dst, src)
     }
 
     /// Append a new entry to the tar archive with the given file contents.
@@ -127,16 +207,23 @@ impl BuilderExt {
     /// Finish writing the tar archive. For async counterpart, see
     /// [`BuilderExt::finish`].
     pub fn blocking_finish(self) -> std::io::Result<()> {
-        Arc::try_unwrap(self.tar)
+        let mut bb: BuilderBox = Arc::try_unwrap(self.tar)
             .map_err(|_| {
                 std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "finish called with multiple references to the tar builder",
                 )
             })?
-            .into_inner()
-            .into_inner()?
-            .flush()
+            .into_inner();
+
+        // Extract the builder out of bb.
+        let tar: tar::Builder<WriteBox> = bb.tar.take().unwrap();
+
+        // Finish and flush before BuilderBox is dropped.
+        let mut wb: WriteBox = tar.into_inner()?; // calls finish()
+        wb.inner.flush()?;
+
+        Ok(())
     }
 
     /// Finish writing the tar archive.
@@ -146,14 +233,14 @@ impl BuilderExt {
 
     async fn run_async<T, E>(
         &self,
-        f: impl FnOnce(&mut tar::Builder<File>) -> Result<T, E> + Send + 'static,
+        f: impl FnOnce(&mut tar::Builder<WriteBox>) -> Result<T, E> + Send + 'static,
     ) -> Result<T, E>
     where
         T: Send + 'static,
         E: Send + 'static + From<JoinError>,
     {
         let tar = Arc::clone(&self.tar);
-        tokio::task::spawn_blocking(move || f(&mut tar.blocking_lock())).await?
+        tokio::task::spawn_blocking(move || f(tar.blocking_lock().tar())).await?
     }
 }
 
@@ -166,4 +253,73 @@ fn join_relative(base: &Path, rel_path: &Path) -> std::io::Result<PathBuf> {
     }
 
     Ok(base.join(rel_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyBridgeWriter(bool, Arc<Mutex<Vec<u8>>>);
+
+    impl Write for DummyBridgeWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if self.0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Forced error in write",
+                ));
+            }
+            self.1.blocking_lock().extend_from_slice(buf); // panics in async
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            if self.0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Forced error in write",
+                ));
+            }
+            let _ = self.1.blocking_lock(); // panics in async
+            Ok(())
+        }
+    }
+
+    impl Seek for DummyBridgeWriter {
+        fn seek(&mut self, _: std::io::SeekFrom) -> std::io::Result<u64> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_finish_ok() {
+        let data = Arc::new(Mutex::new(Vec::new()));
+        let tar = BuilderExt::new(DummyBridgeWriter(false, Arc::clone(&data)));
+        assert!(tar.finish().await.is_ok());
+        assert_eq!(data.lock().await.len(), 1024);
+    }
+
+    #[tokio::test]
+    async fn test_finish_fail() {
+        let data = Arc::new(Mutex::new(Vec::new()));
+        let tar = BuilderExt::new(DummyBridgeWriter(true, Arc::clone(&data)));
+        assert!(tar.finish().await.is_err());
+        assert_eq!(data.lock().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_drop_fail() {
+        let data = Arc::new(Mutex::new(Vec::new()));
+        let tar = BuilderExt::new(DummyBridgeWriter(false, Arc::clone(&data)));
+        drop(tar);
+        assert_eq!(data.lock().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_drop_ok() {
+        let data = Arc::new(Mutex::new(Vec::new()));
+        let tar = BuilderExt::new(DummyBridgeWriter(false, Arc::clone(&data)));
+        drop(tar);
+        assert_eq!(data.lock().await.len(), 0);
+    }
 }

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -10,58 +10,49 @@ use tokio::sync::Mutex;
 use tokio::task::JoinError;
 
 /// A wrapper around [`tar::Builder`] that:
-/// 1. Usable in async contexts.
+/// 1. Usable both in sync and async contexts.
 /// 2. Provides the [`BuilderExt::descend`] method.
-/// 3. Supports both seekable and streaming outputs.
-#[derive(Clone)]
-pub struct BuilderExt {
-    tar: Arc<Mutex<BlowFuseOnDrop>>,
+/// 3. Supports both seekable (i.e. file) and streaming (i.e. sockets) outputs.
+pub struct BuilderExt<W: Write + Seek = WriteSeekBoxOwned> {
+    tar: Arc<Mutex<BlowFuseOnDrop<W>>>,
     path: PathBuf,
 }
 
-/// A wrapper around [`tar::Builder<FusedOutput>`] that disables [`FusedOutput`]
-/// when it is dropped.
+/// A wrapper around [`tar::Builder<FusedWriteSeek>`] that disables
+/// [`FusedWriteSeek`] when it is dropped.
 ///
-/// Disabling the [`FusedOutput`] is a workaround for the inconvenient
+/// Disabling the [`FusedWriteSeek`] is a workaround for the inconvenient
 /// [`tar::Builder`] behavior: dropping a [`tar::Builder`] might cause a final
 /// write of archive footer.
 /// This behavior is problematic for [`Write`] implementations that could panic
 /// when used in an async context, such as [`SyncIoBridge`].
 ///
 /// [`SyncIoBridge`]: https://docs.rs/tokio-util/0.7.12/tokio_util/io/struct.SyncIoBridge.html#method.new
-struct BlowFuseOnDrop {
-    tar: Option<tar::Builder<FusedOutput>>,
+struct BlowFuseOnDrop<W: Write + Seek> {
+    tar: Option<tar::Builder<FusedWriteSeek<W>>>,
     enabled: Arc<AtomicBool>,
 }
 
-/// A wrapper around [`Output`] that could be disabled by [`BlowFuseOnDrop`].
-struct FusedOutput {
-    output: Output,
+/// A wrapper around [`WriteSeek`] that could be disabled by [`BlowFuseOnDrop`].
+struct FusedWriteSeek<W> {
+    output: W,
     enabled: Arc<AtomicBool>,
 }
 
-enum Output {
-    Streaming(Box<dyn Send + Write>),
-    Seekable(Box<dyn Send + WriteSeek>),
-}
-
-trait WriteSeek: Write + Seek {}
-impl<T: Write + Seek> WriteSeek for T {}
-
-impl BlowFuseOnDrop {
-    fn tar(&mut self) -> &mut tar::Builder<FusedOutput> {
+impl<W: Write + Seek> BlowFuseOnDrop<W> {
+    fn tar(&mut self) -> &mut tar::Builder<FusedWriteSeek<W>> {
         self.tar.as_mut().unwrap()
     }
 }
 
-impl Drop for BlowFuseOnDrop {
+impl<W: Write + Seek> Drop for BlowFuseOnDrop<W> {
     fn drop(&mut self) {
         // Blow the fuse.
         self.enabled.store(false, Ordering::Release);
     }
 }
 
-impl Write for FusedOutput {
+impl<W: Write> Write for FusedWriteSeek<W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if !self.enabled.load(Ordering::Acquire) {
             // This error shouldn't be observable. It might appear only in
@@ -71,50 +62,132 @@ impl Write for FusedOutput {
                 "Using WriteBox after it is disabled",
             ));
         }
-        match self.output {
-            Output::Streaming(ref mut w) => w.write(buf),
-            Output::Seekable(ref mut w) => w.write(buf),
-        }
+        self.output.write(buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         // This method is never called by `tar::Builder`.
-        match self.output {
-            Output::Streaming(ref mut w) => w.flush(),
-            Output::Seekable(ref mut w) => w.flush(),
+        self.output.flush()
+    }
+}
+
+impl<W: Seek> Seek for FusedWriteSeek<W> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.output.seek(pos)
+    }
+}
+
+/// Either [`Write`] or [`Write`] + [`Seek`], configurable at runtime.
+/// This is owned variant for use in async contexts.
+#[allow(private_interfaces)]
+pub enum WriteSeekBoxOwned {
+    Streaming(Box<dyn Send + Write + 'static>),
+    Seekable(Box<dyn Send + WriteSeek + 'static>),
+}
+
+/// Either [`Write`] or [`Write`] + [`Seek`], configurable at runtime.
+/// This variant is for borrowed writers, e.g. [`tar::EntryWriter`].
+#[allow(private_interfaces)]
+pub enum WriteSeekBoxBorrowed<'a> {
+    Streaming(Box<dyn Write + 'a>),
+    Seekable(Box<dyn WriteSeek + 'a>),
+}
+
+trait WriteSeek: Write + Seek {}
+impl<T: Write + Seek> WriteSeek for T {}
+
+impl Write for WriteSeekBoxOwned {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            WriteSeekBoxOwned::Streaming(ref mut w) => w.write(buf),
+            WriteSeekBoxOwned::Seekable(ref mut w) => w.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            WriteSeekBoxOwned::Streaming(ref mut w) => w.flush(),
+            WriteSeekBoxOwned::Seekable(ref mut w) => w.flush(),
         }
     }
 }
 
-impl Seek for FusedOutput {
+impl Seek for WriteSeekBoxOwned {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        match self.output {
-            Output::Streaming(_) => Err(std::io::Error::new(
+        match self {
+            WriteSeekBoxOwned::Streaming(_) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "Seeking is not supported",
             )),
-            Output::Seekable(ref mut w) => w.seek(pos),
+            WriteSeekBoxOwned::Seekable(ref mut w) => w.seek(pos),
         }
     }
 }
 
-impl BuilderExt {
-    #[inline]
-    pub fn new_seekable(output: impl Send + Write + Seek + 'static) -> Self {
-        Self::from_box(Output::Seekable(Box::new(output)))
+impl Write for WriteSeekBoxBorrowed<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            WriteSeekBoxBorrowed::Streaming(ref mut w) => w.write(buf),
+            WriteSeekBoxBorrowed::Seekable(ref mut w) => w.write(buf),
+        }
     }
 
-    #[inline]
-    pub fn new_streaming(output: impl Send + Write + 'static) -> Self {
-        Self::from_box(Output::Streaming(Box::new(output)))
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            WriteSeekBoxBorrowed::Streaming(ref mut w) => w.flush(),
+            WriteSeekBoxBorrowed::Seekable(ref mut w) => w.flush(),
+        }
+    }
+}
+
+impl Seek for WriteSeekBoxBorrowed<'_> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            WriteSeekBoxBorrowed::Streaming(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Seeking is not supported",
+            )),
+            WriteSeekBoxBorrowed::Seekable(ref mut w) => w.seek(pos),
+        }
+    }
+}
+
+impl BuilderExt<WriteSeekBoxOwned> {
+    pub fn new_seekable_owned(output: impl Send + Write + Seek + 'static) -> Self {
+        Self::new(WriteSeekBoxOwned::Seekable(Box::new(output)))
     }
 
-    fn from_box(output: Output) -> Self {
+    pub fn new_streaming_owned(output: impl Send + Write + 'static) -> Self {
+        Self::new(WriteSeekBoxOwned::Streaming(Box::new(output)))
+    }
+}
+
+impl<'a> BuilderExt<WriteSeekBoxBorrowed<'a>> {
+    pub fn new_seekable_borrowed(output: impl Write + Seek + 'a) -> Self {
+        Self::new(WriteSeekBoxBorrowed::Seekable(Box::new(output)))
+    }
+
+    pub fn new_streaming_borrowed(output: impl Write + 'a) -> Self {
+        Self::new(WriteSeekBoxBorrowed::Streaming(Box::new(output)))
+    }
+}
+
+impl<W: Write + Seek> Clone for BuilderExt<W> {
+    fn clone(&self) -> Self {
+        Self {
+            tar: Arc::clone(&self.tar),
+            path: self.path.clone(),
+        }
+    }
+}
+
+impl<W: Write + Seek> BuilderExt<W> {
+    fn new(output: W) -> Self {
         let enabled = Arc::new(AtomicBool::new(true));
         Self {
             tar: Arc::new(Mutex::new(BlowFuseOnDrop {
                 tar: Some(
-                    tar::Builder::new(FusedOutput {
+                    tar::Builder::new(FusedWriteSeek {
                         output,
                         enabled: Arc::clone(&enabled),
                     })
@@ -133,16 +206,17 @@ impl BuilderExt {
     /// builder.descend(Path::new("foo/bar"))?.append_data(data, Path::new("baz")).await?;
     /// ```
     pub fn descend(&self, subdir: &Path) -> std::io::Result<Self> {
-        Ok(BuilderExt {
+        Ok(Self {
             tar: Arc::clone(&self.tar),
             path: join_relative(&self.path, subdir)?,
         })
     }
 
     /// Write an entry to the tar archive. Takes a closure that takes an
-    /// `impl Write` and writes the entry contents into it. Works only on
-    /// builders created by [`BuilderExt::new_seekable()`]. Returns an error if
-    /// the builder was created by [`BuilderExt::new_streaming()`].
+    /// `impl Write` and writes the entry contents into it.
+    ///
+    /// Require the underlying writer to be [`Seek`]. Returns an error for
+    /// non-seekable aka streaming writers.
     ///
     /// # Panics
     ///
@@ -177,14 +251,6 @@ impl BuilderExt {
             .append_path_with_name(src, dst)
     }
 
-    /// Append a file to the tar archive.
-    pub async fn append_file(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
-        let src = src.to_path_buf();
-        let dst = join_relative(&self.path, dst)?;
-        self.run_async(move |tar| tar.append_path_with_name(src, dst))
-            .await
-    }
-
     /// Append a directory to the tar archive.
     ///
     /// # Panics
@@ -212,6 +278,38 @@ impl BuilderExt {
             .append_data(&mut header, dst, src)
     }
 
+    /// Finish writing the tar archive. For async counterpart, see
+    /// [`BuilderExt::finish`].
+    pub fn blocking_finish(self) -> std::io::Result<()> {
+        let mut bb: BlowFuseOnDrop<_> = Arc::try_unwrap(self.tar)
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "finish called with multiple references to the tar builder",
+                )
+            })?
+            .into_inner();
+
+        // Extract the builder out of bb.
+        let tar: tar::Builder<FusedWriteSeek<_>> = bb.tar.take().unwrap();
+
+        // Finish and flush before BuilderBox is dropped.
+        let mut wb: FusedWriteSeek<_> = tar.into_inner()?; // calls finish()
+        wb.flush()?;
+
+        Ok(())
+    }
+}
+
+impl<W: Send + Write + Seek + 'static> BuilderExt<W> {
+    /// Append a file to the tar archive.
+    pub async fn append_file(&self, src: &Path, dst: &Path) -> std::io::Result<()> {
+        let src = src.to_path_buf();
+        let dst = join_relative(&self.path, dst)?;
+        self.run_async(move |tar| tar.append_path_with_name(src, dst))
+            .await
+    }
+
     /// Append a new entry to the tar archive with the given file contents.
     ///
     /// # Panics
@@ -226,28 +324,6 @@ impl BuilderExt {
             .await
     }
 
-    /// Finish writing the tar archive. For async counterpart, see
-    /// [`BuilderExt::finish`].
-    pub fn blocking_finish(self) -> std::io::Result<()> {
-        let mut bb: BlowFuseOnDrop = Arc::try_unwrap(self.tar)
-            .map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "finish called with multiple references to the tar builder",
-                )
-            })?
-            .into_inner();
-
-        // Extract the builder out of bb.
-        let tar: tar::Builder<FusedOutput> = bb.tar.take().unwrap();
-
-        // Finish and flush before BuilderBox is dropped.
-        let mut wb: FusedOutput = tar.into_inner()?; // calls finish()
-        wb.flush()?;
-
-        Ok(())
-    }
-
     /// Finish writing the tar archive.
     pub async fn finish(self) -> std::io::Result<()> {
         tokio::task::spawn_blocking(move || self.blocking_finish()).await?
@@ -255,7 +331,7 @@ impl BuilderExt {
 
     async fn run_async<T, E>(
         &self,
-        f: impl FnOnce(&mut tar::Builder<FusedOutput>) -> Result<T, E> + Send + 'static,
+        f: impl FnOnce(&mut tar::Builder<FusedWriteSeek<W>>) -> Result<T, E> + Send + 'static,
     ) -> Result<T, E>
     where
         T: Send + 'static,
@@ -322,7 +398,7 @@ mod tests {
     #[tokio::test]
     async fn test_dummy_finish_ok() {
         let data = Arc::new(Mutex::new(Vec::new()));
-        let tar = BuilderExt::new_seekable(DummyBridgeWriter(false, Arc::clone(&data)));
+        let tar = BuilderExt::new_seekable_owned(DummyBridgeWriter(false, Arc::clone(&data)));
         assert!(tar.finish().await.is_ok());
         assert_eq!(data.lock().await.len(), 1024);
     }
@@ -330,7 +406,7 @@ mod tests {
     #[tokio::test]
     async fn test_dummy_finish_fail() {
         let data = Arc::new(Mutex::new(Vec::new()));
-        let tar = BuilderExt::new_seekable(DummyBridgeWriter(true, Arc::clone(&data)));
+        let tar = BuilderExt::new_seekable_owned(DummyBridgeWriter(true, Arc::clone(&data)));
         assert!(tar.finish().await.is_err());
         assert_eq!(data.lock().await.len(), 0);
     }
@@ -338,7 +414,7 @@ mod tests {
     #[tokio::test]
     async fn test_dummy_drop_fail() {
         let data = Arc::new(Mutex::new(Vec::new()));
-        let tar = BuilderExt::new_seekable(DummyBridgeWriter(false, Arc::clone(&data)));
+        let tar = BuilderExt::new_seekable_owned(DummyBridgeWriter(false, Arc::clone(&data)));
         drop(tar);
         assert_eq!(data.lock().await.len(), 0);
     }
@@ -346,7 +422,7 @@ mod tests {
     #[tokio::test]
     async fn test_dummy_drop_ok() {
         let data = Arc::new(Mutex::new(Vec::new()));
-        let tar = BuilderExt::new_seekable(DummyBridgeWriter(false, Arc::clone(&data)));
+        let tar = BuilderExt::new_seekable_owned(DummyBridgeWriter(false, Arc::clone(&data)));
         drop(tar);
         assert_eq!(data.lock().await.len(), 0);
     }
@@ -357,14 +433,14 @@ mod tests {
 
     #[test]
     fn test_write_ok() {
-        let tar = BuilderExt::new_streaming(Vec::new());
+        let tar = BuilderExt::new_streaming_borrowed(Vec::new());
         tar.blocking_append_data(b"foo", Path::new("foo")).unwrap();
         tar.blocking_finish().unwrap();
     }
 
     #[test]
     fn test_write_fail() {
-        let tar = BuilderExt::new_streaming(Vec::new());
+        let tar = BuilderExt::new_streaming_borrowed(Vec::new());
         tar.blocking_append_data(b"foo", Path::new("foo")).unwrap();
         let result = tar.blocking_write_fn(Path::new("foo"), |writer| writer.write_all(b"bar"));
         assert_eq!(result.unwrap_err().to_string(), "Seeking is not supported");
@@ -372,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_writeseek_ok() {
-        let tar = BuilderExt::new_seekable(Cursor::new(Vec::new()));
+        let tar = BuilderExt::new_seekable_borrowed(Cursor::new(Vec::new()));
         tar.blocking_append_data(b"foo", Path::new("foo")).unwrap();
         tar.blocking_write_fn(Path::new("foo"), |writer| writer.write_all(b"bar"))
             .unwrap()

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -837,7 +837,7 @@ impl SegmentEntry for Segment {
             builder.finish()?;
 
             Result::<_, OperationError>::Ok(())
-        })?;
+        })??;
 
         // remove tmp directory in background
         let _ = thread::spawn(move || {

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -219,7 +219,7 @@ fn test_snapshot() {
     let snapshot_name = snapshot_dir.path().join("snapshot.tar");
 
     // snapshotting!
-    let tar = tar_ext::BuilderExt::new(File::create(&snapshot_name).unwrap());
+    let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_name).unwrap());
     segment
         .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
         .unwrap();

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -219,7 +219,7 @@ fn test_snapshot() {
     let snapshot_name = snapshot_dir.path().join("snapshot.tar");
 
     // snapshotting!
-    let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_name).unwrap());
+    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(&snapshot_name).unwrap());
     segment
         .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
         .unwrap();

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -137,7 +137,7 @@ fn test_on_disk_segment_snapshot() {
     let snapshot_name = snapshot_dir.path().join("snapshot.tar");
 
     // take snapshot
-    let tar = tar_ext::BuilderExt::new(File::create(&snapshot_name).unwrap());
+    let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_name).unwrap());
     segment
         .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
         .unwrap();

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -137,7 +137,7 @@ fn test_on_disk_segment_snapshot() {
     let snapshot_name = snapshot_dir.path().join("snapshot.tar");
 
     // take snapshot
-    let tar = tar_ext::BuilderExt::new_seekable(File::create(&snapshot_name).unwrap());
+    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(&snapshot_name).unwrap());
     segment
         .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
         .unwrap();


### PR DESCRIPTION
This PR updates `tar_ext::BuilderExt` with the following changes:

1. Generalize: instead of taking `std::fs::File`, take `impl Write + Seek`. Later this requirement will be reduced further to `impl Write` to support both `File` and an async stream (`SyncIoBridge`).
2. Add a workaround for drop: `tar::Builder<W>::drop` might panic if the underlying writer panics when using in async context. See a comment for `BuilderBox` and newly added unit tests for more details on the issue.