### PR TITLE
Experiment: set_replica_state does not need to be async

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -227,7 +227,7 @@ impl Collection {
                 };
 
                 if transfer.to == self.this_peer_id {
-                    replica_set.set_replica_state(transfer.to, state).await?;
+                    replica_set.set_replica_state(transfer.to, state)?;
                 } else {
                     replica_set.add_remote(transfer.to, state).await?;
                 }
@@ -319,9 +319,7 @@ impl Collection {
                     //   and so failed transfer does not introduce any inconsistencies to points
                     //   that are not affected by resharding in all other shards
                 } else if transfer.sync {
-                    replica_set
-                        .set_replica_state(transfer.to, ReplicaState::Dead)
-                        .await?;
+                    replica_set.set_replica_state(transfer.to, ReplicaState::Dead)?;
                 } else {
                     replica_set.remove_peer(transfer.to).await?;
                 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -602,7 +602,7 @@ impl ShardReplicaSet {
         state: ReplicaState,
     ) -> CollectionResult<()> {
         if peer_id == self.this_peer_id() {
-            self.set_replica_state(peer_id, state).await?;
+            self.set_replica_state(peer_id, state)?;
         } else {
             // Create remote shard if necessary
             self.add_remote(peer_id, state).await?;
@@ -610,11 +610,7 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub async fn set_replica_state(
-        &self,
-        peer_id: PeerId,
-        state: ReplicaState,
-    ) -> CollectionResult<()> {
+    pub fn set_replica_state(&self, peer_id: PeerId, state: ReplicaState) -> CollectionResult<()> {
         log::debug!(
             "Changing local shard {}:{} state from {:?} to {state:?}",
             self.collection_id,

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -573,12 +573,10 @@ mod tests {
         // at build time the replicas are all dead, they need to be activated
         assert_eq!(rs.highest_alive_replica_peer_id(), None);
 
-        rs.set_replica_state(1, ReplicaState::Active).await.unwrap();
-        rs.set_replica_state(3, ReplicaState::Active).await.unwrap();
-        rs.set_replica_state(4, ReplicaState::Active).await.unwrap();
-        rs.set_replica_state(5, ReplicaState::Partial)
-            .await
-            .unwrap();
+        rs.set_replica_state(1, ReplicaState::Active).unwrap();
+        rs.set_replica_state(3, ReplicaState::Active).unwrap();
+        rs.set_replica_state(4, ReplicaState::Active).unwrap();
+        rs.set_replica_state(5, ReplicaState::Partial).unwrap();
 
         assert_eq!(rs.highest_replica_peer_id(), Some(5));
         assert_eq!(rs.highest_alive_replica_peer_id(), Some(4));

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -701,7 +701,6 @@ impl ShardHolder {
                     log::warn!("Local shard {collection_id}:{} stuck in Initializing state, changing to Active", replica_set.shard_id);
                     replica_set
                         .set_replica_state(local_peer_id, ReplicaState::Active)
-                        .await
                         .expect("Failed to set local shard state");
                 }
                 let shard_key = shard_id_to_key_mapping.get(&shard_id).cloned();

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -306,7 +306,7 @@ impl ShardHolder {
                 // Revert replicas in `Resharding` state back into `Active` state
                 for (peer, state) in shard.peers() {
                     if state == ReplicaState::Resharding {
-                        shard.set_replica_state(peer, ReplicaState::Active).await?;
+                        shard.set_replica_state(peer, ReplicaState::Active)?;
                     }
                 }
 


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/5349> we added an await in `set_replica_state` and made the function async.

In <https://github.com/qdrant/qdrant/pull/5372> we removed all awaits from the function again.

I forgot to remove the `async` flag from the function, as it's now not needed anymore. This PR makes the change.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?