### PR TITLE
Experiment: also don't write clock tags to WAL in partial state

### DIFF
--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -63,18 +63,21 @@ impl RecoverableWal {
         &'a self,
         operation: &mut OperationWithClockTag,
     ) -> crate::wal::Result<(u64, ParkingMutexGuard<'a, SerdeWal<OperationWithClockTag>>)> {
-        // Update last seen clock map and correct clock tag if necessary
-        if self.clocks_enabled.load(Ordering::Acquire) {
-            if let Some(clock_tag) = &mut operation.clock_tag {
-                let operation_accepted = self
-                    .newest_clocks
-                    .lock()
-                    .await
-                    .advance_clock_and_correct_tag(clock_tag);
+        // If clcoks are disabled, remove the clock tag from the operation and always accept it
+        if !self.clocks_enabled.load(Ordering::Acquire) {
+            operation.clock_tag.take();
+        }
 
-                if !operation_accepted {
-                    return Err(crate::wal::WalError::ClockRejected);
-                }
+        // Update last seen clock map and correct clock tag if necessary
+        if let Some(clock_tag) = &mut operation.clock_tag {
+            let operation_accepted = self
+                .newest_clocks
+                .lock()
+                .await
+                .advance_clock_and_correct_tag(clock_tag);
+
+            if !operation_accepted {
+                return Err(crate::wal::WalError::ClockRejected);
             }
         }
 


### PR DESCRIPTION
Extends experiment in <https://github.com/qdrant/qdrant/pull/5349>.

Don't just ignore the clock tag in partial state, but also prevent writing it in the WAL.

Otherwise we'll still bump our last seen clocks with the tags replayed from the WAL.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?