### PR TITLE
Disable manual trigger on Docker release image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,6 @@
 name: Build and deploy docker image
 
 on:
-  workflow_dispatch:
   push:
     # Pattern matched against refs/tags
     tags:


### PR DESCRIPTION
Disable the 'Run workflow' button on the top right for the 'Build and deploy docker image' workflow:

![image](https://github.com/user-attachments/assets/16a24d4b-76f1-420a-a09c-552f6c33843f)

This button pushes a new public release, also retagging the `latest` Docker image. We normally never use this as releases are triggered automatically through git tags.

A few days ago I accidentally used this button for a test release. What wasn't entirely obvious to me is that we should use a different workflow instead. This action did cause downtime in our cloud because it depends on the latest tag.

Because this button is more confusing than helpful I vote to remove it so we don't have the same problem again.

Note: this merges into `master` to immediately apply the change in the GitHub interface. I'll manually cherry-pick this back into `dev` on merge.