### PR TITLE
Make some or's more lazy

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1211,15 +1211,17 @@ impl TryFrom<FieldCondition> for segment::types::FieldCondition {
         let geo_radius = geo_radius.map_or_else(|| Ok(None), |g| g.try_into().map(Some))?;
         let geo_polygon = geo_polygon.map_or_else(|| Ok(None), |g| g.try_into().map(Some))?;
 
-        let range = range.map(Into::into);
-        let datetime_range = datetime_range
-            .map(segment::types::RangeInterface::try_from)
-            .transpose()?;
+        let mut range = range.map(Into::into);
+        if range.is_none() {
+            range = datetime_range
+                .map(segment::types::RangeInterface::try_from)
+                .transpose()?;
+        }
 
         Ok(Self {
             key: json::json_path_from_proto(&key)?,
             r#match: r#match.map_or_else(|| Ok(None), |m| m.try_into().map(Some))?,
-            range: range.or(datetime_range),
+            range,
             geo_bounding_box,
             geo_radius,
             geo_polygon,

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -45,7 +45,7 @@ impl Collection {
             self.update_runtime.clone(),
             self.search_runtime.clone(),
             self.optimizer_cpu_budget.clone(),
-            init_state.or(Some(ReplicaState::Active)),
+            Some(init_state.unwrap_or(ReplicaState::Active)),
         )
         .await
     }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -332,9 +332,9 @@ impl CollectionParams {
 
             if let Some(index) = index {
                 if let Some(existing_index) = &mut sparse_vector_params.index {
-                    existing_index.update_from_other(&index);
+                    existing_index.update_from_other(index);
                 } else {
-                    sparse_vector_params.index = Some(index);
+                    sparse_vector_params.index.replace(index);
                 }
             }
         }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -12,6 +12,7 @@ use api::rest::{
     SearchGroupsRequestInternal, SearchRequestInternal, ShardKeySelector, VectorStructOutput,
 };
 use common::defaults;
+use common::ext::OptionExt;
 use common::types::ScoreType;
 use common::validation::validate_range_generic;
 use io::file_operations::FileStorageError;
@@ -1499,18 +1500,17 @@ impl Anonymize for SparseIndexParams {
 }
 
 impl SparseIndexParams {
-    pub fn update_from_other(&mut self, other: &SparseIndexParams) {
+    pub fn update_from_other(&mut self, other: SparseIndexParams) {
         let SparseIndexParams {
             full_scan_threshold,
             on_disk,
             datatype,
         } = other;
 
-        *self = SparseIndexParams {
-            full_scan_threshold: full_scan_threshold.or(self.full_scan_threshold),
-            on_disk: on_disk.or(self.on_disk),
-            datatype: datatype.or(self.datatype),
-        };
+        self.full_scan_threshold
+            .replace_if_some(full_scan_threshold);
+        self.on_disk.replace_if_some(on_disk);
+        self.datatype.replace_if_some(datatype);
     }
 }
 

--- a/lib/common/common/src/ext.rs
+++ b/lib/common/common/src/ext.rs
@@ -1,0 +1,13 @@
+pub trait OptionExt {
+    /// `replace` if the given `value` is `Some`
+    fn replace_if_some(&mut self, value: Self);
+}
+
+impl<T> OptionExt for Option<T> {
+    #[inline]
+    fn replace_if_some(&mut self, value: Self) {
+        if let Some(value) = value {
+            self.replace(value);
+        }
+    }
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cpu;
 pub mod defaults;
 pub mod disk;
+pub mod ext;
 pub mod fixed_length_priority_queue;
 pub mod iterator_ext;
 pub mod math;

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -25,7 +25,10 @@ impl LoggerConfig {
             );
         }
 
-        logger_config.default.log_level = logger_config.default.log_level.take().or(log_level);
+        if logger_config.default.log_level.is_none() {
+            logger_config.default.log_level = log_level;
+        }
+
         logger_config
     }
 

--- a/src/tracing/default.rs
+++ b/src/tracing/default.rs
@@ -16,9 +16,21 @@ pub struct Config {
 
 impl Config {
     pub fn merge(&mut self, other: Self) {
-        self.log_level = other.log_level.or(self.log_level.take());
-        self.span_events = other.span_events.or(self.span_events.take());
-        self.color = other.color.or(self.color.take());
+        let Self {
+            log_level,
+            span_events,
+            color,
+        } = other;
+
+        if let Some(log_level) = log_level {
+            self.log_level.replace(log_level);
+        }
+        if let Some(span_events) = span_events {
+            self.span_events.replace(span_events);
+        }
+        if let Some(color) = color {
+            self.color.replace(color);
+        }
     }
 }
 

--- a/src/tracing/default.rs
+++ b/src/tracing/default.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use common::ext::OptionExt;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter, fmt, registry};
@@ -22,15 +23,9 @@ impl Config {
             color,
         } = other;
 
-        if let Some(log_level) = log_level {
-            self.log_level.replace(log_level);
-        }
-        if let Some(span_events) = span_events {
-            self.span_events.replace(span_events);
-        }
-        if let Some(color) = color {
-            self.color.replace(color);
-        }
+        self.log_level.replace_if_some(log_level);
+        self.span_events.replace_if_some(span_events);
+        self.color.replace_if_some(color);
     }
 }
 

--- a/src/tracing/on_disk.rs
+++ b/src/tracing/on_disk.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use std::{fs, io};
 
 use anyhow::Context as _;
+use common::ext::OptionExt;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter, fmt, registry};
@@ -27,18 +28,10 @@ impl Config {
             span_events,
         } = other;
 
-        if let Some(enabled) = enabled {
-            self.enabled.replace(enabled);
-        }
-        if let Some(log_file) = log_file {
-            self.log_file.replace(log_file);
-        }
-        if let Some(log_level) = log_level {
-            self.log_level.replace(log_level);
-        }
-        if let Some(span_events) = span_events {
-            self.span_events.replace(span_events);
-        }
+        self.enabled.replace_if_some(enabled);
+        self.log_file.replace_if_some(log_file);
+        self.log_level.replace_if_some(log_level);
+        self.span_events.replace_if_some(span_events);
     }
 }
 

--- a/src/tracing/on_disk.rs
+++ b/src/tracing/on_disk.rs
@@ -20,10 +20,25 @@ pub struct Config {
 
 impl Config {
     pub fn merge(&mut self, other: Self) {
-        self.enabled = other.enabled.or(self.enabled.take());
-        self.log_file = other.log_file.or(self.log_file.take());
-        self.log_level = other.log_level.or(self.log_level.take());
-        self.span_events = other.span_events.or(self.span_events.take());
+        let Self {
+            enabled,
+            log_file,
+            log_level,
+            span_events,
+        } = other;
+
+        if let Some(enabled) = enabled {
+            self.enabled.replace(enabled);
+        }
+        if let Some(log_file) = log_file {
+            self.log_file.replace(log_file);
+        }
+        if let Some(log_level) = log_level {
+            self.log_level.replace(log_level);
+        }
+        if let Some(span_events) = span_events {
+            self.span_events.replace(span_events);
+        }
     }
 }
 


### PR DESCRIPTION
Continues with the philosophy of <https://github.com/qdrant/qdrant/pull/5254>.

This makes some [`or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.or)s more lazy.

It also replaces some aggressive [`take`](https://doc.rust-lang.org/std/option/enum.Option.html#method.take)-out-and-put-back-in's with a new `replace_if_some` helper.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?