### PR TITLE
Manual rocksdb's WAL flush

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -61,6 +61,7 @@ pub fn make_db_options() -> Options {
     options.create_missing_column_families(true);
     options.set_max_open_files(DB_MAX_OPEN_FILES as i32);
     options.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    options.set_manual_wal_flush(true);
 
     // Qdrant relies on it's own WAL for durability
     options.set_wal_recovery_mode(DBRecoveryMode::TolerateCorruptedTailRecords);
@@ -210,6 +211,10 @@ impl DatabaseColumnWrapper {
             db.flush_cf(column_family).map_err(|err| {
                 OperationError::service_error(format!("RocksDB flush_cf error: {err}"))
             })?;
+            db.flush_wal(false).map_err(|err| {
+                OperationError::service_error(format!("RocksDB flush_wal error: {err}"))
+            })?;
+
             Ok(())
         })
     }


### PR DESCRIPTION
We do not depend on rocksdb's WAL for durability, so this PR disables its WAL to be flushed on every write. Instead, we flush it at the same time as the other manual flushing.

Note that these changes also make the test suite green on #5190 without https://github.com/qdrant/qdrant/pull/5190/commits/0e70a454961eb9433c368486122cd66083e61b99. Although, tbh, it also passes without triggering the manual WAL flush in the `flusher()` implementation 🤷 

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
