### PR TITLE
Add unit test for set_payload bug

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -72,15 +72,22 @@ mod tests {
     use std::sync::Arc;
 
     use itertools::Itertools;
+    use parking_lot::RwLockUpgradableReadGuard;
     use segment::data_types::vectors::{
         only_default_vector, VectorStructInternal, DEFAULT_VECTOR_NAME,
     };
-    use segment::types::{Payload, WithPayload};
+    use segment::entry::entry_point::SegmentEntry;
+    use segment::json_path::JsonPath;
+    use segment::types::PayloadSchemaType::Keyword;
+    use segment::types::{Payload, PayloadContainer, PayloadFieldSchema, WithPayload};
     use serde_json::json;
     use tempfile::Builder;
 
     use super::*;
-    use crate::collection_manager::fixtures::build_test_holder;
+    use crate::collection_manager::fixtures::{
+        build_segment_1, build_segment_2, build_test_holder,
+    };
+    use crate::collection_manager::holders::segment_holder::LockedSegment::Original;
     use crate::collection_manager::segments_searcher::SegmentsSearcher;
     use crate::collection_manager::segments_updater::upsert_points;
     use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
@@ -316,5 +323,145 @@ mod tests {
 
         assert_eq!(res.len(), 1);
         assert!(!res[0].payload.as_ref().unwrap().contains_key("color"));
+    }
+
+    #[test]
+    fn test_nested_payload_update_with_index() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let path = dir.path();
+
+        let meta_key_path = JsonPath::new("meta");
+        let nested_key_path: JsonPath = JsonPath::new("meta.color");
+
+        let mut segment1 = build_segment_1(path);
+        segment1
+            .create_field_index(
+                100,
+                &nested_key_path,
+                Some(&PayloadFieldSchema::FieldType(Keyword)),
+            )
+            .unwrap();
+
+        let mut segment2 = build_segment_2(path);
+        segment2
+            .create_field_index(
+                101,
+                &nested_key_path,
+                Some(&PayloadFieldSchema::FieldType(Keyword)),
+            )
+            .unwrap();
+
+        let mut holder = SegmentHolder::default();
+        let segment_ids = vec![holder.add_new(segment1), holder.add_new(segment2)];
+
+        let segments_guard = RwLock::new(holder);
+        let segments = Arc::new(segments_guard);
+
+        // payload with nested structure
+        let payload: Payload = serde_json::from_str(r#"{"color":"red"}"#).unwrap();
+        let is_stopped = AtomicBool::new(false);
+
+        // update points from segment 2
+        let points = vec![11.into(), 12.into(), 13.into()];
+
+        process_payload_operation(
+            &segments,
+            102,
+            PayloadOps::SetPayload(SetPayloadOp {
+                payload,
+                points: Some(points.clone()),
+                filter: None,
+                key: Some(meta_key_path.clone()),
+            }),
+        )
+        .unwrap();
+
+        let res = SegmentsSearcher::retrieve_blocking(
+            segments.clone(),
+            &points,
+            &WithPayload::from(true),
+            &false.into(),
+            &is_stopped,
+        )
+        .unwrap()
+        .into_values()
+        .collect_vec();
+
+        assert_eq!(res.len(), 3);
+
+        match res.first() {
+            None => panic!(),
+            Some(r) => match &r.payload {
+                None => panic!("No payload assigned"),
+                Some(actual_payload) => {
+                    let expect_value = json!({"color":"red"});
+                    assert_eq!(
+                        actual_payload.get_value(&meta_key_path).first().unwrap(),
+                        &&expect_value
+                    )
+                }
+            },
+        };
+
+        // segment 2 is marked as not appendable to trigger COW mechanism
+        let upgradable = segments.upgradable_read();
+        let segments = RwLockUpgradableReadGuard::upgrade(upgradable).remove(&segment_ids);
+        match segments.get(segment_ids[1]) {
+            Some(Original(segment)) => {
+                let mut guard = segment.write();
+                guard.appendable_flag = false;
+            }
+            x => panic!("Unexpected segment type: {x:?}"),
+        };
+
+        let mut holder = SegmentHolder::default();
+        for segment in segments {
+            holder.add_new(segment);
+        }
+
+        let segments_guard = RwLock::new(holder);
+        let segments = Arc::new(segments_guard);
+
+        // update points nested values
+        let payload: Payload = serde_json::from_str(r#"{ "color":"blue"}"#).unwrap();
+
+        process_payload_operation(
+            &segments,
+            103,
+            PayloadOps::SetPayload(SetPayloadOp {
+                payload,
+                points: Some(points.clone()),
+                filter: None,
+                key: Some(meta_key_path.clone()),
+            }),
+        )
+        .unwrap();
+
+        let res = SegmentsSearcher::retrieve_blocking(
+            segments.clone(),
+            &points,
+            &WithPayload::from(true),
+            &false.into(),
+            &is_stopped,
+        )
+        .unwrap()
+        .into_values()
+        .collect_vec();
+
+        assert_eq!(res.len(), 3);
+
+        match res.first() {
+            None => panic!(),
+            Some(r) => match &r.payload {
+                None => panic!("No payload assigned"),
+                Some(actual_payload) => {
+                    let expect_value = json!({"color":"blue"});
+                    assert_eq!(
+                        actual_payload.get_value(&meta_key_path).first().unwrap(),
+                        &&expect_value
+                    )
+                }
+            },
+        };
     }
 }


### PR DESCRIPTION
This PR adds a non regression test for https://github.com/qdrant/qdrant/pull/5113

The conditions are:
- set_payload op
- targeting nested key
- key must be indexed
- the point must be on a non appendable segment
