### PR TITLE
Track vector storage usage in bytes for each of the segments

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10596,7 +10596,7 @@
             "format": "uint",
             "minimum": 0
           },
-          "vector_size_bytes": {
+          "vectors_size_bytes": {
             "type": "integer",
             "format": "uint",
             "minimum": 0

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10569,7 +10569,8 @@
           "num_vectors",
           "ram_usage_bytes",
           "segment_type",
-          "vector_data"
+          "vector_data",
+          "vectors_size_bytes"
         ],
         "properties": {
           "segment_type": {
@@ -10591,6 +10592,11 @@
             "minimum": 0
           },
           "num_deleted_vectors": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "vector_size_bytes": {
             "type": "integer",
             "format": "uint",
             "minimum": 0

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -905,6 +905,7 @@ impl SegmentEntry for ProxySegment {
             num_indexed_vectors,
             num_points: self.available_point_count(),
             num_deleted_vectors: write_info.num_deleted_vectors,
+            vectors_size_bytes: wrapped_info.vectors_size_bytes + write_info.vectors_size_bytes,
             ram_usage_bytes: wrapped_info.ram_usage_bytes + write_info.ram_usage_bytes,
             disk_usage_bytes: wrapped_info.disk_usage_bytes + write_info.disk_usage_bytes,
             is_appendable: false,

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -67,7 +67,7 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
         self.vectors.len()
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<VectorElementType>()
     }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -116,7 +116,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 let vector_storage = vector_storage.borrow();
                 let available_vectors = vector_storage.available_vector_count();
                 let full_scan_threshold = vector_storage
-                    .available_size_in_bytes()
+                    .size_in_bytes()
                     .checked_div(available_vectors)
                     .and_then(|avg_vector_size| {
                         hnsw_config
@@ -210,7 +210,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let total_vector_count = vector_storage.total_vector_count();
 
         let full_scan_threshold = vector_storage
-            .available_size_in_bytes()
+            .size_in_bytes()
             .checked_div(total_vector_count)
             .and_then(|avg_vector_size| {
                 hnsw_config

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -251,8 +251,7 @@ impl PlainIndex {
         let vector_storage = self.vector_storage.borrow();
         let available_vector_count = vector_storage.available_vector_count();
         if available_vector_count > 0 {
-            let vector_size_bytes =
-                vector_storage.size_in_bytes() / available_vector_count;
+            let vector_size_bytes = vector_storage.size_in_bytes() / available_vector_count;
             let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
 
             if let Some(payload_filter) = filter {

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -252,7 +252,7 @@ impl PlainIndex {
         let available_vector_count = vector_storage.available_vector_count();
         if available_vector_count > 0 {
             let vector_size_bytes =
-                vector_storage.available_size_in_bytes() / available_vector_count;
+                vector_storage.size_in_bytes() / available_vector_count;
             let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
 
             if let Some(payload_filter) = filter {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -449,7 +449,7 @@ impl SegmentEntry for Segment {
             .map(|data| data.vector_storage.borrow().available_vector_count())
             .sum();
 
-        let vector_data_info = self
+        let vector_data_info: HashMap<_, _> = self
             .vector_data
             .iter()
             .map(|(key, vector_data)| {
@@ -465,6 +465,7 @@ impl SegmentEntry for Segment {
                         0
                     },
                     num_deleted_vectors: vector_storage.deleted_vector_count(),
+                    size_bytes: vector_storage.available_size_in_bytes(),
                 };
                 (key.to_string(), vector_data_info)
             })
@@ -479,14 +480,19 @@ impl SegmentEntry for Segment {
             0
         };
 
+        let total_vector_size_bytes = vector_data_info
+            .iter()
+            .map(|(_, vector_data)| vector_data.size_bytes)
+            .sum();
+
         SegmentInfo {
             segment_type: self.segment_type,
             num_vectors,
             num_indexed_vectors,
             num_points: self.available_point_count(),
             num_deleted_vectors: self.deleted_point_count(),
-            ram_usage_bytes: 0,  // ToDo: Implement
-            disk_usage_bytes: 0, // ToDo: Implement
+            ram_usage_bytes: 0, // ToDo: Implement
+            disk_usage_bytes: total_vector_size_bytes,
             is_appendable: self.appendable_flag,
             index_schema: schema,
             vector_data: vector_data_info,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -460,7 +460,7 @@ impl SegmentEntry for Segment {
                 let vector_index = vector_data.vector_index.borrow();
                 let is_indexed = vector_index.is_index();
 
-                vectors_size_bytes += vector_storage.size_in_bytes() as u64;
+                vectors_size_bytes += vector_storage.size_in_bytes();
 
                 let vector_data_info = VectorDataInfo {
                     num_vectors,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -390,7 +390,7 @@ impl SegmentEntry for Segment {
         Ok(self.vector_data[vector_name]
             .vector_storage
             .borrow()
-            .available_size_in_bytes())
+            .size_in_bytes())
     }
 
     fn estimate_point_count<'a>(&'a self, filter: Option<&'a Filter>) -> CardinalityEstimation {
@@ -449,7 +449,7 @@ impl SegmentEntry for Segment {
             .map(|data| data.vector_storage.borrow().available_vector_count())
             .sum();
 
-        let mut total_segment_size_bytes = 0;
+        let mut vectors_size_bytes: u64 = 0;
 
         let vector_data_info: HashMap<_, _> = self
             .vector_data
@@ -460,7 +460,7 @@ impl SegmentEntry for Segment {
                 let vector_index = vector_data.vector_index.borrow();
                 let is_indexed = vector_index.is_index();
 
-                total_segment_size_bytes += vector_storage.available_size_in_bytes();
+                vectors_size_bytes += vector_storage.size_in_bytes();
 
                 let vector_data_info = VectorDataInfo {
                     num_vectors,
@@ -490,8 +490,9 @@ impl SegmentEntry for Segment {
             num_indexed_vectors,
             num_points: self.available_point_count(),
             num_deleted_vectors: self.deleted_point_count(),
+            vectors_size_bytes, // Considers vector storage, but not payload or indices
             ram_usage_bytes: 0, // ToDo: Implement
-            disk_usage_bytes: total_segment_size_bytes,
+            disk_usage_bytes: 0, // ToDo: Implement
             is_appendable: self.appendable_flag,
             index_schema: schema,
             vector_data: vector_data_info,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -449,7 +449,7 @@ impl SegmentEntry for Segment {
             .map(|data| data.vector_storage.borrow().available_vector_count())
             .sum();
 
-        let mut vectors_size_bytes: u64 = 0;
+        let mut vectors_size_bytes: usize = 0;
 
         let vector_data_info: HashMap<_, _> = self
             .vector_data
@@ -460,7 +460,7 @@ impl SegmentEntry for Segment {
                 let vector_index = vector_data.vector_index.borrow();
                 let is_indexed = vector_index.is_index();
 
-                vectors_size_bytes += vector_storage.size_in_bytes();
+                vectors_size_bytes += vector_storage.size_in_bytes() as u64;
 
                 let vector_data_info = VectorDataInfo {
                     num_vectors,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -449,6 +449,8 @@ impl SegmentEntry for Segment {
             .map(|data| data.vector_storage.borrow().available_vector_count())
             .sum();
 
+        let mut total_vector_size_bytes = 0;
+
         let vector_data_info: HashMap<_, _> = self
             .vector_data
             .iter()
@@ -457,6 +459,9 @@ impl SegmentEntry for Segment {
                 let num_vectors = vector_storage.available_vector_count();
                 let vector_index = vector_data.vector_index.borrow();
                 let is_indexed = vector_index.is_index();
+
+                total_vector_size_bytes += vector_storage.available_size_in_bytes();
+
                 let vector_data_info = VectorDataInfo {
                     num_vectors,
                     num_indexed_vectors: if is_indexed {
@@ -465,7 +470,6 @@ impl SegmentEntry for Segment {
                         0
                     },
                     num_deleted_vectors: vector_storage.deleted_vector_count(),
-                    size_bytes: vector_storage.available_size_in_bytes(),
                 };
                 (key.to_string(), vector_data_info)
             })
@@ -480,10 +484,10 @@ impl SegmentEntry for Segment {
             0
         };
 
-        let total_vector_size_bytes = vector_data_info
-            .iter()
-            .map(|(_, vector_data)| vector_data.size_bytes)
-            .sum();
+        // let total_vector_size_bytes = vector_data_info
+        //     .iter()
+        //     .map(|(_, vector_data)| vector_data.size_bytes)
+        //     .sum();
 
         SegmentInfo {
             segment_type: self.segment_type,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -449,7 +449,7 @@ impl SegmentEntry for Segment {
             .map(|data| data.vector_storage.borrow().available_vector_count())
             .sum();
 
-        let mut total_vector_size_bytes = 0;
+        let mut total_segment_size_bytes = 0;
 
         let vector_data_info: HashMap<_, _> = self
             .vector_data
@@ -460,7 +460,7 @@ impl SegmentEntry for Segment {
                 let vector_index = vector_data.vector_index.borrow();
                 let is_indexed = vector_index.is_index();
 
-                total_vector_size_bytes += vector_storage.available_size_in_bytes();
+                total_segment_size_bytes += vector_storage.available_size_in_bytes();
 
                 let vector_data_info = VectorDataInfo {
                     num_vectors,
@@ -484,11 +484,6 @@ impl SegmentEntry for Segment {
             0
         };
 
-        // let total_vector_size_bytes = vector_data_info
-        //     .iter()
-        //     .map(|(_, vector_data)| vector_data.size_bytes)
-        //     .sum();
-
         SegmentInfo {
             segment_type: self.segment_type,
             num_vectors,
@@ -496,7 +491,7 @@ impl SegmentEntry for Segment {
             num_points: self.available_point_count(),
             num_deleted_vectors: self.deleted_point_count(),
             ram_usage_bytes: 0, // ToDo: Implement
-            disk_usage_bytes: total_vector_size_bytes,
+            disk_usage_bytes: total_segment_size_bytes,
             is_appendable: self.appendable_flag,
             index_schema: schema,
             vector_data: vector_data_info,

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -85,6 +85,7 @@ impl Anonymize for SegmentInfo {
             num_points: self.num_points.anonymize(),
             num_indexed_vectors: self.num_indexed_vectors.anonymize(),
             num_deleted_vectors: self.num_deleted_vectors.anonymize(),
+            vectors_size_bytes: self.vectors_size_bytes.anonymize(),
             ram_usage_bytes: self.ram_usage_bytes.anonymize(),
             disk_usage_bytes: self.disk_usage_bytes.anonymize(),
             is_appendable: self.is_appendable,

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -100,6 +100,7 @@ impl Anonymize for VectorDataInfo {
             num_vectors: self.num_vectors.anonymize(),
             num_indexed_vectors: self.num_indexed_vectors.anonymize(),
             num_deleted_vectors: self.num_deleted_vectors.anonymize(),
+            size_bytes: self.size_bytes.anonymize(),
         }
     }
 }

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -100,7 +100,6 @@ impl Anonymize for VectorDataInfo {
             num_vectors: self.num_vectors.anonymize(),
             num_indexed_vectors: self.num_indexed_vectors.anonymize(),
             num_deleted_vectors: self.num_deleted_vectors.anonymize(),
-            size_bytes: self.size_bytes.anonymize(),
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -317,6 +317,7 @@ pub struct VectorDataInfo {
     pub num_vectors: usize,
     pub num_indexed_vectors: usize,
     pub num_deleted_vectors: usize,
+    pub size_bytes: usize,
 }
 
 /// Aggregated information about segment

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -328,6 +328,7 @@ pub struct SegmentInfo {
     pub num_points: usize,
     pub num_indexed_vectors: usize,
     pub num_deleted_vectors: usize,
+    pub vectors_size_bytes: u64,
     pub ram_usage_bytes: usize,
     pub disk_usage_bytes: usize,
     pub is_appendable: bool,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -317,7 +317,6 @@ pub struct VectorDataInfo {
     pub num_vectors: usize,
     pub num_indexed_vectors: usize,
     pub num_deleted_vectors: usize,
-    pub size_bytes: usize,
 }
 
 /// Aggregated information about segment

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -328,7 +328,7 @@ pub struct SegmentInfo {
     pub num_points: usize,
     pub num_indexed_vectors: usize,
     pub num_deleted_vectors: usize,
-    pub vectors_size_bytes: u64,
+    pub vectors_size_bytes: usize,
     pub ram_usage_bytes: usize,
     pub disk_usage_bytes: usize,
     pub is_appendable: bool,

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -86,7 +86,7 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
         self.vectors.len()
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
 

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -153,7 +153,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         self.mmap_store.as_ref().unwrap().num_vectors
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
 

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -209,7 +209,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         self.vectors.len()
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -146,7 +146,7 @@ impl<
         self.offsets.len()
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         if self.total_vector_count() > 0 {
             let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
             (total_size as u128 * self.available_vector_count() as u128

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -329,7 +329,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
         self.vectors_metadata.len()
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         if self.total_vector_count() > 0 {
             let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
             (total_size as u128 * self.available_vector_count() as u128

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -162,7 +162,7 @@ impl VectorStorage for SimpleSparseVectorStorage {
         self.total_vector_count
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         self.total_sparse_size * (std::mem::size_of::<f32>() + std::mem::size_of::<u32>())
     }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -53,7 +53,7 @@ pub trait VectorStorage {
             .saturating_sub(self.deleted_vector_count())
     }
 
-    fn available_size_in_bytes(&self) -> usize;
+    fn size_in_bytes(&self) -> usize;
 
     /// Get the vector by the given key
     fn get_vector(&self, key: PointOffsetType) -> CowVector;
@@ -441,30 +441,30 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn available_size_in_bytes(&self) -> usize {
+    fn size_in_bytes(&self) -> usize {
         match self {
-            VectorStorageEnum::DenseSimple(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseSimpleByte(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseSimpleHalf(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseMemmap(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseMemmapByte(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseAppendableInRam(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseAppendableInRamByte(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::DenseAppendableInRamHalf(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::SparseSimple(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseSimple(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseSimpleByte(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableInRam(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => v.available_size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => v.available_size_in_bytes(),
+            VectorStorageEnum::DenseSimple(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseSimpleByte(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseSimpleHalf(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseMemmap(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseMemmapByte(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseAppendableInRam(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseAppendableInRamByte(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseAppendableInRamHalf(v) => v.size_in_bytes(),
+            VectorStorageEnum::SparseSimple(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseSimple(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableInRam(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => v.size_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => v.size_in_bytes(),
         }
     }
 


### PR DESCRIPTION
We need this to aggregate the size of replicas for CM.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
