### PR TITLE
Enable jemalloc background threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ pyroscope_pprofrs = "0.2.7"
 rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemallocator = { version = "0.6", features = ["stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 
 [workspace.lints.clippy]


### PR DESCRIPTION
Recommended by jemalloc author https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733

It seems to decrease even more the memory usage on my tests.

## Benchmarks

- sparse: http://78.47.239.240:3000/d/41-6HeeVz/continuous-benchmarks?orgId=1&var-table=benchmark_manual&var-dataset=msmarco-sparse-100K&var-branch_a=ghcr%2Fjemalloc-background-threads&var-branch_b=ghcr%2Fdev
- laion: http://78.47.239.240:3000/d/41-6HeeVz/continuous-benchmarks?orgId=1&var-table=benchmark_manual&var-dataset=laion-small-clip&var-branch_a=ghcr%2Fjemalloc-background-threads&var-branch_b=ghcr%2Fdev
- h-and-m-2048-angular-filters: http://78.47.239.240:3000/d/41-6HeeVz/continuous-benchmarks?orgId=1&var-table=benchmark_manual&var-dataset=h-and-m-2048-angular-filters&var-branch_a=ghcr%2Fjemalloc-background-threads&var-branch_b=ghcr%2Fdev
- dbpedia-openai-100K-1536-angular: http://78.47.239.240:3000/d/41-6HeeVz/continuous-benchmarks?orgId=1&var-table=benchmark_manual&var-dataset=dbpedia-openai-100K-1536-angular&var-branch_a=ghcr%2Fjemalloc-background-threads&var-branch_b=ghcr%2Fdev