### PR TITLE
Fix shard snapshot operations for s3

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -290,6 +290,12 @@ jobs:
           MINIO_ACCESS_KEY: "minioadmin"
           MINIO_SECRET_KEY: "minioadmin"
     steps:
+      - name: Setup test bucket
+        env:
+          AWS_ACCESS_KEY_ID: "minioadmin"
+          AWS_SECRET_ACCESS_KEY: "minioadmin"
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
       - name: Install minimal stable
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -302,11 +308,26 @@ jobs:
         run: sudo apt-get install clang jq
       - name: Build
         run: cargo build --bin qdrant
-      - name: Run Shard Snapshot API Tests
+      - name: Run Shard Snapshot API Tests (local)
         shell: bash
         run: |
           cargo run &
           trap 'kill $(jobs -p) &>/dev/null || :' EXIT
           sleep 10
+
           ./tests/shard-snapshot-api.sh test-all
-          ./tests/shard-snapshot-api.sh storage-s3-test-all
+      - name: Run Shard Snapshot API Tests (s3)
+        shell: bash
+        run: |
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use actix_web::HttpRequest;
+use common::tempfile_ext::MaybeTempPath;
 use object_store::aws::AmazonS3Builder;
 use serde::Deserialize;
 use tempfile::TempPath;
@@ -102,6 +103,7 @@ impl SnapshotStorageManager {
             }
         }
     }
+
     pub async fn list_snapshots(
         &self,
         directory: &Path,
@@ -115,6 +117,7 @@ impl SnapshotStorageManager {
             }
         }
     }
+
     pub async fn store_file(
         &self,
         source_path: &Path,
@@ -214,8 +217,27 @@ impl SnapshotStorageManager {
         }
     }
 
+    pub async fn get_snapshot_file(
+        &self,
+        snapshot_path: &Path,
+        temp_dir: &Path,
+    ) -> CollectionResult<MaybeTempPath> {
+        match self {
+            SnapshotStorageManager::LocalFS(storage_impl) => {
+                storage_impl
+                    .get_snapshot_file(snapshot_path, temp_dir)
+                    .await
+            }
+            SnapshotStorageManager::S3(storage_impl) => {
+                storage_impl
+                    .get_snapshot_file(snapshot_path, temp_dir)
+                    .await
+            }
+        }
+    }
+
     pub async fn get_snapshot_stream(
-        self,
+        &self,
         req: HttpRequest,
         snapshot_path: &Path,
     ) -> CollectionResult<SnapshotStream> {
@@ -238,7 +260,12 @@ impl SnapshotStorageLocalFS {
             tokio::fs::remove_file(checksum_path),
         );
 
-        delete_snapshot?;
+        delete_snapshot.map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => {
+                CollectionError::not_found(format!("Snapshot {snapshot_path:?}"))
+            }
+            _ => e.into(),
+        })?;
 
         // We might not have a checksum file for the snapshot, ignore deletion errors in that case
         if let Err(err) = delete_checksum {
@@ -249,7 +276,11 @@ impl SnapshotStorageLocalFS {
     }
 
     async fn list_snapshots(&self, directory: &Path) -> CollectionResult<Vec<SnapshotDescription>> {
-        let mut entries = tokio::fs::read_dir(directory).await?;
+        let mut entries = match tokio::fs::read_dir(directory).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
         let mut snapshots = Vec::new();
 
         while let Some(entry) = entries.next_entry().await? {
@@ -402,6 +433,19 @@ impl SnapshotStorageLocalFS {
             .await
     }
 
+    async fn get_snapshot_file(
+        &self,
+        snapshot_path: &Path,
+        _temp_dir: &Path,
+    ) -> CollectionResult<MaybeTempPath> {
+        if !snapshot_path.exists() {
+            return Err(CollectionError::not_found(format!(
+                "Snapshot {snapshot_path:?}"
+            )));
+        }
+        Ok(MaybeTempPath::Persistent(snapshot_path.to_path_buf()))
+    }
+
     async fn get_snapshot_stream(
         &self,
         req: HttpRequest,
@@ -479,6 +523,26 @@ impl SnapshotStorageCloud {
         Ok(snapshots_path
             .join(format!("shards/{shard_id}"))
             .join(snapshot_file_name))
+    }
+
+    async fn get_snapshot_file(
+        &self,
+        snapshot_path: &Path,
+        temp_dir: &Path,
+    ) -> CollectionResult<MaybeTempPath> {
+        let temp_path = tempfile::Builder::new()
+            .prefix(
+                snapshot_path
+                    .file_stem()
+                    .ok_or(CollectionError::bad_request("Invalid snapshot path"))?,
+            )
+            .suffix(".snapshot")
+            .tempfile_in(temp_dir)?
+            .into_temp_path();
+
+        snapshot_storage_ops::download_snapshot(&self.client, snapshot_path, &temp_path).await?;
+
+        Ok(MaybeTempPath::Temporary(temp_path))
     }
 
     pub async fn get_snapshot_stream(

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -835,10 +835,6 @@ impl ShardHolder {
 
         let snapshots_path = Self::snapshots_path_for_shard_unchecked(snapshots_path, shard_id);
 
-        if !snapshots_path.exists() {
-            return Ok(Vec::new());
-        }
-
         let shard = self
             .get_shard(&shard_id)
             .ok_or_else(|| shard_not_found_error(shard_id))?;

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod math;
 pub mod mmap_hashmap;
 pub mod panic;
 pub mod tar_ext;
+pub mod tempfile_ext;
 pub mod top_k;
 pub mod types;
 pub mod validation;

--- a/lib/common/common/src/tempfile_ext.rs
+++ b/lib/common/common/src/tempfile_ext.rs
@@ -1,0 +1,42 @@
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use tempfile::{PathPersistError, TempPath};
+
+/// Either a temporary or a persistent path.
+#[must_use = "returns a TempPath, if dropped the downloaded file is deleted"]
+pub enum MaybeTempPath {
+    Temporary(TempPath),
+    Persistent(PathBuf),
+}
+
+impl MaybeTempPath {
+    /// Keep the temporary file from being deleted.
+    /// No-op if the path is persistent.
+    pub fn keep(self) -> Result<PathBuf, PathPersistError> {
+        match self {
+            MaybeTempPath::Temporary(path) => path.keep(),
+            MaybeTempPath::Persistent(path) => Ok(path),
+        }
+    }
+
+    /// Close the temporary file, deleting it.
+    /// No-op if the path is persistent.
+    pub fn close(self) -> Result<(), std::io::Error> {
+        match self {
+            MaybeTempPath::Temporary(path) => path.close(),
+            MaybeTempPath::Persistent(_) => Ok(()),
+        }
+    }
+}
+
+impl Deref for MaybeTempPath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            MaybeTempPath::Temporary(path) => path,
+            MaybeTempPath::Persistent(path) => path,
+        }
+    }
+}

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -537,13 +537,11 @@ async fn download_shard_snapshot(
         .get_collection(&collection_pass)
         .await?;
     let snapshots_storage_manager = collection.get_snapshots_storage_manager()?;
-    let snapshot_path = snapshots_storage_manager
-        .get_shard_snapshot_path(
-            collection.shards_holder(),
-            shard,
-            collection.snapshots_path(),
-            &snapshot,
-        )
+    let snapshot_path = collection
+        .shards_holder()
+        .read()
+        .await
+        .get_shard_snapshot_path(collection.snapshots_path(), shard, &snapshot)
         .await?;
     let snapshot_stream = snapshots_storage_manager
         .get_snapshot_stream(req, &snapshot_path)

--- a/tests/shard-snapshot-api.sh
+++ b/tests/shard-snapshot-api.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eEuo pipefail
 
 
 declare QDRANT_HOST="${QDRANT_HOST:-localhost}"
@@ -38,6 +38,7 @@ declare FILESERVER_PID=''
 
 function main {
 	load-qdrant-status
+	trap 'failure $LINENO' ERR
 	trap cleanup EXIT
 	"$@"
 }
@@ -78,6 +79,21 @@ function cleanup {
 	then
 		rm "$DOWNLOADED_SNAPSHOT"
 	fi
+}
+
+function failure {
+	printf "Exit code: %d\n" $? >&2
+	declare INDEX
+	for (( INDEX=0; INDEX<${#BASH_LINENO[@]}-1; INDEX++ ))
+	do
+		printf "%s:%d@%s: " \
+			"${BASH_SOURCE[INDEX+1]}" \
+			"$(( INDEX > 0 ? BASH_LINENO[INDEX] : $1 ))" \
+			"${FUNCNAME[INDEX+1]}"
+		(( INDEX > 0 )) && \
+			printf "%s\n" "${FUNCNAME[INDEX]}" || \
+			printf "%s\n" " $BASH_COMMAND"
+	done >&2
 }
 
 function kill-jobs {

--- a/tests/shard-snapshot-api.sh
+++ b/tests/shard-snapshot-api.sh
@@ -101,23 +101,6 @@ function kill-jobs {
 	kill $(jobs -p) &>/dev/null || :
 }
 
-function storage-s3-test-all {
-	echo "Using S3 storage"
-  CONFIG_FILE="./config/config.yaml"
-
-	yq eval -i '.storage.snapshots_config += {"s3_config": {}}' $CONFIG_FILE
-
-	# Set to S3 with dynamic or fixed credentials
-	yq eval -i '.storage.snapshots_config.snapshots_storage = "s3"' $CONFIG_FILE
-	yq eval -i '.storage.snapshots_config.s3_config.bucket = "test-bucket"' $CONFIG_FILE
-	yq eval -i '.storage.snapshots_config.s3_config.region = "us-east-1"' $CONFIG_FILE
-	yq eval -i '.storage.snapshots_config.s3_config.access_key = "minioadmin"' $CONFIG_FILE
-	yq eval -i '.storage.snapshots_config.s3_config.secret_key = "minioadmin"' $CONFIG_FILE
-	yq eval -i '.storage.snapshots_config.s3_config.endpoint_url = "http://127.0.0.1:9000"' $CONFIG_FILE
-
-	test-all
-}
-
 
 declare TESTS=(
 	list


### PR DESCRIPTION
It turned out that some shard snapshot operations (implemented in #4150) are buggy:

- [List all snapshots (shard)](https://api.qdrant.tech/api-reference/snapshots/list-shard-snapshots) always return an empty list (`[]`).
- [Recover from a snapshot (shard)](https://api.qdrant.tech/api-reference/snapshots/recover-shard-from-snapshot) and [Delete a snapshot (shard)](https://api.qdrant.tech/api-reference/snapshots/delete-shard-snapshot) fail.

It seems these bugs went unnoticed because the test [shard-snapshot-api.sh] is also buggy: it enables s3 in the config file, but it doesn't restart qdrant after that. As a result, this integration test doesn't test s3 scenario, but rather tests the local scenario twice.

[shard-snapshot-api.sh]: https://github.com/qdrant/qdrant/blob/9c20e9e27960228019b4606f137ca82b42fc3e66/tests/shard-snapshot-api.sh#L88-L103

This PR fixes shard snapshot operations for s3, and fixes the test.