### PR TITLE
Gpu vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5956,6 +5956,7 @@ dependencies = [
  "fs_extra",
  "geo",
  "geohash",
+ "gpu",
  "half 2.4.1",
  "http 1.0.0",
  "indexmap 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio-tracing = ["tokio/tracing"]
 stacktrace = ["rstack-self"]
 chaos-testing = []
 data-consistency-check = ["collection/data-consistency-check"]
-gpu = ["gpu/gpu"]
+gpu = ["gpu/gpu", "segment/gpu"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/lib/gpu/src/descriptor_set.rs
+++ b/lib/gpu/src/descriptor_set.rs
@@ -247,14 +247,14 @@ impl DescriptorSet {
 
 impl Drop for DescriptorSet {
     fn drop(&mut self) {
-        unsafe {
-            if self.vk_descriptor_pool != vk::DescriptorPool::null() {
+        if self.vk_descriptor_pool != vk::DescriptorPool::null() {
+            unsafe {
                 self.device.vk_device().destroy_descriptor_pool(
                     self.vk_descriptor_pool,
                     self.device.cpu_allocation_callbacks(),
                 );
-                self.vk_descriptor_pool = vk::DescriptorPool::null()
             }
+            self.vk_descriptor_pool = vk::DescriptorPool::null()
         }
         self.uniform_buffers.clear();
         self.storage_buffers.clear();

--- a/lib/gpu/src/descriptor_set_layout.rs
+++ b/lib/gpu/src/descriptor_set_layout.rs
@@ -84,17 +84,17 @@ impl DescriptorSetLayoutBuilder {
 
 impl Drop for DescriptorSetLayout {
     fn drop(&mut self) {
-        unsafe {
-            if self.vk_descriptor_set_layout != vk::DescriptorSetLayout::null() {
+        if self.vk_descriptor_set_layout != vk::DescriptorSetLayout::null() {
+            unsafe {
                 self.device.vk_device().destroy_descriptor_set_layout(
                     self.vk_descriptor_set_layout,
                     self.device.cpu_allocation_callbacks(),
                 );
-                self.vk_descriptor_set_layout = vk::DescriptorSetLayout::null();
             }
-            self.storage_buffer_bindings.clear();
-            self.uniform_buffer_bindings.clear();
+            self.vk_descriptor_set_layout = vk::DescriptorSetLayout::null();
         }
+        self.storage_buffer_bindings.clear();
+        self.uniform_buffer_bindings.clear();
     }
 }
 

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -254,6 +254,19 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
             (DistanceType::L1 | DistanceType::L2, false) => xor_product - zeros_count,
         }
     }
+
+    pub fn get_quantized_vector(&self, i: u32) -> &[u8] {
+        self.encoded_vectors
+            .get_vector_data(i as _, self.get_quantized_vector_size())
+    }
+
+    pub fn get_vector_parameters(&self) -> &VectorParameters {
+        &self.metadata.vector_parameters
+    }
+
+    pub fn vectors_count(&self) -> usize {
+        self.metadata.vector_parameters.count
+    }
 }
 
 impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -33,10 +33,10 @@ pub struct EncodedQueryPQ {
 }
 
 #[derive(Serialize, Deserialize)]
-struct Metadata {
-    centroids: Vec<Vec<f32>>,
-    vector_division: Vec<Range<usize>>,
-    vector_parameters: VectorParameters,
+pub struct Metadata {
+    pub centroids: Vec<Vec<f32>>,
+    pub vector_division: Vec<Range<usize>>,
+    pub vector_parameters: VectorParameters,
 }
 
 impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
@@ -422,6 +422,19 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
                 value
             })
             .sum()
+    }
+
+    pub fn get_quantized_vector(&self, i: u32) -> &[u8] {
+        self.encoded_vectors
+            .get_vector_data(i as _, self.metadata.vector_division.len())
+    }
+
+    pub fn get_metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    pub fn vectors_count(&self) -> usize {
+        self.metadata.vector_parameters.count
     }
 }
 

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -250,13 +250,38 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         }
     }
 
+    pub fn get_quantized_vector(&self, i: u32) -> (f32, &[u8]) {
+        let (offset, v_ptr) = self.get_vec_ptr(i);
+        let vector_data_size = self.metadata.actual_dim;
+        (offset, unsafe {
+            std::slice::from_raw_parts(v_ptr, vector_data_size)
+        })
+    }
+
     pub fn get_quantized_vector_size(vector_parameters: &VectorParameters) -> usize {
         let actual_dim = Self::get_actual_dim(vector_parameters);
         actual_dim + std::mem::size_of::<f32>()
     }
 
+    pub fn get_multiplier(&self) -> f32 {
+        self.metadata.multiplier
+    }
+
+    pub fn get_diff(&self) -> f32 {
+        let diff = self.metadata.actual_dim as f32 * self.metadata.offset * self.metadata.offset;
+        if self.metadata.vector_parameters.invert {
+            -diff
+        } else {
+            diff
+        }
+    }
+
     pub fn get_actual_dim(vector_parameters: &VectorParameters) -> usize {
         vector_parameters.dim + (ALIGNMENT - vector_parameters.dim % ALIGNMENT) % ALIGNMENT
+    }
+
+    pub fn vectors_count(&self) -> usize {
+        self.metadata.vector_parameters.count
     }
 }
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -16,6 +16,7 @@ multiling-chinese = ["charabia/chinese-segmentation", "charabia/chinese-normaliz
 multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
 testing = ["common/testing", "sparse/testing"]
+gpu = ["gpu/gpu"]
 
 [build-dependencies]
 cc = "1.1"
@@ -96,6 +97,7 @@ issues = { path = "../common/issues" }
 memory = { path = "../common/memory" }
 quantization = { path = "../quantization" }
 sparse = { path = "../sparse" }
+gpu = { path = "../gpu" }
 
 tracing = { workspace = true, optional = true }
 macro_rules_attribute = "0.2.0"

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -192,6 +192,13 @@ impl From<TryReserveError> for OperationError {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl From<gpu::GpuError> for OperationError {
+    fn from(err: gpu::GpuError) -> Self {
+        Self::service_error(format!("GPU error: {err:?}"))
+    }
+}
+
 pub type OperationResult<T> = Result<T, OperationError>;
 
 pub fn get_service_error<T>(err: &OperationResult<T>) -> Option<OperationError> {

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common::types::PointOffsetType;
+use quantization::EncodedVectors;
+
+use super::gpu_quantization::MAX_QUANTIZATION_BINDINGS;
+use super::STORAGES_COUNT;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::index::hnsw_index::gpu::shader_builder::ShaderBuilderParameters;
+use crate::index::hnsw_index::gpu::GPU_TIMEOUT;
+use crate::vector_storage::quantized::quantized_multivector_storage::{
+    MultivectorOffsetsStorage, QuantizedMultivectorStorage,
+};
+use crate::vector_storage::MultiVectorStorage;
+
+// Multivector shader binding is after vectot data and quantization data bindings.
+const START_MULTIVECTORS_BINDING: usize = STORAGES_COUNT + MAX_QUANTIZATION_BINDINGS;
+
+/// Shader struct for multivector offsets with start id and count of vectors in multivector.
+#[repr(C)]
+struct GpuMultivectorOffset {
+    start: u32,
+    count: u32,
+}
+
+/// Gpu data for multivectors
+pub struct GpuMultivectors {
+    /// Positions of multivector offsets.
+    offsets_buffer: Arc<gpu::Buffer>,
+    /// Shader binding for offsets.
+    offsets_binding: usize,
+}
+
+impl ShaderBuilderParameters for GpuMultivectors {
+    fn shader_includes(&self) -> HashMap<String, String> {
+        // No additional includes for multivectors.
+        // Cause all multivector logic is defined in `vector_storage.comp` shader.
+        Default::default()
+    }
+
+    fn shader_defines(&self) -> HashMap<String, Option<String>> {
+        let mut defines = HashMap::new();
+        // Set enabled flag for multivectors.
+        defines.insert("MULTIVECTORS".to_owned(), None);
+        // Provide shader binding of multivector offsets.
+        defines.insert(
+            "MULTIVECTOR_OFFSETS_BINDING".to_owned(),
+            Some(self.offsets_binding.to_string()),
+        );
+        defines
+    }
+}
+
+impl GpuMultivectors {
+    /// Construct multivectors data from quantized storage.
+    pub fn new_quantized<
+        TEncodedQuery: Sized,
+        QuantizedStorage: EncodedVectors<TEncodedQuery>,
+        TMultivectorOffsetsStorage: MultivectorOffsetsStorage,
+    >(
+        device: Arc<gpu::Device>,
+        quantized_storage: &QuantizedMultivectorStorage<
+            TEncodedQuery,
+            QuantizedStorage,
+            TMultivectorOffsetsStorage,
+        >,
+    ) -> OperationResult<GpuMultivectors> {
+        Self::new_impl(
+            device,
+            (0..quantized_storage.vectors_count())
+                .map(|id| quantized_storage.inner_vector_offset(id as PointOffsetType))
+                .map(|x| GpuMultivectorOffset {
+                    start: x.start,
+                    count: x.count,
+                }),
+        )
+    }
+
+    /// Construct multivectors data from vector storage.
+    pub fn new_multidense<T: PrimitiveVectorElement, TVectorStorage: MultiVectorStorage<T>>(
+        device: Arc<gpu::Device>,
+        vector_storage: &TVectorStorage,
+    ) -> OperationResult<GpuMultivectors> {
+        Self::new_impl(
+            device,
+            (0..vector_storage.total_vector_count())
+                // map ID to count of vectors in multivector
+                .map(|id| {
+                    vector_storage
+                        .get_multi(id as PointOffsetType)
+                        .vectors_count()
+                })
+                // Map count of vectors to start and count of vectors in multivector.
+                .scan(0, |acc, count| {
+                    let start = *acc;
+                    *acc += count;
+                    Some(GpuMultivectorOffset {
+                        start: start as u32,
+                        count: count as u32,
+                    })
+                }),
+        )
+    }
+
+    /// Adds multivector data to the descriptor set builder.
+    pub fn add_descriptor_set(
+        &self,
+        descriptor_set_builder: gpu::DescriptorSetBuilder,
+    ) -> gpu::DescriptorSetBuilder {
+        descriptor_set_builder.add_storage_buffer(self.offsets_binding, self.offsets_buffer.clone())
+    }
+
+    /// Adds multivector data to the descriptor set layout builder.
+    pub fn add_descriptor_set_layout(
+        &self,
+        descriptor_set_layout_builder: gpu::DescriptorSetLayoutBuilder,
+    ) -> gpu::DescriptorSetLayoutBuilder {
+        descriptor_set_layout_builder.add_storage_buffer(self.offsets_binding)
+    }
+
+    fn new_impl(
+        device: Arc<gpu::Device>,
+        vector_offsets: impl Iterator<Item = GpuMultivectorOffset> + Clone,
+    ) -> OperationResult<GpuMultivectors> {
+        let multivectors_count = vector_offsets.clone().count();
+        let offsets = gpu::Buffer::new(
+            device.clone(),
+            "Multivector offsets buffer",
+            gpu::BufferType::Storage,
+            multivectors_count * std::mem::size_of::<GpuMultivectorOffset>(),
+        )?;
+        let offsets_staging_buffer = gpu::Buffer::new(
+            device.clone(),
+            "Multivector offsets staging buffer",
+            gpu::BufferType::CpuToGpu,
+            offsets.size(),
+        )?;
+        for (point_id, offset) in vector_offsets.enumerate() {
+            offsets_staging_buffer.upload(
+                &offset,
+                point_id * std::mem::size_of::<GpuMultivectorOffset>(),
+            )?;
+        }
+
+        let mut upload_context = gpu::Context::new(device.clone())?;
+        upload_context.copy_gpu_buffer(
+            offsets_staging_buffer,
+            offsets.clone(),
+            0,
+            0,
+            offsets.size(),
+        )?;
+        upload_context.run()?;
+        upload_context.wait_finish(GPU_TIMEOUT)?;
+
+        Ok(GpuMultivectors {
+            offsets_buffer: offsets,
+            offsets_binding: START_MULTIVECTORS_BINDING,
+        })
+    }
+}

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_quantization.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_quantization.rs
@@ -1,0 +1,431 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common::types::PointOffsetType;
+use quantization::encoded_vectors_binary::{BitsStoreType, EncodedVectorsBin};
+use quantization::{EncodedStorage, EncodedVectorsPQ, EncodedVectorsU8};
+
+use super::{GpuVectorStorage, STORAGES_COUNT};
+use crate::common::operation_error::OperationResult;
+use crate::index::hnsw_index::gpu::shader_builder::ShaderBuilderParameters;
+use crate::index::hnsw_index::gpu::GPU_TIMEOUT;
+
+pub const START_QUANTIZATION_BINDING: usize = STORAGES_COUNT;
+pub const MAX_QUANTIZATION_BINDINGS: usize = 2;
+
+/// Additional data for quantization in GPU.
+/// Add quantized vectors are stored as reqular vectors with for instance `u8` type.
+/// But quantization requires additional data for decoding.
+/// For instance, centroids for product quantization.
+/// This structures provides all additional data for quantization.
+/// From gpu buffers to shader defines and additional shader files.
+pub enum GpuQuantization {
+    Binary(GpuBinaryQuantization),
+    Scalar(GpuScalarQuantization),
+    Product(GpuProductQuantization),
+}
+
+impl ShaderBuilderParameters for GpuQuantization {
+    fn shader_includes(&self) -> HashMap<String, String> {
+        match self {
+            GpuQuantization::Binary(params) => params.shader_includes(),
+            GpuQuantization::Scalar(params) => params.shader_includes(),
+            GpuQuantization::Product(params) => params.shader_includes(),
+        }
+    }
+
+    fn shader_defines(&self) -> HashMap<String, Option<String>> {
+        match self {
+            GpuQuantization::Binary(params) => params.shader_defines(),
+            GpuQuantization::Scalar(params) => params.shader_defines(),
+            GpuQuantization::Product(params) => params.shader_defines(),
+        }
+    }
+}
+
+impl GpuQuantization {
+    pub fn new_bq<T: BitsStoreType, TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        quantized_storage: &EncodedVectorsBin<T, TStorage>,
+    ) -> GpuQuantization {
+        GpuQuantization::Binary(GpuBinaryQuantization::new(device, quantized_storage))
+    }
+
+    pub fn new_sq<TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        quantized_storage: &EncodedVectorsU8<TStorage>,
+    ) -> OperationResult<GpuQuantization> {
+        Ok(GpuQuantization::Scalar(GpuScalarQuantization::new(
+            device,
+            quantized_storage,
+        )?))
+    }
+
+    pub fn new_pq<TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        quantized_storage: &EncodedVectorsPQ<TStorage>,
+    ) -> OperationResult<GpuQuantization> {
+        Ok(GpuQuantization::Product(GpuProductQuantization::new(
+            device,
+            quantized_storage,
+        )?))
+    }
+
+    /// Adds additional bindings to descriptor set.
+    pub fn add_descriptor_set(
+        &self,
+        descriptor_set_builder: gpu::DescriptorSetBuilder,
+    ) -> gpu::DescriptorSetBuilder {
+        match self {
+            GpuQuantization::Binary(bq) => bq.add_descriptor_set(descriptor_set_builder),
+            GpuQuantization::Scalar(sq) => sq.add_descriptor_set(descriptor_set_builder),
+            GpuQuantization::Product(pq) => pq.add_descriptor_set(descriptor_set_builder),
+        }
+    }
+
+    /// Adds additional bindings to descriptor set layout.
+    pub fn add_descriptor_set_layout(
+        &self,
+        descriptor_set_layout_builder: gpu::DescriptorSetLayoutBuilder,
+    ) -> gpu::DescriptorSetLayoutBuilder {
+        match self {
+            GpuQuantization::Binary(bq) => {
+                bq.add_descriptor_set_layout(descriptor_set_layout_builder)
+            }
+            GpuQuantization::Scalar(sq) => {
+                sq.add_descriptor_set_layout(descriptor_set_layout_builder)
+            }
+            GpuQuantization::Product(pq) => {
+                pq.add_descriptor_set_layout(descriptor_set_layout_builder)
+            }
+        }
+    }
+}
+
+/// Additional data for binary quantization in GPU.
+/// It imnplements all shader definitions for BQ.
+pub struct GpuBinaryQuantization {
+    /// How many bits are added while aligning.
+    /// We need to subtract them after XOR+popcnt operation.
+    skip_count: usize,
+}
+
+impl ShaderBuilderParameters for GpuBinaryQuantization {
+    fn shader_includes(&self) -> HashMap<String, String> {
+        HashMap::from([(
+            "vector_storage_bq.comp".to_string(),
+            include_str!("../shaders/vector_storage_bq.comp").to_string(),
+        )])
+    }
+
+    fn shader_defines(&self) -> HashMap<String, Option<String>> {
+        let mut defines = HashMap::new();
+        // Define that we are using quantization.
+        defines.insert("VECTOR_STORAGE_QUANTIZATION".to_owned(), None);
+        // Define that quantization is binary.
+        defines.insert("VECTOR_STORAGE_ELEMENT_BQ".to_owned(), None);
+        // Provide skip count for BQ.
+        defines.insert(
+            "BQ_SKIP_COUNT".to_owned(),
+            Some(self.skip_count.to_string()),
+        );
+        defines
+    }
+}
+
+impl GpuBinaryQuantization {
+    fn new<T: BitsStoreType, TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        quantized_storage: &EncodedVectorsBin<T, TStorage>,
+    ) -> Self {
+        let orig_dim = quantized_storage.get_vector_parameters().dim;
+        // Bytes count for quantized vector.
+        let quantized_vector_len = if quantized_storage.vectors_count() > 0 {
+            quantized_storage.get_quantized_vector(0).len()
+        } else {
+            0
+        };
+        // Find bits count for aligned gpu vector.
+        let gpu_bits_count = GpuVectorStorage::gpu_vector_capacity(&device, quantized_vector_len)
+            * u8::BITS as usize;
+        Self {
+            skip_count: gpu_bits_count - orig_dim,
+        }
+    }
+
+    #[allow(clippy::unused_self)]
+    fn add_descriptor_set(
+        &self,
+        descriptor_set_builder: gpu::DescriptorSetBuilder,
+    ) -> gpu::DescriptorSetBuilder {
+        descriptor_set_builder
+    }
+
+    #[allow(clippy::unused_self)]
+    fn add_descriptor_set_layout(
+        &self,
+        descriptor_set_layout_builder: gpu::DescriptorSetLayoutBuilder,
+    ) -> gpu::DescriptorSetLayoutBuilder {
+        descriptor_set_layout_builder
+    }
+}
+
+pub struct GpuScalarQuantization {
+    multiplier: f32,
+    diff: f32,
+    offsets_buffer: Arc<gpu::Buffer>,
+    offsets_buffer_binding: usize,
+}
+
+impl ShaderBuilderParameters for GpuScalarQuantization {
+    fn shader_includes(&self) -> HashMap<String, String> {
+        HashMap::from([(
+            "vector_storage_sq.comp".to_string(),
+            include_str!("../shaders/vector_storage_sq.comp").to_string(),
+        )])
+    }
+
+    fn shader_defines(&self) -> HashMap<String, Option<String>> {
+        let mut defines = HashMap::new();
+        // Define that we are using quantization.
+        defines.insert("VECTOR_STORAGE_QUANTIZATION".to_owned(), None);
+        // Define that quantization is scalar.
+        defines.insert("VECTOR_STORAGE_ELEMENT_SQ".to_owned(), None);
+        // Provide shader binding of SQ offsets.
+        defines.insert(
+            "VECTOR_STORAGE_SQ_OFFSETS_BINDING".to_owned(),
+            Some(self.offsets_buffer_binding.to_string()),
+        );
+        // Provide multiplier and diff for quantization.
+        defines.insert(
+            "SQ_MULTIPLIER".to_owned(),
+            Some(self.multiplier.to_string()),
+        );
+        defines.insert("SQ_DIFF".to_owned(), Some(self.diff.to_string()));
+        defines
+    }
+}
+
+impl GpuScalarQuantization {
+    fn new<TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        quantized_storage: &EncodedVectorsU8<TStorage>,
+    ) -> OperationResult<Self> {
+        Ok(GpuScalarQuantization {
+            multiplier: quantized_storage.get_multiplier(),
+            diff: quantized_storage.get_diff(),
+            offsets_buffer: GpuScalarQuantization::create_sq_offsets_buffer(
+                device,
+                quantized_storage,
+            )?,
+            offsets_buffer_binding: START_QUANTIZATION_BINDING,
+        })
+    }
+
+    fn create_sq_offsets_buffer<TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        quantized_storage: &EncodedVectorsU8<TStorage>,
+    ) -> OperationResult<Arc<gpu::Buffer>> {
+        let sq_offsets_buffer = gpu::Buffer::new(
+            device.clone(),
+            "SQ offsets buffer",
+            gpu::BufferType::Storage,
+            quantized_storage.vectors_count() * std::mem::size_of::<f32>(),
+        )?;
+
+        let sq_offsets_staging_buffer = gpu::Buffer::new(
+            device.clone(),
+            "SQ offsets staging buffer",
+            gpu::BufferType::CpuToGpu,
+            sq_offsets_buffer.size(),
+        )?;
+
+        let mut upload_context = gpu::Context::new(device.clone())?;
+
+        for i in 0..quantized_storage.vectors_count() {
+            let (offset, _) = quantized_storage.get_quantized_vector(i as PointOffsetType);
+            sq_offsets_staging_buffer.upload(&offset, i * std::mem::size_of::<f32>())?;
+        }
+
+        upload_context.copy_gpu_buffer(
+            sq_offsets_staging_buffer,
+            sq_offsets_buffer.clone(),
+            0,
+            0,
+            sq_offsets_buffer.size(),
+        )?;
+        upload_context.run()?;
+        upload_context.wait_finish(GPU_TIMEOUT)?;
+
+        Ok(sq_offsets_buffer)
+    }
+
+    pub fn add_descriptor_set(
+        &self,
+        descriptor_set_builder: gpu::DescriptorSetBuilder,
+    ) -> gpu::DescriptorSetBuilder {
+        descriptor_set_builder
+            .add_storage_buffer(self.offsets_buffer_binding, self.offsets_buffer.clone())
+    }
+
+    pub fn add_descriptor_set_layout(
+        &self,
+        descriptor_set_layout_builder: gpu::DescriptorSetLayoutBuilder,
+    ) -> gpu::DescriptorSetLayoutBuilder {
+        descriptor_set_layout_builder.add_storage_buffer(self.offsets_buffer_binding)
+    }
+}
+
+pub struct GpuProductQuantization {
+    centroids_buffer: Arc<gpu::Buffer>,
+    centroids_buffer_binding: usize,
+    vector_division_buffer: Arc<gpu::Buffer>,
+    vector_division_buffer_binding: usize,
+    divisions_count: usize,
+    centroids_dim: usize,
+}
+
+impl ShaderBuilderParameters for GpuProductQuantization {
+    fn shader_includes(&self) -> HashMap<String, String> {
+        HashMap::from([(
+            "vector_storage_pq.comp".to_string(),
+            include_str!("../shaders/vector_storage_pq.comp").to_string(),
+        )])
+    }
+
+    fn shader_defines(&self) -> HashMap<String, Option<String>> {
+        let mut defines = HashMap::new();
+        // Define that we are using quantization.
+        defines.insert("VECTOR_STORAGE_QUANTIZATION".to_owned(), None);
+        // Define that quantization is product.
+        defines.insert("VECTOR_STORAGE_ELEMENT_PQ".to_owned(), None);
+        // Provide shader binding of PQ centroids.
+        defines.insert(
+            "VECTOR_STORAGE_PQ_CENTROIDS_BINDING".to_owned(),
+            Some(self.centroids_buffer_binding.to_string()),
+        );
+        // Provide shader binding of PQ vector division.
+        defines.insert(
+            "VECTOR_STORAGE_PQ_DIVISIONS_BINDING".to_owned(),
+            Some(self.vector_division_buffer_binding.to_string()),
+        );
+        // Provide vector divisions count and centroids count for quantization.
+        defines.insert(
+            "PQ_DIVISIONS_COUNT".to_owned(),
+            Some(self.divisions_count.to_string()),
+        );
+        defines.insert(
+            "PQ_CENTROIDS_DIM".to_owned(),
+            Some(self.centroids_dim.to_string()),
+        );
+        defines
+    }
+}
+
+impl GpuProductQuantization {
+    fn new<TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        quantized_storage: &EncodedVectorsPQ<TStorage>,
+    ) -> OperationResult<Self> {
+        let centroids_buffer = gpu::Buffer::new(
+            device.clone(),
+            "PQ centroids buffer",
+            gpu::BufferType::Storage,
+            quantized_storage
+                .get_metadata()
+                .centroids
+                .iter()
+                .map(|c| c.len())
+                .sum::<usize>()
+                * std::mem::size_of::<f32>(),
+        )?;
+        let centroids_staging_buffer = gpu::Buffer::new(
+            device.clone(),
+            "PQ centroids staging buffer",
+            gpu::BufferType::CpuToGpu,
+            centroids_buffer.size(),
+        )?;
+        let vector_division_buffer = gpu::Buffer::new(
+            device.clone(),
+            "PQ vector division buffer",
+            gpu::BufferType::Storage,
+            quantized_storage.get_metadata().vector_division.len() * std::mem::size_of::<u32>() * 2,
+        )?;
+        let vector_division_staging_buffer = gpu::Buffer::new(
+            device.clone(),
+            "PQ vector division staging buffer",
+            gpu::BufferType::CpuToGpu,
+            vector_division_buffer.size(),
+        )?;
+
+        let mut upload_context = gpu::Context::new(device.clone())?;
+
+        let mut centroids_offset = 0;
+        for centroids in &quantized_storage.get_metadata().centroids {
+            centroids_staging_buffer.upload_slice(centroids, centroids_offset)?;
+            centroids_offset += centroids.len() * std::mem::size_of::<f32>();
+        }
+
+        upload_context.copy_gpu_buffer(
+            centroids_staging_buffer,
+            centroids_buffer.clone(),
+            0,
+            0,
+            centroids_buffer.size(),
+        )?;
+
+        let vector_division: Vec<_> = quantized_storage
+            .get_metadata()
+            .vector_division
+            .iter()
+            .flat_map(|range| [range.start as u32, range.end as u32].into_iter())
+            .collect();
+        vector_division_staging_buffer.upload_slice(&vector_division, 0)?;
+
+        upload_context.copy_gpu_buffer(
+            vector_division_staging_buffer,
+            vector_division_buffer.clone(),
+            0,
+            0,
+            vector_division_buffer.size(),
+        )?;
+
+        upload_context.run()?;
+        upload_context.wait_finish(GPU_TIMEOUT)?;
+
+        Ok(Self {
+            centroids_buffer,
+            vector_division_buffer,
+            divisions_count: quantized_storage.get_metadata().vector_division.len(),
+            centroids_dim: quantized_storage
+                .get_metadata()
+                .centroids
+                .first()
+                .map(|c| c.len())
+                .unwrap_or_default(),
+            centroids_buffer_binding: START_QUANTIZATION_BINDING,
+            vector_division_buffer_binding: START_QUANTIZATION_BINDING + 1,
+        })
+    }
+
+    pub fn add_descriptor_set(
+        &self,
+        descriptor_set_builder: gpu::DescriptorSetBuilder,
+    ) -> gpu::DescriptorSetBuilder {
+        let descriptor_set_builder = descriptor_set_builder
+            .add_storage_buffer(self.centroids_buffer_binding, self.centroids_buffer.clone());
+        descriptor_set_builder.add_storage_buffer(
+            self.vector_division_buffer_binding,
+            self.vector_division_buffer.clone(),
+        )
+    }
+
+    pub fn add_descriptor_set_layout(
+        &self,
+        descriptor_set_layout_builder: gpu::DescriptorSetLayoutBuilder,
+    ) -> gpu::DescriptorSetLayoutBuilder {
+        let descriptor_set_layout_builder =
+            descriptor_set_layout_builder.add_storage_buffer(self.centroids_buffer_binding);
+        descriptor_set_layout_builder.add_storage_buffer(self.vector_division_buffer_binding)
+    }
+}

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -1,0 +1,689 @@
+mod gpu_multivectors;
+mod gpu_quantization;
+
+#[cfg(test)]
+mod tests;
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use common::types::PointOffsetType;
+use gpu_multivectors::GpuMultivectors;
+use gpu_quantization::GpuQuantization;
+use quantization::encoded_vectors_binary::{BitsStoreType, EncodedVectorsBin};
+use quantization::{EncodedStorage, EncodedVectorsPQ, EncodedVectorsU8};
+
+use super::shader_builder::ShaderBuilderParameters;
+use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
+use crate::index::hnsw_index::gpu::GPU_TIMEOUT;
+use crate::types::{Distance, VectorStorageDatatype};
+use crate::vector_storage::quantized::quantized_vectors::{
+    QuantizedVectorStorage, QuantizedVectors,
+};
+use crate::vector_storage::{
+    DenseVectorStorage, MultiVectorStorage, VectorStorage, VectorStorageEnum,
+};
+
+pub const ELEMENTS_PER_SUBGROUP: usize = 4;
+pub const UPLOAD_CHUNK_SIZE: usize = 64 * 1024 * 1024;
+pub const STORAGES_COUNT: usize = 4;
+
+/// GPU storage for vectors.
+pub struct GpuVectorStorage {
+    descriptor_set_layout: Arc<gpu::DescriptorSetLayout>,
+    descriptor_set: Arc<gpu::DescriptorSet>,
+    dim: usize,
+    element_type: VectorStorageDatatype,
+    distance: Distance,
+    /// Additional quantization data.
+    quantization: Option<GpuQuantization>,
+    /// Additional multivectors data.
+    multivectors: Option<GpuMultivectors>,
+}
+
+impl ShaderBuilderParameters for GpuVectorStorage {
+    fn shader_includes(&self) -> HashMap<String, String> {
+        let mut includes = HashMap::from([
+            (
+                "vector_storage.comp".to_string(),
+                include_str!("../shaders/vector_storage.comp").to_string(),
+            ),
+            (
+                "vector_storage_dense.comp".to_string(),
+                include_str!("../shaders/vector_storage_dense.comp").to_string(),
+            ),
+            (
+                "vector_storage_f16.comp".to_string(),
+                include_str!("../shaders/vector_storage_f16.comp").to_string(),
+            ),
+            (
+                "vector_storage_f32.comp".to_string(),
+                include_str!("../shaders/vector_storage_f32.comp").to_string(),
+            ),
+            (
+                "vector_storage_u8.comp".to_string(),
+                include_str!("../shaders/vector_storage_u8.comp").to_string(),
+            ),
+        ]);
+
+        if let Some(quantization) = &self.quantization {
+            includes.extend(quantization.shader_includes());
+        }
+        if let Some(multivectors) = &self.multivectors {
+            includes.extend(multivectors.shader_includes());
+        }
+
+        includes
+    }
+
+    fn shader_defines(&self) -> HashMap<String, Option<String>> {
+        let mut defines = HashMap::new();
+        match self.element_type {
+            VectorStorageDatatype::Float32 => {
+                defines.insert("VECTOR_STORAGE_ELEMENT_FLOAT32".to_owned(), None);
+            }
+            VectorStorageDatatype::Float16 => {
+                defines.insert("VECTOR_STORAGE_ELEMENT_FLOAT16".to_owned(), None);
+            }
+            VectorStorageDatatype::Uint8 => {
+                defines.insert("VECTOR_STORAGE_ELEMENT_UINT8".to_owned(), None);
+            }
+        }
+
+        match self.distance {
+            Distance::Cosine => {
+                defines.insert("COSINE_DISTANCE".to_owned(), None);
+            }
+            Distance::Euclid => {
+                defines.insert("EUCLID_DISTANCE".to_owned(), None);
+            }
+            Distance::Dot => {
+                defines.insert("DOT_DISTANCE".to_owned(), None);
+            }
+            Distance::Manhattan => {
+                defines.insert("MANHATTAN_DISTANCE".to_owned(), None);
+            }
+        }
+
+        if let Some(quantization) = &self.quantization {
+            defines.extend(quantization.shader_defines());
+        }
+
+        if let Some(multivectors) = &self.multivectors {
+            defines.extend(multivectors.shader_defines());
+        }
+
+        defines.insert("DIM".to_owned(), Some(self.dim.to_string()));
+        defines.insert(
+            "STORAGES_COUNT".to_owned(),
+            Some(STORAGES_COUNT.to_string()),
+        );
+        defines
+    }
+}
+
+impl GpuVectorStorage {
+    pub fn new(
+        device: Arc<gpu::Device>,
+        vector_storage: &VectorStorageEnum,
+        quantized_storage: Option<&QuantizedVectors>,
+        // Force half precision for `f32` vectors.
+        force_half_precision: bool,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        // GPU buffers should not be empty.
+        // Check that we have enough vectors to store at least one vector in each buffer.
+        if vector_storage.total_vector_count() < STORAGES_COUNT {
+            return Err(OperationError::service_error(
+                "Vectors count is less than `STORAGES_COUNT`",
+            ));
+        }
+        if let Some(quantized_storage) = quantized_storage {
+            Self::new_quantized(
+                device,
+                vector_storage.distance(),
+                quantized_storage.get_storage(),
+                stopped,
+            )
+        } else {
+            Self::new_from_vector_storage(device, vector_storage, force_half_precision, stopped)
+        }
+    }
+
+    fn new_quantized(
+        device: Arc<gpu::Device>,
+        distance: Distance,
+        quantized_storage: &QuantizedVectorStorage,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        match quantized_storage {
+            QuantizedVectorStorage::ScalarRam(quantized_storage) => {
+                Self::new_sq(device.clone(), distance, quantized_storage, None, stopped)
+            }
+            QuantizedVectorStorage::ScalarMmap(quantized_storage) => {
+                Self::new_sq(device.clone(), distance, quantized_storage, None, stopped)
+            }
+            QuantizedVectorStorage::PQRam(quantized_storage) => {
+                Self::new_pq(device.clone(), distance, quantized_storage, None, stopped)
+            }
+            QuantizedVectorStorage::PQMmap(quantized_storage) => {
+                Self::new_pq(device.clone(), distance, quantized_storage, None, stopped)
+            }
+            QuantizedVectorStorage::BinaryRam(quantized_storage) => {
+                Self::new_bq(device.clone(), distance, quantized_storage, None, stopped)
+            }
+            QuantizedVectorStorage::BinaryMmap(quantized_storage) => {
+                Self::new_bq(device.clone(), distance, quantized_storage, None, stopped)
+            }
+            QuantizedVectorStorage::ScalarRamMulti(quantized_storage) => Self::new_sq(
+                device.clone(),
+                distance,
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+            QuantizedVectorStorage::ScalarMmapMulti(quantized_storage) => Self::new_sq(
+                device.clone(),
+                distance,
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+            QuantizedVectorStorage::PQRamMulti(quantized_storage) => Self::new_pq(
+                device.clone(),
+                distance,
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+            QuantizedVectorStorage::PQMmapMulti(quantized_storage) => Self::new_pq(
+                device.clone(),
+                distance,
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+            QuantizedVectorStorage::BinaryRamMulti(quantized_storage) => Self::new_bq(
+                device.clone(),
+                distance,
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+            QuantizedVectorStorage::BinaryMmapMulti(quantized_storage) => Self::new_bq(
+                device.clone(),
+                distance,
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+        }
+    }
+
+    pub fn new_sq<TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        distance: Distance,
+        quantized_storage: &EncodedVectorsU8<TStorage>,
+        multivectors: Option<GpuMultivectors>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        Self::new_typed::<VectorElementTypeByte>(
+            device.clone(),
+            distance,
+            quantized_storage.vectors_count(),
+            quantized_storage.get_quantized_vector(0).1.len(),
+            (0..quantized_storage.vectors_count()).map(|id| {
+                let (_, vector) = quantized_storage.get_quantized_vector(id as PointOffsetType);
+                Cow::Borrowed(vector)
+            }),
+            Some(GpuQuantization::new_sq(device, quantized_storage)?),
+            multivectors,
+            stopped,
+        )
+    }
+
+    fn new_pq<TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        distance: Distance,
+        quantized_storage: &EncodedVectorsPQ<TStorage>,
+        multivectors: Option<GpuMultivectors>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        Self::new_typed::<VectorElementTypeByte>(
+            device.clone(),
+            distance,
+            quantized_storage.vectors_count(),
+            quantized_storage.get_quantized_vector(0).len(),
+            (0..quantized_storage.vectors_count()).map(|id| {
+                let vector = quantized_storage.get_quantized_vector(id as PointOffsetType);
+                Cow::Borrowed(vector)
+            }),
+            Some(GpuQuantization::new_pq(device, quantized_storage)?),
+            multivectors,
+            stopped,
+        )
+    }
+
+    fn new_bq<T: BitsStoreType, TStorage: EncodedStorage>(
+        device: Arc<gpu::Device>,
+        distance: Distance,
+        quantized_storage: &EncodedVectorsBin<T, TStorage>,
+        multivectors: Option<GpuMultivectors>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        Self::new_typed::<VectorElementTypeByte>(
+            device.clone(),
+            distance,
+            quantized_storage.vectors_count(),
+            quantized_storage.get_quantized_vector(0).len(),
+            (0..quantized_storage.vectors_count()).map(|id| {
+                Cow::Borrowed(quantized_storage.get_quantized_vector(id as PointOffsetType))
+            }),
+            Some(GpuQuantization::new_bq(device, quantized_storage)),
+            multivectors,
+            stopped,
+        )
+    }
+
+    fn new_from_vector_storage(
+        device: Arc<gpu::Device>,
+        vector_storage: &VectorStorageEnum,
+        force_half_precision: bool,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        match vector_storage {
+            VectorStorageEnum::DenseSimple(vector_storage) => {
+                Self::new_dense_f32(device, vector_storage, force_half_precision, stopped)
+            }
+            VectorStorageEnum::DenseSimpleByte(vector_storage) => {
+                Self::new_dense(device, vector_storage, stopped)
+            }
+            VectorStorageEnum::DenseSimpleHalf(vector_storage) => {
+                Self::new_dense(device, vector_storage, stopped)
+            }
+            VectorStorageEnum::DenseMemmap(vector_storage) => Self::new_dense_f32(
+                device,
+                vector_storage.as_ref(),
+                force_half_precision,
+                stopped,
+            ),
+            VectorStorageEnum::DenseMemmapByte(vector_storage) => {
+                Self::new_dense(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::DenseMemmapHalf(vector_storage) => {
+                Self::new_dense(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::DenseAppendableMemmap(vector_storage) => Self::new_dense_f32(
+                device,
+                vector_storage.as_ref(),
+                force_half_precision,
+                stopped,
+            ),
+            VectorStorageEnum::DenseAppendableMemmapByte(vector_storage) => {
+                Self::new_dense(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(vector_storage) => {
+                Self::new_dense(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::DenseAppendableInRam(vector_storage) => Self::new_dense_f32(
+                device,
+                vector_storage.as_ref(),
+                force_half_precision,
+                stopped,
+            ),
+            VectorStorageEnum::DenseAppendableInRamByte(vector_storage) => {
+                Self::new_dense(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::DenseAppendableInRamHalf(vector_storage) => {
+                Self::new_dense(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::SparseSimple(_) => Err(OperationError::from(
+                gpu::GpuError::NotSupported("Sparse vectors are not supported on GPU".to_string()),
+            )),
+            VectorStorageEnum::MultiDenseSimple(vector_storage) => Self::new_multi_f32(
+                device.clone(),
+                vector_storage,
+                force_half_precision,
+                stopped,
+            ),
+            VectorStorageEnum::MultiDenseSimpleByte(vector_storage) => {
+                Self::new_multi(device, vector_storage, stopped)
+            }
+            VectorStorageEnum::MultiDenseSimpleHalf(vector_storage) => {
+                Self::new_multi(device, vector_storage, stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmap(vector_storage) => Self::new_multi_f32(
+                device.clone(),
+                vector_storage.as_ref(),
+                force_half_precision,
+                stopped,
+            ),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(vector_storage) => {
+                Self::new_multi(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(vector_storage) => {
+                Self::new_multi(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableInRam(vector_storage) => Self::new_multi_f32(
+                device.clone(),
+                vector_storage.as_ref(),
+                force_half_precision,
+                stopped,
+            ),
+            VectorStorageEnum::MultiDenseAppendableInRamByte(vector_storage) => {
+                Self::new_multi(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(vector_storage) => {
+                Self::new_multi(device, vector_storage.as_ref(), stopped)
+            }
+        }
+    }
+
+    fn new_dense_f32<TVectorStorage: DenseVectorStorage<VectorElementType>>(
+        device: Arc<gpu::Device>,
+        vector_storage: &TVectorStorage,
+        force_half_precision: bool,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        if force_half_precision {
+            Self::new_typed::<VectorElementTypeHalf>(
+                device,
+                vector_storage.distance(),
+                vector_storage.total_vector_count(),
+                vector_storage.vector_dim(),
+                (0..vector_storage.total_vector_count()).map(|id| {
+                    VectorElementTypeHalf::slice_from_float_cow(Cow::Borrowed(
+                        vector_storage.get_dense(id as PointOffsetType),
+                    ))
+                }),
+                None,
+                None,
+                stopped,
+            )
+        } else {
+            Self::new_dense(device, vector_storage, stopped)
+        }
+    }
+
+    fn new_dense<TElement: PrimitiveVectorElement, TVectorStorage: DenseVectorStorage<TElement>>(
+        device: Arc<gpu::Device>,
+        vector_storage: &TVectorStorage,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        Self::new_typed::<TElement>(
+            device,
+            vector_storage.distance(),
+            vector_storage.total_vector_count(),
+            vector_storage.vector_dim(),
+            (0..vector_storage.total_vector_count())
+                .map(|id| Cow::Borrowed(vector_storage.get_dense(id as PointOffsetType))),
+            None,
+            None,
+            stopped,
+        )
+    }
+
+    fn new_multi_f32<TVectorStorage: MultiVectorStorage<VectorElementType>>(
+        device: Arc<gpu::Device>,
+        vector_storage: &TVectorStorage,
+        force_half_precision: bool,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        if force_half_precision {
+            Self::new_typed::<VectorElementTypeHalf>(
+                device.clone(),
+                vector_storage.distance(),
+                (0..vector_storage.total_vector_count())
+                    .map(|id| {
+                        vector_storage
+                            .get_multi(id as PointOffsetType)
+                            .vectors_count()
+                    })
+                    .sum(),
+                vector_storage.vector_dim(),
+                vector_storage.iterate_inner_vectors().map(|vector| {
+                    VectorElementTypeHalf::slice_from_float_cow(Cow::Borrowed(vector))
+                }),
+                None,
+                Some(GpuMultivectors::new_multidense(device, vector_storage)?),
+                stopped,
+            )
+        } else {
+            Self::new_multi(device, vector_storage, stopped)
+        }
+    }
+
+    fn new_multi<TElement: PrimitiveVectorElement, TVectorStorage: MultiVectorStorage<TElement>>(
+        device: Arc<gpu::Device>,
+        vector_storage: &TVectorStorage,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        Self::new_typed::<TElement>(
+            device.clone(),
+            vector_storage.distance(),
+            (0..vector_storage.total_vector_count())
+                .map(|id| {
+                    vector_storage
+                        .get_multi(id as PointOffsetType)
+                        .vectors_count()
+                })
+                .sum(),
+            vector_storage.vector_dim(),
+            vector_storage.iterate_inner_vectors().map(Cow::Borrowed),
+            None,
+            Some(GpuMultivectors::new_multidense(device, vector_storage)?),
+            stopped,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_typed<'a, TElement: PrimitiveVectorElement>(
+        device: Arc<gpu::Device>,
+        distance: Distance,
+        count: usize,
+        dim: usize,
+        vectors: impl Iterator<Item = Cow<'a, [TElement]>> + Clone,
+        quantization: Option<GpuQuantization>,
+        multivectors: Option<GpuMultivectors>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        check_process_stopped(stopped)?;
+        let timer = std::time::Instant::now();
+
+        let gpu_vector_capacity = Self::gpu_vector_capacity(&device, dim);
+        let gpu_vector_size = gpu_vector_capacity * std::mem::size_of::<TElement>();
+        let upload_points_count = UPLOAD_CHUNK_SIZE / gpu_vector_size;
+
+        let points_in_storage_count = Self::points_in_storage_count(count);
+        let vectors_buffer: Vec<Arc<gpu::Buffer>> = (0..STORAGES_COUNT)
+            .map(|_| -> gpu::GpuResult<Arc<gpu::Buffer>> {
+                gpu::Buffer::new(
+                    device.clone(),
+                    "Vector storage buffer",
+                    gpu::BufferType::Storage,
+                    points_in_storage_count * gpu_vector_size,
+                )
+            })
+            .collect::<gpu::GpuResult<Vec<_>>>()?;
+        log::trace!("Storage buffer size {}", vectors_buffer[0].size());
+
+        let mut upload_context = gpu::Context::new(device.clone())?;
+
+        // Fill all vector storages with zeros.
+        for buffer in vectors_buffer.iter() {
+            upload_context.clear_buffer(buffer.clone())?;
+        }
+        upload_context.run()?;
+        upload_context.wait_finish(GPU_TIMEOUT)?;
+
+        let staging_buffer = gpu::Buffer::new(
+            device.clone(),
+            "Vector storage upload staging buffer",
+            gpu::BufferType::CpuToGpu,
+            upload_points_count * gpu_vector_size,
+        )?;
+        // fill staging buffer with zeros
+        let zero_vector = vec![TElement::default(); gpu_vector_capacity];
+        for i in 0..upload_points_count {
+            staging_buffer.upload_slice(&zero_vector, i * gpu_vector_capacity)?;
+        }
+        log::trace!(
+            "GPU staging buffer size {}, `upload_points_count` = {}",
+            staging_buffer.size(),
+            upload_points_count
+        );
+
+        // Upload vectors to GPU.
+        // Upload storage-by storage and iterate over all vectors for each storage.
+        for (storage_index, vector_buffer) in vectors_buffer.iter().enumerate() {
+            let mut gpu_offset = 0;
+            let mut upload_size = 0;
+            let mut upload_points = 0;
+
+            for vector in vectors.clone().skip(storage_index).step_by(STORAGES_COUNT) {
+                check_process_stopped(stopped)?;
+                staging_buffer.upload_slice(vector.as_ref(), upload_points * gpu_vector_size)?;
+                upload_size += gpu_vector_size;
+                upload_points += 1;
+
+                if upload_points == upload_points_count {
+                    upload_context.copy_gpu_buffer(
+                        staging_buffer.clone(),
+                        vector_buffer.clone(),
+                        0,
+                        gpu_offset,
+                        upload_size,
+                    )?;
+                    upload_context.run()?;
+                    upload_context.wait_finish(GPU_TIMEOUT)?;
+
+                    log::trace!(
+                        "Uploaded {} vectors, {} MB",
+                        upload_points,
+                        upload_size / 1024 / 1024,
+                    );
+
+                    gpu_offset += upload_size;
+                    upload_size = 0;
+                    upload_points = 0;
+                }
+            }
+            if upload_points > 0 {
+                upload_context.copy_gpu_buffer(
+                    staging_buffer.clone(),
+                    vectors_buffer[storage_index].clone(),
+                    0,
+                    gpu_offset,
+                    upload_size,
+                )?;
+                upload_context.run()?;
+                upload_context.wait_finish(GPU_TIMEOUT)?;
+
+                log::trace!(
+                    "Uploaded {} vectors, {} MB",
+                    upload_points,
+                    upload_size / 1024 / 1024,
+                );
+            }
+        }
+
+        log::trace!(
+            "Upload vector data to GPU time = {:?}, vector data size {} MB, element type: {:?}",
+            timer.elapsed(),
+            STORAGES_COUNT * points_in_storage_count * gpu_vector_size / 1024 / 1024,
+            TElement::datatype(),
+        );
+
+        let descriptor_set_layout =
+            Self::create_descriptor_set_layout(device, &quantization, &multivectors)?;
+        let descriptor_set = Self::create_descriptor_set(
+            descriptor_set_layout.clone(),
+            &vectors_buffer,
+            &quantization,
+            &multivectors,
+        )?;
+
+        Ok(Self {
+            descriptor_set_layout,
+            descriptor_set,
+            dim: gpu_vector_capacity,
+            element_type: TElement::datatype(),
+            distance,
+            quantization,
+            multivectors,
+        })
+    }
+
+    fn create_descriptor_set_layout(
+        device: Arc<gpu::Device>,
+        quantization: &Option<GpuQuantization>,
+        multivectors: &Option<GpuMultivectors>,
+    ) -> OperationResult<Arc<gpu::DescriptorSetLayout>> {
+        let mut descriptor_set_layout_builder = gpu::DescriptorSetLayout::builder();
+        for i in 0..STORAGES_COUNT {
+            descriptor_set_layout_builder = descriptor_set_layout_builder.add_storage_buffer(i);
+        }
+        descriptor_set_layout_builder = if let Some(quantization) = &quantization {
+            quantization.add_descriptor_set_layout(descriptor_set_layout_builder)
+        } else {
+            descriptor_set_layout_builder
+        };
+        descriptor_set_layout_builder = if let Some(multivectors) = &multivectors {
+            multivectors.add_descriptor_set_layout(descriptor_set_layout_builder)
+        } else {
+            descriptor_set_layout_builder
+        };
+        Ok(descriptor_set_layout_builder.build(device.clone())?)
+    }
+
+    fn create_descriptor_set(
+        descriptor_set_layout: Arc<gpu::DescriptorSetLayout>,
+        vectors_buffer: &[Arc<gpu::Buffer>],
+        quantization: &Option<GpuQuantization>,
+        multivectors: &Option<GpuMultivectors>,
+    ) -> OperationResult<Arc<gpu::DescriptorSet>> {
+        let mut descriptor_set_builder = gpu::DescriptorSet::builder(descriptor_set_layout.clone());
+        for (i, vector_buffer) in vectors_buffer.iter().enumerate() {
+            descriptor_set_builder =
+                descriptor_set_builder.add_storage_buffer(i, vector_buffer.clone());
+        }
+        descriptor_set_builder = if let Some(quantization) = &quantization {
+            quantization.add_descriptor_set(descriptor_set_builder)
+        } else {
+            descriptor_set_builder
+        };
+        descriptor_set_builder = if let Some(multivectors) = &multivectors {
+            multivectors.add_descriptor_set(descriptor_set_builder)
+        } else {
+            descriptor_set_builder
+        };
+        Ok(descriptor_set_builder.build()?)
+    }
+
+    /// GPU aligned vector size in elements count.
+    fn gpu_vector_capacity(device: &Arc<gpu::Device>, dim: usize) -> usize {
+        // BQ is a `u8` vector with `u128`=16bytes alignment.
+        // We need to keep this alignment for bq case that's why we have `max` here.
+        // But TBH even CPU emulator has 8 subgroups to that we don't expect in practice
+        // that we will have less than 16 bytes alignment.
+        let alignment = std::cmp::max(device.subgroup_size() * ELEMENTS_PER_SUBGROUP, 16);
+        dim.next_multiple_of(alignment)
+    }
+
+    /// Number of vectors in each gpu buffer.
+    fn points_in_storage_count(num_vectors: usize) -> usize {
+        num_vectors.next_multiple_of(STORAGES_COUNT) / STORAGES_COUNT
+    }
+
+    pub fn descriptor_set_layout(&self) -> Arc<gpu::DescriptorSetLayout> {
+        self.descriptor_set_layout.clone()
+    }
+
+    pub fn descriptor_set(&self) -> Arc<gpu::DescriptorSet> {
+        self.descriptor_set.clone()
+    }
+}

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -1,0 +1,677 @@
+use std::path::Path;
+
+use bitvec::vec::BitVec;
+use parking_lot::RwLock;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use rocksdb::DB;
+use rstest::rstest;
+
+use super::*;
+use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
+use crate::data_types::vectors::{MultiDenseVectorInternal, QueryVector, VectorRef};
+use crate::fixtures::index_fixtures::random_vector;
+use crate::fixtures::payload_fixtures::random_dense_byte_vector;
+use crate::index::hnsw_index::gpu::shader_builder::ShaderBuilder;
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
+use crate::types::{
+    BinaryQuantization, BinaryQuantizationConfig, Distance, ProductQuantization,
+    ProductQuantizationConfig, QuantizationConfig, ScalarQuantization, ScalarQuantizationConfig,
+};
+use crate::vector_storage::dense::simple_dense_vector_storage::{
+    open_simple_dense_byte_vector_storage, open_simple_dense_half_vector_storage,
+    open_simple_dense_vector_storage,
+};
+use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::{
+    open_simple_multi_dense_vector_storage, open_simple_multi_dense_vector_storage_byte,
+    open_simple_multi_dense_vector_storage_half,
+};
+use crate::vector_storage::{new_raw_scorer, RawScorer};
+
+#[derive(Debug, Clone, Copy)]
+enum TestElementType {
+    Float32,
+    Float16,
+    Uint8,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TestStorageType {
+    Dense(TestElementType),
+    Multi(TestElementType),
+}
+
+impl TestStorageType {
+    pub fn element_type(&self) -> TestElementType {
+        match self {
+            TestStorageType::Dense(element_type) => *element_type,
+            TestStorageType::Multi(element_type) => *element_type,
+        }
+    }
+}
+
+#[rstest]
+fn test_gpu_vector_storage_sq(
+    #[values(Distance::Cosine, Distance::Dot, Distance::Euclid, Distance::Manhattan)]
+    distance: Distance,
+    #[values(
+        TestStorageType::Dense(TestElementType::Float32),
+        TestStorageType::Dense(TestElementType::Float16),
+        TestStorageType::Dense(TestElementType::Uint8),
+        TestStorageType::Multi(TestElementType::Float32),
+        TestStorageType::Multi(TestElementType::Float16),
+        TestStorageType::Multi(TestElementType::Uint8)
+    )]
+    storage_type: TestStorageType,
+    #[values(
+        15,
+        512,
+        256 + 17,
+    )]
+    dim: usize,
+    #[values(2048 + 17)] num_vectors: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let quantization_config = QuantizationConfig::Scalar(ScalarQuantization {
+        scalar: ScalarQuantizationConfig {
+            always_ram: Some(true),
+            r#type: crate::types::ScalarType::Int8,
+            quantile: Some(0.99),
+        },
+    });
+
+    let precision = get_precision(storage_type, dim, distance);
+    log::info!(
+        "Testing SQ distance {:?}, element type {:?}, dim {} with precision {}",
+        distance,
+        storage_type,
+        dim,
+        precision
+    );
+    test_gpu_vector_storage_impl(
+        storage_type,
+        num_vectors,
+        dim,
+        distance,
+        Some(quantization_config.clone()),
+        false,
+        precision,
+    );
+}
+
+#[rstest]
+fn test_gpu_vector_storage_bq(
+    #[values(Distance::Cosine, Distance::Dot, Distance::Euclid, Distance::Manhattan)]
+    distance: Distance,
+    #[values(
+        TestStorageType::Dense(TestElementType::Float32),
+        TestStorageType::Dense(TestElementType::Float16),
+        TestStorageType::Dense(TestElementType::Uint8),
+        TestStorageType::Multi(TestElementType::Float32),
+        TestStorageType::Multi(TestElementType::Float16),
+        TestStorageType::Multi(TestElementType::Uint8)
+    )]
+    storage_type: TestStorageType,
+    #[values(15, 1536, 256 + 17)] dim: usize,
+    #[values(2048 + 17)] num_vectors: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let quantization_config = QuantizationConfig::Binary(BinaryQuantization {
+        binary: BinaryQuantizationConfig {
+            always_ram: Some(true),
+        },
+    });
+
+    let precision = get_precision(storage_type, dim, distance);
+    log::info!(
+        "Testing BQ distance {:?}, element type {:?}, dim {} with precision {}",
+        distance,
+        storage_type,
+        dim,
+        precision
+    );
+    test_gpu_vector_storage_impl(
+        storage_type,
+        num_vectors,
+        dim,
+        distance,
+        Some(quantization_config.clone()),
+        false,
+        precision,
+    );
+}
+
+#[rstest]
+fn test_gpu_vector_storage_pq(
+    #[values(Distance::Cosine, Distance::Dot, Distance::Euclid, Distance::Manhattan)]
+    distance: Distance,
+    #[values(
+        TestStorageType::Dense(TestElementType::Float32),
+        TestStorageType::Dense(TestElementType::Float16),
+        TestStorageType::Multi(TestElementType::Float32),
+        TestStorageType::Multi(TestElementType::Float16)
+    )]
+    storage_type: TestStorageType,
+    #[values(15, 256 + 17)] dim: usize,
+    #[values(512 + 17)] num_vectors: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let quantization_config = QuantizationConfig::Product(ProductQuantization {
+        product: ProductQuantizationConfig {
+            always_ram: Some(true),
+            compression: crate::types::CompressionRatio::X8,
+        },
+    });
+
+    let precision = get_precision(storage_type, dim, distance);
+    log::info!(
+        "Testing PQ distance {:?}, element type {:?}, dim {} with precision {}",
+        distance,
+        storage_type,
+        dim,
+        precision
+    );
+    test_gpu_vector_storage_impl(
+        storage_type,
+        num_vectors,
+        dim,
+        distance,
+        Some(quantization_config.clone()),
+        false,
+        precision,
+    );
+}
+
+#[rstest]
+fn test_gpu_vector_storage(
+    #[values(Distance::Cosine, Distance::Dot, Distance::Euclid, Distance::Manhattan)]
+    distance: Distance,
+    #[values(
+        TestStorageType::Dense(TestElementType::Float32),
+        TestStorageType::Dense(TestElementType::Float16),
+        TestStorageType::Dense(TestElementType::Uint8),
+        TestStorageType::Multi(TestElementType::Float32),
+        TestStorageType::Multi(TestElementType::Float16),
+        TestStorageType::Multi(TestElementType::Uint8)
+    )]
+    storage_type: TestStorageType,
+    #[values(
+        15,
+        512,
+        256 + 17,
+    )]
+    dim: usize,
+    #[values(2048 + 17)] num_vectors: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let precision = get_precision(storage_type, dim, distance);
+    log::info!(
+        "Testing distance {:?}, element type {:?}, dim {} with precision {}",
+        distance,
+        storage_type,
+        dim,
+        precision
+    );
+    test_gpu_vector_storage_impl(
+        storage_type,
+        num_vectors,
+        dim,
+        distance,
+        None,
+        false,
+        precision,
+    );
+}
+
+#[rstest]
+fn test_gpu_vector_storage_force_half(
+    #[values(Distance::Cosine, Distance::Dot, Distance::Euclid, Distance::Manhattan)]
+    distance: Distance,
+    #[values(
+        TestStorageType::Dense(TestElementType::Float32),
+        TestStorageType::Multi(TestElementType::Float32)
+    )]
+    storage_type: TestStorageType,
+    #[values(15, 256 + 17)] dim: usize,
+    #[values(2048 + 17)] num_vectors: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let precision = 5.0 * get_precision(storage_type, dim, distance);
+    log::info!(
+        "Testing distance {:?}, element type {:?}, dim {} with precision {}",
+        distance,
+        storage_type,
+        dim,
+        precision
+    );
+    test_gpu_vector_storage_impl(
+        storage_type,
+        num_vectors,
+        dim,
+        distance,
+        None,
+        true, // force half precision
+        precision,
+    );
+}
+
+fn get_precision(storage_type: TestStorageType, dim: usize, distance: Distance) -> f32 {
+    let distance_persision = match distance {
+        Distance::Cosine => 0.01,
+        Distance::Dot => 0.01,
+        Distance::Euclid => dim as f32 * 0.001,
+        Distance::Manhattan => dim as f32 * 0.001,
+    };
+    match storage_type.element_type() {
+        TestElementType::Float32 => distance_persision,
+        TestElementType::Float16 => distance_persision * 5.0,
+        TestElementType::Uint8 => distance_persision * 10.0,
+    }
+}
+
+fn create_vector_storage(
+    path: &Path,
+    storage_type: TestStorageType,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+) -> VectorStorageEnum {
+    let db = open_db(path, &[DB_VECTOR_CF]).unwrap();
+    match storage_type {
+        TestStorageType::Dense(TestElementType::Float32) => {
+            create_vector_storage_f32(db, num_vectors, dim, distance)
+        }
+        TestStorageType::Dense(TestElementType::Float16) => {
+            create_vector_storage_f16(db, num_vectors, dim, distance)
+        }
+        TestStorageType::Dense(TestElementType::Uint8) => {
+            create_vector_storage_u8(db, num_vectors, dim, distance)
+        }
+        TestStorageType::Multi(TestElementType::Float32) => {
+            create_vector_storage_f32_multi(db, num_vectors, dim, distance)
+        }
+        TestStorageType::Multi(TestElementType::Float16) => {
+            create_vector_storage_f16_multi(db, num_vectors, dim, distance)
+        }
+        TestStorageType::Multi(TestElementType::Uint8) => {
+            create_vector_storage_u8_multi(db, num_vectors, dim, distance)
+        }
+    }
+}
+
+fn create_vector_storage_f32(
+    db: Arc<RwLock<DB>>,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+) -> VectorStorageEnum {
+    let mut rnd = StdRng::seed_from_u64(42);
+    let mut vector_storage =
+        open_simple_dense_vector_storage(db, DB_VECTOR_CF, dim, distance, &false.into()).unwrap();
+    for i in 0..num_vectors {
+        let vec = random_vector(&mut rnd, dim);
+        let vec = match distance {
+            Distance::Cosine => <CosineMetric as Metric<VectorElementType>>::preprocess(vec),
+            Distance::Euclid => <EuclidMetric as Metric<VectorElementType>>::preprocess(vec),
+            Distance::Dot => <DotProductMetric as Metric<VectorElementType>>::preprocess(vec),
+            Distance::Manhattan => <ManhattanMetric as Metric<VectorElementType>>::preprocess(vec),
+        };
+        let vec_ref = VectorRef::from(&vec);
+        vector_storage
+            .insert_vector(i as PointOffsetType, vec_ref)
+            .unwrap();
+    }
+    vector_storage
+}
+
+fn create_vector_storage_f16(
+    db: Arc<RwLock<DB>>,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+) -> VectorStorageEnum {
+    let mut rnd = StdRng::seed_from_u64(42);
+    let mut vector_storage =
+        open_simple_dense_half_vector_storage(db, DB_VECTOR_CF, dim, distance, &false.into())
+            .unwrap();
+    for i in 0..num_vectors {
+        let vec = random_vector(&mut rnd, dim);
+        let vec = match distance {
+            Distance::Cosine => <CosineMetric as Metric<VectorElementTypeHalf>>::preprocess(vec),
+            Distance::Euclid => <EuclidMetric as Metric<VectorElementTypeHalf>>::preprocess(vec),
+            Distance::Dot => <DotProductMetric as Metric<VectorElementTypeHalf>>::preprocess(vec),
+            Distance::Manhattan => {
+                <ManhattanMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
+            }
+        };
+        let vec_ref = VectorRef::from(&vec);
+        vector_storage
+            .insert_vector(i as PointOffsetType, vec_ref)
+            .unwrap();
+    }
+    vector_storage
+}
+
+fn create_vector_storage_u8(
+    db: Arc<RwLock<DB>>,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+) -> VectorStorageEnum {
+    let mut rnd = StdRng::seed_from_u64(42);
+    let mut vector_storage =
+        open_simple_dense_byte_vector_storage(db, DB_VECTOR_CF, dim, distance, &false.into())
+            .unwrap();
+    for i in 0..num_vectors {
+        let vec = random_dense_byte_vector(&mut rnd, dim);
+        let vec = match distance {
+            Distance::Cosine => <CosineMetric as Metric<VectorElementTypeByte>>::preprocess(vec),
+            Distance::Euclid => <EuclidMetric as Metric<VectorElementTypeByte>>::preprocess(vec),
+            Distance::Dot => <DotProductMetric as Metric<VectorElementTypeByte>>::preprocess(vec),
+            Distance::Manhattan => {
+                <ManhattanMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
+            }
+        };
+        let vec_ref = VectorRef::from(&vec);
+        vector_storage
+            .insert_vector(i as PointOffsetType, vec_ref)
+            .unwrap();
+    }
+    vector_storage
+}
+
+fn create_vector_storage_f32_multi(
+    db: Arc<RwLock<DB>>,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+) -> VectorStorageEnum {
+    let mut rnd = StdRng::seed_from_u64(42);
+    let multivector_config = Default::default();
+    let mut vector_storage = open_simple_multi_dense_vector_storage(
+        db,
+        DB_VECTOR_CF,
+        dim,
+        distance,
+        multivector_config,
+        &false.into(),
+    )
+    .unwrap();
+    for i in 0..num_vectors {
+        let mut vectors = vec![];
+        let num_vectors_per_points = 1 + rnd.gen::<usize>() % 3;
+        for _ in 0..num_vectors_per_points {
+            let vec = random_vector(&mut rnd, dim);
+            let vec = match distance {
+                Distance::Cosine => <CosineMetric as Metric<VectorElementType>>::preprocess(vec),
+                Distance::Euclid => <EuclidMetric as Metric<VectorElementType>>::preprocess(vec),
+                Distance::Dot => <DotProductMetric as Metric<VectorElementType>>::preprocess(vec),
+                Distance::Manhattan => {
+                    <ManhattanMetric as Metric<VectorElementType>>::preprocess(vec)
+                }
+            };
+            vectors.extend(vec);
+        }
+        let multivector = MultiDenseVectorInternal::new(vectors, dim);
+        let vec_ref = VectorRef::from(&multivector);
+        vector_storage
+            .insert_vector(i as PointOffsetType, vec_ref)
+            .unwrap();
+    }
+    vector_storage
+}
+
+fn create_vector_storage_f16_multi(
+    db: Arc<RwLock<DB>>,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+) -> VectorStorageEnum {
+    let mut rnd = StdRng::seed_from_u64(42);
+    let multivector_config = Default::default();
+    let mut vector_storage = open_simple_multi_dense_vector_storage_half(
+        db,
+        DB_VECTOR_CF,
+        dim,
+        distance,
+        multivector_config,
+        &false.into(),
+    )
+    .unwrap();
+    for i in 0..num_vectors {
+        let mut vectors = vec![];
+        let num_vectors_per_points = 1 + rnd.gen::<usize>() % 3;
+        for _ in 0..num_vectors_per_points {
+            let vec = random_vector(&mut rnd, dim);
+            let vec = match distance {
+                Distance::Cosine => {
+                    <CosineMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
+                }
+                Distance::Euclid => {
+                    <EuclidMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
+                }
+                Distance::Dot => {
+                    <DotProductMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
+                }
+                Distance::Manhattan => {
+                    <ManhattanMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
+                }
+            };
+            vectors.extend(vec);
+        }
+        let multivector = MultiDenseVectorInternal::new(vectors, dim);
+        let vec_ref = VectorRef::from(&multivector);
+        vector_storage
+            .insert_vector(i as PointOffsetType, vec_ref)
+            .unwrap();
+    }
+    vector_storage
+}
+
+fn create_vector_storage_u8_multi(
+    db: Arc<RwLock<DB>>,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+) -> VectorStorageEnum {
+    let mut rnd = StdRng::seed_from_u64(42);
+    let multivector_config = Default::default();
+    let mut vector_storage = open_simple_multi_dense_vector_storage_byte(
+        db,
+        DB_VECTOR_CF,
+        dim,
+        distance,
+        multivector_config,
+        &false.into(),
+    )
+    .unwrap();
+    for i in 0..num_vectors {
+        let mut vectors = vec![];
+        let num_vectors_per_points = 1 + rnd.gen::<usize>() % 3;
+        for _ in 0..num_vectors_per_points {
+            let vec = random_dense_byte_vector(&mut rnd, dim);
+            let vec = match distance {
+                Distance::Cosine => {
+                    <CosineMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
+                }
+                Distance::Euclid => {
+                    <EuclidMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
+                }
+                Distance::Dot => {
+                    <DotProductMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
+                }
+                Distance::Manhattan => {
+                    <ManhattanMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
+                }
+            };
+            vectors.extend(vec);
+        }
+        let multivector = MultiDenseVectorInternal::new(vectors, dim);
+        let vec_ref = VectorRef::from(&multivector);
+        vector_storage
+            .insert_vector(i as PointOffsetType, vec_ref)
+            .unwrap();
+    }
+    vector_storage
+}
+
+fn test_gpu_vector_storage_impl(
+    storage_type: TestStorageType,
+    num_vectors: usize,
+    dim: usize,
+    distance: Distance,
+    quantization_config: Option<QuantizationConfig>,
+    force_half_precision: bool,
+    precision: f32,
+) {
+    let test_point_id: PointOffsetType = 0;
+
+    let dir = tempfile::Builder::new().prefix("db_dir").tempdir().unwrap();
+    let storage = create_vector_storage(dir.path(), storage_type, num_vectors, dim, distance);
+
+    let quantized_vectors = quantization_config.as_ref().map(|quantization_config| {
+        QuantizedVectors::create(&storage, quantization_config, dir.path(), 1, &false.into())
+            .unwrap()
+    });
+
+    let debug_messenger = gpu::PanicIfErrorMessenger {};
+    let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+    let device = gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap();
+
+    let gpu_vector_storage = GpuVectorStorage::new(
+        device.clone(),
+        &storage,
+        quantized_vectors.as_ref(),
+        force_half_precision,
+        &false.into(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        gpu_vector_storage.element_type,
+        if let Some(_quantization_config) = quantization_config.as_ref() {
+            VectorStorageDatatype::Uint8
+        } else {
+            match storage_type.element_type() {
+                TestElementType::Float32 => {
+                    if force_half_precision {
+                        VectorStorageDatatype::Float16
+                    } else {
+                        VectorStorageDatatype::Float32
+                    }
+                }
+                TestElementType::Float16 => VectorStorageDatatype::Float16,
+                TestElementType::Uint8 => VectorStorageDatatype::Uint8,
+            }
+        }
+    );
+
+    let scores_buffer = gpu::Buffer::new(
+        device.clone(),
+        "Scores buffer",
+        gpu::BufferType::Storage,
+        num_vectors * std::mem::size_of::<f32>(),
+    )
+    .unwrap();
+
+    let descriptor_set_layout = gpu::DescriptorSetLayout::builder()
+        .add_storage_buffer(0)
+        .build(device.clone())
+        .unwrap();
+
+    let descriptor_set = gpu::DescriptorSet::builder(descriptor_set_layout.clone())
+        .add_storage_buffer(0, scores_buffer.clone())
+        .build()
+        .unwrap();
+
+    let shader = ShaderBuilder::new(device.clone())
+        .with_shader_code(include_str!("../shaders/tests/test_vector_storage.comp"))
+        .with_parameters(&gpu_vector_storage)
+        .build()
+        .unwrap();
+
+    let pipeline = gpu::Pipeline::builder()
+        .add_descriptor_set_layout(0, descriptor_set_layout.clone())
+        .add_descriptor_set_layout(1, gpu_vector_storage.descriptor_set_layout.clone())
+        .add_shader(shader.clone())
+        .build(device.clone())
+        .unwrap();
+
+    let mut context = gpu::Context::new(device.clone()).unwrap();
+    context
+        .bind_pipeline(
+            pipeline,
+            &[descriptor_set, gpu_vector_storage.descriptor_set.clone()],
+        )
+        .unwrap();
+    context.dispatch(num_vectors, 1, 1).unwrap();
+
+    let timer = std::time::Instant::now();
+    context.run().unwrap();
+    context.wait_finish(GPU_TIMEOUT).unwrap();
+    log::trace!("GPU scoring time = {:?}", timer.elapsed());
+
+    let staging_buffer = gpu::Buffer::new(
+        device.clone(),
+        "Scores staging buffer",
+        gpu::BufferType::GpuToCpu,
+        num_vectors * std::mem::size_of::<f32>(),
+    )
+    .unwrap();
+    context
+        .copy_gpu_buffer(
+            scores_buffer,
+            staging_buffer.clone(),
+            0,
+            0,
+            num_vectors * std::mem::size_of::<f32>(),
+        )
+        .unwrap();
+    context.run().unwrap();
+    context.wait_finish(GPU_TIMEOUT).unwrap();
+
+    let mut gpu_scores = vec![0.0f32; num_vectors];
+    staging_buffer.download_slice(&mut gpu_scores, 0).unwrap();
+
+    let stopped = false.into();
+    let point_deleted = BitVec::repeat(false, num_vectors);
+    let query = QueryVector::Nearest(storage.get_vector(test_point_id).to_owned());
+    let scorer: Box<dyn RawScorer> = if let Some(quantized_vectors) = quantized_vectors.as_ref() {
+        quantized_vectors
+            .raw_scorer(query, &point_deleted, &point_deleted, &stopped)
+            .unwrap()
+    } else {
+        new_raw_scorer(query, &storage, &point_deleted).unwrap()
+    };
+
+    for (point_id, gpu_score) in gpu_scores.iter().enumerate() {
+        let score = scorer.score_internal(
+            test_point_id as PointOffsetType,
+            point_id as PointOffsetType,
+        );
+        assert!((score - gpu_score).abs() < precision);
+    }
+
+    scorer.take_hardware_counter().discard_results();
+}

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -1,3 +1,5 @@
+//! Unit tests for GPU vector storage, covering f32, f16, u8 dense/multivectors with SQ, BQ, PQ.
+
 use std::path::Path;
 
 use bitvec::vec::BitVec;

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -1,0 +1,4 @@
+pub mod gpu_vector_storage;
+pub mod shader_builder;
+
+static GPU_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -1,4 +1,8 @@
 pub mod gpu_vector_storage;
 pub mod shader_builder;
 
+/// Each GPU operation has a timeout by Vulkan API specification.
+/// Choose large enough timeout.
+/// We cannot use too small timeout and check stopper in the loop because
+/// GPU resources should be alive while GPU operation is in progress.
 static GPU_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);

--- a/lib/segment/src/index/hnsw_index/gpu/shader_builder.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/shader_builder.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::common::operation_error::OperationResult;
+
+pub struct ShaderBuilder {
+    device: Arc<gpu::Device>,
+    shader_code: String,
+    includes: HashMap<String, String>,
+    defines: HashMap<String, Option<String>>,
+}
+
+pub trait ShaderBuilderParameters {
+    fn shader_includes(&self) -> HashMap<String, String>;
+    fn shader_defines(&self) -> HashMap<String, Option<String>>;
+}
+
+impl ShaderBuilder {
+    pub fn new(device: Arc<gpu::Device>) -> Self {
+        let includes = HashMap::from([
+            (
+                "common.comp".to_string(),
+                include_str!("shaders/common.comp").to_string(),
+            ),
+            (
+                "extensions.comp".to_string(),
+                include_str!("shaders/extensions.comp").to_string(),
+            ),
+        ]);
+
+        let mut defines = HashMap::new();
+        defines.insert(
+            "SUBGROUP_SIZE".to_owned(),
+            Some(device.subgroup_size().to_string()),
+        );
+
+        Self {
+            device,
+            shader_code: Default::default(),
+            includes,
+            defines,
+        }
+    }
+
+    pub fn with_parameters<T: ShaderBuilderParameters>(&mut self, parameters: &T) -> &mut Self {
+        self.includes.extend(parameters.shader_includes());
+        self.defines.extend(parameters.shader_defines());
+        self
+    }
+
+    pub fn with_shader_code(&mut self, shader_code: &str) -> &mut Self {
+        self.shader_code.push_str(shader_code);
+        self.shader_code.push('\n');
+        self
+    }
+
+    pub fn build(&self) -> OperationResult<Arc<gpu::Shader>> {
+        let timer = std::time::Instant::now();
+        let compiled = self.device.instance().compile_shader(
+            &self.shader_code,
+            Some(&self.defines),
+            Some(&self.includes),
+        )?;
+        log::debug!("Shader compilation took: {:?}", timer.elapsed());
+        Ok(gpu::Shader::new(self.device.clone(), &compiled)?)
+    }
+}

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/common.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/common.comp
@@ -1,0 +1,20 @@
+#ifndef COMMON_HEADER
+#define COMMON_HEADER
+
+#define SUBGROUP_ID (gl_GlobalInvocationID.x / SUBGROUP_SIZE)
+
+#define CONCAT(a, b) a##_##b
+
+const float positive_infinity = 1.0 / 0.0;
+const float negative_infinity = -1.0 / 0.0;
+#define UINT_MAX 0xffffffff
+
+#define POINT_ID uint
+const POINT_ID INVALID_POINT_ID = UINT_MAX;
+
+struct ScoredPoint {
+    POINT_ID id;
+    float score;
+};
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/extensions.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/extensions.comp
@@ -1,0 +1,13 @@
+#ifndef EXTENSIONS_HEADER
+#define EXTENSIONS_HEADER
+
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+#extension GL_KHR_shader_subgroup_shuffle : enable
+#extension GL_KHR_shader_subgroup_shuffle_relative : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_KHR_shader_subgroup_vote : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_vector_storage.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_vector_storage.comp
@@ -1,0 +1,22 @@
+#version 450
+
+#include "extensions.comp"
+
+#include "common.comp"
+layout(local_size_x = SUBGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
+
+#define VECTOR_STORAGE_LAYOUT_SET 1
+#include "vector_storage.comp"
+
+layout(set = 0, binding = 0) buffer ScoresData {
+    float data[];
+} scores;
+
+void main() {
+    uint idx = SUBGROUP_ID;
+    set_target(0);
+    float score = similarity(idx);
+    if (subgroupElect()) {
+        scores.data[idx] = score;
+    }
+}

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage.comp
@@ -1,0 +1,57 @@
+#ifndef VECTOR_STORAGE_HEADER
+#define VECTOR_STORAGE_HEADER
+
+#include "vector_storage_dense.comp"
+
+#ifdef MULTIVECTORS
+
+struct MultivectorOffset {
+    uint offset;
+    uint count;
+};
+
+layout(set = VECTOR_STORAGE_LAYOUT_SET, binding = MULTIVECTOR_OFFSETS_BINDING) \
+readonly buffer MultivectorOffsets { \
+    MultivectorOffset data[]; \
+} multivector_offsets;
+
+uint target_id;
+
+void set_target(uint point_id) {
+    target_id = point_id;
+}
+
+float similarity(uint point_id) {
+    MultivectorOffset offset_a = multivector_offsets.data[target_id];
+    MultivectorOffset offset_b = multivector_offsets.data[point_id];
+
+    float sum = 0.0;
+    for (uint a = 0; a < offset_a.count; a++) {
+        set_target_dense(offset_a.offset + a);
+        float max_sim = negative_infinity;
+
+        for (uint b = 0; b < offset_b.count; b++) {
+            float sim = similarity_dense(offset_b.offset + b);
+            if (sim > max_sim) {
+                max_sim = sim;
+            }
+        }
+
+        // sum of max similarity
+        sum += max_sim;
+    }
+    return sum;
+}
+
+#else
+
+void set_target(uint point_id) {
+    set_target_dense(point_id);
+}
+
+float similarity(uint point_id) {
+    return similarity_dense(point_id);
+}
+
+#endif
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_bq.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_bq.comp
@@ -1,0 +1,35 @@
+#ifndef VECTOR_STORAGE_BQ_HEADER
+#define VECTOR_STORAGE_BQ_HEADER
+
+// uint = 4 * uint8_t, vec4 analogue for BQ
+#define VECTOR_STORAGE_ELEMENT_TYPE uint
+#define VECTOR_STORAGE_SCORE_TYPE uint
+
+#define BITS_IN_UINT 32
+
+float bq_postprocess_score(uint result) {
+    float xor_product = float(subgroupAdd(result));
+    float zeros_count = float((DIM / ELEMENTS_PER_SUBGROUP) * BITS_IN_UINT) - xor_product;
+    return zeros_count - xor_product - BQ_SKIP_COUNT;
+}
+
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) \
+    bq_postprocess_score(RESULT)
+
+#ifdef COSINE_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) bitCount(a ^ b)
+#endif
+
+#ifdef DOT_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) bitCount(a ^ b)
+#endif
+
+#ifdef EUCLID_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) bitCount(a ^ b)
+#endif
+
+#ifdef MANHATTAN_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) bitCount(a ^ b)
+#endif
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_dense.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_dense.comp
@@ -1,0 +1,138 @@
+#ifndef VECTOR_STORAGE_DENSE_HEADER
+#define VECTOR_STORAGE_DENSE_HEADER
+
+#ifndef VECTOR_STORAGE_LAYOUT_SET
+#error "VECTOR_STORAGE_LAYOUT_SET not defined"
+#endif
+
+#include "common.comp"
+
+#define ELEMENTS_PER_SUBGROUP 4
+#define STORAGE(STORAGE_INDEX) CONCAT(vectors, STORAGE_INDEX)
+
+#define SUBGROUPS_COUNT_PER_VECTOR (DIM / (ELEMENTS_PER_SUBGROUP * SUBGROUP_SIZE))
+#if SUBGROUPS_COUNT_PER_VECTOR < 2
+// Define that describes that the whole vector is stored in a single subgroup.
+// For single subgroup vector we can avoid `for` loops.
+#define SINGLE_SUBGROUP_PER_VECTOR
+#endif
+
+#ifndef VECTOR_STORAGE_QUANTIZATION
+#ifdef VECTOR_STORAGE_ELEMENT_FLOAT32
+#include "vector_storage_f32.comp"
+#endif
+
+#ifdef VECTOR_STORAGE_ELEMENT_FLOAT16
+#include "vector_storage_f16.comp"
+#endif
+
+#ifdef VECTOR_STORAGE_ELEMENT_UINT8
+#include "vector_storage_u8.comp"
+#endif
+#endif
+
+#ifdef VECTOR_STORAGE_ELEMENT_PQ
+#include "vector_storage_pq.comp"
+#endif
+
+#ifdef VECTOR_STORAGE_ELEMENT_SQ
+#include "vector_storage_sq.comp"
+#endif
+
+#ifdef VECTOR_STORAGE_ELEMENT_BQ
+#include "vector_storage_bq.comp"
+#endif
+
+#define VECTOR_STORAGE_DEFINE(STORAGE_INDEX) \
+    layout(set = VECTOR_STORAGE_LAYOUT_SET, binding = STORAGE_INDEX) \
+    readonly buffer CONCAT(Vectors, STORAGE_INDEX) { \
+        VECTOR_STORAGE_ELEMENT_TYPE data[]; \
+    } STORAGE(STORAGE_INDEX);
+
+VECTOR_STORAGE_DEFINE(0)
+VECTOR_STORAGE_DEFINE(1)
+VECTOR_STORAGE_DEFINE(2)
+VECTOR_STORAGE_DEFINE(3)
+
+#ifdef SINGLE_SUBGROUP_PER_VECTOR
+
+#define VECTOR_STORAGE_SCORE_SUBGROUP(STORAGE_INDEX) \
+    result += VECTOR_STORAGE_SCORE_ELEMENT( \
+        STORAGE(STORAGE_INDEX).data[index], \
+        target_cache \
+    );
+
+#define VECTOR_STORAGE_SET_TARGET(STORAGE_INDEX) \
+    target_cache = STORAGE(STORAGE_INDEX).data[index];
+
+VECTOR_STORAGE_ELEMENT_TYPE target_cache;
+
+#else
+
+#define VECTOR_STORAGE_SCORE_SUBGROUP(STORAGE_INDEX) \
+    for (uint i = 0; i < SUBGROUPS_COUNT_PER_VECTOR; i++, index += SUBGROUP_SIZE) { \
+        result += VECTOR_STORAGE_SCORE_ELEMENT( \
+            STORAGE(STORAGE_INDEX).data[index], \
+            target_cache[i] \
+        ); \
+    }
+
+#define VECTOR_STORAGE_SET_TARGET(STORAGE_INDEX) \
+    for (uint i = 0; i < SUBGROUPS_COUNT_PER_VECTOR; i++, index += SUBGROUP_SIZE) { \
+        target_cache[i] = STORAGE(STORAGE_INDEX).data[index]; \
+    }
+
+VECTOR_STORAGE_ELEMENT_TYPE target_cache[SUBGROUPS_COUNT_PER_VECTOR];
+
+#endif
+
+void set_target_dense(uint point_id) {
+    uint index = (point_id / STORAGES_COUNT) * (DIM / ELEMENTS_PER_SUBGROUP) + gl_SubgroupInvocationID;
+    uint storage_index = point_id % STORAGES_COUNT;
+    switch (storage_index) {
+    case 0:
+        VECTOR_STORAGE_SET_TARGET(0);
+        break;
+    case 1:
+        VECTOR_STORAGE_SET_TARGET(1);
+        break;
+    case 2:
+        VECTOR_STORAGE_SET_TARGET(2);
+        break;
+    case 3:
+        VECTOR_STORAGE_SET_TARGET(3);
+        break;
+    }
+
+#ifdef VECTOR_STORAGE_POSTPROCESS_SET_TARGET
+    VECTOR_STORAGE_POSTPROCESS_SET_TARGET();
+#endif
+}
+
+float similarity_dense(uint point_id) {
+#ifdef VECTOR_STORAGE_PREPROCESS
+    VECTOR_STORAGE_PREPROCESS();
+#endif
+
+    VECTOR_STORAGE_SCORE_TYPE result = 0;
+    uint index = (point_id / STORAGES_COUNT) * (DIM / ELEMENTS_PER_SUBGROUP) + gl_SubgroupInvocationID;
+    uint storage_index = point_id % STORAGES_COUNT;
+    switch (storage_index) {
+    case 0:
+        VECTOR_STORAGE_SCORE_SUBGROUP(0);
+        break;
+    case 1:
+        VECTOR_STORAGE_SCORE_SUBGROUP(1);
+        break;
+    case 2:
+        VECTOR_STORAGE_SCORE_SUBGROUP(2);
+        break;
+    case 3:
+        VECTOR_STORAGE_SCORE_SUBGROUP(3);
+        break;
+    }
+
+    return VECTOR_STORAGE_POSTPROCESS_SCORE(result);
+}
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_f16.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_f16.comp
@@ -1,0 +1,32 @@
+#ifndef VECTOR_STORAGE_F16_HEADER
+#define VECTOR_STORAGE_F16_HEADER
+
+#define VECTOR_STORAGE_ELEMENT_TYPE f16vec4
+#define VECTOR_STORAGE_SCORE_TYPE float
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) subgroupAdd(RESULT)
+
+#ifdef COSINE_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot(a, b)
+#endif
+
+#ifdef DOT_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot(a, b)
+#endif
+
+#ifdef EUCLID_DISTANCE
+float euclid_metric_f16(f16vec4 v1, f16vec4 v2) {
+    f16vec4 v = v1 - v2;
+    return float(-v.x * v.x - v.y * v.y - v.z * v.z - v.w * v.w);
+}
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) euclid_metric_f16(a, b)
+#endif
+
+#ifdef MANHATTAN_DISTANCE
+float manhattan_metric_f16(f16vec4 v1, f16vec4 v2) {
+    f16vec4 v = abs(v1 - v2);
+    return float(-v.x - v.y - v.z - v.w);
+}
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) manhattan_metric_f16(a, b)
+#endif
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_f32.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_f32.comp
@@ -1,0 +1,32 @@
+#ifndef VECTOR_STORAGE_F32_HEADER
+#define VECTOR_STORAGE_F32_HEADER
+
+#define VECTOR_STORAGE_ELEMENT_TYPE vec4
+#define VECTOR_STORAGE_SCORE_TYPE float
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) subgroupAdd(RESULT)
+
+#ifdef COSINE_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot(a, b)
+#endif
+
+#ifdef DOT_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot(a, b)
+#endif
+
+#ifdef EUCLID_DISTANCE
+float euclid_metric_f32(vec4 v1, vec4 v2) {
+    vec4 v = v1 - v2;
+    return -v.x * v.x - v.y * v.y - v.z * v.z - v.w * v.w;
+}
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) euclid_metric_f32(a, b)
+#endif
+
+#ifdef MANHATTAN_DISTANCE
+float manhattan_metric_f32(vec4 v1, vec4 v2) {
+    vec4 v = abs(v1 - v2);
+    return -v.x - v.y - v.z - v.w;
+}
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) manhattan_metric_f32(a, b)
+#endif
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_pq.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_pq.comp
@@ -1,0 +1,61 @@
+#ifndef VECTOR_STORAGE_PQ_HEADER
+#define VECTOR_STORAGE_PQ_HEADER
+
+struct PQRange {
+    uint start;
+    uint end;
+};
+
+layout(set = VECTOR_STORAGE_LAYOUT_SET, binding = VECTOR_STORAGE_PQ_CENTROIDS_BINDING) \
+readonly buffer Centroids { \
+    float data[]; \
+} centroids;
+
+layout(set = VECTOR_STORAGE_LAYOUT_SET, binding = VECTOR_STORAGE_PQ_DIVISIONS_BINDING) \
+readonly buffer VectorDivisions { \
+    PQRange data[]; \
+} vector_divisions;
+
+#define VECTOR_STORAGE_ELEMENT_TYPE u8vec4
+#define VECTOR_STORAGE_SCORE_TYPE float
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) subgroupAdd(RESULT)
+
+float score_pq(u8vec4 a, u8vec4 b, uint i) {
+    float score = 0.0;
+    uint index = i * 4;
+    uint max_index = min(index + 4, PQ_DIVISIONS_COUNT);
+    for (; index < max_index; index++) {
+        uint c_a = a[index % 4] * PQ_CENTROIDS_DIM;
+        uint c_b = b[index % 4] * PQ_CENTROIDS_DIM;
+        PQRange range = vector_divisions.data[index];
+        for (uint j = range.start; j < range.end; j++) {
+            float data_a = centroids.data[c_a + j];
+            float data_b = centroids.data[c_b + j];
+
+#ifdef COSINE_DISTANCE
+            score += data_a * data_b;
+#endif
+
+#ifdef DOT_DISTANCE
+            score += data_a * data_b;
+#endif
+
+#ifdef EUCLID_DISTANCE
+            score -= (data_a - data_b) * (data_a - data_b);
+#endif
+
+#ifdef MANHATTAN_DISTANCE
+            score -= abs(data_a - data_b);
+#endif
+        }
+    }
+    return score;
+}
+
+#ifdef SINGLE_SUBGROUP_PER_VECTOR
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) score_pq(a, b, gl_SubgroupInvocationID)
+#else
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) score_pq(a, b, i * SUBGROUP_SIZE + gl_SubgroupInvocationID) 
+#endif
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_sq.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_sq.comp
@@ -1,0 +1,51 @@
+#ifndef VECTOR_STORAGE_SQ_HEADER
+#define VECTOR_STORAGE_SQ_HEADER
+
+layout(set = VECTOR_STORAGE_LAYOUT_SET, binding = VECTOR_STORAGE_SQ_OFFSETS_BINDING) \
+readonly buffer VectorOffsets { \
+    float data[]; \
+} vector_offsets;
+
+float target_offset;
+
+uint dot_u8vec4(u8vec4 a, u8vec4 b) {
+    uvec4 sum = uvec4(a) * uvec4(b);
+    return sum.x + sum.y + sum.z + sum.w;
+}
+
+#define VECTOR_STORAGE_ELEMENT_TYPE u8vec4
+#define VECTOR_STORAGE_SCORE_TYPE uint
+#define VECTOR_STORAGE_POSTPROCESS_SET_TARGET() \
+    target_offset = vector_offsets.data[point_id]
+
+float sq_postprocess_score(VECTOR_STORAGE_SCORE_TYPE result, POINT_ID point_id, float target_offset) {
+    float sq_offset = target_offset + vector_offsets.data[point_id] - SQ_DIFF;
+    return SQ_MULTIPLIER * float(subgroupAdd(result)) + sq_offset;
+}
+
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) \
+    sq_postprocess_score(RESULT, point_id, target_offset);
+
+#ifdef COSINE_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot_u8vec4(a, b)
+#endif
+
+#ifdef DOT_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot_u8vec4(a, b)
+#endif
+
+#ifdef EUCLID_DISTANCE
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot_u8vec4(a, b)
+#endif
+
+#ifdef MANHATTAN_DISTANCE
+
+VECTOR_STORAGE_SCORE_TYPE manhattan_u8vec4(u8vec4 a, u8vec4 b) {
+    ivec4 diff = ivec4(a) - ivec4(b);
+    return abs(diff.x) + abs(diff.y) + abs(diff.z) + abs(diff.w);
+}
+
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) manhattan_u8vec4(a, b)
+#endif
+
+#endif

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_u8.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/vector_storage_u8.comp
@@ -1,0 +1,76 @@
+#ifndef VECTOR_STORAGE_U8_HEADER
+#define VECTOR_STORAGE_U8_HEADER
+
+#define VECTOR_STORAGE_ELEMENT_TYPE u8vec4
+#define VECTOR_STORAGE_SCORE_TYPE uint
+
+#ifdef COSINE_DISTANCE
+
+uint dot_u8vec4(u8vec4 a, u8vec4 b, in out uint vector1Len, in out uint vector2Len) {
+    uvec4 square1 = uvec4(a) * uvec4(a);
+    vector1Len += square1.x + square1.y + square1.z + square1.w;
+
+    uvec4 square2 = uvec4(b) * uvec4(b);
+    vector2Len += square2.x + square2.y + square2.z + square2.w;
+
+    uvec4 mul = uvec4(a) * uvec4(b);
+    return mul.x + mul.y + mul.z + mul.w;
+}
+
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot_u8vec4(a, b, vector1Len, vector2Len)
+
+float u8_postprocess_cosine_score(float result, uint vector1Len, uint vector2Len) {
+    float len1 = float(subgroupAdd(vector1Len));
+    float len2 = float(subgroupAdd(vector2Len));
+    if (len1 > 0 && len2 > 0) {
+        return float(subgroupAdd(result)) / sqrt(len1 * len2);
+    } else {
+        return 0;
+    }
+}
+
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) \
+    u8_postprocess_cosine_score(RESULT, vector1Len, vector2Len)
+
+#define VECTOR_STORAGE_PREPROCESS() \
+    uint vector1Len = 0; \
+    uint vector2Len = 0;
+
+#endif
+
+#ifdef DOT_DISTANCE
+
+uint dot_u8vec4(u8vec4 a, u8vec4 b) {
+    uvec4 mul = uvec4(a) * uvec4(b);
+    return mul.x + mul.y + mul.z + mul.w;
+}
+
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) dot_u8vec4(a, b)
+
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) float(subgroupAdd(RESULT))
+
+#endif
+
+#ifdef EUCLID_DISTANCE
+
+uint euclid_u8vec4(u8vec4 v1, u8vec4 v2) {
+    ivec4 v = ivec4(v1) - ivec4(v2);
+    return uint(v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w);
+}
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) euclid_u8vec4(a, b)
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) -float(subgroupAdd(RESULT))
+
+#endif
+
+#ifdef MANHATTAN_DISTANCE
+uint manhattan_u8vec4(u8vec4 v1, u8vec4 v2) {
+    ivec4 v = abs(ivec4(v1) - ivec4(v2));
+    return uint(v.x + v.y + v.z + v.w);
+}
+
+#define VECTOR_STORAGE_SCORE_ELEMENT(a, b) manhattan_u8vec4(a, b)
+#define VECTOR_STORAGE_POSTPROCESS_SCORE(RESULT) -float(subgroupAdd(RESULT))
+
+#endif
+
+#endif

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -11,6 +11,9 @@ pub mod hnsw;
 pub mod point_scorer;
 mod search_context;
 
+#[cfg(feature = "gpu")]
+pub mod gpu;
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -26,6 +26,12 @@ pub trait MultivectorOffsetsStorage: Sized {
     fn save(&self, path: &Path) -> OperationResult<()>;
 
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset;
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl MultivectorOffsetsStorage for Vec<MultivectorOffset> {
@@ -47,6 +53,10 @@ impl MultivectorOffsetsStorage for Vec<MultivectorOffset> {
 
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         self[idx as usize]
+    }
+
+    fn len(&self) -> usize {
+        self.len()
     }
 }
 
@@ -82,6 +92,10 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
 
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         self.offsets[idx as usize]
+    }
+
+    fn len(&self) -> usize {
+        self.offsets.len()
     }
 }
 
@@ -200,6 +214,18 @@ where
             sum += max_sim;
         }
         sum
+    }
+
+    pub fn inner_storage(&self) -> &QuantizedStorage {
+        &self.quantized_storage
+    }
+
+    pub fn inner_vector_offset(&self, id: PointOffsetType) -> MultivectorOffset {
+        self.offsets.get_offset(id)
+    }
+
+    pub fn vectors_count(&self) -> usize {
+        self.offsets.len()
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -932,4 +932,8 @@ impl QuantizedVectors {
             CompressionRatio::X64 => 16,
         }
     }
+
+    pub fn get_storage(&self) -> &QuantizedVectorStorage {
+        &self.storage_impl
+    }
 }


### PR DESCRIPTION
This PR introduced GPU storing and scoring of vectors. It supports dense vectors with `f32, f16, u8` type, SQ/BQ/PQ + multivectors for all types and quantization.

I marker in the comments all pieces of changes that are not under GPU-feature.