### PR TITLE
Hash/lookup point version only once, not 3 times

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -389,44 +390,49 @@ impl SegmentsSearcher {
                 let version = segment.point_version(id).ok_or_else(|| {
                     OperationError::service_error(format!("No version for point {id}"))
                 })?;
-                // If this point was not found yet or this segment have later version
-                if !point_version.contains_key(&id) || point_version[&id] < version {
-                    point_records.insert(
-                        id,
-                        RecordInternal {
-                            id,
-                            payload: if with_payload.enable {
-                                if let Some(selector) = &with_payload.payload_selector {
-                                    Some(selector.process(segment.payload(id)?))
-                                } else {
-                                    Some(segment.payload(id)?)
-                                }
-                            } else {
-                                None
-                            },
-                            vector: {
-                                match with_vector {
-                                    WithVector::Bool(true) => {
-                                        Some(VectorStructInternal::from(segment.all_vectors(id)?))
-                                    }
-                                    WithVector::Bool(false) => None,
-                                    WithVector::Selector(vector_names) => {
-                                        let mut selected_vectors = NamedVectors::default();
-                                        for vector_name in vector_names {
-                                            if let Some(vector) = segment.vector(vector_name, id)? {
-                                                selected_vectors.insert(vector_name.into(), vector);
-                                            }
-                                        }
-                                        Some(VectorStructInternal::from(selected_vectors))
-                                    }
-                                }
-                            },
-                            shard_key: None,
-                            order_value: None,
-                        },
-                    );
-                    point_version.insert(id, version);
+
+                // If we already have the latest point version, keep that and continue
+                let version_entry = point_version.entry(id);
+                if matches!(version_entry, Entry::Occupied(ref entry) if *entry.get() >= version) {
+                    return Ok(true);
                 }
+
+                point_records.insert(
+                    id,
+                    RecordInternal {
+                        id,
+                        payload: if with_payload.enable {
+                            if let Some(selector) = &with_payload.payload_selector {
+                                Some(selector.process(segment.payload(id)?))
+                            } else {
+                                Some(segment.payload(id)?)
+                            }
+                        } else {
+                            None
+                        },
+                        vector: {
+                            match with_vector {
+                                WithVector::Bool(true) => {
+                                    Some(VectorStructInternal::from(segment.all_vectors(id)?))
+                                }
+                                WithVector::Bool(false) => None,
+                                WithVector::Selector(vector_names) => {
+                                    let mut selected_vectors = NamedVectors::default();
+                                    for vector_name in vector_names {
+                                        if let Some(vector) = segment.vector(vector_name, id)? {
+                                            selected_vectors.insert(vector_name.into(), vector);
+                                        }
+                                    }
+                                    Some(VectorStructInternal::from(selected_vectors))
+                                }
+                            }
+                        },
+                        shard_key: None,
+                        order_value: None,
+                    },
+                );
+                *version_entry.or_default() = version;
+
                 Ok(true)
             })?;
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -393,7 +393,7 @@ impl SegmentsSearcher {
 
                 // If we already have the latest point version, keep that and continue
                 let version_entry = point_version.entry(id);
-                if matches!(version_entry, Entry::Occupied(ref entry) if *entry.get() >= version) {
+                if matches!(&version_entry, Entry::Occupied(entry) if *entry.get() >= version) {
                     return Ok(true);
                 }
 


### PR DESCRIPTION
In the segments searcher retrieve logic we loop over points and keep their latest version.

This PR improves it by only hashing/looking up once, rather than three times. For this we use the entry API.

Note that this doesn't fix bad behavior, and it's just low hanging fruit in terms of performance improvement.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?