### PR TITLE
Draft: fix snapshot transfer recovery causing inconsistencies

### DIFF
--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -886,7 +886,8 @@ impl ShardHolder {
                 snapshot_temp_dir.path(),
                 &tar,
                 SnapshotFormat::Regular,
-                false,
+                // TODO: include WAL in snapshot - this should not be necessary
+                true,
             )
             .await?;
 


### PR DESCRIPTION
_WIP_

This is unfinished, and requires further investigation/implementation.

Including the WAL in shard snapshots, and creating it before snapshotting the segments, seems to fix the problem entirely.

I don't understand why this is the case because the queue/forward proxies we have in place during the snapshot transfer should take care of any consistency problems.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
