### PR TITLE
Omit segment reference in worst segment return of vacuum optimizer

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -65,7 +65,7 @@ impl VacuumOptimizer {
         &self,
         segments: LockedSegmentHolder,
         excluded_ids: &HashSet<SegmentId>,
-    ) -> Option<(SegmentId, LockedSegment)> {
+    ) -> Option<SegmentId> {
         let segments_read_guard = segments.read();
         segments_read_guard
             .iter()
@@ -81,7 +81,7 @@ impl VacuumOptimizer {
                     .map(|ratio| (*idx, ratio))
             })
             .max_by_key(|(_, ratio)| OrderedFloat(*ratio))
-            .map(|(idx, _)| (idx, segments_read_guard.get(idx).unwrap().clone()))
+            .map(|(idx, _)| idx)
     }
 
     /// Calculate littered ratio for segment on point level
@@ -196,10 +196,9 @@ impl SegmentOptimizer for VacuumOptimizer {
         segments: LockedSegmentHolder,
         excluded_ids: &HashSet<SegmentId>,
     ) -> Vec<SegmentId> {
-        match self.worst_segment(segments, excluded_ids) {
-            None => vec![],
-            Some((segment_id, _segment)) => vec![segment_id],
-        }
+        self.worst_segment(segments, excluded_ids)
+            .into_iter()
+            .collect()
     }
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {


### PR DESCRIPTION
We don't need the segment reference, so we remove it.

This is good because it removes carrying the segment reference over the life time of the segment holder.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?