### PR TITLE
Promote iter function to payload storage interface

### DIFF
--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use common::types::PointOffsetType;
 
-use crate::common::operation_error::OperationResult;
 use crate::types::Payload;
 
 /// Same as `SimplePayloadStorage` but without persistence
@@ -15,18 +14,5 @@ pub struct InMemoryPayloadStorage {
 impl InMemoryPayloadStorage {
     pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
         self.payload.get(&point_id)
-    }
-
-    pub fn iter<F>(&self, mut callback: F) -> OperationResult<()>
-    where
-        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
-    {
-        for (key, val) in self.payload.iter() {
-            let do_continue = callback(*key, val)?;
-            if !do_continue {
-                return Ok(());
-            }
-        }
-        Ok(())
     }
 }

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -73,6 +73,19 @@ impl PayloadStorage for InMemoryPayloadStorage {
     fn flusher(&self) -> Flusher {
         Box::new(|| Ok(()))
     }
+
+    fn iter<F>(&self, mut callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
+    {
+        for (key, val) in self.payload.iter() {
+            let do_continue = callback(*key, val)?;
+            if !do_continue {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -52,22 +52,6 @@ impl OnDiskPayloadStorage {
             .transpose()
             .map_err(OperationError::from)
     }
-
-    pub fn iter<F>(&self, mut callback: F) -> OperationResult<()>
-    where
-        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
-    {
-        for (key, val) in self.db_wrapper.lock_db().iter()? {
-            let do_continue = callback(
-                serde_cbor::from_slice(&key)?,
-                &serde_cbor::from_slice(&val)?,
-            )?;
-            if !do_continue {
-                return Ok(());
-            }
-        }
-        Ok(())
-    }
 }
 
 impl PayloadStorage for OnDiskPayloadStorage {
@@ -142,5 +126,21 @@ impl PayloadStorage for OnDiskPayloadStorage {
 
     fn flusher(&self) -> Flusher {
         self.db_wrapper.flusher()
+    }
+
+    fn iter<F>(&self, mut callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
+    {
+        for (key, val) in self.db_wrapper.lock_db().iter()? {
+            let do_continue = callback(
+                serde_cbor::from_slice(&key)?,
+                &serde_cbor::from_slice(&val)?,
+            )?;
+            if !do_continue {
+                return Ok(());
+            }
+        }
+        Ok(())
     }
 }

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -36,6 +36,14 @@ pub trait PayloadStorage {
 
     /// Return function that forces persistence of current storage state.
     fn flusher(&self) -> Flusher;
+
+    /// Iterate over all stored payload and apply the provided callback.
+    /// Stop iteration if callback returns false or error.
+    ///
+    /// Required for building payload index.
+    fn iter<F>(&self, callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>;
 }
 
 pub trait ConditionChecker {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -38,20 +38,6 @@ impl From<OnDiskPayloadStorage> for PayloadStorageEnum {
     }
 }
 
-impl PayloadStorageEnum {
-    pub fn iter<F>(&self, callback: F) -> OperationResult<()>
-    where
-        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
-    {
-        match self {
-            #[cfg(feature = "testing")]
-            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.iter(callback),
-            PayloadStorageEnum::SimplePayloadStorage(s) => s.iter(callback),
-            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.iter(callback),
-        }
-    }
-}
-
 impl PayloadStorage for PayloadStorageEnum {
     fn overwrite(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         match self {
@@ -127,6 +113,18 @@ impl PayloadStorage for PayloadStorageEnum {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.flusher(),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.flusher(),
             PayloadStorageEnum::OnDiskPayloadStorage(s) => s.flusher(),
+        }
+    }
+
+    fn iter<F>(&self, callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
+    {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.iter(callback),
+            PayloadStorageEnum::SimplePayloadStorage(s) => s.iter(callback),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.iter(callback),
         }
     }
 }

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -56,17 +56,4 @@ impl SimplePayloadStorage {
     pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
         self.payload.get(&point_id)
     }
-
-    pub fn iter<F>(&self, mut callback: F) -> OperationResult<()>
-    where
-        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
-    {
-        for (key, val) in self.payload.iter() {
-            let do_continue = callback(*key, val)?;
-            if !do_continue {
-                return Ok(());
-            }
-        }
-        Ok(())
-    }
 }

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -85,6 +85,19 @@ impl PayloadStorage for SimplePayloadStorage {
     fn flusher(&self) -> Flusher {
         self.db_wrapper.flusher()
     }
+
+    fn iter<F>(&self, mut callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
+    {
+        for (key, val) in self.payload.iter() {
+            let do_continue = callback(*key, val)?;
+            if !do_continue {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The function `iter` to apply a callback on all elements of the payload storage is in practice mandatory so we might as well promote it to make things consistent.