### PR TITLE
Fix eager backtrace generation

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -503,18 +503,12 @@ where
 
     let mut res = updated_points.len();
     // Insert new points, which was not updated or existed
-    let new_point_ids = ids
-        .iter()
-        .cloned()
-        .filter(|x| !(updated_points.contains(x)));
+    let new_point_ids = ids.iter().cloned().filter(|x| !updated_points.contains(x));
 
     {
-        let default_write_segment =
-            segments
-                .smallest_appendable_segment()
-                .ok_or(CollectionError::service_error(
-                    "No appendable segments exists, expected at least one",
-                ))?;
+        let default_write_segment = segments.smallest_appendable_segment().ok_or_else(|| {
+            CollectionError::service_error("No appendable segments exists, expected at least one")
+        })?;
 
         let segment_arc = default_write_segment.get();
         let mut write_segment = segment_arc.write();


### PR DESCRIPTION
similar: https://github.com/qdrant/qdrant/pull/5219

While doing jemalloc profiling I found out that we are eagerly generating backtraces during points updates.

![eager](https://github.com/user-attachments/assets/6defbefc-a6d4-4d87-b536-75e4959769eb)
