### PR TITLE
Introduce SnapshotFormat

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -6,6 +6,7 @@ use common::tar_ext::BuilderExt;
 use io::file_operations::read_json;
 use io::storage_version::StorageVersion as _;
 use segment::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
+use segment::types::SnapshotFormat;
 
 use super::Collection;
 use crate::collection::payload_index_schema::PAYLOAD_INDEX_CONFIG_FILE;
@@ -102,6 +103,7 @@ impl Collection {
                     .create_snapshot(
                         snapshot_temp_temp_dir.path(),
                         &tar.descend(&shard_snapshot_path)?,
+                        SnapshotFormat::Regular,
                         save_wal,
                     )
                     .await

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -18,7 +18,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
-use segment::types::{Payload, PointIdType, SegmentConfig, SeqNumberType};
+use segment::types::{Payload, PointIdType, SegmentConfig, SeqNumberType, SnapshotFormat};
 
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
@@ -1156,6 +1156,7 @@ impl<'s> SegmentHolder {
         payload_index_schema: &PayloadIndexSchema,
         temp_dir: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
     ) -> OperationResult<()> {
         // Snapshotting may take long-running read locks on segments blocking incoming writes, do
         // this through proxied segments to allow writes to continue.
@@ -1168,7 +1169,7 @@ impl<'s> SegmentHolder {
             payload_index_schema,
             |segment| {
                 let read_segment = segment.read();
-                read_segment.take_snapshot(temp_dir, tar, &mut snapshotted_segments)?;
+                read_segment.take_snapshot(temp_dir, tar, format, &mut snapshotted_segments)?;
                 Ok(())
             },
         )
@@ -1654,6 +1655,7 @@ mod tests {
             &PayloadIndexSchema::default(),
             temp_dir.path(),
             &tar,
+            SnapshotFormat::Regular,
         )
         .unwrap();
 

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -7,7 +7,8 @@ use common::tar_ext;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
+    ExtendedPointId, Filter, ScoredPoint, SnapshotFormat, WithPayload, WithPayloadInterface,
+    WithVector,
 };
 use tokio::runtime::Handle;
 
@@ -36,6 +37,7 @@ impl DummyShard {
         &self,
         _temp_path: &Path,
         _tar: &tar_ext::BuilderExt,
+        _format: SnapshotFormat,
         _save_wal: bool,
     ) -> CollectionResult<()> {
         self.dummy()

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -8,8 +8,8 @@ use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
-    ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
-    WithVector,
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, SnapshotFormat, WithPayload,
+    WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
@@ -192,10 +192,11 @@ impl ForwardProxyShard {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.wrapped_shard
-            .create_snapshot(temp_path, tar, save_wal)
+            .create_snapshot(temp_path, tar, format, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -29,7 +29,7 @@ use segment::segment::Segment;
 use segment::segment_constructor::{build_segment, load_segment};
 use segment::types::{
     CompressionRatio, Filter, PayloadIndexInfo, PayloadKeyType, PayloadStorageType, PointIdType,
-    QuantizationConfig, SegmentConfig, SegmentType,
+    QuantizationConfig, SegmentConfig, SegmentType, SnapshotFormat,
 };
 use segment::utils::mem::Mem;
 use tokio::fs::{create_dir_all, remove_dir_all, remove_file};
@@ -781,6 +781,7 @@ impl LocalShard {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         save_wal: bool,
     ) -> CollectionResult<()> {
         let segments = self.segments.clone();
@@ -811,6 +812,7 @@ impl LocalShard {
                 &payload_index_schema.read().clone(),
                 &temp_path,
                 &tar_c.descend(Path::new(SEGMENTS_PATH))?,
+                format,
             )?;
 
             if save_wal {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -10,8 +10,8 @@ use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
-    ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
-    WithVector,
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, SnapshotFormat, WithPayload,
+    WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
 use tokio::sync::{oneshot, RwLock};
@@ -72,10 +72,11 @@ impl ProxyShard {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.wrapped_shard
-            .create_snapshot(temp_path, tar, save_wal)
+            .create_snapshot(temp_path, tar, format, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -10,7 +10,8 @@ use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
+    ExtendedPointId, Filter, ScoredPoint, SnapshotFormat, WithPayload, WithPayloadInterface,
+    WithVector,
 };
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
@@ -125,11 +126,12 @@ impl QueueProxyShard {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.inner_unchecked()
             .wrapped_shard
-            .create_snapshot(temp_path, tar, save_wal)
+            .create_snapshot(temp_path, tar, format, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -2,6 +2,7 @@ use std::ops::Deref as _;
 use std::path::Path;
 
 use common::tar_ext;
+use segment::types::SnapshotFormat;
 
 use super::{ReplicaSetState, ReplicaState, ShardReplicaSet, REPLICA_STATE_FILE};
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -16,12 +17,15 @@ impl ShardReplicaSet {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         save_wal: bool,
     ) -> CollectionResult<()> {
         let local_read = self.local.read().await;
 
         if let Some(local) = &*local_read {
-            local.create_snapshot(temp_path, tar, save_wal).await?
+            local
+                .create_snapshot(temp_path, tar, format, save_wal)
+                .await?
         }
 
         self.replica_state

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use common::tar_ext;
 use common::types::TelemetryDetail;
+use segment::types::SnapshotFormat;
 
 use super::local_shard::clock_map::RecoveryPoint;
 use super::update_tracker::UpdateTracker;
@@ -86,23 +87,34 @@ impl Shard {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         save_wal: bool,
     ) -> CollectionResult<()> {
         match self {
             Shard::Local(local_shard) => {
-                local_shard.create_snapshot(temp_path, tar, save_wal).await
+                local_shard
+                    .create_snapshot(temp_path, tar, format, save_wal)
+                    .await
             }
             Shard::Proxy(proxy_shard) => {
-                proxy_shard.create_snapshot(temp_path, tar, save_wal).await
+                proxy_shard
+                    .create_snapshot(temp_path, tar, format, save_wal)
+                    .await
             }
             Shard::ForwardProxy(proxy_shard) => {
-                proxy_shard.create_snapshot(temp_path, tar, save_wal).await
+                proxy_shard
+                    .create_snapshot(temp_path, tar, format, save_wal)
+                    .await
             }
             Shard::QueueProxy(proxy_shard) => {
-                proxy_shard.create_snapshot(temp_path, tar, save_wal).await
+                proxy_shard
+                    .create_snapshot(temp_path, tar, format, save_wal)
+                    .await
             }
             Shard::Dummy(dummy_shard) => {
-                dummy_shard.create_snapshot(temp_path, tar, save_wal).await
+                dummy_shard
+                    .create_snapshot(temp_path, tar, format, save_wal)
+                    .await
             }
         }
     }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -12,7 +12,7 @@ use common::tar_ext::BuilderExt;
 use futures::Future;
 use itertools::Itertools;
 use segment::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
-use segment::types::ShardKey;
+use segment::types::{ShardKey, SnapshotFormat};
 use tokio::runtime::Handle;
 use tokio::sync::{broadcast, RwLock};
 
@@ -873,7 +873,12 @@ impl ShardHolder {
         let tar = BuilderExt::new(File::create(temp_file.path())?);
 
         shard
-            .create_snapshot(snapshot_temp_dir.path(), &tar, false)
+            .create_snapshot(
+                snapshot_temp_dir.path(),
+                &tar,
+                SnapshotFormat::Regular,
+                false,
+            )
             .await?;
 
         let snapshot_temp_dir_path = snapshot_temp_dir.path().to_path_buf();

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -16,8 +16,8 @@ use crate::json_path::JsonPath;
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PointIdType,
-    ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType, WithPayload,
-    WithVector,
+    ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
+    SnapshotFormat, WithPayload, WithVector,
 };
 
 /// Define all operations which can be performed with Segment or Segment-like entity.
@@ -274,6 +274,7 @@ pub trait SegmentEntry {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()>;
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -29,7 +29,7 @@ use crate::telemetry::SegmentTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadIndexInfo, PayloadKeyType, PayloadKeyTypeRef,
     PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
-    VectorDataInfo, WithPayload, WithVector,
+    SnapshotFormat, VectorDataInfo, WithPayload, WithVector,
 };
 use crate::utils;
 use crate::vector_storage::VectorStorage;
@@ -731,8 +731,16 @@ impl SegmentEntry for Segment {
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
+        format: SnapshotFormat,
         snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()> {
+        if format != SnapshotFormat::Regular {
+            debug_assert!(false, "Unsupported snapshot format");
+            return Err(OperationError::service_error(
+                "Unsupported snapshot format".to_string(),
+            ));
+        }
+
         let segment_id = self
             .current_path
             .file_stem()

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -25,7 +25,7 @@ use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::types::{
     Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointIdType,
-    SegmentState, SeqNumberType,
+    SegmentState, SeqNumberType, SnapshotFormat,
 };
 use crate::utils;
 use crate::utils::fs::find_symlink;
@@ -441,6 +441,8 @@ impl Segment {
         let snapshot_path = segment_path.join(SNAPSHOT_PATH);
 
         if snapshot_path.exists() {
+            log::info!("Snapshot format: {:?}", SnapshotFormat::Regular);
+
             let db_backup_path = snapshot_path.join(DB_BACKUP_PATH);
             let payload_index_db_backup = snapshot_path.join(PAYLOAD_DB_BACKUP_PATH);
 
@@ -469,7 +471,7 @@ impl Segment {
                 ))
             })?;
         } else {
-            log::info!("Attempt to restore legacy snapshot format");
+            log::info!("Snapshot format: {:?}", SnapshotFormat::Ancient);
             // Do nothing, legacy format is just plain archive
         }
 

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -13,8 +13,8 @@ use crate::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use crate::entry::entry_point::SegmentEntry;
 use crate::segment_constructor::{build_segment, load_segment};
 use crate::types::{
-    Distance, Filter, Indexes, Payload, SegmentConfig, VectorDataConfig, VectorStorageType,
-    WithPayload, WithVector,
+    Distance, Filter, Indexes, Payload, SegmentConfig, SnapshotFormat, VectorDataConfig,
+    VectorStorageType, WithPayload, WithVector,
 };
 
 #[test]
@@ -221,7 +221,12 @@ fn test_snapshot() {
     // snapshotting!
     let tar = tar_ext::BuilderExt::new(File::create(&snapshot_name).unwrap());
     segment
-        .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
+        .take_snapshot(
+            temp_dir.path(),
+            &tar,
+            SnapshotFormat::Regular,
+            &mut HashSet::new(),
+        )
         .unwrap();
     tar.blocking_finish().unwrap();
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2420,6 +2420,73 @@ impl Filter {
     }
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SnapshotFormat {
+    /// Created by Qdrant `<0.11.0`.
+    ///
+    /// The collection snapshot contains nested tar archives for segments.
+    /// Segment tar archives contain a plain copy of the segment directory.
+    ///
+    /// ```plaintext
+    /// ./0/segments/
+    /// ├── 0b31e274-dc65-40e4-8493-67ebed4bcf10.tar
+    /// │   ├── segment.json
+    /// │   ├── CURRENT
+    /// │   ├── 000009.sst
+    /// │   ├── 000010.sst
+    /// │   └── …
+    /// ├── 1d6c96ec-7965-491a-9c45-362d55361e9b.tar
+    /// └── …
+    /// ```
+    Ancient,
+    /// Qdrant `>=0.11.0` `<=1.13` (and maybe even later).
+    ///
+    /// The collection snapshot contains nested tar archives for segments.
+    /// Distinguished by a single top-level directory `snapshot` in each segment
+    /// tar archive. RocksDB data stored as backups and requires unpacking
+    /// procedure.
+    ///
+    /// ```plaintext
+    /// ./0/segments/
+    /// ├── 0b31e274-dc65-40e4-8493-67ebed4bcf10.tar
+    /// │   └── snapshot/                               # single top-level dir
+    /// │       ├── db_backup/                          # rockdb backup
+    /// │       │   ├── meta/
+    /// │       │   ├── private/
+    /// │       │   └── shared_checksum/
+    /// │       ├── payload_index_db_backup             # rocksdb backup
+    /// │       │   ├── meta/
+    /// │       │   ├── private/
+    /// │       │   └── shared_checksum/
+    /// │       └── files/                              # regular files
+    /// │           ├── segment.json
+    /// │           └── …
+    /// ├── 1d6c96ec-7965-491a-9c45-362d55361e9b.tar
+    /// └── …
+    /// ```
+    Regular,
+    /// New experimental format.
+    ///
+    /// ```plaintext
+    /// ./0/segments/
+    /// ├── 0b31e274-dc65-40e4-8493-67ebed4bcf10/
+    /// │   ├── db_backup/                              # rockdb backup
+    /// │   │   ├── meta/
+    /// │   │   ├── private/
+    /// │   │   └── shared_checksum/
+    /// │   ├── payload_index_db_backup                 # rocksdb backup
+    /// │   │   ├── meta/
+    /// │   │   ├── private/
+    /// │   │   └── shared_checksum/
+    /// │   └── files/                                  # regular files
+    /// │       ├── segment.json
+    /// │       └── …
+    /// ├── 1d6c96ec-7965-491a-9c45-362d55361e9b/
+    /// └── …
+    /// ```
+    Streamable,
+}
+
 #[cfg(test)]
 pub(crate) mod test_utils {
     use super::{GeoLineString, GeoPoint, GeoPolygon};

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -15,7 +15,7 @@ use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::{build_segment, load_segment};
 use segment::types::{
     Distance, HnswConfig, Indexes, PayloadFieldSchema, PayloadSchemaParams, PayloadStorageType,
-    SegmentConfig, VectorDataConfig, VectorStorageType,
+    SegmentConfig, SnapshotFormat, VectorDataConfig, VectorStorageType,
 };
 use tempfile::Builder;
 
@@ -139,7 +139,12 @@ fn test_on_disk_segment_snapshot() {
     // take snapshot
     let tar = tar_ext::BuilderExt::new(File::create(&snapshot_name).unwrap());
     segment
-        .take_snapshot(temp_dir.path(), &tar, &mut HashSet::new())
+        .take_snapshot(
+            temp_dir.path(),
+            &tar,
+            SnapshotFormat::Regular,
+            &mut HashSet::new(),
+        )
         .unwrap();
     tar.blocking_finish().unwrap();
 


### PR DESCRIPTION
This PR introduces `enum SnapshotFormat`. The usage in this PR is minimal:
- Passed across `create_snapshot()` invocations.
- The name appears in log output during unpacking.

In subsequent PRs it will be used to control the format of resulting snapshots.