### PR TITLE
Enable running integration tests against non-localhost available instance

### DIFF
--- a/tests/basic_multivector_grpc_test.sh
+++ b/tests/basic_multivector_grpc_test.sh
@@ -5,15 +5,21 @@ set -ex
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_HOST='localhost:6334'
+QDRANT_HOST=${QDRANT_HOST:-'localhost:6334'}
 
-docker_grpcurl="docker run --rm --network=host -v ${PWD}/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
+docker_grpcurl=("docker" "run" "--rm" "--network=host" "-v" "${PWD}/lib/api/src/grpc/proto:/proto" "fullstorydev/grpcurl" "-plaintext" "-import-path" "/proto" "-proto" "qdrant.proto")
 
-$docker_grpcurl -d '{
+if [ -n "${QDRANT_HOST_HEADERS}" ]; then
+  while read h; do
+    docker_grpcurl+=("-H" "$h")
+  done <<<  $(echo "${QDRANT_HOST_HEADERS}" | jq -r 'to_entries|map("\(.key): \(.value)")[]')
+fi
+
+"${docker_grpcurl[@]}" -d '{
    "collection_name": "test_multivector_collection"
 }' $QDRANT_HOST qdrant.Collections/Delete
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
    "collection_name": "test_multivector_collection",
    "vectors_config": {
       "params_map": {
@@ -30,9 +36,9 @@ $docker_grpcurl -d '{
    }
 }' $QDRANT_HOST qdrant.Collections/Create
 
-$docker_grpcurl -d '{}' $QDRANT_HOST qdrant.Collections/List
+"${docker_grpcurl[@]}" -d '{}' $QDRANT_HOST qdrant.Collections/List
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_multivector_collection",
   "wait": true,
   "ordering": null,
@@ -129,9 +135,9 @@ $docker_grpcurl -d '{
   ]
 }' $QDRANT_HOST qdrant.Points/Upsert
 
-$docker_grpcurl -d '{ "collection_name": "test_multivector_collection" }' $QDRANT_HOST qdrant.Collections/Get
+"${docker_grpcurl[@]}" -d '{ "collection_name": "test_multivector_collection" }' $QDRANT_HOST qdrant.Collections/Get
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_multivector_collection",
   "limit": 2,
   "with_vectors": {"enable": true},
@@ -149,7 +155,7 @@ $docker_grpcurl -d '{
   }
 }' $QDRANT_HOST qdrant.Points/Scroll
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_multivector_collection",
   "with_vectors": {"enable": true},
   "ids": [{ "num": 2 }, { "num": 3 }, { "num": 4 }]
@@ -159,7 +165,7 @@ $docker_grpcurl -d '{
 set +e
 
 response=$(
-  $docker_grpcurl -d '{
+  "${docker_grpcurl[@]}" -d '{
     "collection_name": "test_multivector_collection",
     "wait": true,
     "ordering": null,
@@ -187,7 +193,7 @@ if [[ $response != *"Wrong input: Vector dimension error: expected dim: 4, got 8
 fi
 
 response=$(
-  $docker_grpcurl -d '{
+  "${docker_grpcurl[@]}" -d '{
     "collection_name": "test_multivector_collection",
     "wait": true,
     "ordering": null,
@@ -215,7 +221,7 @@ if [[ $response != *"Validation error: invalid dense vector length for vectors c
 fi
 
 response=$(
-  $docker_grpcurl -d '{
+  "${docker_grpcurl[@]}" -d '{
     "collection_name": "test_multivector_collection",
     "wait": true,
     "ordering": null,
@@ -244,7 +250,7 @@ fi
 
 # search fails if the dense vector is not of the right dimension
 response=$(
-  $docker_grpcurl -d '{
+  "${docker_grpcurl[@]}" -d '{
       "collection_name": "test_multivector_collection",
       "vector": [0.2,0.1,0.9],
       "limit": 3,
@@ -260,7 +266,7 @@ fi
 set -e
 
 # search with a single dense vector with the right dimension works against a multivector collection
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
     "collection_name": "test_multivector_collection",
     "vector": [0.2,0.1,0.9,0.7],
     "limit": 3,

--- a/tests/basic_query_grpc_test.sh
+++ b/tests/basic_query_grpc_test.sh
@@ -6,15 +6,21 @@ set -ex
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_HOST='localhost:6334'
+QDRANT_HOST=${QDRANT_HOST:-'localhost:6334'}
 
-docker_grpcurl="docker run --rm --network=host -v ${PWD}/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
+docker_grpcurl=("docker" "run" "--rm" "--network=host" "-v" "${PWD}/lib/api/src/grpc/proto:/proto" "fullstorydev/grpcurl" "-plaintext" "-import-path" "/proto" "-proto" "qdrant.proto")
 
-$docker_grpcurl -d '{
+if [ -n "${QDRANT_HOST_HEADERS}" ]; then
+  while read h; do
+    docker_grpcurl+=("-H" "$h")
+  done <<<  $(echo "${QDRANT_HOST_HEADERS}" | jq -r 'to_entries|map("\(.key): \(.value)")[]')
+fi
+
+"${docker_grpcurl[@]}" -d '{
    "collection_name": "test_collection"
 }' $QDRANT_HOST qdrant.Collections/Delete
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
    "collection_name": "test_collection",
    "vectors_config": {
       "params": {
@@ -24,9 +30,9 @@ $docker_grpcurl -d '{
    }
 }' $QDRANT_HOST qdrant.Collections/Create
 
-$docker_grpcurl -d '{}' $QDRANT_HOST qdrant.Collections/List
+"${docker_grpcurl[@]}" -d '{}' $QDRANT_HOST qdrant.Collections/List
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",
   "wait": true,
   "ordering": null,
@@ -50,7 +56,7 @@ $docker_grpcurl -d '{
   ]
 }' $QDRANT_HOST qdrant.Points/Upsert
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",
   "query": {
     "nearest": {
@@ -62,7 +68,7 @@ $docker_grpcurl -d '{
   "limit": 3
 }' $QDRANT_HOST qdrant.Points/Query
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",
   "query_points": [
     {
@@ -79,7 +85,7 @@ $docker_grpcurl -d '{
   ]
 }' $QDRANT_HOST qdrant.Points/QueryBatch
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",
   "query": {
     "nearest": {
@@ -94,7 +100,7 @@ $docker_grpcurl -d '{
 }' $QDRANT_HOST qdrant.Points/QueryGroups
 
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",
   "filter": {
     "should": [
@@ -118,7 +124,7 @@ $docker_grpcurl -d '{
   "limit": 3
 }' $QDRANT_HOST qdrant.Points/Query
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",
   "limit": 2,
   "with_vectors": {"enable": true},
@@ -136,7 +142,7 @@ $docker_grpcurl -d '{
   }
 }' $QDRANT_HOST qdrant.Points/Query
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",
   "query": {
     "recommend": {

--- a/tests/basic_sparse_grpc_test.sh
+++ b/tests/basic_sparse_grpc_test.sh
@@ -6,15 +6,21 @@ set -ex
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_HOST='localhost:6334'
+QDRANT_HOST=${QDRANT_HOST:-'localhost:6334'}
 
-docker_grpcurl="docker run --rm --network=host -v ${PWD}/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
+docker_grpcurl=("docker" "run" "--rm" "--network=host" "-v" "${PWD}/lib/api/src/grpc/proto:/proto" "fullstorydev/grpcurl" "-plaintext" "-import-path" "/proto" "-proto" "qdrant.proto")
 
-$docker_grpcurl -d '{
+if [ -n "${QDRANT_HOST_HEADERS}" ]; then
+  while read h; do
+    docker_grpcurl+=("-H" "$h")
+  done <<<  $(echo "${QDRANT_HOST_HEADERS}" | jq -r 'to_entries|map("\(.key): \(.value)")[]')
+fi
+
+"${docker_grpcurl[@]}" -d '{
    "collection_name": "test_sparse_collection"
 }' $QDRANT_HOST qdrant.Collections/Delete
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
    "collection_name": "test_sparse_collection",
    "sparse_vectors_config": {
       "map": {
@@ -23,9 +29,9 @@ $docker_grpcurl -d '{
    }
 }' $QDRANT_HOST qdrant.Collections/Create
 
-$docker_grpcurl -d '{}' $QDRANT_HOST qdrant.Collections/List
+"${docker_grpcurl[@]}" -d '{}' $QDRANT_HOST qdrant.Collections/List
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_sparse_collection",
   "wait": true,
   "ordering": null,
@@ -104,9 +110,9 @@ $docker_grpcurl -d '{
   ]
 }' $QDRANT_HOST qdrant.Points/Upsert
 
-$docker_grpcurl -d '{ "collection_name": "test_sparse_collection" }' $QDRANT_HOST qdrant.Collections/Get
+"${docker_grpcurl[@]}" -d '{ "collection_name": "test_sparse_collection" }' $QDRANT_HOST qdrant.Collections/Get
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_sparse_collection",
   "vector": [0.2,0.1,0.9,0.7],
   "sparse_indices": { "data": [0,1,2,3] },
@@ -114,7 +120,7 @@ $docker_grpcurl -d '{
   "limit": 3
 }' $QDRANT_HOST qdrant.Points/Search
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_sparse_collection",
   "filter": {
     "should": [
@@ -134,7 +140,7 @@ $docker_grpcurl -d '{
   "limit": 3
 }' $QDRANT_HOST qdrant.Points/Search
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_sparse_collection",
   "limit": 2,
   "with_vectors": {"enable": true},
@@ -152,7 +158,7 @@ $docker_grpcurl -d '{
   }
 }' $QDRANT_HOST qdrant.Points/Scroll
 
-$docker_grpcurl -d '{
+"${docker_grpcurl[@]}" -d '{
   "collection_name": "test_sparse_collection",
   "with_vectors": {"enable": true},
   "ids": [{ "num": 2 }, { "num": 3 }, { "num": 4 }]
@@ -161,7 +167,7 @@ $docker_grpcurl -d '{
 # validate search request when vector and indices have different sizes
 set +e
 response=$(
-  $docker_grpcurl -d '{
+  "${docker_grpcurl[@]}" -d '{
     "collection_name": "test_sparse_collection",
     "vector": [0.2,0.1],
     "sparse_indices": { "data": [0,1,2,3] },
@@ -175,7 +181,7 @@ if [[ $response != *"Sparse indices does not match sparse vector conditions"* ]]
 fi
 
 response=$(
-  $docker_grpcurl -d '{
+  "${docker_grpcurl[@]}" -d '{
     "collection_name": "test_sparse_collection",
     "wait": true,
     "ordering": null,

--- a/tests/openapi/conftest.py
+++ b/tests/openapi/conftest.py
@@ -2,7 +2,10 @@ import http.server
 import pytest
 import socketserver
 import threading
+import os
 
+
+HTTP_SERVER_HOST = os.environ.get("HTTP_SERVER_HOST", "localhost")
 
 @pytest.fixture(params=[False, True], scope="module")
 def on_disk_vectors(request):
@@ -30,7 +33,7 @@ def http_server(tmpdir):
             # Silence logging
             pass
 
-    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+    with socketserver.TCPServer(("0.0.0.0", 0), Handler) as httpd:
         httpd.allow_reuse_address = True
         thread = threading.Thread(
             target=httpd.serve_forever,
@@ -38,6 +41,6 @@ def http_server(tmpdir):
             kwargs={"poll_interval": 0.1},
         )
         thread.start()
-        yield (tmpdir, f"http://127.0.0.1:{httpd.server_address[1]}")
+        yield (tmpdir, f"http://{HTTP_SERVER_HOST}:{httpd.server_address[1]}")
         httpd.shutdown()
         thread.join()

--- a/tests/openapi/helpers/helpers.py
+++ b/tests/openapi/helpers/helpers.py
@@ -1,11 +1,13 @@
+import json
 from typing import Any, Dict, List
 import jsonschema
 import requests
 from schemathesis.models import APIOperation
 from schemathesis.specs.openapi.references import ConvertingResolver
 from schemathesis.specs.openapi.schemas import OpenApi30
+from functools import lru_cache
 
-from .settings import QDRANT_HOST, SCHEMA
+from .settings import QDRANT_HOST, SCHEMA, QDRANT_HOST_HEADERS
 
 
 def get_api_string(host, api, path_params):
@@ -76,7 +78,8 @@ def request_with_validation(
     response = action(
         url=get_api_string(QDRANT_HOST, api, path_params),
         params=query_params,
-        json=body
+        json=body,
+        headers=qdrant_host_headers()
     )
 
     operation.validate_response(response)
@@ -140,5 +143,9 @@ def distribution_based_score_fusion(responses: List[List[Any]], limit: int = 10)
     sorted_points = sorted(points_map.values(), key=lambda item: item['score'], reverse=True)
     
     return sorted_points[:limit]
-    
-    
+
+
+@lru_cache
+def qdrant_host_headers():
+    headers = json.loads(QDRANT_HOST_HEADERS)
+    return headers

--- a/tests/openapi/helpers/settings.py
+++ b/tests/openapi/helpers/settings.py
@@ -7,3 +7,5 @@ OPENAPI_FILE = os.environ.get("OPENAPI_FILE", os.path.join(os.path.dirname(ROOT_
 
 SCHEMA = schemathesis.from_file(open(OPENAPI_FILE))
 QDRANT_HOST = os.environ.get("QDRANT_HOST", "http://localhost:6333")
+
+QDRANT_HOST_HEADERS = os.environ.get("QDRANT_HOST_HEADERS", "{}")

--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -4,7 +4,6 @@ import os
 from .helpers.collection_setup import drop_collection
 from .helpers.helpers import request_with_validation
 
-QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost:6333")
 
 collection_name = 'test_multi_vector_persistence'
 

--- a/tests/openapi/test_multi_vector_uint8.py
+++ b/tests/openapi/test_multi_vector_uint8.py
@@ -4,7 +4,6 @@ import os
 from .helpers.collection_setup import drop_collection
 from .helpers.helpers import request_with_validation
 
-QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost:6333")
 
 collection_name = 'test_multi_vector_uint8_persistence'
 

--- a/tests/openapi/test_multi_vector_unnamed.py
+++ b/tests/openapi/test_multi_vector_unnamed.py
@@ -4,7 +4,6 @@ import os
 from .helpers.collection_setup import drop_collection
 from .helpers.helpers import request_with_validation
 
-QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost:6333")
 
 collection_name = 'test_multi_vector_persistence'
 

--- a/tests/openapi/test_query.py
+++ b/tests/openapi/test_query.py
@@ -4,9 +4,10 @@ import requests
 import os
 
 from .helpers.collection_setup import basic_collection_setup, drop_collection
-from .helpers.helpers import distribution_based_score_fusion, reciprocal_rank_fusion, request_with_validation
+from .helpers.helpers import distribution_based_score_fusion, reciprocal_rank_fusion, request_with_validation, \
+    qdrant_host_headers
+from .helpers.settings import QDRANT_HOST
 
-QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost:6333")
 collection_name = "test_query"
 
 
@@ -74,7 +75,8 @@ def test_query_validation():
 
 
     # raw query to bypass local validation
-    response = requests.post(f"http://{QDRANT_HOST}/collections/{collection_name}/points/query",
+    response = requests.post(f"{QDRANT_HOST}/collections/{collection_name}/points/query",
+        headers=qdrant_host_headers(),
         json={
             "query": {
                 "recommend": {

--- a/tests/openapi/test_shard_snapshot.py
+++ b/tests/openapi/test_shard_snapshot.py
@@ -6,8 +6,7 @@ import requests
 
 from .helpers.collection_setup import basic_collection_setup, drop_collection
 from .helpers.helpers import request_with_validation
-
-QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost:6333")
+from .helpers.settings import QDRANT_HOST
 
 collection_name = 'test_collection_snapshot'
 
@@ -215,7 +214,7 @@ def test_shard_snapshot_security():
     # ensure we cannot do simple arbitrary path traversal
     snapshot_name = "/etc/passwd"
     response = requests.get(
-        f"http://{QDRANT_HOST}/collections/{collection_name}/shards/0/snapshots/{snapshot_name}",
+        f"{QDRANT_HOST}/collections/{collection_name}/shards/0/snapshots/{snapshot_name}",
         headers={"Content-Type": "application/json"},
     )
     assert not response.ok
@@ -223,7 +222,7 @@ def test_shard_snapshot_security():
 
     snapshot_name = "../../../../../../../etc/passwd"
     response = requests.get(
-        f"http://{QDRANT_HOST}/collections/{collection_name}/shards/0/snapshots/{snapshot_name}",
+        f"{QDRANT_HOST}/collections/{collection_name}/shards/0/snapshots/{snapshot_name}",
         headers={"Content-Type": "application/json"},
     )
     assert not response.ok

--- a/tests/openapi/test_snapshot.py
+++ b/tests/openapi/test_snapshot.py
@@ -1,3 +1,4 @@
+import time
 from time import sleep
 import hashlib
 import os
@@ -6,8 +7,7 @@ import requests
 
 from .helpers.collection_setup import basic_collection_setup, drop_collection
 from .helpers.helpers import request_with_validation
-
-QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost:6333")
+from .helpers.settings import QDRANT_HOST
 
 collection_name = 'test_collection_snapshot'
 
@@ -371,7 +371,7 @@ def test_full_snapshot_security():
     # ensure we cannot do simple arbitrary path traversal
     snapshot_name = "/etc/passwd"
     response = requests.get(
-        f"http://{QDRANT_HOST}/snapshots/{snapshot_name}",
+        f"{QDRANT_HOST}/snapshots/{snapshot_name}",
         headers={"Content-Type": "application/json"},
     )
     assert not response.ok
@@ -379,7 +379,7 @@ def test_full_snapshot_security():
 
     snapshot_name = "../../../../../../../etc/passwd"
     response = requests.get(
-        f"http://{QDRANT_HOST}/snapshots/{snapshot_name}",
+        f"{QDRANT_HOST}/snapshots/{snapshot_name}",
         headers={"Content-Type": "application/json"},
     )
     assert not response.ok
@@ -399,7 +399,7 @@ def test_collection_snapshot_security():
     # ensure we cannot do simple arbitrary path traversal
     snapshot_name = "/etc/passwd"
     response = requests.get(
-        f"http://{QDRANT_HOST}/collections/{collection_name}/snapshots/{snapshot_name}",
+        f"{QDRANT_HOST}/collections/{collection_name}/snapshots/{snapshot_name}",
         headers={"Content-Type": "application/json"},
     )
     assert not response.ok
@@ -407,7 +407,7 @@ def test_collection_snapshot_security():
 
     snapshot_name = "../../../../../../../etc/passwd"
     response = requests.get(
-        f"http://{QDRANT_HOST}/collections/{collection_name}/snapshots/{snapshot_name}",
+        f"{QDRANT_HOST}/collections/{collection_name}/snapshots/{snapshot_name}",
         headers={"Content-Type": "application/json"},
     )
     assert not response.ok


### PR DESCRIPTION
* `QDRANT_HOST` variable is used by all openapi tests, removed its copies from  `test_multi_vector_uint8.py`, `test_multi_vector_unnamed.py`, `test_query.py`,  `test_shard_snapshot.py`, and `test_snapshot.py`
* Added optional `QDRANT_HOST_HEADERS` env variable to set custom HTTP headers  in order to reach Qdrant instance behind a reverse proxy. The content of the  variable is JSON payload, e.g. `{"host": "qdrant.local"}`
* Adapted `./tests/basic_*.sh` scripts to be aware of `QDRANT_HOST_HEADERS` env variable

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

