### PR TITLE
Remove quantization from root crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4612,7 +4612,6 @@ dependencies = [
  "prost 0.11.9",
  "pyroscope",
  "pyroscope_pprofrs",
- "quantization",
  "raft",
  "raft-proto",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ common = { path = "lib/common/common" }
 cancel = { path = "lib/common/cancel" }
 memory = { path = "lib/common/memory" }
 issues = { path = "lib/common/issues" }
-quantization = { path = "lib/quantization" }
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }
 storage = { path = "lib/storage" }


### PR DESCRIPTION
The `quantization` crate is not used in the root crate therefore the dependency can be removed :broom: 