### PR TITLE
Add wait=true in openapi test for all point delete calls transparently

### DIFF
--- a/tests/openapi/helpers/helpers.py
+++ b/tests/openapi/helpers/helpers.py
@@ -1,7 +1,9 @@
 import json
+from logging import warning
 from typing import Any, Dict, List
 import jsonschema
 import requests
+import warnings
 from schemathesis.models import APIOperation
 from schemathesis.specs.openapi.references import ConvertingResolver
 from schemathesis.specs.openapi.schemas import OpenApi30
@@ -74,6 +76,10 @@ def request_with_validation(
 
     if not action:
         raise RuntimeError(f"Method {method} does not exists")
+
+    if api.endswith("/delete") and method == "POST" and "wait" not in query_params:
+        warnings.warn(f"Delete call for {api} missing wait=true param, adding it")
+        query_params["wait"] = "true"
 
     response = action(
         url=get_api_string(QDRANT_HOST, api, path_params),


### PR DESCRIPTION
If `wait=true` param is not set for delete vector API calls, a test asserting later that data are gone can become flaky, because at the assertion time the data could be still there.

The following files contain such tests at the moment:
* `test_multi_vector_uint8.py`
* `test_multi_vector.py`
* `test_multi_vector_unnamed.py`
* `test_optional_vectors.py`

In order to fix these and prevent the flakiness of future test, `request_with_validation` helper adds `wait=true` param, if it is not set for delete vector calls.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

