### PR TITLE
Experiment: don't bump newest clocks when setting cutoff point

### DIFF
--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -91,22 +91,12 @@ impl RecoverableWal {
     /// This can only increase clock ticks in the cutoff clock map. If there already are higher
     /// clock ticks, they're kept.
     ///
-    /// It updates the highest seen clocks alongside with it.
+    /// Note that this does not update the highest seen clocks, meaning its possible that they'll
+    /// be lower.
     pub async fn update_cutoff(&self, cutoff: &RecoveryPoint) {
-        // Lock highest and cutoff maps separately to avoid deadlocks
-
-        {
-            let mut newest_clocks = self.newest_clocks.lock().await;
-            for clock_tag in cutoff.iter_as_clock_tags() {
-                newest_clocks.advance_clock(clock_tag);
-            }
-        }
-
-        {
-            let mut oldest_clocks = self.oldest_clocks.lock().await;
-            for clock_tag in cutoff.iter_as_clock_tags() {
-                oldest_clocks.advance_clock(clock_tag);
-            }
+        let mut oldest_clocks = self.oldest_clocks.lock().await;
+        for clock_tag in cutoff.iter_as_clock_tags() {
+            oldest_clocks.advance_clock(clock_tag);
         }
     }
 

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1178,7 +1178,7 @@ mod tests {
         let delta_from = b_wal.resolve_wal_delta(a_recovery_point.clone()).await;
 
         // No diff expected
-        assert_eq!(delta_from, Ok(None));
+        assert_eq!(delta_from, Err(WalDeltaError::UnknownClocks));
 
         let op7 = mock_operation(7);
         // Add operation to B but not A


### PR DESCRIPTION
Extends <https://github.com/qdrant/qdrant/pull/5352>.

At the end of some transfers - such as stream records - we bump the cutoff point on the receiving node to the latest clocks of the sender. The idea is that it prevents the node from providing a WAL delta with operations that may not be ordered correctly in it's WAL.

Bumping the cutoff point also bumps the newest seen clocks. I believe this can be problematic causing the node to reject operations it did not receive yet. The sender may have different clocks than the receiver due to the distributed nature of the implementation.

In other words, if we bump the cutoff point on some node with newer clocks than it already has, it may reject operations that are still incoming.

Look at the following time table:

| Time | Node 1 (n1)               | Node 2 (n2)                    | Node 3 (n3)                     |
|-----:|---------------------------|--------------------------------|---------------------------------|
|    1 | stream records n1→n2      | stream records n1→n2           |                                 |
|    2 | transfer last batch to n2 | receive last batch from n1     |                                 |
|    3 |                           |                                | new operation c2 (fwd to n1,n2) |
|    4 | apply operation c2        |                                |                                 |
|    5 | bump cutoff on n2 (c2)    | bump cutoff via n1 (c2)        |                                 |
|    6 | end transfer, activate n2 |                                |                                 |
|    7 |                           | end transfer, activate replica |                                 |
|    8 |                           | reject operation c2            |                                 |

In this example node 2 will reject (and never apply) operation c2. That is because node 1 already bumped its clocks, causing the incoming operation that was received late to be rejected.

While this is unlikely to happen in practice, we don't seem to have anything in place to prevent it.

Also bumping the newest clocks does not really provide us anything useful. We implemented it this way to prevent accidentally bumping the cutoff too high in a way that it would never accept new operations again.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?