### PR TITLE
Fix off by one in WAL delta causing operation to be sent twice

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -100,9 +100,10 @@ impl QueueProxyShard {
         let wal = wrapped_shard.wal.wal.clone();
         let wal_lock = wal.lock();
 
-        // If start version is not in current WAL bounds [first_idx, last_idx], we cannot reliably transfer WAL
+        // If start version is not in current WAL bounds [first_idx, last_idx + 1], we cannot reliably transfer WAL
+        // Allow it to be one higher than the last index to only send new updates
         let (first_idx, last_idx) = (wal_lock.first_closed_index(), wal_lock.last_index());
-        if !(first_idx..=last_idx).contains(&version) {
+        if !(first_idx..=last_idx + 1).contains(&version) {
             return Err((wrapped_shard, CollectionError::service_error(format!("Cannot create queue proxy shard from version {version} because it is out of WAL bounds ({first_idx}..={last_idx})"))));
         }
 


### PR DESCRIPTION
Improvement on <https://github.com/qdrant/qdrant/pull/5271>.

If we resolve an empty WAL delta we still create a queue proxy to transmit new updates.

The queue proxy expects the version to start sending updates from. Before this PR we gave it our last version, which means the last operation would be sent a second time.

This is not necessary and we can bump the version to only transmit new updates.

I've tested this change locally on 1000 WAL delta transfers.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?