### PR TITLE
Fix consensus sync peers waiting on wrong value

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -225,6 +225,13 @@ impl Persistent {
         self.apply_progress_queue.get_last_applied()
     }
 
+    /// Get the last applied commit and term, reflected in our current state.
+    pub fn applied_commit_term(&self) -> (u64, u64) {
+        let hard_state = &self.state().hard_state;
+        let last_commit = self.last_applied_entry().unwrap_or(hard_state.commit);
+        (last_commit, hard_state.term)
+    }
+
     pub fn first_voter(&self) -> Option<PeerId> {
         self.first_voter
     }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -228,7 +228,10 @@ impl Persistent {
     /// Get the last applied commit and term, reflected in our current state.
     pub fn applied_commit_term(&self) -> (u64, u64) {
         let hard_state = &self.state().hard_state;
-        let last_commit = self.last_applied_entry().unwrap_or(hard_state.commit);
+
+        // Fall back to 0 because it's always less than any commit
+        let last_commit = self.last_applied_entry().unwrap_or(0);
+
         (last_commit, hard_state.term)
     }
 

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -35,7 +35,7 @@ pub struct Persistent {
     /// for this last snapshot ID (term + commit)
     #[serde(default)] // TODO quick fix to avoid breaking the compat. with 0.8.1
     pub latest_snapshot_meta: SnapshotMetadataSer,
-    /// Operations to applied, consensus consider them committed, but this peer didn't apply them yet
+    /// Operations to be applied, consensus considers them committed, but this peer didn't apply them yet
     #[serde(default)]
     pub apply_progress_queue: EntryApplyProgressQueue,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -23,8 +23,7 @@ impl ShardTransferConsensus for TocDispatcher {
     }
 
     fn consensus_commit_term(&self) -> (u64, u64) {
-        let state = self.consensus_state.hard_state();
-        (state.commit, state.term)
+        self.consensus_state.0.persistent.read().applied_commit_term()
     }
 
     fn recovered_switch_to_partial(

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -23,7 +23,11 @@ impl ShardTransferConsensus for TocDispatcher {
     }
 
     fn consensus_commit_term(&self) -> (u64, u64) {
-        self.consensus_state.0.persistent.read().applied_commit_term()
+        self.consensus_state
+            .0
+            .persistent
+            .read()
+            .applied_commit_term()
     }
 
     fn recovered_switch_to_partial(


### PR DESCRIPTION
When synchronizing the consensus commit and peer we were waiting on the wrong commit value.

We waited on the commit in hard state, but we should wait on the last applied entry instead. The last applied entry better reflects what collection metadata we're actually seeing, while the hard state commit might be somewhere in the future.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?