### PR TITLE
Use Jemalloc unprefixed_malloc_on_supported_platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ pyroscope_pprofrs = "0.2.7"
 rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = { version = "0.6.0", features = ["unprefixed_malloc_on_supported_platforms"] }
 
 [workspace.lints.clippy]
 cast_lossless = "warn"


### PR DESCRIPTION
With this feature, both Rust code and linked C/C++ code will use jemalloc for memory allocation.

This would explain why the memory reported by jemalloc was too low, because it is missing RocksDB related allocations.

I can see the impact of this change in Heaptrack which seems unable to track Jemalloc allocations.
Before this change I see only RocksDB allocations and after I see nothing :) 