### PR TITLE
Populate hardware counter to REST API

### DIFF
--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -15,6 +15,7 @@ use collection::optimizers_builder::OptimizersConfig;
 use collection::save_on_disk::SaveOnDisk;
 use collection::shards::local_shard::LocalShard;
 use collection::shards::shard_trait::ShardOperation;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::thread_rng;
@@ -174,7 +175,12 @@ fn batch_search_bench(c: &mut Criterion) {
                     }
 
                     let result = shard
-                        .query_batch(Arc::new(searches), search_runtime_handle, None)
+                        .query_batch(
+                            Arc::new(searches),
+                            search_runtime_handle,
+                            None,
+                            HwMeasurementAcc::new(),
+                        )
                         .await
                         .unwrap();
                     assert!(!result.is_empty());
@@ -204,7 +210,12 @@ fn batch_search_bench(c: &mut Criterion) {
 
                     let search_query = CoreSearchRequestBatch { searches };
                     let result = shard
-                        .core_search(Arc::new(search_query), search_runtime_handle, None)
+                        .core_search(
+                            Arc::new(search_query),
+                            search_runtime_handle,
+                            None,
+                            HwMeasurementAcc::new(),
+                        )
                         .await
                         .unwrap();
                     assert!(!result.is_empty());
@@ -267,7 +278,12 @@ fn batch_rrf_query_bench(c: &mut Criterion) {
                     }
 
                     let result = shard
-                        .query_batch(Arc::new(searches), search_runtime_handle, None)
+                        .query_batch(
+                            Arc::new(searches),
+                            search_runtime_handle,
+                            None,
+                            HwMeasurementAcc::new(),
+                        )
                         .await
                         .unwrap();
                     assert!(!result.is_empty());
@@ -320,7 +336,12 @@ fn batch_rescore_bench(c: &mut Criterion) {
                     }
 
                     let result = shard
-                        .query_batch(Arc::new(searches), search_runtime_handle, None)
+                        .query_batch(
+                            Arc::new(searches),
+                            search_runtime_handle,
+                            None,
+                            HwMeasurementAcc::new(),
+                        )
                         .await
                         .unwrap();
                     assert!(!result.is_empty());

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -12,6 +12,7 @@ use collection::optimizers_builder::OptimizersConfig;
 use collection::save_on_disk::SaveOnDisk;
 use collection::shards::local_shard::LocalShard;
 use collection::shards::shard_trait::ShardOperation;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::thread_rng;
@@ -160,6 +161,7 @@ fn batch_search_bench(c: &mut Criterion) {
                                 }),
                                 search_runtime_handle,
                                 None,
+                                HwMeasurementAcc::new(),
                             )
                             .await
                             .unwrap();
@@ -191,7 +193,12 @@ fn batch_search_bench(c: &mut Criterion) {
 
                     let search_query = CoreSearchRequestBatch { searches };
                     let result = shard
-                        .core_search(Arc::new(search_query), search_runtime_handle, None)
+                        .core_search(
+                            Arc::new(search_query),
+                            search_runtime_handle,
+                            None,
+                            HwMeasurementAcc::new(),
+                        )
                         .await
                         .unwrap();
                     assert!(!result.is_empty());

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 use std::sync::Arc;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::{future, TryStreamExt as _};
 use lazy_static::lazy_static;
 use segment::types::{QuantizationConfig, StrictModeConfig};
@@ -341,7 +342,7 @@ impl Collection {
                     .copied()
                     .unwrap_or(ReplicaState::Dead);
                 let count_result = replica_set
-                    .count_local(count_request.clone(), None)
+                    .count_local(count_request.clone(), None, HwMeasurementAcc::new())
                     .await
                     .unwrap_or_default();
                 let points_count = count_result.map(|x| x.count).unwrap_or(0);

--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -5,6 +5,7 @@ use api::rest::{
     SearchMatrixOffsetsResponse, SearchMatrixPair, SearchMatrixPairsResponse,
     SearchMatrixRequestInternal,
 };
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::vectors::{NamedVectorStruct, DEFAULT_VECTOR_NAME};
 use segment::types::{
     Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, WithVector,
@@ -138,6 +139,7 @@ impl Collection {
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CollectionSearchMatrixResponse> {
         let CollectionSearchMatrixRequest {
             sample_size,
@@ -180,6 +182,7 @@ impl Collection {
                 read_consistency,
                 shard_selection.clone(),
                 timeout,
+                hw_measurement_acc.clone(),
             )
             .await?;
 
@@ -230,7 +233,13 @@ impl Collection {
         // run batch search request
         let batch_request = CoreSearchRequestBatch { searches };
         let mut nearest = self
-            .core_search_batch(batch_request, read_consistency, shard_selection, timeout)
+            .core_search_batch(
+                batch_request,
+                read_consistency,
+                shard_selection,
+                timeout,
+                hw_measurement_acc,
+            )
             .await?;
 
         // postprocess the results to account for overlapping samples

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::stream::FuturesUnordered;
 use futures::{future, StreamExt as _, TryFutureExt, TryStreamExt as _};
 use itertools::Itertools;
@@ -376,6 +377,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         let shards_holder = self.shards_holder.read().await;
         let shards = shards_holder.select_shards(shard_selection)?;
@@ -391,6 +393,7 @@ impl Collection {
                     read_consistency,
                     timeout,
                     shard_selection.is_shard_id(),
+                    hw_measurement_acc.clone(),
                 )
             })
             .collect();

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::ScoreType;
 use futures::future::try_join_all;
 use itertools::Itertools;
@@ -230,6 +231,7 @@ impl SegmentsSearcher {
         runtime_handle: &Handle,
         sampling_enabled: bool,
         query_context: QueryContext,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let query_context_arc = Arc::new(query_context);
 
@@ -254,25 +256,24 @@ impl SegmentsSearcher {
             segments
                 .map(|segment| {
                     let query_context_arc_segment = query_context_arc.clone();
+                    let hw_counter_clone = hw_measurement_acc.clone();
                     let search = runtime_handle.spawn_blocking({
                         let (segment, batch_request) = (segment.clone(), batch_request.clone());
                         move || {
                             let segment_query_context =
                                 query_context_arc_segment.get_segment_query_context();
 
-                            let result = search_in_segment(
+                            let res = search_in_segment(
                                 segment,
                                 batch_request,
                                 use_sampling,
                                 &segment_query_context,
                             );
 
-                            // TODO: propagate measurements instead of discarding!
-                            segment_query_context
-                                .take_hardware_counter()
-                                .discard_results();
+                            hw_counter_clone
+                                .apply_from_cell(&segment_query_context.take_hardware_counter());
 
-                            result
+                            res
                         }
                     });
                     (segment.clone(), search)
@@ -314,19 +315,21 @@ impl SegmentsSearcher {
                             .map(|batch_id| batch_request.searches[*batch_id].clone())
                             .collect(),
                     });
+                    let hw_counter_clone = hw_measurement_acc.clone();
                     res.push(runtime_handle.spawn_blocking(move || {
                         let segment_query_context =
                             query_context_arc_segment.get_segment_query_context();
+
                         let result = search_in_segment(
                             segment,
                             partial_batch_request,
                             false,
                             &segment_query_context,
                         );
-                        // TODO: propagate measurements instead of discarding!
-                        segment_query_context
-                            .take_hardware_counter()
-                            .discard_results();
+
+                        hw_counter_clone
+                            .apply_from_cell(&segment_query_context.take_hardware_counter());
+
                         result
                     }))
                 }
@@ -764,6 +767,7 @@ mod tests {
             &Handle::current(),
             true,
             QueryContext::new(DEFAULT_INDEXING_THRESHOLD_KB),
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap()
@@ -823,15 +827,21 @@ mod tests {
 
             let batch_request = Arc::new(batch_request);
 
+            let hw_measurement_acc = HwMeasurementAcc::new();
+
             let result_no_sampling = SegmentsSearcher::search(
                 segment_holder.clone(),
                 batch_request.clone(),
                 &Handle::current(),
                 false,
                 QueryContext::new(DEFAULT_INDEXING_THRESHOLD_KB),
+                hw_measurement_acc.clone(),
             )
             .await
             .unwrap();
+
+            assert_ne!(hw_measurement_acc.get_cpu(), 0);
+            hw_measurement_acc.clear();
 
             assert!(!result_no_sampling.is_empty());
 
@@ -841,10 +851,14 @@ mod tests {
                 &Handle::current(),
                 true,
                 QueryContext::new(DEFAULT_INDEXING_THRESHOLD_KB),
+                hw_measurement_acc.clone(),
             )
             .await
             .unwrap();
             assert!(!result_sampling.is_empty());
+
+            assert_ne!(hw_measurement_acc.get_cpu(), 0);
+            hw_measurement_acc.clear();
 
             // assert equivalence in depth
             assert_eq!(result_no_sampling[0].len(), result_sampling[0].len());

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -271,7 +271,7 @@ impl SegmentsSearcher {
                             );
 
                             hw_counter_clone
-                                .apply_from_cell(&segment_query_context.take_hardware_counter());
+                                .merge_from_cell(segment_query_context.take_hardware_counter());
 
                             res
                         }
@@ -328,7 +328,7 @@ impl SegmentsSearcher {
                         );
 
                         hw_counter_clone
-                            .apply_from_cell(&segment_query_context.take_hardware_counter());
+                            .merge_from_cell(segment_query_context.take_hardware_counter());
 
                         result
                     }))

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::Future;
 use itertools::Itertools;
 use segment::data_types::vectors::NamedQuery;
@@ -130,6 +131,7 @@ pub async fn discover<'a, F, Fut>(
     read_consistency: Option<ReadConsistency>,
     shard_selector: ShardSelectorInternal,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<Vec<ScoredPoint>>
 where
     F: Fn(String) -> Fut,
@@ -147,6 +149,7 @@ where
         collection_by_name,
         read_consistency,
         timeout,
+        hw_measurement_acc,
     )
     .await?;
     Ok(results.into_iter().next().unwrap())
@@ -158,6 +161,7 @@ pub async fn discover_batch<'a, F, Fut>(
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
 where
     F: Fn(String) -> Fut,
@@ -229,6 +233,7 @@ where
                 read_consistency,
                 shard_selector,
                 timeout,
+                hw_measurement_acc.clone(),
             ));
 
             Ok(())

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -35,7 +35,12 @@ where
     Fut: Future<Output = Option<RwLockReadGuard<'a, Collection>>>,
 {
     /// Creates a basic GroupBy builder
-    pub fn new(group_by: GroupRequest, collection: &'a Collection, collection_by_name: F) -> Self {
+    pub fn new(
+        group_by: GroupRequest,
+        collection: &'a Collection,
+        collection_by_name: F,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> Self {
         Self {
             group_by,
             collection,
@@ -43,7 +48,7 @@ where
             read_consistency: None,
             shard_selection: ShardSelectorInternal::All,
             timeout: None,
-            hw_measurement_acc: HwMeasurementAcc::new(),
+            hw_measurement_acc,
         }
     }
 

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::Future;
 use itertools::Itertools;
 use tokio::sync::RwLockReadGuard;
@@ -25,6 +26,7 @@ where
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 }
 
 impl<'a, F, Fut> GroupBy<'a, F, Fut>
@@ -41,6 +43,7 @@ where
             read_consistency: None,
             shard_selection: ShardSelectorInternal::All,
             timeout: None,
+            hw_measurement_acc: HwMeasurementAcc::new(),
         }
     }
 
@@ -95,6 +98,7 @@ where
             self.read_consistency,
             self.shard_selection.clone(),
             self.timeout,
+            self.hw_measurement_acc.clone(),
         )
         .await?;
 

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
 use segment::json_path::JsonPath;
@@ -146,6 +147,7 @@ impl QueryGroupRequest {
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         let mut request = self.source.clone();
 
@@ -165,7 +167,13 @@ impl QueryGroupRequest {
         request.with_vector = WithVector::Bool(false);
 
         collection
-            .query(request, read_consistency, shard_selection, timeout)
+            .query(
+                request,
+                read_consistency,
+                shard_selection,
+                timeout,
+                hw_measurement_acc,
+            )
             .await
     }
 }
@@ -305,6 +313,7 @@ pub async fn group_by(
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<Vec<PointGroup>> {
     let start = std::time::Instant::now();
     let collection_params = collection.collection_config.read().await.params.clone();
@@ -365,6 +374,7 @@ pub async fn group_by(
                 read_consistency,
                 shard_selection.clone(),
                 timeout,
+                hw_measurement_acc.clone(),
             )
             .await?;
 
@@ -427,6 +437,7 @@ pub async fn group_by(
                     read_consistency,
                     shard_selection.clone(),
                     timeout,
+                    hw_measurement_acc.clone(),
                 )
                 .await?;
 

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -3,6 +3,7 @@ use std::iter::Peekable;
 use std::time::Duration;
 
 use api::rest::RecommendStrategy;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::vectors::{
     DenseVector, NamedQuery, NamedVectorStruct, TypedMultiDenseVector, VectorElementType,
@@ -151,6 +152,7 @@ pub async fn recommend_by<'a, F, Fut>(
     read_consistency: Option<ReadConsistency>,
     shard_selector: ShardSelectorInternal,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<Vec<ScoredPoint>>
 where
     F: Fn(String) -> Fut,
@@ -167,6 +169,7 @@ where
         collection_by_name,
         read_consistency,
         timeout,
+        hw_measurement_acc,
     )
     .await?;
     Ok(results.into_iter().next().unwrap())
@@ -239,6 +242,7 @@ pub async fn recommend_batch_by<'a, F, Fut>(
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
 where
     F: Fn(String) -> Fut,
@@ -315,6 +319,7 @@ where
                 read_consistency,
                 shard_selector,
                 timeout,
+                hw_measurement_acc.clone(),
             ));
 
             Ok(())

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::tar_ext;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
@@ -93,6 +94,7 @@ impl ShardOperation for DummyShard {
         _: Arc<CoreSearchRequestBatch>,
         _: &Handle,
         _: Option<Duration>,
+        _: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.dummy()
     }
@@ -122,6 +124,7 @@ impl ShardOperation for DummyShard {
         _requests: Arc<Vec<ShardQueryRequest>>,
         _search_runtime_handle: &Handle,
         _timeout: Option<Duration>,
+        _: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         self.dummy()
     }

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -104,6 +104,7 @@ impl ShardOperation for DummyShard {
         _: Arc<CountRequestInternal>,
         _: &Handle,
         _: Option<Duration>,
+        _: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         self.dummy()
     }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -368,10 +368,11 @@ impl ShardOperation for ForwardProxyShard {
         request: Arc<CountRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .count(request, search_runtime_handle, timeout)
+            .count(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
@@ -354,10 +355,11 @@ impl ShardOperation for ForwardProxyShard {
         request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .core_search(request, search_runtime_handle, timeout)
+            .core_search(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 
@@ -398,10 +400,11 @@ impl ShardOperation for ForwardProxyShard {
         requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .query_batch(requests, search_runtime_handle, timeout)
+            .query_batch(requests, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::ScoredPoint;
 use tokio::runtime::Handle;
 
@@ -16,6 +17,7 @@ impl LocalShard {
         core_request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_counter_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let is_stopped_guard = StoppingGuard::new();
 
@@ -44,6 +46,7 @@ impl LocalShard {
             search_runtime_handle,
             true,
             query_context,
+            hw_counter_acc,
         );
 
         let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -181,6 +181,7 @@ impl ShardOperation for LocalShard {
         request: Arc<CountRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        _hw_measurement_acc: HwMeasurementAcc, // TODO: measure hardware when counting
     ) -> CollectionResult<CountResult> {
         let total_count = if request.exact {
             let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
@@ -169,8 +170,9 @@ impl ShardOperation for LocalShard {
         request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        self.do_search(request, search_runtime_handle, timeout)
+        self.do_search(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 
@@ -233,11 +235,17 @@ impl ShardOperation for LocalShard {
         requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let planned_query = PlannedQuery::try_from(requests.as_ref().to_owned())?;
 
-        self.do_planned_query(planned_query, search_runtime_handle, timeout)
-            .await
+        self.do_planned_query(
+            planned_query,
+            search_runtime_handle,
+            timeout,
+            hw_measurement_acc,
+        )
+        .await
     }
 
     async fn facet(

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -249,10 +249,11 @@ impl ShardOperation for ProxyShard {
         request: Arc<CountRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .count(request, search_runtime_handle, timeout)
+            .count(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
@@ -234,10 +235,11 @@ impl ShardOperation for ProxyShard {
         request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .core_search(request, search_runtime_handle, timeout)
+            .core_search(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 
@@ -281,10 +283,11 @@ impl ShardOperation for ProxyShard {
         request: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .query_batch(request, search_runtime_handle, timeout)
+            .query_batch(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -266,9 +266,10 @@ impl ShardOperation for QueueProxyShard {
         request: Arc<CountRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         self.inner_unchecked()
-            .count(request, search_runtime_handle, timeout)
+            .count(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 
@@ -584,10 +585,11 @@ impl ShardOperation for Inner {
         request: Arc<CountRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .count(request, search_runtime_handle, timeout)
+            .count(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::tar_ext;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex as ParkingMutex;
@@ -252,9 +253,10 @@ impl ShardOperation for QueueProxyShard {
         request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.inner_unchecked()
-            .core_search(request, search_runtime_handle, timeout)
+            .core_search(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 
@@ -296,10 +298,11 @@ impl ShardOperation for QueueProxyShard {
         requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         self.inner_unchecked()
             .wrapped_shard
-            .query_batch(requests, search_runtime_handle, timeout)
+            .query_batch(requests, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 
@@ -567,10 +570,11 @@ impl ShardOperation for Inner {
         request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .core_search(request, search_runtime_handle, timeout)
+            .core_search(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 
@@ -614,10 +618,11 @@ impl ShardOperation for Inner {
         request: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .query_batch(request, search_runtime_handle, timeout)
+            .query_batch(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
 

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -786,6 +786,7 @@ impl ShardOperation for RemoteShard {
         request: Arc<CountRequestInternal>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        _hw_measurement_acc: HwMeasurementAcc, // TODO: measure hardware when counting
     ) -> CollectionResult<CountResult> {
         let count_points = CountPoints {
             collection_name: self.collection_id.clone(),

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -18,6 +18,7 @@ use api::grpc::qdrant::{
 };
 use api::grpc::transport_channel_pool::{AddTimeout, MAX_GRPC_CHANNEL_TIMEOUT};
 use async_trait::async_trait;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::TelemetryDetail;
 use itertools::Itertools;
 use parking_lot::Mutex;
@@ -726,6 +727,7 @@ impl ShardOperation for RemoteShard {
         batch_request: Arc<CoreSearchRequestBatch>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        _hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);
         timer.set_success(false);
@@ -865,6 +867,7 @@ impl ShardOperation for RemoteShard {
         requests: Arc<Vec<ShardQueryRequest>>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        _hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);
         timer.set_success(false);

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -93,13 +93,20 @@ impl ShardReplicaSet {
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
         local_only: bool,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         self.execute_and_resolve_read_operation(
             |shard| {
                 let request = request.clone();
                 let search_runtime = self.search_runtime.clone();
 
-                async move { shard.count(request, &search_runtime, timeout).await }.boxed()
+                let hw_measurement_acc_clone = hw_measurement_acc.clone();
+                async move {
+                    shard
+                        .count(request, &search_runtime, timeout, hw_measurement_acc_clone)
+                        .await
+                }
+                .boxed()
             },
             read_consistency,
             local_only,
@@ -157,6 +164,7 @@ impl ShardReplicaSet {
         &self,
         request: Arc<CountRequestInternal>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Option<CountResult>> {
         let local = self.local.read().await;
         match &*local {
@@ -164,7 +172,10 @@ impl ShardReplicaSet {
             Some(shard) => {
                 let search_runtime = self.search_runtime.clone();
                 Ok(Some(
-                    shard.get().count(request, &search_runtime, timeout).await?,
+                    shard
+                        .get()
+                        .count(request, &search_runtime, timeout, hw_measurement_acc)
+                        .await?,
                 ))
             }
         }

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::FutureExt as _;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
@@ -66,13 +67,19 @@ impl ShardReplicaSet {
         read_consistency: Option<ReadConsistency>,
         local_only: bool,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.execute_and_resolve_read_operation(
             |shard| {
                 let request = Arc::clone(&request);
                 let search_runtime = self.search_runtime.clone();
-
-                async move { shard.core_search(request, &search_runtime, timeout).await }.boxed()
+                let hw_counter_acc_clone = hw_measurement_acc.clone();
+                async move {
+                    shard
+                        .core_search(request, &search_runtime, timeout, hw_counter_acc_clone)
+                        .await
+                }
+                .boxed()
             },
             read_consistency,
             local_only,
@@ -169,13 +176,19 @@ impl ShardReplicaSet {
         read_consistency: Option<ReadConsistency>,
         local_only: bool,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         self.execute_and_resolve_read_operation(
             |shard| {
                 let requests = Arc::clone(&requests);
                 let search_runtime = self.search_runtime.clone();
-
-                async move { shard.query_batch(requests, &search_runtime, timeout).await }.boxed()
+                let hw_counter_acc_clone = hw_measurement_acc.clone();
+                async move {
+                    shard
+                        .query_batch(requests, &search_runtime, timeout, hw_counter_acc_clone)
+                        .await
+                }
+                .boxed()
             },
             read_consistency,
             local_only,

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -48,6 +48,7 @@ pub trait ShardOperation {
         request: Arc<CountRequestInternal>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult>;
 
     async fn retrieve(

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::*;
@@ -39,6 +40,7 @@ pub trait ShardOperation {
         request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>>;
 
     async fn count(
@@ -62,6 +64,7 @@ pub trait ShardOperation {
         requests: Arc<Vec<ShardQueryRequest>>,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>>;
 
     async fn facet(

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use parking_lot::Mutex;
 
 use super::transfer_tasks_pool::TransferTaskProgress;
@@ -69,6 +70,7 @@ pub(crate) async fn transfer_resharding_stream_records(
                     exact: true,
                 }),
                 None,
+                HwMeasurementAcc::new(),
             )
             .await?
         else {

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use parking_lot::Mutex;
 
 use super::transfer_tasks_pool::TransferTaskProgress;
@@ -54,6 +55,7 @@ pub(super) async fn transfer_stream_records(
                     exact: true,
                 }),
                 None, // no timeout
+                HwMeasurementAcc::new(),
             )
             .await?
         else {

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use api::rest::OrderByInterface;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use rand::{thread_rng, Rng};
 use segment::data_types::vectors::NamedVectorStruct;
@@ -258,6 +259,7 @@ async fn test_search_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .expect("failed to search");

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use segment::data_types::vectors::{NamedVectorStruct, VectorInternal, DEFAULT_VECTOR_NAME};
 use segment::types::{PointIdType, WithPayloadInterface, WithVector};
@@ -65,7 +66,12 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await;
     let expected_error =
         CollectionError::bad_request("cannot apply Fusion without prefetches".to_string());
@@ -99,7 +105,12 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap()
         .pop()
@@ -145,7 +156,12 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap()
         .pop()
@@ -188,7 +204,12 @@ async fn test_shard_query_rrf_rescoring() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap()
         .pop()
@@ -266,7 +287,12 @@ async fn test_shard_query_vector_rescoring() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap()
         .pop()
@@ -292,7 +318,12 @@ async fn test_shard_query_vector_rescoring() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap()
         .pop()
@@ -321,7 +352,12 @@ async fn test_shard_query_vector_rescoring() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap()
         .pop()
@@ -388,7 +424,12 @@ async fn test_shard_query_payload_vector() {
     };
 
     let sources_scores = shard
-        .query_batch(Arc::new(vec![query]), &current_runtime, None)
+        .query_batch(
+            Arc::new(vec![query]),
+            &current_runtime,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap()
         .pop()

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -184,7 +184,13 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
     };
 
     let count_res = collection
-        .count(count_request, None, &ShardSelectorInternal::All, None)
+        .count(
+            count_request,
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap();
     assert_eq!(count_res.count, 1);

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -15,6 +15,7 @@ use collection::operations::types::{
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
 use collection::shards::replica_set::{ReplicaSetState, ReplicaState};
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::order_by::{Direction, OrderBy};
 use segment::data_types::vectors::VectorStructInternal;
@@ -85,6 +86,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await;
 
@@ -153,6 +155,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await;
 
@@ -370,6 +373,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
+        HwMeasurementAcc::new(),
     )
     .await
     .unwrap();

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -3,6 +3,7 @@ use collection::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, WriteOrdering,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -28,7 +29,13 @@ async fn distance_matrix_empty() {
         using: "".to_string(), // default vector name
     };
     let matrix = collection
-        .search_points_matrix(request, ShardSelectorInternal::All, None, None)
+        .search_points_matrix(
+            request,
+            ShardSelectorInternal::All,
+            None,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap();
 
@@ -77,7 +84,13 @@ async fn distance_matrix_anonymous_vector() {
         using: "".to_string(), // default vector name
     };
     let matrix = collection
-        .search_points_matrix(request, ShardSelectorInternal::All, None, None)
+        .search_points_matrix(
+            request,
+            ShardSelectorInternal::All,
+            None,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -24,6 +24,7 @@ mod group_by {
     use collection::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
     };
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
 
     use super::*;
 
@@ -99,6 +100,7 @@ mod group_by {
             resources.request.clone(),
             &resources.collection,
             |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
         );
 
         let result = group_by.execute().await;
@@ -149,9 +151,12 @@ mod group_by {
             2,
         );
 
-        let group_by = GroupBy::new(request.clone(), &resources.collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            request.clone(),
+            &resources.collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -209,9 +214,12 @@ mod group_by {
             3,
         );
 
-        let group_by = GroupBy::new(group_by_request, &resources.collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            group_by_request,
+            &resources.collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -241,9 +249,12 @@ mod group_by {
             3,
         );
 
-        let group_by = GroupBy::new(group_by_request.clone(), &resources.collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            group_by_request.clone(),
+            &resources.collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -279,9 +290,12 @@ mod group_by {
             3,
         );
 
-        let group_by = GroupBy::new(group_by_request.clone(), &collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            group_by_request.clone(),
+            &collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -315,9 +329,12 @@ mod group_by {
             0,
         );
 
-        let group_by = GroupBy::new(group_by_request.clone(), &collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            group_by_request.clone(),
+            &collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -347,9 +364,12 @@ mod group_by {
             3,
         );
 
-        let group_by = GroupBy::new(group_by_request.clone(), &collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            group_by_request.clone(),
+            &collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -379,9 +399,12 @@ mod group_by {
             3,
         );
 
-        let group_by = GroupBy::new(group_by_request.clone(), &collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            group_by_request.clone(),
+            &collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -415,9 +438,12 @@ mod group_by {
             400,
         );
 
-        let group_by = GroupBy::new(group_by_request.clone(), &collection, |_| async {
-            unreachable!()
-        });
+        let group_by = GroupBy::new(
+            group_by_request.clone(),
+            &collection,
+            |_| async { unreachable!() },
+            HwMeasurementAcc::new(),
+        );
 
         let result = group_by.execute().await;
 
@@ -442,6 +468,7 @@ mod group_by_builder {
     use collection::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
     };
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
     use segment::json_path::JsonPath;
     use tokio::sync::RwLock;
 
@@ -557,9 +584,14 @@ mod group_by_builder {
 
         let collection_by_name = |_: String| async { unreachable!() };
 
-        let result = GroupBy::new(request.clone(), &collection, collection_by_name)
-            .execute()
-            .await;
+        let result = GroupBy::new(
+            request.clone(),
+            &collection,
+            collection_by_name,
+            HwMeasurementAcc::new(),
+        )
+        .execute()
+        .await;
 
         assert!(result.is_ok());
 
@@ -590,9 +622,14 @@ mod group_by_builder {
 
         let collection_by_name = |_: String| async { Some(lookup_collection.read().await) };
 
-        let result = GroupBy::new(request.clone(), &collection, collection_by_name)
-            .execute()
-            .await;
+        let result = GroupBy::new(
+            request.clone(),
+            &collection,
+            collection_by_name,
+            HwMeasurementAcc::new(),
+        )
+        .execute()
+        .await;
 
         assert!(result.is_ok());
 

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -16,6 +16,7 @@ use collection::operations::types::{
 use collection::operations::vector_params_builder::VectorParamsBuilder;
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{NamedVector, VectorStructInternal};
 use segment::types::{Distance, WithPayloadInterface, WithVector};
@@ -127,6 +128,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -161,6 +163,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await;
 
@@ -190,6 +193,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -242,6 +246,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
+        HwMeasurementAcc::new(),
     )
     .await;
 
@@ -268,6 +273,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
+        HwMeasurementAcc::new(),
     )
     .await
     .unwrap();

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -5,6 +5,7 @@ use collection::operations::point_ops::{
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::CollectionUpdateOperations;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::WithPayloadInterface;
 use tempfile::Builder;
 
@@ -60,6 +61,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -86,6 +88,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -113,6 +116,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -15,6 +15,7 @@ use collection::operations::CollectionUpdateOperations;
 use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::ReplicaState;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use segment::types::{Distance, WithPayloadInterface, WithVector};
 use tempfile::Builder;
@@ -161,6 +162,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -171,6 +173,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -26,8 +26,8 @@ impl HwMeasurementAcc {
     }
 
     /// Consumes and accumulates the values from `hw_counter_cell` into the accumulator.
-    pub fn apply_from_cell(&self, hw_counter_cell: &HardwareCounterCell) {
-        let HardwareCounterCell { cpu_counter } = hw_counter_cell;
+    pub fn merge_from_cell(&self, hw_counter_cell: HardwareCounterCell) {
+        let HardwareCounterCell { ref cpu_counter } = hw_counter_cell;
 
         self.cpu_counter
             .fetch_add(cpu_counter.take(), Ordering::Relaxed);

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -159,6 +159,7 @@ impl TableOfContent {
     ///
     /// Number of points in the collection.
     ///
+    #[allow(clippy::too_many_arguments)]
     pub async fn count(
         &self,
         collection_name: &str,
@@ -167,12 +168,19 @@ impl TableOfContent {
         timeout: Option<Duration>,
         shard_selection: ShardSelectorInternal,
         access: Access,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> StorageResult<CountResult> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
         let collection = self.get_collection(&collection_pass).await?;
         collection
-            .count(request, read_consistency, &shard_selection, timeout)
+            .count(
+                request,
+                read_consistency,
+                &shard_selection,
+                timeout,
+                hw_measurement_acc,
+            )
             .await
             .map_err(|err| err.into())
     }
@@ -206,6 +214,7 @@ impl TableOfContent {
             .map_err(|err| err.into())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn group(
         &self,
         collection_name: &str,
@@ -214,6 +223,7 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> StorageResult<GroupsResult> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -221,7 +231,7 @@ impl TableOfContent {
 
         let collection_by_name = |name| self.get_collection_opt(name);
 
-        let group_by = GroupBy::new(request, &collection, collection_by_name)
+        let group_by = GroupBy::new(request, &collection, collection_by_name, hw_measurement_acc)
             .set_read_consistency(read_consistency)
             .set_shard_selection(shard_selection)
             .set_timeout(timeout);

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -6,6 +6,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::UpdateResult;
 use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use collection::shards::shard::ShardId;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 
 use super::TableOfContent;
@@ -19,11 +20,12 @@ impl TableOfContent {
         requests: Vec<ShardQueryRequest>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> StorageResult<Vec<ShardQueryResponse>> {
         let collection = self.get_collection_unchecked(collection_name).await?;
 
         let res = collection
-            .query_batch_internal(requests, &shard_selection, timeout)
+            .query_batch_internal(requests, &shard_selection, timeout, hw_measurement_acc)
             .await?;
 
         Ok(res)

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -2,6 +2,7 @@ use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::CountRequest;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use storage::content_manager::collection_verification::check_strict_mode;
 use storage::dispatcher::Dispatcher;
 use tokio::time::Instant;
@@ -11,6 +12,7 @@ use crate::actix::api::read_params::ReadParams;
 use crate::actix::auth::ActixAccess;
 use crate::actix::helpers::{self, process_response_error};
 use crate::common::points::do_count_points;
+use crate::settings::ServiceConfig;
 
 #[post("/collections/{name}/points/count")]
 async fn count_points(
@@ -18,6 +20,7 @@ async fn count_points(
     collection: Path<CollectionPath>,
     request: Json<CountRequest>,
     params: Query<ReadParams>,
+    service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
     let CountRequest {
@@ -43,14 +46,21 @@ async fn count_points(
         Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
     };
 
-    helpers::time(do_count_points(
-        dispatcher.toc(&access, &pass),
-        &collection.name,
-        count_request,
-        params.consistency,
-        params.timeout(),
-        shard_selector,
-        access,
-    ))
+    let hw_measurement_acc = HwMeasurementAcc::new();
+
+    helpers::time_and_hardware_opt(
+        do_count_points(
+            dispatcher.toc(&access, &pass),
+            &collection.name,
+            count_request,
+            params.consistency,
+            params.timeout(),
+            shard_selector,
+            access,
+            hw_measurement_acc.clone(),
+        ),
+        hw_measurement_acc,
+        service_config.hardware_reporting(),
+    )
     .await
 }

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -62,6 +62,7 @@ async fn discover_points(
                 shard_selection,
                 access,
                 params.timeout(),
+                hw_measurement_acc.clone(),
             )
             .map_ok(|scored_points| {
                 scored_points
@@ -109,6 +110,7 @@ async fn discover_batch_points(
             params.consistency,
             access,
             params.timeout(),
+            hw_measurement_acc.clone(),
         )
         .map_ok(|batch_scored_points| {
             batch_scored_points

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -163,6 +163,7 @@ async fn query_points_groups(
     collection: Path<CollectionPath>,
     request: Json<QueryGroupsRequest>,
     params: Query<ReadParams>,
+    service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
     let QueryGroupsRequest {
@@ -183,26 +184,34 @@ async fn query_points_groups(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    helpers::time(async move {
-        let shard_selection = match shard_key {
-            None => ShardSelectorInternal::All,
-            Some(shard_keys) => shard_keys.into(),
-        };
+    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc_clone = hw_measurement_acc.clone();
 
-        let query_group_request =
-            convert_query_groups_request_from_rest(search_group_request).await?;
+    helpers::time_and_hardware_opt(
+        async move {
+            let shard_selection = match shard_key {
+                None => ShardSelectorInternal::All,
+                Some(shard_keys) => shard_keys.into(),
+            };
 
-        do_query_point_groups(
-            dispatcher.toc(&access, &pass),
-            &collection.name,
-            query_group_request,
-            params.consistency,
-            shard_selection,
-            access,
-            params.timeout(),
-        )
-        .await
-    })
+            let query_group_request =
+                convert_query_groups_request_from_rest(search_group_request).await?;
+
+            do_query_point_groups(
+                dispatcher.toc(&access, &pass),
+                &collection.name,
+                query_group_request,
+                params.consistency,
+                shard_selection,
+                access,
+                params.timeout(),
+                hw_measurement_acc_clone,
+            )
+            .await
+        },
+        hw_measurement_acc,
+        service_config.hardware_reporting(),
+    )
     .await
 }
 

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -49,6 +49,7 @@ async fn query_points(
     };
 
     let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc_clone = hw_measurement_acc.clone();
     helpers::time_and_hardware_opt(
         async move {
             let shard_selection = match shard_key {
@@ -66,6 +67,7 @@ async fn query_points(
                     params.consistency,
                     access,
                     params.timeout(),
+                    hw_measurement_acc_clone,
                 )
                 .await?
                 .pop()
@@ -109,6 +111,7 @@ async fn query_points_batch(
     };
 
     let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc_clone = hw_measurement_acc.clone();
     helpers::time_and_hardware_opt(
         async move {
             let mut batch = Vec::with_capacity(searches.len());
@@ -135,6 +138,7 @@ async fn query_points_batch(
                     params.consistency,
                     access,
                     params.timeout(),
+                    hw_measurement_acc_clone,
                 )
                 .await?
                 .into_iter()
@@ -145,7 +149,6 @@ async fn query_points_batch(
                         .collect_vec(),
                 })
                 .collect_vec();
-
             Ok(res)
         },
         hw_measurement_acc,

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -70,6 +70,7 @@ async fn recommend_points(
                 shard_selection,
                 access,
                 params.timeout(),
+                hw_measurement_acc.clone(),
             )
             .map_ok(|scored_points| {
                 scored_points
@@ -90,6 +91,7 @@ async fn do_recommend_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = request
         .searches
@@ -104,8 +106,15 @@ async fn do_recommend_batch_points(
         })
         .collect();
 
-    toc.recommend_batch(collection_name, requests, read_consistency, access, timeout)
-        .await
+    toc.recommend_batch(
+        collection_name,
+        requests,
+        read_consistency,
+        access,
+        timeout,
+        hw_measurement_acc,
+    )
+    .await
 }
 
 #[post("/collections/{name}/points/recommend/batch")]
@@ -140,6 +149,7 @@ async fn recommend_batch_points(
             params.consistency,
             access,
             params.timeout(),
+            hw_measurement_acc.clone(),
         )
         .map_ok(|batch_scored_points| {
             batch_scored_points

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -56,7 +56,7 @@ async fn search_points(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_counter_accumulator = HwMeasurementAcc::new();
+    let hw_measurement_acc = HwMeasurementAcc::new();
 
     helpers::time_and_hardware_opt(
         do_core_search_points(
@@ -67,6 +67,7 @@ async fn search_points(
             shard_selection,
             access,
             params.timeout(),
+            hw_measurement_acc.clone(),
         )
         .map_ok(|scored_points| {
             scored_points
@@ -74,7 +75,7 @@ async fn search_points(
                 .map(api::rest::ScoredPoint::from)
                 .collect_vec()
         }),
-        hw_counter_accumulator,
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -121,7 +122,7 @@ async fn batch_search_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_counter_accumulator = HwMeasurementAcc::new();
+    let hw_measurement_acc = HwMeasurementAcc::new();
 
     helpers::time_and_hardware_opt(
         do_search_batch_points(
@@ -131,6 +132,7 @@ async fn batch_search_points(
             params.consistency,
             access,
             params.timeout(),
+            hw_measurement_acc.clone(),
         )
         .map_ok(|batch_scored_points| {
             batch_scored_points
@@ -143,7 +145,7 @@ async fn batch_search_points(
                 })
                 .collect_vec()
         }),
-        hw_counter_accumulator,
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -225,6 +227,8 @@ async fn search_points_matrix_pairs(
         Some(shard_keys) => shard_keys.into(),
     };
 
+    let hw_measurement_acc = HwMeasurementAcc::new();
+
     let response = do_search_points_matrix(
         dispatcher.toc(&access, &pass),
         &collection.name,
@@ -233,6 +237,7 @@ async fn search_points_matrix_pairs(
         shard_selection,
         access,
         params.timeout(),
+        hw_measurement_acc.clone(),
     )
     .await
     .map(SearchMatrixPairsResponse::from);
@@ -273,6 +278,8 @@ async fn search_points_matrix_offsets(
         Some(shard_keys) => shard_keys.into(),
     };
 
+    let hw_measurement_acc = HwMeasurementAcc::new();
+
     let response = do_search_points_matrix(
         dispatcher.toc(&access, &pass),
         &collection.name,
@@ -281,6 +288,7 @@ async fn search_points_matrix_offsets(
         shard_selection,
         access,
         params.timeout(),
+        hw_measurement_acc,
     )
     .await
     .map(SearchMatrixOffsetsResponse::from);

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -34,6 +34,7 @@ use collection::operations::{
     ClockTag, CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
 use collection::shards::shard::ShardId;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use schemars::JsonSchema;
 use segment::json_path::JsonPath;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, ScoredPoint, StrictModeConfig};
@@ -831,6 +832,7 @@ pub async fn do_delete_index(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_core_search_points(
     toc: &TableOfContent,
     collection_name: &str,
@@ -839,6 +841,7 @@ pub async fn do_core_search_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let batch_res = do_core_search_batch_points(
         toc,
@@ -850,6 +853,7 @@ pub async fn do_core_search_points(
         shard_selection,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await?;
     batch_res
@@ -865,6 +869,7 @@ pub async fn do_search_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = batch_requests::<
         (CoreSearchRequest, ShardSelectorInternal),
@@ -894,6 +899,7 @@ pub async fn do_search_batch_points(
                 shard_selector,
                 access.clone(),
                 timeout,
+                hw_measurement_acc.clone(),
             );
             res.push(req);
             Ok(())
@@ -905,6 +911,7 @@ pub async fn do_search_batch_points(
     Ok(flatten_results)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_core_search_batch_points(
     toc: &TableOfContent,
     collection_name: &str,
@@ -913,6 +920,7 @@ pub async fn do_core_search_batch_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.core_search_batch(
         collection_name,
@@ -921,6 +929,7 @@ pub async fn do_core_search_batch_points(
         shard_selection,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await
 }
@@ -972,6 +981,7 @@ pub async fn do_discover_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = request
         .searches
@@ -986,8 +996,15 @@ pub async fn do_discover_batch_points(
         })
         .collect();
 
-    toc.discover_batch(collection_name, requests, read_consistency, access, timeout)
-        .await
+    toc.discover_batch(
+        collection_name,
+        requests,
+        read_consistency,
+        access,
+        timeout,
+        hw_measurement_acc,
+    )
+    .await
 }
 
 pub async fn do_count_points(
@@ -1050,6 +1067,7 @@ pub async fn do_scroll_points(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_query_points(
     toc: &TableOfContent,
     collection_name: &str,
@@ -1058,10 +1076,18 @@ pub async fn do_query_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let requests = vec![(request, shard_selection)];
     let batch_res = toc
-        .query_batch(collection_name, requests, read_consistency, access, timeout)
+        .query_batch(
+            collection_name,
+            requests,
+            read_consistency,
+            access,
+            timeout,
+            hw_measurement_acc,
+        )
         .await?;
     batch_res
         .into_iter()
@@ -1069,6 +1095,7 @@ pub async fn do_query_points(
         .ok_or_else(|| StorageError::service_error("Empty query result"))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_query_batch_points(
     toc: &TableOfContent,
     collection_name: &str,
@@ -1076,9 +1103,17 @@ pub async fn do_query_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
-    toc.query_batch(collection_name, requests, read_consistency, access, timeout)
-        .await
+    toc.query_batch(
+        collection_name,
+        requests,
+        read_consistency,
+        access,
+        timeout,
+        hw_measurement_acc,
+    )
+    .await
 }
 
 pub async fn do_query_point_groups(
@@ -1101,6 +1136,7 @@ pub async fn do_query_point_groups(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_search_points_matrix(
     toc: &TableOfContent,
     collection_name: &str,
@@ -1109,6 +1145,7 @@ pub async fn do_search_points_matrix(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<CollectionSearchMatrixResponse, StorageError> {
     toc.search_points_matrix(
         collection_name,
@@ -1117,6 +1154,7 @@ pub async fn do_search_points_matrix(
         shard_selection,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await
 }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -934,6 +934,7 @@ pub async fn do_core_search_batch_points(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_search_point_groups(
     toc: &TableOfContent,
     collection_name: &str,
@@ -942,6 +943,7 @@ pub async fn do_search_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -950,10 +952,12 @@ pub async fn do_search_point_groups(
         shard_selection,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_recommend_point_groups(
     toc: &TableOfContent,
     collection_name: &str,
@@ -962,6 +966,7 @@ pub async fn do_recommend_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -970,6 +975,7 @@ pub async fn do_recommend_point_groups(
         shard_selection,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await
 }
@@ -1007,6 +1013,7 @@ pub async fn do_discover_batch_points(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_count_points(
     toc: &TableOfContent,
     collection_name: &str,
@@ -1015,6 +1022,7 @@ pub async fn do_count_points(
     timeout: Option<Duration>,
     shard_selection: ShardSelectorInternal,
     access: Access,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<CountResult, StorageError> {
     toc.count(
         collection_name,
@@ -1023,6 +1031,7 @@ pub async fn do_count_points(
         timeout,
         shard_selection,
         access,
+        hw_measurement_acc,
     )
     .await
 }
@@ -1116,6 +1125,7 @@ pub async fn do_query_batch_points(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_query_point_groups(
     toc: &TableOfContent,
     collection_name: &str,
@@ -1124,6 +1134,7 @@ pub async fn do_query_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -1132,6 +1143,7 @@ pub async fn do_query_point_groups(
         shard_selection,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await
 }

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -40,6 +40,7 @@ use collection::operations::vector_ops::DeleteVectors;
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
 use collection::shards::shard::ShardId;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::facets::FacetParams;
 use segment::data_types::order_by::OrderBy;
@@ -1053,6 +1054,9 @@ pub async fn search(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
+
     let timing = Instant::now();
     let scored_points = do_core_search_points(
         toc,
@@ -1062,6 +1066,7 @@ pub async fn search(
         shard_selector,
         access,
         timeout.map(Duration::from_secs),
+        hw_measurement_acc.clone(),
     )
     .await?;
 
@@ -1096,6 +1101,8 @@ pub async fn core_search_batch(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let timing = Instant::now();
 
     let scored_points = do_search_batch_points(
@@ -1105,6 +1112,7 @@ pub async fn core_search_batch(
         read_consistency,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await?;
 
@@ -1151,6 +1159,8 @@ pub async fn core_search_list(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let scored_points = toc
         .core_search_batch(
             &collection_name,
@@ -1159,6 +1169,7 @@ pub async fn core_search_list(
             shard_selection,
             access,
             timeout,
+            hw_measurement_acc,
         )
         .await?;
 
@@ -1306,6 +1317,8 @@ pub async fn recommend(
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
     let timeout = timeout.map(Duration::from_secs);
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let timing = Instant::now();
     let recommended_points = toc
         .recommend(
@@ -1315,6 +1328,7 @@ pub async fn recommend(
             shard_selector,
             access,
             timeout,
+            hw_measurement_acc,
         )
         .await?;
 
@@ -1359,6 +1373,8 @@ pub async fn recommend_batch(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let timing = Instant::now();
     let scored_points = toc
         .recommend_batch(
@@ -1367,6 +1383,7 @@ pub async fn recommend_batch(
             read_consistency,
             access,
             timeout,
+            hw_measurement_acc,
         )
         .await?;
 
@@ -1411,6 +1428,9 @@ pub async fn recommend_groups(
 
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
 
+    // TODO: Apply hardware counter value
+    // let hw_measurement_acc = AtomicHardwareAccumulator::new();
+
     let timing = Instant::now();
     let groups_result = crate::common::points::do_recommend_point_groups(
         toc,
@@ -1453,6 +1473,8 @@ pub async fn discover(
 
     let timing = Instant::now();
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
 
     let discovered_points = toc
@@ -1463,6 +1485,7 @@ pub async fn discover(
             shard_selector,
             access,
             timeout,
+            hw_measurement_acc,
         )
         .await?;
 
@@ -1506,6 +1529,8 @@ pub async fn discover_batch(
         )
         .await?;
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let timing = Instant::now();
     let scored_points = toc
         .discover_batch(
@@ -1514,6 +1539,7 @@ pub async fn discover_batch(
             read_consistency,
             access,
             timeout,
+            hw_measurement_acc,
         )
         .await?;
 
@@ -1750,6 +1776,8 @@ pub async fn query(
 
     let timeout = timeout.map(Duration::from_secs);
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let timing = Instant::now();
     let scored_points = do_query_points(
         toc,
@@ -1759,6 +1787,7 @@ pub async fn query(
         shard_selector,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await?;
 
@@ -1800,6 +1829,8 @@ pub async fn query_batch(
         )
         .await?;
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let timing = Instant::now();
     let scored_points = do_query_batch_points(
         toc,
@@ -1808,6 +1839,7 @@ pub async fn query_batch(
         read_consistency,
         access,
         timeout,
+        hw_measurement_acc,
     )
     .await?;
 
@@ -1977,6 +2009,8 @@ pub async fn search_points_matrix(
         )
         .await?;
 
+    // TODO: Apply hardware counter value
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let timeout = timeout.map(Duration::from_secs);
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
@@ -1990,6 +2024,7 @@ pub async fn search_points_matrix(
             shard_selector,
             access,
             timeout,
+            hw_measurement_acc,
         )
         .await?;
 

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1215,6 +1215,9 @@ pub async fn search_groups(
 
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
 
+    // TODO: put in grpc API
+    let hw_measuerement_acc = HwMeasurementAcc::new();
+
     let timing = Instant::now();
     let groups_result = crate::common::points::do_search_point_groups(
         toc,
@@ -1224,6 +1227,7 @@ pub async fn search_groups(
         shard_selector,
         access,
         timeout.map(Duration::from_secs),
+        hw_measuerement_acc.clone(),
     )
     .await?;
 
@@ -1429,7 +1433,7 @@ pub async fn recommend_groups(
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
 
     // TODO: Apply hardware counter value
-    // let hw_measurement_acc = AtomicHardwareAccumulator::new();
+    let hw_measurement_acc = HwMeasurementAcc::new();
 
     let timing = Instant::now();
     let groups_result = crate::common::points::do_recommend_point_groups(
@@ -1440,6 +1444,7 @@ pub async fn recommend_groups(
         shard_selector,
         access,
         timeout.map(Duration::from_secs),
+        hw_measurement_acc.clone(),
     )
     .await?;
 
@@ -1667,6 +1672,9 @@ pub async fn count(
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
 
     let timing = Instant::now();
+    // TODO: use value
+    let hw_measurement_acc = HwMeasurementAcc::new();
+
     let count_result = do_count_points(
         toc,
         &collection_name,
@@ -1675,6 +1683,7 @@ pub async fn count(
         timeout,
         shard_selector,
         access.clone(),
+        hw_measurement_acc,
     )
     .await?;
 
@@ -1884,6 +1893,9 @@ pub async fn query_groups(
 
     let timeout = timeout.map(Duration::from_secs);
     let timing = Instant::now();
+
+    // TODO: put this value in API
+    let hw_measurement_acc = HwMeasurementAcc::new();
     let groups_result = do_query_point_groups(
         toc,
         &collection_name,
@@ -1892,6 +1904,7 @@ pub async fn query_groups(
         shard_selector,
         access,
         timeout,
+        hw_measurement_acc.clone(),
     )
     .await?;
 

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -16,6 +16,7 @@ use api::grpc::qdrant::{
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use collection::shards::shard::ShardId;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::json_path::JsonPath;
@@ -70,8 +71,17 @@ pub async fn query_batch_internal(
         Some(shard_id) => ShardSelectorInternal::ShardId(shard_id),
     };
 
+    // TODO: Apply hardware counter in response
+    let hw_measurement_acc = HwMeasurementAcc::new();
+
     let batch_response = toc
-        .query_batch_internal(&collection_name, batch_requests, shard_selection, timeout)
+        .query_batch_internal(
+            &collection_name,
+            batch_requests,
+            shard_selection,
+            timeout,
+            hw_measurement_acc,
+        )
         .await?;
 
     let response = QueryBatchResponseInternal {


### PR DESCRIPTION
Depends on #5306

Populates the measurements collected by `HardwareCounterCells` back to the API, where it gets added to the response body.

Note that not all request endpoints have been implemented yet. Also setups with more than one Qdrant node is also not part of this PR.
Those will be addressed in future PRs, to not make this PR bigger than it already is.