### PR TITLE
[WIP] Multithreaded sparse index build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6069,6 +6069,7 @@ dependencies = [
  "parking_lot",
  "pprof 0.13.0",
  "rand 0.8.5",
+ "rayon",
  "schemars",
  "serde",
  "serde_json",

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -79,8 +79,8 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     // intent: measure in-memory build time from storage
     group.bench_function("build-ram-index", |b| {
         b.iter(|| {
-            let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> =
-                SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+            let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> = SparseVectorIndex::open(
+                SparseVectorIndexOpenArgs {
                     config: index_config,
                     id_tracker: id_tracker.clone(),
                     vector_storage: vector_storage.clone(),
@@ -88,15 +88,17 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
                     path: index_dir.path(),
                     stopped: &stopped,
                     tick_progress: || (),
-                })
-                .unwrap();
+                },
+                None,
+            )
+            .unwrap();
             assert_eq!(sparse_vector_index.indexed_vector_count(), NUM_VECTORS);
         })
     });
 
     // build once to reuse in mmap conversion benchmark
-    let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> =
-        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+    let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> = SparseVectorIndex::open(
+        SparseVectorIndexOpenArgs {
             config: index_config,
             id_tracker,
             vector_storage,
@@ -104,8 +106,10 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
             path: index_dir.path(),
             stopped: &stopped,
             tick_progress: || (),
-        })
-        .unwrap();
+        },
+        None,
+    )
+    .unwrap();
 
     // intent: measure mmap conversion time
     group.bench_function("convert-mmap-index", |b| {

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -105,15 +105,18 @@ fn sparse_vector_index_search_benchmark_impl(
         SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap, None);
     let pb = progress("Indexing (2/2)", vectors_len);
     let sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexCompressedMmap<f32>> =
-        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
-            config: sparse_index_config,
-            id_tracker: sparse_vector_index.id_tracker().clone(),
-            vector_storage: sparse_vector_index.vector_storage().clone(),
-            payload_index: sparse_vector_index.payload_index().clone(),
-            path: mmap_index_dir.path(),
-            stopped: &stopped,
-            tick_progress: || pb.inc(1),
-        })
+        SparseVectorIndex::open(
+            SparseVectorIndexOpenArgs {
+                config: sparse_index_config,
+                id_tracker: sparse_vector_index.id_tracker().clone(),
+                vector_storage: sparse_vector_index.vector_storage().clone(),
+                payload_index: sparse_vector_index.payload_index().clone(),
+                path: mmap_index_dir.path(),
+                stopped: &stopped,
+                tick_progress: || pb.inc(1),
+            },
+            None,
+        )
         .unwrap();
     pb.finish_and_clear();
     assert_eq!(sparse_vector_index_mmap.indexed_vector_count(), vectors_len);

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -74,8 +74,8 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
     );
 
     let sparse_index_config = SparseIndexConfig::new(Some(full_scan_threshold), index_type, None);
-    let sparse_vector_index: SparseVectorIndex<I> =
-        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+    let sparse_vector_index: SparseVectorIndex<I> = SparseVectorIndex::open(
+        SparseVectorIndexOpenArgs {
             config: sparse_index_config,
             id_tracker,
             vector_storage: vector_storage.clone(),
@@ -83,7 +83,9 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
             path: index_dir,
             stopped: &stopped,
             tick_progress: || (),
-        })?;
+        },
+        None,
+    )?;
 
     assert_eq!(
         sparse_vector_index.indexed_vector_count(),

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -495,15 +495,18 @@ impl SegmentBuilder {
 
                 let vector_storage_arc = Arc::new(AtomicRefCell::new(vector_storage));
 
-                create_sparse_vector_index(SparseVectorIndexOpenArgs {
-                    config: sparse_vector_config.index,
-                    id_tracker: id_tracker_arc.clone(),
-                    vector_storage: vector_storage_arc.clone(),
-                    payload_index: payload_index_arc.clone(),
-                    path: &vector_index_path,
-                    stopped,
-                    tick_progress: || (),
-                })?;
+                create_sparse_vector_index(
+                    SparseVectorIndexOpenArgs {
+                        config: sparse_vector_config.index,
+                        id_tracker: id_tracker_arc.clone(),
+                        vector_storage: vector_storage_arc.clone(),
+                        payload_index: payload_index_arc.clone(),
+                        path: &vector_index_path,
+                        stopped,
+                        tick_progress: || (),
+                    },
+                    Some(permit.clone()),
+                )?;
             }
 
             // We're done with CPU-intensive tasks, release CPU permit

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -208,15 +208,18 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexCompressedMmap<f32>> =
-        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
-            config: sparse_index_config,
-            id_tracker: sparse_vector_ram_index.id_tracker().clone(),
-            vector_storage: sparse_vector_ram_index.vector_storage().clone(),
-            payload_index: sparse_vector_ram_index.payload_index().clone(),
-            path: mmap_index_dir.path(),
-            stopped: &stopped,
-            tick_progress: || (),
-        })
+        SparseVectorIndex::open(
+            SparseVectorIndexOpenArgs {
+                config: sparse_index_config,
+                id_tracker: sparse_vector_ram_index.id_tracker().clone(),
+                vector_storage: sparse_vector_ram_index.vector_storage().clone(),
+                payload_index: sparse_vector_ram_index.payload_index().clone(),
+                path: mmap_index_dir.path(),
+                stopped: &stopped,
+                tick_progress: || (),
+            },
+            None,
+        )
         .unwrap();
 
     assert_eq!(
@@ -234,15 +237,18 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexCompressedMmap<f32>> =
-        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
-            config: sparse_index_config,
-            id_tracker: sparse_vector_ram_index.id_tracker().clone(),
-            vector_storage: sparse_vector_ram_index.vector_storage().clone(),
-            payload_index: sparse_vector_ram_index.payload_index().clone(),
-            path: mmap_index_dir.path(),
-            stopped: &stopped,
-            tick_progress: || (),
-        })
+        SparseVectorIndex::open(
+            SparseVectorIndexOpenArgs {
+                config: sparse_index_config,
+                id_tracker: sparse_vector_ram_index.id_tracker().clone(),
+                vector_storage: sparse_vector_ram_index.vector_storage().clone(),
+                payload_index: sparse_vector_ram_index.payload_index().clone(),
+                path: mmap_index_dir.path(),
+                stopped: &stopped,
+                tick_progress: || (),
+            },
+            None,
+        )
         .unwrap();
 
     assert_eq!(
@@ -656,21 +662,24 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
         .unwrap();
 
     let open_index = || -> SparseVectorIndex<TInvertedIndex> {
-        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
-            config: SparseIndexConfig {
-                full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
-                index_type: SparseIndexType::Mmap,
-                datatype: Some(VectorStorageDatatype::Float32),
+        SparseVectorIndex::open(
+            SparseVectorIndexOpenArgs {
+                config: SparseIndexConfig {
+                    full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
+                    index_type: SparseIndexType::Mmap,
+                    datatype: Some(VectorStorageDatatype::Float32),
+                },
+                id_tracker: segment.id_tracker.clone(),
+                vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
+                    .vector_storage
+                    .clone(),
+                payload_index: segment.payload_index.clone(),
+                path: inverted_index_dir.path(),
+                stopped: &stopped,
+                tick_progress: || (),
             },
-            id_tracker: segment.id_tracker.clone(),
-            vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
-                .vector_storage
-                .clone(),
-            payload_index: segment.payload_index.clone(),
-            path: inverted_index_dir.path(),
-            stopped: &stopped,
-            tick_progress: || (),
-        })
+            None,
+        )
         .unwrap()
     };
 

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -31,6 +31,7 @@ validator = { workspace = true }
 itertools = { workspace = true }
 parking_lot = { workspace = true }
 log = { workspace = true }
+rayon = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
The sparse index is currently built on a single thread which happens:
- when opening a RAM sparse index on startup
- when optimizing existing segments

Building a sparse index means populating posting list from payload storage and then sorting those at the end.

This PR explores the possibility to sort the posting list using multi-thread by leveraging the existing CPU permit infrastructure.

The efficiency depends on the size of the posting lists, it does not make sense to use a dedicated thread for sorting a short list.

## TODO
- [ ] benchmarks with real data