### PR TITLE
Optimize VisitedList counter reset

### DIFF
--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -75,10 +75,7 @@ impl<'a> VisitedListHandle<'a> {
         self.visited_list.current_iter = self.visited_list.current_iter.wrapping_add(1);
         if self.visited_list.current_iter == 0 {
             self.visited_list.current_iter = 1;
-            self.visited_list
-                .visit_counters
-                .iter_mut()
-                .for_each(|x| *x = 0);
+            self.visited_list.visit_counters.fill(0);
         }
     }
 


### PR DESCRIPTION
```console
$ cargo bench -p segment --bench hnsw_search_graph # old
hnsw-index-search-group/hnsw_search
                        time:   [386.29 µs 388.57 µs 391.12 µs]

$ cargo bench -p segment --bench hnsw_search_graph # new
hnsw-index-search-group/hnsw_search
                        time:   [360.82 µs 363.07 µs 365.57 µs]
                        change: [-7.0677% -5.5386% -3.9408%] (p = 0.00 < 0.05)
                        Performance has improved.     
```