### PR TITLE
Bump version to 1.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "api"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "chrono",
  "common",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.11.4"
+version = "1.11.5"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.11.4"
+version = "1.11.5"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.11.4";
+pub const QDRANT_VERSION_STRING: &str = "1.11.5";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=6f8dd8176afb2097be3aca6274f97eb872c735be
+IGNORE_UPTO=bcd9bfd5ac3826b5682a5e65c19a1e84d04f1e32
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
PR to release Qdrant 1.11.5.

Follows the pattern of https://github.com/qdrant/qdrant/pull/5098.

---

# Change log

## Bug fixes
- https://github.com/qdrant/qdrant/pull/5113 - Fix set payload with nested key not updating nested structure properly in some cases
- https://github.com/qdrant/qdrant/pull/5111 - Fix optimizations potentially getting stuck if low optimization limit is configured
- https://github.com/qdrant/qdrant/pull/5105 - Properly configure RocksDB to use LZ4 compression for payload index
- https://github.com/qdrant/qdrant/pull/5123 - If populating mmap with syscall fails, fall back to naive population