### PR TITLE
Hw counter utilization checks

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -311,6 +311,9 @@ impl ProxySegment {
             &segment_query_context,
         )?;
 
+        // TODO: propagate this value to callers instead.
+        segment_query_context.hardware_counter().discard_results();
+
         Ok(result.into_iter().next().unwrap())
     }
 }
@@ -1261,7 +1264,9 @@ mod tests {
         eprintln!("search_batch_result = {search_batch_result:#?}");
 
         assert!(!search_result.is_empty());
-        assert_eq!(search_result, search_batch_result[0].clone())
+        assert_eq!(search_result, search_batch_result[0].clone());
+        assert!(segment_query_context.hardware_counter().cpu_counter().get() > 0);
+        segment_query_context.hardware_counter().discard_results();
     }
 
     #[test]
@@ -1314,6 +1319,8 @@ mod tests {
                 &segment_query_context,
             )
             .unwrap();
+
+        segment_query_context.hardware_counter().discard_results();
 
         eprintln!("search_batch_result = {search_batch_result:#?}");
 
@@ -1381,6 +1388,8 @@ mod tests {
                 &segment_query_context,
             )
             .unwrap();
+
+        segment_query_context.hardware_counter().discard_results();
 
         eprintln!("search_batch_result = {search_batch_result:#?}");
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -311,7 +311,7 @@ impl ProxySegment {
             &segment_query_context,
         )?;
 
-        // TODO: propagate this value to callers instead.
+        // This function is only for testing and no measurements are needed.
         segment_query_context.hardware_counter().discard_results();
 
         Ok(result.into_iter().next().unwrap())

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -259,6 +259,9 @@ impl SegmentsSearcher {
                         move || {
                             let segment_query_context =
                                 query_context_arc_segment.get_segment_query_context();
+
+                            segment_query_context.hardware_counter().set_checked(false); // TODO: propagate measurements instead of discarding!
+
                             search_in_segment(
                                 segment,
                                 batch_request,
@@ -309,6 +312,7 @@ impl SegmentsSearcher {
                     res.push(runtime_handle.spawn_blocking(move || {
                         let segment_query_context =
                             query_context_arc_segment.get_segment_query_context();
+                        segment_query_context.hardware_counter().set_checked(false); // TODO: propagate measurements instead of discarding!
                         search_in_segment(
                             segment,
                             partial_batch_request,

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -1,0 +1,42 @@
+use super::hardware_counter::HardwareCounterCell;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+/// A "slow" but thread-safe accumulator for measurement results of `HardwareCounterCell` values.
+#[derive(Clone)]
+pub struct AtomicHardwareAccumulator {
+    cpu_counter: Arc<AtomicUsize>,
+}
+
+impl AtomicHardwareAccumulator {
+    pub fn new() -> Self {
+        Self {
+            cpu_counter: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn get_cpu(&self) -> usize {
+        self.cpu_counter.load(Ordering::Relaxed)
+    }
+
+    pub fn clear(&self) {
+        let AtomicHardwareAccumulator { cpu_counter } = self;
+
+        cpu_counter.store(0, Ordering::Relaxed);
+    }
+
+    /// Consumes and accumulates the values from `hw_counter_cell` into the accumulator.
+    pub fn apply_from_cell(&self, hw_counter_cell: &HardwareCounterCell) {
+        let HardwareCounterCell {
+            cpu_counter,
+            checked: _,
+        } = hw_counter_cell;
+
+        self.cpu_counter.store(cpu_counter.get(), Ordering::Relaxed);
+
+        // Clear the cells measurements to 'consume' it.
+        cpu_counter.set(0);
+    }
+}

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -1,5 +1,3 @@
-use std::cell::Cell;
-
 use crate::counter::counter_cell::CounterCell;
 
 /// Collection of different types of hardware measurements.
@@ -7,10 +5,9 @@ use crate::counter::counter_cell::CounterCell;
 /// To ensure we don't miss consuming measurements, this struct will cause a panic on drop in tests and debug mode
 /// if it still holds values and checking is not disabled using eg. `unchecked()`.
 /// In release mode it'll only log a warning in this case.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct HardwareCounterCell {
     cpu_counter: CounterCell,
-    checked: Cell<bool>,
 }
 
 impl HardwareCounterCell {
@@ -21,20 +18,8 @@ impl HardwareCounterCell {
     pub fn new_with(cpu: usize) -> Self {
         Self {
             cpu_counter: CounterCell::new_with(cpu),
-            checked: Cell::new(true),
         }
     }
-
-    /// Don't check whether counter got fully consumed on drop.
-    pub fn unchecked(mut self) -> Self {
-        *self.checked.get_mut() = false;
-        self
-    }
-
-    pub fn set_checked(&self, checked: bool) {
-        self.checked.set(checked)
-    }
-
     #[inline]
     pub fn cpu_counter(&self) -> &CounterCell {
         &self.cpu_counter
@@ -47,33 +32,24 @@ impl HardwareCounterCell {
 
     /// Accumulates the measurements from `other` into this counter.
     /// This consumes `other`, leaving it with zeroed metrics.
-    pub fn apply_from(&self, other: &HardwareCounterCell) {
-        let HardwareCounterCell {
-            cpu_counter,
-            checked: _,
-        } = other;
+    pub fn apply_from(&self, other: HardwareCounterCell) {
+        let HardwareCounterCell { ref cpu_counter } = other;
 
         self.cpu_counter.incr_delta(cpu_counter.get());
 
-        other.cpu_counter.set(0);
+        other.clear();
     }
 
     /// Returns `true` if at least one metric has non-consumed values.
     pub fn has_values(&self) -> bool {
-        let HardwareCounterCell {
-            cpu_counter,
-            checked: _,
-        } = self;
+        let HardwareCounterCell { cpu_counter } = self;
 
         cpu_counter.get() > 0
     }
 
     /// Resets all measurements in this hardware counter.
     pub fn clear(&self) {
-        let HardwareCounterCell {
-            cpu_counter,
-            checked: _,
-        } = self;
+        let HardwareCounterCell { cpu_counter } = self;
 
         cpu_counter.clear();
     }
@@ -81,7 +57,6 @@ impl HardwareCounterCell {
     pub fn take(&self) -> HardwareCounterCell {
         let new_counter = HardwareCounterCell {
             cpu_counter: self.cpu_counter.clone(),
-            checked: self.checked.clone(),
         };
 
         self.clear();
@@ -97,18 +72,9 @@ impl HardwareCounterCell {
     }
 }
 
-impl Default for HardwareCounterCell {
-    fn default() -> Self {
-        Self {
-            cpu_counter: Default::default(),
-            checked: Cell::new(true),
-        }
-    }
-}
-
 impl Drop for HardwareCounterCell {
     fn drop(&mut self) {
-        if self.checked.get() && self.has_values() {
+        if self.has_values() {
             #[cfg(any(debug_assertions, test))] // We want this to fail in both, release and debug tests
             panic!("Checked HardwareCounterCell dropped without consuming all values!");
 

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -3,6 +3,9 @@ use std::cell::Cell;
 use crate::counter::counter_cell::CounterCell;
 
 /// Collection of different types of hardware measurements.
+///
+/// To ensure we don't miss consuming measurements, this struct will cause a panic on drop in tests and debug mode
+/// if it still holds values and checking is not disabled using eg. `unchecked()`.
 #[derive(Debug)]
 pub struct HardwareCounterCell {
     cpu_counter: CounterCell,
@@ -52,17 +55,6 @@ impl HardwareCounterCell {
         self.cpu_counter.incr_delta(cpu_counter.get());
 
         other.cpu_counter.set(0);
-    }
-
-    /// Sets the currents counter values to the ones in `other`.
-    /// This consumes `other`, leaving it with zeroed metrics.
-    pub fn set_from(&self, other: &HardwareCounterCell) {
-        let HardwareCounterCell {
-            cpu_counter,
-            checked: _,
-        } = other;
-
-        self.cpu_counter.set(cpu_counter.get());
     }
 
     /// Returns `true` if at least one metric has non-consumed values.

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -25,7 +25,7 @@ impl HardwareCounterCell {
         }
     }
 
-    /// Don't check wether counter got full consumed on dropping.
+    /// Don't check whether counter got fully consumed on drop.
     pub fn unchecked(mut self) -> Self {
         *self.checked.get_mut() = false;
         self

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -1,9 +1,12 @@
+use std::cell::Cell;
+
 use crate::counter::counter_cell::CounterCell;
 
 /// Collection of different types of hardware measurements.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug)]
 pub struct HardwareCounterCell {
     cpu_counter: CounterCell,
+    checked: Cell<bool>,
 }
 
 impl HardwareCounterCell {
@@ -14,7 +17,18 @@ impl HardwareCounterCell {
     pub fn new_with(cpu: usize) -> Self {
         Self {
             cpu_counter: CounterCell::new_with(cpu),
+            checked: Cell::new(true),
         }
+    }
+
+    /// Don't check wether counter got full consumed on dropping.
+    pub fn unchecked(mut self) -> Self {
+        *self.checked.get_mut() = false;
+        self
+    }
+
+    pub fn set_checked(&self, checked: bool) {
+        self.checked.set(checked)
     }
 
     #[inline]
@@ -27,15 +41,91 @@ impl HardwareCounterCell {
         &mut self.cpu_counter
     }
 
+    /// Accumulates the measurements from `other` into this counter.
+    /// This consumes `other`, leaving it with zeroed metrics.
     pub fn apply_from(&self, other: &HardwareCounterCell) {
-        let HardwareCounterCell { cpu_counter } = other;
+        let HardwareCounterCell {
+            cpu_counter,
+            checked: _,
+        } = other;
 
         self.cpu_counter.incr_delta(cpu_counter.get());
+
+        other.cpu_counter.set(0);
     }
 
+    /// Sets the currents counter values to the ones in `other`.
+    /// This consumes `other`, leaving it with zeroed metrics.
     pub fn set_from(&self, other: &HardwareCounterCell) {
-        let HardwareCounterCell { cpu_counter } = other;
+        let HardwareCounterCell {
+            cpu_counter,
+            checked: _,
+        } = other;
 
         self.cpu_counter.set(cpu_counter.get());
+    }
+
+    /// Returns `true` if at least one metric has non-consumed values.
+    pub fn has_values(&self) -> bool {
+        let HardwareCounterCell {
+            cpu_counter,
+            checked: _,
+        } = self;
+
+        cpu_counter.get() > 0
+    }
+
+    /// Resets all measurements in this hardware counter.
+    pub fn clear(&self) {
+        let HardwareCounterCell {
+            cpu_counter,
+            checked: _,
+        } = self;
+
+        cpu_counter.clear();
+    }
+
+    pub fn take(&self) -> HardwareCounterCell {
+        let new_counter = HardwareCounterCell {
+            cpu_counter: self.cpu_counter.clone(),
+            checked: self.checked.clone(),
+        };
+
+        self.clear();
+
+        new_counter
+    }
+
+    /// Drops the hardware counter controlled and discards all values if any.
+    /// Since we only chechk in tests+debug mode for correct consumption of the values,
+    /// this is a no-op in release mode.
+    pub fn drop_and_discard_results(self) {
+        #[cfg(any(debug_assertions, test))]
+        self.clear();
+    }
+
+    /// Sets the status of this hardware counter to consumed to not panic on drop in debug build or tests.
+    /// This is currently equal to calling `.clear()` should be preferred if the goal is to prevent
+    /// panics in tests eg. after manually 'consuming' the counted values.
+    pub fn discard_results(&self) {
+        self.clear();
+    }
+}
+
+impl Default for HardwareCounterCell {
+    fn default() -> Self {
+        Self {
+            cpu_counter: Default::default(),
+            checked: Cell::new(true),
+        }
+    }
+}
+
+#[cfg(any(debug_assertions, test))] // We want this to fail in both, release and debug tests
+impl Drop for HardwareCounterCell {
+    fn drop(&mut self) {
+        if self.checked.get() && self.has_values() {
+            panic!("Checked HardwareCounterCell dropped without consuming all values!");
+        }
     }
 }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -174,7 +174,7 @@ impl VectorQueryContext<'_> {
             hardware_counter.apply_from(other);
         } else {
             // If we don't specify a hardware counter reference when initiating a new VectorQueryContext,
-            // we don't want it's result and need to discard the results in order to not panic in tests/debug mode.
+            // we don't want it's result and need to discard the results here in order to not panic in tests/debug mode.
             other.discard_results();
         }
     }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -174,7 +174,7 @@ impl VectorQueryContext<'_> {
             hardware_counter.apply_from(other);
         } else {
             // If we don't specify a hardware counter reference when initiating a new VectorQueryContext,
-            // we don't want it's result and need to discard the results here in order to not panic in tests/debug mode.
+            // we don't want its result and need to discard the results here in order to not panic in tests/debug mode.
             other.discard_results();
         }
     }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -319,6 +319,8 @@ mod tests {
     ) -> Vec<ScoredPointOffset> {
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_storage.get_raw_scorer(query.to_owned()).unwrap();
+        raw_scorer.set_hardware_counter_checked(false);
+
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         graph.search(top, ef, scorer, None)
@@ -362,6 +364,8 @@ mod tests {
             .get(linking_idx as VectorOffsetType)
             .to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
+        raw_scorer.set_hardware_counter_checked(false);
+
         let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
         let nearest_on_level = graph_layers.search_on_level(

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -319,11 +319,12 @@ mod tests {
     ) -> Vec<ScoredPointOffset> {
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_storage.get_raw_scorer(query.to_owned()).unwrap();
-        raw_scorer.set_hardware_counter_checked(false);
 
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
-        graph.search(top, ef, scorer, None)
+        let res = graph.search(top, ef, scorer, None);
+        raw_scorer.take_hardware_counter().discard_results();
+        res
     }
 
     const M: usize = 8;
@@ -364,8 +365,6 @@ mod tests {
             .get(linking_idx as VectorOffsetType)
             .to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
-        raw_scorer.set_hardware_counter_checked(false);
-
         let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
         let nearest_on_level = graph_layers.search_on_level(
@@ -387,6 +386,8 @@ mod tests {
                 scorer.score_internal(linking_idx, nearest.idx)
             )
         }
+
+        raw_scorer.take_hardware_counter().discard_results();
     }
 
     #[test]

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -541,6 +541,7 @@ mod tests {
                     let fake_filter_context = FakeFilterContext {};
                     let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
                     let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
+                    raw_scorer.set_hardware_counter_checked(false);
                     let scorer =
                         FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
                     graph_layers.link_new_point(idx, scorer);
@@ -583,6 +584,7 @@ mod tests {
             let fake_filter_context = FakeFilterContext {};
             let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
             let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
+            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             graph_layers.link_new_point(idx, scorer);
         }
@@ -652,6 +654,7 @@ mod tests {
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
+        raw_scorer.set_hardware_counter_checked(false);
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
@@ -735,6 +738,7 @@ mod tests {
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
+        raw_scorer.set_hardware_counter_checked(false);
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
@@ -760,6 +764,7 @@ mod tests {
         for idx in 0..(NUM_VECTORS as PointOffsetType) {
             let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
             let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
+            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(idx, level);
@@ -808,6 +813,7 @@ mod tests {
         let new_vector_to_insert = random_vector(&mut rng, DIM);
 
         let scorer = vector_holder.get_raw_scorer(new_vector_to_insert).unwrap();
+        scorer.set_hardware_counter_checked(false);
 
         for i in 0..NUM_VECTORS {
             candidates.push(ScoredPointOffset {

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -541,10 +541,10 @@ mod tests {
                     let fake_filter_context = FakeFilterContext {};
                     let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
                     let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
-                    raw_scorer.set_hardware_counter_checked(false);
                     let scorer =
                         FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
                     graph_layers.link_new_point(idx, scorer);
+                    raw_scorer.take_hardware_counter().discard_results();
                 });
         });
 
@@ -584,9 +584,9 @@ mod tests {
             let fake_filter_context = FakeFilterContext {};
             let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
             let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
-            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             graph_layers.link_new_point(idx, scorer);
+            raw_scorer.take_hardware_counter().discard_results();
         }
 
         (vector_holder, graph_layers)
@@ -654,11 +654,11 @@ mod tests {
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
-        raw_scorer.set_hardware_counter_checked(false);
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
 
+        raw_scorer.take_hardware_counter().discard_results();
         assert_eq!(reference_top.into_vec(), graph_search);
     }
 
@@ -738,11 +738,10 @@ mod tests {
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
-        raw_scorer.set_hardware_counter_checked(false);
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
-
+        raw_scorer.take_hardware_counter().discard_results();
         assert_eq!(reference_top.into_vec(), graph_search);
     }
 
@@ -764,11 +763,11 @@ mod tests {
         for idx in 0..(NUM_VECTORS as PointOffsetType) {
             let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
             let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
-            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(idx, level);
             graph_layers_builder.link_new_point(idx, scorer);
+            raw_scorer.take_hardware_counter().discard_results();
         }
         let graph_layers = graph_layers_builder
             .into_graph_layers::<GraphLinksRam>(None)
@@ -813,7 +812,6 @@ mod tests {
         let new_vector_to_insert = random_vector(&mut rng, DIM);
 
         let scorer = vector_holder.get_raw_scorer(new_vector_to_insert).unwrap();
-        scorer.set_hardware_counter_checked(false);
 
         for i in 0..NUM_VECTORS {
             candidates.push(ScoredPointOffset {
@@ -837,6 +835,8 @@ mod tests {
         for x in selected_candidates.iter() {
             eprintln!("selected_candidates = {x}");
         }
+
+        scorer.take_hardware_counter().discard_results();
     }
 
     #[test]

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -310,7 +310,10 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 } else {
                     new_raw_scorer(vector, vector_storage, id_tracker.deleted_point_bitslice())
                 }?;
+
+                // We don't need to process measurements for building HNSW indices.
                 raw_scorer.set_hardware_counter_checked(false);
+
                 let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
 
                 graph_layers_builder.link_new_point(vector_id, points_scorer);
@@ -463,6 +466,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 ),
                 None => new_raw_scorer(vector, vector_storage, id_tracker.deleted_point_bitslice()),
             }?;
+            // We don't need to process measurements for building HNSW indices.
             raw_scorer.set_hardware_counter_checked(false);
 
             let block_condition_checker = BuildConditionChecker {

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -43,12 +43,12 @@ where
         let fake_filter_context = FakeFilterContext {};
         let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
-        raw_scorer.set_hardware_counter_checked(false);
 
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let level = graph_layers_builder.get_random_layer(rng);
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);
+        raw_scorer.take_hardware_counter().discard_results();
     }
     (vector_holder, graph_layers_builder)
 }

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -43,6 +43,8 @@ where
         let fake_filter_context = FakeFilterContext {};
         let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
+        raw_scorer.set_hardware_counter_checked(false);
+
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let level = graph_layers_builder.get_random_layer(rng);
         graph_layers_builder.set_levels(idx, level);

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -61,6 +61,7 @@ fn test_compact_graph_layers() {
         .iter()
         .map(|query| {
             let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
+            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
             search_in_builder(&graph_layers_builder, top, ef, scorer)
         })
@@ -74,6 +75,7 @@ fn test_compact_graph_layers() {
         .iter()
         .map(|query| {
             let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
+            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
             graph_layers.search(top, ef, scorer, None)
         })

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -61,9 +61,10 @@ fn test_compact_graph_layers() {
         .iter()
         .map(|query| {
             let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
-            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
-            search_in_builder(&graph_layers_builder, top, ef, scorer)
+            let res = search_in_builder(&graph_layers_builder, top, ef, scorer);
+            raw_scorer.take_hardware_counter().discard_results();
+            res
         })
         .collect_vec();
 
@@ -75,9 +76,10 @@ fn test_compact_graph_layers() {
         .iter()
         .map(|query| {
             let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
-            raw_scorer.set_hardware_counter_checked(false);
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
-            graph_layers.search(top, ef, scorer, None)
+            let res = graph_layers.search(top, ef, scorer, None);
+            raw_scorer.take_hardware_counter().discard_results();
+            res
         })
         .collect_vec();
 

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -313,7 +313,7 @@ impl VectorIndex for PlainIndex {
                         .map(|scorer| {
                             let res =
                                 scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top);
-                            query_context.apply_hardware_counter(&scorer.hardware_counter());
+                            query_context.apply_hardware_counter(scorer.take_hardware_counter());
                             res
                         })
                     })
@@ -337,7 +337,7 @@ impl VectorIndex for PlainIndex {
                         )
                         .map(|scorer| {
                             let res = scorer.peek_top_all(top);
-                            query_context.apply_hardware_counter(&scorer.hardware_counter());
+                            query_context.apply_hardware_counter(scorer.take_hardware_counter());
                             res
                         })
                     })

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -307,12 +307,12 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                     }
                 };
                 let res = raw_scorer.peek_top_iter(&mut filtered_points, top);
-                vector_query_context.apply_hardware_counter(&raw_scorer.hardware_counter());
+                vector_query_context.apply_hardware_counter(raw_scorer.take_hardware_counter());
                 Ok(res)
             }
             None => {
                 let res = raw_scorer.peek_top_all(top);
-                vector_query_context.apply_hardware_counter(&raw_scorer.hardware_counter());
+                vector_query_context.apply_hardware_counter(raw_scorer.take_hardware_counter());
                 Ok(res)
             }
         }
@@ -359,7 +359,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             &is_stopped,
         );
         let search_result = search_context.plain_search(&ids);
-        vector_query_context.apply_hardware_counter(search_context.hardware_counter());
+        vector_query_context.apply_hardware_counter(search_context.take_hardware_counter());
         Ok(search_result)
     }
 
@@ -402,12 +402,12 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                     not_deleted_condition(idx) && filter_context.check(idx)
                 };
                 let res = search_context.search(&matches_filter_condition);
-                vector_query_context.apply_hardware_counter(search_context.hardware_counter());
+                vector_query_context.apply_hardware_counter(search_context.take_hardware_counter());
                 res
             }
             None => {
                 let res = search_context.search(&not_deleted_condition);
-                vector_query_context.apply_hardware_counter(search_context.hardware_counter());
+                vector_query_context.apply_hardware_counter(search_context.take_hardware_counter());
                 res
             }
         }

--- a/lib/segment/src/segment/search.rs
+++ b/lib/segment/src/segment/search.rs
@@ -112,6 +112,8 @@ impl Segment {
             &segment_query_context,
         )?;
 
+        segment_query_context.hardware_counter().discard_results(); // TODO: Propagate results instead of discarding!
+
         Ok(result.into_iter().next().unwrap())
     }
 }

--- a/lib/segment/src/segment/search.rs
+++ b/lib/segment/src/segment/search.rs
@@ -113,7 +113,9 @@ impl Segment {
         )?;
 
         // This function is only for testing and no measurements are needed.
-        segment_query_context.hardware_counter().discard_results();
+        segment_query_context
+            .take_hardware_counter()
+            .discard_results();
 
         Ok(result.into_iter().next().unwrap())
     }

--- a/lib/segment/src/segment/search.rs
+++ b/lib/segment/src/segment/search.rs
@@ -112,7 +112,8 @@ impl Segment {
             &segment_query_context,
         )?;
 
-        segment_query_context.hardware_counter().discard_results(); // TODO: Propagate results instead of discarding!
+        // This function is only for testing and no measurements are needed.
+        segment_query_context.hardware_counter().discard_results();
 
         Ok(result.into_iter().next().unwrap())
     }

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -84,7 +84,7 @@ fn test_search_batch_equivalence_single() {
 
     assert!(!search_result.is_empty());
     assert_eq!(search_result, search_batch_result[0].clone());
-    segment_query_context.hardware_counter().discard_results();
+    segment_query_context.take_hardware_counter().discard_results();
 }
 
 #[test]

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -84,7 +84,9 @@ fn test_search_batch_equivalence_single() {
 
     assert!(!search_result.is_empty());
     assert_eq!(search_result, search_batch_result[0].clone());
-    segment_query_context.take_hardware_counter().discard_results();
+    segment_query_context
+        .take_hardware_counter()
+        .discard_results();
 }
 
 #[test]

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -83,7 +83,8 @@ fn test_search_batch_equivalence_single() {
     eprintln!("search_batch_result = {search_batch_result:#?}");
 
     assert!(!search_result.is_empty());
-    assert_eq!(search_result, search_batch_result[0].clone())
+    assert_eq!(search_result, search_batch_result[0].clone());
+    segment_query_context.hardware_counter().discard_results();
 }
 
 #[test]

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -206,6 +206,10 @@ where
     fn hardware_counter(&self) -> HardwareCounterCell {
         self.query_scorer.hardware_counter()
     }
+
+    fn set_hardware_counter_checked(&self, checked: bool) {
+        self.query_scorer.set_hardware_counter_checked(checked);
+    }
 }
 
 struct AsyncRawScorerBuilder<'a> {

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -203,12 +203,8 @@ where
         pq.into_vec()
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
-        self.query_scorer.hardware_counter()
-    }
-
-    fn set_hardware_counter_checked(&self, checked: bool) {
-        self.query_scorer.set_hardware_counter_checked(checked);
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
+        self.query_scorer.take_hardware_counter()
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -392,6 +392,7 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
+        raw_scorer.set_hardware_counter_checked(false);
         let res = raw_scorer.peek_top_all(2);
 
         assert_eq!(res.len(), 2);
@@ -466,17 +467,21 @@ mod tests {
 
         let vector = vec![0.0, 1.0, 1.1, 1.0];
         let query = vector.as_slice().into();
-        let closest = new_raw_scorer(
+        let scorer = new_raw_scorer(
             query,
             &storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        .unwrap();
+        scorer.set_hardware_counter_checked(false);
+
+        let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
         assert_eq!(closest[0].idx, 0);
         assert_eq!(closest[1].idx, 1);
         assert_eq!(closest[2].idx, 4);
+
+        drop(scorer);
 
         // Delete 1, redelete 2
         storage.delete_vector(1 as PointOffsetType).unwrap();
@@ -490,16 +495,18 @@ mod tests {
         let vector = vec![1.0, 0.0, 0.0, 0.0];
         let query = vector.as_slice().into();
 
-        let closest = new_raw_scorer(
+        let scorer = new_raw_scorer(
             query,
             &storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        .unwrap();
+        scorer.set_hardware_counter_checked(false);
+        let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
         assert_eq!(closest[0].idx, 4);
         assert_eq!(closest[1].idx, 0);
+        drop(scorer);
 
         // Delete all
         storage.delete_vector(0 as PointOffsetType).unwrap();
@@ -512,13 +519,14 @@ mod tests {
 
         let vector = vec![1.0, 0.0, 0.0, 0.0];
         let query = vector.as_slice().into();
-        let closest = new_raw_scorer(
+        let scorer = new_raw_scorer(
             query,
             &storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
-        .unwrap()
-        .peek_top_all(5);
+        .unwrap();
+        scorer.set_hardware_counter_checked(false);
+        let closest = scorer.peek_top_all(5);
         assert!(closest.is_empty(), "must have no results, all deleted");
     }
 
@@ -577,13 +585,16 @@ mod tests {
 
         let vector = vec![0.0, 1.0, 1.1, 1.0];
         let query = vector.as_slice().into();
-        let closest = new_raw_scorer(
+        let scorer = new_raw_scorer(
             query,
             &storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        .unwrap();
+        scorer.set_hardware_counter_checked(false);
+        let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        drop(scorer);
+
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
         assert_eq!(closest[0].idx, 0);
         assert_eq!(closest[1].idx, 1);
@@ -652,6 +663,7 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
+        scorer.set_hardware_counter_checked(false);
 
         let mut res = vec![ScoredPointOffset { idx: 0, score: 0. }; query_points.len()];
         let res_count = scorer.score_points(&query_points, &mut res);
@@ -747,12 +759,14 @@ mod tests {
                 &stopped,
             )
             .unwrap();
+        scorer_quant.set_hardware_counter_checked(false);
         let scorer_orig = new_raw_scorer(
             query.clone(),
             &storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
+        scorer_orig.set_hardware_counter_checked(false);
         for i in 0..5 {
             let quant = scorer_quant.score_point(i);
             let orig = scorer_orig.score_point(i);
@@ -778,12 +792,14 @@ mod tests {
                 &stopped,
             )
             .unwrap();
+        scorer_quant.set_hardware_counter_checked(false);
         let scorer_orig = new_raw_scorer(
             query,
             &storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
+        scorer_orig.set_hardware_counter_checked(false);
 
         for i in 0..5 {
             let quant = scorer_quant.score_point(i);

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -151,6 +151,10 @@ where
 
     fn hardware_counter(&self) -> HardwareCounterCell {
         // TODO: implement!
-        HardwareCounterCell::new()
+        HardwareCounterCell::new().unchecked()
+    }
+
+    fn set_hardware_counter_checked(&self, _checked: bool) {
+        // TODO: implement
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -149,12 +149,8 @@ where
         unimplemented!("Custom scorer compares against multiple vectors, not just one")
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
-        // TODO: implement!
-        HardwareCounterCell::new().unchecked()
-    }
-
-    fn set_hardware_counter_checked(&self, _checked: bool) {
-        // TODO: implement
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
+        // ToDO: implement
+        HardwareCounterCell::new()
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -103,12 +103,8 @@ where
         self.quantized_data.score_internal(point_a, point_b)
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
         // TODO: implement!
         HardwareCounterCell::new()
-    }
-
-    fn set_hardware_counter_checked(&self, _checked: bool) {
-        // TODO: implement!
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -107,4 +107,8 @@ where
         // TODO: implement!
         HardwareCounterCell::new()
     }
+
+    fn set_hardware_counter_checked(&self, _checked: bool) {
+        // TODO: implement!
+    }
 }

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -112,11 +112,7 @@ impl<
         unimplemented!("Custom scorer can compare against multiple vectors, not just one")
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
-    }
-
-    fn set_hardware_counter_checked(&self, checked: bool) {
-        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -71,7 +71,7 @@ impl<
     > CustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TInputQuery, TStoredQuery>
 {
     fn hardware_counter_finalized(&self) -> HardwareCounterCell {
-        let mut counter = self.hardware_counter.clone();
+        let mut counter = self.hardware_counter.take();
 
         // Calculate the dimension multiplier here to improve performance of measuring.
         counter
@@ -114,5 +114,9 @@ impl<
 
     fn hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
+    }
+
+    fn set_hardware_counter_checked(&self, checked: bool) {
+        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -48,7 +48,7 @@ impl<
     }
 
     fn hardware_counter_finalized(&self) -> HardwareCounterCell {
-        let mut counter = self.hardware_counter.clone();
+        let mut counter = self.hardware_counter.take();
 
         // Calculate the dimension multiplier here to improve performance of measuring.
         counter
@@ -87,5 +87,9 @@ impl<
 
     fn hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
+    }
+
+    fn set_hardware_counter_checked(&self, checked: bool) {
+        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -85,11 +85,7 @@ impl<
         TMetric::similarity(v1, v2)
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
-    }
-
-    fn set_hardware_counter_checked(&self, checked: bool) {
-        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -19,9 +19,7 @@ pub trait QueryScorer<TVector: ?Sized> {
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType;
 
-    fn hardware_counter(&self) -> HardwareCounterCell;
-
-    fn set_hardware_counter_checked(&self, checked: bool);
+    fn take_hardware_counter(&self) -> HardwareCounterCell;
 }
 
 /// Colbert MaxSim metric, metric for multi-dense vectors

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -20,6 +20,8 @@ pub trait QueryScorer<TVector: ?Sized> {
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType;
 
     fn hardware_counter(&self) -> HardwareCounterCell;
+
+    fn set_hardware_counter_checked(&self, checked: bool);
 }
 
 /// Colbert MaxSim metric, metric for multi-dense vectors

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -140,11 +140,7 @@ impl<
         unimplemented!("Custom scorer can compare against multiple vectors, not just one")
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
-    }
-
-    fn set_hardware_counter_checked(&self, checked: bool) {
-        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -81,7 +81,7 @@ impl<
     > MultiCustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TQuery, TInputQuery>
 {
     fn hardware_counter_finalized(&self) -> HardwareCounterCell {
-        let mut counter = self.hardware_counter.clone();
+        let mut counter = self.hardware_counter.take();
 
         // Calculate the dimension multiplier here to improve performance of measuring.
         counter
@@ -142,5 +142,9 @@ impl<
 
     fn hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
+    }
+
+    fn set_hardware_counter_checked(&self, checked: bool) {
+        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -114,11 +114,7 @@ impl<
         self.score_multi(v1, v2)
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
-    }
-
-    fn set_hardware_counter_checked(&self, checked: bool) {
-        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -73,7 +73,7 @@ impl<
     > MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
     fn hardware_counter_finalized(&self) -> HardwareCounterCell {
-        let mut counter = self.hardware_counter.clone();
+        let mut counter = self.hardware_counter.take();
 
         // Calculate the dimension multiplier here to improve performance of measuring.
         counter
@@ -116,5 +116,9 @@ impl<
 
     fn hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter_finalized()
+    }
+
+    fn set_hardware_counter_checked(&self, checked: bool) {
+        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -65,11 +65,7 @@ impl<'a, TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> Query
         unimplemented!("Custom scorer can compare against multiple vectors, not just one")
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
         self.hardware_counter.take()
-    }
-
-    fn set_hardware_counter_checked(&self, checked: bool) {
-        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -66,6 +66,10 @@ impl<'a, TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> Query
     }
 
     fn hardware_counter(&self) -> HardwareCounterCell {
-        self.hardware_counter.clone()
+        self.hardware_counter.take()
+    }
+
+    fn set_hardware_counter_checked(&self, checked: bool) {
+        self.hardware_counter.set_checked(checked);
     }
 }

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -25,6 +25,7 @@ use crate::vector_storage::query_scorer::QueryScorer;
 
 /// RawScorer composition:
 ///
+/// ```plaintext
 ///                                              Metric
 ///                                             ┌───────────────────┐
 ///                                             │  - Cosine         │
@@ -44,6 +45,8 @@ use crate::vector_storage::query_scorer::QueryScorer;
 ///                       - Vector storage       └───────────────────┘
 ///                                              - Scoring logic
 ///                                              - Complex queries
+///
+/// ```
 ///
 /// Optimized scorer for multiple scoring requests comparing with a single query
 /// Holds current query and params, receives only subset of points to score
@@ -85,8 +88,7 @@ pub trait RawScorer {
 
     fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset>;
 
-    fn hardware_counter(&self) -> HardwareCounterCell;
-    fn set_hardware_counter_checked(&self, checked: bool);
+    fn take_hardware_counter(&self) -> HardwareCounterCell;
 }
 
 pub struct RawScorerImpl<'a, TVector: ?Sized, TQueryScorer>
@@ -926,12 +928,8 @@ where
         peek_top_largest_iterable(scores, top)
     }
 
-    fn hardware_counter(&self) -> HardwareCounterCell {
-        self.query_scorer.hardware_counter()
-    }
-
-    fn set_hardware_counter_checked(&self, checked: bool) {
-        self.query_scorer.set_hardware_counter_checked(checked);
+    fn take_hardware_counter(&self) -> HardwareCounterCell {
+        self.query_scorer.take_hardware_counter()
     }
 }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -86,6 +86,7 @@ pub trait RawScorer {
     fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset>;
 
     fn hardware_counter(&self) -> HardwareCounterCell;
+    fn set_hardware_counter_checked(&self, checked: bool);
 }
 
 pub struct RawScorerImpl<'a, TVector: ?Sized, TQueryScorer>
@@ -927,6 +928,10 @@ where
 
     fn hardware_counter(&self) -> HardwareCounterCell {
         self.query_scorer.hardware_counter()
+    }
+
+    fn set_hardware_counter_checked(&self, checked: bool) {
+        self.query_scorer.set_hardware_counter_checked(checked);
     }
 }
 

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -111,6 +111,7 @@ fn test_random_score(
     let query: QueryVector = sampler(&mut rng).take(dim).collect_vec().into();
 
     let raw_scorer = new_raw_scorer(query.clone(), storage, deleted_points).unwrap();
+    raw_scorer.set_hardware_counter_checked(false);
 
     let is_stopped = AtomicBool::new(false);
     let async_raw_scorer = if let VectorStorageEnum::DenseMemmap(storage) = storage {
@@ -118,6 +119,7 @@ fn test_random_score(
     } else {
         unreachable!();
     };
+    async_raw_scorer.set_hardware_counter_checked(false);
 
     let points = rng.gen_range(1..storage.total_vector_count());
     let points = (0..storage.total_vector_count() as _).choose_multiple(&mut rng, points);

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -111,7 +111,6 @@ fn test_random_score(
     let query: QueryVector = sampler(&mut rng).take(dim).collect_vec().into();
 
     let raw_scorer = new_raw_scorer(query.clone(), storage, deleted_points).unwrap();
-    raw_scorer.set_hardware_counter_checked(false);
 
     let is_stopped = AtomicBool::new(false);
     let async_raw_scorer = if let VectorStorageEnum::DenseMemmap(storage) = storage {
@@ -119,7 +118,6 @@ fn test_random_score(
     } else {
         unreachable!();
     };
-    async_raw_scorer.set_hardware_counter_checked(false);
 
     let points = rng.gen_range(1..storage.total_vector_count());
     let points = (0..storage.total_vector_count() as _).choose_multiple(&mut rng, points);
@@ -129,5 +127,7 @@ fn test_random_score(
 
     assert_eq!(res, async_res);
 
+    raw_scorer.take_hardware_counter().discard_results();
+    async_raw_scorer.take_hardware_counter().discard_results();
     Ok(())
 }

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -248,7 +248,6 @@ fn scoring_equivalency(
             id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
-        raw_scorer.set_hardware_counter_checked(false);
 
         let is_stopped = AtomicBool::new(false);
 
@@ -268,7 +267,6 @@ fn scoring_equivalency(
             )
             .unwrap(),
         };
-        other_scorer.set_hardware_counter_checked(false);
 
         let points =
             (0..other_storage.total_vector_count() as _).choose_multiple(&mut rng, SAMPLE_SIZE);
@@ -315,6 +313,9 @@ fn scoring_equivalency(
                 only {intersection} of {top} top results are shared",
             );
         }
+
+        raw_scorer.take_hardware_counter().discard_results();
+        other_scorer.take_hardware_counter().discard_results();
     }
 
     Ok(())

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -248,6 +248,7 @@ fn scoring_equivalency(
             id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
+        raw_scorer.set_hardware_counter_checked(false);
 
         let is_stopped = AtomicBool::new(false);
 
@@ -267,6 +268,7 @@ fn scoring_equivalency(
             )
             .unwrap(),
         };
+        other_scorer.set_hardware_counter_checked(false);
 
         let points =
             (0..other_storage.total_vector_count() as _).choose_multiple(&mut rng, SAMPLE_SIZE);

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -51,13 +51,15 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
 
     let vector = vec![0.0, 1.0, 1.1, 1.0];
     let query = vector.as_slice().into();
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);
     assert_eq!(closest[2].idx, 4);
+    drop(scorer);
 
     // Delete 1, redelete 2
     storage.delete_vector(1 as PointOffsetType).unwrap();
@@ -70,12 +72,14 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
 
     let vector = vec![1.0, 0.0, 0.0, 0.0];
     let query = vector.as_slice().into();
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
     assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
     assert_eq!(closest[0].idx, 4);
     assert_eq!(closest[1].idx, 0);
+    drop(scorer);
 
     // Delete all
     storage.delete_vector(0 as PointOffsetType).unwrap();
@@ -88,9 +92,10 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
 
     let vector = vec![1.0, 0.0, 0.0, 0.0];
     let query = vector.as_slice().into();
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_all(5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_all(5);
     assert!(closest.is_empty(), "must have no results, all deleted");
 }
 
@@ -146,9 +151,11 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
     let vector = vec![0.0, 1.0, 1.1, 1.0];
     let query = vector.as_slice().into();
 
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);
@@ -185,13 +192,15 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
 
     let query: QueryVector = [0.0, 1.0, 1.1, 1.0].into();
 
-    let closest = new_raw_scorer(
+    let scorer = new_raw_scorer(
         query.clone(),
         storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
-    .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
+    .unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
+    drop(scorer);
 
     let top_idx = match closest.first() {
         Some(scored_point) => {
@@ -207,6 +216,7 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
 
     let raw_scorer =
         new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    raw_scorer.set_hardware_counter_checked(false);
     let closest = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
     let query_points = vec![0, 1, 2, 3, 4];
@@ -280,12 +290,14 @@ fn test_score_quantized_points(storage: &mut VectorStorageEnum) {
             &stopped,
         )
         .unwrap();
+    scorer_quant.set_hardware_counter_checked(false);
     let scorer_orig = new_raw_scorer(
         query.clone(),
         storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap();
+    scorer_orig.set_hardware_counter_checked(false);
     for i in 0..5 {
         let quant = scorer_quant.score_point(i);
         let orig = scorer_orig.score_point(i);
@@ -312,8 +324,10 @@ fn test_score_quantized_points(storage: &mut VectorStorageEnum) {
             &stopped,
         )
         .unwrap();
+    scorer_quant.set_hardware_counter_checked(false);
     let scorer_orig =
         new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer_orig.set_hardware_counter_checked(false);
     for i in 0..5 {
         let quant = scorer_quant.score_point(i);
         let orig = scorer_orig.score_point(i);

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -118,9 +118,11 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     );
     let vector: Vec<Vec<f32>> = vec![vec![2.0; vector_dim]];
     let query = QueryVector::Nearest(vector.try_into().unwrap());
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 4);
     assert_eq!(closest[1].idx, 1);
@@ -137,9 +139,11 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
 
     let vector: Vec<Vec<f32>> = vec![vec![1.0; vector_dim]];
     let query = QueryVector::Nearest(vector.try_into().unwrap());
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    drop(scorer);
     assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
     assert_eq!(closest[0].idx, 4);
     assert_eq!(closest[1].idx, 0);
@@ -155,9 +159,10 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
 
     let vector: Vec<Vec<f32>> = vec![vec![1.0; vector_dim]];
     let query = QueryVector::Nearest(vector.try_into().unwrap());
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_all(5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_all(5);
     assert!(closest.is_empty(), "must have no results, all deleted");
 }
 
@@ -215,9 +220,11 @@ fn do_test_update_from_delete_points(
 
     let query = QueryVector::Nearest(vector.try_into().unwrap());
 
-    let closest = new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let scorer =
+        new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 4);
     assert_eq!(closest[1].idx, 1);

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -120,8 +120,8 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     let query = QueryVector::Nearest(vector.try_into().unwrap());
     let scorer =
         new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
-    scorer.set_hardware_counter_checked(false);
     let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    scorer.take_hardware_counter().discard_results();
     drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 4);
@@ -141,8 +141,8 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     let query = QueryVector::Nearest(vector.try_into().unwrap());
     let scorer =
         new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
-    scorer.set_hardware_counter_checked(false);
     let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    scorer.take_hardware_counter().discard_results();
     drop(scorer);
     assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
     assert_eq!(closest[0].idx, 4);
@@ -161,8 +161,8 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     let query = QueryVector::Nearest(vector.try_into().unwrap());
     let scorer =
         new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
-    scorer.set_hardware_counter_checked(false);
     let closest = scorer.peek_top_all(5);
+    scorer.take_hardware_counter().discard_results();
     assert!(closest.is_empty(), "must have no results, all deleted");
 }
 
@@ -222,8 +222,8 @@ fn do_test_update_from_delete_points(
 
     let scorer =
         new_raw_scorer(query, storage, borrowed_id_tracker.deleted_point_bitslice()).unwrap();
-    scorer.set_hardware_counter_checked(false);
     let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    scorer.take_hardware_counter().discard_results();
     drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 4);

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -72,13 +72,15 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         negatives: vec![],
     });
     // Because nearest search for raw scorer is incorrect,
-    let closest = new_raw_scorer(
+    let scorer = new_raw_scorer(
         query_vector,
         storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
-    .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    .unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);
@@ -161,13 +163,15 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         positives: vec![vector.into()],
         negatives: vec![],
     });
-    let closest = new_raw_scorer(
+    let scorer = new_raw_scorer(
         query_vector,
         storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
-    .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    .unwrap();
+    scorer.set_hardware_counter_checked(false);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -78,8 +78,8 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap();
-    scorer.set_hardware_counter_checked(false);
     let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    scorer.take_hardware_counter().discard_results();
     drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
@@ -169,8 +169,8 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap();
-    scorer.set_hardware_counter_checked(false);
     let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    scorer.take_hardware_counter().discard_results();
     drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -115,7 +115,6 @@ fn test_batch_and_single_request_equivalency() {
 
         let query_context = QueryContext::default();
         let segment_query_context = query_context.get_segment_query_context();
-        segment_query_context.hardware_counter().set_checked(false);
 
         let batch_res = segment
             .search_batch(
@@ -129,6 +128,9 @@ fn test_batch_and_single_request_equivalency() {
                 &segment_query_context,
             )
             .unwrap();
+
+        // Ignore the hardware counter in tests
+        segment_query_context.take_hardware_counter().discard_results();
 
         assert_eq!(search_res_1, batch_res[0]);
         assert_eq!(search_res_2, batch_res[1]);

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -130,7 +130,9 @@ fn test_batch_and_single_request_equivalency() {
             .unwrap();
 
         // Ignore the hardware counter in tests
-        segment_query_context.take_hardware_counter().discard_results();
+        segment_query_context
+            .take_hardware_counter()
+            .discard_results();
 
         assert_eq!(search_res_1, batch_res[0]);
         assert_eq!(search_res_2, batch_res[1]);

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -115,6 +115,7 @@ fn test_batch_and_single_request_equivalency() {
 
         let query_context = QueryContext::default();
         let segment_query_context = query_context.get_segment_query_context();
+        segment_query_context.hardware_counter().set_checked(false);
 
         let batch_res = segment
             .search_batch(

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -212,6 +212,11 @@ fn sparse_index_discover_test() {
         let query_context = QueryContext::default();
         let segment_query_context = query_context.get_segment_query_context();
         let vector_context = segment_query_context.get_vector_context(SPARSE_VECTOR_NAME);
+        vector_context
+            .hardware_counter()
+            .unwrap()
+            .set_checked(false);
+
         let sparse_search_result = sparse_index
             .search(&[&sparse_query], None, top, None, &vector_context)
             .unwrap();
@@ -223,7 +228,6 @@ fn sparse_index_discover_test() {
                 .get()
                 > 0
         );
-        vector_context.hardware_counter().unwrap().discard_results();
 
         let dense_search_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
@@ -306,6 +310,10 @@ fn sparse_index_hardware_measurement_test() {
     let segment_query_context = query_context.get_segment_query_context();
     let vector_context = segment_query_context.get_vector_context(SPARSE_VECTOR_NAME);
     assert!(vector_context.hardware_counter().is_some());
+    vector_context
+        .hardware_counter()
+        .unwrap()
+        .set_checked(false);
     assert_eq!(
         vector_context
             .hardware_counter()
@@ -331,5 +339,4 @@ fn sparse_index_hardware_measurement_test() {
             .get()
             > 0
     );
-    vector_context.hardware_counter().unwrap().discard_results();
 }

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -231,7 +231,9 @@ fn sparse_index_discover_test() {
             .search(&[&dense_query], None, top, None, &vector_context)
             .unwrap();
 
-        segment_query_context.take_hardware_counter().discard_results();
+        segment_query_context
+            .take_hardware_counter()
+            .discard_results();
 
         // check that nearest search uses sparse index
         let telemetry = sparse_index.get_telemetry_data(TelemetryDetail::default());
@@ -334,5 +336,7 @@ fn sparse_index_hardware_measurement_test() {
             > 0
     );
 
-    segment_query_context.take_hardware_counter().discard_results();
+    segment_query_context
+        .take_hardware_counter()
+        .discard_results();
 }

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::query_context::QueryContext;
+use segment::data_types::query_context::{QueryContext, VectorQueryContext};
 use segment::data_types::vectors::{QueryVector, VectorElementType, VectorInternal};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
@@ -183,14 +183,15 @@ fn sparse_index_discover_test() {
         // do discovery search
         let (sparse_query, dense_query) = random_discovery_query(&mut rnd, dim);
 
+        let vec_context = VectorQueryContext::default();
         let sparse_discovery_result = sparse_index
-            .search(&[&sparse_query], None, top, None, &Default::default())
+            .search(&[&sparse_query], None, top, None, &vec_context)
             .unwrap();
 
         let dense_discovery_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&dense_query], None, top, None, &Default::default())
+            .search(&[&dense_query], None, top, None, &vec_context)
             .unwrap();
 
         // check id only because scores can be epsilon-size different
@@ -222,6 +223,7 @@ fn sparse_index_discover_test() {
                 .get()
                 > 0
         );
+        vector_context.hardware_counter().unwrap().discard_results();
 
         let dense_search_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
@@ -329,4 +331,5 @@ fn sparse_index_hardware_measurement_test() {
             .get()
             > 0
     );
+    vector_context.hardware_counter().unwrap().discard_results();
 }

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -212,10 +212,6 @@ fn sparse_index_discover_test() {
         let query_context = QueryContext::default();
         let segment_query_context = query_context.get_segment_query_context();
         let vector_context = segment_query_context.get_vector_context(SPARSE_VECTOR_NAME);
-        vector_context
-            .hardware_counter()
-            .unwrap()
-            .set_checked(false);
 
         let sparse_search_result = sparse_index
             .search(&[&sparse_query], None, top, None, &vector_context)
@@ -232,8 +228,10 @@ fn sparse_index_discover_test() {
         let dense_search_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&dense_query], None, top, None, &Default::default())
+            .search(&[&dense_query], None, top, None, &vector_context)
             .unwrap();
+
+        segment_query_context.take_hardware_counter().discard_results();
 
         // check that nearest search uses sparse index
         let telemetry = sparse_index.get_telemetry_data(TelemetryDetail::default());
@@ -310,10 +308,6 @@ fn sparse_index_hardware_measurement_test() {
     let segment_query_context = query_context.get_segment_query_context();
     let vector_context = segment_query_context.get_vector_context(SPARSE_VECTOR_NAME);
     assert!(vector_context.hardware_counter().is_some());
-    vector_context
-        .hardware_counter()
-        .unwrap()
-        .set_checked(false);
     assert_eq!(
         vector_context
             .hardware_counter()
@@ -339,4 +333,6 @@ fn sparse_index_hardware_measurement_test() {
             .get()
             > 0
     );
+
+    segment_query_context.take_hardware_counter().discard_results();
 }

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -391,8 +391,8 @@ impl<'a, 'b, T: PostingListIter> SearchContext<'a, 'b, T> {
     }
 
     /// Return the current hardware measurement counter.
-    pub fn hardware_counter(&self) -> &HardwareCounterCell {
-        &self.hardware_counter
+    pub fn take_hardware_counter(&self) -> HardwareCounterCell {
+        self.hardware_counter.take()
     }
 }
 
@@ -560,8 +560,9 @@ mod tests {
         );
 
         // len(QueryVector)=3 * len(vector)=3 => 3*3 => 9
-        assert_eq!(search_context.hardware_counter().cpu_counter().get(), 9);
-        search_context.hardware_counter().discard_results();
+        let counter = search_context.take_hardware_counter();
+        assert_eq!(counter.cpu_counter().get(), 9);
+        counter.discard_results();
     }
 
     #[test]
@@ -608,7 +609,7 @@ mod tests {
                 },
             ]
         );
-        search_context.hardware_counter().discard_results();
+        search_context.take_hardware_counter().discard_results();
         drop(search_context);
 
         // update index with new point
@@ -652,7 +653,7 @@ mod tests {
                 },
             ]
         );
-        search_context.hardware_counter().discard_results();
+        search_context.take_hardware_counter().discard_results();
     }
 
     #[test]
@@ -706,7 +707,7 @@ mod tests {
         // [ID=3] (Retrieve 1-3)           => 3
         //                       3 + 3 + 9 => 15
         assert_eq!(search_context.hardware_counter.cpu_counter().get(), 15);
-        search_context.hardware_counter().discard_results();
+        search_context.take_hardware_counter().discard_results();
 
         let mut search_context = SearchContext::new(
             RemappedSparseVector {
@@ -741,7 +742,7 @@ mod tests {
         // No difference to previous calculation because it's the same amount of score
         // calculations when increasing the "top" parameter.
         assert_eq!(search_context.hardware_counter.cpu_counter().get(), 15);
-        search_context.hardware_counter().discard_results();
+        search_context.take_hardware_counter().discard_results();
     }
 
     #[test]
@@ -958,8 +959,9 @@ mod tests {
         // [ID=2] (Retrieve two sparse vectors (1,3))     + QueryLength=3 => 5
         // [ID=3] (Retrieve two sparse vectors (1,3))     + QueryLength=3 => 5
         //                                                      6 + 5 + 5 => 16
-        assert_eq!(search_context.hardware_counter().cpu_counter().get(), 16);
-        search_context.hardware_counter().discard_results();
+        let hardware_counter = search_context.take_hardware_counter();
+        assert_eq!(hardware_counter.cpu_counter().get(), 16);
+        hardware_counter.discard_results();
     }
 
     #[test]
@@ -1008,7 +1010,8 @@ mod tests {
         // [ID=2] (Retrieve two sparse vectors (1,3)) + QueryLength=2 => 4
         // [ID=3] (Retrieve one sparse vector (3))    + QueryLength=2 => 3
         //                                                  4 + 4 + 3 => 11
-        assert_eq!(search_context.hardware_counter().cpu_counter().get(), 11);
-        search_context.hardware_counter().discard_results();
+        let hardware_counter = search_context.take_hardware_counter();
+        assert_eq!(hardware_counter.cpu_counter().get(), 11);
+        hardware_counter.discard_results();
     }
 }

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -561,6 +561,7 @@ mod tests {
 
         // len(QueryVector)=3 * len(vector)=3 => 3*3 => 9
         assert_eq!(search_context.hardware_counter().cpu_counter().get(), 9);
+        search_context.hardware_counter().discard_results();
     }
 
     #[test]
@@ -607,6 +608,7 @@ mod tests {
                 },
             ]
         );
+        search_context.hardware_counter().discard_results();
         drop(search_context);
 
         // update index with new point
@@ -650,6 +652,7 @@ mod tests {
                 },
             ]
         );
+        search_context.hardware_counter().discard_results();
     }
 
     #[test]
@@ -703,6 +706,7 @@ mod tests {
         // [ID=3] (Retrieve 1-3)           => 3
         //                       3 + 3 + 9 => 15
         assert_eq!(search_context.hardware_counter.cpu_counter().get(), 15);
+        search_context.hardware_counter().discard_results();
 
         let mut search_context = SearchContext::new(
             RemappedSparseVector {
@@ -737,6 +741,7 @@ mod tests {
         // No difference to previous calculation because it's the same amount of score
         // calculations when increasing the "top" parameter.
         assert_eq!(search_context.hardware_counter.cpu_counter().get(), 15);
+        search_context.hardware_counter().discard_results();
     }
 
     #[test]
@@ -954,6 +959,7 @@ mod tests {
         // [ID=3] (Retrieve two sparse vectors (1,3))     + QueryLength=3 => 5
         //                                                      6 + 5 + 5 => 16
         assert_eq!(search_context.hardware_counter().cpu_counter().get(), 16);
+        search_context.hardware_counter().discard_results();
     }
 
     #[test]
@@ -1003,5 +1009,6 @@ mod tests {
         // [ID=3] (Retrieve one sparse vector (3))    + QueryLength=2 => 3
         //                                                  4 + 4 + 3 => 11
         assert_eq!(search_context.hardware_counter().cpu_counter().get(), 11);
+        search_context.hardware_counter().discard_results();
     }
 }


### PR DESCRIPTION
Depends on #5261

Allows to easily detect losing hardware measurements by panicing (in debug mode) and logging a warning (in release mode) when measurements don't get processed.
This helps keeping track of many different `HardwareCounterCells` across the code and in new code.