### PR TITLE
Prefer owned versus referenced usage of PeerId/ShardId, they are Copy

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -198,7 +198,7 @@ impl Collection {
                 Change::Remove(shard_id, peer_id) => (shard_id, peer_id),
             };
 
-            let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+            let Some(replica_set) = shard_holder.get_shard(shard_id) else {
                 return Err(CollectionError::BadRequest {
                     description: format!("Shard {} of {} not found", shard_id, self.name()),
                 });
@@ -333,7 +333,6 @@ impl Collection {
 
         // extract shards info
         for (shard_id, replica_set) in shards_holder.get_shards() {
-            let shard_id = *shard_id;
             let peers = replica_set.peers();
 
             if replica_set.has_local_shard().await {

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -92,7 +92,7 @@ impl Collection {
         let result = tokio::task::spawn(async move {
             let _update_lock = update_lock;
 
-            let Some(shard) = shard_holder.get_shard(&shard_selection) else {
+            let Some(shard) = shard_holder.get_shard(shard_selection) else {
                 return Ok(None);
             };
 

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -194,7 +194,7 @@ impl Collection {
         if resharding_key.direction == ReshardingDirection::Down {
             // Remove the shard we've now migrated all points out of
             if let Some(shard_key) = &resharding_key.shard_key {
-                shard_holder.remove_shard_from_key_mapping(&resharding_key.shard_id, shard_key)?;
+                shard_holder.remove_shard_from_key_mapping(resharding_key.shard_id, shard_key)?;
             }
             shard_holder
                 .drop_and_remove_shard(resharding_key.shard_id)

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -100,7 +100,7 @@ impl Collection {
             // Create snapshot of each shard
             for (shard_id, replica_set) in shards_holder.get_shards() {
                 let shard_snapshot_path =
-                    shard_versioning::versioned_shard_path(Path::new(""), *shard_id, 0);
+                    shard_versioning::versioned_shard_path(Path::new(""), shard_id, 0);
 
                 // If node is listener, we can save whatever currently is in the storage
                 let save_wal = self.shared_storage_config.node_type != NodeType::Listener;
@@ -284,7 +284,7 @@ impl Collection {
     ) -> CollectionResult<SnapshotStream> {
         let shard = OwnedRwLockReadGuard::try_map(
             Arc::clone(&self.shards_holder).read_owned().await,
-            |x| x.get_shard(&shard_id),
+            |x| x.get_shard(shard_id),
         )
         .map_err(|_| shard_not_found_error(shard_id))?;
 

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -96,7 +96,7 @@ impl Collection {
         // and create new shards if needed
 
         for (shard_id, shard_info) in shards {
-            match self.shards_holder.read().await.get_shard(&shard_id) {
+            match self.shards_holder.read().await.get_shard(shard_id) {
                 Some(replica_set) => replica_set.apply_state(shard_info.replicas).await?,
                 None => {
                     let shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();

--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -55,8 +55,8 @@ impl ShardReplicaSet {
 
         let read_consistency = read_consistency.unwrap_or_default();
 
-        let local_count = usize::from(self.peer_state(&self.this_peer_id()).is_some());
-        let active_local_count = usize::from(self.peer_is_active(&self.this_peer_id()));
+        let local_count = usize::from(self.peer_state(self.this_peer_id()).is_some());
+        let active_local_count = usize::from(self.peer_is_active(self.this_peer_id()));
 
         let remotes = self.remotes.read().await;
 
@@ -65,7 +65,7 @@ impl ShardReplicaSet {
         // TODO(resharding): Handle resharded shard?
         let active_remotes_count = remotes
             .iter()
-            .filter(|remote| self.peer_is_active(&remote.peer_id))
+            .filter(|remote| self.peer_is_active(remote.peer_id))
             .count();
 
         let total_count = local_count + remotes_count;
@@ -159,7 +159,7 @@ impl ShardReplicaSet {
             Err(_) => (self.local.read().right_future(), false, None),
         };
 
-        let local_is_active = self.peer_is_active(&self.this_peer_id());
+        let local_is_active = self.peer_is_active(self.this_peer_id());
 
         let local_operation = if local_is_active {
             let local_operation = async {
@@ -183,7 +183,7 @@ impl ShardReplicaSet {
         // TODO(resharding): Handle resharded shard?
         let mut active_remotes: Vec<_> = remotes
             .iter()
-            .filter(|remote| self.peer_is_active(&remote.peer_id))
+            .filter(|remote| self.peer_is_active(remote.peer_id))
             .collect();
 
         active_remotes.shuffle(&mut rand::thread_rng());

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -132,12 +132,11 @@ async fn drive_up(
 
                 let source_peer_ids = {
                     let shard_holder = shard_holder.read().await;
-                    let replica_set =
-                        shard_holder.get_shard(&source_shard_id).ok_or_else(|| {
-                            CollectionError::service_error(format!(
-                                "Shard {source_shard_id} not found in the shard holder for resharding",
-                            ))
-                        })?;
+                    let replica_set = shard_holder.get_shard(source_shard_id).ok_or_else(|| {
+                        CollectionError::service_error(format!(
+                            "Shard {source_shard_id} not found in the shard holder for resharding",
+                        ))
+                    })?;
 
                     let active_peer_ids = replica_set.active_shards().await;
                     if active_peer_ids.is_empty() {
@@ -147,13 +146,13 @@ async fn drive_up(
                     }
 
                     // Respect shard transfer limits, always allow local transfers
-                    let (incoming, _) = shard_holder.count_shard_transfer_io(&this_peer_id);
+                    let (incoming, _) = shard_holder.count_shard_transfer_io(this_peer_id);
                     if incoming < incoming_limit {
                         active_peer_ids
                             .into_iter()
-                            .filter(|peer_id| {
+                            .filter(|&peer_id| {
                                 let (_, outgoing) = shard_holder.count_shard_transfer_io(peer_id);
-                                outgoing < outgoing_limit || peer_id == &this_peer_id
+                                outgoing < outgoing_limit || peer_id == this_peer_id
                             })
                             .collect()
                     } else if active_peer_ids.contains(&this_peer_id) {
@@ -299,14 +298,14 @@ async fn drive_down(
 
             let source_replica_set =
                 shard_holder
-                    .get_shard(&reshard_key.shard_id)
+                    .get_shard(reshard_key.shard_id)
                     .ok_or_else(|| {
                         CollectionError::service_error(format!(
                             "Shard {} not found in the shard holder for resharding",
                             reshard_key.shard_id,
                         ))
                     })?;
-            let target_replica_set = shard_holder.get_shard(&target_shard_id).ok_or_else(|| {
+            let target_replica_set = shard_holder.get_shard(target_shard_id).ok_or_else(|| {
                 CollectionError::service_error(format!(
                     "Shard {target_shard_id} not found in the shard holder for resharding",
                 ))
@@ -415,7 +414,7 @@ async fn migrate_local(
     // Normally consensus takes care of this, but we don't use consensus here
     {
         let shard_holder = shard_holder.read().await;
-        let replica_set = shard_holder.get_shard(&source_shard_id).ok_or_else(|| {
+        let replica_set = shard_holder.get_shard(source_shard_id).ok_or_else(|| {
             CollectionError::service_error(format!(
                 "Shard {source_shard_id} not found in the shard holder for resharding",
             ))

--- a/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
+++ b/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
@@ -55,7 +55,7 @@ pub(super) async fn drive(
         loop {
             let shard_holder = shard_holder.read().await;
 
-            let replica_set = shard_holder.get_shard(&source_shard_id).ok_or_else(|| {
+            let replica_set = shard_holder.get_shard(source_shard_id).ok_or_else(|| {
                 CollectionError::service_error(format!(
                     "Shard {source_shard_id} not found in the shard holder for resharding",
                 ))

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -306,7 +306,7 @@ impl ShardHolder {
                 // Revert replicas in `Resharding` state back into `Active` state
                 for (peer, state) in shard.peers() {
                     if state == ReplicaState::Resharding {
-                        shard.set_replica_state(&peer, ReplicaState::Active)?;
+                        shard.set_replica_state(peer, ReplicaState::Active)?;
                     }
                 }
 
@@ -334,8 +334,8 @@ impl ShardHolder {
 
         // Remove new shard if resharding up
         if direction == ReshardingDirection::Up {
-            if let Some(shard) = self.get_shard(&shard_id) {
-                match shard.peer_state(&peer_id) {
+            if let Some(shard) = self.get_shard(shard_id) {
+                match shard.peer_state(peer_id) {
                     Some(ReplicaState::Resharding) => {
                         log::debug!("removing peer {peer_id} from {shard_id} replica set");
                         shard.remove_peer(peer_id).await?;
@@ -514,7 +514,7 @@ impl ShardHolder {
     }
 
     pub async fn cleanup_local_shard(&self, shard_id: ShardId) -> CollectionResult<UpdateResult> {
-        let shard = self.get_shard(&shard_id).ok_or_else(|| {
+        let shard = self.get_shard(shard_id).ok_or_else(|| {
             CollectionError::not_found(format!("shard {shard_id} does not exist"))
         })?;
 
@@ -535,7 +535,7 @@ impl ShardHolder {
     }
 
     pub fn hash_ring_filter(&self, shard_id: ShardId) -> Option<hash_ring::HashRingFilter> {
-        if !self.contains_shard(&shard_id) {
+        if !self.contains_shard(shard_id) {
             return None;
         }
 

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -166,7 +166,7 @@ pub async fn revert_proxy_shard_to_local(
     shard_holder: &ShardHolder,
     shard_id: ShardId,
 ) -> CollectionResult<bool> {
-    let replica_set = match shard_holder.get_shard(&shard_id) {
+    let replica_set = match shard_holder.get_shard(shard_id) {
         None => return Ok(false),
         Some(replica_set) => replica_set,
     };
@@ -241,7 +241,7 @@ where
 
             if is_err || is_cancelled {
                 // Revert queue proxy if we still have any to prepare for the next attempt
-                if let Some(shard) = shards_holder.read().await.get_shard(&transfer.shard_id) {
+                if let Some(shard) = shards_holder.read().await.get_shard(transfer.shard_id) {
                     shard.revert_queue_proxy_local().await;
                 }
             }

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -41,7 +41,7 @@ pub(crate) async fn transfer_resharding_stream_records(
     {
         let shard_holder = shard_holder.read().await;
 
-        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
             return Err(CollectionError::service_error(format!(
                 "Shard {shard_id} cannot be proxied because it does not exist"
             )));
@@ -91,7 +91,7 @@ pub(crate) async fn transfer_resharding_stream_records(
     loop {
         let shard_holder = shard_holder.read().await;
 
-        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
             // Forward proxy gone?!
             // That would be a programming error.
             return Err(CollectionError::service_error(format!(
@@ -120,7 +120,7 @@ pub(crate) async fn transfer_resharding_stream_records(
     // Update cutoff point on remote shard, disallow recovery before our current last seen
     {
         let shard_holder = shard_holder.read().await;
-        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
             // Forward proxy gone?!
             // That would be a programming error.
             return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -175,7 +175,7 @@ pub(super) async fn transfer_snapshot(
     let shard_holder_read = shard_holder.read().await;
     let local_rest_address = channel_service.current_rest_address(transfer_config.from)?;
 
-    let transferring_shard = shard_holder_read.get_shard(&shard_id);
+    let transferring_shard = shard_holder_read.get_shard(shard_id);
     let Some(replica_set) = transferring_shard else {
         return Err(CollectionError::service_error(format!(
             "Shard {shard_id} cannot be queue proxied because it does not exist"

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -38,7 +38,7 @@ pub(super) async fn transfer_stream_records(
     {
         let shard_holder = shard_holder.read().await;
 
-        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
             return Err(CollectionError::service_error(format!(
                 "Shard {shard_id} cannot be proxied because it does not exist"
             )));
@@ -76,7 +76,7 @@ pub(super) async fn transfer_stream_records(
     loop {
         let shard_holder = shard_holder.read().await;
 
-        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
             // Forward proxy gone?!
             // That would be a programming error.
             return Err(CollectionError::service_error(format!(
@@ -105,7 +105,7 @@ pub(super) async fn transfer_stream_records(
     // Update cutoff point on remote shard, disallow recovery before our current last seen
     {
         let shard_holder = shard_holder.read().await;
-        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
+        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
             // Forward proxy gone?!
             // That would be a programming error.
             return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -98,7 +98,7 @@ pub(super) async fn transfer_wal_delta(
 
     let shard_holder_read = shard_holder.read().await;
 
-    let transferring_shard = shard_holder_read.get_shard(&shard_id);
+    let transferring_shard = shard_holder_read.get_shard(shard_id);
     let Some(replica_set) = transferring_shard else {
         return Err(CollectionError::service_error(format!(
             "Shard {shard_id} cannot be queue proxied because it does not exist"

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -109,13 +109,13 @@ async fn fixture() -> Collection {
         let op = OperationWithClockTag::from(CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(vec![
                 PointStructPersisted {
-                    id: u64::from(*shard_id).into(),
+                    id: u64::from(shard_id).into(),
                     vector: VectorStructPersisted::Single(
                         (0..DIM).map(|_| rng.gen_range(0.0..1.0)).collect(),
                     ),
                     payload: Some(Payload(Map::from_iter([(
                         "num".to_string(),
-                        Value::from(-(*shard_id as i32)),
+                        Value::from(-(shard_id as i32)),
                     )]))),
                 },
                 PointStructPersisted {
@@ -125,7 +125,7 @@ async fn fixture() -> Collection {
                     ),
                     payload: Some(Payload(Map::from_iter([(
                         "num".to_string(),
-                        Value::from(100 - *shard_id as i32),
+                        Value::from(100 - shard_id as i32),
                     )]))),
                 },
             ])),
@@ -139,7 +139,7 @@ async fn fixture() -> Collection {
     // Activate all shards
     for shard_id in 0..SHARD_COUNT {
         collection
-            .set_shard_replica_state(shard_id as ShardId, PEER_ID, ReplicaState::Active, None)
+            .set_shard_replica_state(shard_id, PEER_ID, ReplicaState::Active, None)
             .await
             .expect("failed to active shard");
     }

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -148,15 +148,15 @@ async fn _test_snapshot_collection(node_type: NodeType) {
     {
         let shards_holder = &recovered_collection.shards_holder.read().await;
 
-        let replica_ser_0 = shards_holder.get_shard(&0).unwrap();
+        let replica_ser_0 = shards_holder.get_shard(0).unwrap();
         assert!(replica_ser_0.is_local().await);
-        let replica_ser_1 = shards_holder.get_shard(&1).unwrap();
+        let replica_ser_1 = shards_holder.get_shard(1).unwrap();
         assert!(replica_ser_1.is_local().await);
-        let replica_ser_2 = shards_holder.get_shard(&2).unwrap();
+        let replica_ser_2 = shards_holder.get_shard(2).unwrap();
         assert!(!replica_ser_2.is_local().await);
         assert_eq!(replica_ser_2.peers().len(), 1);
 
-        let replica_ser_3 = shards_holder.get_shard(&3).unwrap();
+        let replica_ser_3 = shards_holder.get_shard(3).unwrap();
 
         assert!(replica_ser_3.is_local().await);
         assert_eq!(replica_ser_3.peers().len(), 3); // 2 remotes + 1 local

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -461,7 +461,7 @@ impl TableOfContent {
         let collections = self.collections.read().await;
         if let Some(proposal_sender) = &self.consensus_proposal_sender {
             for collection in collections.values() {
-                for transfer in collection.get_outgoing_transfers(&self.this_peer_id).await {
+                for transfer in collection.get_outgoing_transfers(self.this_peer_id).await {
                     let cancel_transfer =
                         ConsensusOperations::abort_transfer(collection.name(), transfer, reason);
                     proposal_sender.send(cancel_transfer)?;


### PR DESCRIPTION
We have mixed usage of owned/referenced `PeerId` and `ShardId` types. This attempts to unify it a bit preferring owned usage because the types implement `Copy`.

This PR contains no logic changes.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
