### PR TITLE
Only fall back to different shard transfer method for specific transfers

### DIFF
--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -141,8 +141,15 @@ pub async fn transfer_shard_fallback_default(
     collection_id: &CollectionId,
     fallback_method: ShardTransferMethod,
 ) -> CollectionResult<bool> {
-    // Do not attempt to fall back to the same method
     let old_method = transfer_config.method;
+
+    // Falling back must be supported
+    if !old_method.unwrap_or_default().can_fallback() {
+        log::debug!("Failed shard transfer fallback, current method does not allow falling back");
+        return Ok(false);
+    }
+
+    // Do not attempt to fall back to the same method
     if old_method.map_or(false, |method| method == fallback_method) {
         log::warn!("Failed shard transfer fallback, because it would use the same transfer method: {fallback_method:?}");
         return Ok(false);

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -126,7 +126,7 @@ pub enum ShardTransferMethod {
 }
 
 impl ShardTransferMethod {
-    pub fn is_resharding(&self) -> bool {
+    pub fn is_resharding(self) -> bool {
         matches!(self, Self::ReshardingStreamRecords)
     }
 

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -129,6 +129,18 @@ impl ShardTransferMethod {
     pub fn is_resharding(&self) -> bool {
         matches!(self, Self::ReshardingStreamRecords)
     }
+
+    pub fn can_fallback(self) -> bool {
+        match self {
+            Self::StreamRecords => true,
+            // WAL delta needs to fall back if diff cannot be resolved
+            Self::WalDelta => true,
+            // Snapshot includes index, other methods don't so falling back may be too expensive
+            Self::Snapshot => false,
+            // Special method, other methods are not compatible
+            Self::ReshardingStreamRecords => false,
+        }
+    }
 }
 
 /// Interface to consensus for shard transfer operations.


### PR DESCRIPTION
Adjust our shard transfer fallback mechanism to only fall back on specific shard transfers.

Fallback:
- stream records: yes
- wal delta: yes, needed in case a diff cannot be resolved
- snapshot: no, fallback method is likely expensive because it doesn't contain index
- resharding stream records: no, special transfer type incompatible with other methods

In other words, do not fall back anymore on snapshot or resharding stream record transfers.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?