### PR TITLE
do not fail if posting list does not exist on deletion

### DIFF
--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -60,7 +60,11 @@ impl InvertedIndex for InvertedIndexRam {
 
     fn remove(&mut self, id: PointOffsetType, old_vector: RemappedSparseVector) {
         for dim_id in old_vector.indices {
-            self.postings[dim_id as usize].delete(id);
+            if let Some(posting) = self.postings.get_mut(dim_id as usize) {
+                posting.delete(id);
+            } else {
+                debug_assert!(false, "Posting list for dimension {dim_id} not found");
+            }
         }
 
         self.vector_count = self.vector_count.saturating_sub(1);
@@ -125,6 +129,8 @@ impl InvertedIndexRam {
             for dim_id in elements_to_delete {
                 if let Some(posting) = self.postings.get_mut(dim_id) {
                     posting.delete(id);
+                } else {
+                    debug_assert!(false, "Posting list for dimension {dim_id} not found");
                 }
             }
         }


### PR DESCRIPTION
It might be technically possible, that during insertion of spare vectors, the operation is interrupted and data is only persisted in vector storage but not vector index.

In this case on the attempt to overwrite this vector, we might try to delete from posting list which doesn't exist. 
This is rare but possible situation will lead to panic in the current version.

This PR allows to ignore deleting from non-existing posting list, but still keeps the debug assert for simpler debugging in a case.

related: https://github.com/qdrant/qdrant/issues/5231