### PR TITLE
Add wait parameter to cluster metadata API

### DIFF
--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -297,7 +297,7 @@ impl TableOfContent {
 
         match operation {
             ReshardingOperation::Start(key) => {
-                let consensus = match self.shard_transfer_dispatcher.lock().as_ref() {
+                let consensus = match self.toc_dispatcher.lock().as_ref() {
                     Some(consensus) => Box::new(consensus.clone()),
                     None => {
                         return Err(StorageError::service_error(
@@ -395,7 +395,7 @@ impl TableOfContent {
         };
         let key = resharding_state.key();
 
-        let consensus = match self.shard_transfer_dispatcher.lock().as_ref() {
+        let consensus = match self.toc_dispatcher.lock().as_ref() {
             Some(consensus) => Box::new(consensus.clone()),
             None => {
                 return Err(StorageError::service_error(
@@ -512,7 +512,7 @@ impl TableOfContent {
                     }
                 };
 
-                let shard_consensus = match self.shard_transfer_dispatcher.lock().as_ref() {
+                let shard_consensus = match self.toc_dispatcher.lock().as_ref() {
                     Some(consensus) => Box::new(consensus.clone()),
                     None => {
                         return Err(StorageError::service_error(

--- a/lib/storage/src/content_manager/toc/dispatcher.rs
+++ b/lib/storage/src/content_manager/toc/dispatcher.rs
@@ -1,0 +1,28 @@
+use std::sync::Weak;
+
+use super::TableOfContent;
+use crate::content_manager::consensus_manager::ConsensusStateRef;
+
+#[derive(Clone)]
+pub struct TocDispatcher {
+    /// Reference to table of contents
+    ///
+    /// This dispatcher is stored inside the table of contents after construction. It therefore
+    /// uses a weak reference to avoid a reference cycle which would prevent dropping the table of
+    /// contents on exit.
+    pub(super) toc: Weak<TableOfContent>,
+    pub(super) consensus_state: ConsensusStateRef,
+}
+
+impl TocDispatcher {
+    pub fn new(toc: Weak<TableOfContent>, consensus_state: ConsensusStateRef) -> Self {
+        Self {
+            toc,
+            consensus_state,
+        }
+    }
+
+    pub fn consensus_state(&self) -> &ConsensusStateRef {
+        &self.consensus_state
+    }
+}

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -21,8 +21,8 @@ use collection::collection::{Collection, RequestShardTransfer};
 use collection::config::{default_replication_factor, CollectionConfig};
 use collection::operations::types::*;
 use collection::shards::channel_service::ChannelService;
-use collection::shards::replica_set::{AbortShardTransfer, ReplicaState};
 use collection::shards::replica_set;
+use collection::shards::replica_set::{AbortShardTransfer, ReplicaState};
 use collection::shards::shard::{PeerId, ShardId};
 use collection::telemetry::CollectionTelemetry;
 use common::cpu::{get_num_cpus, CpuBudget};
@@ -408,10 +408,9 @@ impl TableOfContent {
         let operation = ConsensusOperations::UpdateClusterMetadata { key, value };
 
         if wait {
-            let dispatcher = self.toc_dispatcher
-                .lock()
-                .clone()
-                .ok_or_else(|| StorageError::service_error("Qdrant is running in standalone mode"))?;
+            let dispatcher = self.toc_dispatcher.lock().clone().ok_or_else(|| {
+                StorageError::service_error("Qdrant is running in standalone mode")
+            })?;
             dispatcher
                 .consensus_state()
                 .propose_consensus_op_with_await(operation, None)
@@ -420,8 +419,7 @@ impl TableOfContent {
                     StorageError::service_error(format!("Failed to propose and confirm metadata update operation through consensus: {err}"))
                 })?;
         } else {
-            self.get_consensus_proposal_sender()?
-                .send(operation)?;
+            self.get_consensus_proposal_sender()?.send(operation)?;
         }
 
         Ok(())

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -402,9 +402,9 @@ impl TableOfContent {
         &self,
         key: String,
         value: serde_json::Value,
+        wait: bool,
     ) -> Result<(), StorageError> {
         let operation = ConsensusOperations::UpdateClusterMetadata { key, value };
-        let wait = false;
 
         if wait {
             let dispatcher = self.shard_transfer_dispatcher

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,5 +1,3 @@
-use std::sync::Weak;
-
 use async_trait::async_trait;
 use collection::operations::types::{CollectionError, CollectionResult};
 use collection::shards::replica_set::ReplicaState;
@@ -8,35 +6,14 @@ use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::transfer::{ShardTransfer, ShardTransferConsensus, ShardTransferKey};
 use collection::shards::CollectionId;
 
-use super::TableOfContent;
 use crate::content_manager::collection_meta_ops::{
     CollectionMetaOperations, ReshardingOperation, ShardTransferOperations,
 };
-use crate::content_manager::consensus_manager::ConsensusStateRef;
 use crate::content_manager::consensus_ops::ConsensusOperations;
-
-#[derive(Clone)]
-pub struct ShardTransferDispatcher {
-    /// Reference to table of contents
-    ///
-    /// This dispatcher is stored inside the table of contents after construction. It therefore
-    /// uses a weak reference to avoid a reference cycle which would prevent dropping the table of
-    /// contents on exit.
-    toc: Weak<TableOfContent>,
-    consensus_state: ConsensusStateRef,
-}
-
-impl ShardTransferDispatcher {
-    pub fn new(toc: Weak<TableOfContent>, consensus_state: ConsensusStateRef) -> Self {
-        Self {
-            toc,
-            consensus_state,
-        }
-    }
-}
+use super::dispatcher::TocDispatcher;
 
 #[async_trait]
-impl ShardTransferConsensus for ShardTransferDispatcher {
+impl ShardTransferConsensus for TocDispatcher {
     fn this_peer_id(&self) -> PeerId {
         self.consensus_state.this_peer_id()
     }

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -6,11 +6,11 @@ use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::transfer::{ShardTransfer, ShardTransferConsensus, ShardTransferKey};
 use collection::shards::CollectionId;
 
+use super::dispatcher::TocDispatcher;
 use crate::content_manager::collection_meta_ops::{
     CollectionMetaOperations, ReshardingOperation, ShardTransferOperations,
 };
 use crate::content_manager::consensus_ops::ConsensusOperations;
-use super::dispatcher::TocDispatcher;
 
 #[async_trait]
 impl ShardTransferConsensus for TocDispatcher {

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -3,7 +3,8 @@ use std::future::Future;
 use actix_web::{delete, get, post, put, web, HttpResponse};
 use actix_web_validator::Query;
 use collection::operations::verification::new_unchecked_verification_pass;
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use storage::content_manager::consensus_ops::ConsensusOperations;
 use storage::content_manager::errors::StorageError;
 use storage::dispatcher::Dispatcher;
@@ -20,6 +21,12 @@ struct QueryParams {
     #[serde(default)]
     #[validate(range(min = 1))]
     timeout: Option<u64>,
+}
+
+#[derive(Deserialize, Serialize, JsonSchema, Validate)]
+pub struct MetadataParams {
+    #[serde(default)]
+    pub wait: bool,
 }
 
 #[get("/cluster")]
@@ -134,6 +141,7 @@ async fn update_cluster_metadata_key(
     dispatcher: web::Data<Dispatcher>,
     ActixAccess(access): ActixAccess,
     key: web::Path<String>,
+    params: Query<MetadataParams>,
     value: web::Json<serde_json::Value>,
 ) -> HttpResponse {
     // Not a collection level request.
@@ -142,7 +150,7 @@ async fn update_cluster_metadata_key(
         let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
-        toc.update_cluster_metadata(key.into_inner(), value.into_inner()).await?;
+        toc.update_cluster_metadata(key.into_inner(), value.into_inner(), params.wait).await?;
         Ok(true)
     })
     .await
@@ -153,6 +161,7 @@ async fn delete_cluster_metadata_key(
     dispatcher: web::Data<Dispatcher>,
     ActixAccess(access): ActixAccess,
     key: web::Path<String>,
+    params: Query<MetadataParams>,
 ) -> HttpResponse {
     // Not a collection level request.
     let pass = new_unchecked_verification_pass();
@@ -160,7 +169,7 @@ async fn delete_cluster_metadata_key(
         let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
-        toc.update_cluster_metadata(key.into_inner(), serde_json::Value::Null).await?;
+        toc.update_cluster_metadata(key.into_inner(), serde_json::Value::Null, params.wait).await?;
         Ok(true)
     })
     .await

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -142,7 +142,7 @@ async fn update_cluster_metadata_key(
         let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
-        toc.update_cluster_metadata(key.into_inner(), value.into_inner())?;
+        toc.update_cluster_metadata(key.into_inner(), value.into_inner()).await?;
         Ok(true)
     })
     .await
@@ -160,7 +160,7 @@ async fn delete_cluster_metadata_key(
         let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
-        toc.update_cluster_metadata(key.into_inner(), serde_json::Value::Null)?;
+        toc.update_cluster_metadata(key.into_inner(), serde_json::Value::Null).await?;
         Ok(true)
     })
     .await

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -150,7 +150,8 @@ async fn update_cluster_metadata_key(
         let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
-        toc.update_cluster_metadata(key.into_inner(), value.into_inner(), params.wait).await?;
+        toc.update_cluster_metadata(key.into_inner(), value.into_inner(), params.wait)
+            .await?;
         Ok(true)
     })
     .await
@@ -169,7 +170,8 @@ async fn delete_cluster_metadata_key(
         let toc = dispatcher.toc(&access, &pass);
         access.check_global_access(AccessRequirements::new().write())?;
 
-        toc.update_cluster_metadata(key.into_inner(), serde_json::Value::Null, params.wait).await?;
+        toc.update_cluster_metadata(key.into_inner(), serde_json::Value::Null, params.wait)
+            .await?;
         Ok(true)
     })
     .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use startup::setup_panic_hook;
 use storage::content_manager::consensus::operation_sender::OperationSender;
 use storage::content_manager::consensus::persistent::Persistent;
 use storage::content_manager::consensus_manager::{ConsensusManager, ConsensusStateRef};
-use storage::content_manager::toc::transfer::ShardTransferDispatcher;
+use storage::content_manager::toc::dispatcher::TocDispatcher;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::Access;
@@ -290,9 +290,9 @@ fn main() -> anyhow::Result<()> {
 
         dispatcher = dispatcher.with_consensus(consensus_state.clone());
 
-        let shard_transfer_dispatcher =
-            ShardTransferDispatcher::new(Arc::downgrade(&toc_arc), consensus_state.clone());
-        toc_arc.with_shard_transfer_dispatcher(shard_transfer_dispatcher);
+        let toc_dispatcher =
+            TocDispatcher::new(Arc::downgrade(&toc_arc), consensus_state.clone());
+        toc_arc.with_toc_dispatcher(toc_dispatcher);
 
         let dispatcher_arc = Arc::new(dispatcher);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,8 +290,7 @@ fn main() -> anyhow::Result<()> {
 
         dispatcher = dispatcher.with_consensus(consensus_state.clone());
 
-        let toc_dispatcher =
-            TocDispatcher::new(Arc::downgrade(&toc_arc), consensus_state.clone());
+        let toc_dispatcher = TocDispatcher::new(Arc::downgrade(&toc_arc), consensus_state.clone());
         toc_arc.with_toc_dispatcher(toc_dispatcher);
 
         let dispatcher_arc = Arc::new(dispatcher);


### PR DESCRIPTION
Add a wait parameter to the cluster metadata API. This is desirable for resharding, because without it, data races are very likely on this interface.

If wait=true is set, the metadata API will wait for consensus to confirm the message before responding.

Along with this the PR has quite some refactoring going on as well to make it work with the consensus reference needed for this change.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?