### PR TITLE
Fix immutable map index mishandling point deletions

### DIFF
--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -74,6 +74,7 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
     }
 
     /// Shrinks the range of values-to-points by one.
+    ///
     /// Returns true if the last element was removed.
     fn shrink_value_range(
         value_to_points: &mut HashMap<N::Owned, ContainerSegment>,
@@ -136,8 +137,9 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
                 deleted_value_to_points_container.resize(pos + 1, false);
             }
 
-            // TODO: add debug assertion to ensure we actually flip a bit here?
-            deleted_value_to_points_container.set(pos, true);
+            #[allow(unused_variables)]
+            let did_exist = !deleted_value_to_points_container.replace(pos, true);
+            debug_assert!(did_exist, "value {value} was already deleted");
         }
 
         if Self::shrink_value_range(value_to_points, value) {
@@ -231,6 +233,12 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
                 value.borrow(),
             ) {
                 slice.sort_unstable();
+            } else {
+                debug_assert!(
+                    false,
+                    "value {} not found in value_to_points",
+                    value.borrow(),
+                );
             }
         }
 

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -57,16 +57,17 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
     /// Return mutable slice of a container which holds point_ids for given value.
     ///
     /// The returned slice is sorted and does contain deleted values.
+    /// The returned offset is the start of the range in the container.
     fn get_mut_point_ids_slice<'a>(
         value_to_points: &HashMap<N::Owned, ContainerSegment>,
         value_to_points_container: &'a mut [PointOffsetType],
         value: &N,
-    ) -> Option<&'a mut [PointOffsetType]> {
+    ) -> Option<(&'a mut [PointOffsetType], usize)> {
         match value_to_points.get(value) {
             Some(entry) if entry.count > 0 => {
                 let range = entry.range.start as usize..entry.range.end as usize;
                 let vals = &mut value_to_points_container[range];
-                Some(vals)
+                Some((vals, entry.range.start as usize))
             }
             _ => None,
         }
@@ -119,7 +120,7 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
         value: &N,
         idx: PointOffsetType,
     ) {
-        let Some(values) =
+        let Some((values, offset)) =
             Self::get_mut_point_ids_slice(value_to_points, value_to_points_container, value)
         else {
             debug_assert!(false, "value {value} not found in value_to_points");
@@ -128,7 +129,9 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
 
         // Finds the index of `idx` in values-to-points map which we want to remove
         // We mark it as removed in deleted flags
-        if let Ok(pos) = values.binary_search(&idx) {
+        if let Ok(local_pos) = values.binary_search(&idx) {
+            let pos = offset + local_pos;
+
             if deleted_value_to_points_container.len() < pos + 1 {
                 deleted_value_to_points_container.resize(pos + 1, false);
             }
@@ -222,7 +225,7 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
         // Sort IDs in each slice of points
         // This is very important because we binary search
         for value in self.value_to_points.keys() {
-            if let Some(slice) = Self::get_mut_point_ids_slice(
+            if let Some((slice, _offset)) = Self::get_mut_point_ids_slice(
                 &self.value_to_points,
                 &mut self.value_to_points_container,
                 value.borrow(),

--- a/tests/openapi/test_filtered_delete.py
+++ b/tests/openapi/test_filtered_delete.py
@@ -1,0 +1,138 @@
+import time
+
+import pytest
+import random
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = 'test_delete_by_filter'
+
+
+def setup_big_collection(num_points, dim, keywords=5):
+    drop_collection(collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": dim,
+                "distance": "Dot",
+                "on_disk": False,
+            },
+            "optimizers_config": {
+                "default_segment_number": 4,
+                "indexing_threshold": 10
+            }
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    # Create payload index
+    response = request_with_validation(
+        api='/collections/{collection_name}/index',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "field_name": "a",
+            "field_schema": "keyword"
+        }
+    )
+
+    assert response.ok
+
+    points = [
+        {
+            "id": i,
+            "vector": [random.random() for _ in range(dim)],
+            "payload": {
+                "a": f"keyword_{i % keywords}"
+            }
+        }
+        for i in range(num_points)
+    ]
+
+    for i in range(0, len(points), 100):
+        response = request_with_validation(
+            api='/collections/{collection_name}/points',
+            method="PUT",
+            path_params={'collection_name': collection_name},
+            query_params={'wait': 'true'},
+            body={"points": points[i:i + 100]}
+        )
+        assert response.ok
+
+
+def wait_collection_green():
+    while True:
+        response = request_with_validation(
+            api='/collections/{collection_name}',
+            method="GET",
+            path_params={'collection_name': collection_name},
+        )
+        assert response.ok
+
+        json = response.json()
+        if json['result']['status'] == 'green':
+            break
+
+        time.sleep(1)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(on_disk_vectors):
+    setup_big_collection(num_points=3000, dim=4)
+    wait_collection_green()
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def delete_payload(payload_value):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/delete',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "a",
+                        "match": {"value": payload_value}
+                    }
+                ]
+            }
+        }
+    )
+    assert response.ok
+
+
+def test_delete_by_payload_filter():
+    delete_payload("keyword_0")
+    delete_payload("keyword_1")
+    delete_payload("keyword_2")
+    delete_payload("keyword_3")
+    delete_payload("keyword_4")
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/query',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "limit": 1000,
+        }
+    )
+
+    assert response.ok
+    json = response.json()
+    assert len(json['result']['points']) == 0


### PR DESCRIPTION
Fix a problem where the immutable map index is mishandling point deletions. This was introduced in <https://github.com/qdrant/qdrant/pull/5072>.

The problem is that while deleting points, the index of a subslice is used. We should use the global index on the container instead.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?