### PR TITLE
Add ResultExt::context() for wrapping errors

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::service_error::Context as _;
 use common::types::ScoreType;
 use futures::{future, TryFutureExt};
 use itertools::{Either, Itertools};
@@ -161,11 +162,9 @@ impl Collection {
             _ => {
                 // Otherwise, it will be a list with a single list of scored points.
                 debug_assert_eq!(intermediates.len(), 1);
-                intermediates.pop().ok_or_else(|| {
-                    CollectionError::service_error(
-                        "Query response was expected to have one list of results.",
-                    )
-                })?
+                intermediates
+                    .pop()
+                    .context("Query response was expected to have one list of results.")?
             }
         };
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common::defaults;
+use common::service_error::Context as _;
 use parking_lot::Mutex;
 
 use super::Collection;
@@ -67,12 +68,12 @@ impl Collection {
                 .unwrap_or(shard_transfer.shard_id);
 
             let shards_holder = self.shards_holder.read().await;
-            let from_replica_set = shards_holder.get_shard(&from_shard_id).ok_or_else(|| {
-                CollectionError::service_error(format!("Shard {from_shard_id} doesn't exist"))
-            })?;
-            let to_replica_set = shards_holder.get_shard(&to_shard_id).ok_or_else(|| {
-                CollectionError::service_error(format!("Shard {to_shard_id} doesn't exist"))
-            })?;
+            let from_replica_set = shards_holder
+                .get_shard(&from_shard_id)
+                .with_context(|| format!("Shard {from_shard_id} doesn't exist"))?;
+            let to_replica_set = shards_holder
+                .get_shard(&to_shard_id)
+                .with_context(|| format!("Shard {to_shard_id} doesn't exist"))?;
             let _was_not_transferred =
                 shards_holder.register_start_shard_transfer(shard_transfer.clone())?;
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use common::cpu::CpuPermit;
 use common::disk::dir_size;
+use common::service_error::Context as _;
 use io::storage_version::StorageVersion;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
@@ -160,12 +161,11 @@ pub trait SegmentOptimizer {
         // Ensure temp_path exists
 
         if !self.temp_path().exists() {
-            std::fs::create_dir_all(self.temp_path()).map_err(|err| {
-                CollectionError::service_error(format!(
-                    "Could not create temp directory `{}`: {}",
+            std::fs::create_dir_all(self.temp_path()).with_context(|| {
+                format!(
+                    "Could not create temp directory `{}`",
                     self.temp_path().display(),
-                    err
-                ))
+                )
             })?;
         }
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -3,11 +3,11 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::service_error::Context as _;
 use common::types::ScoreType;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use ordered_float::Float;
-use segment::common::operation_error::OperationError;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
 use segment::data_types::vectors::{QueryVector, VectorStructInternal};
@@ -391,9 +391,9 @@ impl SegmentsSearcher {
         segments
             .read()
             .read_points(points, is_stopped, |id, segment| {
-                let version = segment.point_version(id).ok_or_else(|| {
-                    OperationError::service_error(format!("No version for point {id}"))
-                })?;
+                let version = segment
+                    .point_version(id)
+                    .with_context(|| format!("No version for point {id}"))?;
 
                 // If we already have the latest point version, keep that and continue
                 let version_entry = point_version.entry(id);

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicBool;
 
+use common::service_error::Context as _;
 use itertools::iproduct;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use segment::common::operation_error::{OperationError, OperationResult};
@@ -506,9 +507,9 @@ where
     let new_point_ids = ids.iter().cloned().filter(|x| !updated_points.contains(x));
 
     {
-        let default_write_segment = segments.smallest_appendable_segment().ok_or_else(|| {
-            CollectionError::service_error("No appendable segments exists, expected at least one")
-        })?;
+        let default_write_segment = segments
+            .smallest_appendable_segment()
+            .context("No appendable segments exists, expected at least one")?;
 
         let segment_arc = default_write_segment.get();
         let mut write_segment = segment_arc.write();

--- a/lib/collection/src/common/file_utils.rs
+++ b/lib/collection/src/common/file_utils.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
 
+use common::service_error::{Context as _, ServiceError, ServiceResult};
 use fs_extra::dir::CopyOptions;
 
-use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::types::CollectionResult;
 
 /// Move directory from one location to another.
 /// Handles the case when the source and destination are on different filesystems.
@@ -16,13 +17,8 @@ pub async fn move_dir(from: impl Into<PathBuf>, to: impl Into<PathBuf>) -> Colle
         // It is possible that the source and destination are on different filesystems.
         let task = tokio::task::spawn_blocking(move || {
             let options = CopyOptions::new().copy_inside(true);
-            fs_extra::dir::move_dir(&from, &to, &options).map_err(|err| {
-                CollectionError::service_error(format!(
-                    "Can't move dir from {} to {} due to {}",
-                    from.display(),
-                    to.display(),
-                    err
-                ))
+            fs_extra::dir::move_dir(&from, &to, &options).with_context(|| {
+                format!("Can't move dir from {} to {}", from.display(), to.display())
             })
         });
         task.await??;
@@ -32,7 +28,7 @@ pub async fn move_dir(from: impl Into<PathBuf>, to: impl Into<PathBuf>) -> Colle
 
 /// Move file from one location to another.
 /// Handles the case when the source and destination are on different filesystems.
-pub async fn move_file(from: impl AsRef<Path>, to: impl AsRef<Path>) -> CollectionResult<()> {
+pub async fn move_file(from: impl AsRef<Path>, to: impl AsRef<Path>) -> ServiceResult<()> {
     let from = from.as_ref();
     let to = to.as_ref();
 
@@ -45,7 +41,7 @@ pub async fn move_file(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Collecti
     // It is possible that the source and destination are on different filesystems.
     if let Err(err) = tokio::fs::copy(from, to).await {
         cleanup_file(to).await;
-        return Err(CollectionError::service_error(format!(
+        return Err(ServiceError::new(format!(
             "Can't move file from {} to {} due to {}",
             from.display(),
             to.display(),
@@ -55,7 +51,7 @@ pub async fn move_file(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Collecti
 
     if let Err(err) = tokio::fs::remove_file(from).await {
         cleanup_file(to).await;
-        return Err(CollectionError::service_error(format!(
+        return Err(ServiceError::new(format!(
             "Can't remove file {} due to {}",
             from.display(),
             err

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use common::service_error::Context as _;
 use common::tempfile_ext::MaybeTempPath;
 use object_store::aws::AmazonS3Builder;
 use serde::Deserialize;
@@ -80,9 +81,7 @@ impl SnapshotStorageManager {
                     }
                 }
                 let client: Box<dyn object_store::ObjectStore> =
-                    Box::new(builder.build().map_err(|e| {
-                        CollectionError::service_error(format!("Failed to create S3 client: {e}"))
-                    })?);
+                    Box::new(builder.build().context("Failed to create S3 client")?);
 
                 Ok(SnapshotStorageManager::S3(SnapshotStorageCloud { client }))
             }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use atomicwrites::AtomicFile;
 use atomicwrites::OverwriteBehavior::AllowOverwrite;
+use common::service_error::Context as _;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
@@ -176,9 +177,8 @@ impl CollectionConfig {
         let config_path = path.join(COLLECTION_CONFIG_FILE);
         let af = AtomicFile::new(&config_path, AllowOverwrite);
         let state_bytes = serde_json::to_vec(self).unwrap();
-        af.write(|f| f.write_all(&state_bytes)).map_err(|err| {
-            CollectionError::service_error(format!("Can't write {config_path:?}, error: {err}"))
-        })?;
+        af.write(|f| f.write_all(&state_bytes))
+            .with_context(|| format!("Can't write {config_path:?}"))?;
         Ok(())
     }
 

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use api::grpc::qdrant::qdrant_internal_client::QdrantInternalClient;
 use api::grpc::qdrant::WaitOnConsensusCommitRequest;
 use api::grpc::transport_channel_pool::{AddTimeout, TransportChannelPool};
+use common::service_error::Context as _;
 use futures::future::try_join_all;
 use futures::Future;
 use semver::Version;
@@ -87,11 +88,7 @@ impl ChannelService {
                 description: "Failed to wait for consensus commit on all peers, timed out.".into(),
             })?
             // Await consensus error
-            .map_err(|err| {
-                CollectionError::service_error(format!(
-                    "Failed to wait for consensus commit on peer: {err}"
-                ))
-            })?;
+            .context("Failed to wait for consensus commit on peer")?;
         Ok(())
     }
 
@@ -121,11 +118,7 @@ impl ChannelService {
                 client.wait_on_consensus_commit(Request::new(request)).await
             })
             .await
-            .map_err(|err| {
-                CollectionError::service_error(format!(
-                    "Failed to wait for consensus commit on peer {peer_id}: {err}"
-                ))
-            })?
+            .with_context(|| format!("Failed to wait for consensus commit on peer {peer_id}"))?
             .into_inner();
 
         // Create error if wait request failed
@@ -146,7 +139,7 @@ impl ChannelService {
             .id_to_address
             .read()
             .get(&peer_id)
-            .ok_or_else(|| CollectionError::service_error("Address for peer ID is not found."))?
+            .context("Address for peer ID is not found.")?
             .clone();
         self.channel_pool
             .with_channel(&address, |channel| {
@@ -195,10 +188,11 @@ impl ChannelService {
             .read()
             .get(&this_peer_id)
             .cloned()
-            .ok_or_else(|| {
-                CollectionError::service_error(format!(
-                    "Cannot determine REST address, this peer not found in cluster by ID {this_peer_id} ",
-                ))
+            .with_context(|| {
+                format!(
+                    "Cannot determine REST address, \
+                     this peer not found in cluster by ID {this_peer_id}",
+                )
             })?;
 
         // Construct REST URL from URI

--- a/lib/collection/src/shards/local_shard/disk_usage_watcher.rs
+++ b/lib/collection/src/shards/local_shard/disk_usage_watcher.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
+use common::service_error::Context as _;
 use tokio::sync::Mutex;
 use tokio::time::Instant;
 
-use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::types::CollectionResult;
 
 /// Defines how often the disk usage should be checked if the disk is far from being full
 const DEFAULT_FREQUENCY: usize = 128;
@@ -105,9 +106,7 @@ impl DiskUsageWatcher {
         let path = self.disk_path.clone();
         let result = tokio::task::spawn_blocking(move || fs4::available_space(path.as_path()))
             .await
-            .map_err(|e| {
-                CollectionError::service_error(format!("Failed to join async task: {e}"))
-            })?;
+            .context("Failed to join async task")?;
 
         let result = match result {
             Ok(result) => Some(result),

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use common::service_error::Context as _;
 use futures::future::try_join_all;
 use itertools::Itertools as _;
 use rand::distributions::WeightedIndex;
@@ -362,11 +363,8 @@ impl LocalShard {
             return Ok(Vec::new());
         }
         // Select points in a weighted fashion from each segment, depending on how many points each segment has.
-        let distribution = WeightedIndex::new(availability).map_err(|err| {
-            CollectionError::service_error(format!(
-                "Failed to create weighted index for random scroll: {err:?}"
-            ))
-        })?;
+        let distribution = WeightedIndex::new(availability)
+            .context("Failed to create weighted index for random scroll")?;
 
         let mut rng = StdRng::from_entropy();
         let mut random_points = HashSet::with_capacity(limit);

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common::cpu::CpuBudget;
+use common::service_error::Context as _;
 use common::types::TelemetryDetail;
 use schemars::JsonSchema;
 use segment::types::{ExtendedPointId, Filter};
@@ -461,11 +462,7 @@ impl ShardReplicaSet {
         let timed_out =
             !tokio::task::spawn_blocking(move || replica_state.wait_for(check, timeout))
                 .await
-                .map_err(|err| {
-                    CollectionError::service_error(format!(
-                        "Failed to wait for replica set state: {err}"
-                    ))
-                })?;
+                .context("Failed to wait for replica set state")?;
 
         if timed_out {
             return Err(CollectionError::service_error(

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref as _;
 use std::sync::Arc;
 
+use common::service_error::{ServiceError, ServiceResult};
 use parking_lot::Mutex;
 use segment::types::PointIdType;
 
@@ -487,10 +488,10 @@ impl ShardReplicaSet {
         local_shard.resolve_wal_delta(recovery_point).await
     }
 
-    pub async fn wal_version(&self) -> CollectionResult<Option<u64>> {
+    pub async fn wal_version(&self) -> ServiceResult<Option<u64>> {
         let local_shard_read = self.local.read().await;
         let Some(local_shard) = local_shard_read.deref() else {
-            return Err(CollectionError::service_error(
+            return Err(ServiceError::new(
                 "Cannot get WAL version, shard replica set does not have local shard",
             ));
         };

--- a/lib/collection/src/shards/resharding/stage_replicate.rs
+++ b/lib/collection/src/shards/resharding/stage_replicate.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::service_error::Context as _;
 use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use tokio::sync::RwLock;
@@ -149,11 +150,11 @@ pub(super) async fn drive(
             await_transfer_end,
         )
         .await
-        .map_err(|err| {
-            CollectionError::service_error(format!(
-                "Failed to replicate shard {} to peer {target_peer} for resharding: {err}",
+        .with_context(|| {
+            format!(
+                "Failed to replicate shard {} to peer {target_peer} for resharding",
                 reshard_key.shard_id
-            ))
+            )
         })?;
         log::debug!(
             "Shard {} successfully replicated to peer {target_peer} for resharding",

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::defaults::{self, CONSENSUS_CONFIRM_RETRIES};
+use common::service_error::Context as _;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
@@ -221,13 +222,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
         }
 
-        result.map_err(|err| {
-            CollectionError::service_error(format!(
+        Ok(result.with_context(|| {
+            format!(
                 "Failed to confirm snapshot recovered operation on consensus \
-                 after {CONSENSUS_CONFIRM_RETRIES} retries: \
-                 {err}"
-            ))
-        })
+                 after {CONSENSUS_CONFIRM_RETRIES} retries",
+            )
+        })?)
     }
 
     /// Propose to start a shard transfer
@@ -277,12 +277,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
         }
 
-        result.map_err(|err| {
-            CollectionError::service_error(format!(
+        Ok(result.with_context(|| {
+            format!(
                 "Failed to start shard transfer through consensus \
-                 after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
-            ))
-        })
+                 after {CONSENSUS_CONFIRM_RETRIES} retries",
+            )
+        })?)
     }
 
     /// Propose to restart a shard transfer with a different given configuration
@@ -332,12 +332,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
         }
 
-        result.map_err(|err| {
-            CollectionError::service_error(format!(
+        Ok(result.with_context(|| {
+            format!(
                 "Failed to restart shard transfer through consensus \
-                 after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
-            ))
-        })
+                 after {CONSENSUS_CONFIRM_RETRIES} retries",
+            )
+        })?)
     }
 
     /// Propose to abort a shard transfer
@@ -389,12 +389,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
         }
 
-        result.map_err(|err| {
-            CollectionError::service_error(format!(
+        Ok(result.with_context(|| {
+            format!(
                 "Failed to abort shard transfer through consensus \
-                 after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
-            ))
-        })
+                 after {CONSENSUS_CONFIRM_RETRIES} retries",
+            )
+        })?)
     }
 
     /// Set the shard replica state on this peer through consensus
@@ -448,12 +448,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
         }
 
-        result.map_err(|err| {
-            CollectionError::service_error(format!(
+        Ok(result.with_context(|| {
+            format!(
                 "Failed to set shard replica set state through consensus \
-                 after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
-            ))
-        })
+                 after {CONSENSUS_CONFIRM_RETRIES} retries",
+            )
+        })?)
     }
 
     /// Propose to commit the read hash ring.
@@ -503,12 +503,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
         }
 
-        result.map_err(|err| {
-            CollectionError::service_error(format!(
+        Ok(result.with_context(|| {
+            format!(
                 "Failed to commit read hashring through consensus \
-                 after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
-            ))
-        })
+                 after {CONSENSUS_CONFIRM_RETRIES} retries",
+            )
+        })?)
     }
 
     /// Propose to commit the write hash ring.
@@ -558,12 +558,12 @@ pub trait ShardTransferConsensus: Send + Sync {
             }
         }
 
-        result.map_err(|err| {
-            CollectionError::service_error(format!(
+        Ok(result.with_context(|| {
+            format!(
                 "Failed to commit write hashring through consensus \
-                 after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
-            ))
-        })
+                 after {CONSENSUS_CONFIRM_RETRIES} retries",
+            )
+        })?)
     }
 
     /// Wait for all other peers to reach the current consensus

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use common::cpu::CpuBudget;
 use common::panic;
+use common::service_error::Context as _;
 use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
 use parking_lot::Mutex;
@@ -669,11 +670,10 @@ impl UpdateHandler {
                     wait,
                 }) => {
                     let flush_res = if wait {
-                        wal.lock().flush().map_err(|err| {
-                            CollectionError::service_error(format!(
-                                "Can't flush WAL before operation {op_num} - {err}"
-                            ))
-                        })
+                        wal.lock()
+                            .flush()
+                            .with_context(|| format!("Can't flush WAL before operation {op_num}"))
+                            .map_err(Into::into)
                     } else {
                         Ok(())
                     };

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -29,6 +29,7 @@ validator = { workspace = true }
 lazy_static = "1.5.0"
 memmap2 = { workspace = true }
 semver = { workspace = true }
+thiserror = { workspace = true }
 zerocopy = { workspace = true }
 log = { workspace = true }
 
@@ -37,7 +38,6 @@ common = { path = ".", features = ["testing"] }
 criterion = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-thiserror = { workspace = true }
 thread-priority = "1.1"
 
 [[bench]]

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod iterator_ext;
 pub mod math;
 pub mod mmap_hashmap;
 pub mod panic;
+pub mod service_error;
 pub mod tar_ext;
 pub mod tempfile_ext;
 pub mod top_k;

--- a/lib/common/common/src/service_error.rs
+++ b/lib/common/common/src/service_error.rs
@@ -1,0 +1,189 @@
+use std::backtrace::Backtrace;
+
+use thiserror::Error;
+
+pub type ServiceResult<T> = Result<T, ServiceError>;
+
+#[derive(Debug, Clone, Error, Eq, PartialEq)]
+#[error("Service runtime error: {description}")]
+pub struct ServiceError {
+    pub description: String,
+    pub backtrace: Option<String>,
+}
+
+impl ServiceError {
+    pub fn new(description: impl Into<String>) -> Self {
+        Self {
+            description: description.into(),
+            backtrace: Some(Backtrace::force_capture().to_string()),
+        }
+    }
+}
+
+pub trait Context<T> {
+    /// Converts [`Result::Err`] or [`None`] into an [`ServiceError`] with an
+    /// additional context string. Keeps the original error message, but
+    /// prepends it with the `context`.
+    fn context(self, context: &str) -> Result<T, ServiceError>;
+
+    /// Similar to [`Context::context`], but the context string is evaluated
+    /// lazily.
+    fn with_context(self, context: impl FnOnce() -> String) -> Result<T, ServiceError>;
+}
+
+impl<T, E: std::error::Error + 'static> Context<T> for Result<T, E> {
+    fn context(self, context: &str) -> Result<T, ServiceError> {
+        self.map_err(|e| wrap(e, context))
+    }
+
+    fn with_context(self, context: impl FnOnce() -> String) -> Result<T, ServiceError> {
+        self.map_err(|e| wrap(e, &context()))
+    }
+}
+
+impl<T> Context<T> for Option<T> {
+    fn context(self, context: &str) -> Result<T, ServiceError> {
+        self.ok_or_else(|| ServiceError::new(context))
+    }
+
+    fn with_context(self, context: impl FnOnce() -> String) -> Result<T, ServiceError> {
+        self.ok_or_else(|| ServiceError::new(context()))
+    }
+}
+
+/// Wrap the error, prepending the `context` to the error message.
+/// Keep the original backtrace when possible.
+fn wrap(mut e: impl std::error::Error + 'static, context: &str) -> ServiceError {
+    if let Some(se) = e
+        .source()
+        .and_then(|source| source.downcast_ref::<ServiceError>())
+    {
+        return ServiceError {
+            description: format!("{context}: {}", se.description.clone()),
+            backtrace: se.backtrace.clone(),
+        };
+    }
+
+    if let Some(se) = (&mut e as &mut dyn std::error::Error).downcast_mut::<ServiceError>() {
+        return ServiceError {
+            description: format!("{context}: {}", se.description),
+            backtrace: std::mem::take(&mut se.backtrace),
+        };
+    }
+
+    ServiceError {
+        description: format!("{context}: {e}"),
+        backtrace: Some(Backtrace::force_capture().to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Error)]
+    #[allow(clippy::enum_variant_names)]
+    enum TestError {
+        #[error("IoError: {0}")]
+        IoError(#[source] std::io::Error),
+        #[error("{0}")]
+        ServiceError(#[from] ServiceError),
+        #[error("EmptyError")]
+        EmptyError,
+    }
+
+    fn err_empty() -> Result<(), TestError> {
+        Err(TestError::EmptyError)
+    }
+
+    fn err_io() -> Result<(), TestError> {
+        Err(TestError::IoError(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "io error",
+        )))
+    }
+
+    fn err_context_service(
+        context: &str,
+        e: Result<(), impl std::error::Error + 'static>,
+    ) -> Result<(), ServiceError> {
+        e.context(context)
+    }
+
+    fn err_context_aggregate(
+        context: &str,
+        e: Result<(), impl std::error::Error + 'static>,
+    ) -> Result<(), TestError> {
+        Ok(e.context(context)?)
+    }
+
+    fn check(res: Result<(), impl std::error::Error + 'static>, expected: &str) {
+        assert_eq!(res.unwrap_err().to_string(), expected);
+    }
+
+    #[test]
+    fn test_empty() {
+        check(
+            err_context_service("ctx1", err_empty()),
+            "Service runtime error: ctx1: EmptyError",
+        );
+
+        check(
+            err_context_aggregate("ctx1", err_empty()),
+            "Service runtime error: ctx1: EmptyError",
+        );
+
+        check(
+            err_context_service("ctx2", err_context_service("ctx1", err_empty())),
+            "Service runtime error: ctx2: ctx1: EmptyError",
+        );
+
+        check(
+            err_context_aggregate("ctx2", err_context_aggregate("ctx1", err_empty())),
+            "Service runtime error: ctx2: ctx1: EmptyError",
+        );
+
+        check(
+            err_context_aggregate("ctx2", err_context_service("ctx1", err_empty())),
+            "Service runtime error: ctx2: ctx1: EmptyError",
+        );
+
+        check(
+            err_context_service("ctx2", err_context_aggregate("ctx1", err_empty())),
+            "Service runtime error: ctx2: ctx1: EmptyError",
+        );
+    }
+
+    #[test]
+    fn test_aggregate() {
+        check(
+            err_context_service("ctx1", err_io()),
+            "Service runtime error: ctx1: IoError: io error",
+        );
+
+        check(
+            err_context_aggregate("ctx1", err_io()),
+            "Service runtime error: ctx1: IoError: io error",
+        );
+
+        check(
+            err_context_service("ctx2", err_context_service("ctx1", err_io())),
+            "Service runtime error: ctx2: ctx1: IoError: io error",
+        );
+
+        check(
+            err_context_aggregate("ctx2", err_context_aggregate("ctx1", err_io())),
+            "Service runtime error: ctx2: ctx1: IoError: io error",
+        );
+
+        check(
+            err_context_aggregate("ctx2", err_context_service("ctx1", err_io())),
+            "Service runtime error: ctx2: ctx1: IoError: io error",
+        );
+
+        check(
+            err_context_service("ctx2", err_context_aggregate("ctx1", err_io())),
+            "Service runtime error: ctx2: ctx1: IoError: io error",
+        );
+    }
+}

--- a/lib/segment/src/common/validate_snapshot_archive.rs
+++ b/lib/segment/src/common/validate_snapshot_archive.rs
@@ -1,17 +1,15 @@
 use std::fs::File;
 use std::path::Path;
 
+use common::service_error::Context as _;
 use tar::Archive;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 
 pub fn open_snapshot_archive_with_validation(path: &Path) -> OperationResult<Archive<File>> {
     {
-        let archive_file = File::open(path).map_err(|err| {
-            OperationError::service_error(format!(
-                "failed to open segment snapshot archive {path:?}: {err}"
-            ))
-        })?;
+        let archive_file = File::open(path)
+            .with_context(|| format!("failed to open segment snapshot archive {path:?}"))?;
         let mut ar = Archive::new(archive_file);
 
         for entry in ar.entries_with_seek()? {
@@ -39,11 +37,8 @@ pub fn open_snapshot_archive_with_validation(path: &Path) -> OperationResult<Arc
         }
     }
 
-    let archive_file = File::open(path).map_err(|err| {
-        OperationError::service_error(format!(
-            "failed to open segment snapshot archive {path:?}: {err}"
-        ))
-    })?;
+    let archive_file = File::open(path)
+        .with_context(|| format!("failed to open segment snapshot archive {path:?}"))?;
 
     let mut ar = Archive::new(archive_file);
     ar.set_overwrite(false);

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use ahash::HashMap;
 use common::mmap_hashmap::Key;
+use common::service_error::Context as _;
 use common::types::PointOffsetType;
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -240,9 +241,7 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
 
     pub fn decode_db_record(s: &str) -> OperationResult<(N::Owned, PointOffsetType)> {
         const DECODE_ERR: &str = "Index db parsing error: wrong data format";
-        let separator_pos = s
-            .rfind('/')
-            .ok_or_else(|| OperationError::service_error(DECODE_ERR))?;
+        let separator_pos = s.rfind('/').context(DECODE_ERR)?;
         if separator_pos == s.len() - 1 {
             return Err(OperationError::service_error(DECODE_ERR));
         }

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use common::service_error::Context as _;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::{DatabaseColumnWrapper, DB_PAYLOAD_CF};
 use crate::types::Payload;
@@ -28,10 +29,10 @@ impl SimplePayloadStorage {
         ));
 
         for (key, val) in db_wrapper.lock_db().iter()? {
-            let point_id: PointOffsetType = serde_cbor::from_slice(&key)
-                .map_err(|_| OperationError::service_error("cannot deserialize point id"))?;
-            let payload: Payload = serde_cbor::from_slice(&val)
-                .map_err(|_| OperationError::service_error("cannot deserialize payload"))?;
+            let point_id: PointOffsetType =
+                serde_cbor::from_slice(&key).context("cannot deserialize point id")?;
+            let payload: Payload =
+                serde_cbor::from_slice(&val).context("cannot deserialize payload")?;
             payload_map.insert(point_id, payload);
         }
 

--- a/lib/segment/src/rocksdb_backup.rs
+++ b/lib/segment/src/rocksdb_backup.rs
@@ -1,9 +1,9 @@
 use std::fs;
 use std::path::Path;
 
-use crate::common::operation_error::{OperationError, OperationResult};
+use common::service_error::{Context as _, ServiceError, ServiceResult};
 
-pub fn create(db: &rocksdb::DB, backup_path: &Path) -> OperationResult<()> {
+pub fn create(db: &rocksdb::DB, backup_path: &Path) -> ServiceResult<()> {
     if !backup_path.exists() {
         create_dir_all(backup_path)?;
     } else if !backup_path.is_dir() {
@@ -14,51 +14,35 @@ pub fn create(db: &rocksdb::DB, backup_path: &Path) -> OperationResult<()> {
 
     backup_engine(backup_path)?
         .create_new_backup(db)
-        .map_err(|err| {
-            OperationError::service_error(format!("failed to create RocksDB backup: {err}"))
-        })
+        .context("failed to create RocksDB backup")
 }
 
-pub fn restore(backup_path: &Path, restore_path: &Path) -> OperationResult<()> {
+pub fn restore(backup_path: &Path, restore_path: &Path) -> ServiceResult<()> {
     backup_engine(backup_path)?
         .restore_from_latest_backup(restore_path, restore_path, &Default::default())
-        .map_err(|err| {
-            OperationError::service_error(format!("failed to restore RocksDB backup: {err}"))
-        })
+        .context("failed to restore RocksDB backup")
 }
 
-fn backup_engine(path: &Path) -> OperationResult<rocksdb::backup::BackupEngine> {
-    let options = rocksdb::backup::BackupEngineOptions::new(path).map_err(|err| {
-        OperationError::service_error(format!(
-            "failed to create RocksDB backup engine options: {err}"
-        ))
-    })?;
-    let env = rocksdb::Env::new().map_err(|err| {
-        OperationError::service_error(format!(
-            "failed to create RocksDB backup engine environment: {err}"
-        ))
-    })?;
-    rocksdb::backup::BackupEngine::open(&options, &env).map_err(|err| {
-        OperationError::service_error(format!(
-            "failed to open RocksDB backup engine {path:?}: {err}"
-        ))
-    })
+fn backup_engine(path: &Path) -> ServiceResult<rocksdb::backup::BackupEngine> {
+    let options = rocksdb::backup::BackupEngineOptions::new(path)
+        .context("failed to create RocksDB backup engine options")?;
+
+    let env = rocksdb::Env::new().context("failed to create RocksDB backup engine environment")?;
+    rocksdb::backup::BackupEngine::open(&options, &env)
+        .with_context(|| format!("failed to open RocksDB backup engine {path:?})"))
 }
 
-fn create_dir_all(path: &Path) -> OperationResult<()> {
-    fs::create_dir_all(path).map_err(|err| {
-        OperationError::service_error(format!(
-            "failed to create RocksDB backup directory {path:?}: {err}"
-        ))
-    })
+fn create_dir_all(path: &Path) -> ServiceResult<()> {
+    fs::create_dir_all(path)
+        .with_context(|| format!("failed to create RocksDB backup directory {path:?}"))
 }
 
-fn not_a_directory_error(path: &Path) -> OperationError {
-    OperationError::service_error(format!("RocksDB backup path {path:?} is not a directory"))
+fn not_a_directory_error(path: &Path) -> ServiceError {
+    ServiceError::new(format!("RocksDB backup path {path:?} is not a directory"))
 }
 
-fn directory_not_empty_error(path: &Path) -> OperationError {
-    OperationError::service_error(format!(
+fn directory_not_empty_error(path: &Path) -> ServiceError {
+    ServiceError::new(format!(
         "RockDB backup directory {path:?} already exists and is not empty"
     ))
 }

--- a/lib/segment/src/utils/path.rs
+++ b/lib/segment/src/utils/path.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
-use crate::common::operation_error::{OperationError, OperationResult};
+use common::service_error::Context as _;
+
+use crate::common::operation_error::OperationResult;
 
 pub fn strip_prefix<'a>(path: &'a Path, prefix: &Path) -> OperationResult<&'a Path> {
-    path.strip_prefix(prefix).map_err(|err| {
-        OperationError::service_error(format!(
-            "failed to strip {prefix:?} prefix from {path:?}: {err}"
-        ))
-    })
+    Ok(path
+        .strip_prefix(prefix)
+        .with_context(|| format!("failed to strip {prefix:?} prefix from {path:?}"))?)
 }

--- a/lib/segment/src/vector_storage/async_io.rs
+++ b/lib/segment/src/vector_storage/async_io.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::fs::File;
 use std::os::fd::AsRawFd;
 
+use common::service_error::Context as _;
 use common::types::PointOffsetType;
 use io_uring::{opcode, types, IoUring};
 use memory::mmap_ops::transmute_from_u8_to_slice;
@@ -136,9 +137,10 @@ impl<T: PrimitiveVectorElement> UringReader<T> {
 
             unsafe {
                 // self.io_uring.submission().push(&read_e).unwrap();
-                io_uring.submission().push(&read_e).map_err(|err| {
-                    OperationError::service_error(format!("Failed using io-uring: {err}"))
-                })?;
+                io_uring
+                    .submission()
+                    .push(&read_e)
+                    .context("Failed using io-uring")?;
             }
         }
 

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use bitvec::prelude::{BitSlice, BitVec};
+use common::service_error::Context as _;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -134,10 +135,10 @@ fn open_simple_multi_dense_vector_storage_impl<T: PrimitiveVectorElement>(
     let db_wrapper = DatabaseColumnWrapper::new(database, database_column_name);
     db_wrapper.lock_db().iter()?;
     for (key, value) in db_wrapper.lock_db().iter()? {
-        let point_id: PointOffsetType = bincode::deserialize(&key)
-            .map_err(|_| OperationError::service_error("cannot deserialize point id from db"))?;
-        let stored_record: StoredMultiDenseVector<T> = bincode::deserialize(&value)
-            .map_err(|_| OperationError::service_error("cannot deserialize record from db"))?;
+        let point_id: PointOffsetType =
+            bincode::deserialize(&key).context("cannot deserialize point id from db")?;
+        let stored_record: StoredMultiDenseVector<T> =
+            bincode::deserialize(&value).context("cannot deserialize record from db")?;
 
         // Propagate deleted flag
         if stored_record.deleted {

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -716,9 +716,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             is_leader_established.await_ready_for_timeout(wait_timeout)
         });
 
-        let is_leader_established = await_ready_for_timeout_future
-            .await
-            .map_err(|err| StorageError::service_error(err.to_string()))?;
+        let is_leader_established = await_ready_for_timeout_future.await?;
 
         if !is_leader_established {
             return Err(StorageError::service_error(format!(

--- a/lib/storage/src/content_manager/toc/temp_directories.rs
+++ b/lib/storage/src/content_manager/toc/temp_directories.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use collection::operations::types::{CollectionError, CollectionResult};
+use collection::operations::types::CollectionResult;
+use common::service_error::Context as _;
 use tempfile::TempDir;
 
 use crate::content_manager::toc::TableOfContent;
@@ -53,12 +54,8 @@ impl TableOfContent {
         let path = self.get_snapshots_temp_path();
 
         if !path.exists() {
-            std::fs::create_dir_all(&path).map_err(|e| {
-                CollectionError::service_error(format!(
-                    "Failed to create snapshots temp directory at {}: {:?}",
-                    path.display(),
-                    e,
-                ))
+            std::fs::create_dir_all(&path).with_context(|| {
+                format!("Failed to create snapshots temp directory at {path:?}")
             })?;
         }
         Ok(path)
@@ -69,13 +66,8 @@ impl TableOfContent {
         let path = self.get_storage_temp_path();
 
         if !path.exists() {
-            std::fs::create_dir_all(&path).map_err(|e| {
-                CollectionError::service_error(format!(
-                    "Failed to create storage temp directory at {}: {:?}",
-                    path.display(),
-                    e,
-                ))
-            })?;
+            std::fs::create_dir_all(&path)
+                .with_context(|| format!("Failed to create storage temp directory at {path:?}"))?;
         }
         Ok(path)
     }
@@ -84,12 +76,8 @@ impl TableOfContent {
     pub fn optional_temp_path(&self) -> CollectionResult<Option<PathBuf>> {
         if let Some(path) = self.get_optional_temp_path() {
             if !path.exists() {
-                std::fs::create_dir_all(&path).map_err(|e| {
-                    CollectionError::service_error(format!(
-                        "Failed to create optional temp directory at {}: {:?}",
-                        path.display(),
-                        e,
-                    ))
+                std::fs::create_dir_all(&path).with_context(|| {
+                    format!("Failed to create optional temp directory at {path:?}")
                 })?;
             }
             Ok(Some(path))
@@ -128,13 +116,8 @@ impl TableOfContent {
         let upload_dir = tmp_storage_dir.join(FILE_UPLOAD_SUBDIR_NAME);
 
         if !upload_dir.exists() {
-            std::fs::create_dir_all(&upload_dir).map_err(|e| {
-                CollectionError::service_error(format!(
-                    "Failed to create upload directory at {}: {:?}",
-                    upload_dir.display(),
-                    e,
-                ))
-            })?;
+            std::fs::create_dir_all(&upload_dir)
+                .with_context(|| format!("Failed to create upload directory at {upload_dir:?}"))?;
         }
         Ok(upload_dir)
     }
@@ -159,33 +142,24 @@ impl TableOfContent {
         let optional_temp_path = self.get_optional_temp_path();
 
         if snapshots_temp_path.exists() {
-            std::fs::remove_dir_all(&snapshots_temp_path).map_err(|e| {
-                CollectionError::service_error(format!(
-                    "Failed to remove snapshots temp directory at {}: {:?}",
-                    snapshots_temp_path.display(),
-                    e,
-                ))
+            std::fs::remove_dir_all(&snapshots_temp_path).with_context(|| {
+                format!("Failed to remove snapshots temp directory at {snapshots_temp_path:?}")
             })?;
         }
 
         if storage_temp_path.exists() {
-            std::fs::remove_dir_all(&storage_temp_path).map_err(|e| {
-                CollectionError::service_error(format!(
-                    "Failed to remove storage temp directory at {}: {:?}",
-                    storage_temp_path.display(),
-                    e,
-                ))
+            std::fs::remove_dir_all(&storage_temp_path).with_context(|| {
+                format!(
+                    "Failed to remove storage temp directory at {}",
+                    storage_temp_path.display()
+                )
             })?;
         }
 
         if let Some(path) = optional_temp_path {
             if path.exists() {
-                std::fs::remove_dir_all(&path).map_err(|e| {
-                    CollectionError::service_error(format!(
-                        "Failed to remove optional temp directory at {}: {:?}",
-                        path.display(),
-                        e,
-                    ))
+                std::fs::remove_dir_all(&path).with_context(|| {
+                    format!("Failed to remove optional temp directory at {path:?}")
                 })?;
             }
         }

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use actix_web::{delete, get, post, put, web, HttpResponse};
 use actix_web_validator::Query;
 use collection::operations::verification::new_unchecked_verification_pass;
+use common::service_error::Context as _;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use storage::content_manager::consensus_ops::ConsensusOperations;
@@ -105,7 +106,7 @@ async fn get_cluster_metadata_keys(
 
         let keys = dispatcher
             .consensus_state()
-            .ok_or_else(|| StorageError::service_error("Qdrant is running in standalone mode"))?
+            .context("Qdrant is running in standalone mode")?
             .persistent
             .read()
             .get_cluster_metadata_keys();
@@ -126,7 +127,7 @@ async fn get_cluster_metadata_key(
 
         let value = dispatcher
             .consensus_state()
-            .ok_or_else(|| StorageError::service_error("Qdrant is running in standalone mode"))?
+            .context("Qdrant is running in standalone mode")?
             .persistent
             .read()
             .get_cluster_metadata_key(key.as_ref());

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -2,11 +2,11 @@ use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
+use common::service_error::Context as _;
 use itertools::Itertools;
 use storage::content_manager::collection_verification::{
     check_strict_mode, check_strict_mode_batch,
 };
-use storage::content_manager::errors::StorageError;
 use storage::dispatcher::Dispatcher;
 use tokio::time::Instant;
 
@@ -64,9 +64,7 @@ async fn query_points(
             )
             .await?
             .pop()
-            .ok_or_else(|| {
-                StorageError::service_error("Expected at least one response for one query")
-            })?
+            .context("Expected at least one response for one query")?
             .into_iter()
             .map(api::rest::ScoredPoint::from)
             .collect_vec();

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -102,10 +102,10 @@ where
 }
 
 fn log_service_error(err: &StorageError) {
-    if let StorageError::ServiceError { backtrace, .. } = err {
+    if let StorageError::ServiceError(err) = err {
         log::error!("Error processing request: {err}");
 
-        if let Some(backtrace) = backtrace {
+        if let Some(backtrace) = &err.backtrace {
             log::trace!("Backtrace: {backtrace}");
         }
     }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -34,6 +34,7 @@ use collection::operations::{
     ClockTag, CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
 use collection::shards::shard::ShardId;
+use common::service_error::Context as _;
 use schemars::JsonSchema;
 use segment::json_path::JsonPath;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, ScoredPoint, StrictModeConfig};
@@ -852,10 +853,10 @@ pub async fn do_core_search_points(
         timeout,
     )
     .await?;
-    batch_res
+    Ok(batch_res
         .into_iter()
         .next()
-        .ok_or_else(|| StorageError::service_error("Empty search result"))
+        .context("Empty search result")?)
 }
 
 pub async fn do_search_batch_points(
@@ -1063,10 +1064,7 @@ pub async fn do_query_points(
     let batch_res = toc
         .query_batch(collection_name, requests, read_consistency, access, timeout)
         .await?;
-    batch_res
-        .into_iter()
-        .next()
-        .ok_or_else(|| StorageError::service_error("Empty query result"))
+    Ok(batch_res.into_iter().next().context("Empty query result")?)
 }
 
 pub async fn do_query_batch_points(


### PR DESCRIPTION
This PR adds a shortcut to wrap arbitrary errors into `OperationError::ServiceError`.

- Old style (current `dev`):
  ```rust
  some_operation()
      .map_err(|err| OperationError::service_error(format!("Some operation failed: {err}")))?;
  ```
- New style (this PR):
  ```rust
  some_operation().context("Some operation failed")?;
  ```

Besides being more laconic, this method is also improves debuggability as it preserves the original backtrace if the wrapped error is already `ServiceError`. Inspired by [`anyhow::Context::context`] and [`snafu::ResultExt::whatever_context`].

[`anyhow::Context::context`]: https://docs.rs/anyhow/1.0.89/anyhow/trait.Context.html#tymethod.context
[`snafu::ResultExt::whatever_context`]: https://docs.rs/snafu/0.8.5/snafu/trait.ResultExt.html#tymethod.whatever_context