### PR TITLE
In /readyz, wait for Raft commit to be actually applied

### DIFF
--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -287,9 +287,8 @@ impl Task {
         self.consensus_state
             .persistent
             .read()
-            .state
-            .hard_state
-            .commit
+            .last_applied_entry()
+            .unwrap_or(0)
     }
 
     /// List shards that are unhealthy, which may undergo automatic recovery.


### PR DESCRIPTION
Similar to <https://github.com/qdrant/qdrant/pull/5350>.

Our `/readyz` will wait for the node to reach the highest Raft commit reported by other peers.

The implementation is wrong. It only waits for that commit to be received, it does not wait for that commit to actually be applied.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?