### PR TITLE
Instantly self-elect Raft leader, when cluster contains single peer

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -448,6 +448,13 @@ impl Consensus {
     }
 
     pub fn start(&mut self) -> anyhow::Result<()> {
+        // When starting first peer of a new cluster, tick a few times to establish leader instantly
+        if self.node.store().is_new_deployment() && self.node.store().peer_count() == 1 {
+            while !self.node.has_ready() {
+                self.node.tick();
+            }
+        }
+
         let tick_period = Duration::from_millis(self.config.tick_period_ms);
 
         let mut previous_tick = Instant::now();

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -448,15 +448,15 @@ impl Consensus {
     }
 
     pub fn start(&mut self) -> anyhow::Result<()> {
-        // When starting first peer of a new cluster, tick a few times to establish leader instantly
-        if self.node.store().is_new_deployment() && self.node.store().peer_count() == 1 {
+        // If this is the only peer in the cluster, tick Raft node a few times to instantly
+        // self-elect itself as Raft leader
+        if self.node.store().peer_count() == 1 {
             while !self.node.has_ready() {
                 self.node.tick();
             }
         }
 
         let tick_period = Duration::from_millis(self.config.tick_period_ms);
-
         let mut previous_tick = Instant::now();
 
         loop {


### PR DESCRIPTION
Currently, when starting first peer of a new cluster, we have to wait for a short while (a second or two) until the first peer self-elects itself as a leader. Before the leader is elected, we can't bootstrap other nodes of the cluster or create a collection.

This PR checks if we are the only peer in the cluster and if so, ticks the node few times, so that it self-elects itself as a leader instantly.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~Have you written new tests for your core changes, as applicable?~~
* [ ] ~~Have you successfully ran tests with your changes locally?~~
