### PR TITLE
Inference Service, query requests (rest)

### DIFF
--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -70,16 +70,7 @@ impl Validate for VectorInput {
                 errors.add("image", err);
                 Err(errors)
             }
-            VectorInput::Object(_) => {
-                let mut errors = ValidationErrors::default();
-                let mut err = ValidationError::new("not_supported_inference");
-                err.add_param(
-                    Cow::from("message"),
-                    &"Object inference is not implemented, please use vectors instead",
-                );
-                errors.add("object", err);
-                Err(errors)
-            }
+            VectorInput::Object(_) => Ok(()),
         }
     }
 }

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -268,7 +268,7 @@ async fn process_inference_input<T: std::fmt::Debug>(
         ))
     })?;
 
-    info!("Starting inference processing for {input_type}");
+    debug!("Starting inference processing for {input_type}");
 
     let vectors = service
         .infer(data, InferenceType::Query)

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -6,7 +6,7 @@ use collection::operations::universal_query::collection_query::{
 };
 use collection::operations::universal_query::shard_query::{FusionInternal, SampleInternal};
 use futures_util::future::try_join_all;
-use log::{error, info, warn};
+use log::{debug, error, warn};
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{MultiDenseVectorInternal, VectorInternal, DEFAULT_VECTOR_NAME};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
@@ -271,7 +271,7 @@ async fn process_inference_input<T: std::fmt::Debug>(
     debug!("Starting inference processing for {input_type}");
 
     let vectors = service
-        .infer(data, InferenceType::Query)
+        .infer(data, InferenceType::Search)
         .await
         .map_err(|e| {
             error!(

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -301,7 +301,7 @@ async fn process_inference_input<T: std::fmt::Debug>(
         );
     }
 
-    info!(
+    debug!(
         "Successfully processed {input_type} inference. Vector count: {count}",
         count = vectors.len()
     );

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -282,7 +282,7 @@ async fn process_inference_input<T: std::fmt::Debug>(
         })?;
 
     if vectors.is_empty() {
-        /// log the content too in case of empty vector
+        // log the content too in case of empty vector
         if let Some(content) = debug_content {
             warn!("Empty vector array for {input_type}. Content: {content:?}");
         } else {

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -5,10 +5,14 @@ use collection::operations::universal_query::collection_query::{
     VectorInputInternal, VectorQuery,
 };
 use collection::operations::universal_query::shard_query::{FusionInternal, SampleInternal};
+use futures_util::future::try_join_all;
+use log::{error, info, warn};
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{MultiDenseVectorInternal, VectorInternal, DEFAULT_VECTOR_NAME};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use storage::content_manager::errors::StorageError;
+
+use crate::common::inference::service::{InferenceData, InferenceService, InferenceType};
 
 pub async fn convert_query_groups_request_from_rest(
     request: rest::QueryGroupsRequestInternal,
@@ -26,13 +30,17 @@ pub async fn convert_query_groups_request_from_rest(
         group_request,
     } = request;
 
-    let prefetch = prefetch
-        .into_iter()
-        .flatten()
-        .map(convert_collection_prefetch)
-        .collect();
+    let query = if let Some(q) = query {
+        Some(convert_query(q).await?)
+    } else {
+        None
+    };
 
-    let query = query.map(convert_query);
+    let prefetch = if let Some(prefetches) = prefetch {
+        try_join_all(prefetches.into_iter().map(convert_collection_prefetch)).await?
+    } else {
+        Vec::new()
+    };
 
     Ok(CollectionQueryGroupsRequest {
         prefetch,
@@ -72,13 +80,17 @@ pub async fn convert_query_request_from_rest(
         lookup_from,
     } = request;
 
-    let prefetch = prefetch
-        .into_iter()
-        .flatten()
-        .map(convert_collection_prefetch)
-        .collect();
+    let prefetch = if let Some(prefetches) = prefetch {
+        try_join_all(prefetches.into_iter().map(convert_collection_prefetch)).await?
+    } else {
+        Vec::new()
+    };
 
-    let query = query.map(convert_query);
+    let query = if let Some(q) = query {
+        Some(convert_query(q).await?)
+    } else {
+        None
+    };
 
     Ok(CollectionQueryRequest {
         prefetch,
@@ -95,7 +107,9 @@ pub async fn convert_query_request_from_rest(
     })
 }
 
-fn convert_collection_prefetch(prefetch: rest::Prefetch) -> CollectionPrefetch {
+async fn convert_collection_prefetch(
+    prefetch: rest::Prefetch,
+) -> Result<CollectionPrefetch, StorageError> {
     let rest::Prefetch {
         prefetch,
         query,
@@ -107,15 +121,20 @@ fn convert_collection_prefetch(prefetch: rest::Prefetch) -> CollectionPrefetch {
         lookup_from,
     } = prefetch;
 
-    let prefetch = prefetch
-        .into_iter()
-        .flatten()
-        .map(convert_collection_prefetch)
-        .collect();
+    let query = match query {
+        Some(q) => Some(convert_query(q).await?),
+        None => None,
+    };
 
-    let query = query.map(convert_query);
+    let prefetch = try_join_all(
+        prefetch
+            .into_iter()
+            .flatten()
+            .map(convert_collection_prefetch),
+    )
+    .await?;
 
-    CollectionPrefetch {
+    Ok(CollectionPrefetch {
         prefetch,
         query,
         using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
@@ -124,111 +143,210 @@ fn convert_collection_prefetch(prefetch: rest::Prefetch) -> CollectionPrefetch {
         limit: limit.unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
         params,
         lookup_from,
-    }
+    })
 }
 
-fn convert_query(query: rest::QueryInterface) -> Query {
+async fn convert_query(query: rest::QueryInterface) -> Result<Query, StorageError> {
     let query = rest::Query::from(query);
 
     match query {
-        rest::Query::Nearest(nearest) => {
-            Query::Vector(VectorQuery::Nearest(convert_vector_input(nearest.nearest)))
+        rest::Query::Nearest(nearest) => Ok(Query::Vector(VectorQuery::Nearest(
+            convert_vector_input(nearest.nearest).await?,
+        ))),
+        rest::Query::Recommend(recommend) => Ok(Query::Vector(
+            convert_recommend_input(recommend.recommend).await?,
+        )),
+        rest::Query::Discover(discover) => Ok(Query::Vector(
+            convert_discover_input(discover.discover).await?,
+        )),
+        rest::Query::Context(context) => {
+            Ok(Query::Vector(convert_context_input(context.context).await?))
         }
-        rest::Query::Recommend(recommend) => {
-            Query::Vector(convert_recommend_input(recommend.recommend))
-        }
-        rest::Query::Discover(discover) => Query::Vector(convert_discover_input(discover.discover)),
-        rest::Query::Context(context) => Query::Vector(convert_context_input(context.context)),
-        rest::Query::OrderBy(order_by) => Query::OrderBy(OrderBy::from(order_by.order_by)),
-        rest::Query::Fusion(fusion) => Query::Fusion(FusionInternal::from(fusion.fusion)),
-        rest::Query::Sample(sample) => Query::Sample(SampleInternal::from(sample.sample)),
+        rest::Query::OrderBy(order_by) => Ok(Query::OrderBy(OrderBy::from(order_by.order_by))),
+        rest::Query::Fusion(fusion) => Ok(Query::Fusion(FusionInternal::from(fusion.fusion))),
+        rest::Query::Sample(sample) => Ok(Query::Sample(SampleInternal::from(sample.sample))),
     }
 }
 
-fn convert_recommend_input(recommend: rest::RecommendInput) -> VectorQuery<VectorInputInternal> {
+async fn convert_recommend_input(
+    recommend: rest::RecommendInput,
+) -> Result<VectorQuery<VectorInputInternal>, StorageError> {
     let rest::RecommendInput {
         positive,
         negative,
         strategy,
     } = recommend;
 
-    let positives = positive
-        .into_iter()
-        .flatten()
-        .map(convert_vector_input)
-        .collect();
-    let negatives = negative
-        .into_iter()
-        .flatten()
-        .map(convert_vector_input)
-        .collect();
+    let positives = try_join_all(positive.into_iter().flatten().map(convert_vector_input)).await?;
+    let negatives = try_join_all(negative.into_iter().flatten().map(convert_vector_input)).await?;
+
     let reco_query = RecoQuery::new(positives, negatives);
 
     match strategy.unwrap_or_default() {
-        rest::RecommendStrategy::AverageVector => VectorQuery::RecommendAverageVector(reco_query),
-        rest::RecommendStrategy::BestScore => VectorQuery::RecommendBestScore(reco_query),
+        rest::RecommendStrategy::AverageVector => {
+            Ok(VectorQuery::RecommendAverageVector(reco_query))
+        }
+        rest::RecommendStrategy::BestScore => Ok(VectorQuery::RecommendBestScore(reco_query)),
     }
 }
 
-fn convert_discover_input(discover: rest::DiscoverInput) -> VectorQuery<VectorInputInternal> {
+async fn convert_discover_input(
+    discover: rest::DiscoverInput,
+) -> Result<VectorQuery<VectorInputInternal>, StorageError> {
     let rest::DiscoverInput { target, context } = discover;
 
-    let target = convert_vector_input(target);
-    let context = context
-        .into_iter()
-        .flatten()
-        .map(context_pair_from_rest)
-        .collect();
-
-    VectorQuery::Discover(DiscoveryQuery::new(target, context))
+    let target = convert_vector_input(target).await?;
+    let context = try_join_all(
+        context
+            .into_iter()
+            .flatten()
+            .map(context_pair_from_rest)
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    Ok(VectorQuery::Discover(DiscoveryQuery::new(target, context)))
 }
 
-fn convert_context_input(context: rest::ContextInput) -> VectorQuery<VectorInputInternal> {
+async fn convert_context_input(
+    context: rest::ContextInput,
+) -> Result<VectorQuery<VectorInputInternal>, StorageError> {
     let rest::ContextInput(context) = context;
 
-    let context = context
-        .into_iter()
-        .flatten()
-        .map(context_pair_from_rest)
-        .collect();
-
-    VectorQuery::Context(ContextQuery::new(context))
+    let context = try_join_all(context.into_iter().flatten().map(context_pair_from_rest)).await?;
+    Ok(VectorQuery::Context(ContextQuery::new(context)))
 }
 
-fn convert_vector_input(vector: rest::VectorInput) -> VectorInputInternal {
+async fn convert_vector_input(
+    vector: rest::VectorInput,
+) -> Result<VectorInputInternal, StorageError> {
     match vector {
-        rest::VectorInput::Id(id) => VectorInputInternal::Id(id),
+        rest::VectorInput::Id(id) => Ok(VectorInputInternal::Id(id)),
         rest::VectorInput::DenseVector(dense) => {
-            VectorInputInternal::Vector(VectorInternal::Dense(dense))
+            Ok(VectorInputInternal::Vector(VectorInternal::Dense(dense)))
         }
         rest::VectorInput::SparseVector(sparse) => {
-            VectorInputInternal::Vector(VectorInternal::Sparse(sparse))
+            Ok(VectorInputInternal::Vector(VectorInternal::Sparse(sparse)))
         }
-        rest::VectorInput::MultiDenseVector(multi_dense) => VectorInputInternal::Vector(
+        rest::VectorInput::MultiDenseVector(multi_dense) => Ok(VectorInputInternal::Vector(
             // TODO(universal-query): Validate at API level
             VectorInternal::MultiDense(MultiDenseVectorInternal::new_unchecked(multi_dense)),
-        ),
-        rest::VectorInput::Document(_) => {
-            // If this is reached, it means validation failed
-            unimplemented!("Document inference is not implemented")
+        )),
+        rest::VectorInput::Document(doc) => {
+            process_inference_input(InferenceData::Document(doc.clone()), "document", Some(doc))
+                .await
         }
-        rest::VectorInput::Image(_) => {
-            // If this is reached, it means validation failed
-            unimplemented!("Image inference is not implemented")
+        rest::VectorInput::Image(img) => {
+            process_inference_input(InferenceData::Image(img.clone()), "image", Some(img)).await
         }
-        rest::VectorInput::Object(_) => {
-            // If this is reached, it means validation failed
-            unimplemented!("Object inference is not implemented")
+        rest::VectorInput::Object(obj) => {
+            process_inference_input(InferenceData::Object(obj.clone()), "object", Some(obj)).await
         }
     }
 }
 
 /// Circular dependencies prevents us from implementing `From` directly
-fn context_pair_from_rest(value: rest::ContextPair) -> ContextPair<VectorInputInternal> {
+async fn context_pair_from_rest(
+    value: rest::ContextPair,
+) -> Result<ContextPair<VectorInputInternal>, StorageError> {
     let rest::ContextPair { positive, negative } = value;
 
-    ContextPair {
-        positive: convert_vector_input(positive),
-        negative: convert_vector_input(negative),
+    Ok(ContextPair {
+        positive: convert_vector_input(positive).await?,
+        negative: convert_vector_input(negative).await?,
+    })
+}
+
+async fn process_inference_input<T: std::fmt::Debug>(
+    data: InferenceData,
+    input_type: &str,
+    debug_content: Option<T>,
+) -> Result<VectorInputInternal, StorageError> {
+    let service = InferenceService::global().clone().ok_or_else(|| {
+        error!("InferenceService not initialized for {input_type}");
+        StorageError::inference_error(format!(
+            "InferenceService not initialized for {input_type} processing"
+        ))
+    })?;
+
+    info!("Starting inference processing for {input_type}");
+
+    let vectors = service
+        .infer(data, InferenceType::Query)
+        .await
+        .map_err(|e| {
+            error!(
+                "Failed to process {input_type}: {error}",
+                error = e.to_string()
+            );
+            StorageError::inference_error(format!("Failed to process {input_type}: {e}"))
+        })?;
+
+    if vectors.is_empty() {
+        /// log the content too in case of empty vector
+        if let Some(content) = debug_content {
+            warn!("Empty vector array for {input_type}. Content: {content:?}");
+        } else {
+            warn!("Empty vector array for {input_type}");
+        }
+
+        return Err(StorageError::inference_error(format!(
+            "Inference service returned empty result for {input_type}. This might indicate an issue with the input format or the inference service configuration."
+        )));
+    }
+
+    if vectors.len() > 1 {
+        warn!(
+            "Multiple vectors returned for {input_type}. Count: {count}. Using only the first one",
+            count = vectors.len()
+        );
+    }
+
+    info!(
+        "Successfully processed {input_type} inference. Vector count: {count}",
+        count = vectors.len()
+    );
+
+    Ok(VectorInputInternal::Vector(VectorInternal::from(
+        vectors.into_iter().next().unwrap(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use api::rest::schema as rest;
+    use segment::data_types::vectors::VectorInternal;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_context_pair_from_rest_dense_vectors() {
+        let input = rest::ContextPair {
+            positive: rest::VectorInput::DenseVector(vec![1.0, 2.0, 3.0]),
+            negative: rest::VectorInput::DenseVector(vec![4.0, 5.0, 6.0]),
+        };
+
+        let result = context_pair_from_rest(input).await.unwrap();
+
+        match (result.positive, result.negative) {
+            (
+                VectorInputInternal::Vector(VectorInternal::Dense(pos)),
+                VectorInputInternal::Vector(VectorInternal::Dense(neg)),
+            ) => {
+                assert_eq!(pos, vec![1.0, 2.0, 3.0]);
+                assert_eq!(neg, vec![4.0, 5.0, 6.0]);
+            }
+            _ => panic!("Expected Dense vectors"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_convert_vector_input_dense() {
+        let input = rest::VectorInput::DenseVector(vec![1.0, 2.0, 3.0]);
+        match convert_vector_input(input).await.unwrap() {
+            VectorInputInternal::Vector(VectorInternal::Dense(vec)) => {
+                assert_eq!(vec, vec![1.0, 2.0, 3.0]);
+            }
+            _ => panic!("Expected dense vector"),
+        }
     }
 }

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -21,8 +21,8 @@ const AUDIO_DATA_TYPE: &str = "audio";
 #[serde(rename_all = "lowercase")]
 pub enum InferenceType {
     #[default]
-    Document,
-    Query,
+    Update,
+    Search,
 }
 
 impl Display for InferenceType {

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -19,7 +19,7 @@ const AUDIO_DATA_TYPE: &str = "audio";
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
-enum InferenceType {
+pub enum InferenceType {
     #[default]
     Document,
     Query,
@@ -162,7 +162,11 @@ impl InferenceService {
         }
     }
 
-    pub async fn infer(&self, data: InferenceData) -> Result<Vec<VectorPersisted>, StorageError> {
+    pub async fn infer(
+        &self,
+        data: InferenceData,
+        inference_type: InferenceType,
+    ) -> Result<Vec<VectorPersisted>, StorageError> {
         let input: InferenceInput = data.into();
         let url = self
             .config
@@ -172,7 +176,7 @@ impl InferenceService {
 
         let request = InferenceRequest {
             inputs: vec![input],
-            inference: InferenceType::Document, // todo: add 'query|document' parameter
+            inference: inference_type,
             token: self.config.token.clone(),
         };
 

--- a/src/common/inference/update_requests.rs
+++ b/src/common/inference/update_requests.rs
@@ -203,7 +203,7 @@ async fn convert_single_vector(vector: Vector) -> Result<VectorPersisted, Storag
         Vector::Image(img) => match inference_service {
             Some(service) => {
                 let vector = service
-                    .infer(InferenceData::Image(img), InferenceType::Document)
+                    .infer(InferenceData::Image(img), InferenceType::Update)
                     .await
                     .map_err(|e| StorageError::inference_error(e.to_string()))?;
                 vector.into_iter().next().ok_or_else(|| {
@@ -219,7 +219,7 @@ async fn convert_single_vector(vector: Vector) -> Result<VectorPersisted, Storag
         Vector::Object(obj) => match inference_service {
             Some(service) => {
                 let vector = service
-                    .infer(InferenceData::Object(obj), InferenceType::Document)
+                    .infer(InferenceData::Object(obj), InferenceType::Update)
                     .await
                     .map_err(|e| StorageError::inference_error(e.to_string()))?;
                 vector.into_iter().next().ok_or_else(|| {

--- a/src/common/inference/update_requests.rs
+++ b/src/common/inference/update_requests.rs
@@ -187,7 +187,7 @@ async fn convert_single_vector(vector: Vector) -> Result<VectorPersisted, Storag
         Vector::Document(doc) => match inference_service {
             Some(service) => {
                 let vector = service
-                    .infer(InferenceData::Document(doc), InferenceType::Document)
+                    .infer(InferenceData::Document(doc), InferenceType::Update)
                     .await
                     .map_err(|e| StorageError::inference_error(e.to_string()))?;
                 vector.into_iter().next().ok_or_else(|| {

--- a/src/common/inference/update_requests.rs
+++ b/src/common/inference/update_requests.rs
@@ -9,7 +9,7 @@ use collection::operations::vector_ops::PointVectorsPersisted;
 use futures::stream::{self, StreamExt};
 use storage::content_manager::errors::StorageError;
 
-use crate::common::inference::service::{InferenceData, InferenceService};
+use crate::common::inference::service::{InferenceData, InferenceService, InferenceType};
 
 pub async fn convert_vectors(vectors: Vec<Vector>) -> Result<Vec<VectorPersisted>, StorageError> {
     let results: Vec<Result<VectorPersisted, StorageError>> = stream::iter(vectors)
@@ -187,7 +187,7 @@ async fn convert_single_vector(vector: Vector) -> Result<VectorPersisted, Storag
         Vector::Document(doc) => match inference_service {
             Some(service) => {
                 let vector = service
-                    .infer(InferenceData::Document(doc))
+                    .infer(InferenceData::Document(doc), InferenceType::Document)
                     .await
                     .map_err(|e| StorageError::inference_error(e.to_string()))?;
                 vector.into_iter().next().ok_or_else(|| {
@@ -203,7 +203,7 @@ async fn convert_single_vector(vector: Vector) -> Result<VectorPersisted, Storag
         Vector::Image(img) => match inference_service {
             Some(service) => {
                 let vector = service
-                    .infer(InferenceData::Image(img))
+                    .infer(InferenceData::Image(img), InferenceType::Document)
                     .await
                     .map_err(|e| StorageError::inference_error(e.to_string()))?;
                 vector.into_iter().next().ok_or_else(|| {
@@ -219,7 +219,7 @@ async fn convert_single_vector(vector: Vector) -> Result<VectorPersisted, Storag
         Vector::Object(obj) => match inference_service {
             Some(service) => {
                 let vector = service
-                    .infer(InferenceData::Object(obj))
+                    .infer(InferenceData::Object(obj), InferenceType::Document)
                     .await
                     .map_err(|e| StorageError::inference_error(e.to_string()))?;
                 vector.into_iter().next().ok_or_else(|| {


### PR DESCRIPTION
Requests like that:

```
POST /collections/sparse_charts/points/query
{
  "query": {
    "object": "hello red planet mars",
    "model": "qdrant/bm25"
  },
  "using": "keywords"
}
```

will use 'query' mode when possible, for example in BM25 

