### PR TITLE
Experiment: disable clocks in initializing state, propagate ignore flag

### DIFF
--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -93,7 +93,7 @@ fn setup() -> (TempDir, LocalShard) {
     let rnd_batch = create_rnd_batch();
 
     handle
-        .block_on(shard.update(rnd_batch.into(), true))
+        .block_on(shard.update(rnd_batch.into(), true, false))
         .unwrap();
 
     (storage_dir, shard)

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -112,7 +112,7 @@ fn batch_search_bench(c: &mut Criterion) {
     let rnd_batch = create_rnd_batch();
 
     handle
-        .block_on(shard.update(rnd_batch.into(), true))
+        .block_on(shard.update(rnd_batch.into(), true, false))
         .unwrap();
 
     let mut group = c.benchmark_group("batch-search-bench");

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -66,7 +66,12 @@ impl DummyShard {
 
 #[async_trait]
 impl ShardOperation for DummyShard {
-    async fn update(&self, _: OperationWithClockTag, _: bool) -> CollectionResult<UpdateResult> {
+    async fn update(
+        &self,
+        _: OperationWithClockTag,
+        _: bool,
+        _: bool,
+    ) -> CollectionResult<UpdateResult> {
         self.dummy()
     }
 

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -103,6 +103,7 @@ impl ForwardProxyShard {
                         }),
                     )),
                     false,
+                    false,
                 )
                 .await?;
         }
@@ -179,7 +180,11 @@ impl ForwardProxyShard {
 
         // TODO: Is cancelling `RemoteShard::update` safe for *receiver*?
         self.remote_shard
-            .update(OperationWithClockTag::from(insert_points_operation), wait) // TODO: Assign clock tag!? 🤔
+            .update(
+                OperationWithClockTag::from(insert_points_operation),
+                wait,
+                false,
+            ) // TODO: Assign clock tag!? 🤔
             .await?;
 
         Ok(next_page_offset)
@@ -234,6 +239,7 @@ impl ShardOperation for ForwardProxyShard {
         &self,
         operation: OperationWithClockTag,
         _wait: bool,
+        ignore_local_clocks: bool,
     ) -> CollectionResult<UpdateResult> {
         // If we apply `local_shard` update, we *have to* execute `remote_shard` update to completion
         // (or we *might* introduce an inconsistency between shards?), so this method is not cancel
@@ -246,7 +252,10 @@ impl ShardOperation for ForwardProxyShard {
 
         // We always have to wait for the result of the update, cause after we release the lock,
         // the transfer needs to have access to the latest version of points.
-        let mut result = self.wrapped_shard.update(operation.clone(), true).await?;
+        let mut result = self
+            .wrapped_shard
+            .update(operation.clone(), true, ignore_local_clocks)
+            .await?;
 
         let forward_operation = if let Some(ring) = &self.resharding_hash_ring {
             // If `ForwardProxyShard::resharding_hash_ring` is `Some`, we assume that proxy is used
@@ -296,13 +305,13 @@ impl ShardOperation for ForwardProxyShard {
         };
 
         if let Some(operation) = forward_operation {
-            let remote_result =
-                self.remote_shard
-                    .update(operation, false)
-                    .await
-                    .map_err(|err| {
-                        CollectionError::forward_proxy_error(self.remote_shard.peer_id, err)
-                    })?;
+            let remote_result = self
+                .remote_shard
+                .update(operation, false, false)
+                .await
+                .map_err(|err| {
+                    CollectionError::forward_proxy_error(self.remote_shard.peer_id, err)
+                })?;
 
             // Merge `result` and `remote_result`:
             //

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -222,10 +222,6 @@ impl ForwardProxyShard {
     pub fn update_tracker(&self) -> &UpdateTracker {
         self.wrapped_shard.update_tracker()
     }
-
-    pub fn set_clocks_enabled(&self, enabled: bool) {
-        self.wrapped_shard.set_clocks_enabled(enabled);
-    }
 }
 
 #[async_trait]

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1093,10 +1093,6 @@ impl LocalShard {
     pub async fn update_cutoff(&self, cutoff: &RecoveryPoint) {
         self.wal.update_cutoff(cutoff).await
     }
-
-    pub fn set_clocks_enabled(&self, enabled: bool) {
-        self.wal.set_clocks_enabled(enabled);
-    }
 }
 
 impl Drop for LocalShard {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -136,10 +136,6 @@ impl ProxyShard {
     pub fn update_tracker(&self) -> &UpdateTracker {
         self.wrapped_shard.update_tracker()
     }
-
-    pub fn set_clocks_enabled(&self, enabled: bool) {
-        self.wrapped_shard.set_clocks_enabled(enabled);
-    }
 }
 
 #[async_trait]

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -153,6 +153,7 @@ impl ShardOperation for ProxyShard {
         &self,
         operation: OperationWithClockTag,
         wait: bool,
+        ignore_local_clocks: bool,
     ) -> CollectionResult<UpdateResult> {
         // If we modify `self.changed_points`, we *have to* (?) execute `local_shard` update
         // to completion, so this method is not cancel safe.
@@ -196,7 +197,9 @@ impl ShardOperation for ProxyShard {
 
             // Shard update is within a write lock scope, because we need a way to block the shard updates
             // during the transfer restart and finalization.
-            local_shard.update(operation, wait).await
+            local_shard
+                .update(operation, wait, ignore_local_clocks)
+                .await
         }
     }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -201,12 +201,6 @@ impl QueueProxyShard {
 
         (queue_proxy.wrapped_shard, queue_proxy.remote_shard)
     }
-
-    pub fn set_clocks_enabled(&self, enabled: bool) {
-        self.inner_unchecked()
-            .wrapped_shard
-            .set_clocks_enabled(enabled);
-    }
 }
 
 #[async_trait]

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -220,9 +220,12 @@ impl ShardOperation for QueueProxyShard {
         &self,
         operation: OperationWithClockTag,
         wait: bool,
+        ignore_local_clocks: bool,
     ) -> CollectionResult<UpdateResult> {
         // `Inner::update` is cancel safe, so this is also cancel safe.
-        self.inner_unchecked().update(operation, wait).await
+        self.inner_unchecked()
+            .update(operation, wait, ignore_local_clocks)
+            .await
     }
 
     /// Forward read-only `scroll_by` to `wrapped_shard`
@@ -528,6 +531,7 @@ impl ShardOperation for Inner {
         &self,
         operation: OperationWithClockTag,
         wait: bool,
+        ignore_local_clocks: bool,
     ) -> CollectionResult<UpdateResult> {
         // `LocalShard::update` is cancel safe, so this is also cancel safe.
 
@@ -536,7 +540,9 @@ impl ShardOperation for Inner {
         let local_shard = &self.wrapped_shard;
         // Shard update is within a write lock scope, because we need a way to block the shard updates
         // during the transfer restart and finalization.
-        local_shard.update(operation.clone(), wait).await
+        local_shard
+            .update(operation.clone(), wait, ignore_local_clocks)
+            .await
     }
 
     /// Forward read-only `scroll_by` to `wrapped_shard`

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -644,6 +644,7 @@ impl ShardOperation for RemoteShard {
         &self,
         operation: OperationWithClockTag,
         wait: bool,
+        _ignore_local_clocks: bool,
     ) -> CollectionResult<UpdateResult> {
         // `RemoteShard::execute_update_operation` is cancel safe, so this method is cancel safe.
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1120,6 +1120,24 @@ impl ReplicaState {
             | ReplicaState::Listener => false,
         }
     }
+
+    /// Check whether this is a state in which we ignore local clocks.
+    ///
+    /// During some replica states, using clocks may create gaps. That'll be problematic if WAL
+    /// delta recovery is used later, resulting in missing opeartions. In these states we ignore
+    /// clocks all together to prevent this problem.
+    pub fn is_ignore_local_clocks(self) -> bool {
+        match self {
+            ReplicaState::Partial => true,
+            ReplicaState::Active
+            | ReplicaState::Listener
+            | ReplicaState::Resharding
+            | ReplicaState::Dead
+            | ReplicaState::Initializing
+            | ReplicaState::PartialSnapshot
+            | ReplicaState::Recovery => false,
+        }
+    }
 }
 
 /// Represents a change in replica set, due to scaling of `replication_factor`

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1128,12 +1128,11 @@ impl ReplicaState {
     /// clocks all together to prevent this problem.
     pub fn is_ignore_local_clocks(self) -> bool {
         match self {
-            ReplicaState::Partial => true,
+            ReplicaState::Initializing | ReplicaState::Partial => true,
             ReplicaState::Active
             | ReplicaState::Listener
             | ReplicaState::Resharding
             | ReplicaState::Dead
-            | ReplicaState::Initializing
             | ReplicaState::PartialSnapshot
             | ReplicaState::Recovery => false,
         }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -628,12 +628,6 @@ impl ShardReplicaSet {
             }
             rs.set_peer_state(peer_id, state);
         })?;
-
-        // Disable WAL clocks only if the replica is in Partial state
-        if let Some(local) = self.local.read().await.as_ref() {
-            local.set_clocks_enabled(state != ReplicaState::Partial);
-        }
-
         self.update_locally_disabled(peer_id);
         Ok(())
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1086,7 +1086,8 @@ pub enum ReplicaState {
 
 impl ReplicaState {
     /// Check whether the replica state is active or listener or resharding.
-    pub fn is_active_or_listener_or_resharding(self) -> bool {
+    #[inline]
+    pub const fn is_active_or_listener_or_resharding(self) -> bool {
         match self {
             ReplicaState::Active | ReplicaState::Listener | ReplicaState::Resharding => true,
 
@@ -1101,7 +1102,8 @@ impl ReplicaState {
     /// Check whether the replica state is partial or partial-like.
     ///
     /// In other words: is the state related to shard transfers?
-    pub fn is_partial_or_recovery(self) -> bool {
+    #[inline]
+    pub const fn is_partial_or_recovery(self) -> bool {
         match self {
             ReplicaState::Partial
             | ReplicaState::PartialSnapshot
@@ -1120,7 +1122,8 @@ impl ReplicaState {
     /// During some replica states, using clocks may create gaps. That'll be problematic if WAL
     /// delta recovery is used later, resulting in missing opeartions. In these states we ignore
     /// clocks all together to prevent this problem.
-    pub fn is_ignore_local_clocks(self) -> bool {
+    #[inline]
+    pub const fn is_ignore_local_clocks(self) -> bool {
         match self {
             ReplicaState::Initializing | ReplicaState::Partial => true,
             ReplicaState::Active

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1120,8 +1120,8 @@ impl ReplicaState {
     /// Check whether this is a state in which we ignore local clocks.
     ///
     /// During some replica states, using clocks may create gaps. That'll be problematic if WAL
-    /// delta recovery is used later, resulting in missing opeartions. In these states we ignore
     /// clocks all together to prevent this problem.
+    /// delta recovery is used later, resulting in missing operations. In these states we ignore
     #[inline]
     pub const fn is_ignore_local_clocks(self) -> bool {
         match self {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -39,19 +39,29 @@ impl ShardReplicaSet {
         if let Some(local_shard) = local.deref() {
             match self.peer_state(self.this_peer_id()) {
                 Some(
-                    ReplicaState::Active
+                    state @ (ReplicaState::Active
                     | ReplicaState::Partial
                     | ReplicaState::Initializing
-                    | ReplicaState::Resharding,
-                ) => Ok(Some(local_shard.get().update(operation, wait).await?)),
-                Some(ReplicaState::Listener) => {
-                    Ok(Some(local_shard.get().update(operation, false).await?))
+                    | ReplicaState::Resharding),
+                ) => {
+                    let ignore_local_clocks = state.is_ignore_local_clocks();
+                    Ok(Some(
+                        local_shard
+                            .get()
+                            .update(operation, wait, ignore_local_clocks)
+                            .await?,
+                    ))
                 }
+                Some(ReplicaState::Listener) => Ok(Some(
+                    local_shard.get().update(operation, false, false).await?,
+                )),
                 // In recovery state, only allow operations with force flag
                 Some(ReplicaState::PartialSnapshot | ReplicaState::Recovery)
                     if operation.clock_tag.map_or(false, |tag| tag.force) =>
                 {
-                    Ok(Some(local_shard.get().update(operation, wait).await?))
+                    Ok(Some(
+                        local_shard.get().update(operation, wait, false).await?,
+                    ))
                 }
                 Some(
                     ReplicaState::PartialSnapshot | ReplicaState::Recovery | ReplicaState::Dead,
@@ -230,18 +240,21 @@ impl ShardReplicaSet {
 
         if let Some(local) = local.deref() {
             if self.is_peer_updatable(this_peer_id) {
-                let local_wait = if self.peer_state(this_peer_id) == Some(ReplicaState::Listener) {
+                let peer_state = self.peer_state(this_peer_id);
+                let local_wait = if peer_state == Some(ReplicaState::Listener) {
                     false
                 } else {
                     wait
                 };
+                let ignore_local_clocks =
+                    peer_state.map_or(false, ReplicaState::is_ignore_local_clocks);
 
                 let operation = operation.clone();
 
                 let local_update = async move {
                     local
                         .get()
-                        .update(operation, local_wait)
+                        .update(operation, local_wait, ignore_local_clocks)
                         .await
                         .map(|ok| (this_peer_id, ok))
                         .map_err(|err| (this_peer_id, err))
@@ -256,7 +269,7 @@ impl ShardReplicaSet {
 
             let remote_update = async move {
                 remote
-                    .update(operation, wait)
+                    .update(operation, wait, false)
                     .await
                     .map(|ok| (remote.peer_id, ok))
                     .map_err(|err| (remote.peer_id, err))

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -251,14 +251,4 @@ impl Shard {
             }
         }
     }
-
-    pub fn set_clocks_enabled(&self, enabled: bool) {
-        match self {
-            Self::Local(local_shard) => local_shard.set_clocks_enabled(enabled),
-            Self::Proxy(proxy_shard) => proxy_shard.set_clocks_enabled(enabled),
-            Self::ForwardProxy(proxy_shard) => proxy_shard.set_clocks_enabled(enabled),
-            Self::QueueProxy(proxy_shard) => proxy_shard.set_clocks_enabled(enabled),
-            Self::Dummy(_) => (),
-        }
-    }
 }

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -18,6 +18,7 @@ pub trait ShardOperation {
         &self,
         operation: OperationWithClockTag,
         wait: bool,
+        ignore_local_clocks: bool,
     ) -> CollectionResult<UpdateResult>;
 
     #[allow(clippy::too_many_arguments)]

--- a/lib/collection/src/tests/fix_payload_indices.rs
+++ b/lib/collection/src/tests/fix_payload_indices.rs
@@ -42,14 +42,17 @@ async fn test_fix_payload_indices() {
     .unwrap();
 
     let upsert_ops = upsert_operation();
-    shard.update(upsert_ops.into(), true).await.unwrap();
+    shard.update(upsert_ops.into(), true, false).await.unwrap();
 
     // Create payload index in shard locally, not in global collection configuration
     let index_op = create_payload_index_operation();
-    shard.update(index_op.into(), true).await.unwrap();
+    shard.update(index_op.into(), true, false).await.unwrap();
 
     let delete_point_op = delete_point_operation(4);
-    shard.update(delete_point_op.into(), true).await.unwrap();
+    shard
+        .update(delete_point_op.into(), true, false)
+        .await
+        .unwrap();
 
     std::thread::sleep(std::time::Duration::from_secs(1));
 

--- a/lib/collection/src/tests/payload.rs
+++ b/lib/collection/src/tests/payload.rs
@@ -50,7 +50,7 @@ async fn test_payload_missing_index_check() {
 
     let upsert_ops = upsert_operation();
 
-    shard.update(upsert_ops.into(), true).await.unwrap();
+    shard.update(upsert_ops.into(), true, false).await.unwrap();
 
     let geo_filter = Filter::new_must(Condition::Field(FieldCondition::new_geo_radius(
         JsonPath::from_str("location").unwrap(),
@@ -161,5 +161,8 @@ async fn create_index(
             field_schema: Some(PayloadFieldSchema::FieldType(field_type)),
         }),
     );
-    shard.update(create_index.into(), true).await.unwrap();
+    shard
+        .update(create_index.into(), true, false)
+        .await
+        .unwrap();
 }

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -50,7 +50,7 @@ async fn test_shard_query_rrf_rescoring() {
 
     let upsert_ops = upsert_operation();
 
-    shard.update(upsert_ops.into(), true).await.unwrap();
+    shard.update(upsert_ops.into(), true, false).await.unwrap();
 
     // RRF query without prefetches
     let query = ShardQueryRequest {
@@ -255,7 +255,7 @@ async fn test_shard_query_vector_rescoring() {
 
     let upsert_ops = upsert_operation();
 
-    shard.update(upsert_ops.into(), true).await.unwrap();
+    shard.update(upsert_ops.into(), true, false).await.unwrap();
 
     let nearest_query = QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
         VectorInternal::Dense(vec![1.0, 2.0, 3.0, 4.0]),
@@ -402,7 +402,7 @@ async fn test_shard_query_payload_vector() {
 
     let upsert_ops = upsert_operation();
 
-    shard.update(upsert_ops.into(), true).await.unwrap();
+    shard.update(upsert_ops.into(), true, false).await.unwrap();
 
     let nearest_query = QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
         VectorInternal::Dense(vec![1.0, 2.0, 3.0, 4.0]),

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -43,7 +43,7 @@ async fn test_delete_from_indexed_payload() {
 
     let upsert_ops = upsert_operation();
 
-    shard.update(upsert_ops.into(), true).await.unwrap();
+    shard.update(upsert_ops.into(), true, false).await.unwrap();
 
     let index_op = create_payload_index_operation();
 
@@ -55,10 +55,13 @@ async fn test_delete_from_indexed_payload() {
             );
         })
         .unwrap();
-    shard.update(index_op.into(), true).await.unwrap();
+    shard.update(index_op.into(), true, false).await.unwrap();
 
     let delete_point_op = delete_point_operation(4);
-    shard.update(delete_point_op.into(), true).await.unwrap();
+    shard
+        .update(delete_point_op.into(), true, false)
+        .await
+        .unwrap();
 
     let info = shard.info().await.unwrap();
     eprintln!("info = {:#?}", info.payload_schema);
@@ -89,7 +92,10 @@ async fn test_delete_from_indexed_payload() {
 
     eprintln!("dropping point 5");
     let delete_point_op = delete_point_operation(5);
-    shard.update(delete_point_op.into(), true).await.unwrap();
+    shard
+        .update(delete_point_op.into(), true, false)
+        .await
+        .unwrap();
 
     drop(shard);
 


### PR DESCRIPTION
Extend experiment in <https://github.com/qdrant/qdrant/pull/5352>.

We should also ignore clock tags in initializing state. Initializing state basically behaves the same as partial, we send operations to it and we accept them.

Along with that we now propagate a boolean defining whether to ignore clock tags. It uses the current replica set state for the update as source.

It replaces the atomic boolean which was externally set to achieve the same. The old implementation did not properly update the boolean in some cases, because there are multiple ways to update the reflected replica set state. The new implementation does not have this problem.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?