### PR TITLE
Draft: don't kill replicas with precondition failure if active

### DIFF
--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -471,7 +471,14 @@ impl ShardReplicaSet {
 
             // Handle a special case where transfer receiver is not in the expected replica state yet.
             // Data consistency will be handled by the shard transfer and the associated proxies.
-            if peer_state.is_partial_or_recovery() && err.is_pre_condition_failed() {
+            if err.is_pre_condition_failed() {
+                if !peer_state.is_partial_or_recovery() {
+                    log::warn!(
+                        "Precondition failure on peer {peer_id} replica {}/{} while not in transfer, replica states may temporarily be out of sync",
+                        self.collection_id,
+                        self.shard_id,
+                    );
+                }
                 continue;
             }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -473,6 +473,8 @@ impl ShardReplicaSet {
             // Data consistency will be handled by the shard transfer and the associated proxies.
             if err.is_pre_condition_failed() {
                 if !peer_state.is_partial_or_recovery() {
+                    // TODO: this replica is now inconsistent. We must ensure it's undergoing a
+                    // shard transfer to become consistent again.
                     log::warn!(
                         "Precondition failure on peer {peer_id} replica {}/{} while not in transfer, replica states may temporarily be out of sync",
                         self.collection_id,


### PR DESCRIPTION
_WIP_

Prevent killing replicas for which we get a precondition failure while they're active. 

Even though our peer might still think the replica should be active, it may already have been switched into a different state for a shard transfer on the remote.

### Problems:
This still prevents killing the replica even if we never switch into a different replica state. As far as I understand this is undesirable. This replica is now inconsistent and must undergo a transfer to become consistent again.

We might need to fetch the current replica state from the remote to confirm it is undergoing a transfer. Alternatively we may include this state in the returned error.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
