### PR TITLE
VisitedList: Vec<usize> -> Vec<u8>

### DIFF
--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -124,3 +124,28 @@ impl Default for VisitedPool {
         VisitedPool::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_visited_list() {
+        let pool = VisitedPool::new();
+        let mut visited_list = pool.get(10);
+
+        for _ in 0..2 {
+            assert!(!visited_list.check(0));
+            assert!(!visited_list.check_and_update_visited(0));
+            assert!(visited_list.check(0));
+
+            assert!(visited_list.check_and_update_visited(0));
+            assert!(visited_list.check(0));
+
+            for _ in 0..260 {
+                visited_list.next_iteration();
+                assert!(!visited_list.check(0));
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -54,19 +54,6 @@ impl<'a> VisitedListHandle<'a> {
         }
     }
 
-    pub fn get_current_iteration_id(&self) -> usize {
-        self.visited_list.current_iter
-    }
-
-    // Count how many points were visited since the given iteration
-    pub fn count_visits_since(&self, iteration_id: usize) -> usize {
-        self.visited_list
-            .visit_counters
-            .iter()
-            .filter(|x| **x >= iteration_id)
-            .count()
-    }
-
     /// Return `true` if visited
     pub fn check(&self, point_id: PointOffsetType) -> bool {
         self.visited_list


### PR DESCRIPTION
This PR optimizes `VisitedList` by switching counters from `usize` to `u8` (and memset them every 256 iterations). Surprisingly, this change improves not only the memory usage, but also the search/build performance.

```console
$ cargo bench -p segment --bench hnsw_search_graph # old
hnsw-index-search-group/hnsw_search
                        time:   [634.32 µs 640.56 µs 646.44 µs]
…

$ cargo bench -p segment --bench hnsw_search_graph # new
hnsw-index-search-group/hnsw_search
                        time:   [596.08 µs 601.57 µs 606.93 µs]
```

Large graphs are also improved. Graph build time (dim=4, npoints=10_000_000): 892s → 640s.