### PR TITLE
Clean up temporary snapshot files

### DIFF
--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -115,11 +115,17 @@ impl SnapshotStorageManager {
         }
     }
 
+    /// Store file in the snapshot storage.
+    /// On success, the `source_path` is deleted.
     pub async fn store_file(
         &self,
         source_path: &Path,
         target_path: &Path,
     ) -> CollectionResult<SnapshotDescription> {
+        debug_assert_ne!(
+            source_path, target_path,
+            "Source and target paths must be different"
+        );
         match self {
             SnapshotStorageManager::LocalFS(storage_impl) => {
                 storage_impl.store_file(source_path, target_path).await
@@ -274,18 +280,14 @@ impl SnapshotStorageLocalFS {
         // 5. Move the temporary file to the target file. (move is atomic, copy is not)
 
         if let Some(target_dir) = target_path.parent() {
-            if !target_dir.exists() {
-                std::fs::create_dir_all(target_dir)?;
-            }
+            std::fs::create_dir_all(target_dir)?;
         }
 
         // Move snapshot to permanent location.
         // We can't move right away, because snapshot folder can be on another mounting point.
         // We can't copy to the target location directly, because copy is not atomic.
         // So we copy to the final location with a temporary name and then rename atomically.
-        let target_path_tmp_move = target_path.with_extension("tmp");
-        // Ensure that the temporary file is deleted on error
-        let _temp_path = TempPath::from_path(&target_path_tmp_move);
+        let target_path_tmp = TempPath::from_path(target_path.with_extension("tmp"));
 
         // compute and store the file's checksum before the final snapshot file is saved
         // to avoid making snapshot available without checksum
@@ -295,10 +297,8 @@ impl SnapshotStorageLocalFS {
         let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;
         file.write_all(checksum.as_bytes()).await?;
 
-        if target_path != source_path {
-            move_file(&source_path, &target_path_tmp_move).await?;
-            tokio::fs::rename(&target_path_tmp_move, &target_path).await?;
-        }
+        move_file(&source_path, &target_path_tmp).await?;
+        target_path_tmp.persist(target_path).map_err(|e| e.error)?;
 
         checksum_file.keep()?;
         get_snapshot_description(target_path).await
@@ -425,6 +425,7 @@ impl SnapshotStorageCloud {
         target_path: &Path,
     ) -> CollectionResult<SnapshotDescription> {
         snapshot_storage_ops::multipart_upload(&self.client, source_path, target_path).await?;
+        tokio::fs::remove_file(source_path).await?;
         snapshot_storage_ops::get_snapshot_description(&self.client, target_path).await
     }
 


### PR DESCRIPTION
Continuation of #5227.

This PR fixes the following bug: when s3 storage is used, a leftover temporary file appears after creating a shard snapshot.
```console
$ ls snapshots/tmp/                                                  
upload

$ curl -X POST http://localhost:6333/collections/q/shards/0/snapshots
{"result":{"name":"q-shard-0-2024-10-14-23-03-54.snapshot","creation_time":"2024-10-14T23:03:55","size":425984},"status":"ok","time":0.863852705}

$ ls snapshots/tmp/                                                  
q-shard-0-2024-10-14-23-03-54.snapshot-38We4I.tar  upload
```

Additionally, this PR makes the local (non-s3) case more robust: temporary files now getting cleaned up in case of an error.