### PR TITLE
Transfer shard snapshots using streaming endpoint

### DIFF
--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -176,6 +176,17 @@ impl ChannelService {
             .all(|metadata| metadata.version >= version)
     }
 
+    /// Check whether the specified peer is running at least the given version
+    ///
+    /// If the version is not known for the peer, this returns `false`.
+    /// Peer versions are known since 1.9 and up.
+    pub fn peer_is_at_version(&self, peer_id: PeerId, version: Version) -> bool {
+        self.id_to_metadata
+            .read()
+            .get(&peer_id)
+            .map_or(false, |metadata| metadata.version >= version)
+    }
+
     /// Get the REST address for the current peer.
     pub fn current_rest_address(&self, this_peer_id: PeerId) -> CollectionResult<Url> {
         // Get local peer URI

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -254,7 +254,10 @@ where
         match &result {
             Ok(Ok(true)) => on_finish.await,
             Ok(Ok(false)) => (), // do nothing, we should not finish the task
-            Ok(Err(_)) => on_error.await,
+            Ok(Err(e)) => {
+                debug_assert!(false, "Snapshot transfer failed: {e}");
+                on_error.await
+            }
             Err(_) => (), // do nothing, if task was cancelled
         }
 


### PR DESCRIPTION
This PR lets the shard snapshot transfer process to use the new streaming snapshot endpoint.

Additionally, it adds a `debug_assert` to catch shard transfer errors during integration tests.