### PR TITLE
GraphLinksMmap: remove Option

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -307,7 +307,7 @@ where
 }
 
 impl GraphLayers<GraphLinksMmap> {
-    pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
+    pub fn prefault_mmap_pages(&self, path: &Path) -> mmap_ops::PrefaultMmapPages {
         self.links.prefault_mmap_pages(path)
     }
 }
@@ -364,20 +364,18 @@ mod tests {
         let vector_holder =
             TestRawScorerProducer::<DotProductMetric>::new(dim, num_vectors, &mut rng);
 
-        let mut graph_layers = GraphLayers {
-            m,
-            m0: 2 * m,
-            ef_construct,
-            links: GraphLinksRam::default(),
-            entry_points: EntryPoints::new(entry_points_num),
-            visited_pool: VisitedPool::new(),
-        };
-
         let mut graph_links = vec![vec![Vec::new()]; num_vectors];
         graph_links[0][0] = vec![1, 2, 3, 4, 5, 6];
 
-        graph_layers.links =
-            GraphLinksRam::from_converter(GraphLinksConverter::new(graph_links.clone())).unwrap();
+        let graph_layers = GraphLayers {
+            m,
+            m0: 2 * m,
+            ef_construct,
+            links: GraphLinksRam::from_converter(GraphLinksConverter::new(graph_links.clone()))
+                .unwrap(),
+            entry_points: EntryPoints::new(entry_points_num),
+            visited_pool: VisitedPool::new(),
+        };
 
         let linking_idx: PointOffsetType = 7;
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -804,7 +804,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 }
 
 impl HNSWIndex<GraphLinksMmap> {
-    pub fn prefault_mmap_pages(&self) -> Option<mmap_ops::PrefaultMmapPages> {
+    pub fn prefault_mmap_pages(&self) -> mmap_ops::PrefaultMmapPages {
         self.graph.prefault_mmap_pages(&self.path)
     }
 }

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -94,7 +94,7 @@ impl fmt::Debug for VectorData {
 impl VectorData {
     pub fn prefault_mmap_pages(&self) -> impl Iterator<Item = mmap_ops::PrefaultMmapPages> {
         let index_task = match &*self.vector_index.borrow() {
-            VectorIndexEnum::HnswMmap(index) => index.prefault_mmap_pages(),
+            VectorIndexEnum::HnswMmap(index) => Some(index.prefault_mmap_pages()),
             _ => None,
         };
 


### PR DESCRIPTION
This PR removes unnecessary usage of `Option` in `GraphLinksMmap`. It was required because this field was under `#[serde(skip)]`.

Before this PR:
- `GraphLinksMmap::mmap` is `Option<Arc<Mmap>>`.
- The trait `GraphLinks` requires implementing `Default`.
- `struct GraphLayers` implements `Serialize`/`Deserealize`, but skips some fields using `#[serde(skip)]`.

After this PR:
- `GraphLinksMmap::mmap` is `Arc<Mmap>`.
- The trait `GraphLinks` no longer requires implementing `Default`.
- Serializable fields of `GraphLayers` are moved into `GraphLayerData`.