### PR TITLE
Refactor `ConsensusOpWal`

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -47,6 +47,10 @@ impl ConsensusOpWal {
         self.entry_by_wal_index(wal_index)
     }
 
+    /// Get all entries in the given range
+    ///
+    /// The end of the range is exclusive (`[from_raft_index, until_raft_index)`).
+    /// A specified `max_size_bytes` will be ignored for the first entry.
     pub fn entries(
         &self,
         from_raft_index: u64,

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -128,6 +128,7 @@ impl ConsensusOpWal {
 
                 // Check that new entry index is sequential (it's not greater than next WAL index),
                 // or truncate entries at the tail of WAL, if it overwrites some
+                #[allow(clippy::comparison_chain)] // stupid ahh diagnostics 🙄
                 if new_entry_wal_index > next_wal_index {
                     return Err(StorageError::service_error(format!(
                         "Can't append entry with Raft index {} (expected WAL index {}), \

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -104,6 +104,9 @@ pub struct ConsensusConfig {
     #[validate(range(min = 1))]
     #[serde(default = "default_message_timeout_tics")]
     pub message_timeout_ticks: u64,
+    #[allow(dead_code)] // `schema_generator` complains about this 🙄
+    #[serde(default)]
+    pub compact_wal_entries: u64, // compact WAL when it grows to enough applied entries
 }
 
 impl Default for ConsensusConfig {
@@ -113,6 +116,7 @@ impl Default for ConsensusConfig {
             tick_period_ms: default_tick_period_ms(),
             bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
             message_timeout_ticks: default_message_timeout_tics(),
+            compact_wal_entries: 0,
         }
     }
 }

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -30,7 +30,10 @@ fn print_consensus_wal(wal_path: &Path) {
     println!("First entry: {first_index:?}");
     let last_index = wal.last_entry().unwrap();
     println!("Last entry: {last_index:?}");
-    println!("Offset of first entry: {:?}", wal.index_offset().unwrap());
+    println!(
+        "Offset of first entry: {:?}",
+        wal.index_offset().unwrap().wal_to_raft_offset
+    );
     let entries = wal
         .entries(
             first_index.map(|f| f.index).unwrap_or(1),


### PR DESCRIPTION
While working on WAL compaction I've refactored `ConsensusOpWal` (cause it was too confusing to work with) and decided to split it into separate PR. The behavior after refactoring should be exactly the same, just with (hopefully 🤞) cleaner code and some trivial optimizations.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
