### PR TITLE
Inference Service, query requests (batch processing)

### DIFF
--- a/lib/api/src/conversions/inference.rs
+++ b/lib/api/src/conversions/inference.rs
@@ -2,14 +2,18 @@ use tonic::Status;
 
 use crate::conversions::json::{dict_to_proto, json_to_proto, proto_dict_to_json, proto_to_json};
 use crate::grpc::qdrant as grpc;
-use crate::rest::schema as rest;
+use crate::rest::{schema as rest, Options};
 
 impl From<rest::Document> for grpc::Document {
     fn from(document: rest::Document) -> Self {
         Self {
             text: document.text,
             model: document.model,
-            options: document.options.map(dict_to_proto).unwrap_or_default(),
+            options: document
+                .options
+                .options
+                .map(dict_to_proto)
+                .unwrap_or_default(),
         }
     }
 }
@@ -21,7 +25,9 @@ impl TryFrom<grpc::Document> for rest::Document {
         Ok(Self {
             text: document.text,
             model: document.model,
-            options: Some(proto_dict_to_json(document.options)?),
+            options: Options {
+                options: Some(proto_dict_to_json(document.options)?),
+            },
         })
     }
 }
@@ -31,7 +37,7 @@ impl From<rest::Image> for grpc::Image {
         Self {
             image: image.image,
             model: image.model,
-            options: image.options.map(dict_to_proto).unwrap_or_default(),
+            options: image.options.options.map(dict_to_proto).unwrap_or_default(),
         }
     }
 }
@@ -43,7 +49,9 @@ impl TryFrom<grpc::Image> for rest::Image {
         Ok(Self {
             image: image.image,
             model: image.model,
-            options: Some(proto_dict_to_json(image.options)?),
+            options: Options {
+                options: Some(proto_dict_to_json(image.options)?),
+            },
         })
     }
 }
@@ -53,7 +61,11 @@ impl From<rest::InferenceObject> for grpc::InferenceObject {
         Self {
             object: Some(json_to_proto(object.object)),
             model: object.model,
-            options: object.options.map(dict_to_proto).unwrap_or_default(),
+            options: object
+                .options
+                .options
+                .map(dict_to_proto)
+                .unwrap_or_default(),
         }
     }
 }
@@ -74,7 +86,9 @@ impl TryFrom<grpc::InferenceObject> for rest::InferenceObject {
         Ok(Self {
             object: proto_to_json(object)?,
             model,
-            options: Some(proto_dict_to_json(options)?),
+            options: Options {
+                options: Some(proto_dict_to_json(options)?),
+            },
         })
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -142,7 +142,7 @@ impl Validate for VectorStruct {
 /// WARN: Work-in-progress, unimplemented
 ///
 /// Text document for embedding. Requires inference infrastructure, unimplemented.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct Document {
     /// Text of the document
     /// This field will be used as input for the embedding model
@@ -158,7 +158,7 @@ pub struct Document {
 /// WARN: Work-in-progress, unimplemented
 ///
 /// Image object for embedding. Requires inference infrastructure, unimplemented.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct Image {
     /// Image data: base64 encoded image or an URL
     pub image: String,
@@ -173,7 +173,7 @@ pub struct Image {
 /// WARN: Work-in-progress, unimplemented
 ///
 /// Custom object for embedding. Requires inference infrastructure, unimplemented.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct InferenceObject {
     /// Arbitrary data, used as input for the embedding model
     /// Used if the model requires more than one input or a custom input

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
 use common::types::ScoreType;
 use common::validation::validate_multi_vector;
@@ -139,10 +140,31 @@ impl Validate for VectorStruct {
     }
 }
 
+#[derive(Clone, Default, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct Options {
+    /// Parameters for the model
+    /// Values of the parameters are model-specific
+    pub options: Option<HashMap<String, Value>>,
+}
+
+impl Hash for Options {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Order of keys in the map should not affect the hash
+        if let Some(options) = &self.options {
+            let mut keys: Vec<_> = options.keys().collect();
+            keys.sort();
+            for key in keys {
+                key.hash(state);
+                options.get(key).unwrap().hash(state);
+            }
+        }
+    }
+}
+
 /// WARN: Work-in-progress, unimplemented
 ///
 /// Text document for embedding. Requires inference infrastructure, unimplemented.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema, Hash)]
 pub struct Document {
     /// Text of the document
     /// This field will be used as input for the embedding model
@@ -150,15 +172,14 @@ pub struct Document {
     /// Name of the model used to generate the vector
     /// List of available models depends on a provider
     pub model: Option<String>,
-    /// Parameters for the model
-    /// Values of the parameters are model-specific
-    pub options: Option<HashMap<String, Value>>,
+    #[serde(flatten)]
+    pub options: Options,
 }
 
 /// WARN: Work-in-progress, unimplemented
 ///
 /// Image object for embedding. Requires inference infrastructure, unimplemented.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema, Hash)]
 pub struct Image {
     /// Image data: base64 encoded image or an URL
     pub image: String,
@@ -167,13 +188,14 @@ pub struct Image {
     pub model: Option<String>,
     /// Parameters for the model
     /// Values of the parameters are model-specific
-    pub options: Option<HashMap<String, Value>>,
+    #[serde(flatten)]
+    pub options: Options,
 }
 
 /// WARN: Work-in-progress, unimplemented
 ///
 /// Custom object for embedding. Requires inference infrastructure, unimplemented.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema, Hash)]
 pub struct InferenceObject {
     /// Arbitrary data, used as input for the embedding model
     /// Used if the model requires more than one input or a custom input
@@ -183,7 +205,8 @@ pub struct InferenceObject {
     pub model: Option<String>,
     /// Parameters for the model
     /// Values of the parameters are model-specific
-    pub options: Option<HashMap<String, Value>>,
+    #[serde(flatten)]
+    pub options: Options,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -34,7 +34,12 @@ impl BatchAccum {
 impl From<&BatchAccum> for InferenceRequest {
     fn from(batch: &BatchAccum) -> Self {
         Self {
-            inputs: batch.objects.iter().cloned().map(InferenceInput::from).collect(),
+            inputs: batch
+                .objects
+                .iter()
+                .cloned()
+                .map(InferenceInput::from)
+                .collect(),
             inference: None,
             token: None,
         }

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -1,5 +1,5 @@
 // use collection::operations::point_ops::VectorPersisted;
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use api::rest::{
     ContextPair, DiscoverInput, Prefetch, Query, QueryGroupsRequestInternal, QueryInterface,
@@ -9,18 +9,18 @@ use api::rest::{
 use crate::common::inference::service::InferenceData;
 
 pub struct BatchAccum {
-    objects: HashMap<InferenceData, InferenceData>,
+    objects: HashSet<InferenceData>,
 }
 
 impl BatchAccum {
     pub fn new() -> Self {
         Self {
-            objects: HashMap::new(),
+            objects: HashSet::new(),
         }
     }
 
     pub fn add(&mut self, data: InferenceData) {
-        self.objects.insert(data.clone(), data);
+        self.objects.insert(data);
     }
 
     pub fn extend(&mut self, other: BatchAccum) {
@@ -158,7 +158,7 @@ mod tests {
         batch.add(doc.clone());
         assert_eq!(batch.objects.len(), 1);
 
-        batch.add(doc.clone());
+        batch.add(doc);
         assert_eq!(batch.objects.len(), 1);
     }
 

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -28,50 +28,50 @@ impl BatchAccum {
     }
 }
 
-fn collect_vector_input(vector: &VectorInput, batch: &mut BatchAccum) {
+fn collect_vector_input(vector: VectorInput, batch: &mut BatchAccum) {
     match vector {
-        VectorInput::Document(doc) => batch.add(InferenceData::Document(doc.clone())),
-        VectorInput::Image(img) => batch.add(InferenceData::Image(img.clone())),
-        VectorInput::Object(obj) => batch.add(InferenceData::Object(obj.clone())),
+        VectorInput::Document(doc) => batch.add(InferenceData::Document(doc)),
+        VectorInput::Image(img) => batch.add(InferenceData::Image(img)),
+        VectorInput::Object(obj) => batch.add(InferenceData::Object(obj)),
         // types that are not supported in the Inference Service
         _ => {}
     }
 }
 
-fn collect_context_pair(pair: &ContextPair, batch: &mut BatchAccum) {
-    collect_vector_input(&pair.positive, batch);
-    collect_vector_input(&pair.negative, batch);
+fn collect_context_pair(pair: ContextPair, batch: &mut BatchAccum) {
+    collect_vector_input(pair.positive, batch);
+    collect_vector_input(pair.negative, batch);
 }
 
-fn collect_discover_input(discover: &DiscoverInput, batch: &mut BatchAccum) {
-    collect_vector_input(&discover.target, batch);
-    if let Some(context) = &discover.context {
+fn collect_discover_input(discover: DiscoverInput, batch: &mut BatchAccum) {
+    collect_vector_input(discover.target, batch);
+    if let Some(context) = discover.context {
         for pair in context {
             collect_context_pair(pair, batch);
         }
     }
 }
 
-fn collect_recommend_input(recommend: &RecommendInput, batch: &mut BatchAccum) {
-    if let Some(positive) = &recommend.positive {
+fn collect_recommend_input(recommend: RecommendInput, batch: &mut BatchAccum) {
+    if let Some(positive) = recommend.positive {
         for vector in positive {
             collect_vector_input(vector, batch);
         }
     }
-    if let Some(negative) = &recommend.negative {
+    if let Some(negative) = recommend.negative {
         for vector in negative {
             collect_vector_input(vector, batch);
         }
     }
 }
 
-fn collect_query(query: &Query, batch: &mut BatchAccum) {
+fn collect_query(query: Query, batch: &mut BatchAccum) {
     match query {
-        Query::Nearest(nearest) => collect_vector_input(&nearest.nearest, batch),
-        Query::Recommend(recommend) => collect_recommend_input(&recommend.recommend, batch),
-        Query::Discover(discover) => collect_discover_input(&discover.discover, batch),
+        Query::Nearest(nearest) => collect_vector_input(nearest.nearest, batch),
+        Query::Recommend(recommend) => collect_recommend_input(recommend.recommend, batch),
+        Query::Discover(discover) => collect_discover_input(discover.discover, batch),
         Query::Context(context) => {
-            if let Some(pairs) = &context.context.0 {
+            if let Some(pairs) = context.context.0 {
                 for pair in pairs {
                     collect_context_pair(pair, batch);
                 }
@@ -81,33 +81,33 @@ fn collect_query(query: &Query, batch: &mut BatchAccum) {
     }
 }
 
-fn collect_query_interface(query: &QueryInterface, batch: &mut BatchAccum) {
+fn collect_query_interface(query: QueryInterface, batch: &mut BatchAccum) {
     match query {
         QueryInterface::Nearest(vector) => collect_vector_input(vector, batch),
         QueryInterface::Query(query) => collect_query(query, batch),
     }
 }
 
-fn collect_prefetch(prefetch: &Prefetch, batch: &mut BatchAccum) {
-    if let Some(query) = &prefetch.query {
+fn collect_prefetch(prefetch: Prefetch, batch: &mut BatchAccum) {
+    if let Some(query) = prefetch.query {
         collect_query_interface(query, batch);
     }
 
-    if let Some(prefetches) = &prefetch.prefetch {
+    if let Some(prefetches) = prefetch.prefetch {
         for p in prefetches {
             collect_prefetch(p, batch);
         }
     }
 }
 
-pub fn collect_query_groups_request(request: &QueryGroupsRequestInternal) -> BatchAccum {
+pub fn collect_query_groups_request(request: QueryGroupsRequestInternal) -> BatchAccum {
     let mut batch = BatchAccum::new();
 
-    if let Some(query) = &request.query {
+    if let Some(query) = request.query {
         collect_query_interface(query, &mut batch);
     }
 
-    if let Some(prefetches) = &request.prefetch {
+    if let Some(prefetches) = request.prefetch {
         for prefetch in prefetches {
             collect_prefetch(prefetch, &mut batch);
         }
@@ -198,9 +198,9 @@ mod tests {
         let img_input = VectorInput::Image(create_test_image("test.jpg"));
         let obj_input = VectorInput::Object(create_test_object("test"));
 
-        collect_vector_input(&doc_input, &mut batch);
-        collect_vector_input(&img_input, &mut batch);
-        collect_vector_input(&obj_input, &mut batch);
+        collect_vector_input(doc_input, &mut batch);
+        collect_vector_input(img_input, &mut batch);
+        collect_vector_input(obj_input, &mut batch);
 
         assert_eq!(batch.objects.len(), 3);
     }
@@ -232,7 +232,7 @@ mod tests {
         };
 
         let mut batch = BatchAccum::new();
-        collect_prefetch(&prefetch, &mut batch);
+        collect_prefetch(prefetch, &mut batch);
         assert_eq!(batch.objects.len(), 2);
     }
 
@@ -275,7 +275,7 @@ mod tests {
             },
         };
 
-        let batch = collect_query_groups_request(&request);
+        let batch = collect_query_groups_request(request);
         assert_eq!(batch.objects.len(), 4);
     }
 

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -2,8 +2,8 @@
 use std::collections::HashSet;
 
 use api::rest::{
-    ContextPair, DiscoverInput, Prefetch, Query, QueryGroupsRequestInternal, QueryInterface,
-    RecommendInput, VectorInput,
+    ContextInput, ContextPair, DiscoverInput, Prefetch, Query, QueryGroupsRequestInternal,
+    QueryInterface, RecommendInput, VectorInput,
 };
 
 use crate::common::inference::service::InferenceData;
@@ -28,53 +28,53 @@ impl BatchAccum {
     }
 }
 
-fn collect_vector_input(vector: VectorInput, batch: &mut BatchAccum) {
+fn collect_vector_input(vector: &VectorInput, batch: &mut BatchAccum) {
     match vector {
-        VectorInput::Document(doc) => batch.add(InferenceData::Document(doc)),
-        VectorInput::Image(img) => batch.add(InferenceData::Image(img)),
-        VectorInput::Object(obj) => batch.add(InferenceData::Object(obj)),
+        VectorInput::Document(doc) => batch.add(InferenceData::Document(doc.clone())),
+        VectorInput::Image(img) => batch.add(InferenceData::Image(img.clone())),
+        VectorInput::Object(obj) => batch.add(InferenceData::Object(obj.clone())),
         // types that are not supported in the Inference Service
-        VectorInput::DenseVector(_)  => {}
+        VectorInput::DenseVector(_) => {}
+        VectorInput::SparseVector(_) => {}
         VectorInput::MultiDenseVector(_) => {}
         VectorInput::Id(_) => {}
-        VectorInput::SparseVector(_) => {}
     }
 }
 
-fn collect_context_pair(pair: ContextPair, batch: &mut BatchAccum) {
-    collect_vector_input(pair.positive, batch);
-    collect_vector_input(pair.negative, batch);
+fn collect_context_pair(pair: &ContextPair, batch: &mut BatchAccum) {
+    collect_vector_input(&pair.positive, batch);
+    collect_vector_input(&pair.negative, batch);
 }
 
-fn collect_discover_input(discover: DiscoverInput, batch: &mut BatchAccum) {
-    collect_vector_input(discover.target, batch);
-    if let Some(context) = discover.context {
+fn collect_discover_input(discover: &DiscoverInput, batch: &mut BatchAccum) {
+    collect_vector_input(&discover.target, batch);
+    if let Some(context) = &discover.context {
         for pair in context {
             collect_context_pair(pair, batch);
         }
     }
 }
 
-fn collect_recommend_input(recommend: RecommendInput, batch: &mut BatchAccum) {
-    if let Some(positive) = recommend.positive {
+fn collect_recommend_input(recommend: &RecommendInput, batch: &mut BatchAccum) {
+    if let Some(positive) = &recommend.positive {
         for vector in positive {
             collect_vector_input(vector, batch);
         }
     }
-    if let Some(negative) = recommend.negative {
+    if let Some(negative) = &recommend.negative {
         for vector in negative {
             collect_vector_input(vector, batch);
         }
     }
 }
 
-fn collect_query(query: Query, batch: &mut BatchAccum) {
+fn collect_query(query: &Query, batch: &mut BatchAccum) {
     match query {
-        Query::Nearest(nearest) => collect_vector_input(nearest.nearest, batch),
-        Query::Recommend(recommend) => collect_recommend_input(recommend.recommend, batch),
-        Query::Discover(discover) => collect_discover_input(discover.discover, batch),
+        Query::Nearest(nearest) => collect_vector_input(&nearest.nearest, batch),
+        Query::Recommend(recommend) => collect_recommend_input(&recommend.recommend, batch),
+        Query::Discover(discover) => collect_discover_input(&discover.discover, batch),
         Query::Context(context) => {
-            if let Some(pairs) = context.context.0 {
+            if let ContextInput(Some(pairs)) = &context.context {
                 for pair in pairs {
                     collect_context_pair(pair, batch);
                 }
@@ -84,33 +84,33 @@ fn collect_query(query: Query, batch: &mut BatchAccum) {
     }
 }
 
-fn collect_query_interface(query: QueryInterface, batch: &mut BatchAccum) {
+fn collect_query_interface(query: &QueryInterface, batch: &mut BatchAccum) {
     match query {
         QueryInterface::Nearest(vector) => collect_vector_input(vector, batch),
         QueryInterface::Query(query) => collect_query(query, batch),
     }
 }
 
-fn collect_prefetch(prefetch: Prefetch, batch: &mut BatchAccum) {
-    if let Some(query) = prefetch.query {
+fn collect_prefetch(prefetch: &Prefetch, batch: &mut BatchAccum) {
+    if let Some(query) = &prefetch.query {
         collect_query_interface(query, batch);
     }
 
-    if let Some(prefetches) = prefetch.prefetch {
+    if let Some(prefetches) = &prefetch.prefetch {
         for p in prefetches {
             collect_prefetch(p, batch);
         }
     }
 }
 
-pub fn collect_query_groups_request(request: QueryGroupsRequestInternal) -> BatchAccum {
+pub fn collect_query_groups_request(request: &QueryGroupsRequestInternal) -> BatchAccum {
     let mut batch = BatchAccum::new();
 
-    if let Some(query) = request.query {
+    if let Some(query) = &request.query {
         collect_query_interface(query, &mut batch);
     }
 
-    if let Some(prefetches) = request.prefetch {
+    if let Some(prefetches) = &request.prefetch {
         for prefetch in prefetches {
             collect_prefetch(prefetch, &mut batch);
         }
@@ -123,7 +123,6 @@ pub fn collect_query_groups_request(request: QueryGroupsRequestInternal) -> Batc
 mod tests {
     use api::rest::schema::{DiscoverQuery, Document, Image, InferenceObject, NearestQuery};
     use api::rest::QueryBaseGroupRequest;
-    use segment::json_path::JsonPath;
     use serde_json::json;
 
     use super::*;
@@ -132,7 +131,7 @@ mod tests {
         Document {
             text: text.to_string(),
             model: Some("test-model".to_string()),
-            options: None,
+            options: Default::default(),
         }
     }
 
@@ -140,7 +139,7 @@ mod tests {
         Image {
             image: url.to_string(),
             model: Some("test-model".to_string()),
-            options: None,
+            options: Default::default(),
         }
     }
 
@@ -148,7 +147,7 @@ mod tests {
         InferenceObject {
             object: json!({"data": data}),
             model: Some("test-model".to_string()),
-            options: None,
+            options: Default::default(),
         }
     }
 
@@ -201,9 +200,9 @@ mod tests {
         let img_input = VectorInput::Image(create_test_image("test.jpg"));
         let obj_input = VectorInput::Object(create_test_object("test"));
 
-        collect_vector_input(doc_input, &mut batch);
-        collect_vector_input(img_input, &mut batch);
-        collect_vector_input(obj_input, &mut batch);
+        collect_vector_input(&doc_input, &mut batch);
+        collect_vector_input(&img_input, &mut batch);
+        collect_vector_input(&obj_input, &mut batch);
 
         assert_eq!(batch.objects.len(), 3);
     }
@@ -235,7 +234,7 @@ mod tests {
         };
 
         let mut batch = BatchAccum::new();
-        collect_prefetch(prefetch, &mut batch);
+        collect_prefetch(&prefetch, &mut batch);
         assert_eq!(batch.objects.len(), 2);
     }
 
@@ -271,14 +270,14 @@ mod tests {
             with_payload: None,
             lookup_from: None,
             group_request: QueryBaseGroupRequest {
-                group_by: JsonPath::from("test".parse().unwrap()),
+                group_by: "test".parse().unwrap(),
                 group_size: None,
                 limit: None,
                 with_lookup: None,
             },
         };
 
-        let batch = collect_query_groups_request(request);
+        let batch = collect_query_groups_request(&request);
         assert_eq!(batch.objects.len(), 4);
     }
 

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -77,7 +77,7 @@ fn collect_query(query: &Query, batch: &mut BatchAccum) {
                 }
             }
         }
-        _ => {}
+        Query::OrderBy(_) | Query::Fusion(_) | Query::Sample(_) => {}
     }
 }
 

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -1,0 +1,330 @@
+// use collection::operations::point_ops::VectorPersisted;
+use std::collections::HashMap;
+
+use api::rest::{
+    ContextPair, DiscoverInput, Prefetch, Query, QueryGroupsRequestInternal, QueryInterface,
+    RecommendInput, VectorInput,
+};
+
+use crate::common::inference::service::InferenceData;
+
+pub struct BatchAccum {
+    objects: HashMap<InferenceData, InferenceData>,
+}
+
+impl BatchAccum {
+    pub fn new() -> Self {
+        Self {
+            objects: HashMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, data: InferenceData) {
+        self.objects.insert(data.clone(), data);
+    }
+
+    pub fn extend(&mut self, other: BatchAccum) {
+        self.objects.extend(other.objects);
+    }
+}
+
+fn collect_vector_input(vector: &VectorInput, batch: &mut BatchAccum) {
+    match vector {
+        VectorInput::Document(doc) => batch.add(InferenceData::Document(doc.clone())),
+        VectorInput::Image(img) => batch.add(InferenceData::Image(img.clone())),
+        VectorInput::Object(obj) => batch.add(InferenceData::Object(obj.clone())),
+        // types that are not supported in the Inference Service
+        _ => {}
+    }
+}
+
+fn collect_context_pair(pair: &ContextPair, batch: &mut BatchAccum) {
+    collect_vector_input(&pair.positive, batch);
+    collect_vector_input(&pair.negative, batch);
+}
+
+fn collect_discover_input(discover: &DiscoverInput, batch: &mut BatchAccum) {
+    collect_vector_input(&discover.target, batch);
+    if let Some(context) = &discover.context {
+        for pair in context {
+            collect_context_pair(pair, batch);
+        }
+    }
+}
+
+fn collect_recommend_input(recommend: &RecommendInput, batch: &mut BatchAccum) {
+    if let Some(positive) = &recommend.positive {
+        for vector in positive {
+            collect_vector_input(vector, batch);
+        }
+    }
+    if let Some(negative) = &recommend.negative {
+        for vector in negative {
+            collect_vector_input(vector, batch);
+        }
+    }
+}
+
+fn collect_query(query: &Query, batch: &mut BatchAccum) {
+    match query {
+        Query::Nearest(nearest) => collect_vector_input(&nearest.nearest, batch),
+        Query::Recommend(recommend) => collect_recommend_input(&recommend.recommend, batch),
+        Query::Discover(discover) => collect_discover_input(&discover.discover, batch),
+        Query::Context(context) => {
+            if let Some(pairs) = &context.context.0 {
+                for pair in pairs {
+                    collect_context_pair(pair, batch);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_query_interface(query: &QueryInterface, batch: &mut BatchAccum) {
+    match query {
+        QueryInterface::Nearest(vector) => collect_vector_input(vector, batch),
+        QueryInterface::Query(query) => collect_query(query, batch),
+    }
+}
+
+fn collect_prefetch(prefetch: &Prefetch, batch: &mut BatchAccum) {
+    if let Some(query) = &prefetch.query {
+        collect_query_interface(query, batch);
+    }
+
+    if let Some(prefetches) = &prefetch.prefetch {
+        for p in prefetches {
+            collect_prefetch(p, batch);
+        }
+    }
+}
+
+pub fn collect_query_groups_request(request: &QueryGroupsRequestInternal) -> BatchAccum {
+    let mut batch = BatchAccum::new();
+
+    if let Some(query) = &request.query {
+        collect_query_interface(query, &mut batch);
+    }
+
+    if let Some(prefetches) = &request.prefetch {
+        for prefetch in prefetches {
+            collect_prefetch(prefetch, &mut batch);
+        }
+    }
+
+    batch
+}
+
+#[cfg(test)]
+mod tests {
+    use api::rest::schema::{DiscoverQuery, Document, Image, InferenceObject, NearestQuery};
+    use api::rest::QueryBaseGroupRequest;
+    use segment::json_path::JsonPath;
+    use serde_json::json;
+
+    use super::*;
+
+    fn create_test_document(text: &str) -> Document {
+        Document {
+            text: text.to_string(),
+            model: Some("test-model".to_string()),
+            options: None,
+        }
+    }
+
+    fn create_test_image(url: &str) -> Image {
+        Image {
+            image: url.to_string(),
+            model: Some("test-model".to_string()),
+            options: None,
+        }
+    }
+
+    fn create_test_object(data: &str) -> InferenceObject {
+        InferenceObject {
+            object: json!({"data": data}),
+            model: Some("test-model".to_string()),
+            options: None,
+        }
+    }
+
+    #[test]
+    fn test_batch_accum_basic() {
+        let mut batch = BatchAccum::new();
+        assert!(batch.objects.is_empty());
+
+        let doc = InferenceData::Document(create_test_document("test"));
+        batch.add(doc.clone());
+        assert_eq!(batch.objects.len(), 1);
+
+        batch.add(doc.clone());
+        assert_eq!(batch.objects.len(), 1);
+    }
+
+    #[test]
+    fn test_batch_accum_extend() {
+        let mut batch1 = BatchAccum::new();
+        let mut batch2 = BatchAccum::new();
+
+        let doc1 = InferenceData::Document(create_test_document("test1"));
+        let doc2 = InferenceData::Document(create_test_document("test2"));
+
+        batch1.add(doc1);
+        batch2.add(doc2);
+
+        batch1.extend(batch2);
+        assert_eq!(batch1.objects.len(), 2);
+    }
+
+    #[test]
+    fn test_deduplication() {
+        let mut batch = BatchAccum::new();
+
+        let doc1 = InferenceData::Document(create_test_document("same"));
+        let doc2 = InferenceData::Document(create_test_document("same"));
+
+        batch.add(doc1);
+        batch.add(doc2);
+
+        assert_eq!(batch.objects.len(), 1);
+    }
+
+    #[test]
+    fn test_collect_vector_input() {
+        let mut batch = BatchAccum::new();
+
+        let doc_input = VectorInput::Document(create_test_document("test"));
+        let img_input = VectorInput::Image(create_test_image("test.jpg"));
+        let obj_input = VectorInput::Object(create_test_object("test"));
+
+        collect_vector_input(&doc_input, &mut batch);
+        collect_vector_input(&img_input, &mut batch);
+        collect_vector_input(&obj_input, &mut batch);
+
+        assert_eq!(batch.objects.len(), 3);
+    }
+
+    #[test]
+    fn test_collect_prefetch() {
+        let prefetch = Prefetch {
+            query: Some(QueryInterface::Nearest(VectorInput::Document(
+                create_test_document("test"),
+            ))),
+            prefetch: Some(vec![Prefetch {
+                query: Some(QueryInterface::Nearest(VectorInput::Image(
+                    create_test_image("nested.jpg"),
+                ))),
+                prefetch: None,
+                using: None,
+                filter: None,
+                params: None,
+                score_threshold: None,
+                limit: None,
+                lookup_from: None,
+            }]),
+            using: None,
+            filter: None,
+            params: None,
+            score_threshold: None,
+            limit: None,
+            lookup_from: None,
+        };
+
+        let mut batch = BatchAccum::new();
+        collect_prefetch(&prefetch, &mut batch);
+        assert_eq!(batch.objects.len(), 2);
+    }
+
+    #[test]
+    fn test_collect_query_groups_request() {
+        let request = QueryGroupsRequestInternal {
+            query: Some(QueryInterface::Query(Query::Nearest(NearestQuery {
+                nearest: VectorInput::Document(create_test_document("test")),
+            }))),
+            prefetch: Some(vec![Prefetch {
+                query: Some(QueryInterface::Query(Query::Discover(DiscoverQuery {
+                    discover: DiscoverInput {
+                        target: VectorInput::Image(create_test_image("test.jpg")),
+                        context: Some(vec![ContextPair {
+                            positive: VectorInput::Document(create_test_document("pos")),
+                            negative: VectorInput::Image(create_test_image("neg.jpg")),
+                        }]),
+                    },
+                }))),
+                prefetch: None,
+                using: None,
+                filter: None,
+                params: None,
+                score_threshold: None,
+                limit: None,
+                lookup_from: None,
+            }]),
+            using: None,
+            filter: None,
+            params: None,
+            score_threshold: None,
+            with_vector: None,
+            with_payload: None,
+            lookup_from: None,
+            group_request: QueryBaseGroupRequest {
+                group_by: JsonPath::from("test".parse().unwrap()),
+                group_size: None,
+                limit: None,
+                with_lookup: None,
+            },
+        };
+
+        let batch = collect_query_groups_request(&request);
+        assert_eq!(batch.objects.len(), 4);
+    }
+
+    #[test]
+    fn test_different_model_same_content() {
+        let mut batch = BatchAccum::new();
+
+        let mut doc1 = create_test_document("same");
+        let mut doc2 = create_test_document("same");
+        doc1.model = Some("model1".to_string());
+        doc2.model = Some("model2".to_string());
+
+        batch.add(InferenceData::Document(doc1));
+        batch.add(InferenceData::Document(doc2));
+
+        assert_eq!(batch.objects.len(), 2);
+    }
+}
+
+// pub struct BatchAccumInferred {
+//     objects: HashMap<InferenceData, VectorPersisted>,
+// }
+//
+// impl BatchAccumInferred {
+//     pub fn add(&mut self, data: InferenceData, result: VectorPersisted) {
+//         self.objects.insert(data, result);
+//     }
+//
+//     pub fn get(&self, data: &InferenceData) -> Option<&VectorPersisted> {
+//         self.objects.get(data)
+//     }
+// }
+
+// fn collect_collection_prefetch(
+//     prefetch: rest::Prefetch,
+//     batch_accum: &mut BatchAccummulator,
+// ) -> Result<(), StorageError> {
+//     todo!()
+// }
+//
+//
+// fn convert_collection_prefetch(
+//     prefetch: rest::Prefetch,
+//     batch_accum_inferred: &BatchAccumInferred,
+// ) -> Result<CollectionPrefetch, StorageError> {
+//     todo!()
+// }
+
+// How to implement:
+// QueryGroupsRequestInternal -> BatchAccum <- function should be sync (not async), extract vectors to infer
+// BatchAccum -> BatchAccumInferred <- Async, makes actual inference
+// f(QueryGroupsRequestInternal, BatchAccumInferred) -> CollectionQueryGroupsRequest <- should be sync (not async), replace original Docs with inferred vectors

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -1,4 +1,3 @@
-// use collection::operations::point_ops::VectorPersisted;
 use std::collections::HashSet;
 
 use api::rest::{
@@ -6,10 +5,10 @@ use api::rest::{
     QueryInterface, RecommendInput, VectorInput,
 };
 
-use crate::common::inference::service::InferenceData;
+use super::service::{InferenceData, InferenceRequest};
 
 pub struct BatchAccum {
-    objects: HashSet<InferenceData>,
+    pub(crate) objects: HashSet<InferenceData>,
 }
 
 impl BatchAccum {
@@ -25,6 +24,20 @@ impl BatchAccum {
 
     pub fn extend(&mut self, other: BatchAccum) {
         self.objects.extend(other.objects);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.objects.is_empty()
+    }
+}
+
+impl From<&BatchAccum> for InferenceRequest {
+    fn from(batch: &BatchAccum) -> Self {
+        Self {
+            inputs: batch.objects.iter().cloned().map(Into::into).collect(),
+            inference: None,
+            token: None,
+        }
     }
 }
 
@@ -118,215 +131,3 @@ pub fn collect_query_groups_request(request: &QueryGroupsRequestInternal) -> Bat
 
     batch
 }
-
-#[cfg(test)]
-mod tests {
-    use api::rest::schema::{DiscoverQuery, Document, Image, InferenceObject, NearestQuery};
-    use api::rest::QueryBaseGroupRequest;
-    use serde_json::json;
-
-    use super::*;
-
-    fn create_test_document(text: &str) -> Document {
-        Document {
-            text: text.to_string(),
-            model: Some("test-model".to_string()),
-            options: Default::default(),
-        }
-    }
-
-    fn create_test_image(url: &str) -> Image {
-        Image {
-            image: url.to_string(),
-            model: Some("test-model".to_string()),
-            options: Default::default(),
-        }
-    }
-
-    fn create_test_object(data: &str) -> InferenceObject {
-        InferenceObject {
-            object: json!({"data": data}),
-            model: Some("test-model".to_string()),
-            options: Default::default(),
-        }
-    }
-
-    #[test]
-    fn test_batch_accum_basic() {
-        let mut batch = BatchAccum::new();
-        assert!(batch.objects.is_empty());
-
-        let doc = InferenceData::Document(create_test_document("test"));
-        batch.add(doc.clone());
-        assert_eq!(batch.objects.len(), 1);
-
-        batch.add(doc);
-        assert_eq!(batch.objects.len(), 1);
-    }
-
-    #[test]
-    fn test_batch_accum_extend() {
-        let mut batch1 = BatchAccum::new();
-        let mut batch2 = BatchAccum::new();
-
-        let doc1 = InferenceData::Document(create_test_document("test1"));
-        let doc2 = InferenceData::Document(create_test_document("test2"));
-
-        batch1.add(doc1);
-        batch2.add(doc2);
-
-        batch1.extend(batch2);
-        assert_eq!(batch1.objects.len(), 2);
-    }
-
-    #[test]
-    fn test_deduplication() {
-        let mut batch = BatchAccum::new();
-
-        let doc1 = InferenceData::Document(create_test_document("same"));
-        let doc2 = InferenceData::Document(create_test_document("same"));
-
-        batch.add(doc1);
-        batch.add(doc2);
-
-        assert_eq!(batch.objects.len(), 1);
-    }
-
-    #[test]
-    fn test_collect_vector_input() {
-        let mut batch = BatchAccum::new();
-
-        let doc_input = VectorInput::Document(create_test_document("test"));
-        let img_input = VectorInput::Image(create_test_image("test.jpg"));
-        let obj_input = VectorInput::Object(create_test_object("test"));
-
-        collect_vector_input(&doc_input, &mut batch);
-        collect_vector_input(&img_input, &mut batch);
-        collect_vector_input(&obj_input, &mut batch);
-
-        assert_eq!(batch.objects.len(), 3);
-    }
-
-    #[test]
-    fn test_collect_prefetch() {
-        let prefetch = Prefetch {
-            query: Some(QueryInterface::Nearest(VectorInput::Document(
-                create_test_document("test"),
-            ))),
-            prefetch: Some(vec![Prefetch {
-                query: Some(QueryInterface::Nearest(VectorInput::Image(
-                    create_test_image("nested.jpg"),
-                ))),
-                prefetch: None,
-                using: None,
-                filter: None,
-                params: None,
-                score_threshold: None,
-                limit: None,
-                lookup_from: None,
-            }]),
-            using: None,
-            filter: None,
-            params: None,
-            score_threshold: None,
-            limit: None,
-            lookup_from: None,
-        };
-
-        let mut batch = BatchAccum::new();
-        collect_prefetch(&prefetch, &mut batch);
-        assert_eq!(batch.objects.len(), 2);
-    }
-
-    #[test]
-    fn test_collect_query_groups_request() {
-        let request = QueryGroupsRequestInternal {
-            query: Some(QueryInterface::Query(Query::Nearest(NearestQuery {
-                nearest: VectorInput::Document(create_test_document("test")),
-            }))),
-            prefetch: Some(vec![Prefetch {
-                query: Some(QueryInterface::Query(Query::Discover(DiscoverQuery {
-                    discover: DiscoverInput {
-                        target: VectorInput::Image(create_test_image("test.jpg")),
-                        context: Some(vec![ContextPair {
-                            positive: VectorInput::Document(create_test_document("pos")),
-                            negative: VectorInput::Image(create_test_image("neg.jpg")),
-                        }]),
-                    },
-                }))),
-                prefetch: None,
-                using: None,
-                filter: None,
-                params: None,
-                score_threshold: None,
-                limit: None,
-                lookup_from: None,
-            }]),
-            using: None,
-            filter: None,
-            params: None,
-            score_threshold: None,
-            with_vector: None,
-            with_payload: None,
-            lookup_from: None,
-            group_request: QueryBaseGroupRequest {
-                group_by: "test".parse().unwrap(),
-                group_size: None,
-                limit: None,
-                with_lookup: None,
-            },
-        };
-
-        let batch = collect_query_groups_request(&request);
-        assert_eq!(batch.objects.len(), 4);
-    }
-
-    #[test]
-    fn test_different_model_same_content() {
-        let mut batch = BatchAccum::new();
-
-        let mut doc1 = create_test_document("same");
-        let mut doc2 = create_test_document("same");
-        doc1.model = Some("model1".to_string());
-        doc2.model = Some("model2".to_string());
-
-        batch.add(InferenceData::Document(doc1));
-        batch.add(InferenceData::Document(doc2));
-
-        assert_eq!(batch.objects.len(), 2);
-    }
-}
-
-// pub struct BatchAccumInferred {
-//     objects: HashMap<InferenceData, VectorPersisted>,
-// }
-//
-// impl BatchAccumInferred {
-//     pub fn add(&mut self, data: InferenceData, result: VectorPersisted) {
-//         self.objects.insert(data, result);
-//     }
-//
-//     pub fn get(&self, data: &InferenceData) -> Option<&VectorPersisted> {
-//         self.objects.get(data)
-//     }
-// }
-
-// fn collect_collection_prefetch(
-//     prefetch: rest::Prefetch,
-//     batch_accum: &mut BatchAccummulator,
-// ) -> Result<(), StorageError> {
-//     todo!()
-// }
-//
-//
-// fn convert_collection_prefetch(
-//     prefetch: rest::Prefetch,
-//     batch_accum_inferred: &BatchAccumInferred,
-// ) -> Result<CollectionPrefetch, StorageError> {
-//     todo!()
-// }
-
-// How to implement:
-// QueryGroupsRequestInternal -> BatchAccum <- function should be sync (not async), extract vectors to infer
-// BatchAccum -> BatchAccumInferred <- Async, makes actual inference
-// f(QueryGroupsRequestInternal, BatchAccumInferred) -> CollectionQueryGroupsRequest <- should be sync (not async), replace original Docs with inferred vectors

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -34,7 +34,10 @@ fn collect_vector_input(vector: VectorInput, batch: &mut BatchAccum) {
         VectorInput::Image(img) => batch.add(InferenceData::Image(img)),
         VectorInput::Object(obj) => batch.add(InferenceData::Object(obj)),
         // types that are not supported in the Inference Service
-        _ => {}
+        VectorInput::DenseVector(_)  => {}
+        VectorInput::MultiDenseVector(_) => {}
+        VectorInput::Id(_) => {}
+        VectorInput::SparseVector(_) => {}
     }
 }
 

--- a/src/common/inference/infer_processing.rs
+++ b/src/common/inference/infer_processing.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
+use std::ops::Deref;
 
 use collection::operations::point_ops::VectorPersisted;
 use storage::content_manager::errors::StorageError;
 
 use super::batch_processing::BatchAccum;
-use super::service::{InferenceData, InferenceService, InferenceType};
+use super::service::{InferenceData, InferenceInput, InferenceService, InferenceType};
 
 pub struct BatchAccumInferred {
     objects: HashMap<InferenceData, VectorPersisted>,
@@ -17,27 +18,36 @@ impl BatchAccumInferred {
         }
     }
 
-    pub async fn from_batch_accum(batch: &BatchAccum) -> Result<Self, StorageError> {
-        if batch.is_empty() {
+    pub async fn from_batch_accum(
+        batch: BatchAccum,
+        inference_type: InferenceType,
+    ) -> Result<Self, StorageError> {
+        let BatchAccum { objects } = batch;
+
+        if objects.is_empty() {
             return Ok(Self::new());
         }
 
-        let service = {
-            let guard = InferenceService::global();
-            match &*guard {
-                Some(service) => service.clone(),
-                None => {
-                    return Err(StorageError::service_error(
-                        "InferenceService is not initialized. Please check if it was properly configured and initialized during startup."
-                    ));
-                }
-            }
+        let guard = InferenceService::get_global().await;
+
+        let service = match guard.deref() {
+            None => return Err(StorageError::service_error(
+                "InferenceService is not initialized. Please check if it was properly configured and initialized during startup."
+            )),
+            Some(service) => service
         };
 
-        let service = service.validate_and_create()?;
+        service.validate()?;
+
+        let objects_serialized: Vec<_> = objects.into_iter().collect();
+        let inference_inputs: Vec<_> = objects_serialized
+            .iter()
+            .cloned()
+            .map(InferenceInput::from)
+            .collect();
 
         let vectors = service
-            .infer(batch, InferenceType::Search)
+            .infer(inference_inputs, inference_type)
             .await
             .map_err(|e| StorageError::service_error(
                 format!("Inference request failed. Check if inference service is running and properly configured: {e}")
@@ -49,7 +59,7 @@ impl BatchAccumInferred {
             ));
         }
 
-        let objects = batch.objects.iter().cloned().zip(vectors).collect();
+        let objects = objects_serialized.into_iter().zip(vectors).collect();
 
         Ok(Self { objects })
     }
@@ -57,30 +67,4 @@ impl BatchAccumInferred {
     pub fn get_vector(&self, data: &InferenceData) -> Option<&VectorPersisted> {
         self.objects.get(data)
     }
-}
-
-pub fn validate_inference_config() -> Result<(), StorageError> {
-    let service = {
-        let guard = InferenceService::global();
-        let Some(service) = &*guard else {
-            return Err(StorageError::service_error(
-                "InferenceService is not initialized",
-            ));
-        };
-        service.clone()
-    };
-
-    if service.config.address.is_none() {
-        return Err(StorageError::service_error(
-            "InferenceService address is not configured",
-        ));
-    }
-
-    if service.config.token.is_none() {
-        return Err(StorageError::service_error(
-            "InferenceService token is not configured",
-        ));
-    }
-
-    Ok(())
 }

--- a/src/common/inference/infer_processing.rs
+++ b/src/common/inference/infer_processing.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+use collection::operations::point_ops::VectorPersisted;
+use storage::content_manager::errors::StorageError;
+
+use super::batch_processing::BatchAccum;
+use super::service::{InferenceData, InferenceService, InferenceType};
+
+pub struct BatchAccumInferred {
+    objects: HashMap<InferenceData, VectorPersisted>,
+}
+
+impl BatchAccumInferred {
+    pub fn new() -> Self {
+        Self {
+            objects: HashMap::new(),
+        }
+    }
+
+    pub async fn from_batch_accum(batch: &BatchAccum) -> Result<Self, StorageError> {
+        if batch.is_empty() {
+            return Ok(Self::new());
+        }
+
+        let service = {
+            let guard = InferenceService::global();
+            match &*guard {
+                Some(service) => service.clone(),
+                None => {
+                    return Err(StorageError::service_error(
+                        "InferenceService is not initialized. Please check if it was properly configured and initialized during startup."
+                    ));
+                }
+            }
+        };
+
+        let service = service.validate_and_create()?;
+
+        let vectors = service
+            .infer(batch, InferenceType::Search)
+            .await
+            .map_err(|e| StorageError::service_error(
+                format!("Inference request failed. Check if inference service is running and properly configured: {e}")
+            ))?;
+
+        if vectors.is_empty() {
+            return Err(StorageError::service_error(
+                "Inference service returned no vectors. Check if models are properly loaded.",
+            ));
+        }
+
+        let objects = batch.objects.iter().cloned().zip(vectors).collect();
+
+        Ok(Self { objects })
+    }
+
+    pub fn get_vector(&self, data: &InferenceData) -> Option<&VectorPersisted> {
+        self.objects.get(data)
+    }
+}
+
+pub fn validate_inference_config() -> Result<(), StorageError> {
+    let service = {
+        let guard = InferenceService::global();
+        let Some(service) = &*guard else {
+            return Err(StorageError::service_error(
+                "InferenceService is not initialized",
+            ));
+        };
+        service.clone()
+    };
+
+    if service.config.address.is_none() {
+        return Err(StorageError::service_error(
+            "InferenceService address is not configured",
+        ));
+    }
+
+    if service.config.token.is_none() {
+        return Err(StorageError::service_error(
+            "InferenceService token is not configured",
+        ));
+    }
+
+    Ok(())
+}

--- a/src/common/inference/infer_processing.rs
+++ b/src/common/inference/infer_processing.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ops::Deref;
 
 use collection::operations::point_ops::VectorPersisted;
 use storage::content_manager::errors::StorageError;
@@ -28,13 +27,10 @@ impl BatchAccumInferred {
             return Ok(Self::new());
         }
 
-        let guard = InferenceService::get_global().await;
-
-        let service = match guard.deref() {
-            None => return Err(StorageError::service_error(
+        let Some(service) = InferenceService::get_global() else {
+            return Err(StorageError::service_error(
                 "InferenceService is not initialized. Please check if it was properly configured and initialized during startup."
-            )),
-            Some(service) => service
+            ));
         };
 
         service.validate()?;

--- a/src/common/inference/mod.rs
+++ b/src/common/inference/mod.rs
@@ -1,5 +1,6 @@
 mod batch_processing;
 pub(crate) mod config;
+mod infer_processing;
 pub mod query_requests_grpc;
 pub mod query_requests_rest;
 pub mod service;

--- a/src/common/inference/mod.rs
+++ b/src/common/inference/mod.rs
@@ -1,3 +1,4 @@
+mod batch_processing;
 pub(crate) mod config;
 pub mod query_requests_grpc;
 pub mod query_requests_rest;

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -6,7 +6,7 @@ use collection::operations::universal_query::collection_query::{
 };
 use collection::operations::universal_query::shard_query::{FusionInternal, SampleInternal};
 use segment::data_types::order_by::OrderBy;
-use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, MultiDenseVectorInternal, VectorInternal};
+use segment::data_types::vectors::{MultiDenseVectorInternal, VectorInternal, DEFAULT_VECTOR_NAME};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use storage::content_manager::errors::StorageError;
 

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -5,18 +5,20 @@ use collection::operations::universal_query::collection_query::{
     VectorInputInternal, VectorQuery,
 };
 use collection::operations::universal_query::shard_query::{FusionInternal, SampleInternal};
-use futures_util::future::try_join_all;
-use log::{debug, error, warn};
+use log::{debug, warn};
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{MultiDenseVectorInternal, VectorInternal, DEFAULT_VECTOR_NAME};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use storage::content_manager::errors::StorageError;
 
-use crate::common::inference::service::{InferenceData, InferenceService, InferenceType};
+use crate::common::inference::batch_processing::{collect_query_groups_request, BatchAccum};
+use crate::common::inference::infer_processing::BatchAccumInferred;
+use crate::common::inference::service::InferenceData;
 
 pub async fn convert_query_groups_request_from_rest(
     request: rest::QueryGroupsRequestInternal,
 ) -> Result<CollectionQueryGroupsRequest, StorageError> {
+    let batch = collect_query_groups_request(&request);
     let rest::QueryGroupsRequestInternal {
         prefetch,
         query,
@@ -30,17 +32,20 @@ pub async fn convert_query_groups_request_from_rest(
         group_request,
     } = request;
 
-    let query = if let Some(q) = query {
-        Some(convert_query(q).await?)
-    } else {
-        None
-    };
+    let inferred = BatchAccumInferred::from_batch_accum(&batch).await?;
+    let query = query
+        .map(|q| convert_query_with_inferred(q, &inferred))
+        .transpose()?;
 
-    let prefetch = if let Some(prefetches) = prefetch {
-        try_join_all(prefetches.into_iter().map(convert_collection_prefetch)).await?
-    } else {
-        Vec::new()
-    };
+    let prefetch = prefetch
+        .map(|prefetches| {
+            prefetches
+                .into_iter()
+                .map(|p| convert_prefetch_with_inferred(p, &inferred))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
 
     Ok(CollectionQueryGroupsRequest {
         prefetch,
@@ -80,17 +85,17 @@ pub async fn convert_query_request_from_rest(
         lookup_from,
     } = request;
 
-    let prefetch = if let Some(prefetches) = prefetch {
-        try_join_all(prefetches.into_iter().map(convert_collection_prefetch)).await?
-    } else {
-        Vec::new()
-    };
+    let prefetch = prefetch
+        .map(|prefetches| {
+            prefetches
+                .into_iter()
+                .map(convert_collection_prefetch)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
 
-    let query = if let Some(q) = query {
-        Some(convert_query(q).await?)
-    } else {
-        None
-    };
+    let query = query.map(convert_query).transpose()?;
 
     Ok(CollectionQueryRequest {
         prefetch,
@@ -107,7 +112,7 @@ pub async fn convert_query_request_from_rest(
     })
 }
 
-async fn convert_collection_prefetch(
+fn convert_collection_prefetch(
     prefetch: rest::Prefetch,
 ) -> Result<CollectionPrefetch, StorageError> {
     let rest::Prefetch {
@@ -121,18 +126,17 @@ async fn convert_collection_prefetch(
         lookup_from,
     } = prefetch;
 
-    let query = match query {
-        Some(q) => Some(convert_query(q).await?),
-        None => None,
-    };
+    let query = query.map(convert_query).transpose()?;
 
-    let prefetch = try_join_all(
-        prefetch
-            .into_iter()
-            .flatten()
-            .map(convert_collection_prefetch),
-    )
-    .await?;
+    let prefetch = prefetch
+        .map(|prefetches| {
+            prefetches
+                .into_iter()
+                .map(convert_collection_prefetch)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
 
     Ok(CollectionPrefetch {
         prefetch,
@@ -146,29 +150,27 @@ async fn convert_collection_prefetch(
     })
 }
 
-async fn convert_query(query: rest::QueryInterface) -> Result<Query, StorageError> {
+fn convert_query(query: rest::QueryInterface) -> Result<Query, StorageError> {
     let query = rest::Query::from(query);
 
     match query {
         rest::Query::Nearest(nearest) => Ok(Query::Vector(VectorQuery::Nearest(
-            convert_vector_input(nearest.nearest).await?,
+            convert_vector_input(nearest.nearest)?,
         ))),
-        rest::Query::Recommend(recommend) => Ok(Query::Vector(
-            convert_recommend_input(recommend.recommend).await?,
-        )),
-        rest::Query::Discover(discover) => Ok(Query::Vector(
-            convert_discover_input(discover.discover).await?,
-        )),
-        rest::Query::Context(context) => {
-            Ok(Query::Vector(convert_context_input(context.context).await?))
+        rest::Query::Recommend(recommend) => {
+            Ok(Query::Vector(convert_recommend_input(recommend.recommend)?))
         }
+        rest::Query::Discover(discover) => {
+            Ok(Query::Vector(convert_discover_input(discover.discover)?))
+        }
+        rest::Query::Context(context) => Ok(Query::Vector(convert_context_input(context.context)?)),
         rest::Query::OrderBy(order_by) => Ok(Query::OrderBy(OrderBy::from(order_by.order_by))),
         rest::Query::Fusion(fusion) => Ok(Query::Fusion(FusionInternal::from(fusion.fusion))),
         rest::Query::Sample(sample) => Ok(Query::Sample(SampleInternal::from(sample.sample))),
     }
 }
 
-async fn convert_recommend_input(
+fn convert_recommend_input(
     recommend: rest::RecommendInput,
 ) -> Result<VectorQuery<VectorInputInternal>, StorageError> {
     let rest::RecommendInput {
@@ -177,8 +179,15 @@ async fn convert_recommend_input(
         strategy,
     } = recommend;
 
-    let positives = try_join_all(positive.into_iter().flatten().map(convert_vector_input)).await?;
-    let negatives = try_join_all(negative.into_iter().flatten().map(convert_vector_input)).await?;
+    let positives = positive
+        .map(|pos| pos.into_iter().map(convert_vector_input).collect())
+        .transpose()?
+        .unwrap_or_default();
+
+    let negatives = negative
+        .map(|neg| neg.into_iter().map(convert_vector_input).collect())
+        .transpose()?
+        .unwrap_or_default();
 
     let reco_query = RecoQuery::new(positives, negatives);
 
@@ -190,34 +199,102 @@ async fn convert_recommend_input(
     }
 }
 
-async fn convert_discover_input(
+fn convert_discover_input(
     discover: rest::DiscoverInput,
 ) -> Result<VectorQuery<VectorInputInternal>, StorageError> {
     let rest::DiscoverInput { target, context } = discover;
 
-    let target = convert_vector_input(target).await?;
-    let context = try_join_all(
-        context
-            .into_iter()
-            .flatten()
-            .map(context_pair_from_rest)
-            .collect::<Vec<_>>(),
-    )
-    .await?;
+    let target = convert_vector_input(target)?;
+    let context = context
+        .map(|pairs| {
+            pairs
+                .into_iter()
+                .map(context_pair_from_rest)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
     Ok(VectorQuery::Discover(DiscoveryQuery::new(target, context)))
 }
 
-async fn convert_context_input(
+fn convert_context_input(
     context: rest::ContextInput,
 ) -> Result<VectorQuery<VectorInputInternal>, StorageError> {
     let rest::ContextInput(context) = context;
 
-    let context = try_join_all(context.into_iter().flatten().map(context_pair_from_rest)).await?;
+    let context = context
+        .map(|pairs| {
+            pairs
+                .into_iter()
+                .map(context_pair_from_rest)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
     Ok(VectorQuery::Context(ContextQuery::new(context)))
 }
 
-async fn convert_vector_input(
+fn convert_vector_input(vector: rest::VectorInput) -> Result<VectorInputInternal, StorageError> {
+    match vector {
+        rest::VectorInput::Id(id) => Ok(VectorInputInternal::Id(id)),
+        rest::VectorInput::DenseVector(dense) => {
+            Ok(VectorInputInternal::Vector(VectorInternal::Dense(dense)))
+        }
+        rest::VectorInput::SparseVector(sparse) => {
+            Ok(VectorInputInternal::Vector(VectorInternal::Sparse(sparse)))
+        }
+        rest::VectorInput::MultiDenseVector(multi_dense) => Ok(VectorInputInternal::Vector(
+            VectorInternal::MultiDense(MultiDenseVectorInternal::new_unchecked(multi_dense)),
+        )),
+        rest::VectorInput::Document(_)
+        | rest::VectorInput::Image(_)
+        | rest::VectorInput::Object(_) => Err(StorageError::inference_error(
+            "Inference is not supported in sync context",
+        )),
+    }
+}
+
+async fn convert_inference_data(data: InferenceData) -> Result<VectorInputInternal, StorageError> {
+    let input_type = data.type_name();
+    let mut batch = BatchAccum::new();
+    batch.add(data.clone());
+
+    debug!("Starting inference processing for {input_type}");
+
+    let inferred = BatchAccumInferred::from_batch_accum(&batch).await?;
+
+    let vector = inferred.get_vector(&data)
+        .ok_or_else(|| {
+            warn!("Empty vector array for {input_type}. Content: {data:?}");
+            StorageError::inference_error(format!(
+                "Inference service returned empty result for {input_type}. This might indicate an issue with the input format or the inference service configuration."
+            ))
+        })?;
+
+    debug!("Successfully processed {input_type} inference");
+
+    Ok(VectorInputInternal::Vector(VectorInternal::from(
+        vector.clone(),
+    )))
+}
+
+/// Circular dependencies prevents us from implementing `From` directly
+fn context_pair_from_rest(
+    value: rest::ContextPair,
+) -> Result<ContextPair<VectorInputInternal>, StorageError> {
+    let rest::ContextPair { positive, negative } = value;
+
+    Ok(ContextPair {
+        positive: convert_vector_input(positive)?,
+        negative: convert_vector_input(negative)?,
+    })
+}
+
+fn convert_vector_input_with_inferred(
     vector: rest::VectorInput,
+    inferred: &BatchAccumInferred,
 ) -> Result<VectorInputInternal, StorageError> {
     match vector {
         rest::VectorInput::Id(id) => Ok(VectorInputInternal::Id(id)),
@@ -228,87 +305,152 @@ async fn convert_vector_input(
             Ok(VectorInputInternal::Vector(VectorInternal::Sparse(sparse)))
         }
         rest::VectorInput::MultiDenseVector(multi_dense) => Ok(VectorInputInternal::Vector(
-            // TODO(universal-query): Validate at API level
             VectorInternal::MultiDense(MultiDenseVectorInternal::new_unchecked(multi_dense)),
         )),
         rest::VectorInput::Document(doc) => {
-            process_inference_input(InferenceData::Document(doc.clone()), "document", Some(doc))
-                .await
+            let data = InferenceData::Document(doc);
+            let vector = inferred.get_vector(&data).ok_or_else(|| {
+                StorageError::inference_error("Missing inferred vector for document")
+            })?;
+            Ok(VectorInputInternal::Vector(VectorInternal::from(
+                vector.clone(),
+            )))
         }
         rest::VectorInput::Image(img) => {
-            process_inference_input(InferenceData::Image(img.clone()), "image", Some(img)).await
+            let data = InferenceData::Image(img);
+            let vector = inferred.get_vector(&data).ok_or_else(|| {
+                StorageError::inference_error("Missing inferred vector for image")
+            })?;
+            Ok(VectorInputInternal::Vector(VectorInternal::from(
+                vector.clone(),
+            )))
         }
         rest::VectorInput::Object(obj) => {
-            process_inference_input(InferenceData::Object(obj.clone()), "object", Some(obj)).await
+            let data = InferenceData::Object(obj);
+            let vector = inferred.get_vector(&data).ok_or_else(|| {
+                StorageError::inference_error("Missing inferred vector for object")
+            })?;
+            Ok(VectorInputInternal::Vector(VectorInternal::from(
+                vector.clone(),
+            )))
         }
     }
 }
 
-/// Circular dependencies prevents us from implementing `From` directly
-async fn context_pair_from_rest(
-    value: rest::ContextPair,
-) -> Result<ContextPair<VectorInputInternal>, StorageError> {
-    let rest::ContextPair { positive, negative } = value;
+fn convert_query_with_inferred(
+    query: rest::QueryInterface,
+    inferred: &BatchAccumInferred,
+) -> Result<Query, StorageError> {
+    let query = rest::Query::from(query);
+    match query {
+        rest::Query::Nearest(nearest) => {
+            let vector = convert_vector_input_with_inferred(nearest.nearest, inferred)?;
+            Ok(Query::Vector(VectorQuery::Nearest(vector)))
+        }
+        rest::Query::Recommend(recommend) => {
+            let rest::RecommendInput {
+                positive,
+                negative,
+                strategy,
+            } = recommend.recommend;
+            let positives = positive
+                .into_iter()
+                .flatten()
+                .map(|v| convert_vector_input_with_inferred(v, inferred))
+                .collect::<Result<Vec<_>, _>>()?;
+            let negatives = negative
+                .into_iter()
+                .flatten()
+                .map(|v| convert_vector_input_with_inferred(v, inferred))
+                .collect::<Result<Vec<_>, _>>()?;
+            let reco_query = RecoQuery::new(positives, negatives);
+            match strategy.unwrap_or_default() {
+                rest::RecommendStrategy::AverageVector => Ok(Query::Vector(
+                    VectorQuery::RecommendAverageVector(reco_query),
+                )),
+                rest::RecommendStrategy::BestScore => {
+                    Ok(Query::Vector(VectorQuery::RecommendBestScore(reco_query)))
+                }
+            }
+        }
+        rest::Query::Discover(discover) => {
+            let rest::DiscoverInput { target, context } = discover.discover;
+            let target = convert_vector_input_with_inferred(target, inferred)?;
+            let context = context
+                .into_iter()
+                .flatten()
+                .map(|pair| context_pair_from_rest_with_inferred(pair, inferred))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Query::Vector(VectorQuery::Discover(DiscoveryQuery::new(
+                target, context,
+            ))))
+        }
+        rest::Query::Context(context) => {
+            let rest::ContextInput(context) = context.context;
+            let context = context
+                .into_iter()
+                .flatten()
+                .map(|pair| context_pair_from_rest_with_inferred(pair, inferred))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Query::Vector(VectorQuery::Context(ContextQuery::new(
+                context,
+            ))))
+        }
+        rest::Query::OrderBy(order_by) => Ok(Query::OrderBy(OrderBy::from(order_by.order_by))),
+        rest::Query::Fusion(fusion) => Ok(Query::Fusion(FusionInternal::from(fusion.fusion))),
+        rest::Query::Sample(sample) => Ok(Query::Sample(SampleInternal::from(sample.sample))),
+    }
+}
 
-    Ok(ContextPair {
-        positive: convert_vector_input(positive).await?,
-        negative: convert_vector_input(negative).await?,
+fn convert_prefetch_with_inferred(
+    prefetch: rest::Prefetch,
+    inferred: &BatchAccumInferred,
+) -> Result<CollectionPrefetch, StorageError> {
+    let rest::Prefetch {
+        prefetch,
+        query,
+        using,
+        filter,
+        score_threshold,
+        params,
+        limit,
+        lookup_from,
+    } = prefetch;
+
+    let query = query
+        .map(|q| convert_query_with_inferred(q, inferred))
+        .transpose()?;
+    let nested_prefetches = prefetch
+        .map(|prefetches| {
+            prefetches
+                .into_iter()
+                .map(|p| convert_prefetch_with_inferred(p, inferred))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(CollectionPrefetch {
+        prefetch: nested_prefetches,
+        query,
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        filter,
+        score_threshold,
+        limit: limit.unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
+        params,
+        lookup_from,
     })
 }
 
-async fn process_inference_input<T: std::fmt::Debug>(
-    data: InferenceData,
-    input_type: &str,
-    debug_content: Option<T>,
-) -> Result<VectorInputInternal, StorageError> {
-    let service = InferenceService::global().clone().ok_or_else(|| {
-        error!("InferenceService not initialized for {input_type}");
-        StorageError::inference_error(format!(
-            "InferenceService not initialized for {input_type} processing"
-        ))
-    })?;
-
-    debug!("Starting inference processing for {input_type}");
-
-    let vectors = service
-        .infer(data, InferenceType::Search)
-        .await
-        .map_err(|e| {
-            error!(
-                "Failed to process {input_type}: {error}",
-                error = e.to_string()
-            );
-            StorageError::inference_error(format!("Failed to process {input_type}: {e}"))
-        })?;
-
-    if vectors.is_empty() {
-        // log the content too in case of empty vector
-        if let Some(content) = debug_content {
-            warn!("Empty vector array for {input_type}. Content: {content:?}");
-        } else {
-            warn!("Empty vector array for {input_type}");
-        }
-
-        return Err(StorageError::inference_error(format!(
-            "Inference service returned empty result for {input_type}. This might indicate an issue with the input format or the inference service configuration."
-        )));
-    }
-
-    if vectors.len() > 1 {
-        warn!(
-            "Multiple vectors returned for {input_type}. Count: {count}. Using only the first one",
-            count = vectors.len()
-        );
-    }
-
-    debug!(
-        "Successfully processed {input_type} inference. Vector count: {count}",
-        count = vectors.len()
-    );
-
-    Ok(VectorInputInternal::Vector(VectorInternal::from(
-        vectors.into_iter().next().unwrap(),
-    )))
+fn context_pair_from_rest_with_inferred(
+    value: rest::ContextPair,
+    inferred: &BatchAccumInferred,
+) -> Result<ContextPair<VectorInputInternal>, StorageError> {
+    let rest::ContextPair { positive, negative } = value;
+    Ok(ContextPair {
+        positive: convert_vector_input_with_inferred(positive, inferred)?,
+        negative: convert_vector_input_with_inferred(negative, inferred)?,
+    })
 }
 
 #[cfg(test)]

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -467,7 +467,7 @@ mod tests {
             negative: rest::VectorInput::DenseVector(vec![4.0, 5.0, 6.0]),
         };
 
-        let result = context_pair_from_rest(input).await.unwrap();
+        let result = context_pair_from_rest(input).unwrap();
 
         match (result.positive, result.negative) {
             (
@@ -484,7 +484,7 @@ mod tests {
     #[tokio::test]
     async fn test_convert_vector_input_dense() {
         let input = rest::VectorInput::DenseVector(vec![1.0, 2.0, 3.0]);
-        match convert_vector_input(input).await.unwrap() {
+        match convert_vector_input(input).unwrap() {
             VectorInputInternal::Vector(VectorInternal::Dense(vec)) => {
                 assert_eq!(vec, vec![1.0, 2.0, 3.0]);
             }

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::sync::{RwLock, RwLockReadGuard};
 use std::time::Duration;
 
@@ -53,30 +53,11 @@ pub(crate) struct InferenceResponse {
     pub(crate) embeddings: Vec<VectorPersisted>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub enum InferenceData {
     Document(Document),
     Image(Image),
     Object(InferenceObject),
-}
-
-impl Hash for InferenceData {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            InferenceData::Document(doc) => {
-                doc.text.hash(state);
-                doc.model.as_deref().unwrap_or("");
-            }
-            InferenceData::Image(img) => {
-                img.image.hash(state);
-                img.model.as_deref().unwrap_or("");
-            }
-            InferenceData::Object(obj) => {
-                obj.object.hash(state);
-                obj.model.as_deref().unwrap_or("");
-            }
-        }
-    }
 }
 
 impl From<InferenceData> for InferenceInput {
@@ -92,7 +73,7 @@ impl From<InferenceData> for InferenceInput {
                     data: Value::String(text),
                     data_type: DOCUMENT_DATA_TYPE.to_string(),
                     model: model.unwrap_or_default(),
-                    options,
+                    options: options.options,
                 }
             }
             InferenceData::Image(img) => {
@@ -106,7 +87,7 @@ impl From<InferenceData> for InferenceInput {
                     data: Value::String(image),
                     data_type: IMAGE_DATA_TYPE.to_string(),
                     model: model.unwrap_or_default(),
-                    options,
+                    options: options.options,
                 }
             }
             InferenceData::Object(obj) => {
@@ -120,7 +101,7 @@ impl From<InferenceData> for InferenceInput {
                     data: Value::String(object.to_string()),
                     data_type: DOCUMENT_DATA_TYPE.to_string(),
                     model: model.unwrap_or_default(),
-                    options,
+                    options: options.options,
                 }
             }
         }

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -4,13 +4,12 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Duration;
 
+use api::rest::{Document, Image, InferenceObject};
+use collection::operations::point_ops::VectorPersisted;
 use parking_lot::RwLock;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-
-use api::rest::{Document, Image, InferenceObject};
-use collection::operations::point_ops::VectorPersisted;
 use storage::content_manager::errors::StorageError;
 
 use crate::common::inference::config::InferenceConfig;

--- a/src/common/inference/update_requests.rs
+++ b/src/common/inference/update_requests.rs
@@ -6,7 +6,6 @@ use collection::operations::point_ops::{
     VectorStructPersisted,
 };
 use collection::operations::vector_ops::PointVectorsPersisted;
-use log::{debug, warn};
 use storage::content_manager::errors::StorageError;
 
 use crate::common::inference::batch_processing::BatchAccum;

--- a/src/common/inference/update_requests.rs
+++ b/src/common/inference/update_requests.rs
@@ -6,23 +6,45 @@ use collection::operations::point_ops::{
     VectorStructPersisted,
 };
 use collection::operations::vector_ops::PointVectorsPersisted;
-use futures::stream::{self, StreamExt};
+use log::{debug, warn};
 use storage::content_manager::errors::StorageError;
 
-use crate::common::inference::service::{InferenceData, InferenceService, InferenceType};
-
-pub async fn convert_vectors(vectors: Vec<Vector>) -> Result<Vec<VectorPersisted>, StorageError> {
-    let results: Vec<Result<VectorPersisted, StorageError>> = stream::iter(vectors)
-        .then(convert_single_vector)
-        .collect()
-        .await;
-
-    results.into_iter().collect()
-}
+use crate::common::inference::batch_processing::BatchAccum;
+use crate::common::inference::infer_processing::BatchAccumInferred;
+use crate::common::inference::service::{InferenceData, InferenceType};
 
 pub async fn convert_point_struct(
     point_structs: Vec<PointStruct>,
 ) -> Result<Vec<PointStructPersisted>, StorageError> {
+    let mut batch_accum = BatchAccum::new();
+
+    for point_struct in &point_structs {
+        match &point_struct.vector {
+            VectorStruct::Named(named) => {
+                for vector in named.values() {
+                    match vector {
+                        Vector::Document(doc) => {
+                            batch_accum.add(InferenceData::Document(doc.clone()))
+                        }
+                        Vector::Image(img) => batch_accum.add(InferenceData::Image(img.clone())),
+                        Vector::Object(obj) => batch_accum.add(InferenceData::Object(obj.clone())),
+                        Vector::Dense(_) | Vector::Sparse(_) | Vector::MultiDense(_) => {}
+                    }
+                }
+            }
+            VectorStruct::Document(doc) => batch_accum.add(InferenceData::Document(doc.clone())),
+            VectorStruct::Image(img) => batch_accum.add(InferenceData::Image(img.clone())),
+            VectorStruct::Object(obj) => batch_accum.add(InferenceData::Object(obj.clone())),
+            VectorStruct::MultiDense(_) | VectorStruct::Single(_) => {}
+        }
+    }
+
+    let inferred = if !batch_accum.objects.is_empty() {
+        Some(BatchAccumInferred::from_batch_accum(&batch_accum).await?)
+    } else {
+        None
+    };
+
     let mut converted_points: Vec<PointStructPersisted> = Vec::new();
     for point_struct in point_structs {
         let PointStruct {
@@ -37,13 +59,34 @@ pub async fn convert_point_struct(
             VectorStruct::Named(named) => {
                 let mut named_vectors = HashMap::new();
                 for (name, vector) in named {
-                    let converted_vector = convert_single_vector(vector).await?;
+                    let converted_vector = match &inferred {
+                        Some(inferred) => convert_vector_with_inferred(vector, inferred)?,
+                        None => match vector {
+                            Vector::Dense(dense) => VectorPersisted::Dense(dense),
+                            Vector::Sparse(sparse) => VectorPersisted::Sparse(sparse),
+                            Vector::MultiDense(multi) => VectorPersisted::MultiDense(multi),
+                            Vector::Document(_) | Vector::Image(_) | Vector::Object(_) => {
+                                return Err(StorageError::inference_error(
+                                    "Inference required but service returned no results",
+                                ))
+                            }
+                        },
+                    };
                     named_vectors.insert(name, converted_vector);
                 }
                 VectorStructPersisted::Named(named_vectors)
             }
             VectorStruct::Document(doc) => {
-                let vector = convert_single_vector(Vector::Document(doc)).await?;
+                let vector = match &inferred {
+                    Some(inferred) => {
+                        convert_vector_with_inferred(Vector::Document(doc), inferred)?
+                    }
+                    None => {
+                        return Err(StorageError::inference_error(
+                            "Inference required but service returned no results",
+                        ))
+                    }
+                };
                 match vector {
                     VectorPersisted::Dense(dense) => VectorStructPersisted::Single(dense),
                     VectorPersisted::Sparse(_) => {
@@ -53,7 +96,14 @@ pub async fn convert_point_struct(
                 }
             }
             VectorStruct::Image(img) => {
-                let vector = convert_single_vector(Vector::Image(img)).await?;
+                let vector = match &inferred {
+                    Some(inferred) => convert_vector_with_inferred(Vector::Image(img), inferred)?,
+                    None => {
+                        return Err(StorageError::inference_error(
+                            "Inference required but service returned no results",
+                        ))
+                    }
+                };
                 match vector {
                     VectorPersisted::Dense(dense) => VectorStructPersisted::Single(dense),
                     VectorPersisted::Sparse(_) => {
@@ -63,7 +113,14 @@ pub async fn convert_point_struct(
                 }
             }
             VectorStruct::Object(obj) => {
-                let vector = convert_single_vector(Vector::Object(obj)).await?;
+                let vector = match &inferred {
+                    Some(inferred) => convert_vector_with_inferred(Vector::Object(obj), inferred)?,
+                    None => {
+                        return Err(StorageError::inference_error(
+                            "Inference required but service returned no results",
+                        ))
+                    }
+                };
                 match vector {
                     VectorPersisted::Dense(dense) => VectorStructPersisted::Single(dense),
                     VectorPersisted::Sparse(_) => {
@@ -73,6 +130,7 @@ pub async fn convert_point_struct(
                 }
             }
         };
+
         let converted = PointStructPersisted {
             id,
             vector: converted_vector_struct,
@@ -133,6 +191,26 @@ pub async fn convert_point_vectors(
     point_vectors_list: Vec<PointVectors>,
 ) -> Result<Vec<PointVectorsPersisted>, StorageError> {
     let mut converted_point_vectors = Vec::new();
+    let mut batch_accum = BatchAccum::new();
+
+    for point_vectors in &point_vectors_list {
+        if let VectorStruct::Named(named) = &point_vectors.vector {
+            for vector in named.values() {
+                match vector {
+                    Vector::Document(doc) => batch_accum.add(InferenceData::Document(doc.clone())),
+                    Vector::Image(img) => batch_accum.add(InferenceData::Image(img.clone())),
+                    Vector::Object(obj) => batch_accum.add(InferenceData::Object(obj.clone())),
+                    Vector::Dense(_) | Vector::Sparse(_) | Vector::MultiDense(_) => {}
+                }
+            }
+        }
+    }
+
+    let inferred = if !batch_accum.objects.is_empty() {
+        Some(BatchAccumInferred::from_batch_accum(&batch_accum).await?)
+    } else {
+        None
+    };
 
     for point_vectors in point_vectors_list {
         let PointVectors { id, vector } = point_vectors;
@@ -144,7 +222,19 @@ pub async fn convert_point_vectors(
                 let mut converted = HashMap::new();
 
                 for (name, vec) in named {
-                    let converted_vec = convert_single_vector(vec).await?;
+                    let converted_vec = match &inferred {
+                        Some(inferred) => convert_vector_with_inferred(vec, inferred)?,
+                        None => match vec {
+                            Vector::Dense(dense) => VectorPersisted::Dense(dense),
+                            Vector::Sparse(sparse) => VectorPersisted::Sparse(sparse),
+                            Vector::MultiDense(multi) => VectorPersisted::MultiDense(multi),
+                            Vector::Document(_) | Vector::Image(_) | Vector::Object(_) => {
+                                return Err(StorageError::inference_error(
+                                    "Inference required but service returned no results",
+                                ))
+                            }
+                        },
+                    };
                     converted.insert(name, converted_vec);
                 }
 
@@ -178,59 +268,158 @@ pub async fn convert_point_vectors(
     Ok(converted_point_vectors)
 }
 
-async fn convert_single_vector(vector: Vector) -> Result<VectorPersisted, StorageError> {
-    let inference_service = InferenceService::global().clone();
+async fn convert_inference_data(
+    data: InferenceData,
+    _inference_type: InferenceType,
+) -> Result<VectorPersisted, StorageError> {
+    let input_type = data.type_name();
+    let mut batch = BatchAccum::new();
+    batch.add(data.clone());
+    debug!("Starting inference processing for {input_type}");
+    let inferred = BatchAccumInferred::from_batch_accum(&batch).await?;
+    let vector = inferred.get_vector(&data)
+        .ok_or_else(|| {
+            warn!("Empty vector array for {input_type}. Content: {data:?}");
+            StorageError::inference_error(format!(
+                "Inference service returned empty result for {input_type}. This might indicate an issue with the input format or the inference service configuration."
+            ))
+        })?.clone();
+    debug!("Successfully processed {input_type} inference");
+    Ok(vector)
+}
+
+fn convert_point_struct_with_inferred(
+    point_structs: Vec<PointStruct>,
+    inferred: &BatchAccumInferred,
+) -> Result<Vec<PointStructPersisted>, StorageError> {
+    point_structs
+        .into_iter()
+        .map(|point_struct| {
+            let PointStruct {
+                id,
+                vector,
+                payload,
+            } = point_struct;
+            let converted_vector_struct = match vector {
+                VectorStruct::Single(single) => VectorStructPersisted::Single(single),
+                VectorStruct::MultiDense(multi) => VectorStructPersisted::MultiDense(multi),
+                VectorStruct::Named(named) => {
+                    let mut named_vectors = HashMap::new();
+                    for (name, vector) in named {
+                        let converted_vector = convert_vector_with_inferred(vector, inferred)?;
+                        named_vectors.insert(name, converted_vector);
+                    }
+                    VectorStructPersisted::Named(named_vectors)
+                }
+                VectorStruct::Document(doc) => {
+                    let vector = convert_vector_with_inferred(Vector::Document(doc), inferred)?;
+                    match vector {
+                        VectorPersisted::Dense(dense) => VectorStructPersisted::Single(dense),
+                        VectorPersisted::Sparse(_) => {
+                            return Err(StorageError::bad_request("Sparse vector should be named"))
+                        }
+                        VectorPersisted::MultiDense(multi) => {
+                            VectorStructPersisted::MultiDense(multi)
+                        }
+                    }
+                }
+                VectorStruct::Image(img) => {
+                    let vector = convert_vector_with_inferred(Vector::Image(img), inferred)?;
+                    match vector {
+                        VectorPersisted::Dense(dense) => VectorStructPersisted::Single(dense),
+                        VectorPersisted::Sparse(_) => {
+                            return Err(StorageError::bad_request("Sparse vector should be named"))
+                        }
+                        VectorPersisted::MultiDense(multi) => {
+                            VectorStructPersisted::MultiDense(multi)
+                        }
+                    }
+                }
+                VectorStruct::Object(obj) => {
+                    let vector = convert_vector_with_inferred(Vector::Object(obj), inferred)?;
+                    match vector {
+                        VectorPersisted::Dense(dense) => VectorStructPersisted::Single(dense),
+                        VectorPersisted::Sparse(_) => {
+                            return Err(StorageError::bad_request("Sparse vector should be named"))
+                        }
+                        VectorPersisted::MultiDense(multi) => {
+                            VectorStructPersisted::MultiDense(multi)
+                        }
+                    }
+                }
+            };
+
+            Ok(PointStructPersisted {
+                id,
+                vector: converted_vector_struct,
+                payload,
+            })
+        })
+        .collect()
+}
+
+pub async fn convert_vectors(vectors: Vec<Vector>) -> Result<Vec<VectorPersisted>, StorageError> {
+    let mut batch_accum = BatchAccum::new();
+    for vector in &vectors {
+        match vector {
+            Vector::Document(doc) => batch_accum.add(InferenceData::Document(doc.clone())),
+            Vector::Image(img) => batch_accum.add(InferenceData::Image(img.clone())),
+            Vector::Object(obj) => batch_accum.add(InferenceData::Object(obj.clone())),
+            Vector::Dense(_) | Vector::Sparse(_) | Vector::MultiDense(_) => {}
+        }
+    }
+
+    let inferred = if !batch_accum.objects.is_empty() {
+        Some(BatchAccumInferred::from_batch_accum(&batch_accum).await?)
+    } else {
+        None
+    };
+
+    vectors
+        .into_iter()
+        .map(|vector| match &inferred {
+            Some(inferred) => convert_vector_with_inferred(vector, inferred),
+            None => match vector {
+                Vector::Dense(dense) => Ok(VectorPersisted::Dense(dense)),
+                Vector::Sparse(sparse) => Ok(VectorPersisted::Sparse(sparse)),
+                Vector::MultiDense(multi) => Ok(VectorPersisted::MultiDense(multi)),
+                Vector::Document(_) | Vector::Image(_) | Vector::Object(_) => {
+                    Err(StorageError::inference_error(
+                        "Inference required but service returned no results",
+                    ))
+                }
+            },
+        })
+        .collect()
+}
+
+fn convert_vector_with_inferred(
+    vector: Vector,
+    inferred: &BatchAccumInferred,
+) -> Result<VectorPersisted, StorageError> {
     match vector {
         Vector::Dense(dense) => Ok(VectorPersisted::Dense(dense)),
         Vector::Sparse(sparse) => Ok(VectorPersisted::Sparse(sparse)),
         Vector::MultiDense(multi) => Ok(VectorPersisted::MultiDense(multi)),
-        Vector::Document(doc) => match inference_service {
-            Some(service) => {
-                let vector = service
-                    .infer(InferenceData::Document(doc), InferenceType::Update)
-                    .await
-                    .map_err(|e| StorageError::inference_error(e.to_string()))?;
-                vector.into_iter().next().ok_or_else(|| {
-                    StorageError::inference_error(
-                        "Inference service returned empty vector for document",
-                    )
-                })
-            }
-            None => Err(StorageError::inference_error(
-                "InferenceService not initialized for document processing",
-            )),
-        },
-        Vector::Image(img) => match inference_service {
-            Some(service) => {
-                let vector = service
-                    .infer(InferenceData::Image(img), InferenceType::Update)
-                    .await
-                    .map_err(|e| StorageError::inference_error(e.to_string()))?;
-                vector.into_iter().next().ok_or_else(|| {
-                    StorageError::inference_error(
-                        "Inference service returned empty vector for image",
-                    )
-                })
-            }
-            None => Err(StorageError::inference_error(
-                "InferenceService not initialized for image processing",
-            )),
-        },
-        Vector::Object(obj) => match inference_service {
-            Some(service) => {
-                let vector = service
-                    .infer(InferenceData::Object(obj), InferenceType::Update)
-                    .await
-                    .map_err(|e| StorageError::inference_error(e.to_string()))?;
-                vector.into_iter().next().ok_or_else(|| {
-                    StorageError::inference_error(
-                        "Inference service returned empty vector for object",
-                    )
-                })
-            }
-            None => Err(StorageError::inference_error(
-                "InferenceService not initialized for object processing",
-            )),
-        },
+        Vector::Document(doc) => {
+            let data = InferenceData::Document(doc);
+            inferred.get_vector(&data).cloned().ok_or_else(|| {
+                StorageError::inference_error("Missing inferred vector for document")
+            })
+        }
+        Vector::Image(img) => {
+            let data = InferenceData::Image(img);
+            inferred
+                .get_vector(&data)
+                .cloned()
+                .ok_or_else(|| StorageError::inference_error("Missing inferred vector for image"))
+        }
+        Vector::Object(obj) => {
+            let data = InferenceData::Object(obj);
+            inferred
+                .get_vector(&data)
+                .cloned()
+                .ok_or_else(|| StorageError::inference_error("Missing inferred vector for object"))
+        }
     }
 }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -48,6 +48,7 @@ use storage::dispatcher::Dispatcher;
 use storage::rbac::Access;
 use validator::Validate;
 
+use crate::common::inference::service::InferenceType;
 use crate::common::inference::update_requests::{
     convert_batch, convert_point_struct, convert_point_vectors,
 };
@@ -240,7 +241,9 @@ pub async fn do_upsert_points(
         ),
         PointInsertOperations::PointsList(PointsList { points, shard_key }) => (
             shard_key,
-            PointInsertOperationsInternal::PointsList(convert_point_struct(points).await?),
+            PointInsertOperationsInternal::PointsList(
+                convert_point_struct(points, InferenceType::Update).await?,
+            ),
         ),
     };
 
@@ -306,7 +309,7 @@ pub async fn do_update_vectors(
 ) -> Result<UpdateResult, StorageError> {
     let UpdateVectors { points, shard_key } = operation;
 
-    let persisted_points = convert_point_vectors(points).await?;
+    let persisted_points = convert_point_vectors(points, InferenceType::Update).await?;
 
     let collection_operation = CollectionUpdateOperations::VectorOperation(
         VectorOperations::UpdateVectors(UpdateVectorsOp {

--- a/src/main.rs
+++ b/src/main.rs
@@ -434,7 +434,7 @@ fn main() -> anyhow::Result<()> {
     // Inference Service
     //
     if let Some(inference_config) = settings.inference.clone() {
-        match InferenceService::init(inference_config) {
+        match InferenceService::init_global(inference_config) {
             Ok(_) => {
                 log::info!("Inference service is configured.");
             }

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -56,6 +56,7 @@ use tonic::{Response, Status};
 use crate::common::inference::query_requests_grpc::{
     convert_query_point_groups_from_grpc, convert_query_points_from_grpc,
 };
+use crate::common::inference::service::InferenceType;
 use crate::common::inference::update_requests::convert_point_struct;
 use crate::common::points::{
     do_clear_payload, do_core_search_points, do_count_points, do_create_index,
@@ -169,7 +170,7 @@ pub async fn sync(
 
     // No actual inference should happen here, as we are just syncing existing points
     // So this function is used for consistency only
-    let points = convert_point_struct(point_structs?).await?;
+    let points = convert_point_struct(point_structs?, InferenceType::Update).await?;
 
     let operation = PointSyncOperation {
         points,


### PR DESCRIPTION
- Add BatchProcessor and BatchConverter for efficient vector processing
- Consolidate inference request handling into batches
- Remove individual inference calls in favor of batched operations
- Reduce logging verbosity and remove redundant error handling

Query to try:

```http
PUT collections/sparse_charts/points?wait=true
{
  "points": [
    {
      "id": "76874cce-1fb9-4e16-9b0b-f085ac06ed61",
      "vector": {
        "keywords": {
          "object": "hello red planet mars",
          "model": "qdrant/bm25"
        }
      },
      "payload": {
        "title": "Mars"
      }
    },
    {
      "id": "76874cce-1fb9-4e16-9b0b-f085ac06ed62",
      "vector": {
        "keywords": {
          "object": "greetings blue planet earth",
          "model": "qdrant/bm25"
        }
      },
      "payload": {
        "title": "Earth"
      }
    },
    {
      "id": "76874cce-1fb9-4e16-9b0b-f085ac06ed63",
      "vector": {
        "keywords": {
          "object": "welcome green planet venus",
          "model": "qdrant/bm25"
        }
      },
      "payload": {
        "title": "Venus"
      }
    }
  ]
}
```