### PR TITLE
Fix data race in WAL delta transfer causing inconsistencies

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -433,6 +433,10 @@ impl Inner {
             let items_left = (wal.last_index() + 1).saturating_sub(transfer_from);
             let items_total = (transfer_from - self.started_at) + items_left;
             let batch = wal.read(transfer_from).take(BATCH_SIZE).collect::<Vec<_>>();
+            debug_assert!(
+                batch.len() <= items_left as usize,
+                "batch cannot be larger than items_left",
+            );
             (items_left, items_total, batch)
         };
 

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -486,4 +486,15 @@ impl ShardReplicaSet {
 
         local_shard.resolve_wal_delta(recovery_point).await
     }
+
+    pub async fn wal_version(&self) -> CollectionResult<Option<u64>> {
+        let local_shard_read = self.local.read().await;
+        let Some(local_shard) = local_shard_read.deref() else {
+            return Err(CollectionError::service_error(
+                "Cannot get WAL version, shard replica set does not have local shard",
+            ));
+        };
+
+        local_shard.wal_version()
+    }
 }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -231,4 +231,22 @@ impl Shard {
             ))),
         }
     }
+
+    pub fn wal_version(&self) -> CollectionResult<Option<u64>> {
+        match self {
+            Self::Local(local_shard) => local_shard.wal.wal_version().map_err(|err| {
+                CollectionError::service_error(format!(
+                    "Cannot get WAL version on {}: {err}",
+                    self.variant_name(),
+                ))
+            }),
+
+            Self::Proxy(_) | Self::ForwardProxy(_) | Self::QueueProxy(_) | Self::Dummy(_) => {
+                Err(CollectionError::service_error(format!(
+                    "Cannot get WAL version on {}",
+                    self.variant_name(),
+                )))
+            }
+        }
+    }
 }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -216,8 +216,10 @@ impl Shard {
         // Resolve WAL delta and report
         match wal.resolve_wal_delta(recovery_point).await {
             Ok(Some(version)) => {
-                let size = wal.wal.lock().last_index().saturating_sub(version);
-                log::debug!("Resolved WAL delta from {version}, which counts {size} records");
+                log::debug!(
+                    "Resolved WAL delta from {version}, which counts {} records",
+                    wal.wal.lock().last_index().saturating_sub(version),
+                );
                 Ok(Some(version))
             }
 

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -123,6 +123,15 @@ impl RecoverableWal {
         )
     }
 
+    pub fn wal_version(&self) -> Result<Option<u64>, WalDeltaError> {
+        let wal = self.wal.lock();
+        if wal.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(wal.last_index()))
+        }
+    }
+
     /// Append records to this WAL from `other`, starting at operation `append_from` in `other`.
     #[cfg(test)]
     pub async fn append_from(&self, other: &Self, append_from: u64) -> crate::wal::Result<()> {


### PR DESCRIPTION
Fix a critical problem in WAL delta transfers which can cause missing updates, resulting in data inconsistencies.

First of all, during a WAL delta transfer, the target replica switches between these states:
1. Active: _regular behavior, before transfer_
2. Recovery: _get queued updates from transfer source, skip other updates_
3. Partial: _get last queued updates from transfer source, get all updates from other replicas_
4. Active: _regular behavior, after transfer_

The problem was in how different delta resolutions were handled. If the target shard was outdated and we resolved a diff, then everything was fine. If the target shard was already up-to-date and we resolved an empty diff, then problems occurred.

Imagine the target shard was up-to-date and we resolved an empty diff. In this case, we did not create a queue proxy at all. We did just fall through proxying and continued with the rest of the transfer logic. It did go through the replica states and would finish the transfer shortly after. The assumption was that a queue proxy is not needed because the target already has all the necessary updates. That assumption is wrong however. 

Even though the target shard is up-to-date at the time of resolution, it does not mean it's still up-to-date moments after. During resolution the target shard is in Recovery state. After resolution of an empty diff, we switch to Partial state. The key thing here is that new updates are not send to replicas in Recovery state. If we receive a new update between resolution and switching to Partial, it'll be lost on the target shard. Updates can fall in between.

That means that the following events result in inconsistencies:
- WAL delta transfer is started
- target shard switches into Recovery state
- we resolve WAL delta, it is empty because the target shard is up-to-date
- a new update comes in, the target shard does not receive it because it's still in Recovery state
- we switch the target shard into Partial state
- we finish the transfer and switch the target shard into active state
- the transfer is done, the target shard **never** received the above update

To fix the problem I now create a queue proxy in all cases. If the target shard is up-to-date and our resolved delta is empty, we start queuing/forwarding all new updates from that point on. All updates that fall in between the state switch will still reach the target shard because of the queue proxy, preventing missing updates.

With this fix the events would look like this:
- WAL delta transfer is started
- target shard switches into Recovery state
- we resolve WAL delta, it is empty because the target shard is up-to-date
- we create queue proxy, queueing all new updates
- a new update comes in, the target shard does not receive it yet because it's still in Recovery state
- we forward all queued items to the target shard, the target shard now receives the update
- we switch the target shard into Partial state
- we forward any new items on the queue and convert into a forward proxy
- we finish the transfer and switch the target shard into active state
- the transfer is done, the target shard did receive the above update

I'll attempt to write an integration test for this in a separate PR. I've already tested the update with 1000 subsequent WAL delta transfers, and the problem never appeared again.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?