### PR TITLE
[perf] No backtrace on sparse vector index version mismatch

### DIFF
--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -69,6 +69,14 @@ impl OperationError {
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
+
+    /// Create a new service error with a description and no backtrace
+    pub fn service_error_light(description: impl Into<String>) -> OperationError {
+        OperationError::ServiceError {
+            description: description.into(),
+            backtrace: None,
+        }
+    }
 }
 
 pub fn check_process_stopped(stopped: &AtomicBool) -> OperationResult<()> {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -182,7 +182,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         }
 
         if stored_version != Some(TInvertedIndex::Version::current()) {
-            return Err(OperationError::service_error(format!(
+            return Err(OperationError::service_error_light(format!(
                 "Index version mismatch, expected {}, found {}",
                 TInvertedIndex::Version::current(),
                 stored_version.map_or_else(|| "none".to_string(), |v| v.to_string()),


### PR DESCRIPTION
The sparse vector index is created if it does not exist when trying to open it.

When the data path does not exist, an error regarding mismatched version is created,

The failure is not exceptional and does not require an expensive backtrace which is not returned to the user.