### PR TITLE
Persist and propagate origin peer when bootstrapping new nodes

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -38,6 +38,8 @@ pub struct Persistent {
     /// Operations to applied, consensus consider them committed, but this peer didn't apply them yet
     #[serde(default)]
     pub apply_progress_queue: EntryApplyProgressQueue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_voter: Option<PeerId>,
     /// Last known cluster topology
     #[serde(with = "serialize_peer_addresses")]
     pub peer_address_by_id: Arc<RwLock<PeerAddressById>>,
@@ -200,6 +202,18 @@ impl Persistent {
         self.apply_progress_queue.get_last_applied()
     }
 
+    pub fn first_voter(&self) -> PeerId {
+        match self.first_voter {
+            Some(id) => id,
+            None => self.this_peer_id(),
+        }
+    }
+
+    pub fn set_first_voter(&mut self, id: PeerId) -> Result<(), StorageError> {
+        self.first_voter = Some(id);
+        self.save()
+    }
+
     pub fn peer_address_by_id(&self) -> PeerAddressById {
         self.peer_address_by_id.read().clone()
     }
@@ -244,6 +258,7 @@ impl Persistent {
                 conf_state: ConfState::from((voters, vec![])),
             },
             apply_progress_queue: Default::default(),
+            first_voter: if first_peer { Some(this_peer_id) } else { None },
             peer_address_by_id: Default::default(),
             peer_metadata_by_id: Default::default(),
             cluster_metadata: Default::default(),

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -91,9 +91,6 @@ pub struct ConsensusManager<C: CollectionContainer> {
     /// Sends messages to the consensus thread, which is defined externally, outside of the state.
     /// (e.g. in the `src/consensus.rs`)
     propose_sender: OperationSender,
-    /// Defines if this peer is a first peer of the consensus,
-    /// which might affect the init logic
-    first_voter: RwLock<Option<PeerId>>,
     /// Status of the consensus thread, changed by the consensus thread
     consensus_thread_status: RwLock<ConsensusThreadStatus>,
     /// Consensus thread errors, changed by the consensus thread
@@ -117,7 +114,6 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             toc,
             on_consensus_op_apply: Default::default(),
             propose_sender,
-            first_voter: Default::default(),
             consensus_thread_status: RwLock::new(ConsensusThreadStatus::Working {
                 last_update: Utc::now(),
             }),
@@ -194,14 +190,11 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     }
 
     pub fn first_voter(&self) -> PeerId {
-        match self.first_voter.read().as_ref() {
-            Some(id) => *id,
-            None => self.this_peer_id(),
-        }
+        self.persistent.read().first_voter()
     }
 
-    pub fn set_first_voter(&self, id: PeerId) {
-        *self.first_voter.write() = Some(id);
+    pub fn set_first_voter(&self, id: PeerId) -> Result<(), StorageError> {
+        self.persistent.write().set_first_voter(id)
     }
 
     /// Report aggregated information about the cluster.

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -442,7 +442,7 @@ impl Consensus {
         // Only first peer has itself as a voter in the initial conf state.
         // This needs to be propagated manually to other peers as it is not contained in any log entry.
         // So we skip the learner phase for the first peer.
-        state_ref.set_first_voter(all_peers.first_peer_id);
+        state_ref.set_first_voter(all_peers.first_peer_id)?;
         state_ref.set_conf_state(ConfState::from((vec![all_peers.first_peer_id], vec![])))?;
         Ok(())
     }

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -91,14 +91,34 @@ impl Raft for RaftService {
             )
             .await
             .map_err(|err| Status::internal(format!("Failed to add peer: {err}")))?;
-        let addresses = self.consensus_state.peer_address_by_id();
+
+        let mut addresses = self.consensus_state.peer_address_by_id();
+
         // Make sure that the new peer is now present in the known addresses
         if !addresses.values().contains(&uri) {
             return Err(Status::internal(format!(
                 "Failed to add peer after consensus: {uri}"
             )));
         }
+
         let first_peer_id = self.consensus_state.first_voter();
+
+        // If `first_peer_id` is not present in the list of peers, it means it was removed from
+        // cluster at some point.
+        //
+        // Before Qdrant version 1.11.6 origin peer was not committed to consensus, so if it was
+        // removed from cluster, any node added to the cluster after this would not recognize it as
+        // being part of the cluster in the past and will end up with a broken consensus state.
+        //
+        // To prevent this, we add `first_peer_id` (with a fake URI) to the list of peers.
+        //
+        // `add_peer_to_known` is used to add new peers to the cluster, and so `first_peer_id` (and
+        // its fake URI) would be removed from new peer's state shortly, while it will be synchronizing
+        // and applying past Raft log.
+        addresses
+            .entry(first_peer_id)
+            .or_insert_with(|| Uri::default());
+
         Ok(Response::new(AllPeers {
             all_peers: addresses
                 .into_iter()


### PR DESCRIPTION
Partially fixes #5138 for existing clusters (if origin peer is not yet removed).

**TODO:**
- [ ] recover origin peer ID from the WAL on existing nodes if it was not persisted earlier

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
