### PR TITLE
Fix warning in ConsensusOpWal on non-debug builds

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -227,6 +227,7 @@ impl ConsensusOpWal {
             buf.clear();
             new_entry.encode(&mut buf)?;
 
+            #[cfg_attr(not(debug_assertions), expect(unused_variables))]
             let new_entry_wal_index = self.wal.append(&buf)?;
 
             #[cfg(debug_assertions)]


### PR DESCRIPTION
Fix the following warning on non-debug builds:

```
warning: unused variable: `new_entry_wal_index`
   --> lib/storage/src/content_manager/consensus/consensus_wal.rs:230:17
    |
230 |             let new_entry_wal_index = self.wal.append(&buf)?;
    |                 ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_new_entry_wal_index`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: `storage` (lib) generated 1 warning
```

This slipped through in <https://github.com/qdrant/qdrant/pull/5217>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?