### PR TITLE
[WIP] Allow multi-key in create-index api

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9082,7 +9082,7 @@
         ],
         "properties": {
           "field_name": {
-            "type": "string"
+            "$ref": "#/components/schemas/SingleOrList_for_JsonPath"
           },
           "field_schema": {
             "anyOf": [
@@ -9095,6 +9095,19 @@
             ]
           }
         }
+      },
+      "SingleOrList_for_JsonPath": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "PayloadFieldSchema": {
         "anyOf": [

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -7,7 +7,7 @@ use segment::types::{Filter, PayloadFieldSchema, PayloadKeyType};
 use serde::{Deserialize, Serialize};
 
 use crate::collection::Collection;
-use crate::operations::types::{CollectionResult, UpdateResult};
+use crate::operations::types::{CollectionResult, SingleOrList, UpdateResult};
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::save_on_disk::SaveOnDisk;
 
@@ -34,7 +34,7 @@ impl Collection {
 
     pub async fn create_payload_index(
         &self,
-        field_name: JsonPath,
+        field_name: SingleOrList<JsonPath>,
         field_schema: PayloadFieldSchema,
     ) -> CollectionResult<Option<UpdateResult>> {
         // This function is called from consensus, so we use `wait = false`, because we can't afford
@@ -45,14 +45,14 @@ impl Collection {
 
     pub async fn create_payload_index_with_wait(
         &self,
-        field_name: JsonPath,
+        field_name: SingleOrList<JsonPath>,
         field_schema: PayloadFieldSchema,
         wait: bool,
     ) -> CollectionResult<Option<UpdateResult>> {
+        let single = field_name.clone().unwrap_value();
+
         self.payload_index_schema.write(|schema| {
-            schema
-                .schema
-                .insert(field_name.clone(), field_schema.clone());
+            schema.schema.insert(single.clone(), field_schema.clone());
         })?;
 
         // This operation might be redundant, if we also create index as a regular collection op,

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -4,7 +4,7 @@ use segment::types::ShardKey;
 
 use crate::collection::Collection;
 use crate::config::ShardingMethod;
-use crate::operations::types::CollectionError;
+use crate::operations::types::{CollectionError, SingleOrList};
 use crate::operations::{
     CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
@@ -108,7 +108,7 @@ impl Collection {
             for (field_name, field_schema) in payload_schema.iter() {
                 let create_index_op = CollectionUpdateOperations::FieldIndexOperation(
                     FieldIndexOperations::CreateIndex(CreateIndex {
-                        field_name: field_name.clone(),
+                        field_name: SingleOrList::Single(field_name.clone()),
                         field_schema: Some(field_schema.clone()),
                     }),
                 );

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -4,7 +4,7 @@ use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection::Collection;
 use crate::collection_state::{ShardInfo, State};
 use crate::config::CollectionConfig;
-use crate::operations::types::CollectionResult;
+use crate::operations::types::{CollectionResult, SingleOrList};
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_holder::{ShardKeyMapping, ShardTransferChange};
@@ -122,6 +122,7 @@ impl Collection {
         &self,
         payload_index_schema: PayloadIndexSchema,
     ) -> CollectionResult<()> {
+        // TODO: Allow multi-key
         let state = self.state().await;
 
         for field_name in state.payload_index_schema.schema.keys() {
@@ -131,7 +132,8 @@ impl Collection {
         }
 
         for (field_name, field_schema) in payload_index_schema.schema {
-            self.create_payload_index(field_name, field_schema).await?;
+            self.create_payload_index(SingleOrList::Single(field_name), field_schema)
+                .await?;
         }
         Ok(())
     }

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -304,7 +304,7 @@ mod tests {
         process_field_index_operation, process_point_operation,
     };
     use crate::operations::point_ops::{Batch, PointOperations};
-    use crate::operations::types::{VectorParams, VectorsConfig};
+    use crate::operations::types::{SingleOrList, VectorParams, VectorsConfig};
     use crate::operations::vector_params_builder::VectorParamsBuilder;
     use crate::operations::{CreateIndex, FieldIndexOperations};
 
@@ -509,7 +509,7 @@ mod tests {
             locked_holder.deref(),
             opnum.next().unwrap(),
             &FieldIndexOperations::CreateIndex(CreateIndex {
-                field_name: payload_field.clone(),
+                field_name: SingleOrList::Single(payload_field.clone()),
                 field_schema: Some(PayloadSchemaType::Integer.into()),
             }),
         )

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -24,6 +24,7 @@ use segment::json_path::JsonPath;
 use segment::types::{ExtendedPointId, PayloadFieldSchema, PointIdType};
 use serde::{Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumIter};
+use types::SingleOrList;
 use validator::Validate;
 
 use crate::hash_ring::{HashRingRouter, ShardIds};
@@ -34,7 +35,8 @@ pub type ClockToken = u64;
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct CreateIndex {
-    pub field_name: JsonPath,
+    pub field_name: SingleOrList<JsonPath>,
+    // pub field_name: JsonPath,
     pub field_schema: Option<PayloadFieldSchema>,
 }
 
@@ -522,7 +524,7 @@ mod tests {
 
         fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
             let create = Self::CreateIndex(CreateIndex {
-                field_name: "field_name".parse().unwrap(),
+                field_name: SingleOrList::Single("field_name".parse().unwrap()),
                 field_schema: None,
             });
 

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -269,7 +269,7 @@ mod test {
     use crate::operations::point_ops::{FilterSelector, PointsSelector};
     use crate::operations::shared_storage_config::SharedStorageConfig;
     use crate::operations::types::{
-        CollectionError, CountRequestInternal, DiscoverRequestInternal,
+        CollectionError, CountRequestInternal, DiscoverRequestInternal, SingleOrList,
     };
     use crate::optimizers_builder::OptimizersConfig;
     use crate::shards::channel_service::ChannelService;
@@ -464,7 +464,7 @@ mod test {
 
         collection
             .create_payload_index(
-                INDEXED_KEY.parse().unwrap(),
+                SingleOrList::Single(INDEXED_KEY.parse().unwrap()),
                 PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
             )
             .await

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -358,7 +358,8 @@ pub fn internal_create_index(
         create_field_index_collection: Some(CreateFieldIndexCollection {
             collection_name,
             wait: Some(wait),
-            field_name: create_index.field_name.to_string(),
+            // TODO: allow multiple keys!
+            field_name: create_index.field_name.unwrap_value().to_string(),
             field_type,
             field_index_params,
             ordering: ordering.map(write_ordering_to_proto),

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -22,7 +22,8 @@ use crate::operations::point_ops::{
 };
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
-    CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
+    CountRequestInternal, CountResult, PointRequestInternal, Record, SingleOrList, UpdateResult,
+    UpdateStatus,
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::{
@@ -96,7 +97,7 @@ impl ForwardProxyShard {
                     // TODO: Assign clock tag!? 🤔
                     OperationWithClockTag::from(CollectionUpdateOperations::FieldIndexOperation(
                         FieldIndexOperations::CreateIndex(CreateIndex {
-                            field_name: index_key,
+                            field_name: SingleOrList::Single(index_key),
                             field_schema: Some(index_type.try_into()?),
                         }),
                     )),

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -7,7 +7,7 @@ use segment::types::{
 
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::point_ops::{PointOperations, PointStruct};
-use crate::operations::types::VectorsConfig;
+use crate::operations::types::{SingleOrList, VectorsConfig};
 use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::optimizers_builder::OptimizersConfig;
@@ -96,7 +96,7 @@ pub fn upsert_operation() -> CollectionUpdateOperations {
 pub fn create_payload_index_operation() -> CollectionUpdateOperations {
     CollectionUpdateOperations::FieldIndexOperation(FieldIndexOperations::CreateIndex(
         CreateIndex {
-            field_name: "location".parse().unwrap(),
+            field_name: SingleOrList::Single("location".parse().unwrap()),
             field_schema: Some(PayloadFieldSchema::FieldType(PayloadSchemaType::Geo)),
         },
     ))

--- a/lib/collection/src/tests/payload.rs
+++ b/lib/collection/src/tests/payload.rs
@@ -12,6 +12,7 @@ use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
 use crate::collection::payload_index_schema::PayloadIndexSchema;
+use crate::operations::types::SingleOrList;
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::local_shard::LocalShard;
@@ -157,7 +158,7 @@ async fn create_index(
         .unwrap();
     let create_index = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::CreateIndex(CreateIndex {
-            field_name: name.parse().unwrap(),
+            field_name: SingleOrList::Single(name.parse().unwrap()),
             field_schema: Some(PayloadFieldSchema::FieldType(field_type)),
         }),
     );

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -19,7 +19,7 @@ use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{
-    CoreSearchRequest, PointRequestInternal, ScrollRequestInternal, VectorsConfig,
+    CoreSearchRequest, PointRequestInternal, ScrollRequestInternal, SingleOrList, VectorsConfig,
 };
 use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::operations::{CollectionUpdateOperations, OperationWithClockTag};
@@ -92,7 +92,7 @@ async fn fixture() -> Collection {
     // Create payload index to allow order by
     collection
         .create_payload_index(
-            "num".parse().unwrap(),
+            SingleOrList::Single("num".parse().unwrap()),
             PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
         )
         .await

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -7,7 +7,7 @@ use collection::operations::point_ops::{Batch, PointOperations, PointStruct, Wri
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CountRequestInternal, PointRequestInternal, RecommendRequestInternal, ScrollRequestInternal,
-    UpdateStatus,
+    SingleOrList, UpdateStatus,
 };
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
@@ -15,6 +15,7 @@ use collection::shards::replica_set::{ReplicaSetState, ReplicaState};
 use itertools::Itertools;
 use segment::data_types::order_by::{Direction, OrderBy};
 use segment::data_types::vectors::{BatchVectorStructInternal, VectorStructInternal};
+use segment::json_path::JsonPath;
 use segment::types::{
     Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition, Payload,
     PayloadFieldSchema, PayloadSchemaType, PointIdType, WithPayloadInterface,
@@ -510,7 +511,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
 
     collection
         .create_payload_index_with_wait(
-            PRICE_FLOAT_KEY.parse().unwrap(),
+            SingleOrList::Single(PRICE_FLOAT_KEY.parse::<JsonPath>().unwrap()),
             PayloadFieldSchema::FieldType(PayloadSchemaType::Float),
             true,
         )
@@ -519,7 +520,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
 
     collection
         .create_payload_index_with_wait(
-            PRICE_INT_KEY.parse().unwrap(),
+            SingleOrList::Single(PRICE_INT_KEY.parse::<JsonPath>().unwrap()),
             PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
             true,
         )
@@ -528,7 +529,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
 
     collection
         .create_payload_index_with_wait(
-            MULTI_VALUE_KEY.parse().unwrap(),
+            SingleOrList::Single(MULTI_VALUE_KEY.parse::<JsonPath>().unwrap()),
             PayloadFieldSchema::FieldType(PayloadSchemaType::Float),
             true,
         )

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -6,7 +6,7 @@ use collection::operations::config_diff::{
     StrictModeConfigDiff, WalConfigDiff,
 };
 use collection::operations::types::{
-    SparseVectorParams, SparseVectorsConfig, VectorsConfig, VectorsConfigDiff,
+    SingleOrList, SparseVectorParams, SparseVectorsConfig, VectorsConfig, VectorsConfigDiff,
 };
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::resharding::ReshardKey;
@@ -357,7 +357,7 @@ pub struct DropShardKey {
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
 pub struct CreatePayloadIndex {
     pub collection_name: String,
-    pub field_name: PayloadKeyType,
+    pub field_name: SingleOrList<PayloadKeyType>,
     pub field_schema: PayloadFieldSchema,
 }
 

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -6,7 +6,9 @@ use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
-use collection::operations::types::{CollectionError, CollectionResult, ScrollRequestInternal};
+use collection::operations::types::{
+    CollectionError, CollectionResult, ScrollRequestInternal, SingleOrList,
+};
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
@@ -222,7 +224,7 @@ pub async fn transfer_indexes(
     for (payload_name, schema) in collection_info.payload_schema {
         let request = CollectionUpdateOperations::FieldIndexOperation(
             FieldIndexOperations::CreateIndex(CreateIndex {
-                field_name: payload_name,
+                field_name: SingleOrList::Single(payload_name),
                 field_schema: Some(schema.try_into()?),
             }),
         );

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -699,7 +699,7 @@ impl TableOfContent {
         // We can solve issues related to this missing index
         issues::publish(IndexCreatedEvent {
             collection_id: operation.collection_name,
-            field_name: operation.field_name,
+            field_name: operation.field_name.unwrap_value(),
         });
 
         Ok(())

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -663,7 +663,7 @@ mod tests_ops {
         PointOperationsDiscriminants, PointStruct, PointSyncOperation,
     };
     use collection::operations::query_enum::QueryEnum;
-    use collection::operations::types::UsingVector;
+    use collection::operations::types::{SingleOrList, UsingVector};
     use collection::operations::vector_ops::{
         PointVectors, UpdateVectorsOp, VectorOperationsDiscriminants,
     };
@@ -1339,7 +1339,7 @@ mod tests_ops {
             let inner = match discr {
                 FieldIndexOperationsDiscriminants::CreateIndex => {
                     FieldIndexOperations::CreateIndex(CreateIndex {
-                        field_name: "path".parse().unwrap(),
+                        field_name: SingleOrList::Single("path".parse().unwrap()),
                         field_schema: None,
                     })
                 }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -20,7 +20,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CollectionError, CoreSearchRequest, CoreSearchRequestBatch, CountRequestInternal, CountResult,
     DiscoverRequestBatch, GroupsResult, PointRequestInternal, RecommendGroupsRequestInternal,
-    Record, ScrollRequestInternal, ScrollResult, UpdateResult,
+    Record, ScrollRequestInternal, ScrollResult, SingleOrList, UpdateResult,
 };
 use collection::operations::universal_query::collection_query::{
     CollectionQueryGroupsRequest, CollectionQueryRequest,
@@ -50,7 +50,9 @@ use validator::Validate;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct CreateFieldIndex {
-    pub field_name: PayloadKeyType,
+    #[serde(alias = "field_names")]
+    #[validate(nested)]
+    pub field_name: SingleOrList<PayloadKeyType>,
     #[serde(alias = "field_type")]
     pub field_schema: Option<PayloadFieldSchema>,
 }
@@ -658,7 +660,7 @@ pub async fn do_batch_update_points(
 pub async fn do_create_index_internal(
     toc: Arc<TableOfContent>,
     collection_name: String,
-    field_name: PayloadKeyType,
+    field_name: SingleOrList<PayloadKeyType>,
     field_schema: Option<PayloadFieldSchema>,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -32,7 +32,7 @@ use collection::operations::query_enum::QueryEnum;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     default_exact_count, CoreSearchRequest, CoreSearchRequestBatch, PointRequestInternal,
-    RecommendExample, Record, ScrollRequestInternal,
+    RecommendExample, Record, ScrollRequestInternal, SingleOrList,
 };
 use collection::operations::universal_query::collection_query::{
     CollectionQueryGroupsRequest, CollectionQueryRequest,
@@ -879,7 +879,7 @@ pub async fn create_field_index(
     let field_schema = convert_field_type(field_type, field_index_params)?;
 
     let operation = CreateFieldIndex {
-        field_name,
+        field_name: SingleOrList::Single(field_name),
         field_schema,
     };
 
@@ -922,7 +922,7 @@ pub async fn create_field_index_internal(
     let result = do_create_index_internal(
         toc,
         collection_name,
-        field_name,
+        SingleOrList::Single(field_name),
         field_schema,
         clock_tag,
         shard_selection,


### PR DESCRIPTION
Allows to specify multiple payload-keys in REST API, providing foundations for joint index feature.
