### PR TITLE
Downgrade asserts into logs for sparse vector inconsistencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,6 +6064,7 @@ dependencies = [
  "indicatif",
  "io",
  "itertools 0.13.0",
+ "log",
  "memmap2 0.9.5",
  "memory",
  "ordered-float 4.3.0",

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -30,6 +30,7 @@ rand = { workspace = true }
 validator = { workspace = true }
 itertools = { workspace = true }
 parking_lot = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -63,7 +63,7 @@ impl InvertedIndex for InvertedIndexRam {
             if let Some(posting) = self.postings.get_mut(dim_id as usize) {
                 posting.delete(id);
             } else {
-                debug_assert!(false, "Posting list for dimension {dim_id} not found");
+                log::debug!("Posting list for dimension {dim_id} not found");
             }
         }
 
@@ -130,7 +130,7 @@ impl InvertedIndexRam {
                 if let Some(posting) = self.postings.get_mut(dim_id) {
                     posting.delete(id);
                 } else {
-                    debug_assert!(false, "Posting list for dimension {dim_id} not found");
+                    log::debug!("Posting list for dimension {dim_id} not found");
                 }
             }
         }


### PR DESCRIPTION
Downgrade asserts which were introduced in https://github.com/qdrant/qdrant/pull/5232/files

Those are triggered if a sparse vector was persisted into storage, but was not persisted into inverted index.

This situation [can actually happen](https://github.com/qdrant/crasher/actions/runs/11347761734) after a crash therefore we should not halt the program.
