### PR TITLE
Dont consider resharding shards as unhealthy for /readyz

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1072,18 +1072,17 @@ pub enum ReplicaState {
 }
 
 impl ReplicaState {
-    /// Check whether the replica state is active or listener.
-    pub fn is_active_or_listener(self) -> bool {
+    /// Check whether the replica state is active or listener or resharding.
+    pub fn is_active_or_listener_or_resharding(self) -> bool {
         // Use explicit match, to catch future changes to `ReplicaState`
         match self {
-            ReplicaState::Active | ReplicaState::Listener => true,
+            ReplicaState::Active | ReplicaState::Listener | ReplicaState::Resharding => true,
 
             ReplicaState::Dead
             | ReplicaState::Initializing
             | ReplicaState::Partial
             | ReplicaState::PartialSnapshot
-            | ReplicaState::Recovery
-            | ReplicaState::Resharding => false,
+            | ReplicaState::Recovery => false,
         }
     }
 

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use std::{panic, thread};
 
 use api::grpc::qdrant::qdrant_internal_client::QdrantInternalClient;
-use api::grpc::qdrant::{GetConsensusCommitRequest, GetConsensusCommitResponse};
+use api::grpc::qdrant::{GetConsensusCommitRequest, GetConsensusCommitResponse, ReplicaState};
 use api::grpc::transport_channel_pool::{self, TransportChannelPool};
 use collection::shards::shard::ShardId;
 use collection::shards::CollectionId;
@@ -292,6 +292,10 @@ impl Task {
             .commit
     }
 
+    /// List shards that are unhealthy, which may undergo automatic recovery.
+    ///
+    /// Shards in resharding state are not considered unhealthy and are excluded here.
+    /// They require an external driver to make them active or to drop them.
     async fn unhealthy_shards(&self) -> HashSet<Shard> {
         let this_peer_id = self.toc.this_peer_id;
         let collections = self
@@ -312,7 +316,7 @@ impl Task {
                     continue;
                 };
 
-                if state.is_active_or_listener() {
+                if state.is_active_or_listener_or_resharding() {
                     continue;
                 }
 

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use std::{panic, thread};
 
 use api::grpc::qdrant::qdrant_internal_client::QdrantInternalClient;
-use api::grpc::qdrant::{GetConsensusCommitRequest, GetConsensusCommitResponse, ReplicaState};
+use api::grpc::qdrant::{GetConsensusCommitRequest, GetConsensusCommitResponse};
 use api::grpc::transport_channel_pool::{self, TransportChannelPool};
 use collection::shards::shard::ShardId;
 use collection::shards::CollectionId;


### PR DESCRIPTION
Shards that are under resharding can block scaling the cluster forever because the pod will consider itself as not ready. So our infra will not trigger any operations to scale the cluster.

```
$ curl -i localhost:6333/readyz
HTTP/1.1 503 Service Unavailable
content-length: 25
content-type: text/plain; charset=utf-8
vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
date: Tue, 08 Oct 2024 12:28:01 GMT

some shards are not ready
```

This PR fixes this situation by considering resharding shards as healthy. So `/readyz` returns Healthy state

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
