### PR TITLE
`set_payload`: for `null` args, set the key to `null` instead of removing it from the payload

### DIFF
--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -40,10 +40,7 @@ pub fn merge_map(
     source: &serde_json::Map<String, Value>,
 ) {
     for (key, value) in source {
-        match value {
-            Value::Null => dest.remove(key),
-            _ => dest.insert(key.to_owned(), value.to_owned()),
-        };
+        dest.insert(key.to_owned(), value.to_owned());
     }
 }
 

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -1098,6 +1098,50 @@ mod tests {
     }
 
     #[test]
+    fn test_set_value_to_json_with_null_value() {
+        let mut map = json(
+            r#"
+            {
+                "a": {
+                    "b": [
+                        { "c": 1 },
+                        { "c": 2 },
+                        { "d": { "e": 3 } }
+                    ]
+                },
+                "f": 3,
+                "g": ["g0", "g1", "g2"]
+            }
+            "#,
+        );
+
+        JsonPath::value_set(
+            Some(&JsonPath::new("a.b[0]")),
+            &mut map,
+            &json(r#"{"c":null}"#),
+        );
+
+        assert_eq!(
+            map,
+            json(
+                r#"
+                {
+                    "a": {
+                    "b": [
+                        { "c": null },
+                        { "c": 2 },
+                        { "d": { "e": 3 } }
+                    ]
+                },
+                    "f": 3,
+                    "g": ["g0", "g1", "g2"]
+                }
+                "#,
+            ),
+        );
+    }
+
+    #[test]
     fn test_set_value_to_json_with_array_index() {
         let mut map = json(
             r#"


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

I've added support for explicitly setting a key path to `null` within a payload, which differs from the current behavior of completely removing the key path when `null` is assigned. This is important for my use case, where setting a keypath to `null` carries specific meaning distinct from the key path being missing from the map. An alternative could be using a custom representation like `{ "type": "null" }`, but that feels awkward and inconsistent with how typical JSON implementations do it.

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
