### PR TITLE
Payload storage can include files in snapshots

### DIFF
--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use common::types::PointOffsetType;
 use serde_json::Value;
@@ -85,6 +86,10 @@ impl PayloadStorage for InMemoryPayloadStorage {
             }
         }
         Ok(())
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
     }
 }
 

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use common::types::PointOffsetType;
@@ -142,5 +143,9 @@ impl PayloadStorage for OnDiskPayloadStorage {
             }
         }
         Ok(())
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
     }
 }

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -44,6 +46,10 @@ pub trait PayloadStorage {
     fn iter<F>(&self, callback: F) -> OperationResult<()>
     where
         F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>;
+
+    /// Return all files that are used by storage to include in snapshots.
+    /// RocksDB storages are captured outside of this trait.
+    fn files(&self) -> Vec<PathBuf>;
 }
 
 pub trait ConditionChecker {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -125,6 +127,15 @@ impl PayloadStorage for PayloadStorageEnum {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.iter(callback),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.iter(callback),
             PayloadStorageEnum::OnDiskPayloadStorage(s) => s.iter(callback),
+        }
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.files(),
+            PayloadStorageEnum::SimplePayloadStorage(s) => s.files(),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.files(),
         }
     }
 }

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use common::types::PointOffsetType;
 use serde_json::Value;
@@ -97,6 +98,10 @@ impl PayloadStorage for SimplePayloadStorage {
             }
         }
         Ok(())
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
     }
 }
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -23,6 +23,7 @@ use crate::entry::entry_point::SegmentEntry;
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::json_path::JsonPath;
+use crate::payload_storage::PayloadStorage;
 use crate::segment::{
     DB_BACKUP_PATH, PAYLOAD_DB_BACKUP_PATH, SEGMENT_STATE_FILE, SNAPSHOT_FILES_PATH, SNAPSHOT_PATH,
 };
@@ -859,6 +860,10 @@ fn snapshot_files(
     }
 
     for file in segment.payload_index.borrow().files() {
+        tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
+    }
+
+    for file in segment.payload_storage.borrow().files() {
         tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
     }
 

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -25,6 +25,7 @@ use crate::common::operation_error::{OperationResult, SegmentFailedState};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndexEnum;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::types::{SegmentConfig, SegmentType, SeqNumberType, VectorName};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::VectorStorageEnum;
@@ -65,6 +66,7 @@ pub struct Segment {
     pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     pub vector_data: HashMap<VectorName, VectorData>,
     pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    pub payload_storage: Arc<AtomicRefCell<PayloadStorageEnum>>,
     /// Shows if it is possible to insert more points into this segment
     pub appendable_flag: bool,
     /// Shows what kind of indexes and storages are used in this segment

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -481,7 +481,7 @@ fn create_segment(
 
     let payload_index_path = get_payload_index_path(segment_path);
     let payload_index: Arc<AtomicRefCell<StructPayloadIndex>> = sp(StructPayloadIndex::open(
-        payload_storage,
+        payload_storage.clone(),
         id_tracker.clone(),
         &payload_index_path,
         appendable_flag,
@@ -604,6 +604,7 @@ fn create_segment(
         segment_type,
         appendable_flag,
         payload_index,
+        payload_storage,
         segment_config: config.clone(),
         error_status: None,
         database,


### PR DESCRIPTION
This PR extends the existing payload storage trait to expose files to be captured in the snapshots.

This logic is currently not necessary because the existing storages rely on RocksDB which is snapshotted independently.

However this change is required for the upcoming memap based payload storage whose files will have to part of the snapshots. 