### PR TITLE
Fix killing replicas too earily on state switches

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -39,7 +39,9 @@ use crate::shards::channel_service::ChannelService;
 use crate::shards::collection_shard_distribution::CollectionShardDistribution;
 use crate::shards::local_shard::clock_map::RecoveryPoint;
 use crate::shards::replica_set::ReplicaState::{Active, Dead, Initializing, Listener};
-use crate::shards::replica_set::{ChangePeerState, ReplicaState, ShardReplicaSet};
+use crate::shards::replica_set::{
+    ChangePeerFromState, ChangePeerState, ReplicaState, ShardReplicaSet,
+};
 use crate::shards::resharding::tasks_pool::ReshardTasksPool;
 use crate::shards::resharding::ReshardKey;
 use crate::shards::shard::{PeerId, ShardId};
@@ -65,7 +67,7 @@ pub struct Collection {
     transfer_tasks: Mutex<TransferTasksPool>,
     reshard_tasks: Mutex<ReshardTasksPool>,
     request_shard_transfer_cb: RequestShardTransfer,
-    notify_peer_failure_cb: ChangePeerState,
+    notify_peer_failure_cb: ChangePeerFromState,
     abort_shard_transfer_cb: replica_set::AbortShardTransfer,
     init_time: Duration,
     // One-way boolean flag that is set to true when the collection is fully initialized
@@ -98,7 +100,7 @@ impl Collection {
         shared_storage_config: Arc<SharedStorageConfig>,
         shard_distribution: CollectionShardDistribution,
         channel_service: ChannelService,
-        on_replica_failure: ChangePeerState,
+        on_replica_failure: ChangePeerFromState,
         request_shard_transfer: RequestShardTransfer,
         abort_shard_transfer: replica_set::AbortShardTransfer,
         search_runtime: Option<Handle>,
@@ -185,7 +187,7 @@ impl Collection {
         snapshots_path: &Path,
         shared_storage_config: Arc<SharedStorageConfig>,
         channel_service: ChannelService,
-        on_replica_failure: replica_set::ChangePeerState,
+        on_replica_failure: replica_set::ChangePeerFromState,
         request_shard_transfer: RequestShardTransfer,
         abort_shard_transfer: replica_set::AbortShardTransfer,
         search_runtime: Option<Handle>,

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -258,7 +258,7 @@ mod test {
     use crate::optimizers_builder::OptimizersConfig;
     use crate::shards::channel_service::ChannelService;
     use crate::shards::collection_shard_distribution::CollectionShardDistribution;
-    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState};
+    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 
     const UNINDEXED_KEY: &str = "key";
     const INDEXED_KEY: &str = "num";
@@ -457,8 +457,8 @@ mod test {
         collection
     }
 
-    pub fn dummy_on_replica_failure() -> ChangePeerState {
-        Arc::new(move |_peer_id, _shard_id| {})
+    pub fn dummy_on_replica_failure() -> ChangePeerFromState {
+        Arc::new(move |_peer_id, _shard_id, _from_state| {})
     }
 
     pub fn dummy_request_shard_transfer() -> RequestShardTransfer {

--- a/lib/collection/src/shards/replica_set/locally_disabled_peers.rs
+++ b/lib/collection/src/shards/replica_set/locally_disabled_peers.rs
@@ -2,11 +2,17 @@ use std::cmp;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+use super::ReplicaState;
 use crate::shards::shard::PeerId;
 
 #[derive(Clone, Debug, Default)]
 pub struct Registry {
-    locally_disabled_peers: HashMap<PeerId, Backoff>,
+    /// List of disabled peer IDs and a backoff to prevent spamming consensus.
+    ///
+    /// Each peer optionally specifies what state it was in when it was disabled. They're send
+    /// along with the consensus proposal and prevents accidentally killing replicas if the current
+    /// peer is slow to catch up with consensus.
+    locally_disabled_peers: HashMap<PeerId, (Backoff, Option<ReplicaState>)>,
 }
 
 impl Registry {
@@ -24,11 +30,20 @@ impl Registry {
         self.locally_disabled_peers.entry(peer_id).or_default();
     }
 
-    pub fn disable_peer_and_notify_if_elapsed(&mut self, peer_id: PeerId) -> bool {
-        self.locally_disabled_peers
+    pub fn disable_peer_and_notify_if_elapsed(
+        &mut self,
+        peer_id: PeerId,
+        from_state: Option<ReplicaState>,
+    ) -> bool {
+        let (backoff, _from_state) = self
+            .locally_disabled_peers
             .entry(peer_id)
-            .or_default()
-            .retry_if_elapsed()
+            // Update from state if changed on already disabled peers
+            .and_modify(|(_backoff, value_from_state)| {
+                *value_from_state = from_state;
+            })
+            .or_insert_with(|| (Backoff::default(), from_state));
+        backoff.retry_if_elapsed()
     }
 
     pub fn enable_peer(&mut self, peer_id: PeerId) {
@@ -39,15 +54,11 @@ impl Registry {
         self.locally_disabled_peers.clear();
     }
 
-    pub fn notify_elapsed(&mut self) -> impl Iterator<Item = PeerId> + '_ {
+    pub fn notify_elapsed(&mut self) -> impl Iterator<Item = (PeerId, Option<ReplicaState>)> + '_ {
         self.locally_disabled_peers
             .iter_mut()
-            .filter_map(|(&peer_id, backoff)| {
-                if backoff.retry_if_elapsed() {
-                    Some(peer_id)
-                } else {
-                    None
-                }
+            .filter_map(|(&peer_id, (backoff, from_state))| {
+                backoff.retry_if_elapsed().then_some((peer_id, *from_state))
             })
     }
 }

--- a/lib/collection/src/shards/replica_set/locally_disabled_peers.rs
+++ b/lib/collection/src/shards/replica_set/locally_disabled_peers.rs
@@ -12,6 +12,7 @@ pub struct Registry {
     /// Each peer optionally specifies what state it was in when it was disabled. They're send
     /// along with the consensus proposal and prevents accidentally killing replicas if the current
     /// peer is slow to catch up with consensus.
+    /// See: <https://github.com/qdrant/qdrant/pull/5343>
     locally_disabled_peers: HashMap<PeerId, (Backoff, Option<ReplicaState>)>,
 }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -94,7 +94,7 @@ pub struct ShardReplicaSet {
     locally_disabled_peers: parking_lot::RwLock<locally_disabled_peers::Registry>,
     pub(crate) shard_path: PathBuf,
     pub(crate) shard_id: ShardId,
-    notify_peer_failure_cb: ChangePeerState,
+    notify_peer_failure_cb: ChangePeerFromState,
     abort_shard_transfer_cb: AbortShardTransfer,
     channel_service: ChannelService,
     collection_id: CollectionId,
@@ -113,6 +113,7 @@ pub struct ShardReplicaSet {
 
 pub type AbortShardTransfer = Arc<dyn Fn(ShardTransfer, &str) + Send + Sync>;
 pub type ChangePeerState = Arc<dyn Fn(PeerId, ShardId) + Send + Sync>;
+pub type ChangePeerFromState = Arc<dyn Fn(PeerId, ShardId, Option<ReplicaState>) + Send + Sync>;
 
 const REPLICA_STATE_FILE: &str = "replica_state.json";
 
@@ -125,7 +126,7 @@ impl ShardReplicaSet {
         this_peer_id: PeerId,
         local: bool,
         remotes: HashSet<PeerId>,
-        on_peer_failure: ChangePeerState,
+        on_peer_failure: ChangePeerFromState,
         abort_shard_transfer: AbortShardTransfer,
         collection_path: &Path,
         collection_config: Arc<RwLock<CollectionConfig>>,
@@ -222,7 +223,7 @@ impl ShardReplicaSet {
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         channel_service: ChannelService,
-        on_peer_failure: ChangePeerState,
+        on_peer_failure: ChangePeerFromState,
         abort_shard_transfer: AbortShardTransfer,
         this_peer_id: PeerId,
         update_runtime: Handle,
@@ -686,7 +687,7 @@ impl ShardReplicaSet {
                         // No way we can provide up-to-date replica right away at this point,
                         // so we report a failure to consensus
                         self.set_local(local_shard, Some(state)).await?;
-                        self.notify_peer_failure(peer_id);
+                        self.notify_peer_failure(peer_id, Some(state));
                     }
 
                     ReplicaState::Dead
@@ -735,16 +736,16 @@ impl ShardReplicaSet {
             .notify_elapsed()
             .collect();
 
-        for failed_peer in peers_to_notify {
+        for (failed_peer_id, from_state) in peers_to_notify {
             // TODO: Only `notify_peer_failure` if `failed_peer` is *not* the last `Active` peer? 🤔
-            self.notify_peer_failure(failed_peer);
+            self.notify_peer_failure(failed_peer_id, from_state);
 
-            for transfer in get_shard_transfers(self.shard_id, failed_peer) {
+            for transfer in get_shard_transfers(self.shard_id, failed_peer_id) {
                 self.abort_shard_transfer(
                     transfer,
                     &format!(
-                        "{failed_peer}/{}:{} replica failed",
-                        self.collection_id, self.shard_id
+                        "{failed_peer_id}/{}:{} replica failed",
+                        self.collection_id, self.shard_id,
                     ),
                 );
             }
@@ -901,7 +902,15 @@ impl ShardReplicaSet {
     /// Disables the peer and notifies consensus periodically.
     ///
     /// Prevents disabling the last peer (according to consensus).
-    fn add_locally_disabled(&self, state: &ReplicaSetState, peer_id: PeerId) {
+    ///
+    /// If `from_state` is given, the peer will only be disabled if the given state matches
+    /// consensus.
+    fn add_locally_disabled(
+        &self,
+        state: &ReplicaSetState,
+        peer_id: PeerId,
+        from_state: Option<ReplicaState>,
+    ) {
         let other_peers = state
             .active_or_resharding_peers()
             .filter(|id| id != &peer_id);
@@ -919,8 +928,8 @@ impl ShardReplicaSet {
         }
 
         locally_disabled_peers_guard.with_upgraded(|locally_disabled_peers| {
-            if locally_disabled_peers.disable_peer_and_notify_if_elapsed(peer_id) {
-                self.notify_peer_failure(peer_id);
+            if locally_disabled_peers.disable_peer_and_notify_if_elapsed(peer_id, from_state) {
+                self.notify_peer_failure(peer_id, from_state);
             }
         });
     }
@@ -940,9 +949,9 @@ impl ShardReplicaSet {
         }
     }
 
-    fn notify_peer_failure(&self, peer_id: PeerId) {
+    fn notify_peer_failure(&self, peer_id: PeerId, from_state: Option<ReplicaState>) {
         log::debug!("Notify peer failure: {}", peer_id);
-        self.notify_peer_failure_cb.deref()(peer_id, self.shard_id)
+        self.notify_peer_failure_cb.deref()(peer_id, self.shard_id, from_state)
     }
 
     fn abort_shard_transfer(&self, transfer: ShardTransfer, reason: &str) {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -737,7 +737,6 @@ impl ShardReplicaSet {
             .collect();
 
         for (failed_peer_id, from_state) in peers_to_notify {
-            // TODO: Only `notify_peer_failure` if `failed_peer` is *not* the last `Active` peer? 🤔
             self.notify_peer_failure(failed_peer_id, from_state);
 
             for transfer in get_shard_transfers(self.shard_id, failed_peer_id) {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -368,7 +368,7 @@ impl ShardReplicaSet {
     }
 
     pub fn peer_state(&self, peer_id: PeerId) -> Option<ReplicaState> {
-        self.replica_state.read().get_peer_state(peer_id).copied()
+        self.replica_state.read().get_peer_state(peer_id)
     }
 
     /// List the peer IDs on which this shard is active, both the local and remote peers.
@@ -418,7 +418,7 @@ impl ShardReplicaSet {
     ) -> CollectionResult<()> {
         self.wait_for(
             move |replica_set_state| {
-                replica_set_state.get_peer_state(replica_set_state.this_peer_id) == Some(&state)
+                replica_set_state.get_peer_state(replica_set_state.this_peer_id) == Some(state)
             },
             timeout,
         )
@@ -439,7 +439,7 @@ impl ShardReplicaSet {
         timeout: Duration,
     ) -> CollectionResult<()> {
         self.wait_for(
-            move |replica_set_state| replica_set_state.get_peer_state(peer_id) == Some(&state),
+            move |replica_set_state| replica_set_state.get_peer_state(peer_id) == Some(state),
             timeout,
         )
         .await
@@ -1015,8 +1015,8 @@ pub struct ReplicaSetState {
 }
 
 impl ReplicaSetState {
-    pub fn get_peer_state(&self, peer_id: PeerId) -> Option<&ReplicaState> {
-        self.peers.get(&peer_id)
+    pub fn get_peer_state(&self, peer_id: PeerId) -> Option<ReplicaState> {
+        self.peers.get(&peer_id).copied()
     }
 
     pub fn set_peer_state(&mut self, peer_id: PeerId, state: ReplicaState) {

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -148,10 +148,14 @@ impl ShardReplicaSet {
                     let notify = self
                         .locally_disabled_peers
                         .write()
-                        .disable_peer_and_notify_if_elapsed(self.this_peer_id());
+                        .disable_peer_and_notify_if_elapsed(self.this_peer_id(), None);
 
                     if notify {
-                        self.notify_peer_failure_cb.deref()(self.this_peer_id(), self.shard_id);
+                        self.notify_peer_failure_cb.deref()(
+                            self.this_peer_id(),
+                            self.shard_id,
+                            None,
+                        );
                     }
                 }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -100,7 +100,9 @@ impl ShardReplicaSet {
                 .map_err(|err| {
                     if err.is_transient() {
                         // Deactivate the peer if forwarding failed with transient error
-                        self.add_locally_disabled(&self.replica_state.read(), leader_peer, None);
+                        let replica_state = self.replica_state.read();
+                        let from_state = replica_state.get_peer_state(&leader_peer).cloned();
+                        self.add_locally_disabled(&replica_state, leader_peer, from_state);
 
                         // Return service error
                         CollectionError::service_error(format!(

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -550,7 +550,7 @@ mod tests {
     use crate::operations::vector_params_builder::VectorParamsBuilder;
     use crate::optimizers_builder::OptimizersConfig;
     use crate::save_on_disk::SaveOnDisk;
-    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState};
+    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 
     #[tokio::test]
     async fn test_highest_replica_peer_id() {
@@ -637,8 +637,8 @@ mod tests {
         .unwrap()
     }
 
-    fn dummy_on_replica_failure() -> ChangePeerState {
-        Arc::new(move |_peer_id, _shard_id| {})
+    fn dummy_on_replica_failure() -> ChangePeerFromState {
+        Arc::new(move |_peer_id, _shard_id, _from_state| {})
     }
 
     fn dummy_abort_shard_transfer() -> AbortShardTransfer {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -493,7 +493,11 @@ impl ShardReplicaSet {
                 self.shard_id
             );
 
-            self.add_locally_disabled(state, *peer_id, Some(peer_state));
+            // Deactivate replica in consensus if it matches the state we expect
+            // Always deactivate the replica if its in a shard trnasfer related state
+            let from_state = Some(peer_state).filter(|state| !state.is_partial_or_recovery());
+
+            self.add_locally_disabled(state, *peer_id, from_state);
         }
 
         wait_for_deactivation

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -101,7 +101,7 @@ impl ShardReplicaSet {
                     if err.is_transient() {
                         // Deactivate the peer if forwarding failed with transient error
                         let replica_state = self.replica_state.read();
-                        let from_state = replica_state.get_peer_state(&leader_peer).cloned();
+                        let from_state = replica_state.get_peer_state(leader_peer);
                         self.add_locally_disabled(&replica_state, leader_peer, from_state);
 
                         // Return service error
@@ -456,7 +456,7 @@ impl ShardReplicaSet {
                 self.shard_id,
             );
 
-            let Some(&peer_state) = state.get_peer_state(*peer_id) else {
+            let Some(peer_state) = state.get_peer_state(*peer_id) else {
                 continue;
             };
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -494,7 +494,7 @@ impl ShardReplicaSet {
             );
 
             // Deactivate replica in consensus if it matches the state we expect
-            // Always deactivate the replica if its in a shard trnasfer related state
+            // Always deactivate the replica if its in a shard transfer related state
             let from_state = Some(peer_state).filter(|state| !state.is_partial_or_recovery());
 
             self.add_locally_disabled(state, *peer_id, from_state);

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -490,7 +490,7 @@ impl ShardReplicaSet {
             log::debug!(
                 "Deactivating peer {peer_id} because of failed update of shard {}:{}",
                 self.collection_id,
-                self.shard_id
+                self.shard_id,
             );
 
             // Deactivate replica in consensus if it matches the state we expect

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -100,7 +100,7 @@ impl ShardReplicaSet {
                 .map_err(|err| {
                     if err.is_transient() {
                         // Deactivate the peer if forwarding failed with transient error
-                        self.add_locally_disabled(&self.replica_state.read(), leader_peer);
+                        self.add_locally_disabled(&self.replica_state.read(), leader_peer, None);
 
                         // Return service error
                         CollectionError::service_error(format!(
@@ -493,7 +493,7 @@ impl ShardReplicaSet {
                 self.shard_id
             );
 
-            self.add_locally_disabled(state, *peer_id);
+            self.add_locally_disabled(state, *peer_id, Some(peer_state));
         }
 
         wait_for_deactivation

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -18,7 +18,7 @@ use tokio::sync::{broadcast, OwnedRwLockReadGuard, RwLock};
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tokio_util::io::SyncIoBridge;
 
-use super::replica_set::AbortShardTransfer;
+use super::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use super::resharding::tasks_pool::ReshardTasksPool;
 use super::resharding::{ReshardStage, ReshardState};
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
@@ -38,7 +38,7 @@ use crate::optimizers_builder::OptimizersConfig;
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::local_shard::LocalShard;
-use crate::shards::replica_set::{ChangePeerState, ReplicaState, ShardReplicaSet}; // TODO rename ReplicaShard to ReplicaSetShard
+use crate::shards::replica_set::{ReplicaState, ShardReplicaSet};
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{ShardConfig, ShardType};
 use crate::shards::shard_versioning::latest_shard_paths;
@@ -569,7 +569,7 @@ impl ShardHolder {
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         channel_service: ChannelService,
-        on_peer_failure: ChangePeerState,
+        on_peer_failure: ChangePeerFromState,
         abort_shard_transfer: AbortShardTransfer,
         this_peer_id: PeerId,
         update_runtime: Handle,

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -81,7 +81,7 @@ async fn fixture() -> Collection {
         storage_config.clone(),
         CollectionShardDistribution { shards },
         ChannelService::default(),
-        dummy_on_replica_failure(),
+        dummy_on_replica_failure_from(),
         dummy_request_shard_transfer(),
         dummy_abort_shard_transfer(),
         None,

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -29,7 +29,7 @@ use crate::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::collection_shard_distribution::CollectionShardDistribution;
-use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState, ReplicaState};
+use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState, ReplicaState};
 use crate::shards::shard::{PeerId, ShardId};
 
 const DIM: u64 = 4;
@@ -81,7 +81,7 @@ async fn fixture() -> Collection {
         storage_config.clone(),
         CollectionShardDistribution { shards },
         ChannelService::default(),
-        dummy_on_replica_failure_from(),
+        dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
         dummy_abort_shard_transfer(),
         None,
@@ -274,8 +274,8 @@ async fn test_search_dedup() {
     }
 }
 
-pub fn dummy_on_replica_failure() -> ChangePeerState {
-    Arc::new(move |_peer_id, _shard_id| {})
+pub fn dummy_on_replica_failure() -> ChangePeerFromState {
+    Arc::new(move |_peer_id, _shard_id, _from_state| {})
 }
 
 pub fn dummy_request_shard_transfer() -> RequestShardTransfer {

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -13,11 +13,11 @@ use crate::operations::types::{NodeType, VectorsConfig};
 use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::collection_shard_distribution::CollectionShardDistribution;
-use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState};
+use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use crate::tests::fixtures::TEST_OPTIMIZERS_CONFIG;
 
-pub fn dummy_on_replica_failure() -> ChangePeerState {
-    Arc::new(move |_peer_id, _shard_id| {})
+pub fn dummy_on_replica_failure() -> ChangePeerFromState {
+    Arc::new(move |_peer_id, _shard_id, _from_state| {})
 }
 
 pub fn dummy_request_shard_transfer() -> RequestShardTransfer {

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -9,7 +9,7 @@ use collection::operations::vector_params_builder::VectorParamsBuilder;
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
-use collection::shards::replica_set::{AbortShardTransfer, ChangePeerState, ReplicaState};
+use collection::shards::replica_set::{AbortShardTransfer, ChangePeerFromState, ReplicaState};
 use collection::shards::CollectionId;
 use common::cpu::CpuBudget;
 use segment::types::Distance;
@@ -67,8 +67,8 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
     .unwrap()
 }
 
-pub fn dummy_on_replica_failure() -> ChangePeerState {
-    Arc::new(move |_peer_id, _shard_id| {})
+pub fn dummy_on_replica_failure() -> ChangePeerFromState {
+    Arc::new(move |_peer_id, _shard_id, _from_state| {})
 }
 
 pub fn dummy_request_shard_transfer() -> RequestShardTransfer {

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -152,11 +152,10 @@ impl TableOfContent {
                             .into(),
                         shard_distribution,
                         self.channel_service.clone(),
-                        Self::change_peer_state_callback(
+                        Self::change_peer_from_state_callback(
                             self.consensus_proposal_sender.clone(),
                             id.to_string(),
                             ReplicaState::Dead,
-                            None,
                         ),
                         Self::request_shard_transfer_callback(
                             self.consensus_proposal_sender.clone(),

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -216,11 +216,10 @@ impl TableOfContent {
             storage_config,
             collection_shard_distribution,
             self.channel_service.clone(),
-            Self::change_peer_state_callback(
+            Self::change_peer_from_state_callback(
                 self.consensus_proposal_sender.clone(),
                 collection_name.to_string(),
                 ReplicaState::Dead,
-                None,
             ),
             Self::request_shard_transfer_callback(
                 self.consensus_proposal_sender.clone(),

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -137,11 +137,10 @@ impl TableOfContent {
                     .to_shared_storage_config(is_distributed)
                     .into(),
                 channel_service.clone(),
-                Self::change_peer_state_callback(
+                Self::change_peer_from_state_callback(
                     consensus_proposal_sender.clone(),
                     collection_name.clone(),
                     ReplicaState::Dead,
-                    None,
                 ),
                 Self::request_shard_transfer_callback(
                     consensus_proposal_sender.clone(),
@@ -479,7 +478,17 @@ impl TableOfContent {
         state: ReplicaState,
         from_state: Option<ReplicaState>,
     ) -> replica_set::ChangePeerState {
-        Arc::new(move |peer_id, shard_id| {
+        let callback =
+            Self::change_peer_from_state_callback(proposal_sender, collection_name, state);
+        Arc::new(move |peer_id, shard_id| callback(peer_id, shard_id, from_state))
+    }
+
+    fn change_peer_from_state_callback(
+        proposal_sender: Option<OperationSender>,
+        collection_name: String,
+        state: ReplicaState,
+    ) -> replica_set::ChangePeerFromState {
+        Arc::new(move |peer_id, shard_id, from_state| {
             if let Some(proposal_sender) = &proposal_sender {
                 if let Err(send_error) = Self::send_set_replica_state_proposal_op(
                     proposal_sender,

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -498,13 +498,7 @@ impl TableOfContent {
                     state,
                     from_state,
                 ) {
-                    log::error!(
-                        "Can't send proposal to deactivate replica on peer {} of shard {} of collection {}. Error: {}",
-                        peer_id,
-                        shard_id,
-                        collection_name,
-                        send_error
-                    );
+                    log::error!("Can't send proposal to deactivate replica on peer {peer_id} of shard {shard_id} of collection {collection_name}. Error: {send_error}");
                 }
             } else {
                 log::error!("Can't send proposal to deactivate replica. Error: this is a single node deployment");


### PR DESCRIPTION
We kill other replicas too eagerly if we think there's a problem.

We mark a replica as Dead if we get an error while sending an update to it (such as a precondition failure) and we think the replica is Active. The idea here is that Active replicas should never give errors.

The key thing here is that peers might be slightly out of sync, meaning that consensus operations are not applied at exactly the same time across a fleet.

So while we think we get an error on an Active replica, the actual replica might already be in Recovery state. In that case we expect to get an error back and should not escalate to killing the replica like we do now.

To solve this we now send the current state we expect to consensus when killing a replica. If it is in that state, we still mark it as dead. If it is not, we ignore the message because our peer was lagging behind.

Before this PR I saw a replica getting marked as dead about every 2 seconds while sending high load to it with concurrent shard transfers. After this PR I do not see dead replicas at all anymore. This is a great stability improvement and may prevent a lot of unnecessary replica recoveries.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?