### PR TITLE
Bump rustls-pki-types-1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ tower-layer = "0.3.3"
 reqwest = { workspace = true }
 # rustls minor version must be synced with actix-web
 rustls = { version = "0.23.15", default-features = false, features = [ "logging", "std", "tls12", "ring"] }
-rustls-pki-types = "1.8.0"
+rustls-pki-types = "1.10.0"
 rustls-pemfile = "2.2.0"
 prometheus = { version = "0.13.4", default-features = false }
 validator = { workspace = true }


### PR DESCRIPTION
The `cargo.lock` already contains this version but the `cargo.toml` has not been updated.