### PR TITLE
[Strict mode] migrate toc_new -> toc

### DIFF
--- a/lib/storage/src/content_manager/collection_verification.rs
+++ b/lib/storage/src/content_manager/collection_verification.rs
@@ -98,5 +98,5 @@ fn get_toc_without_verification_pass<'a>(
     access: &Access,
 ) -> &'a Arc<TableOfContent> {
     let pass = new_unchecked_verification_pass();
-    dispatcher.toc_new(access, &pass)
+    dispatcher.toc(access, &pass)
 }

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use collection::operations::snapshot_ops::SnapshotDescription;
+use collection::operations::verification::new_unchecked_verification_pass;
 use serde::{Deserialize, Serialize};
 use tar::Builder as TarBuilder;
 use tempfile::TempPath;
@@ -31,7 +32,11 @@ pub async fn do_delete_full_snapshot(
 ) -> Result<bool, StorageError> {
     access.check_global_access(AccessRequirements::new().manage())?;
 
-    let toc = dispatcher.toc(&access);
+    // All checks should've been done at this point.
+    let pass = new_unchecked_verification_pass();
+
+    let toc = dispatcher.toc_new(&access, &pass);
+
     let snapshot_manager = toc.get_snapshots_storage_manager()?;
     let snapshot_dir = snapshot_manager
         .get_full_snapshot_path(toc.snapshots_path(), snapshot_name)
@@ -55,7 +60,11 @@ pub async fn do_delete_collection_snapshot(
     let collection_pass = access
         .check_collection_access(collection_name, AccessRequirements::new().write().whole())?;
 
-    let toc = dispatcher.toc(&access);
+    // All checks should've been done at this point.
+    let pass = new_unchecked_verification_pass();
+
+    let toc = dispatcher.toc_new(&access, &pass);
+
     let snapshot_name = snapshot_name.to_string();
     let collection = toc.get_collection(&collection_pass).await?;
     let snapshot_manager = toc.get_snapshots_storage_manager()?;
@@ -87,7 +96,11 @@ pub async fn do_create_full_snapshot(
     access: Access,
 ) -> Result<SnapshotDescription, StorageError> {
     access.check_global_access(AccessRequirements::new().manage())?;
-    let toc = dispatcher.toc(&access).clone();
+
+    // All checks should've been done at this point.
+    let pass = new_unchecked_verification_pass();
+    let toc = dispatcher.toc_new(&access, &pass).clone();
+
     let res = tokio::spawn(async move { _do_create_full_snapshot(&toc, access).await }).await??;
     Ok(res)
 }

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -35,7 +35,7 @@ pub async fn do_delete_full_snapshot(
     // All checks should've been done at this point.
     let pass = new_unchecked_verification_pass();
 
-    let toc = dispatcher.toc_new(&access, &pass);
+    let toc = dispatcher.toc(&access, &pass);
 
     let snapshot_manager = toc.get_snapshots_storage_manager()?;
     let snapshot_dir = snapshot_manager
@@ -63,7 +63,7 @@ pub async fn do_delete_collection_snapshot(
     // All checks should've been done at this point.
     let pass = new_unchecked_verification_pass();
 
-    let toc = dispatcher.toc_new(&access, &pass);
+    let toc = dispatcher.toc(&access, &pass);
 
     let snapshot_name = snapshot_name.to_string();
     let collection = toc.get_collection(&collection_pass).await?;
@@ -99,7 +99,7 @@ pub async fn do_create_full_snapshot(
 
     // All checks should've been done at this point.
     let pass = new_unchecked_verification_pass();
-    let toc = dispatcher.toc_new(&access, &pass).clone();
+    let toc = dispatcher.toc(&access, &pass).clone();
 
     let res = tokio::spawn(async move { _do_create_full_snapshot(&toc, access).await }).await??;
     Ok(res)

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -85,7 +85,7 @@ async fn _do_recover_from_snapshot(
     // All checks should've been done at this point.
     let pass = new_unchecked_verification_pass();
 
-    let toc = dispatcher.toc_new(&access, &pass);
+    let toc = dispatcher.toc(&access, &pass);
 
     let this_peer_id = toc.this_peer_id;
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -2,6 +2,7 @@ use collection::collection::Collection;
 use collection::common::sha_256::{hash_file, hashes_equal};
 use collection::config::CollectionConfig;
 use collection::operations::snapshot_ops::{SnapshotPriority, SnapshotRecover};
+use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::shard_config::ShardType;
@@ -80,7 +81,11 @@ async fn _do_recover_from_snapshot(
         checksum,
         api_key: _,
     } = source;
-    let toc = dispatcher.toc(&access);
+
+    // All checks should've been done at this point.
+    let pass = new_unchecked_verification_pass();
+
+    let toc = dispatcher.toc_new(&access, &pass);
 
     let this_peer_id = toc.this_peer_id;
 

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -37,17 +37,9 @@ impl Dispatcher {
     }
 
     /// Get the table of content.
-    /// The `_access` parameter is not used, but it's required to verify caller's possession
-    /// of the [Access] object.
-    /// TODO: replace with `toc_new`
-    pub fn toc(&self, _access: &Access) -> &Arc<TableOfContent> {
-        &self.toc
-    }
-
-    /// Get the table of content.
     /// The `_access` and `_verification_pass` parameter are not used, but it's required to verify caller's possession
     /// of both objects.
-    pub fn toc_new(
+    pub fn toc(
         &self,
         _access: &Access,
         _verification_pass: &VerificationPass,

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -160,9 +160,12 @@ fn test_alias_operation() {
         ))
         .unwrap();
 
+    // Nothing to verify here.
+    let pass = new_unchecked_verification_pass();
+
     let _ = handle
         .block_on(
-            dispatcher.toc(&FULL_ACCESS).get_collection(
+            dispatcher.toc_new(&FULL_ACCESS, &pass).get_collection(
                 &FULL_ACCESS
                     .check_collection_access("test_alias3", AccessRequirements::new())
                     .unwrap(),

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use collection::operations::vector_params_builder::VectorParamsBuilder;
+use collection::operations::verification::new_unchecked_verification_pass;
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::channel_service::ChannelService;
 use common::cpu::CpuBudget;
@@ -165,7 +166,7 @@ fn test_alias_operation() {
 
     let _ = handle
         .block_on(
-            dispatcher.toc_new(&FULL_ACCESS, &pass).get_collection(
+            dispatcher.toc(&FULL_ACCESS, &pass).get_collection(
                 &FULL_ACCESS
                     .check_collection_access("test_alias3", AccessRequirements::new())
                     .unwrap(),

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -43,7 +43,7 @@ fn recover_current_peer(
 
     helpers::time(async move {
         access.check_global_access(AccessRequirements::new().manage())?;
-        dispatcher.toc_new(&access, &pass).request_snapshot()?;
+        dispatcher.toc(&access, &pass).request_snapshot()?;
         Ok(true)
     })
 }
@@ -62,7 +62,7 @@ fn remove_peer(
         access.check_global_access(AccessRequirements::new().manage())?;
 
         let dispatcher = dispatcher.into_inner();
-        let toc = dispatcher.toc_new(&access, &pass);
+        let toc = dispatcher.toc(&access, &pass);
         let peer_id = peer_id.into_inner();
 
         let has_shards = toc.peer_has_shards(peer_id).await;
@@ -139,7 +139,7 @@ async fn update_cluster_metadata_key(
     // Not a collection level request.
     let pass = new_unchecked_verification_pass();
     helpers::time(async move {
-        let toc = dispatcher.toc_new(&access, &pass);
+        let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
         toc.update_cluster_metadata(key.into_inner(), value.into_inner())?;
@@ -157,7 +157,7 @@ async fn delete_cluster_metadata_key(
     // Not a collection level request.
     let pass = new_unchecked_verification_pass();
     helpers::time(async move {
-        let toc = dispatcher.toc_new(&access, &pass);
+        let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
         toc.update_cluster_metadata(key.into_inner(), serde_json::Value::Null)?;

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -39,11 +39,7 @@ async fn get_collections(
     // No request to verify
     let pass = new_unchecked_verification_pass();
 
-    helpers::time(do_list_collections(
-        dispatcher.toc_new(&access, &pass),
-        access,
-    ))
-    .await
+    helpers::time(do_list_collections(dispatcher.toc(&access, &pass), access)).await
 }
 
 #[get("/aliases")]
@@ -54,7 +50,7 @@ async fn get_aliases(
     // No request to verify
     let pass = new_unchecked_verification_pass();
 
-    helpers::time(do_list_aliases(dispatcher.toc_new(&access, &pass), access)).await
+    helpers::time(do_list_aliases(dispatcher.toc(&access, &pass), access)).await
 }
 
 #[get("/collections/{name}")]
@@ -67,7 +63,7 @@ async fn get_collection(
     let pass = new_unchecked_verification_pass();
 
     helpers::time(do_get_collection(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         access,
         &collection.name,
         None,
@@ -85,7 +81,7 @@ async fn get_collection_existence(
     let pass = new_unchecked_verification_pass();
 
     helpers::time(do_collection_exists(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         access,
         &collection.name,
     ))
@@ -102,7 +98,7 @@ async fn get_collection_aliases(
     let pass = new_unchecked_verification_pass();
 
     helpers::time(do_list_collection_aliases(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         access,
         &collection.name,
     ))
@@ -199,7 +195,7 @@ async fn get_cluster_info(
     let pass = new_unchecked_verification_pass();
 
     helpers::time(do_get_collection_cluster(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         access,
         &collection.name,
     ))

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -44,7 +44,7 @@ async fn count_points(
     };
 
     helpers::time(do_count_points(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         &collection.name,
         count_request,
         params.consistency,

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -49,7 +49,7 @@ async fn discover_points(
 
     helpers::time(
         dispatcher
-            .toc_new(&access, &pass)
+            .toc(&access, &pass)
             .discover(
                 &collection.name,
                 discover_request,
@@ -93,7 +93,7 @@ async fn discover_batch_points(
 
     helpers::time(
         do_discover_batch_points(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection.name,
             request,
             params.consistency,

--- a/src/actix/api/facet_api.rs
+++ b/src/actix/api/facet_api.rs
@@ -47,7 +47,7 @@ async fn facet(
     };
 
     let response = dispatcher
-        .toc_new(&access, &pass)
+        .toc(&access, &pass)
         .facet(
             &collection.name,
             facet_params,

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -40,7 +40,7 @@ async fn get_points(
 
     helpers::time(async move {
         let records = points::do_get_points(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &path.collection,
             request.into_inner(),
             params.consistency,
@@ -101,7 +101,7 @@ async fn scroll_points(
         request.filter = merge_with_optional_filter(request.filter.take(), hash_ring_filter);
 
         dispatcher
-            .toc_new(&access, &pass)
+            .toc(&access, &pass)
             .scroll(
                 &path.collection,
                 request,
@@ -160,7 +160,7 @@ async fn count_points(
         request.filter = merge_with_optional_filter(request.filter.take(), hash_ring_filter);
 
         points::do_count_points(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &path.collection,
             request,
             params.consistency,
@@ -185,7 +185,7 @@ async fn cleanup_shard(
     helpers::time(async move {
         let path = path.into_inner();
         dispatcher
-            .toc_new(&access, &pass)
+            .toc(&access, &pass)
             .cleanup_local_shard(&path.collection, path.shard, access)
             .await
     })
@@ -223,7 +223,7 @@ async fn get_hash_ring_filter(
     let pass = access.check_collection_access(collection, reqs)?;
 
     let shard_holder = dispatcher
-        .toc_new(access, verification_pass)
+        .toc(access, verification_pass)
         .get_collection(&pass)
         .await?
         .shards_holder();

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -52,7 +52,7 @@ async fn query_points(
         };
 
         let points = dispatcher
-            .toc_new(&access, &pass)
+            .toc(&access, &pass)
             .query_batch(
                 &collection.name,
                 vec![(query_request.into(), shard_selection)],
@@ -117,7 +117,7 @@ async fn query_points_batch(
             .collect::<Vec<_>>();
 
         let res = dispatcher
-            .toc_new(&access, &pass)
+            .toc(&access, &pass)
             .query_batch(
                 &collection.name,
                 batch,
@@ -175,7 +175,7 @@ async fn query_points_groups(
         let query_group_request = CollectionQueryGroupsRequest::from(search_group_request);
 
         do_query_point_groups(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection.name,
             query_group_request,
             params.consistency,

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -57,7 +57,7 @@ async fn recommend_points(
 
     helpers::time(
         dispatcher
-            .toc_new(&access, &pass)
+            .toc(&access, &pass)
             .recommend(
                 &collection.name,
                 recommend_request,
@@ -124,7 +124,7 @@ async fn recommend_batch_points(
 
     helpers::time(
         do_recommend_batch_points(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection.name,
             request.into_inner(),
             params.consistency,
@@ -178,7 +178,7 @@ async fn recommend_point_groups(
     };
 
     helpers::time(crate::common::points::do_recommend_point_groups(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         &collection.name,
         recommend_group_request,
         params.consistency,

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -86,7 +86,7 @@ async fn get_point(
         })?;
 
         let Some(record) = do_get_point(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection.name,
             point_id,
             params.consistency,
@@ -137,7 +137,7 @@ async fn get_points(
 
     helpers::time(
         do_get_points(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection.name,
             point_request,
             params.consistency,
@@ -186,7 +186,7 @@ async fn scroll_points(
         Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
     };
 
-    helpers::time(dispatcher.toc_new(&access, &pass).scroll(
+    helpers::time(dispatcher.toc(&access, &pass).scroll(
         &collection.name,
         scroll_request,
         params.consistency,

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -55,7 +55,7 @@ async fn search_points(
 
     helpers::time(
         do_core_search_points(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection.name,
             search_request.into(),
             params.consistency,
@@ -115,7 +115,7 @@ async fn batch_search_points(
 
     helpers::time(
         do_search_batch_points(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection.name,
             requests,
             params.consistency,
@@ -169,7 +169,7 @@ async fn search_point_groups(
     };
 
     helpers::time(do_search_point_groups(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         &collection.name,
         search_group_request,
         params.consistency,
@@ -214,7 +214,7 @@ async fn search_points_matrix_pairs(
     };
 
     let response = do_search_points_matrix(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         &collection.name,
         CollectionSearchMatrixRequest::from(search_request),
         params.consistency,
@@ -262,7 +262,7 @@ async fn search_points_matrix_offsets(
     };
 
     let response = do_search_points_matrix(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         &collection.name,
         CollectionSearchMatrixRequest::from(search_request),
         params.consistency,

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -106,7 +106,7 @@ fn put_locks(
     let pass = new_unchecked_verification_pass();
 
     helpers::time(async move {
-        let toc = dispatcher.toc_new(&access, &pass);
+        let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().manage())?;
         let result = LocksOption {
             write: toc.is_write_locked(),
@@ -127,7 +127,7 @@ fn get_locks(
 
     helpers::time(async move {
         access.check_global_access(AccessRequirements::new())?;
-        let toc = dispatcher.toc_new(&access, &pass);
+        let toc = dispatcher.toc(&access, &pass);
         let result = LocksOption {
             write: toc.is_write_locked(),
             error_message: toc.get_lock_error_message(),

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -148,7 +148,7 @@ async fn list_snapshots(
     let pass = new_unchecked_verification_pass();
 
     helpers::time(do_list_snapshots(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         access,
         &path,
     ))
@@ -169,7 +169,7 @@ async fn create_snapshot(
 
     let future = async move {
         do_create_snapshot(
-            dispatcher.toc_new(&access, &pass).clone(),
+            dispatcher.toc(&access, &pass).clone(),
             access,
             &collection_name,
         )
@@ -205,12 +205,9 @@ async fn upload_snapshot(
             }
         }
 
-        let snapshot_location = do_save_uploaded_snapshot(
-            dispatcher.toc_new(&access, &pass),
-            &collection.name,
-            snapshot,
-        )
-        .await?;
+        let snapshot_location =
+            do_save_uploaded_snapshot(dispatcher.toc(&access, &pass), &collection.name, snapshot)
+                .await?;
 
         // Snapshot is a local file, we do not need an API key for that
         let http_client = http_client.client(None)?;
@@ -274,7 +271,7 @@ async fn get_snapshot(
     let (collection_name, snapshot_name) = path.into_inner();
     do_get_snapshot(
         req,
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         access,
         &collection_name,
         &snapshot_name,
@@ -291,7 +288,7 @@ async fn list_full_snapshots(
     let pass = new_unchecked_verification_pass();
 
     helpers::time(do_list_full_snapshots(
-        dispatcher.toc_new(&access, &pass),
+        dispatcher.toc(&access, &pass),
         access,
     ))
     .await
@@ -318,13 +315,7 @@ async fn get_full_snapshot(
     let pass = new_unchecked_verification_pass();
 
     let snapshot_name = path.into_inner();
-    do_get_full_snapshot(
-        req,
-        dispatcher.toc_new(&access, &pass),
-        access,
-        &snapshot_name,
-    )
-    .await
+    do_get_full_snapshot(req, dispatcher.toc(&access, &pass), access, &snapshot_name).await
 }
 
 #[delete("/snapshots/{snapshot_name}")]
@@ -376,7 +367,7 @@ async fn list_shard_snapshots(
     let (collection, shard) = path.into_inner();
 
     let future = common::snapshots::list_shard_snapshots(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         access,
         collection,
         shard,
@@ -398,7 +389,7 @@ async fn create_shard_snapshot(
 
     let (collection, shard) = path.into_inner();
     let future = common::snapshots::create_shard_snapshot(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         access,
         collection,
         shard,
@@ -424,7 +415,7 @@ async fn recover_shard_snapshot(
         let (collection, shard) = path.into_inner();
 
         common::snapshots::recover_shard_snapshot(
-            dispatcher.toc_new(&access, &pass).clone(),
+            dispatcher.toc(&access, &pass).clone(),
             access,
             collection,
             shard,
@@ -479,7 +470,7 @@ async fn upload_shard_snapshot(
 
         let future = async {
             let collection = dispatcher
-                .toc_new(&access, &pass)
+                .toc(&access, &pass)
                 .get_collection(&collection_pass)
                 .await?;
             collection.assert_shard_exists(shard).await?;
@@ -491,7 +482,7 @@ async fn upload_shard_snapshot(
 
         // `recover_shard_snapshot_impl` is *not* cancel safe
         common::snapshots::recover_shard_snapshot_impl(
-            dispatcher.toc_new(&access, &pass),
+            dispatcher.toc(&access, &pass),
             &collection,
             shard,
             form.snapshot.file.path(),
@@ -521,7 +512,7 @@ async fn download_shard_snapshot(
     let collection_pass =
         access.check_collection_access(&collection, AccessRequirements::new().whole())?;
     let collection = dispatcher
-        .toc_new(&access, &pass)
+        .toc(&access, &pass)
         .get_collection(&collection_pass)
         .await?;
     let snapshots_storage_manager = collection.get_snapshots_storage_manager()?;
@@ -551,7 +542,7 @@ async fn delete_shard_snapshot(
 
     let (collection, shard, snapshot) = path.into_inner();
     let future = common::snapshots::delete_shard_snapshot(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         access,
         collection,
         shard,

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -50,7 +50,7 @@ async fn upsert_points(
     let ordering = params.ordering.unwrap_or_default();
 
     helpers::time(do_upsert_points(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -81,7 +81,7 @@ async fn delete_points(
     let ordering = params.ordering.unwrap_or_default();
 
     helpers::time(do_delete_points(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -109,7 +109,7 @@ async fn update_vectors(
     let ordering = params.ordering.unwrap_or_default();
 
     helpers::time(do_update_vectors(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -142,7 +142,7 @@ async fn delete_vectors(
     let ordering = params.ordering.unwrap_or_default();
 
     let response = do_delete_vectors(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -175,7 +175,7 @@ async fn set_payload(
     let ordering = params.ordering.unwrap_or_default();
 
     helpers::time(do_set_payload(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -205,7 +205,7 @@ async fn overwrite_payload(
     let ordering = params.ordering.unwrap_or_default();
 
     helpers::time(do_overwrite_payload(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -235,7 +235,7 @@ async fn delete_payload(
     let ordering = params.ordering.unwrap_or_default();
 
     helpers::time(do_delete_payload(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -266,7 +266,7 @@ async fn clear_payload(
     let ordering = params.ordering.unwrap_or_default();
 
     helpers::time(do_clear_payload(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operation,
         None,
@@ -309,7 +309,7 @@ async fn update_batch(
     let ordering = params.ordering.unwrap_or_default();
 
     let response = do_batch_update_points(
-        dispatcher.toc_new(&access, &pass).clone(),
+        dispatcher.toc(&access, &pass).clone(),
         collection.into_inner().name,
         operations.operations,
         None,

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -19,6 +19,7 @@ use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Res
 use actix_web_extras::middleware::Condition as ConditionEx;
 use api::facet_api::config_facet_api;
 use collection::operations::validation;
+use collection::operations::verification::new_unchecked_verification_pass;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::Access;
 
@@ -61,12 +62,16 @@ pub fn init(
     logger_handle: LoggerHandle,
 ) -> io::Result<()> {
     actix_web::rt::System::new().block_on(async {
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
         let auth_keys = AuthKeys::try_create(
             &settings.service,
-            dispatcher.toc(&Access::full("For JWT validation")).clone(),
+            dispatcher
+                .toc_new(&Access::full("For JWT validation"), &pass)
+                .clone(),
         );
         let upload_dir = dispatcher
-            .toc(&Access::full("For upload dir"))
+            .toc_new(&Access::full("For upload dir"), &pass)
             .upload_dir()
             .unwrap();
         let dispatcher_data = web::Data::from(dispatcher);

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -67,11 +67,11 @@ pub fn init(
         let auth_keys = AuthKeys::try_create(
             &settings.service,
             dispatcher
-                .toc_new(&Access::full("For JWT validation"), &pass)
+                .toc(&Access::full("For JWT validation"), &pass)
                 .clone(),
         );
         let upload_dir = dispatcher
-            .toc_new(&Access::full("For upload dir"), &pass)
+            .toc(&Access::full("For upload dir"), &pass)
             .upload_dir()
             .unwrap();
         let dispatcher_data = web::Data::from(dispatcher);

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -15,6 +15,7 @@ use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
     AliasDescription, CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
 };
+use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::replica_set;
 use collection::shards::resharding::ReshardKey;
 use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
@@ -235,8 +236,11 @@ pub async fn do_update_collection_cluster(
         Ok(())
     };
 
+    // All checks should've been done at this point.
+    let pass = new_unchecked_verification_pass();
+
     let collection = dispatcher
-        .toc(&access)
+        .toc_new(&access, &pass)
         .get_collection(&collection_pass)
         .await?;
 

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -240,7 +240,7 @@ pub async fn do_update_collection_cluster(
     let pass = new_unchecked_verification_pass();
 
     let collection = dispatcher
-        .toc_new(&access, &pass)
+        .toc(&access, &pass)
         .get_collection(&collection_pass)
         .await?;
 

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -28,7 +28,9 @@ use collection::operations::universal_query::collection_query::{
 use collection::operations::vector_ops::{
     DeleteVectors, UpdateVectors, UpdateVectorsOp, VectorOperations,
 };
-use collection::operations::verification::StrictModeVerification;
+use collection::operations::verification::{
+    new_unchecked_verification_pass, StrictModeVerification,
+};
 use collection::operations::{
     ClockTag, CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
@@ -715,7 +717,10 @@ pub async fn do_create_index(
     // Default consensus timeout will be used
     let wait_timeout = None; // ToDo: make it configurable
 
-    let toc = dispatcher.toc(&access).clone();
+    // Nothing to verify here.
+    let pass = new_unchecked_verification_pass();
+
+    let toc = dispatcher.toc_new(&access, &pass).clone();
 
     // TODO: Is `submit_collection_meta_op` cancel-safe!? Should be, I think?.. 🤔
     dispatcher
@@ -791,7 +796,10 @@ pub async fn do_delete_index(
     // Default consensus timeout will be used
     let wait_timeout = None; // ToDo: make it configurable
 
-    let toc = dispatcher.toc(&access).clone();
+    // Nothing to verify here.
+    let pass = new_unchecked_verification_pass();
+
+    let toc = dispatcher.toc_new(&access, &pass).clone();
 
     // TODO: Is `submit_collection_meta_op` cancel-safe!? Should be, I think?.. 🤔
     dispatcher

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -720,7 +720,7 @@ pub async fn do_create_index(
     // Nothing to verify here.
     let pass = new_unchecked_verification_pass();
 
-    let toc = dispatcher.toc_new(&access, &pass).clone();
+    let toc = dispatcher.toc(&access, &pass).clone();
 
     // TODO: Is `submit_collection_meta_op` cancel-safe!? Should be, I think?.. 🤔
     dispatcher
@@ -799,7 +799,7 @@ pub async fn do_delete_index(
     // Nothing to verify here.
     let pass = new_unchecked_verification_pass();
 
-    let toc = dispatcher.toc_new(&access, &pass).clone();
+    let toc = dispatcher.toc(&access, &pass).clone();
 
     // TODO: Is `submit_collection_meta_op` cancel-safe!? Should be, I think?.. 🤔
     dispatcher

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use collection::operations::verification::new_unchecked_verification_pass;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
@@ -75,8 +76,13 @@ impl TelemetryCollector {
     pub async fn prepare_data(&self, access: &Access, detail: TelemetryDetail) -> TelemetryData {
         TelemetryData {
             id: self.process_id.to_string(),
-            collections: CollectionsTelemetry::collect(detail, access, self.dispatcher.toc(access))
-                .await,
+            collections: CollectionsTelemetry::collect(
+                detail,
+                access,
+                self.dispatcher
+                    .toc(access, &new_unchecked_verification_pass()),
+            )
+            .await,
             app: AppBuildTelemetry::collect(detail, &self.app_telemetry_collector, &self.settings),
             cluster: ClusterTelemetry::collect(detail, &self.dispatcher, &self.settings),
             requests: RequestsTelemetry::collect(

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -15,6 +15,7 @@ use collection::operations::cluster_ops::{
     ClusterOperations, CreateShardingKeyOperation, DropShardingKeyOperation,
 };
 use collection::operations::types::CollectionsAliasesResponse;
+use collection::operations::verification::new_unchecked_verification_pass;
 use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status};
 
@@ -65,8 +66,12 @@ impl Collections for CollectionsService {
     ) -> Result<Response<GetCollectionInfoResponse>, Status> {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
+
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         get(
-            self.dispatcher.toc(&access),
+            self.dispatcher.toc_new(&access, &pass),
             request.into_inner(),
             access,
             None,
@@ -81,7 +86,11 @@ impl Collections for CollectionsService {
         validate(request.get_ref())?;
         let timing = Instant::now();
         let access = extract_access(&mut request);
-        let result = do_list_collections(self.dispatcher.toc(&access), access).await?;
+
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
+        let result = do_list_collections(self.dispatcher.toc_new(&access, &pass), access).await?;
 
         let response = ListCollectionsResponse::from((timing, result));
         Ok(Response::new(response))
@@ -126,10 +135,17 @@ impl Collections for CollectionsService {
         validate(request.get_ref())?;
         let timing = Instant::now();
         let access = extract_access(&mut request);
+
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         let ListCollectionAliasesRequest { collection_name } = request.into_inner();
-        let CollectionsAliasesResponse { aliases } =
-            do_list_collection_aliases(self.dispatcher.toc(&access), access, &collection_name)
-                .await?;
+        let CollectionsAliasesResponse { aliases } = do_list_collection_aliases(
+            self.dispatcher.toc_new(&access, &pass),
+            access,
+            &collection_name,
+        )
+        .await?;
         let response = ListAliasesResponse {
             aliases: aliases.into_iter().map(|alias| alias.into()).collect(),
             time: timing.elapsed().as_secs_f64(),
@@ -144,8 +160,12 @@ impl Collections for CollectionsService {
         validate(request.get_ref())?;
         let timing = Instant::now();
         let access = extract_access(&mut request);
+
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         let CollectionsAliasesResponse { aliases } =
-            do_list_aliases(self.dispatcher.toc(&access), access).await?;
+            do_list_aliases(self.dispatcher.toc_new(&access, &pass), access).await?;
         let response = ListAliasesResponse {
             aliases: aliases.into_iter().map(|alias| alias.into()).collect(),
             time: timing.elapsed().as_secs_f64(),
@@ -160,9 +180,17 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
+
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         let CollectionExistsRequest { collection_name } = request.into_inner();
-        let result =
-            do_collection_exists(self.dispatcher.toc(&access), access, &collection_name).await?;
+        let result = do_collection_exists(
+            self.dispatcher.toc_new(&access, &pass),
+            access,
+            &collection_name,
+        )
+        .await?;
         let response = CollectionExistsResponse {
             result: Some(result),
             time: timing.elapsed().as_secs_f64(),
@@ -177,8 +205,12 @@ impl Collections for CollectionsService {
     ) -> Result<Response<CollectionClusterInfoResponse>, Status> {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
+
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         let response = do_get_collection_cluster(
-            self.dispatcher.toc(&access),
+            self.dispatcher.toc_new(&access, &pass),
             access,
             request.into_inner().collection_name.as_str(),
         )

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -71,7 +71,7 @@ impl Collections for CollectionsService {
         let pass = new_unchecked_verification_pass();
 
         get(
-            self.dispatcher.toc_new(&access, &pass),
+            self.dispatcher.toc(&access, &pass),
             request.into_inner(),
             access,
             None,
@@ -90,7 +90,7 @@ impl Collections for CollectionsService {
         // Nothing to verify here.
         let pass = new_unchecked_verification_pass();
 
-        let result = do_list_collections(self.dispatcher.toc_new(&access, &pass), access).await?;
+        let result = do_list_collections(self.dispatcher.toc(&access, &pass), access).await?;
 
         let response = ListCollectionsResponse::from((timing, result));
         Ok(Response::new(response))
@@ -141,7 +141,7 @@ impl Collections for CollectionsService {
 
         let ListCollectionAliasesRequest { collection_name } = request.into_inner();
         let CollectionsAliasesResponse { aliases } = do_list_collection_aliases(
-            self.dispatcher.toc_new(&access, &pass),
+            self.dispatcher.toc(&access, &pass),
             access,
             &collection_name,
         )
@@ -165,7 +165,7 @@ impl Collections for CollectionsService {
         let pass = new_unchecked_verification_pass();
 
         let CollectionsAliasesResponse { aliases } =
-            do_list_aliases(self.dispatcher.toc_new(&access, &pass), access).await?;
+            do_list_aliases(self.dispatcher.toc(&access, &pass), access).await?;
         let response = ListAliasesResponse {
             aliases: aliases.into_iter().map(|alias| alias.into()).collect(),
             time: timing.elapsed().as_secs_f64(),
@@ -186,7 +186,7 @@ impl Collections for CollectionsService {
 
         let CollectionExistsRequest { collection_name } = request.into_inner();
         let result = do_collection_exists(
-            self.dispatcher.toc_new(&access, &pass),
+            self.dispatcher.toc(&access, &pass),
             access,
             &collection_name,
         )
@@ -210,7 +210,7 @@ impl Collections for CollectionsService {
         let pass = new_unchecked_verification_pass();
 
         let response = do_get_collection_cluster(
-            self.dispatcher.toc_new(&access, &pass),
+            self.dispatcher.toc(&access, &pass),
             access,
             request.into_inner().collection_name.as_str(),
         )

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -57,7 +57,7 @@ impl Points for PointsService {
         let access = extract_access(&mut request);
 
         upsert(
-            self.dispatcher.toc_new(&access, &pass).clone(),
+            self.dispatcher.toc(&access, &pass).clone(),
             request.into_inner(),
             None,
             None,
@@ -112,7 +112,7 @@ impl Points for PointsService {
         let access = extract_access(&mut request);
 
         update_vectors(
-            self.dispatcher.toc_new(&access, &pass).clone(),
+            self.dispatcher.toc(&access, &pass).clone(),
             request.into_inner(),
             None,
             None,

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -16,6 +16,7 @@ use api::grpc::qdrant::{
     UpdatePointVectors, UpsertPoints,
 };
 use collection::operations::types::CoreSearchRequest;
+use collection::operations::verification::new_unchecked_verification_pass;
 use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status};
 
@@ -50,10 +51,13 @@ impl Points for PointsService {
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
 
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         let access = extract_access(&mut request);
 
         upsert(
-            self.dispatcher.toc(&access).clone(),
+            self.dispatcher.toc_new(&access, &pass).clone(),
             request.into_inner(),
             None,
             None,
@@ -88,7 +92,7 @@ impl Points for PointsService {
         let access = extract_access(&mut request);
 
         get(
-            self.dispatcher.toc(&access),
+            StrictModeCheckedTocProvider::new(&self.dispatcher),
             request.into_inner(),
             None,
             access,
@@ -102,10 +106,13 @@ impl Points for PointsService {
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
 
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         let access = extract_access(&mut request);
 
         update_vectors(
-            self.dispatcher.toc(&access).clone(),
+            self.dispatcher.toc_new(&access, &pass).clone(),
             request.into_inner(),
             None,
             None,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1652,7 +1652,7 @@ pub async fn count(
 }
 
 pub async fn get(
-    toc: &TableOfContent,
+    toc_provider: impl CheckedTocProvider,
     get_points: GetPoints,
     shard_selection: Option<ShardId>,
     access: Access,
@@ -1677,12 +1677,22 @@ pub async fn get(
             .map(|selector| selector.into())
             .unwrap_or_default(),
     };
-    let timeout = timeout.map(Duration::from_secs);
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
 
     let timing = Instant::now();
+
+    let toc = toc_provider
+        .check_strict_mode(
+            &point_request,
+            &collection_name,
+            timeout.map(|i| i as usize),
+            &access,
+        )
+        .await?;
+
+    let timeout = timeout.map(Duration::from_secs);
 
     let records = do_get_points(
         toc,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -553,7 +553,7 @@ pub async fn update_batch(
                 shard_key_selector,
             }) => {
                 // We don't need strict mode checks for upsert!
-                let toc = dispatcher.toc_new(&access, &new_unchecked_verification_pass());
+                let toc = dispatcher.toc(&access, &new_unchecked_verification_pass());
                 upsert(
                     toc.clone(),
                     UpsertPoints {
@@ -685,7 +685,7 @@ pub async fn update_batch(
                 },
             ) => {
                 // We don't need strict mode checks for vector updates!
-                let toc = dispatcher.toc_new(&access, &new_unchecked_verification_pass());
+                let toc = dispatcher.toc(&access, &new_unchecked_verification_pass());
                 update_vectors(
                     toc.clone(),
                     UpdatePointVectors {

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -486,7 +486,13 @@ impl PointsInternal for PointsInternalService {
 
         get_points.read_consistency = None; // *Have* to be `None`!
 
-        get(self.toc.as_ref(), get_points, shard_id, FULL_ACCESS.clone()).await
+        get(
+            UncheckedTocProvider::new_unchecked(&self.toc),
+            get_points,
+            shard_id,
+            FULL_ACCESS.clone(),
+        )
+        .await
     }
 
     async fn count(

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -51,7 +51,7 @@ impl Snapshots for SnapshotsService {
         let pass = new_unchecked_verification_pass();
 
         let response = do_create_snapshot(
-            Arc::clone(dispatcher.toc_new(&access, &pass)),
+            Arc::clone(dispatcher.toc(&access, &pass)),
             access,
             &collection_name,
         )
@@ -77,7 +77,7 @@ impl Snapshots for SnapshotsService {
         let pass = new_unchecked_verification_pass();
 
         let snapshots = do_list_snapshots(
-            self.dispatcher.toc_new(&access, &pass),
+            self.dispatcher.toc(&access, &pass),
             access,
             &collection_name,
         )
@@ -143,8 +143,7 @@ impl Snapshots for SnapshotsService {
         // Nothing to verify here.
         let pass = new_unchecked_verification_pass();
 
-        let snapshots =
-            do_list_full_snapshots(self.dispatcher.toc_new(&access, &pass), access).await?;
+        let snapshots = do_list_full_snapshots(self.dispatcher.toc(&access, &pass), access).await?;
         Ok(Response::new(ListSnapshotsResponse {
             snapshot_descriptions: snapshots.into_iter().map(|s| s.into()).collect(),
             time: timing.elapsed().as_secs_f64(),

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -10,6 +10,7 @@ use api::grpc::qdrant::{
     ListShardSnapshotsRequest, ListSnapshotsRequest, ListSnapshotsResponse,
     RecoverShardSnapshotRequest, RecoverSnapshotResponse,
 };
+use collection::operations::verification::new_unchecked_verification_pass;
 use storage::content_manager::snapshots::{
     do_create_full_snapshot, do_delete_collection_snapshot, do_delete_full_snapshot,
     do_list_full_snapshots,
@@ -46,8 +47,11 @@ impl Snapshots for SnapshotsService {
         let timing = Instant::now();
         let dispatcher = self.dispatcher.clone();
 
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
         let response = do_create_snapshot(
-            Arc::clone(dispatcher.toc(&access)),
+            Arc::clone(dispatcher.toc_new(&access, &pass)),
             access,
             &collection_name,
         )
@@ -69,8 +73,15 @@ impl Snapshots for SnapshotsService {
         let access = extract_access(&mut request);
         let ListSnapshotsRequest { collection_name } = request.into_inner();
 
-        let snapshots =
-            do_list_snapshots(self.dispatcher.toc(&access), access, &collection_name).await?;
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
+        let snapshots = do_list_snapshots(
+            self.dispatcher.toc_new(&access, &pass),
+            access,
+            &collection_name,
+        )
+        .await?;
 
         Ok(Response::new(ListSnapshotsResponse {
             snapshot_descriptions: snapshots.into_iter().map(|s| s.into()).collect(),
@@ -128,7 +139,12 @@ impl Snapshots for SnapshotsService {
         validate(request.get_ref())?;
         let timing = Instant::now();
         let access = extract_access(&mut request);
-        let snapshots = do_list_full_snapshots(self.dispatcher.toc(&access), access).await?;
+
+        // Nothing to verify here.
+        let pass = new_unchecked_verification_pass();
+
+        let snapshots =
+            do_list_full_snapshots(self.dispatcher.toc_new(&access, &pass), access).await?;
         Ok(Response::new(ListSnapshotsResponse {
             snapshot_descriptions: snapshots.into_iter().map(|s| s.into()).collect(),
             time: timing.elapsed().as_secs_f64(),

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -200,7 +200,7 @@ pub fn init(
                 AuthKeys::try_create(
                     &settings.service,
                     dispatcher
-                        .toc_new(
+                        .toc(
                             &Access::full("For tonic auth middleware"),
                             &new_unchecked_verification_pass(),
                         )

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -29,6 +29,7 @@ use ::api::grpc::qdrant::{
     WaitOnConsensusCommitRequest, WaitOnConsensusCommitResponse,
 };
 use ::api::grpc::QDRANT_DESCRIPTOR_SET;
+use collection::operations::verification::new_unchecked_verification_pass;
 use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
@@ -199,7 +200,10 @@ pub fn init(
                 AuthKeys::try_create(
                     &settings.service,
                     dispatcher
-                        .toc(&Access::full("For tonic auth middleware"))
+                        .toc_new(
+                            &Access::full("For tonic auth middleware"),
+                            &new_unchecked_verification_pass(),
+                        )
                         .clone(),
                 )
                 .map(auth::AuthLayer::new)

--- a/src/tonic/verification.rs
+++ b/src/tonic/verification.rs
@@ -91,7 +91,7 @@ impl<'a> CheckedTocProvider for StrictModeCheckedTocProvider<'a> {
     ) -> Result<&Arc<TableOfContent>, Status> {
         let pass =
             check_strict_mode(request, timeout, collection_name, self.dispatcher, access).await?;
-        Ok(self.dispatcher.toc_new(access, &pass))
+        Ok(self.dispatcher.toc(access, &pass))
     }
 
     async fn check_strict_mode_batch<'b, I, R>(
@@ -113,6 +113,6 @@ impl<'a> CheckedTocProvider for StrictModeCheckedTocProvider<'a> {
             access,
         )
         .await?;
-        Ok(self.dispatcher.toc_new(access, &pass))
+        Ok(self.dispatcher.toc(access, &pass))
     }
 }


### PR DESCRIPTION
Depends on #5037 

Migrates all `toc(..)` calls with the new toc function.