### PR TITLE
Update is_on_disk to restore original default behavior of quantization 

### DIFF
--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -376,6 +376,10 @@ impl<T: Sized + Copy + 'static> ChunkedVectorStorage<T> for ChunkedMmapVectors<T
     fn max_vector_size_bytes(&self) -> usize {
         ChunkedMmapVectors::max_vector_size_bytes(self)
     }
+
+    fn is_on_disk(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/chunked_vector_storage.rs
@@ -35,4 +35,7 @@ pub trait ChunkedVectorStorage<T> {
     fn get_remaining_chunk_keys(&self, start_key: VectorOffsetType) -> usize;
 
     fn max_vector_size_bytes(&self) -> usize;
+
+    /// True, if this storage is on-disk by default.
+    fn is_on_disk(&self) -> bool;
 }

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -79,7 +79,7 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
     }
 
     fn is_on_disk(&self) -> bool {
-        true
+        self.vectors.is_on_disk()
     }
 
     fn total_vector_count(&self) -> usize {

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -86,4 +86,8 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
     fn max_vector_size_bytes(&self) -> usize {
         self.mmap_storage.max_vector_size_bytes()
     }
+
+    fn is_on_disk(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
After the change in #5188 default vector storage is now mmap. This leads to the (undesirable) change of default behavior of quantization storage: instead of being loaded in RAM, it is not loaded on-disk by default, which leads to several undesirable consequences:

- Creation of the quantized vectors with default original vector configuration leads to unexpected performance degradation
- Quantized and original vectors start to compete for RAM, if disk cache is not large enough, so default configuration will degrade in performance and it is hard to diagnose in real life scenario.

Temporary workaround: always specify `always_ram` explicitly.