### PR TITLE
download_file: use tempfile::Builder to avoid name collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,6 +6135,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "strum",
+ "tap",
  "tar",
  "tempfile",
  "thiserror",

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -32,6 +32,7 @@ tonic = { workspace = true }
 http = "0.2"
 parking_lot = { workspace = true }
 strum = { workspace = true }
+tap = { workspace = true }
 tar = { workspace = true }
 chrono = { workspace = true }
 validator = { workspace = true }

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -34,6 +34,9 @@ async fn download_file(
         .suffix(".download")
         .tempfile_in(dir_path)?
         .into_parts();
+
+    log::debug!("Downloading snapshot from {url} to {temp_path:?}");
+
     let mut file = File::from_std(file);
 
     let response = client.get(url.clone()).send().await?;

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -1,27 +1,22 @@
+use std::ffi::OsString;
 use std::path::Path;
 
 use common::tempfile_ext::MaybeTempPath;
 use futures::StreamExt;
 use reqwest;
+use tap::Tap;
 use tempfile::TempPath;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use url::Url;
-use uuid::Uuid;
 
 use crate::StorageError;
 
-fn random_name() -> String {
-    format!("{}.snapshot", Uuid::new_v4())
-}
-
-fn snapshot_name(url: &Url) -> String {
-    let path = Path::new(url.path());
-
-    path.file_name()
-        .and_then(|x| x.to_str())
-        .map(|x| x.to_string())
-        .unwrap_or_else(random_name)
+fn snapshot_prefix(url: &Url) -> OsString {
+    Path::new(url.path())
+        .file_name()
+        .map(|x| OsString::from(x).tap_mut(|x| x.push("-")))
+        .unwrap_or_default()
 }
 
 /// Download a remote file from `url` to `path`
@@ -32,10 +27,14 @@ fn snapshot_name(url: &Url) -> String {
 async fn download_file(
     client: &reqwest::Client,
     url: &Url,
-    path: &Path,
+    dir_path: &Path,
 ) -> Result<TempPath, StorageError> {
-    let temp_path = TempPath::from_path(path);
-    let mut file = File::create(path).await?;
+    let (file, temp_path) = tempfile::Builder::new()
+        .prefix(&snapshot_prefix(url))
+        .suffix(".download")
+        .tempfile_in(dir_path)?
+        .into_parts();
+    let mut file = File::from_std(file);
 
     let response = client.get(url.clone()).send().await?;
 
@@ -82,12 +81,9 @@ pub async fn download_snapshot(
             }
             Ok(MaybeTempPath::Persistent(local_path))
         }
-        "http" | "https" => {
-            let download_to = snapshots_dir.join(snapshot_name(&url));
-
-            let temp_path = download_file(client, &url, &download_to).await?;
-            Ok(MaybeTempPath::Temporary(temp_path))
-        }
+        "http" | "https" => Ok(MaybeTempPath::Temporary(
+            download_file(client, &url, snapshots_dir).await?,
+        )),
         _ => Err(StorageError::bad_request(format!(
             "URL {} with schema {} is not supported",
             url,

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -91,14 +91,12 @@ async fn _do_recover_from_snapshot(
 
     let is_distributed = toc.is_distributed();
 
-    let download_dir = toc.snapshots_download_tempdir()?;
-
-    log::debug!(
-        "Downloading snapshot from {location} to {}",
-        download_dir.path().display(),
-    );
-
-    let snapshot_path = download_snapshot(client, location, download_dir.path()).await?;
+    let snapshot_path = download_snapshot(
+        client,
+        location,
+        &toc.optional_temp_or_snapshot_temp_path()?,
+    )
+    .await?;
 
     if let Some(checksum) = checksum {
         let snapshot_checksum = hash_file(&snapshot_path).await?;

--- a/lib/storage/src/content_manager/toc/temp_directories.rs
+++ b/lib/storage/src/content_manager/toc/temp_directories.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use collection::operations::types::{CollectionError, CollectionResult};
-use tempfile::TempDir;
 
 use crate::content_manager::toc::TableOfContent;
 
@@ -137,20 +136,6 @@ impl TableOfContent {
             })?;
         }
         Ok(upload_dir)
-    }
-
-    pub fn snapshots_download_tempdir(&self) -> CollectionResult<TempDir> {
-        let tmp_storage_dir = match self.optional_temp_path() {
-            Ok(Some(path)) => path,
-            Ok(None) => self.snapshots_temp_path()?,
-            Err(err) => return Err(err),
-        };
-
-        let download_tempdir = tempfile::Builder::new()
-            .prefix("download-")
-            .tempdir_in(tmp_storage_dir)?;
-
-        Ok(download_tempdir)
     }
 
     pub fn clear_all_tmp_directories(&self) -> CollectionResult<()> {

--- a/tests/shard-snapshot-api.sh
+++ b/tests/shard-snapshot-api.sh
@@ -613,7 +613,7 @@ function points-count {
 }
 
 function concurrent {
-	declare PARALLEL ; PARALLEL="$(or-default "$1" 2)"
+	declare PARALLEL ; PARALLEL="$(or-default "$1" 10)"
 	declare CMD=( "${@:2}" )
 
 	declare -A JOBS


### PR DESCRIPTION
Fixup for #5227.

---

The PR #5227 introduced a new flaky CI failure ([example log](https://github.com/qdrant/qdrant/actions/runs/11459823247/job/31885178996?pr=5261)).

```
Failed to remove downloaded shards snapshot after recovery: No such file or directory (os error 2) at path "./snapshots/tmp/downloaded.snapshot"
curl: (22) The requested URL returned error: 500
2024-10-22T12:20:24.818833Z ERROR qdrant::actix::helpers: Error processing request: Service internal error: Can't restore snapshot in local mode with missing data at shard: /home/runner/work/qdrant/qdrant/./snapshots/tmp/test-collection-shard-0-downloaded.snapshotdjoHHc
2024-10-22T12:20:24.819113Z  INFO actix_web::middleware::logger: 127.0.0.1 "PUT /collections/test-collection/shards/0/snapshots/recover HTTP/1.1" 500 228 "-" "curl/7.81.0" 0.445313
Exit code: 22
./tests/shard-snapshot-api.sh:595@curl-ok:  curl -sS --fail-with-body "$@"
./tests/shard-snapshot-api.sh:203@do-recover: curl-ok
./tests/shard-snapshot-api.sh:623@concurrent: do-recover
./tests/shard-snapshot-api.sh:275@recover-remote-concurrent: concurrent
./tests/shard-snapshot-api.sh:153@test-all: recover-remote-concurrent
./tests/shard-snapshot-api.sh:43@main: test-all
./tests/shard-snapshot-api.sh:659@main: main
Exit code: 22
```

---

The cause is [this change] after which the filename of a temporary download file became deterministic.
Before 5227: `./snapshots/tmp/download-{random}/{filename}`.
After: 5227: `./snapshots/tmp/{filename}`.
The CI test `recover-remote-concurrent` triggers a race condition because it tries to upload and restore multiple snapshots with the same name simultaneously.

[this change]: https://github.com/qdrant/qdrant/pull/5227/commits/01998b2a80dad82be5a4a7943896b2689bc8e5d6?diff=unified#diff-7fee21a243cfa32b9275eed260a8cbb4927ddd39ab3a30046b3bd6aedda5c371L135-R128

---

There are two possible ways to fix that:
1. Revert `recover_shard_snapshot` to use `snapshots_download_tempdir` (a random directory inside `./snapshots/tmp`).
2. Update the [`download_file()`](https://github.com/qdrant/qdrant/blob/9c20e9e27960228019b4606f137ca82b42fc3e66/lib/storage/src/content_manager/snapshots/download.rs#L31) function to use random filename (via `tempfile::Builder()`) instead of deterministic user-provided filename (via `tempfile::TempPath::from_path()`).

In this PR I took the second approach as I find it more clean.
The new temp file would be named like this: `./snapshots/tmp/{filename}-{random}.download`.

Additionally, this PR updates the test to spawn 10 concurrent operations instead of 2 to increase the chance of catching this condition again.
