### PR TITLE
Fix set payload by key on non appendable segment

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -190,7 +190,10 @@ pub(crate) fn set_payload(
             op_num,
             chunk,
             |id, write_segment| write_segment.set_payload(op_num, id, payload, key),
-            |_, _, old_payload| old_payload.merge(payload),
+            |_, _, old_payload| match key {
+                Some(key) => old_payload.merge_by_key(payload, key),
+                None => old_payload.merge(payload),
+            },
             |segment| {
                 segment.get_indexed_fields().keys().all(|indexed_path| {
                     !indexed_path.is_affected_by_value_set(&payload.0, key.as_ref())

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -36,11 +36,11 @@ impl PayloadStorage for InMemoryPayloadStorage {
             Some(point_payload) => point_payload.merge_by_key(payload, key),
             None => {
                 let mut dest_payload = Payload::default();
-                dest_payload.merge_by_key(payload, key)?;
+                dest_payload.merge_by_key(payload, key);
                 self.payload.insert(point_id, dest_payload);
-                Ok(())
             }
         }
+        Ok(())
     }
 
     fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload> {

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -96,12 +96,12 @@ impl PayloadStorage for OnDiskPayloadStorage {
         let stored_payload = self.read_payload(point_id)?;
         match stored_payload {
             Some(mut point_payload) => {
-                point_payload.merge_by_key(payload, key)?;
+                point_payload.merge_by_key(payload, key);
                 self.update_storage(point_id, &point_payload)
             }
             None => {
                 let mut dest_payload = Payload::default();
-                dest_payload.merge_by_key(payload, key)?;
+                dest_payload.merge_by_key(payload, key);
                 self.update_storage(point_id, &dest_payload)
             }
         }

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -40,11 +40,11 @@ impl PayloadStorage for SimplePayloadStorage {
             Some(point_payload) => point_payload.merge_by_key(payload, key),
             None => {
                 let mut dest_payload = Payload::default();
-                dest_payload.merge_by_key(payload, key)?;
+                dest_payload.merge_by_key(payload, key);
                 self.payload.insert(point_id, dest_payload);
-                Ok(())
             }
         }
+        Ok(())
     }
 
     fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload> {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -986,9 +986,8 @@ impl Payload {
         utils::merge_map(&mut self.0, &value.0)
     }
 
-    pub fn merge_by_key(&mut self, value: &Payload, key: &JsonPath) -> OperationResult<()> {
+    pub fn merge_by_key(&mut self, value: &Payload, key: &JsonPath) {
         JsonPath::value_set(Some(key), &mut self.0, &value.0);
-        Ok(())
     }
 
     pub fn remove(&mut self, path: &JsonPath) -> Vec<Value> {


### PR DESCRIPTION
fixes: https://github.com/qdrant/qdrant-client/issues/780

The bug affects set payload operation using `key` on non appendable segments.

It manifest itself by the apparition of unexpected payload values at the root level, which are supposed to be added under `key`.

The bug was introduced in [1.11.1](https://github.com/qdrant/qdrant/releases/tag/v1.11.1) with https://github.com/qdrant/qdrant/pull/4855/files#diff-fe6fcf41822e7bcc71c22cfb9067f6e80e36228f69d2727724e4cc51abc12e07R193

The fix is to merge the payloads using the `key`.

I have tested the fix on a user snapshot file.