### PR TITLE
Do not sort sparse vector before remapping it

### DIFF
--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -163,7 +163,7 @@ fn sparse_vector_index_search_benchmark_impl(
                     let mut prefiltered_points = None;
                     let results = sparse_vector_index
                         .search_plain(
-                            vec.clone(),
+                            vec,
                             &filter,
                             TOP,
                             &mut prefiltered_points,
@@ -211,7 +211,7 @@ fn sparse_vector_index_search_benchmark_impl(
                     let mut prefiltered_points = None;
                     let results = sparse_vector_index
                         .search_plain(
-                            vec.clone(),
+                            vec,
                             &filter,
                             TOP,
                             &mut prefiltered_points,

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -163,7 +163,7 @@ fn sparse_vector_index_search_benchmark_impl(
                     let mut prefiltered_points = None;
                     let results = sparse_vector_index
                         .search_plain(
-                            vec,
+                            vec.clone(),
                             &filter,
                             TOP,
                             &mut prefiltered_points,
@@ -211,7 +211,7 @@ fn sparse_vector_index_search_benchmark_impl(
                     let mut prefiltered_points = None;
                     let results = sparse_vector_index
                         .search_plain(
-                            vec,
+                            vec.clone(),
                             &filter,
                             TOP,
                             &mut prefiltered_points,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -320,7 +320,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
     pub fn search_plain(
         &self,
-        sparse_vector: &SparseVector,
+        sparse_vector: SparseVector,
         filter: &Filter,
         top: usize,
         prefiltered_points: &mut Option<Vec<PointOffsetType>>,
@@ -349,7 +349,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         .filter(|&idx| check_deleted_condition(idx, deleted_vectors, deleted_point_bitslice))
         .collect_vec();
 
-        let sparse_vector = self.indices_tracker.remap_vector(sparse_vector.to_owned());
+        let sparse_vector = self.indices_tracker.remap_vector(sparse_vector);
         let memory_handle = self.scores_memory_pool.get();
         let mut search_context = SearchContext::new(
             sparse_vector,
@@ -366,7 +366,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     // search using sparse vector inverted index
     fn search_sparse(
         &self,
-        sparse_vector: &SparseVector,
+        sparse_vector: SparseVector,
         filter: Option<&Filter>,
         top: usize,
         vector_query_context: &VectorQueryContext,
@@ -384,7 +384,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
         let is_stopped = vector_query_context.is_stopped();
 
-        let sparse_vector = self.indices_tracker.remap_vector(sparse_vector.to_owned());
+        let sparse_vector = self.indices_tracker.remap_vector(sparse_vector);
         let memory_handle = self.scores_memory_pool.get();
         let mut search_context = SearchContext::new(
             sparse_vector,
@@ -439,7 +439,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                     let _timer =
                         ScopeDurationMeasurer::new(&self.searches_telemetry.small_cardinality);
                     self.search_plain(
-                        &vector,
+                        vector,
                         filter,
                         top,
                         prefiltered_points,
@@ -448,12 +448,12 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 } else {
                     let _timer =
                         ScopeDurationMeasurer::new(&self.searches_telemetry.filtered_sparse);
-                    Ok(self.search_sparse(&vector, Some(filter), top, vector_query_context))
+                    Ok(self.search_sparse(vector, Some(filter), top, vector_query_context))
                 }
             }
             None => {
                 let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_sparse);
-                Ok(self.search_sparse(&vector, filter, top, vector_query_context))
+                Ok(self.search_sparse(vector, filter, top, vector_query_context))
             }
         }
     }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -334,7 +334,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
         let deleted_point_bitslice = vector_query_context
             .deleted_points()
-            .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+            .unwrap_or(id_tracker.deleted_point_bitslice());
         let deleted_vectors = vector_storage.deleted_vector_bitslice();
 
         let ids = match prefiltered_points {
@@ -375,7 +375,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let id_tracker = self.id_tracker.borrow();
         let deleted_point_bitslice = vector_query_context
             .deleted_points()
-            .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+            .unwrap_or(id_tracker.deleted_point_bitslice());
         let deleted_vectors = vector_storage.deleted_vector_bitslice();
 
         let not_deleted_condition = |idx: PointOffsetType| -> bool {


### PR DESCRIPTION
Sparse vectors indices are remapped and sorted by internal indices right before the search.

Therefore it is not necessary to sort the initial sparse vector.

Running with CI benchmark does not show any improvement sadly. 