### PR TITLE
[perf] Do not capture backtrace on get_sparse_vector_opt

### DIFF
--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -61,6 +61,8 @@ pub enum OperationError {
 }
 
 impl OperationError {
+    /// Create a new service error with a description and a backtrace
+    /// Warning: capturing a backtrace can be an expensive operation on some platforms, so this should be used with caution in performance-sensitive parts of code.
     pub fn service_error(description: impl Into<String>) -> OperationError {
         OperationError::ServiceError {
             description: description.into(),

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -130,6 +130,16 @@ impl DatabaseColumnWrapper {
             .ok_or_else(|| OperationError::service_error("RocksDB get_cf error: key not found"))
     }
 
+    pub fn get_opt<K>(&self, key: K) -> OperationResult<Option<Vec<u8>>>
+    where
+        K: AsRef<[u8]>,
+    {
+        let db = self.database.read();
+        let cf_handle = self.get_column_family(&db)?;
+        db.get_cf(cf_handle, key)
+            .map_err(|err| OperationError::service_error(format!("RocksDB get_cf error: {err}")))
+    }
+
     pub fn get_pinned<T, F>(&self, key: &[u8], f: F) -> OperationResult<Option<T>>
     where
         F: FnOnce(&[u8]) -> T,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -12,7 +12,7 @@ use super::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, MultivectorMmapOffset,
 };
 use super::multi_dense::simple_multi_dense_vector_storage::SimpleMultiDenseVectorStorage;
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -12,7 +12,7 @@ use super::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, MultivectorMmapOffset,
 };
 use super::multi_dense::simple_multi_dense_vector_storage::SimpleMultiDenseVectorStorage;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
@@ -111,6 +111,7 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
 
 pub trait SparseVectorStorage: VectorStorage {
     fn get_sparse(&self, key: PointOffsetType) -> OperationResult<SparseVector>;
+    fn get_sparse_opt(&self, key: PointOffsetType) -> OperationResult<Option<SparseVector>>;
 }
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {


### PR DESCRIPTION
On a `perf` optimized build.

![sparse-opt-perf](https://github.com/user-attachments/assets/4a9d573a-898e-44a8-a981-11190f67bcca)

The problem is that we are capturing backtraces at a high frequency when trying to fetch non existent sparse vectors from RocksDB.

The proposed fix is to have a specialised function for getting optional value from RocksDB.

## Benchmark.

`./bfb --vectors-per-point 0 --sparse-vectors-per-point 1  --sparse-vectors 0.3 --num-vectors 100000`

- before: upload 28s
- after: upload 22s 