### PR TITLE
Distance matrix does not need to use client's filter when looking up by ids

### DIFF
--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -229,18 +229,12 @@ impl Collection {
                 .filter(|id| *id != &point_id)
                 .cloned()
                 .collect();
+            // TODO: optimize this by using the same filter for all searches to leverage search_batch with oversampling
             let only_ids = Filter::new_must(Condition::HasId(HasIdCondition::from(req_ids)));
 
-            // update filter with the only_ids
-            let req_filter = Some(
-                filter
-                    .as_ref()
-                    .map(|filter| filter.merge(&only_ids))
-                    .unwrap_or(only_ids),
-            );
             searches.push(CoreSearchRequest {
                 query,
-                filter: req_filter,
+                filter: Some(only_ids),
                 score_threshold: None,
                 limit: limit_per_sample,
                 offset: 0,


### PR DESCRIPTION
It is not needed to build a merged filter using the client's filter when selecting by point ids.

We have already applied this filter to select the point ids.

This PR also adds a TODO for the next possible optimization.