### PR TITLE
Fix panic on start if resharding shard is partially created

### DIFF
--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -44,15 +44,11 @@ pub async fn create_shard_dir(
     let shard_path = versioned_shard_path(collection_path, shard_id, 0);
     match tokio::fs::create_dir(&shard_path).await {
         Ok(_) => Ok(shard_path),
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::AlreadyExists {
-                Err(CollectionError::service_error(format!(
-                    "shard path already exists: {shard_path:?}"
-                )))
-            } else {
-                Err(CollectionError::from(e))
-            }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            log::warn!("Shard path already exists: {shard_path:?}");
+            Ok(shard_path)
         }
+        Err(e) => Err(CollectionError::from(e)),
     }
 }
 


### PR DESCRIPTION
Fix a panic on start if the resharding shard was only partially created on disk. This may happen if the Qdrant instance is killed midway.

More specifically, it did not panic when trying to load t he start. Instead it paniced when trying to create the shard (a second time) when replaying the resharding start operation, because the directory was already on disk.

To fix this, we allow reusing the existing directory.

### Reproduction

I can reproduce this about 50% of the time when starting two Qdrant instances locally. I start resharding and kill the both instances right away, on restart it shows the problem:

```bash
bfb -n 1000 --shards 1 --replication-factor 2

curl -s -X POST --header 'Content-Type: application/json' --data '{"start_resharding":{"direction":"up"}}' http://127.0.0.1:6333/collections/benchmark/cluster && pkill -9 qdrant
```

When this happens, we see a partial shard on disk missing `shard_config.json` (among others):

```bash
$ ls storage
segments
wal
```

<details>
<summary>Panic that appears</summary>

```
2024-10-02T07:43:43.463148Z ERROR qdrant::startup: Panic backtrace:
   0: qdrant::startup::setup_panic_hook::{{closure}}
             at ./src/startup.rs:19:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/boxed.rs:2084:9
   2: std::panicking::rust_panic_with_hook
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:808:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:674:13
   4: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:168:18
   5: rust_begin_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:665:5
   6: core::panicking::panic_fmt
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:74:14
   7: core::result::unwrap_failed
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/result.rs:1679:5
   8: core::result::Result<T,E>::expect
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/result.rs:1059:23
   9: qdrant::main
             at ./src/main.rs:318:22
  10: core::ops::function::FnOnce::call_once
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/ops/function.rs:250:5
  11: std::sys::backtrace::__rust_begin_short_backtrace
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:152:18
  12: std::rt::lang_start::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:162:18
  13: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/ops/function.rs:284:13
  14: std::panicking::try::do_call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:557:40
  15: std::panicking::try
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:521:19
  16: std::panic::catch_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panic.rs:350:14
  17: std::rt::lang_start_internal::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:141:48
  18: std::panicking::try::do_call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:557:40
  19: std::panicking::try
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:521:19
  20: std::panic::catch_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panic.rs:350:14
  21: std::rt::lang_start_internal
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:141:20
  22: std::rt::lang_start
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:161:17
  23: main
  24: __libc_start_call_main
             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  25: __libc_start_main_impl
             at ./csu/../csu/libc-start.c:360:3
  26: _start

2024-10-02T07:43:43.463215Z ERROR qdrant::startup: Panic occurred in file src/main.rs at line 330: Can't initialize consensus: Failed to apply collection meta operation entry

Caused by:
    Service internal error: shard path already exists: "/tmp/storage_2/collections/benchmark/1"
```

</details>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?