### PR TITLE
Bump dev version to 1.12.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "api"
-version = "1.11.6-dev"
+version = "1.12.1-dev"
 dependencies = [
  "chrono",
  "common",
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.11.6-dev"
+version = "1.12.1-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.11.6-dev"
+version = "1.12.1-dev"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.11.6-dev"
+version = "1.12.1-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.11.6-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.12.1-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to `1.12.1-dev` with the release of <https://github.com/qdrant/qdrant/releases/tag/v1.12.0>.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/5122>.