### PR TITLE
Fix data race in replica state switching causing inconsistencies

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1075,7 +1075,6 @@ pub enum ReplicaState {
 impl ReplicaState {
     /// Check whether the replica state is active or listener or resharding.
     pub fn is_active_or_listener_or_resharding(self) -> bool {
-        // Use explicit match, to catch future changes to `ReplicaState`
         match self {
             ReplicaState::Active | ReplicaState::Listener | ReplicaState::Resharding => true,
 
@@ -1088,8 +1087,9 @@ impl ReplicaState {
     }
 
     /// Check whether the replica state is partial or partial-like.
+    ///
+    /// In other words: is the state related to shard transfers?
     pub fn is_partial_or_recovery(self) -> bool {
-        // Use explicit match, to catch future changes to `ReplicaState`
         match self {
             ReplicaState::Partial
             | ReplicaState::PartialSnapshot

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -297,8 +297,9 @@ impl ShardReplicaSet {
             .params
             .write_consistency_factor
             .get() as usize;
-        let minimal_success_count =
-            write_consistency_factor.min(total_results - pre_condition_fail_count);
+        let minimal_success_count = write_consistency_factor
+            .min(total_results - pre_condition_fail_count)
+            .max(1);
 
         // Advance clock if some replica echoed *newer* tick
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -427,6 +427,7 @@ impl ShardReplicaSet {
             // The replica on the peer may still be active for some time if its consensus is slow.
             // The peer may respond to read requests until it switches to recovery state too. We
             // must keep sending updates to prevent those reads being stale.
+            // See: <https://github.com/qdrant/qdrant/pull/5298>
             Some(ReplicaState::Recovery | ReplicaState::PartialSnapshot) => true,
             Some(ReplicaState::Resharding) => true,
             Some(ReplicaState::Dead) | None => false,


### PR DESCRIPTION
Fix a data race where switching a replica to Recovery state may cause it to respond with stale data, even if wait=true is used on updates. Shortly after the inconsistency goes away. This affects both WAL delta and snapshot transfers.

The key element here is that consensus events are not applied on all nodes at exactly the same time. We normally take this in consideration but forgot an edge case.

To explain the problem, lets look at the following time table:

| Time | Consensus                     | Node 1 (n1)                   | Node 2 (n2)                    |
|-----:|-------------------------------|-------------------------------|--------------------------------|
| 1    | start transfer (n1->n2)       | start transfer (n1->n2)       |                                |
|      |                               | set n2 replica to recovery    |                                |
| 2    |                               | user update, update n1 not n2 |                                |
| 3    |                               |                               | user read, missing update (t2) |
| 4    |                               |                               | start transfer (n1->n2)        |
|      |                               |                               | set n2 replica to recovery     |
| 5    |                               | transfer replica to n1        | receive replica from n1        |
| 6    | finish transfer (n1->n2)      | finish transfer (n1->n2)      | finish transfer (n1->n2)       |
|      |                               | set n2 replica to active      | set n2 replica to active       |
| 7    |                               |                               | user read, has update (t2)     |

This example assumes having one shard, replicated on both nodes.

1. A WAL delta (recovery) transfer is started from node 1 to node 2. It sets the receiving replica to Recovery state. It's only applied on node 1 right away, node 2 lags behind.
2. An update comes in on node 1. It is only applied locally and does not forward to node 2, because it thinks node 2 is in Recovery state.
3. A read comes in on node 2. The local replica is still Active, so it responds with its local data. However, the response is stale because it missed the update at time 2.
4. Node 2 catches up and switches its replica to Recovery state. It won't respond to read requests anymore.
5. The WAL delta is transferred, repairing the inconsistency on node 2.
7. After the transfer, reads on both replicas are consistent again.

In short, updates may temporarily be missing if a write+read falls in between two nodes switching the state of a replica to Recovery.

Note that wait=true on the update does not make a difference. It'll only waits for the update to be applied on node 1, not on node 2. Users should expect all nodes to be up-to-date once an update with wait=true returns. But that isn't the case with this example, which is a problem.

To fix the problem we now keep forwarding updates to replicas in Recovery state. Updates with wait=true will wait for them to be applied on node 2 too, preventing stale reads. Once the receiving replica is in Recovery state, it'll reject the incoming updates to not mess with the recovery process (unless clock.force=true).

Because we now send updates to Recovery replicas the existing write consistency factor logic needs to be adjusted a bit. I've simplified it to use the configured write consistency factor and cap it at the number of replicas known for that shard. It makes it a bit more strict and does not consider what replicas we can or cannot send update requests to.

I've tested the new behavior locally. The problem did not appear with the patch on 1000 WAL delta transfers, while it appeared almost immediately before.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
7. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
9. [x] Have you checked your code using `cargo clippy --all --all-features` command?