### PR TITLE
ID mapping should only be saved on flush

### DIFF
--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::common::operation_error::OperationResult;
-use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_buffered_update_wrapper::DatabaseColumnScheduledUpdateWrapper;
 use crate::common::rocksdb_wrapper::{DatabaseColumnWrapper, DB_MAPPING_CF, DB_VERSIONS_CF};
 use crate::common::Flusher;
@@ -89,7 +88,7 @@ fn external_to_stored_id(point_id: &PointIdType) -> StoredPointId {
 #[derive(Debug)]
 pub struct SimpleIdTracker {
     internal_to_version: Vec<SeqNumberType>,
-    mapping_db_wrapper: DatabaseColumnScheduledDeleteWrapper,
+    mapping_db_wrapper: DatabaseColumnScheduledUpdateWrapper,
     versions_db_wrapper: DatabaseColumnScheduledUpdateWrapper,
     mappings: PointMappings,
 }
@@ -101,7 +100,7 @@ impl SimpleIdTracker {
         let mut external_to_internal_num: BTreeMap<u64, PointOffsetType> = Default::default();
         let mut external_to_internal_uuid: BTreeMap<Uuid, PointOffsetType> = Default::default();
 
-        let mapping_db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(
+        let mapping_db_wrapper = DatabaseColumnScheduledUpdateWrapper::new(
             DatabaseColumnWrapper::new(store.clone(), DB_MAPPING_CF),
         );
         for (key, val) in mapping_db_wrapper.lock_db().iter()? {


### PR DESCRIPTION
This PR fixes the simple id mapper to only persist inserts to mapping on explicit flush.

This is not currently the case because the persistence is handled by RocksDB which persist inserts freely.

This is important because our flushing sequence is:
- id mappings
- vectors
- payloads 
- id versions

Upon restart, the WAL is replayed and operations for which the sequence number are less or equal than the point versions are discarded.

The version of point is resolved like this.

```rust
     id_tracker
            .internal_id(point_id)
            .and_then(|internal_id| id_tracker.internal_version(internal_id))
```

First we fetch the `internal_id` which query the mapping and then follow through by looking up the `version`.

In the current setup this can return invalid version which have not been flushed during WAL replay.

The mappings are flushed outside of our sequence by RocksDB, so they can be present without version, this is the normal state of affair.

However, new points can be added during the WAL replay, which means adding new tracked versions.

```rust
  fn set_internal_version(
        &mut self,
        internal_id: PointOffsetType,
        version: SeqNumberType,
    ) -> OperationResult<()> {
        if let Some(external_id) = self.external_id(internal_id) {
            if internal_id as usize >= self.internal_to_version.len() {
                self.internal_to_version.resize(internal_id as usize + 1, 0);
            }
            self.internal_to_version[internal_id as usize] = version;
            self.versions_db_wrapper.put(
                Self::store_key(&external_id),
                bincode::serialize(&version).unwrap(),
            )?;
        }
        Ok(())
    }
```

If a mapping is found for a new point, we will initialize all previous version to 0 to keep a contiguous memory slice.

Given a dirty mapping, a new 0 version can be created for it when replaying an operation with a point with a higher `internal_id`.

This will falsely ignore the operation during replay, creating missing payloads.

```rust
                if let Some(point_version) = write_segment.point_version(point_id) {
                    if point_version >= op_num {
                        applied_points.insert(point_id);
                        return Ok(false);
                    }
                }
```

This fix has been validated with https://github.com/qdrant/qdrant/pull/5190