### PR TITLE
[Strict mode] Remove obsolete timeout function

### DIFF
--- a/lib/collection/src/operations/verification/count.rs
+++ b/lib/collection/src/operations/verification/count.rs
@@ -8,10 +8,6 @@ impl StrictModeVerification for CountRequestInternal {
         None
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&Filter> {
         self.filter.as_ref()
     }

--- a/lib/collection/src/operations/verification/discovery.rs
+++ b/lib/collection/src/operations/verification/discovery.rs
@@ -9,10 +9,6 @@ impl StrictModeVerification for DiscoverRequestInternal {
         Some(self.limit)
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&Filter> {
         self.filter.as_ref()
     }
@@ -45,10 +41,6 @@ impl StrictModeVerification for DiscoverRequestBatch {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        None
-    }
-
-    fn timeout(&self) -> Option<usize> {
         None
     }
 

--- a/lib/collection/src/operations/verification/facet.rs
+++ b/lib/collection/src/operations/verification/facet.rs
@@ -9,10 +9,6 @@ impl StrictModeVerification for FacetRequestInternal {
         self.limit
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
         self.filter.as_ref()
     }
@@ -33,10 +29,6 @@ impl StrictModeVerification for FacetRequestInternal {
 impl StrictModeVerification for FacetParams {
     fn query_limit(&self) -> Option<usize> {
         Some(self.limit)
-    }
-
-    fn timeout(&self) -> Option<usize> {
-        None
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {

--- a/lib/collection/src/operations/verification/local_shard.rs
+++ b/lib/collection/src/operations/verification/local_shard.rs
@@ -6,10 +6,6 @@ impl StrictModeVerification for ScrollRequestInternal {
         self.limit
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
         self.filter.as_ref()
     }
@@ -29,10 +25,6 @@ impl StrictModeVerification for ScrollRequestInternal {
 
 impl StrictModeVerification for PointRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        None
-    }
-
-    fn timeout(&self) -> Option<usize> {
         None
     }
 

--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -8,10 +8,6 @@ impl StrictModeVerification for SearchMatrixRequestInternal {
         self.limit
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
         self.filter.as_ref()
     }
@@ -32,10 +28,6 @@ impl StrictModeVerification for SearchMatrixRequestInternal {
 impl StrictModeVerification for CollectionSearchMatrixRequest {
     fn query_limit(&self) -> Option<usize> {
         Some(self.limit_per_sample)
-    }
-
-    fn timeout(&self) -> Option<usize> {
-        None
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -43,9 +43,6 @@ pub trait StrictModeVerification {
     /// Implement this to check the limit of a request.
     fn query_limit(&self) -> Option<usize>;
 
-    /// Implement this to check the timeout of a request.
-    fn timeout(&self) -> Option<usize>;
-
     /// Verifies that all keys in the given filter have an index available. Only implement this
     /// if the filter operates on a READ-operation, like search.
     /// For filtered updates implement `request_indexed_filter_write`!
@@ -94,18 +91,6 @@ pub trait StrictModeVerification {
         if let Some(search_params) = self.request_search_params() {
             search_params.check_strict_mode(collection, strict_mode_config)?;
         }
-        Ok(())
-    }
-
-    /// Checks the request timeout.
-    fn check_request_timeout(
-        &self,
-        strict_mode_config: &StrictModeConfig,
-    ) -> Result<(), CollectionError> {
-        if let Some(timeout) = self.timeout() {
-            check_timeout(timeout, strict_mode_config)?;
-        }
-
         Ok(())
     }
 
@@ -232,10 +217,6 @@ impl StrictModeVerification for SearchParams {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        None
-    }
-
-    fn timeout(&self) -> Option<usize> {
         None
     }
 

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -26,10 +26,6 @@ impl StrictModeVerification for QueryRequestInternal {
         self.limit
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
         self.filter.as_ref()
     }
@@ -67,10 +63,6 @@ impl StrictModeVerification for Prefetch {
         self.limit
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
         self.filter.as_ref()
     }
@@ -91,10 +83,6 @@ impl StrictModeVerification for Prefetch {
 impl StrictModeVerification for QueryGroupsRequestInternal {
     fn query_limit(&self) -> Option<usize> {
         self.group_request.limit
-    }
-
-    fn timeout(&self) -> Option<usize> {
-        None
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
@@ -119,10 +107,6 @@ impl StrictModeVerification for CollectionQueryRequest {
         Some(self.limit)
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
         self.filter.as_ref()
     }
@@ -143,10 +127,6 @@ impl StrictModeVerification for CollectionQueryRequest {
 impl StrictModeVerification for CollectionQueryGroupsRequest {
     fn query_limit(&self) -> Option<usize> {
         Some(self.limit)
-    }
-
-    fn timeout(&self) -> Option<usize> {
-        None
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/recommend.rs
+++ b/lib/collection/src/operations/verification/recommend.rs
@@ -8,10 +8,6 @@ impl StrictModeVerification for RecommendRequestInternal {
         Some(self.limit)
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&Filter> {
         self.filter.as_ref()
     }
@@ -32,10 +28,6 @@ impl StrictModeVerification for RecommendRequestInternal {
 impl StrictModeVerification for RecommendGroupsRequestInternal {
     fn query_limit(&self) -> Option<usize> {
         Some(self.group_request.limit as usize)
-    }
-
-    fn timeout(&self) -> Option<usize> {
-        None
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {

--- a/lib/collection/src/operations/verification/search.rs
+++ b/lib/collection/src/operations/verification/search.rs
@@ -14,10 +14,6 @@ impl StrictModeVerification for SearchRequestInternal {
         Some(self.limit)
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_write(&self) -> Option<&Filter> {
         None
     }
@@ -34,10 +30,6 @@ impl StrictModeVerification for SearchRequestInternal {
 impl StrictModeVerification for CoreSearchRequest {
     fn query_limit(&self) -> Option<usize> {
         Some(self.limit)
-    }
-
-    fn timeout(&self) -> Option<usize> {
-        None
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {
@@ -75,10 +67,6 @@ impl StrictModeVerification for SearchRequestBatch {
         None
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&Filter> {
         None
     }
@@ -112,10 +100,6 @@ impl StrictModeVerification for SearchGroupsRequestInternal {
 
     fn request_search_params(&self) -> Option<&SearchParams> {
         self.params.as_ref()
-    }
-
-    fn timeout(&self) -> Option<usize> {
-        None
     }
 
     fn indexed_filter_write(&self) -> Option<&Filter> {

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -17,10 +17,6 @@ impl StrictModeVerification for PointsSelector {
         None
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&Filter> {
         None
     }
@@ -36,10 +32,6 @@ impl StrictModeVerification for PointsSelector {
 
 impl StrictModeVerification for DeleteVectors {
     fn query_limit(&self) -> Option<usize> {
-        None
-    }
-
-    fn timeout(&self) -> Option<usize> {
         None
     }
 
@@ -69,10 +61,6 @@ impl StrictModeVerification for SetPayload {
         None
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&Filter> {
         None
     }
@@ -92,10 +80,6 @@ impl StrictModeVerification for DeletePayload {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        None
-    }
-
-    fn timeout(&self) -> Option<usize> {
         None
     }
 

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -142,10 +142,6 @@ impl StrictModeVerification for UpdateOperation {
         None
     }
 
-    fn timeout(&self) -> Option<usize> {
-        None
-    }
-
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
         None
     }


### PR DESCRIPTION
Depends on #5137 

The `timeout()` function in the `StrictModeVerification` trait is not used anymore since we already check the timeout value in the `check_strict_mode` function. Therefore we can remove it from the trait definition.