### PR TITLE
bump delegate 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "delegate"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+checksum = "5060bb0febb73fa907273f8a7ed17ab4bf831d585eac835b28ec24a1e2460956"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 [workspace.dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
 data-encoding = "2.6.0"
-delegate = "0.12.0"
+delegate = "0.13.0"
 fnv = "1.0"
 futures = "0.3.30"
 futures-util = "0.3.30"


### PR DESCRIPTION
Manually updating `delegate` as it is not picked up by Dependabot.
https://github.com/Kobzol/rust-delegate/blob/main/CHANGELOG.md#0130-2-9-2024