### PR TITLE
handle the case of empty geo hashes

### DIFF
--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -189,7 +189,10 @@ impl From<GeoPoint> for Coord<f64> {
     }
 }
 
-pub fn common_hash_prefix(geo_hashes: &[GeoHash]) -> GeoHash {
+pub fn common_hash_prefix(geo_hashes: &[GeoHash]) -> Option<GeoHash> {
+    if geo_hashes.is_empty() {
+        return None;
+    }
     let first = &geo_hashes[0];
     let mut prefix: usize = first.len();
     for geo_hash in geo_hashes.iter().skip(1) {
@@ -200,7 +203,7 @@ pub fn common_hash_prefix(geo_hashes: &[GeoHash]) -> GeoHash {
             }
         }
     }
-    first.truncate(prefix)
+    Some(first.truncate(prefix))
 }
 
 /// Fix longitude for spherical overflow
@@ -1308,7 +1311,7 @@ mod tests {
             GeoHash::new("zbcd533").unwrap(),
         ];
 
-        let common_prefix = common_hash_prefix(&geo_hashes);
+        let common_prefix = common_hash_prefix(&geo_hashes).unwrap();
         println!("common_prefix = {:?}", SmolStr::from(common_prefix));
 
         //assert_eq!(common_prefix, GeoHash::new("zbcd").unwrap());
@@ -1320,7 +1323,7 @@ mod tests {
             GeoHash::new("dbcd533").unwrap(),
         ];
 
-        let common_prefix = common_hash_prefix(&geo_hashes);
+        let common_prefix = common_hash_prefix(&geo_hashes).unwrap();
         println!("common_prefix = {:?}", SmolStr::from(common_prefix));
 
         assert_eq!(common_prefix, GeoHash::new("").unwrap());

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -204,7 +204,9 @@ impl GeoMapIndex {
             return CardinalityEstimation::exact(0);
         }
 
-        let common_hash = common_hash_prefix(values);
+        let Some(common_hash) = common_hash_prefix(values) else {
+            return CardinalityEstimation::exact(0);
+        };
 
         let total_points = self.points_of_hash(&common_hash);
         let total_values = self.values_of_hash(&common_hash);


### PR DESCRIPTION
Without this fix service panics if `radius: 0`