### PR TITLE
Experiment: ignore clock tags when replica is in partial state

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -227,7 +227,7 @@ impl Collection {
                 };
 
                 if transfer.to == self.this_peer_id {
-                    replica_set.set_replica_state(transfer.to, state)?;
+                    replica_set.set_replica_state(transfer.to, state).await?;
                 } else {
                     replica_set.add_remote(transfer.to, state).await?;
                 }
@@ -319,7 +319,9 @@ impl Collection {
                     //   and so failed transfer does not introduce any inconsistencies to points
                     //   that are not affected by resharding in all other shards
                 } else if transfer.sync {
-                    replica_set.set_replica_state(transfer.to, ReplicaState::Dead)?;
+                    replica_set
+                        .set_replica_state(transfer.to, ReplicaState::Dead)
+                        .await?;
                 } else {
                     replica_set.remove_peer(transfer.to).await?;
                 }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -217,6 +217,10 @@ impl ForwardProxyShard {
     pub fn update_tracker(&self) -> &UpdateTracker {
         self.wrapped_shard.update_tracker()
     }
+
+    pub fn set_clocks_enabled(&self, enabled: bool) {
+        self.wrapped_shard.set_clocks_enabled(enabled);
+    }
 }
 
 #[async_trait]

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1093,6 +1093,10 @@ impl LocalShard {
     pub async fn update_cutoff(&self, cutoff: &RecoveryPoint) {
         self.wal.update_cutoff(cutoff).await
     }
+
+    pub fn set_clocks_enabled(&self, enabled: bool) {
+        self.wal.set_clocks_enabled(enabled);
+    }
 }
 
 impl Drop for LocalShard {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -136,6 +136,10 @@ impl ProxyShard {
     pub fn update_tracker(&self) -> &UpdateTracker {
         self.wrapped_shard.update_tracker()
     }
+
+    pub fn set_clocks_enabled(&self, enabled: bool) {
+        self.wrapped_shard.set_clocks_enabled(enabled);
+    }
 }
 
 #[async_trait]

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -201,6 +201,12 @@ impl QueueProxyShard {
 
         (queue_proxy.wrapped_shard, queue_proxy.remote_shard)
     }
+
+    pub fn set_clocks_enabled(&self, enabled: bool) {
+        self.inner_unchecked()
+            .wrapped_shard
+            .set_clocks_enabled(enabled);
+    }
 }
 
 #[async_trait]

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -412,9 +412,7 @@ impl ShardReplicaSet {
             return Ok(());
         };
 
-        proxy.transfer_all_missed_updates().await?;
-
-        Ok(())
+        proxy.transfer_all_missed_updates().await
     }
 
     /// Send all queue proxy updates to remote and transform into forward proxy

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -554,10 +554,12 @@ mod tests {
         // at build time the replicas are all dead, they need to be activated
         assert_eq!(rs.highest_alive_replica_peer_id(), None);
 
-        rs.set_replica_state(1, ReplicaState::Active).unwrap();
-        rs.set_replica_state(3, ReplicaState::Active).unwrap();
-        rs.set_replica_state(4, ReplicaState::Active).unwrap();
-        rs.set_replica_state(5, ReplicaState::Partial).unwrap();
+        rs.set_replica_state(1, ReplicaState::Active).await.unwrap();
+        rs.set_replica_state(3, ReplicaState::Active).await.unwrap();
+        rs.set_replica_state(4, ReplicaState::Active).await.unwrap();
+        rs.set_replica_state(5, ReplicaState::Partial)
+            .await
+            .unwrap();
 
         assert_eq!(rs.highest_replica_peer_id(), Some(5));
         assert_eq!(rs.highest_alive_replica_peer_id(), Some(4));

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -422,12 +422,9 @@ impl ShardReplicaSet {
             Some(ReplicaState::Partial) => true,
             Some(ReplicaState::Initializing) => true,
             Some(ReplicaState::Listener) => true,
-            // Recovery: keep sending updates to prevent a data race
-            // The replica on the peer may still be active for some time if its consensus is slow.
-            // The peer may respond to read requests until it switches to recovery state too. We
-            // must keep sending updates to prevent those reads being stale.
-            // See: <https://github.com/qdrant/qdrant/pull/5298>
-            Some(ReplicaState::Recovery | ReplicaState::PartialSnapshot) => true,
+            // We must not send updates to replicas in recovery state.
+            // If we do we might create gaps in WAL clock tags.
+            Some(ReplicaState::Recovery | ReplicaState::PartialSnapshot) => false,
             Some(ReplicaState::Resharding) => true,
             Some(ReplicaState::Dead) | None => false,
         };

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -251,4 +251,14 @@ impl Shard {
             }
         }
     }
+
+    pub fn set_clocks_enabled(&self, enabled: bool) {
+        match self {
+            Self::Local(local_shard) => local_shard.set_clocks_enabled(enabled),
+            Self::Proxy(proxy_shard) => proxy_shard.set_clocks_enabled(enabled),
+            Self::ForwardProxy(proxy_shard) => proxy_shard.set_clocks_enabled(enabled),
+            Self::QueueProxy(proxy_shard) => proxy_shard.set_clocks_enabled(enabled),
+            Self::Dummy(_) => (),
+        }
+    }
 }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -701,6 +701,7 @@ impl ShardHolder {
                     log::warn!("Local shard {collection_id}:{} stuck in Initializing state, changing to Active", replica_set.shard_id);
                     replica_set
                         .set_replica_state(local_peer_id, ReplicaState::Active)
+                        .await
                         .expect("Failed to set local shard state");
                 }
                 let shard_key = shard_id_to_key_mapping.get(&shard_id).cloned();

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -306,7 +306,7 @@ impl ShardHolder {
                 // Revert replicas in `Resharding` state back into `Active` state
                 for (peer, state) in shard.peers() {
                     if state == ReplicaState::Resharding {
-                        shard.set_replica_state(peer, ReplicaState::Active)?;
+                        shard.set_replica_state(peer, ReplicaState::Active).await?;
                     }
                 }
 

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -65,6 +65,8 @@ pub async fn transfer_shard(
                 progress,
                 local_shard_id,
                 remote_shard,
+                channel_service,
+                consensus,
                 &collection_id,
             )
             .await?;


### PR DESCRIPTION
It seems that clock tags can be problematic if a replica is in partial state. That is because we might receive updates in arbitrary order from any node, resulting in clock gaps.

This creates two problems:
- during this state we may reject operations we do need
- if we abort an ongoing shard transfer our recovery point may be incorrect

To fix this we now simply ignore clock tags in partial state, and accept all operations.

I've implemented this in quite a naive way. I'd like to merge it into our dev branch so we can test it over the weekend. I plan to implement it in a better way next week.

In my local testing this seems to fix a critical problem with stream records and WAL delta transfers. Before the PR I got a failure every few minutes. With the PR I've been running the test for two hours no without problems.

While I do expect this to improve chaos testing, I'm not confident this fixes all the issues we're seeing.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?