### PR TITLE
Forwarding hardware counter in distributed setup

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use chrono::{NaiveDateTime, Timelike};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
 use itertools::Itertools;
 use segment::common::operation_error::OperationError;
 use segment::data_types::index::{
@@ -2136,5 +2137,12 @@ impl From<HwMeasurementAcc> for HardwareUsage {
         Self {
             cpu: value.get_cpu() as u64,
         }
+    }
+}
+
+impl From<HardwareUsage> for HardwareCounterCell {
+    fn from(value: HardwareUsage) -> Self {
+        let HardwareUsage { cpu } = value;
+        HardwareCounterCell::new_with(cpu as usize)
     }
 }

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -19,6 +19,7 @@ use api::grpc::qdrant::{
 use api::grpc::transport_channel_pool::{AddTimeout, MAX_GRPC_CHANNEL_TIMEOUT};
 use async_trait::async_trait;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::TelemetryDetail;
 use itertools::Itertools;
 use parking_lot::Mutex;
@@ -727,7 +728,7 @@ impl ShardOperation for RemoteShard {
         batch_request: Arc<CoreSearchRequestBatch>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
-        _hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);
         timer.set_success(false);
@@ -756,6 +757,8 @@ impl ShardOperation for RemoteShard {
             })
             .await?
             .into_inner();
+
+        hw_measurement_acc.merge_from_cell(search_batch_response.usage);
 
         let result: Result<Vec<Vec<ScoredPoint>>, Status> = search_batch_response
             .result
@@ -786,7 +789,7 @@ impl ShardOperation for RemoteShard {
         request: Arc<CountRequestInternal>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
-        _hw_measurement_acc: HwMeasurementAcc, // TODO: measure hardware when counting
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<CountResult> {
         let count_points = CountPoints {
             collection_name: self.collection_id.clone(),
@@ -811,6 +814,9 @@ impl ShardOperation for RemoteShard {
             })
             .await?
             .into_inner();
+
+        hw_measurement_acc.merge_from_cell(count_response.usage);
+
         count_response.result.map_or_else(
             || {
                 Err(CollectionError::service_error(
@@ -868,7 +874,7 @@ impl ShardOperation for RemoteShard {
         requests: Arc<Vec<ShardQueryRequest>>,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
-        _hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);
         timer.set_success(false);
@@ -899,6 +905,8 @@ impl ShardOperation for RemoteShard {
             })
             .await?
             .into_inner();
+
+        hw_measurement_acc.merge_from_cell(batch_response.usage);
 
         let result = batch_response
             .results

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -19,7 +19,6 @@ use api::grpc::qdrant::{
 use api::grpc::transport_channel_pool::{AddTimeout, MAX_GRPC_CHANNEL_TIMEOUT};
 use async_trait::async_trait;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::TelemetryDetail;
 use itertools::Itertools;
 use parking_lot::Mutex;

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -15,6 +15,12 @@ impl HwMeasurementAcc {
         Self::default()
     }
 
+    pub fn new_with_values(cpu: usize) -> Self {
+        Self {
+            cpu_counter: Arc::new(AtomicUsize::new(cpu)),
+        }
+    }
+
     pub fn get_cpu(&self) -> usize {
         self.cpu_counter.load(Ordering::Relaxed)
     }
@@ -26,8 +32,8 @@ impl HwMeasurementAcc {
     }
 
     /// Consumes and accumulates the values from `hw_counter_cell` into the accumulator.
-    pub fn merge_from_cell(&self, hw_counter_cell: HardwareCounterCell) {
-        let HardwareCounterCell { ref cpu_counter } = hw_counter_cell;
+    pub fn merge_from_cell(&self, hw_counter_cell: impl Into<HardwareCounterCell>) {
+        let HardwareCounterCell { ref cpu_counter } = hw_counter_cell.into();
 
         self.cpu_counter
             .fetch_add(cpu_counter.take(), Ordering::Relaxed);

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -84,11 +84,11 @@ impl Drop for HardwareCounterCell {
     }
 }
 
-impl<T> Into<HardwareCounterCell> for Option<T>
+impl<T> From<Option<T>> for HardwareCounterCell
 where
     T: Into<HardwareCounterCell>,
 {
-    fn into(self) -> HardwareCounterCell {
-        self.map(|i| i.into()).unwrap_or_default()
+    fn from(value: Option<T>) -> Self {
+        value.map(|i| i.into()).unwrap_or_default()
     }
 }

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -83,3 +83,12 @@ impl Drop for HardwareCounterCell {
         }
     }
 }
+
+impl<T> Into<HardwareCounterCell> for Option<T>
+where
+    T: Into<HardwareCounterCell>,
+{
+    fn into(self) -> HardwareCounterCell {
+        self.map(|i| i.into()).unwrap_or_default()
+    }
+}


### PR DESCRIPTION
Depends on #5369 

Note: only implemented for search, count and query operations for now. 