### PR TITLE
Experiment: in stream records, set cutoff to latest clocks receiver is guaranteed to have

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1120,8 +1120,8 @@ impl ReplicaState {
     /// Check whether this is a state in which we ignore local clocks.
     ///
     /// During some replica states, using clocks may create gaps. That'll be problematic if WAL
-    /// clocks all together to prevent this problem.
     /// delta recovery is used later, resulting in missing operations. In these states we ignore
+    /// clocks all together to prevent this problem.
     #[inline]
     pub const fn is_ignore_local_clocks(self) -> bool {
         match self {

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -35,6 +35,7 @@ pub(super) async fn transfer_stream_records(
     collection_id: &CollectionId,
 ) -> CollectionResult<()> {
     let remote_peer_id = remote_shard.peer_id;
+    let cutoff;
 
     log::debug!("Starting shard {shard_id} transfer to peer {remote_peer_id} by streaming records");
 
@@ -70,6 +71,9 @@ pub(super) async fn transfer_stream_records(
         progress.lock().points_total = count_result.count;
 
         replica_set.transfer_indexes().await?;
+
+        // Take our last seen clocks as cutoff point right before doing content batch transfers
+        cutoff = replica_set.shard_recovery_point().await?;
     }
 
     // Transfer contents batch by batch
@@ -106,37 +110,20 @@ pub(super) async fn transfer_stream_records(
         }
     }
 
-    // Update cutoff point on remote shard, disallow recovery before our current last seen
-    {
-        let shard_holder = shard_holder.read().await;
-        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
-            // Forward proxy gone?!
-            // That would be a programming error.
-            return Err(CollectionError::service_error(format!(
-                "Shard {shard_id} is not found"
-            )));
-        };
-
-        let cutoff = replica_set.shard_recovery_point().await?;
-        let result = remote_shard
-            .update_shard_cutoff_point(collection_id, remote_shard.id, &cutoff)
-            .await;
-
-        // Warn and ignore if remote shard is running an older version, error otherwise
-        // TODO: this is fragile, improve this with stricter matches/checks
-        match result {
-            // This string match is fragile but there does not seem to be a better way
-            Err(err)
-                if err.to_string().starts_with(
-                    "Service internal error: Tonic status error: status: Unimplemented",
-                ) =>
-            {
-                log::warn!("Cannot update cutoff point on remote shard because it is running an older version, ignoring: {err}");
-            }
-            Err(err) => return Err(err),
-            Ok(()) => {}
-        }
-    }
+    // Update cutoff point on remote shard, disallow recovery before it
+    //
+    // We provide it our last seen clocks from just before transferrinmg the content batches, and
+    // not our current last seen clocks. We're sure that after the transfer the remote must have
+    // seen all point data for those clocks. While we cannot guarantee the remote has all point
+    // data for our current last seen clocks because some operations may still be in flight.
+    // This is a trade-off between being conservative and being too conservative.
+    //
+    // We must send a cutoff point to the remote so it can learn about all the clocks that exist.
+    // If we don't do this it is possible the remote will never see a clock, breaking all future
+    // WAL delta transfers.
+    remote_shard
+        .update_shard_cutoff_point(collection_id, remote_shard.id, &cutoff)
+        .await?;
 
     // Synchronize all nodes
     await_consensus_sync(consensus, &channel_service).await;


### PR DESCRIPTION
Replacement for <https://github.com/qdrant/qdrant/pull/5370>.

At the end of some transfers - such as stream records - we bump the cutoff point on the receiving node to the latest clocks of the sender. The idea is that it prevents the node from providing a WAL delta with operations that may not be ordered correctly in it's WAL.

Bumping the cutoff point also bumps the newest seen clocks. I believe this can be problematic in our current implementation causing the node to reject operations it did not receive yet. The sender may have different clocks than the receiver due to the distributed nature of it. So, if we bump the cutoff point on some node with newer clocks than it already has, it may reject operations that are still incoming.

In other words: **we might bump the clocks on the receiver too far in the future**.

Look at the following time table:

| Time | Node 1 (n1)               | Node 2 (n2)                    | Node 3 (n3)                     |
|-----:|---------------------------|--------------------------------|---------------------------------|
|    1 | _stream records n1→n2_    | _stream records n1→n2_         |                                 |
|    2 | transfer last batch to n2 | receive last batch from n1     |                                 |
|    3 |                           |                                | new operation c2 (fwd to n1,n2) |
|    4 | apply operation c2        |                                |                                 |
|    5 | bump cutoff on n2 (c2)    | bump cutoff via n1 (c2)        |                                 |
|    6 | end transfer, activate n2 |                                |                                 |
|    7 |                           | end transfer, activate replica |                                 |
|    8 |                           | reject operation c2            |                                 |

In this example node 2 will reject (and never apply) operation c2. That is because node 1 already bumped its clocks, causing the incoming operation that was received late to be rejected.

We cannot remove bumping the cutoff point. It is required to teach the receiving node about all the clocks the sender knows about. If we don't do it the receiver may never learn about some clock, breaking WAL delta transfers forever.

Instead of not bumping at all, we now send the latest clocks we had right before we do all the content transfers. Those are the latest clock versions we can guarantee the receiver did get once we have transferred all point data batches. The clocks may be a bit older than the actual current data, but that isn't a real problem. In the above example with the table, the cutoff point would be c1 rather than c2, fixing the problem.

With this PR: **we now bump clocks on the receiver to older clocks - the latest it is guaranteed to have, preventing operation rejection**.

While this is unlikely to happen in practice, we don't seem to have anything in place to prevent it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?