### PR TITLE
Report memory usage in metrics & telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,6 +4681,7 @@ dependencies = [
  "sys-info",
  "tempfile",
  "thiserror",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "tonic 0.11.0",
@@ -6404,6 +6405,17 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,8 @@ pyroscope_pprofrs = "0.2.7"
 rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["unprefixed_malloc_on_supported_platforms"] }
+tikv-jemallocator = { version = "0.6", features = ["stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 
 [workspace.lints.clippy]
 cast_lossless = "warn"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10218,6 +10218,7 @@
           "cluster",
           "collections",
           "id",
+          "memory",
           "requests"
         ],
         "properties": {
@@ -10235,6 +10236,9 @@
           },
           "requests": {
             "$ref": "#/components/schemas/RequestsTelemetry"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/MemoryTelemetry"
           }
         }
       },
@@ -11394,6 +11398,48 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/OperationDurationStatistics"
             }
+          }
+        }
+      },
+      "MemoryTelemetry": {
+        "type": "object",
+        "required": [
+          "active",
+          "allocated",
+          "metadata",
+          "resident",
+          "retained"
+        ],
+        "properties": {
+          "active": {
+            "description": "Total number of bytes in active pages allocated by the application",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "allocated": {
+            "description": "Total number of bytes allocated by the application",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "metadata": {
+            "description": "Total number of bytes dedicated to metadata",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "resident": {
+            "description": "Maximum number of bytes in physically resident data pages mapped",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "retained": {
+            "description": "Total number of bytes in virtual memory mappings",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11404,38 +11404,38 @@
       "MemoryTelemetry": {
         "type": "object",
         "required": [
-          "active",
-          "allocated",
-          "metadata",
-          "resident",
-          "retained"
+          "active_bytes",
+          "allocated_bytes",
+          "metadata_bytes",
+          "resident_bytes",
+          "retained_bytes"
         ],
         "properties": {
-          "active": {
+          "active_bytes": {
             "description": "Total number of bytes in active pages allocated by the application",
             "type": "integer",
             "format": "uint",
             "minimum": 0
           },
-          "allocated": {
+          "allocated_bytes": {
             "description": "Total number of bytes allocated by the application",
             "type": "integer",
             "format": "uint",
             "minimum": 0
           },
-          "metadata": {
+          "metadata_bytes": {
             "description": "Total number of bytes dedicated to metadata",
             "type": "integer",
             "format": "uint",
             "minimum": 0
           },
-          "resident": {
+          "resident_bytes": {
             "description": "Maximum number of bytes in physically resident data pages mapped",
             "type": "integer",
             "format": "uint",
             "minimum": 0
           },
-          "retained": {
+          "retained_bytes": {
             "description": "Total number of bytes in virtual memory mappings",
             "type": "integer",
             "format": "uint",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10218,7 +10218,6 @@
           "cluster",
           "collections",
           "id",
-          "memory",
           "requests"
         ],
         "properties": {
@@ -10238,7 +10237,14 @@
             "$ref": "#/components/schemas/RequestsTelemetry"
           },
           "memory": {
-            "$ref": "#/components/schemas/MemoryTelemetry"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MemoryTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -8,6 +8,7 @@ use crate::common::telemetry_ops::cluster_telemetry::{ClusterStatusTelemetry, Cl
 use crate::common::telemetry_ops::collections_telemetry::{
     CollectionTelemetryEnum, CollectionsTelemetry,
 };
+use crate::common::telemetry_ops::memory_telemetry::MemoryTelemetry;
 use crate::common::telemetry_ops::requests_telemetry::{
     GrpcTelemetry, RequestsTelemetry, WebApiTelemetry,
 };
@@ -109,6 +110,7 @@ impl MetricsProvider for TelemetryData {
         self.collections.add_metrics(metrics);
         self.cluster.add_metrics(metrics);
         self.requests.add_metrics(metrics);
+        self.memory.add_metrics(metrics);
     }
 }
 
@@ -273,6 +275,41 @@ impl MetricsProvider for GrpcTelemetry {
             builder.add(stats, &[("endpoint", endpoint.as_str())], true);
         }
         builder.build("grpc", metrics);
+    }
+}
+
+impl MetricsProvider for MemoryTelemetry {
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        metrics.push(metric_family(
+            "memory_active",
+            "Total number of bytes in active pages allocated by the application",
+            MetricType::GAUGE,
+            vec![gauge(self.active as f64, &[])],
+        ));
+        metrics.push(metric_family(
+            "memory_allocated",
+            "Total number of bytes allocated by the application",
+            MetricType::GAUGE,
+            vec![gauge(self.allocated as f64, &[])],
+        ));
+        metrics.push(metric_family(
+            "memory_metadata",
+            "Total number of bytes dedicated to metadata",
+            MetricType::GAUGE,
+            vec![gauge(self.metadata as f64, &[])],
+        ));
+        metrics.push(metric_family(
+            "memory_resident",
+            "Maximum number of bytes in physically resident data pages mapped",
+            MetricType::GAUGE,
+            vec![gauge(self.resident as f64, &[])],
+        ));
+        metrics.push(metric_family(
+            "memory_retained",
+            "Total number of bytes in virtual memory mappings",
+            MetricType::GAUGE,
+            vec![gauge(self.retained as f64, &[])],
+        ));
     }
 }
 

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -281,34 +281,34 @@ impl MetricsProvider for GrpcTelemetry {
 impl MetricsProvider for MemoryTelemetry {
     fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
         metrics.push(metric_family(
-            "memory_active",
+            "memory_active_bytes",
             "Total number of bytes in active pages allocated by the application",
             MetricType::GAUGE,
-            vec![gauge(self.active as f64, &[])],
+            vec![gauge(self.active_bytes as f64, &[])],
         ));
         metrics.push(metric_family(
-            "memory_allocated",
+            "memory_allocated_bytes",
             "Total number of bytes allocated by the application",
             MetricType::GAUGE,
-            vec![gauge(self.allocated as f64, &[])],
+            vec![gauge(self.allocated_bytes as f64, &[])],
         ));
         metrics.push(metric_family(
-            "memory_metadata",
+            "memory_metadata_bytes",
             "Total number of bytes dedicated to metadata",
             MetricType::GAUGE,
-            vec![gauge(self.metadata as f64, &[])],
+            vec![gauge(self.metadata_bytes as f64, &[])],
         ));
         metrics.push(metric_family(
-            "memory_resident",
+            "memory_resident_bytes",
             "Maximum number of bytes in physically resident data pages mapped",
             MetricType::GAUGE,
-            vec![gauge(self.resident as f64, &[])],
+            vec![gauge(self.resident_bytes as f64, &[])],
         ));
         metrics.push(metric_family(
-            "memory_retained",
+            "memory_retained_bytes",
             "Total number of bytes in virtual memory mappings",
             MetricType::GAUGE,
-            vec![gauge(self.retained as f64, &[])],
+            vec![gauge(self.retained_bytes as f64, &[])],
         ));
     }
 }

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -110,7 +110,9 @@ impl MetricsProvider for TelemetryData {
         self.collections.add_metrics(metrics);
         self.cluster.add_metrics(metrics);
         self.requests.add_metrics(metrics);
-        self.memory.add_metrics(metrics);
+        if let Some(mem) = &self.memory {
+            mem.add_metrics(metrics);
+        }
     }
 }
 

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use crate::common::telemetry_ops::app_telemetry::{AppBuildTelemetry, AppBuildTelemetryCollector};
 use crate::common::telemetry_ops::cluster_telemetry::ClusterTelemetry;
 use crate::common::telemetry_ops::collections_telemetry::CollectionsTelemetry;
+use crate::common::telemetry_ops::memory_telemetry::MemoryTelemetry;
 use crate::common::telemetry_ops::requests_telemetry::{
     ActixTelemetryCollector, RequestsTelemetry, TonicTelemetryCollector,
 };
@@ -35,6 +36,7 @@ pub struct TelemetryData {
     pub(crate) collections: CollectionsTelemetry,
     pub(crate) cluster: ClusterTelemetry,
     pub(crate) requests: RequestsTelemetry,
+    pub(crate) memory: MemoryTelemetry,
 }
 
 impl Anonymize for TelemetryData {
@@ -45,6 +47,7 @@ impl Anonymize for TelemetryData {
             collections: self.collections.anonymize(),
             cluster: self.cluster.anonymize(),
             requests: self.requests.anonymize(),
+            memory: self.memory.anonymize(),
         }
     }
 }
@@ -90,6 +93,7 @@ impl TelemetryCollector {
                 &self.tonic_telemetry_collector.lock(),
                 detail,
             ),
+            memory: MemoryTelemetry::collect(),
         }
     }
 }

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use collection::operations::verification::new_unchecked_verification_pass;
-use common::types::TelemetryDetail;
+use common::types::{DetailsLevel, TelemetryDetail};
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
@@ -36,7 +36,7 @@ pub struct TelemetryData {
     pub(crate) collections: CollectionsTelemetry,
     pub(crate) cluster: ClusterTelemetry,
     pub(crate) requests: RequestsTelemetry,
-    pub(crate) memory: MemoryTelemetry,
+    pub(crate) memory: Option<MemoryTelemetry>,
 }
 
 impl Anonymize for TelemetryData {
@@ -93,7 +93,9 @@ impl TelemetryCollector {
                 &self.tonic_telemetry_collector.lock(),
                 detail,
             ),
-            memory: MemoryTelemetry::collect(),
+            memory: (detail.level > DetailsLevel::Level0)
+                .then(MemoryTelemetry::collect)
+                .flatten(),
         }
     }
 }

--- a/src/common/telemetry_ops/memory_telemetry.rs
+++ b/src/common/telemetry_ops/memory_telemetry.rs
@@ -1,6 +1,10 @@
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::Serialize;
+#[cfg(all(
+    not(target_env = "msvc"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use tikv_jemalloc_ctl::{epoch, stats};
 
 #[derive(Debug, Clone, Default, JsonSchema, Serialize)]
@@ -13,6 +17,10 @@ pub struct MemoryTelemetry {
 }
 
 impl MemoryTelemetry {
+    #[cfg(all(
+        not(target_env = "msvc"),
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ))]
     pub fn collect() -> MemoryTelemetry {
         epoch::advance().expect("failed to advance epoch");
         MemoryTelemetry {
@@ -22,6 +30,11 @@ impl MemoryTelemetry {
             resident: stats::resident::read().expect("failed to read resident"),
             retained: stats::retained::read().expect("failed to read retained"),
         }
+    }
+
+    #[cfg(target_env = "msvc")]
+    pub fn collect() -> MemoryTelemetry {
+        MemoryTelemetry::default()
     }
 }
 

--- a/src/common/telemetry_ops/memory_telemetry.rs
+++ b/src/common/telemetry_ops/memory_telemetry.rs
@@ -1,0 +1,38 @@
+use schemars::JsonSchema;
+use segment::common::anonymize::Anonymize;
+use serde::Serialize;
+use tikv_jemalloc_ctl::{epoch, stats};
+
+#[derive(Debug, Clone, Default, JsonSchema, Serialize)]
+pub struct MemoryTelemetry {
+    pub active: usize,
+    pub allocated: usize,
+    pub metadata: usize,
+    pub resident: usize,
+    pub retained: usize,
+}
+
+impl MemoryTelemetry {
+    pub fn collect() -> MemoryTelemetry {
+        epoch::advance().expect("failed to advance epoch");
+        MemoryTelemetry {
+            active: stats::active::read().expect("failed to read active"),
+            allocated: stats::allocated::read().expect("failed to read allocated"),
+            metadata: stats::metadata::read().expect("failed to read metadata"),
+            resident: stats::resident::read().expect("failed to read resident"),
+            retained: stats::retained::read().expect("failed to read retained"),
+        }
+    }
+}
+
+impl Anonymize for MemoryTelemetry {
+    fn anonymize(&self) -> Self {
+        MemoryTelemetry {
+            active: self.active,
+            allocated: self.allocated,
+            metadata: self.metadata,
+            resident: self.resident,
+            retained: self.retained,
+        }
+    }
+}

--- a/src/common/telemetry_ops/memory_telemetry.rs
+++ b/src/common/telemetry_ops/memory_telemetry.rs
@@ -10,15 +10,15 @@ use tikv_jemalloc_ctl::{epoch, stats};
 #[derive(Debug, Clone, Default, JsonSchema, Serialize)]
 pub struct MemoryTelemetry {
     /// Total number of bytes in active pages allocated by the application
-    pub active: usize,
+    pub active_bytes: usize,
     /// Total number of bytes allocated by the application
-    pub allocated: usize,
+    pub allocated_bytes: usize,
     /// Total number of bytes dedicated to metadata
-    pub metadata: usize,
+    pub metadata_bytes: usize,
     /// Maximum number of bytes in physically resident data pages mapped
-    pub resident: usize,
+    pub resident_bytes: usize,
     /// Total number of bytes in virtual memory mappings
-    pub retained: usize,
+    pub retained_bytes: usize,
 }
 
 impl MemoryTelemetry {
@@ -29,11 +29,11 @@ impl MemoryTelemetry {
     pub fn collect() -> MemoryTelemetry {
         if epoch::advance().is_ok() {
             MemoryTelemetry {
-                active: stats::active::read().unwrap_or_default(),
-                allocated: stats::allocated::read().unwrap_or_default(),
-                metadata: stats::metadata::read().unwrap_or_default(),
-                resident: stats::resident::read().unwrap_or_default(),
-                retained: stats::retained::read().unwrap_or_default(),
+                active_bytes: stats::active::read().unwrap_or_default(),
+                allocated_bytes: stats::allocated::read().unwrap_or_default(),
+                metadata_bytes: stats::metadata::read().unwrap_or_default(),
+                resident_bytes: stats::resident::read().unwrap_or_default(),
+                retained_bytes: stats::retained::read().unwrap_or_default(),
             }
         } else {
             log::info!("Failed to advance Jemalloc stats epoch");
@@ -50,11 +50,11 @@ impl MemoryTelemetry {
 impl Anonymize for MemoryTelemetry {
     fn anonymize(&self) -> Self {
         MemoryTelemetry {
-            active: self.active,
-            allocated: self.allocated,
-            metadata: self.metadata,
-            resident: self.resident,
-            retained: self.retained,
+            active_bytes: self.active_bytes,
+            allocated_bytes: self.allocated_bytes,
+            metadata_bytes: self.metadata_bytes,
+            resident_bytes: self.resident_bytes,
+            retained_bytes: self.retained_bytes,
         }
     }
 }

--- a/src/common/telemetry_ops/memory_telemetry.rs
+++ b/src/common/telemetry_ops/memory_telemetry.rs
@@ -26,24 +26,24 @@ impl MemoryTelemetry {
         not(target_env = "msvc"),
         any(target_arch = "x86_64", target_arch = "aarch64")
     ))]
-    pub fn collect() -> MemoryTelemetry {
+    pub fn collect() -> Option<MemoryTelemetry> {
         if epoch::advance().is_ok() {
-            MemoryTelemetry {
+            Some(MemoryTelemetry {
                 active_bytes: stats::active::read().unwrap_or_default(),
                 allocated_bytes: stats::allocated::read().unwrap_or_default(),
                 metadata_bytes: stats::metadata::read().unwrap_or_default(),
                 resident_bytes: stats::resident::read().unwrap_or_default(),
                 retained_bytes: stats::retained::read().unwrap_or_default(),
-            }
+            })
         } else {
             log::info!("Failed to advance Jemalloc stats epoch");
-            MemoryTelemetry::default()
+            None
         }
     }
 
     #[cfg(target_env = "msvc")]
-    pub fn collect() -> MemoryTelemetry {
-        MemoryTelemetry::default()
+    pub fn collect() -> Option<MemoryTelemetry> {
+        None
     }
 }
 

--- a/src/common/telemetry_ops/mod.rs
+++ b/src/common/telemetry_ops/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_telemetry;
 pub mod cluster_telemetry;
 pub mod collections_telemetry;
+pub mod memory_telemetry;
 pub mod requests_telemetry;


### PR DESCRIPTION
This PR adds the internal metric values from Jemalloc to our Prometheus metrics and telemetry.

e.g.

```
# HELP memory_active Total number of bytes in active pages allocated by the application
# TYPE memory_active gauge
memory_active 31473664
# HELP memory_allocated Total number of bytes allocated by the application
# TYPE memory_allocated gauge
memory_allocated 26469784
# HELP memory_metadata Total number of bytes dedicated to metadata
# TYPE memory_metadata gauge
memory_metadata 9560160
# HELP memory_resident Maximum number of bytes in physically resident data pages mapped
# TYPE memory_resident gauge
memory_resident 43413504
# HELP memory_retained Total number of bytes in virtual memory mappings
# TYPE memory_retained gauge
memory_retained 53940224
```

With those numbers we will be able to track precisely memory fragmentation.
 
```
Fragmentation = (Active Memory − Allocated Memory​) / Active Memory

Fragmentation = (31473664 − 26469784) ​/ 31473664 ≈ 0.159
```