### PR TITLE
Simplify logic in /readyz for checking if we have just one peer

### DIFF
--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -212,14 +212,15 @@ impl Task {
         }
 
         // Get *cluster* commit index
-        let this_peer_id = self.toc.this_peer_id;
-        let transport_channel_pool = &self.toc.get_channel_service().channel_pool;
-
         let peer_address_by_id = self.consensus_state.peer_address_by_id();
+        let transport_channel_pool = &self.toc.get_channel_service().channel_pool;
+        let this_peer_id = self.toc.this_peer_id;
+        let this_peer_uri = peer_address_by_id.get(&this_peer_id);
 
         let mut requests = peer_address_by_id
-            .iter()
-            .filter_map(|(&peer_id, uri)| (peer_id != this_peer_id).then_some(uri))
+            .values()
+            // Do not get the current commit from ourselves
+            .filter(|&uri| Some(uri) != this_peer_uri)
             // Historic peers might use the same URLs as our current peers, request each URI once
             .unique()
             .map(|uri| get_consensus_commit(transport_channel_pool, uri))

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -160,6 +160,9 @@ impl Task {
 
         // Check if *local* commit index >= *cluster* commit index...
         while self.commit_index() < cluster_commit_index {
+            // Wait for `/readyz` signal
+            self.check_ready_signal.notified().await;
+
             // If not:
             //
             // - Check if this is the only node in the cluster

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -163,10 +163,10 @@ impl Task {
             // If not:
             //
             // - Check if this is the only node in the cluster
-            let Some(_) = self.cluster_commit_index().await else {
+            if self.consensus_state.peer_count() <= 1 {
                 self.set_ready();
                 return;
-            };
+            }
 
             // TODO: Do we want to update `cluster_commit_index` here?
             //


### PR DESCRIPTION
What we had in place seems overly complicated for what it tries to achieve, and may send a lot of extra unnecessary requests while catching up.

This simplifies the check.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?