### PR TITLE
Compact consensus WAL

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -753,15 +753,15 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             return Ok(false);
         };
 
-        let unapplied_index = applied_index + 1;
+        let first_unapplied_index = applied_index + 1;
 
-        debug_assert!(unapplied_index <= first_entry.index);
+        debug_assert!(first_unapplied_index <= first_entry.index);
 
-        if unapplied_index - first_entry.index < min_entries_to_compact {
+        if first_unapplied_index - first_entry.index < min_entries_to_compact {
             return Ok(false);
         }
 
-        self.wal.lock().compact(unapplied_index)?;
+        self.wal.lock().compact(first_unapplied_index)?;
         Ok(true)
     }
 

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -740,8 +740,8 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         self.toc.sync_local_state()
     }
 
-    pub fn compact_wal(&self, min_entries_to_truncate: u64) -> Result<bool, StorageError> {
-        if min_entries_to_truncate == 0 {
+    pub fn compact_wal(&self, min_entries_to_compact: u64) -> Result<bool, StorageError> {
+        if min_entries_to_compact == 0 {
             return Ok(false);
         }
 
@@ -757,7 +757,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
 
         debug_assert!(unapplied_index <= first_entry.index);
 
-        if unapplied_index - first_entry.index < min_entries_to_truncate {
+        if unapplied_index - first_entry.index < min_entries_to_compact {
             return Ok(false);
         }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -243,6 +243,7 @@ impl Consensus {
         // Before consensus has started apply any unapplied committed entries
         // They might have not been applied due to unplanned Qdrant shutdown
         let _stop_consensus = state_ref.apply_entries(&mut node)?;
+        state_ref.compact_wal(config.compact_wal_entries)?;
 
         let broker = RaftMessageBroker::new(
             runtime.clone(),
@@ -724,17 +725,21 @@ impl Consensus {
         self.store().record_consensus_working();
         // Get the `Ready` with `RawNode::ready` interface.
         let ready = self.node.ready();
-        let (light_rd, role_change) = self.process_ready(ready)?;
-        if let Some(light_ready) = light_rd {
-            let result = self.process_light_ready(light_ready)?;
-            if let Some(role_change) = role_change {
-                self.process_role_change(role_change);
-            }
-            Ok(result)
-        } else {
+
+        let (Some(light_ready), role_change) = self.process_ready(ready)? else {
             // No light ready, so we need to stop consensus.
-            Ok(true)
+            return Ok(true);
+        };
+
+        let result = self.process_light_ready(light_ready)?;
+
+        if let Some(role_change) = role_change {
+            self.process_role_change(role_change);
         }
+
+        self.store().compact_wal(self.config.compact_wal_entries)?;
+
+        Ok(result)
     }
 
     fn process_role_change(&self, role_change: StateRole) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -103,6 +103,9 @@ pub struct ConsensusConfig {
     #[validate(range(min = 1))]
     #[serde(default = "default_message_timeout_tics")]
     pub message_timeout_ticks: u64,
+    #[allow(dead_code)] // `schema_generator` complains about this 🙄
+    #[serde(default)]
+    pub compact_wal_entries: u64, // compact WAL when it grows to enough applied entries
 }
 
 impl Default for ConsensusConfig {
@@ -112,6 +115,7 @@ impl Default for ConsensusConfig {
             tick_period_ms: default_tick_period_ms(),
             bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
             message_timeout_ticks: default_message_timeout_tics(),
+            compact_wal_entries: 0,
         }
     }
 }


### PR DESCRIPTION
Based on top of #5217.

This PR adds optional Raft WAL compaction. There's now a `compact_wal_entries` parameter in consensus config, that if set to a non-zero value, enables consensus WAL compaction every time it grows to N **committed/applied** entries. WAL is also compacted when Qdrant restarts (still following `compact_wal_entries` parameter).

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
