### PR TITLE
Add UUID to collection config

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -452,6 +452,7 @@
 | wal_config | [WalConfigDiff](#qdrant-WalConfigDiff) |  | Configuration of the Write-Ahead-Log |
 | quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Configuration of the vector quantization |
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration of strict mode. |
+| uuid | [bytes](#bytes) | optional | UUID of the collection |
 
 
 
@@ -652,6 +653,7 @@
 | sharding_method | [ShardingMethod](#qdrant-ShardingMethod) | optional | Sharding method |
 | sparse_vectors_config | [SparseVectorConfig](#qdrant-SparseVectorConfig) | optional | Configuration for sparse vectors |
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration for strict mode |
+| uuid | [bytes](#bytes) | optional | UUID of the collection |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -452,7 +452,6 @@
 | wal_config | [WalConfigDiff](#qdrant-WalConfigDiff) |  | Configuration of the Write-Ahead-Log |
 | quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Configuration of the vector quantization |
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration of strict mode. |
-| uuid | [bytes](#bytes) | optional | UUID of the collection |
 
 
 
@@ -653,7 +652,6 @@
 | sharding_method | [ShardingMethod](#qdrant-ShardingMethod) | optional | Sharding method |
 | sparse_vectors_config | [SparseVectorConfig](#qdrant-SparseVectorConfig) | optional | Configuration for sparse vectors |
 | strict_mode_config | [StrictModeConfig](#qdrant-StrictModeConfig) | optional | Configuration for strict mode |
-| uuid | [bytes](#bytes) | optional | UUID of the collection |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6645,12 +6645,12 @@
         ]
       },
       "CollectionConfig": {
+        "description": "Information about the collection configuration",
         "type": "object",
         "required": [
           "hnsw_config",
           "optimizer_config",
-          "params",
-          "wal_config"
+          "params"
         ],
         "properties": {
           "params": {
@@ -6663,13 +6663,30 @@
             "$ref": "#/components/schemas/OptimizersConfig"
           },
           "wal_config": {
-            "$ref": "#/components/schemas/WalConfig"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WalConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "quantization_config": {
             "default": null,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/QuantizationConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "strict_mode_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeConfig"
               },
               {
                 "nullable": true
@@ -7215,6 +7232,58 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0
+          }
+        }
+      },
+      "StrictModeConfig": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "description": "Whether strict mode is enabled for a collection or not.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "max_query_limit": {
+            "description": "Max allowed `limit` parameter for all APIs that don't have their own max limit.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "max_timeout": {
+            "description": "Max allowed `timeout` parameter.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "unindexed_filtering_retrieve": {
+            "description": "Allow usage of unindexed fields in retrieval based (eg. search) filters.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "unindexed_filtering_update": {
+            "description": "Allow usage of unindexed fields in filtered updates (eg. delete by payload).",
+            "type": "boolean",
+            "nullable": true
+          },
+          "search_max_hnsw_ef": {
+            "description": "Max HNSW value allowed in search parameters.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "search_allow_exact": {
+            "description": "Whether exact search is allowed or not.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "search_max_oversampling": {
+            "description": "Max oversampling value allowed in search.",
+            "type": "number",
+            "format": "double",
+            "nullable": true
           }
         }
       },
@@ -9360,58 +9429,6 @@
           }
         }
       },
-      "StrictModeConfig": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "description": "Whether strict mode is enabled for a collection or not.",
-            "type": "boolean",
-            "nullable": true
-          },
-          "max_query_limit": {
-            "description": "Max allowed `limit` parameter for all APIs that don't have their own max limit.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1,
-            "nullable": true
-          },
-          "max_timeout": {
-            "description": "Max allowed `timeout` parameter.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1,
-            "nullable": true
-          },
-          "unindexed_filtering_retrieve": {
-            "description": "Allow usage of unindexed fields in retrieval based (eg. search) filters.",
-            "type": "boolean",
-            "nullable": true
-          },
-          "unindexed_filtering_update": {
-            "description": "Allow usage of unindexed fields in filtered updates (eg. delete by payload).",
-            "type": "boolean",
-            "nullable": true
-          },
-          "search_max_hnsw_ef": {
-            "description": "Max HNSW value allowed in search parameters.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "search_allow_exact": {
-            "description": "Whether exact search is allowed or not.",
-            "type": "boolean",
-            "nullable": true
-          },
-          "search_max_oversampling": {
-            "description": "Max oversampling value allowed in search.",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          }
-        }
-      },
       "UpdateCollection": {
         "description": "Operation for updating parameters of the existing collection",
         "type": "object",
@@ -11007,7 +11024,7 @@
             "minimum": 0
           },
           "config": {
-            "$ref": "#/components/schemas/CollectionConfig"
+            "$ref": "#/components/schemas/CollectionConfigInternal"
           },
           "shards": {
             "type": "array",
@@ -11026,6 +11043,56 @@
             "items": {
               "$ref": "#/components/schemas/ReshardingInfo"
             }
+          }
+        }
+      },
+      "CollectionConfigInternal": {
+        "type": "object",
+        "required": [
+          "hnsw_config",
+          "optimizer_config",
+          "params",
+          "wal_config"
+        ],
+        "properties": {
+          "params": {
+            "$ref": "#/components/schemas/CollectionParams"
+          },
+          "hnsw_config": {
+            "$ref": "#/components/schemas/HnswConfig"
+          },
+          "optimizer_config": {
+            "$ref": "#/components/schemas/OptimizersConfig"
+          },
+          "wal_config": {
+            "$ref": "#/components/schemas/WalConfig"
+          },
+          "quantization_config": {
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QuantizationConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "strict_mode_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "uuid": {
+            "default": null,
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -340,6 +340,7 @@ message CreateCollection {
   optional ShardingMethod sharding_method = 15; // Sharding method
   optional SparseVectorConfig sparse_vectors_config = 16; // Configuration for sparse vectors
   optional StrictModeConfig strict_mode_config = 17; // Configuration for strict mode
+  optional bytes uuid = 18; // UUID of the collection
 }
 
 message UpdateCollection {
@@ -391,6 +392,7 @@ message CollectionConfig {
   WalConfigDiff wal_config = 4; // Configuration of the Write-Ahead-Log
   optional QuantizationConfig quantization_config = 5; // Configuration of the vector quantization
   optional StrictModeConfig strict_mode_config = 6; // Configuration of strict mode.
+  optional bytes uuid = 7; // UUID of the collection
 }
 
 enum TokenizerType {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -340,7 +340,6 @@ message CreateCollection {
   optional ShardingMethod sharding_method = 15; // Sharding method
   optional SparseVectorConfig sparse_vectors_config = 16; // Configuration for sparse vectors
   optional StrictModeConfig strict_mode_config = 17; // Configuration for strict mode
-  optional bytes uuid = 18; // UUID of the collection
 }
 
 message UpdateCollection {
@@ -392,7 +391,6 @@ message CollectionConfig {
   WalConfigDiff wal_config = 4; // Configuration of the Write-Ahead-Log
   optional QuantizationConfig quantization_config = 5; // Configuration of the vector quantization
   optional StrictModeConfig strict_mode_config = 6; // Configuration of strict mode.
-  optional bytes uuid = 7; // UUID of the collection
 }
 
 enum TokenizerType {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -512,9 +512,6 @@ pub struct CreateCollection {
     /// Configuration for strict mode
     #[prost(message, optional, tag = "17")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
-    /// UUID of the collection
-    #[prost(bytes = "vec", optional, tag = "18")]
-    pub uuid: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -656,9 +653,6 @@ pub struct CollectionConfig {
     /// Configuration of strict mode.
     #[prost(message, optional, tag = "6")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
-    /// UUID of the collection
-    #[prost(bytes = "vec", optional, tag = "7")]
-    pub uuid: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -512,6 +512,9 @@ pub struct CreateCollection {
     /// Configuration for strict mode
     #[prost(message, optional, tag = "17")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
+    /// UUID of the collection
+    #[prost(bytes = "vec", optional, tag = "18")]
+    pub uuid: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -653,6 +656,9 @@ pub struct CollectionConfig {
     /// Configuration of strict mode.
     #[prost(message, optional, tag = "6")]
     pub strict_mode_config: ::core::option::Option<StrictModeConfig>,
+    /// UUID of the collection
+    #[prost(bytes = "vec", optional, tag = "7")]
+    pub uuid: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -64,6 +64,7 @@ fn setup() -> (TempDir, LocalShard) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     };
 
     let optimizers_config = collection_config.optimizer_config.clone();

--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use api::rest::SearchRequestInternal;
-use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted,
 };
@@ -48,7 +48,7 @@ fn setup() -> (TempDir, LocalShard) {
         ..CollectionParams::empty()
     };
 
-    let collection_config = CollectionConfig {
+    let collection_config = CollectionConfigInternal {
         params: collection_params,
         optimizer_config: OptimizersConfig {
             deleted_threshold: 0.9,

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -83,6 +83,7 @@ fn batch_search_bench(c: &mut Criterion) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     };
 
     let optimizers_config = collection_config.optimizer_config.clone();

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use api::rest::SearchRequestInternal;
-use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted,
 };
@@ -67,7 +67,7 @@ fn batch_search_bench(c: &mut Criterion) {
         ..CollectionParams::empty()
     };
 
-    let collection_config = CollectionConfig {
+    let collection_config = CollectionConfigInternal {
         params: collection_params,
         optimizer_config: OptimizersConfig {
             deleted_threshold: 0.9,

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -28,7 +28,7 @@ use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_state::{ShardInfo, State};
 use crate::common::is_ready::IsReady;
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::config_diff::{DiffConfig, OptimizersConfigDiff};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult, NodeType};
@@ -54,7 +54,7 @@ use crate::telemetry::CollectionTelemetry;
 pub struct Collection {
     pub(crate) id: CollectionId,
     pub(crate) shards_holder: Arc<LockedShardHolder>,
-    pub(crate) collection_config: Arc<RwLock<CollectionConfig>>,
+    pub(crate) collection_config: Arc<RwLock<CollectionConfigInternal>>,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     optimizers_overwrite: Option<OptimizersConfigDiff>,
@@ -94,7 +94,7 @@ impl Collection {
         this_peer_id: PeerId,
         path: &Path,
         snapshots_path: &Path,
-        collection_config: &CollectionConfig,
+        collection_config: &CollectionConfigInternal,
         shared_storage_config: Arc<SharedStorageConfig>,
         shard_distribution: CollectionShardDistribution,
         channel_service: ChannelService,
@@ -215,7 +215,7 @@ impl Collection {
             }
         }
 
-        let collection_config = CollectionConfig::load(path).unwrap_or_else(|err| {
+        let collection_config = CollectionConfigInternal::load(path).unwrap_or_else(|err| {
             panic!(
                 "Can't read collection config due to {}\nat {}",
                 err,

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -313,6 +313,10 @@ impl Collection {
         self.id.clone()
     }
 
+    pub async fn uuid(&self) -> Option<uuid::Uuid> {
+        self.collection_config.read().await.uuid
+    }
+
     pub async fn get_shard_keys(&self) -> Vec<ShardKey> {
         self.shards_holder
             .read()

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -15,7 +15,7 @@ use crate::collection::payload_index_schema::PAYLOAD_INDEX_CONFIG_FILE;
 use crate::collection::CollectionVersion;
 use crate::common::snapshot_stream::SnapshotStream;
 use crate::common::snapshots_manager::SnapshotStorageManager;
-use crate::config::{CollectionConfig, ShardingMethod, COLLECTION_CONFIG_FILE};
+use crate::config::{CollectionConfigInternal, ShardingMethod, COLLECTION_CONFIG_FILE};
 use crate::operations::snapshot_ops::SnapshotDescription;
 use crate::operations::types::{CollectionError, CollectionResult, NodeType};
 use crate::shards::local_shard::LocalShard;
@@ -170,7 +170,7 @@ impl Collection {
         let mut ar = open_snapshot_archive_with_validation(snapshot_path)?;
         ar.unpack(target_dir)?;
 
-        let config = CollectionConfig::load(target_dir)?;
+        let config = CollectionConfigInternal::load(target_dir)?;
         config.validate_and_warn();
         let configured_shards = config.params.shard_number.get();
 

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection::Collection;
 use crate::collection_state::{ShardInfo, State};
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId};
@@ -11,7 +11,10 @@ use crate::shards::shard_holder::{ShardKeyMapping, ShardTransferChange};
 use crate::shards::transfer::ShardTransfer;
 
 impl Collection {
-    pub async fn check_config_compatible(&self, config: &CollectionConfig) -> CollectionResult<()> {
+    pub async fn check_config_compatible(
+        &self,
+        config: &CollectionConfigInternal,
+    ) -> CollectionResult<()> {
         self.collection_config
             .read()
             .await
@@ -71,7 +74,7 @@ impl Collection {
         Ok(())
     }
 
-    async fn apply_config(&self, new_config: CollectionConfig) -> CollectionResult<()> {
+    async fn apply_config(&self, new_config: CollectionConfigInternal) -> CollectionResult<()> {
         let recreate_optimizers;
 
         {
@@ -100,7 +103,7 @@ impl Collection {
             // complain, if new field is added to `CollectionConfig` struct, but not destructured
             // explicitly. We have to explicitly compare config fields, because we want to compare
             // `wal_config` and `strict_mode_config` independently of other fields.
-            let CollectionConfig {
+            let CollectionConfigInternal {
                 params,
                 hnsw_config,
                 optimizer_config,

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -25,7 +25,7 @@ use crate::collection_manager::holders::segment_holder::LockedSegment;
 use crate::collection_manager::probabilistic_segment_search_sampling::find_search_sampling_over_point_distribution;
 use crate::collection_manager::search_result_aggregator::BatchResultAggregator;
 use crate::common::stopping_guard::StoppingGuard;
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::types::{
     CollectionResult, CoreSearchRequestBatch, Modifier, RecordInternal,
@@ -159,7 +159,7 @@ impl SegmentsSearcher {
     pub async fn prepare_query_context(
         segments: LockedSegmentHolder,
         batch_request: &CoreSearchRequestBatch,
-        collection_config: &CollectionConfig,
+        collection_config: &CollectionConfigInternal,
         is_stopped_guard: &StoppingGuard,
     ) -> CollectionResult<Option<QueryContext>> {
         let indexing_threshold_kb = collection_config

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::collection::payload_index_schema::PayloadIndexSchema;
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::resharding::ReshardState;
 use crate::shards::shard::{PeerId, ShardId};
@@ -19,7 +19,7 @@ pub struct ShardInfo {
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct State {
     #[validate(nested)]
-    pub config: CollectionConfig,
+    pub config: CollectionConfigInternal,
     pub shards: HashMap<ShardId, ShardInfo>,
     pub resharding: Option<ReshardState>,
     #[serde(default)]

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -210,7 +210,7 @@ pub const fn default_on_disk_payload() -> bool {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
-pub struct CollectionConfig {
+pub struct CollectionConfigInternal {
     #[validate(nested)]
     pub params: CollectionParams,
     #[validate(nested)]
@@ -222,14 +222,12 @@ pub struct CollectionConfig {
     #[serde(default)]
     pub quantization_config: Option<QuantizationConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(skip)]
     pub strict_mode_config: Option<StrictModeConfig>,
     #[serde(default)]
-    #[schemars(skip)]
     pub uuid: Option<Uuid>,
 }
 
-impl CollectionConfig {
+impl CollectionConfigInternal {
     pub fn to_bytes(&self) -> CollectionResult<Vec<u8>> {
         serde_json::to_vec(self).map_err(|err| CollectionError::service_error(err.to_string()))
     }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -17,6 +17,7 @@ use segment::types::{
     VectorStorageDatatype, VectorStorageType,
 };
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use validator::Validate;
 use wal::WalOptions;
 
@@ -220,10 +221,12 @@ pub struct CollectionConfig {
     pub wal_config: WalConfig,
     #[serde(default)]
     pub quantization_config: Option<QuantizationConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)]
+    pub strict_mode_config: Option<StrictModeConfig>,
     #[serde(default)]
     #[schemars(skip)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub strict_mode_config: Option<StrictModeConfig>,
+    pub uuid: Option<Uuid>,
 }
 
 impl CollectionConfig {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -437,7 +437,6 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                 strict_mode_config: config
                     .strict_mode_config
                     .map(api::grpc::qdrant::StrictModeConfig::from),
-                uuid: config.uuid.map(|uuid| uuid.into_bytes().into()),
             }),
             payload_schema: payload_schema
                 .into_iter()
@@ -779,14 +778,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                 }
             },
             strict_mode_config: config.strict_mode_config.map(StrictModeConfig::from),
-            uuid: config
-                .uuid
-                .map(|uuid| {
-                    uuid.try_into().map_err(|err| {
-                        tonic::Status::invalid_argument(format!("failed to parse UUID: {err}"))
-                    })
-                })
-                .transpose()?,
+            uuid: None,
         })
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -437,6 +437,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                 strict_mode_config: config
                     .strict_mode_config
                     .map(api::grpc::qdrant::StrictModeConfig::from),
+                uuid: config.uuid.map(|uuid| uuid.into_bytes().into()),
             }),
             payload_schema: payload_schema
                 .into_iter()
@@ -778,6 +779,14 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                 }
             },
             strict_mode_config: config.strict_mode_config.map(StrictModeConfig::from),
+            uuid: config
+                .uuid
+                .map(|uuid| {
+                    uuid.try_into().map_err(|err| {
+                        tonic::Status::invalid_argument(format!("failed to parse UUID: {err}"))
+                    })
+                })
+                .transpose()?,
         })
     }
 }

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -416,6 +416,7 @@ mod test {
             hnsw_config: Default::default(),
             quantization_config: Default::default(),
             strict_mode_config: Some(strict_mode_config.clone()),
+            uuid: None,
         };
 
         let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -249,7 +249,7 @@ mod test {
 
     use super::StrictModeVerification;
     use crate::collection::{Collection, RequestShardTransfer};
-    use crate::config::{CollectionConfig, CollectionParams, WalConfig};
+    use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
     use crate::operations::point_ops::{FilterSelector, PointsSelector};
     use crate::operations::shared_storage_config::SharedStorageConfig;
     use crate::operations::types::{
@@ -409,7 +409,7 @@ mod test {
         let wal_config = WalConfig::default();
         let collection_params = CollectionParams::empty();
 
-        let config = CollectionConfig {
+        let config = CollectionConfigInternal {
             params: collection_params,
             optimizer_config: OptimizersConfig::fixture(),
             wal_config,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -50,7 +50,7 @@ use crate::collection_manager::holders::segment_holder::{
 use crate::collection_manager::optimizers::TrackerLog;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::common::file_utils::{move_dir, move_file};
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{
     check_sparse_compatible_with_segment_config, CollectionError, CollectionResult,
@@ -81,7 +81,7 @@ const SEGMENTS_PATH: &str = "segments";
 /// Holds all object, required for collection functioning
 pub struct LocalShard {
     pub(super) segments: LockedSegmentHolder,
-    pub(super) collection_config: Arc<TokioRwLock<CollectionConfig>>,
+    pub(super) collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
     pub(super) shared_storage_config: Arc<SharedStorageConfig>,
     pub(crate) payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     pub(super) wal: RecoverableWal,
@@ -144,7 +144,7 @@ impl LocalShard {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         segment_holder: SegmentHolder,
-        collection_config: Arc<TokioRwLock<CollectionConfig>>,
+        collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         wal: SerdeWal<OperationWithClockTag>,
@@ -224,7 +224,7 @@ impl LocalShard {
         id: ShardId,
         collection_id: CollectionId,
         shard_path: &Path,
-        collection_config: Arc<TokioRwLock<CollectionConfig>>,
+        collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
         effective_optimizers_config: OptimizersConfig,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
@@ -413,7 +413,7 @@ impl LocalShard {
         id: ShardId,
         collection_id: CollectionId,
         shard_path: &Path,
-        collection_config: Arc<TokioRwLock<CollectionConfig>>,
+        collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         update_runtime: Handle,
@@ -446,7 +446,7 @@ impl LocalShard {
         id: ShardId,
         collection_id: CollectionId,
         shard_path: &Path,
-        collection_config: Arc<TokioRwLock<CollectionConfig>>,
+        collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         update_runtime: Handle,

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -27,7 +27,7 @@ use super::transfer::ShardTransfer;
 use super::CollectionId;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::common::snapshots_manager::SnapshotStorageManager;
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::point_ops::{self};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
@@ -98,7 +98,7 @@ pub struct ShardReplicaSet {
     abort_shard_transfer_cb: AbortShardTransfer,
     channel_service: ChannelService,
     collection_id: CollectionId,
-    collection_config: Arc<RwLock<CollectionConfig>>,
+    collection_config: Arc<RwLock<CollectionConfigInternal>>,
     optimizers_config: OptimizersConfig,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
@@ -129,7 +129,7 @@ impl ShardReplicaSet {
         on_peer_failure: ChangePeerFromState,
         abort_shard_transfer: AbortShardTransfer,
         collection_path: &Path,
-        collection_config: Arc<RwLock<CollectionConfig>>,
+        collection_config: Arc<RwLock<CollectionConfigInternal>>,
         effective_optimizers_config: OptimizersConfig,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
@@ -218,7 +218,7 @@ impl ShardReplicaSet {
         shard_id: ShardId,
         collection_id: CollectionId,
         shard_path: &Path,
-        collection_config: Arc<RwLock<CollectionConfig>>,
+        collection_config: Arc<RwLock<CollectionConfigInternal>>,
         effective_optimizers_config: OptimizersConfig,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -615,6 +615,7 @@ mod tests {
             hnsw_config: Default::default(),
             quantization_config: None,
             strict_mode_config: None,
+            uuid: None,
         };
 
         let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -608,7 +608,7 @@ mod tests {
             ..CollectionParams::empty()
         };
 
-        let config = CollectionConfig {
+        let config = CollectionConfigInternal {
             params: collection_params,
             optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
             wal_config,

--- a/lib/collection/src/shards/resharding/driver.rs
+++ b/lib/collection/src/shards/resharding/driver.rs
@@ -11,7 +11,7 @@ use tokio::time::sleep;
 
 use super::tasks_pool::ReshardTaskProgress;
 use super::ReshardKey;
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -224,7 +224,7 @@ pub async fn drive_resharding(
     consensus: &dyn ShardTransferConsensus,
     collection_id: CollectionId,
     collection_path: PathBuf,
-    collection_config: Arc<RwLock<CollectionConfig>>,
+    collection_config: Arc<RwLock<CollectionConfigInternal>>,
     shared_storage_config: &SharedStorageConfig,
     channel_service: ChannelService,
     can_resume: bool,

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -27,7 +27,7 @@ use tokio::time::sleep;
 use super::shard::{PeerId, ShardId};
 use super::transfer::ShardTransferConsensus;
 use crate::common::stoppable_task_async::{spawn_async_cancellable, CancellableAsyncTaskHandle};
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::shards::channel_service::ChannelService;
@@ -118,7 +118,7 @@ pub fn spawn_resharding_task<T, F>(
     consensus: Box<dyn ShardTransferConsensus>,
     collection_id: CollectionId,
     collection_path: PathBuf,
-    collection_config: Arc<RwLock<CollectionConfig>>,
+    collection_config: Arc<RwLock<CollectionConfigInternal>>,
     shared_storage_config: Arc<SharedStorageConfig>,
     channel_service: ChannelService,
     can_resume: bool,

--- a/lib/collection/src/shards/resharding/stage_replicate.rs
+++ b/lib/collection/src/shards/resharding/stage_replicate.rs
@@ -10,7 +10,7 @@ use tokio::time::sleep;
 use super::driver::{PersistedState, Stage};
 use super::tasks_pool::ReshardTaskProgress;
 use super::ReshardKey;
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -31,7 +31,7 @@ pub(super) async fn is_completed(
     reshard_key: &ReshardKey,
     state: &PersistedState,
     shard_holder: &Arc<LockedShardHolder>,
-    collection_config: &Arc<RwLock<CollectionConfig>>,
+    collection_config: &Arc<RwLock<CollectionConfigInternal>>,
 ) -> CollectionResult<bool> {
     Ok(state.read().all_peers_completed(Stage::S3_Replicate)
         && has_enough_replicas(reshard_key, shard_holder, collection_config).await?)
@@ -48,7 +48,7 @@ pub(super) async fn drive(
     shard_holder: Arc<LockedShardHolder>,
     consensus: &dyn ShardTransferConsensus,
     collection_id: &CollectionId,
-    collection_config: Arc<RwLock<CollectionConfig>>,
+    collection_config: Arc<RwLock<CollectionConfigInternal>>,
     shared_storage_config: &SharedStorageConfig,
 ) -> CollectionResult<()> {
     let this_peer_id = consensus.this_peer_id();
@@ -173,7 +173,7 @@ pub(super) async fn drive(
 async fn has_enough_replicas(
     reshard_key: &ReshardKey,
     shard_holder: &Arc<LockedShardHolder>,
-    collection_config: &Arc<RwLock<CollectionConfig>>,
+    collection_config: &Arc<RwLock<CollectionConfigInternal>>,
 ) -> CollectionResult<bool> {
     // We don't need to replicate when scaling down
     if reshard_key.direction == ReshardingDirection::Down {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -24,7 +24,7 @@ use super::resharding::{ReshardStage, ReshardState};
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::common::snapshot_stream::SnapshotStream;
-use crate::config::{CollectionConfig, ShardingMethod};
+use crate::config::{CollectionConfigInternal, ShardingMethod};
 use crate::hash_ring::HashRingRouter;
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
@@ -564,7 +564,7 @@ impl ShardHolder {
         &mut self,
         collection_path: &Path,
         collection_id: &CollectionId,
-        collection_config: Arc<RwLock<CollectionConfig>>,
+        collection_config: Arc<RwLock<CollectionConfigInternal>>,
         effective_optimizers_config: OptimizersConfig,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::Serialize;
 
-use crate::config::CollectionConfig;
+use crate::config::CollectionConfigInternal;
 use crate::operations::types::{ReshardingInfo, ShardTransferInfo};
 use crate::shards::telemetry::ReplicaSetTelemetry;
 
@@ -10,7 +10,7 @@ use crate::shards::telemetry::ReplicaSetTelemetry;
 pub struct CollectionTelemetry {
     pub id: String,
     pub init_time_ms: u64,
-    pub config: CollectionConfig,
+    pub config: CollectionConfigInternal,
     pub shards: Vec<ReplicaSetTelemetry>,
     pub transfers: Vec<ShardTransferInfo>,
     pub resharding: Vec<ReshardingInfo>,
@@ -40,9 +40,9 @@ impl Anonymize for CollectionTelemetry {
     }
 }
 
-impl Anonymize for CollectionConfig {
+impl Anonymize for CollectionConfigInternal {
     fn anonymize(&self) -> Self {
-        CollectionConfig {
+        CollectionConfigInternal {
             params: self.params.clone(),
             hnsw_config: self.hnsw_config.clone(),
             optimizer_config: self.optimizer_config.clone(),

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -49,6 +49,7 @@ impl Anonymize for CollectionConfig {
             wal_config: self.wal_config.clone(),
             quantization_config: self.quantization_config.clone(),
             strict_mode_config: self.strict_mode_config.clone(),
+            uuid: None,
         }
     }
 }

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -5,7 +5,7 @@ use segment::types::{
     Condition, Distance, Filter, PayloadFieldSchema, PayloadSchemaType, PointIdType,
 };
 
-use crate::config::{CollectionConfig, CollectionParams, WalConfig};
+use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted,
 };
@@ -25,7 +25,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     max_optimization_threads: Some(2),
 };
 
-pub fn create_collection_config() -> CollectionConfig {
+pub fn create_collection_config() -> CollectionConfigInternal {
     let wal_config = WalConfig {
         wal_capacity_mb: 1,
         wal_segments_ahead: 0,
@@ -41,7 +41,7 @@ pub fn create_collection_config() -> CollectionConfig {
     optimizer_config.default_segment_number = 1;
     optimizer_config.flush_interval_sec = 0;
 
-    CollectionConfig {
+    CollectionConfigInternal {
         params: collection_params,
         optimizer_config,
         wal_config,

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -48,6 +48,7 @@ pub fn create_collection_config() -> CollectionConfig {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     }
 }
 

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -59,6 +59,7 @@ async fn fixture() -> Collection {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     };
 
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -14,7 +14,7 @@ use serde_json::{Map, Value};
 use tempfile::Builder;
 
 use crate::collection::{Collection, RequestShardTransfer};
-use crate::config::{CollectionConfig, CollectionParams, WalConfig};
+use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
 };
@@ -52,7 +52,7 @@ async fn fixture() -> Collection {
         ..CollectionParams::empty()
     };
 
-    let config = CollectionConfig {
+    let config = CollectionConfigInternal {
         params: collection_params,
         optimizer_config: OptimizersConfig::fixture(),
         wal_config,

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -7,7 +7,7 @@ use segment::types::Distance;
 use tempfile::Builder;
 
 use crate::collection::{Collection, RequestShardTransfer};
-use crate::config::{CollectionConfig, CollectionParams, WalConfig};
+use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{NodeType, VectorsConfig};
 use crate::operations::vector_params_builder::VectorParamsBuilder;
@@ -46,7 +46,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         ..CollectionParams::empty()
     };
 
-    let config = CollectionConfig {
+    let config = CollectionConfigInternal {
         params: collection_params,
         optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
         wal_config,

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -53,6 +53,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     };
 
     let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -52,6 +52,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     };
 
     let snapshot_path = collection_path.join("snapshots");

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use collection::collection::{Collection, RequestShardTransfer};
-use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use collection::operations::types::CollectionError;
 use collection::operations::vector_params_builder::VectorParamsBuilder;
 use collection::optimizers_builder::OptimizersConfig;
@@ -45,7 +45,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
         ..CollectionParams::empty()
     };
 
-    let collection_config = CollectionConfig {
+    let collection_config = CollectionConfigInternal {
         params: collection_params,
         optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
         wal_config,
@@ -86,7 +86,7 @@ pub async fn new_local_collection(
     id: CollectionId,
     path: &Path,
     snapshots_path: &Path,
-    config: &CollectionConfig,
+    config: &CollectionConfigInternal,
 ) -> Result<Collection, CollectionError> {
     let collection = Collection::new(
         id,

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use api::rest::SearchRequestInternal;
 use collection::collection::Collection;
-use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
     WriteOrdering,
@@ -54,7 +54,7 @@ pub async fn multi_vec_collection_fixture(collection_path: &Path, shard_number: 
         ..CollectionParams::empty()
     };
 
-    let collection_config = CollectionConfig {
+    let collection_config = CollectionConfigInternal {
         params: collection_params,
         optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
         wal_config,

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -61,6 +61,7 @@ pub async fn multi_vec_collection_fixture(collection_path: &Path, shard_number: 
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     };
 
     let snapshot_path = collection_path.join("snapshots");

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -43,6 +43,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
         strict_mode_config: Default::default(),
+        uuid: None,
     };
 
     let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use api::rest::SearchRequestInternal;
 use collection::collection::Collection;
-use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
     WriteOrdering,
@@ -36,7 +36,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         ..CollectionParams::empty()
     };
 
-    let config = CollectionConfig {
+    let config = CollectionConfigInternal {
         params: collection_params,
         optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
         wal_config,

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -18,6 +18,7 @@ use segment::types::{
     PayloadFieldSchema, PayloadKeyType, QuantizationConfig, ShardKey, StrictModeConfig,
 };
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use validator::Validate;
 
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
@@ -173,6 +174,8 @@ pub struct CreateCollection {
     /// Strict-mode config.
     #[validate(nested)]
     pub strict_mode_config: Option<StrictModeConfig>,
+    #[serde(default)]
+    pub uuid: Option<Uuid>,
 }
 
 /// Operation for creating new collection and (optionally) specify index params
@@ -409,6 +412,7 @@ impl From<CollectionConfig> for CreateCollection {
             quantization_config: value.quantization_config,
             sparse_vectors: value.params.sparse_vectors,
             strict_mode_config: value.strict_mode_config,
+            uuid: value.uuid,
         }
     }
 }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use collection::config::{CollectionConfig, ShardingMethod};
+use collection::config::{CollectionConfigInternal, ShardingMethod};
 use collection::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
     WalConfigDiff,
@@ -397,8 +397,8 @@ pub enum CollectionMetaOperations {
 
 /// Use config of the existing collection to generate a create collection operation
 /// for the new collection
-impl From<CollectionConfig> for CreateCollection {
-    fn from(value: CollectionConfig) -> Self {
+impl From<CollectionConfigInternal> for CreateCollection {
+    fn from(value: CollectionConfigInternal) -> Self {
         Self {
             vectors: value.params.vectors,
             shard_number: Some(value.params.shard_number.get()),

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -175,6 +175,7 @@ pub struct CreateCollection {
     #[validate(nested)]
     pub strict_mode_config: Option<StrictModeConfig>,
     #[serde(default)]
+    #[schemars(skip)]
     pub uuid: Option<Uuid>,
 }
 

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -68,6 +68,14 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
                     .map(sharding_method_from_proto)
                     .transpose()?,
                 strict_mode_config: value.strict_mode_config.map(strict_mode_from_api),
+                uuid: value
+                    .uuid
+                    .map(|uuid| {
+                        uuid.try_into().map_err(|err| {
+                            tonic::Status::invalid_argument(format!("failed to parse UUID: {err}"))
+                        })
+                    })
+                    .transpose()?,
             },
         )))
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -68,14 +68,7 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
                     .map(sharding_method_from_proto)
                     .transpose()?,
                 strict_mode_config: value.strict_mode_config.map(strict_mode_from_api),
-                uuid: value
-                    .uuid
-                    .map(|uuid| {
-                        uuid.try_into().map_err(|err| {
-                            tonic::Status::invalid_argument(format!("failed to parse UUID: {err}"))
-                        })
-                    })
-                    .transpose()?,
+                uuid: None,
             },
         )))
     }

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -1,6 +1,6 @@
 use collection::collection::Collection;
 use collection::common::sha_256::{hash_file, hashes_equal};
-use collection::config::CollectionConfig;
+use collection::config::CollectionConfigInternal;
 use collection::operations::snapshot_ops::{SnapshotPriority, SnapshotRecover};
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::replica_set::ReplicaState;
@@ -137,7 +137,7 @@ async fn _do_recover_from_snapshot(
     });
     restoring.await??;
 
-    let snapshot_config = CollectionConfig::load(tmp_collection_dir.path())?;
+    let snapshot_config = CollectionConfigInternal::load(tmp_collection_dir.path())?;
     snapshot_config.validate_and_warn();
 
     let collection = match toc.get_collection(&collection_pass).await.ok() {

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::num::NonZeroU32;
 
 use collection::collection::Collection;
-use collection::config::{self, CollectionConfig, CollectionParams, ShardingMethod};
+use collection::config::{self, CollectionConfigInternal, CollectionParams, ShardingMethod};
 use collection::operations::config_diff::DiffConfig as _;
 use collection::operations::types::{
     check_sparse_compatible, CollectionResult, SparseVectorParams, VectorsConfig,
@@ -199,7 +199,7 @@ impl TableOfContent {
             .to_shared_storage_config(self.is_distributed())
             .into();
 
-        let collection_config = CollectionConfig {
+        let collection_config = CollectionConfigInternal {
             wal_config,
             params: collection_params,
             optimizer_config: optimizers_config,

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -45,6 +45,7 @@ impl TableOfContent {
             quantization_config,
             sparse_vectors,
             strict_mode_config,
+            uuid,
         } = operation;
 
         self.collections
@@ -205,6 +206,7 @@ impl TableOfContent {
             hnsw_config,
             quantization_config,
             strict_mode_config,
+            uuid,
         };
         let collection = Collection::new(
             collection_name.to_string(),

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use collection::collection::{Collection, RequestShardTransfer};
-use collection::config::{default_replication_factor, CollectionConfig};
+use collection::config::{default_replication_factor, CollectionConfigInternal};
 use collection::operations::types::*;
 use collection::shards::channel_service::ChannelService;
 use collection::shards::replica_set;
@@ -108,7 +108,7 @@ impl TableOfContent {
                 .expect("Can't access of one of the collection files")
                 .path();
 
-            if !CollectionConfig::check(&collection_path) {
+            if !CollectionConfigInternal::check(&collection_path) {
                 log::warn!(
                     "Collection config is not found in the collection directory: {}, skipping",
                     collection_path.display(),
@@ -586,7 +586,7 @@ impl TableOfContent {
         let path = self.get_collection_path(collection_name);
 
         if path.exists() {
-            if CollectionConfig::check(&path) {
+            if CollectionConfigInternal::check(&path) {
                 return Err(StorageError::bad_input(format!(
                     "Can't create collection with name {collection_name}. Collection data already exists at {path}",
                     collection_name = collection_name,

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -123,9 +123,9 @@ impl Dispatcher {
                              new random UUID will be generated instead",
                             op.collection_name,
                         );
-
-                        op.create_collection.uuid = Some(uuid::Uuid::new_v4());
                     }
+
+                    op.create_collection.uuid = Some(uuid::Uuid::new_v4());
 
                     CollectionMetaOperations::CreateCollection(op)
                 }

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -115,6 +115,18 @@ impl Dispatcher {
                             }
                         }
                     }
+
+                    if let Some(uuid) = &op.create_collection.uuid {
+                        log::warn!(
+                            "Collection UUID {uuid} explicitly specified, \
+                             when proposing create collection {} operation, \
+                             new random UUID will be generated instead",
+                            op.collection_name,
+                        );
+
+                        op.create_collection.uuid = Some(uuid::Uuid::new_v4());
+                    }
+
                     CollectionMetaOperations::CreateCollection(op)
                 }
                 CollectionMetaOperations::CreateShardKey(op) => {

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -115,6 +115,7 @@ fn test_alias_operation() {
                         quantization_config: None,
                         sharding_method: None,
                         strict_mode_config: None,
+                        uuid: None,
                     },
                 )),
                 FULL_ACCESS,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1486,6 +1486,7 @@ mod tests {
                             quantization_config: None,
                             sharding_method: None,
                             strict_mode_config: None,
+                            uuid: None,
                         },
                     )),
                     Access::full("For test"),

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -63,6 +63,7 @@ pub async fn handle_existing_collections(
                 init_from: None,
                 quantization_config: collection_state.config.quantization_config,
                 strict_mode_config: collection_state.config.strict_mode_config,
+                uuid: collection_state.config.uuid,
             },
         );
 


### PR DESCRIPTION
When applying Raft snapshot, we receive a list of collections that currently exist in the cluster. However, it is _generally_ impossible to determine, if a collection was deleted and then another collection with the same name was created in its place.

E.g., imagine that
- collection "example" is created
- node A is temporarily shut down
- collection "example" is deleted
- and *another* collection, also named "example", with exactly the same configuration is created
- now node A is restarted, and receives Raft snapshot to synchronize consensus state
- this Raft snapshot will contain collection "example" with exactly the same parameters as the collection that exists on node A, and it's impossible to detect, that collection has been recreated

This PR adds a UUID field to collection config, so that it is possible to compare UUIDs of existing collection, and collection in the Raft snapshot, to determine if the collection needs to be recreated from scratch.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
