### PR TITLE
Per collection hardware metrics

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10984,7 +10984,6 @@
         "type": "object",
         "required": [
           "config",
-          "hardware_usage",
           "id",
           "init_time_ms",
           "resharding",
@@ -11022,7 +11021,14 @@
             }
           },
           "hardware_usage": {
-            "$ref": "#/components/schemas/HardwareInfo"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HardwareInfo"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10984,6 +10984,7 @@
         "type": "object",
         "required": [
           "config",
+          "hardware_usage",
           "id",
           "init_time_ms",
           "resharding",
@@ -11019,6 +11020,9 @@
             "items": {
               "$ref": "#/components/schemas/ReshardingInfo"
             }
+          },
+          "hardware_usage": {
+            "$ref": "#/components/schemas/HardwareInfo"
           }
         }
       },
@@ -11758,6 +11762,19 @@
           },
           "updates": {
             "$ref": "#/components/schemas/OperationDurationStatistics"
+          }
+        }
+      },
+      "HardwareInfo": {
+        "type": "object",
+        "required": [
+          "cpu"
+        ],
+        "properties": {
+          "cpu": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2134,6 +2134,7 @@ impl From<rest::SearchMatrixPair> for SearchMatrixPair {
 
 impl From<HwMeasurementAcc> for HardwareUsage {
     fn from(value: HwMeasurementAcc) -> Self {
+        value.set_applied();
         Self {
             cpu: value.get_cpu() as u64,
         }

--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -179,7 +179,7 @@ fn batch_search_bench(c: &mut Criterion) {
                             Arc::new(searches),
                             search_runtime_handle,
                             None,
-                            HwMeasurementAcc::new(),
+                            HwMeasurementAcc::new_unchecked(),
                         )
                         .await
                         .unwrap();
@@ -214,7 +214,7 @@ fn batch_search_bench(c: &mut Criterion) {
                             Arc::new(search_query),
                             search_runtime_handle,
                             None,
-                            HwMeasurementAcc::new(),
+                            HwMeasurementAcc::new_unchecked(),
                         )
                         .await
                         .unwrap();
@@ -282,7 +282,7 @@ fn batch_rrf_query_bench(c: &mut Criterion) {
                             Arc::new(searches),
                             search_runtime_handle,
                             None,
-                            HwMeasurementAcc::new(),
+                            HwMeasurementAcc::new_unchecked(),
                         )
                         .await
                         .unwrap();
@@ -340,7 +340,7 @@ fn batch_rescore_bench(c: &mut Criterion) {
                             Arc::new(searches),
                             search_runtime_handle,
                             None,
-                            HwMeasurementAcc::new(),
+                            HwMeasurementAcc::new_unchecked(),
                         )
                         .await
                         .unwrap();

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -161,7 +161,7 @@ fn batch_search_bench(c: &mut Criterion) {
                                 }),
                                 search_runtime_handle,
                                 None,
-                                HwMeasurementAcc::new(),
+                                HwMeasurementAcc::new_unchecked(),
                             )
                             .await
                             .unwrap();
@@ -197,7 +197,7 @@ fn batch_search_bench(c: &mut Criterion) {
                             Arc::new(search_query),
                             search_runtime_handle,
                             None,
-                            HwMeasurementAcc::new(),
+                            HwMeasurementAcc::new_unchecked(),
                         )
                         .await
                         .unwrap();

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -341,7 +341,11 @@ impl Collection {
                     .copied()
                     .unwrap_or(ReplicaState::Dead);
                 let count_result = replica_set
-                    .count_local(count_request.clone(), None, HwMeasurementAcc::new())
+                    .count_local(
+                        count_request.clone(),
+                        None,
+                        HwMeasurementAcc::new_unchecked(),
+                    )
                     .await
                     .unwrap_or_default();
                 let points_count = count_result.map(|x| x.count).unwrap_or(0);

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -344,6 +344,8 @@ impl Collection {
                     .count_local(
                         count_request.clone(),
                         None,
+                        // We don't need to measure hardware here and can safely discard the measurements,
+                        // since the endpoint calling this function doesn't need them.
                         HwMeasurementAcc::new_unchecked(),
                     )
                     .await

--- a/lib/collection/src/collection/common.rs
+++ b/lib/collection/src/collection/common.rs
@@ -1,0 +1,35 @@
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+
+use super::Collection;
+
+#[derive(Clone)]
+pub struct CollectionAppliedHardwareAcc(pub(crate) HwMeasurementAcc);
+
+impl CollectionAppliedHardwareAcc {
+    pub fn new_unchecked() -> Self {
+        Self(HwMeasurementAcc::new_unchecked())
+    }
+
+    pub fn new() -> Self {
+        Self(HwMeasurementAcc::new())
+    }
+
+    pub fn into_hw_measurement_acc(self) -> HwMeasurementAcc {
+        self.0
+    }
+
+    fn apply(&self, src: HwMeasurementAcc, collection_counter: &HwMeasurementAcc) {
+        self.0.merge(src.clone());
+        collection_counter.merge(src);
+    }
+}
+
+impl Collection {
+    pub(crate) fn accumulate_hw_counter(
+        &self,
+        src: HwMeasurementAcc,
+        out: &CollectionAppliedHardwareAcc,
+    ) {
+        out.apply(src, &self.hardware_usage);
+    }
+}

--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -5,12 +5,12 @@ use api::rest::{
     SearchMatrixOffsetsResponse, SearchMatrixPair, SearchMatrixPairsResponse,
     SearchMatrixRequestInternal,
 };
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::vectors::{NamedVectorStruct, DEFAULT_VECTOR_NAME};
 use segment::types::{
     Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, WithVector,
 };
 
+use super::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::query_enum::QueryEnum;
@@ -139,7 +139,7 @@ impl Collection {
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> CollectionResult<CollectionSearchMatrixResponse> {
         let CollectionSearchMatrixRequest {
             sample_size,

--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -11,7 +11,7 @@ use segment::types::{
 };
 
 use crate::collection::Collection;
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
@@ -139,7 +139,7 @@ impl Collection {
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<CollectionSearchMatrixResponse> {
         let CollectionSearchMatrixRequest {
             sample_size,

--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -10,8 +10,8 @@ use segment::types::{
     Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, WithVector,
 };
 
-use super::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -178,6 +178,8 @@ impl Collection {
             update_runtime: update_runtime.unwrap_or_else(Handle::current),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
             optimizer_cpu_budget,
+            // We only drop collections when we delete them. In this case, we don't need
+            // hardware measurements anymore, so no check needed here.
             hardware_usage: HwMeasurementAcc::new_unchecked(),
         })
     }
@@ -288,6 +290,8 @@ impl Collection {
             update_runtime: update_runtime.unwrap_or_else(Handle::current),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
             optimizer_cpu_budget,
+            // We only drop collections when we delete them. In this case, we don't need
+            // hardware measurements anymore, so no check needed here.
             hardware_usage: HwMeasurementAcc::new_unchecked(),
         }
     }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -1,5 +1,4 @@
 mod collection_ops;
-pub mod common;
 pub mod distance_matrix;
 mod facet;
 pub mod payload_index_schema;
@@ -84,7 +83,7 @@ pub struct Collection {
     // Search runtime handle.
     search_runtime: Handle,
     optimizer_cpu_budget: CpuBudget,
-    hardware_usage: HwMeasurementAcc,
+    pub(crate) hardware_usage: HwMeasurementAcc,
 }
 
 pub type RequestShardTransfer = Arc<dyn Fn(ShardTransfer) + Send + Sync>;

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -758,9 +758,9 @@ impl Collection {
             shards: shards_telemetry,
             transfers,
             resharding,
-            hardware_usage: HardwareInfo {
+            hardware_usage: Some(HardwareInfo {
                 cpu: self.hardware_usage.get_cpu(),
-            },
+            }),
         }
     }
 

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -10,7 +10,7 @@ use segment::data_types::order_by::{Direction, OrderBy};
 use segment::types::{ShardKey, WithPayload, WithPayloadInterface};
 
 use super::Collection;
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
@@ -378,7 +378,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<CountResult> {
         let shards_holder = self.shards_holder.read().await;
         let shards = shards_holder.select_shards(shard_selection)?;

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -9,8 +9,8 @@ use itertools::Itertools;
 use segment::data_types::order_by::{Direction, OrderBy};
 use segment::types::{ShardKey, WithPayload, WithPayloadInterface};
 
-use super::common::CollectionAppliedHardwareAcc;
 use super::Collection;
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -19,7 +19,7 @@ use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
     build_vector_resolver_queries, resolve_referenced_vectors_batch,
 };
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::common::transpose_iterator::transposed_iter;
 use crate::operations::consistency_params::ReadConsistency;
@@ -44,7 +44,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         if request.limit == 0 {
             return Ok(vec![]);
@@ -68,7 +68,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<Vec<ShardQueryResponse>>> {
         // query all shards concurrently
         let shard_holder = self.shards_holder.read().await;
@@ -111,7 +111,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let instant = Instant::now();
 
@@ -200,7 +200,7 @@ impl Collection {
         collection_by_name: F,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
     where
         F: Fn(String) -> Fut,
@@ -285,7 +285,7 @@ impl Collection {
         requests: Vec<ShardQueryRequest>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let requests_arc = Arc::new(requests);
 

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -14,12 +14,12 @@ use segment::utils::scored_point_ties::ScoredPointTies;
 use tokio::sync::RwLockReadGuard;
 use tokio::time::Instant;
 
-use super::common::CollectionAppliedHardwareAcc;
 use super::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
     build_vector_resolver_queries, resolve_referenced_vectors_batch,
 };
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::common::transpose_iterator::transposed_iter;
 use crate::operations::consistency_params::ReadConsistency;

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -12,8 +12,8 @@ use segment::types::{
 };
 use tokio::time::Instant;
 
-use super::common::CollectionAppliedHardwareAcc;
 use super::Collection;
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::events::SlowQueryEvent;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -13,7 +13,7 @@ use segment::types::{
 use tokio::time::Instant;
 
 use super::Collection;
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::events::SlowQueryEvent;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
@@ -26,7 +26,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         if request.limit == 0 {
             return Ok(vec![]);
@@ -53,7 +53,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let start = Instant::now();
         // shortcuts batch if all requests with limit=0
@@ -148,7 +148,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let request = Arc::new(request);
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -767,7 +767,7 @@ mod tests {
             &Handle::current(),
             true,
             QueryContext::new(DEFAULT_INDEXING_THRESHOLD_KB),
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()
@@ -827,7 +827,7 @@ mod tests {
 
             let batch_request = Arc::new(batch_request);
 
-            let hw_measurement_acc = HwMeasurementAcc::new();
+            let hw_measurement_acc = HwMeasurementAcc::new_unchecked();
 
             let result_no_sampling = SegmentsSearcher::search(
                 segment_holder.clone(),

--- a/lib/collection/src/common/hardware_counting.rs
+++ b/lib/collection/src/common/hardware_counting.rs
@@ -11,7 +11,7 @@ impl CollectionAppliedHardwareAcc {
     }
 
     pub fn new() -> Self {
-        Self(HwMeasurementAcc::new())
+        Self::default()
     }
 
     pub fn into_hw_measurement_acc(self) -> HwMeasurementAcc {
@@ -31,5 +31,11 @@ impl Collection {
         out: &CollectionAppliedHardwareAcc,
     ) {
         out.apply(src, &self.hardware_usage);
+    }
+}
+
+impl Default for CollectionAppliedHardwareAcc {
+    fn default() -> Self {
+        Self(HwMeasurementAcc::new())
     }
 }

--- a/lib/collection/src/common/hardware_counting.rs
+++ b/lib/collection/src/common/hardware_counting.rs
@@ -1,6 +1,6 @@
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 
-use super::Collection;
+use crate::collection::Collection;
 
 #[derive(Clone)]
 pub struct CollectionAppliedHardwareAcc(pub(crate) HwMeasurementAcc);

--- a/lib/collection/src/common/hardware_counting.rs
+++ b/lib/collection/src/common/hardware_counting.rs
@@ -19,6 +19,10 @@ impl CollectionAppliedHardwareAcc {
         Self(HwMeasurementAcc::new_unchecked())
     }
 
+    pub fn set_applied(&self) {
+        self.0.set_applied();
+    }
+
     fn apply(&self, src: HwMeasurementAcc, collection_counter: &HwMeasurementAcc) {
         self.0.merge(src.clone());
         collection_counter.merge(src);

--- a/lib/collection/src/common/hardware_counting.rs
+++ b/lib/collection/src/common/hardware_counting.rs
@@ -4,10 +4,9 @@ use crate::collection::Collection;
 
 /// A wrapper around `HwMeasurementAcc` that encforces by design that all collected
 /// hardware metrics get also to applied to the corresponding collection.
-#[derive(Clone)]
-pub struct CollectionAppliedHardwareAcc(HwMeasurementAcc);
+pub struct RequestHardwareAcc(HwMeasurementAcc);
 
-impl CollectionAppliedHardwareAcc {
+impl RequestHardwareAcc {
     pub fn new() -> Self {
         Self::default()
     }
@@ -30,19 +29,19 @@ impl CollectionAppliedHardwareAcc {
 }
 
 impl Collection {
-    pub fn accumulate_hw_counter(&self, src: HwMeasurementAcc, out: &CollectionAppliedHardwareAcc) {
+    pub fn accumulate_hw_counter(&self, src: HwMeasurementAcc, out: &RequestHardwareAcc) {
         out.apply(src, &self.hardware_usage);
     }
 }
 
-impl Default for CollectionAppliedHardwareAcc {
+impl Default for RequestHardwareAcc {
     fn default() -> Self {
         Self(HwMeasurementAcc::new())
     }
 }
 
-impl From<CollectionAppliedHardwareAcc> for HwMeasurementAcc {
-    fn from(value: CollectionAppliedHardwareAcc) -> Self {
+impl From<RequestHardwareAcc> for HwMeasurementAcc {
+    fn from(value: RequestHardwareAcc) -> Self {
         value.0
     }
 }

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -2,6 +2,7 @@ pub mod batching;
 pub mod eta_calculator;
 pub mod fetch_vectors;
 pub mod file_utils;
+pub mod hardware_counting;
 pub mod is_ready;
 pub mod retrieve_request_trait;
 pub mod sha_256;

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::Future;
 use itertools::Itertools;
 use segment::data_types::vectors::NamedQuery;
@@ -8,6 +7,7 @@ use segment::types::{Condition, Filter, HasIdCondition, ScoredPoint};
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery};
 use tokio::sync::RwLockReadGuard;
 
+use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
@@ -131,7 +131,7 @@ pub async fn discover<'a, F, Fut>(
     read_consistency: Option<ReadConsistency>,
     shard_selector: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> CollectionResult<Vec<ScoredPoint>>
 where
     F: Fn(String) -> Fut,
@@ -161,7 +161,7 @@ pub async fn discover_batch<'a, F, Fut>(
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
 where
     F: Fn(String) -> Fut,

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -1,18 +1,11 @@
 use std::time::Duration;
 
-use futures::Future;
-use itertools::Itertools;
-use segment::data_types::vectors::NamedQuery;
-use segment::types::{Condition, Filter, HasIdCondition, ScoredPoint};
-use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery};
-use tokio::sync::RwLockReadGuard;
-
-use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
     convert_to_vectors, resolve_referenced_vectors_batch, ReferencedVectors,
 };
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::query_enum::QueryEnum;
@@ -21,6 +14,12 @@ use crate::operations::types::{
     CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch,
     DiscoverRequestInternal,
 };
+use futures::Future;
+use itertools::Itertools;
+use segment::data_types::vectors::NamedQuery;
+use segment::types::{Condition, Filter, HasIdCondition, ScoredPoint};
+use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery};
+use tokio::sync::RwLockReadGuard;
 
 fn discovery_into_core_search(
     collection_name: &str,

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -12,7 +12,7 @@ use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
     convert_to_vectors, resolve_referenced_vectors_batch, ReferencedVectors,
 };
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::query_enum::QueryEnum;
@@ -131,7 +131,7 @@ pub async fn discover<'a, F, Fut>(
     read_consistency: Option<ReadConsistency>,
     shard_selector: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> CollectionResult<Vec<ScoredPoint>>
 where
     F: Fn(String) -> Fut,
@@ -161,7 +161,7 @@ pub async fn discover_batch<'a, F, Fut>(
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
 where
     F: Fn(String) -> Fut,

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -1,5 +1,12 @@
 use std::time::Duration;
 
+use futures::Future;
+use itertools::Itertools;
+use segment::data_types::vectors::NamedQuery;
+use segment::types::{Condition, Filter, HasIdCondition, ScoredPoint};
+use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery};
+use tokio::sync::RwLockReadGuard;
+
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
@@ -14,12 +21,6 @@ use crate::operations::types::{
     CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch,
     DiscoverRequestInternal,
 };
-use futures::Future;
-use itertools::Itertools;
-use segment::data_types::vectors::NamedQuery;
-use segment::types::{Condition, Filter, HasIdCondition, ScoredPoint};
-use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery};
-use tokio::sync::RwLockReadGuard;
 
 fn discovery_into_core_search(
     collection_name: &str,

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use tokio::sync::RwLockReadGuard;
 
 use super::group_by::{group_by, GroupRequest};
-use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::lookup::lookup_ids;
 use crate::lookup::types::PseudoId;
 use crate::operations::consistency_params::ReadConsistency;

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::Future;
 use itertools::Itertools;
 use tokio::sync::RwLockReadGuard;
 
 use super::group_by::{group_by, GroupRequest};
+use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::lookup::lookup_ids;
 use crate::lookup::types::PseudoId;
@@ -26,7 +26,7 @@ where
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 }
 
 impl<'a, F, Fut> GroupBy<'a, F, Fut>
@@ -39,7 +39,7 @@ where
         group_by: GroupRequest,
         collection: &'a Collection,
         collection_by_name: F,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> Self {
         Self {
             group_by,

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -6,7 +6,7 @@ use tokio::sync::RwLockReadGuard;
 
 use super::group_by::{group_by, GroupRequest};
 use crate::collection::Collection;
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::lookup::lookup_ids;
 use crate::lookup::types::PseudoId;
 use crate::operations::consistency_params::ReadConsistency;
@@ -26,7 +26,7 @@ where
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 }
 
 impl<'a, F, Fut> GroupBy<'a, F, Fut>
@@ -39,7 +39,7 @@ where
         group_by: GroupRequest,
         collection: &'a Collection,
         collection_by_name: F,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> Self {
         Self {
             group_by,

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -15,10 +15,10 @@ use tokio::sync::RwLockReadGuard;
 
 use super::aggregator::GroupsAggregator;
 use super::types::QueryGroupRequest;
-use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::common::fetch_vectors;
 use crate::common::fetch_vectors::build_vector_resolver_query;
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::lookup::WithLookup;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -18,7 +18,7 @@ use super::types::QueryGroupRequest;
 use crate::collection::Collection;
 use crate::common::fetch_vectors;
 use crate::common::fetch_vectors::build_vector_resolver_query;
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::lookup::WithLookup;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
@@ -147,7 +147,7 @@ impl QueryGroupRequest {
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         let mut request = self.source.clone();
 
@@ -313,7 +313,7 @@ pub async fn group_by(
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> CollectionResult<Vec<PointGroup>> {
     let start = std::time::Instant::now();
     let collection_params = collection.collection_config.read().await.params.clone();

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use std::time::Duration;
 
 use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
 use segment::json_path::JsonPath;
@@ -16,6 +15,7 @@ use tokio::sync::RwLockReadGuard;
 
 use super::aggregator::GroupsAggregator;
 use super::types::QueryGroupRequest;
+use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::common::fetch_vectors;
 use crate::common::fetch_vectors::build_vector_resolver_query;
@@ -147,7 +147,7 @@ impl QueryGroupRequest {
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         let mut request = self.source.clone();
 
@@ -313,7 +313,7 @@ pub async fn group_by(
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> CollectionResult<Vec<PointGroup>> {
     let start = std::time::Instant::now();
     let collection_params = collection.collection_config.read().await.params.clone();

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -331,6 +331,12 @@ pub struct ReshardingInfo {
     pub comment: Option<String>,
 }
 
+#[derive(Debug, Serialize, JsonSchema, Default, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct HardwareInfo {
+    pub cpu: usize,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct LocalShardInfo {

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -15,13 +15,13 @@ use segment::vector_storage::query::RecoQuery;
 use sparse::common::sparse_vector::SparseVector;
 use tokio::sync::RwLockReadGuard;
 
-use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
     convert_to_vectors, convert_to_vectors_owned, resolve_referenced_vectors_batch,
     ReferencedVectors,
 };
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::query_enum::QueryEnum;

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -21,7 +21,7 @@ use crate::common::fetch_vectors::{
     convert_to_vectors, convert_to_vectors_owned, resolve_referenced_vectors_batch,
     ReferencedVectors,
 };
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::query_enum::QueryEnum;
@@ -152,7 +152,7 @@ pub async fn recommend_by<'a, F, Fut>(
     read_consistency: Option<ReadConsistency>,
     shard_selector: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> CollectionResult<Vec<ScoredPoint>>
 where
     F: Fn(String) -> Fut,
@@ -242,7 +242,7 @@ pub async fn recommend_batch_by<'a, F, Fut>(
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
 where
     F: Fn(String) -> Fut,

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -3,7 +3,6 @@ use std::iter::Peekable;
 use std::time::Duration;
 
 use api::rest::RecommendStrategy;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::vectors::{
     DenseVector, NamedQuery, NamedVectorStruct, TypedMultiDenseVector, VectorElementType,
@@ -16,6 +15,7 @@ use segment::vector_storage::query::RecoQuery;
 use sparse::common::sparse_vector::SparseVector;
 use tokio::sync::RwLockReadGuard;
 
+use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
@@ -152,7 +152,7 @@ pub async fn recommend_by<'a, F, Fut>(
     read_consistency: Option<ReadConsistency>,
     shard_selector: ShardSelectorInternal,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> CollectionResult<Vec<ScoredPoint>>
 where
     F: Fn(String) -> Fut,
@@ -242,7 +242,7 @@ pub async fn recommend_batch_by<'a, F, Fut>(
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
 where
     F: Fn(String) -> Fut,

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -70,7 +70,7 @@ pub(crate) async fn transfer_resharding_stream_records(
                     exact: true,
                 }),
                 None,
-                HwMeasurementAcc::new(),
+                HwMeasurementAcc::new_unchecked(),
             )
             .await?
         else {

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -70,6 +70,8 @@ pub(crate) async fn transfer_resharding_stream_records(
                     exact: true,
                 }),
                 None,
+                // Internal operations don't need to be measured so we can
+                // safely discard measurements here.
                 HwMeasurementAcc::new_unchecked(),
             )
             .await?

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -60,7 +60,7 @@ pub(super) async fn transfer_stream_records(
                     exact: true,
                 }),
                 None, // no timeout
-                HwMeasurementAcc::new(),
+                HwMeasurementAcc::new_unchecked(),
             )
             .await?
         else {

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -60,6 +60,8 @@ pub(super) async fn transfer_stream_records(
                     exact: true,
                 }),
                 None, // no timeout
+                // Internal operations don't need to be measured so we can
+                // safely discard measurements here.
                 HwMeasurementAcc::new_unchecked(),
             )
             .await?

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -14,7 +14,7 @@ pub struct CollectionTelemetry {
     pub shards: Vec<ReplicaSetTelemetry>,
     pub transfers: Vec<ShardTransferInfo>,
     pub resharding: Vec<ReshardingInfo>,
-    pub hardware_usage: HardwareInfo,
+    pub hardware_usage: Option<HardwareInfo>,
 }
 
 impl CollectionTelemetry {
@@ -37,7 +37,7 @@ impl Anonymize for CollectionTelemetry {
             shards: self.shards.anonymize(),
             transfers: vec![],
             resharding: vec![],
-            hardware_usage: HardwareInfo::default(),
+            hardware_usage: Some(HardwareInfo::default()),
         }
     }
 }

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -3,7 +3,7 @@ use segment::common::anonymize::Anonymize;
 use serde::Serialize;
 
 use crate::config::CollectionConfig;
-use crate::operations::types::{ReshardingInfo, ShardTransferInfo};
+use crate::operations::types::{HardwareInfo, ReshardingInfo, ShardTransferInfo};
 use crate::shards::telemetry::ReplicaSetTelemetry;
 
 #[derive(Serialize, Clone, Debug, JsonSchema)]
@@ -14,6 +14,7 @@ pub struct CollectionTelemetry {
     pub shards: Vec<ReplicaSetTelemetry>,
     pub transfers: Vec<ShardTransferInfo>,
     pub resharding: Vec<ReshardingInfo>,
+    pub hardware_usage: HardwareInfo,
 }
 
 impl CollectionTelemetry {
@@ -36,6 +37,7 @@ impl Anonymize for CollectionTelemetry {
             shards: self.shards.anonymize(),
             transfers: vec![],
             resharding: vec![],
+            hardware_usage: HardwareInfo::default(),
         }
     }
 }

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -13,7 +13,7 @@ use serde_json::{Map, Value};
 use tempfile::Builder;
 
 use crate::collection::{Collection, RequestShardTransfer};
-use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
+use crate::common::hardware_counting::RequestHardwareAcc;
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
@@ -259,7 +259,7 @@ async fn test_search_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .expect("failed to search");

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -12,8 +12,8 @@ use segment::types::{
 use serde_json::{Map, Value};
 use tempfile::Builder;
 
-use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::{Collection, RequestShardTransfer};
+use crate::common::hardware_counting::CollectionAppliedHardwareAcc;
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -3,7 +3,6 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use api::rest::OrderByInterface;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use rand::{thread_rng, Rng};
 use segment::data_types::vectors::NamedVectorStruct;
@@ -13,6 +12,7 @@ use segment::types::{
 use serde_json::{Map, Value};
 use tempfile::Builder;
 
+use crate::collection::common::CollectionAppliedHardwareAcc;
 use crate::collection::{Collection, RequestShardTransfer};
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::point_ops::{
@@ -259,7 +259,7 @@ async fn test_search_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .expect("failed to search");

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -70,7 +70,7 @@ async fn test_shard_query_rrf_rescoring() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await;
     let expected_error =
@@ -109,7 +109,7 @@ async fn test_shard_query_rrf_rescoring() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()
@@ -160,7 +160,7 @@ async fn test_shard_query_rrf_rescoring() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()
@@ -208,7 +208,7 @@ async fn test_shard_query_rrf_rescoring() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()
@@ -291,7 +291,7 @@ async fn test_shard_query_vector_rescoring() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()
@@ -322,7 +322,7 @@ async fn test_shard_query_vector_rescoring() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()
@@ -356,7 +356,7 @@ async fn test_shard_query_vector_rescoring() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()
@@ -428,7 +428,7 @@ async fn test_shard_query_payload_vector() {
             Arc::new(vec![query]),
             &current_runtime,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::new_unchecked(),
         )
         .await
         .unwrap()

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
 use api::rest::{OrderByInterface, SearchRequestInternal};
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::payload_ops::{PayloadOps, SetPayloadOp};
 use collection::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
 use api::rest::{OrderByInterface, SearchRequestInternal};
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::payload_ops::{PayloadOps, SetPayloadOp};
 use collection::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
@@ -15,7 +16,6 @@ use collection::operations::types::{
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
 use collection::shards::replica_set::{ReplicaSetState, ReplicaState};
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::order_by::{Direction, OrderBy};
 use segment::data_types::vectors::VectorStructInternal;
@@ -86,7 +86,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await;
 
@@ -155,7 +155,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await;
 
@@ -189,7 +189,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new(),
         )
         .await
         .unwrap();
@@ -379,7 +379,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
-        HwMeasurementAcc::new(),
+        CollectionAppliedHardwareAcc::new_unchecked(),
     )
     .await
     .unwrap();

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
 use api::rest::{OrderByInterface, SearchRequestInternal};
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::payload_ops::{PayloadOps, SetPayloadOp};
 use collection::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
@@ -86,7 +86,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await;
 
@@ -155,7 +155,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await;
 
@@ -189,7 +189,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new(),
+            RequestHardwareAcc::new(),
         )
         .await
         .unwrap();
@@ -379,7 +379,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
-        CollectionAppliedHardwareAcc::new_unchecked(),
+        RequestHardwareAcc::new_unchecked(),
     )
     .await
     .unwrap();

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -1,9 +1,9 @@
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::CollectionSearchMatrixRequest;
 use collection::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, WriteOrdering,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -34,7 +34,7 @@ async fn distance_matrix_empty() {
             ShardSelectorInternal::All,
             None,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -89,7 +89,7 @@ async fn distance_matrix_anonymous_vector() {
             ShardSelectorInternal::All,
             None,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -1,5 +1,5 @@
 use collection::collection::distance_matrix::CollectionSearchMatrixRequest;
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, WriteOrdering,
 };
@@ -34,7 +34,7 @@ async fn distance_matrix_empty() {
             ShardSelectorInternal::All,
             None,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -89,7 +89,7 @@ async fn distance_matrix_anonymous_vector() {
             ShardSelectorInternal::All,
             None,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -1,5 +1,5 @@
-use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::CollectionSearchMatrixRequest;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, WriteOrdering,
 };

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -20,7 +20,7 @@ fn rand_dense_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
 
 mod group_by {
     use api::rest::SearchRequestInternal;
-    use collection::collection::common::CollectionAppliedHardwareAcc;
+    use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
     use collection::grouping::GroupBy;
     use collection::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
@@ -462,7 +462,7 @@ mod group_by {
 /// Tests out the different features working together. The individual features are already tested in other places.
 mod group_by_builder {
     use api::rest::SearchRequestInternal;
-    use collection::collection::common::CollectionAppliedHardwareAcc;
+    use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
     use collection::grouping::GroupBy;
     use collection::lookup::types::PseudoId;
     use collection::lookup::WithLookup;

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -20,7 +20,7 @@ fn rand_dense_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
 
 mod group_by {
     use api::rest::SearchRequestInternal;
-    use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+    use collection::common::hardware_counting::RequestHardwareAcc;
     use collection::grouping::GroupBy;
     use collection::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
@@ -100,7 +100,7 @@ mod group_by {
             resources.request.clone(),
             &resources.collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -155,7 +155,7 @@ mod group_by {
             request.clone(),
             &resources.collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -218,7 +218,7 @@ mod group_by {
             group_by_request,
             &resources.collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -253,7 +253,7 @@ mod group_by {
             group_by_request.clone(),
             &resources.collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -294,7 +294,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -333,7 +333,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -368,7 +368,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -403,7 +403,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -442,7 +442,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -462,7 +462,7 @@ mod group_by {
 /// Tests out the different features working together. The individual features are already tested in other places.
 mod group_by_builder {
     use api::rest::SearchRequestInternal;
-    use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+    use collection::common::hardware_counting::RequestHardwareAcc;
     use collection::grouping::GroupBy;
     use collection::lookup::types::PseudoId;
     use collection::lookup::WithLookup;
@@ -588,7 +588,7 @@ mod group_by_builder {
             request.clone(),
             &collection,
             collection_by_name,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .execute()
         .await;
@@ -626,7 +626,7 @@ mod group_by_builder {
             request.clone(),
             &collection,
             collection_by_name,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .execute()
         .await;

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -20,11 +20,11 @@ fn rand_dense_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
 
 mod group_by {
     use api::rest::SearchRequestInternal;
+    use collection::collection::common::CollectionAppliedHardwareAcc;
     use collection::grouping::GroupBy;
     use collection::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
     };
-    use common::counter::hardware_accumulator::HwMeasurementAcc;
 
     use super::*;
 
@@ -100,7 +100,7 @@ mod group_by {
             resources.request.clone(),
             &resources.collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -155,7 +155,7 @@ mod group_by {
             request.clone(),
             &resources.collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -218,7 +218,7 @@ mod group_by {
             group_by_request,
             &resources.collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -253,7 +253,7 @@ mod group_by {
             group_by_request.clone(),
             &resources.collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -294,7 +294,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -333,7 +333,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -368,7 +368,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -403,7 +403,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -442,7 +442,7 @@ mod group_by {
             group_by_request.clone(),
             &collection,
             |_| async { unreachable!() },
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         );
 
         let result = group_by.execute().await;
@@ -462,13 +462,13 @@ mod group_by {
 /// Tests out the different features working together. The individual features are already tested in other places.
 mod group_by_builder {
     use api::rest::SearchRequestInternal;
+    use collection::collection::common::CollectionAppliedHardwareAcc;
     use collection::grouping::GroupBy;
     use collection::lookup::types::PseudoId;
     use collection::lookup::WithLookup;
     use collection::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
     };
-    use common::counter::hardware_accumulator::HwMeasurementAcc;
     use segment::json_path::JsonPath;
     use tokio::sync::RwLock;
 
@@ -588,7 +588,7 @@ mod group_by_builder {
             request.clone(),
             &collection,
             collection_by_name,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .execute()
         .await;
@@ -626,7 +626,7 @@ mod group_by_builder {
             request.clone(),
             &collection,
             collection_by_name,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .execute()
         .await;

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroU32;
 use std::path::Path;
 
 use api::rest::SearchRequestInternal;
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
@@ -16,7 +17,6 @@ use collection::operations::types::{
 use collection::operations::vector_params_builder::VectorParamsBuilder;
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{NamedVector, VectorStructInternal};
 use segment::types::{Distance, WithPayloadInterface, WithVector};
@@ -128,7 +128,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -163,7 +163,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await;
 
@@ -193,7 +193,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -246,7 +246,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
-        HwMeasurementAcc::new(),
+        CollectionAppliedHardwareAcc::new_unchecked(),
     )
     .await;
 
@@ -273,7 +273,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
-        HwMeasurementAcc::new(),
+        CollectionAppliedHardwareAcc::new_unchecked(),
     )
     .await
     .unwrap();

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use api::rest::SearchRequestInternal;
 use collection::collection::Collection;
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
@@ -128,7 +128,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -163,7 +163,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await;
 
@@ -193,7 +193,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -246,7 +246,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
-        CollectionAppliedHardwareAcc::new_unchecked(),
+        RequestHardwareAcc::new_unchecked(),
     )
     .await;
 
@@ -273,7 +273,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         None,
         ShardSelectorInternal::All,
         None,
-        CollectionAppliedHardwareAcc::new_unchecked(),
+        RequestHardwareAcc::new_unchecked(),
     )
     .await
     .unwrap();

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -3,8 +3,8 @@ use std::num::NonZeroU32;
 use std::path::Path;
 
 use api::rest::SearchRequestInternal;
-use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::Collection;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -1,11 +1,11 @@
 use api::rest::SearchRequestInternal;
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
     WriteOrdering,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::CollectionUpdateOperations;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::WithPayloadInterface;
 use tempfile::Builder;
 
@@ -61,7 +61,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -88,7 +88,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -116,7 +116,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -1,5 +1,5 @@
 use api::rest::SearchRequestInternal;
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
     WriteOrdering,
@@ -61,7 +61,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -88,7 +88,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -116,7 +116,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -1,5 +1,5 @@
 use api::rest::SearchRequestInternal;
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
     WriteOrdering,

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use api::rest::SearchRequestInternal;
 use collection::collection::Collection;
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
@@ -162,7 +162,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -173,7 +173,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
             None,
             &ShardSelectorInternal::All,
             None,
-            CollectionAppliedHardwareAcc::new_unchecked(),
+            RequestHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use api::rest::SearchRequestInternal;
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
@@ -15,7 +16,6 @@ use collection::operations::CollectionUpdateOperations;
 use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::ReplicaState;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use segment::types::{Distance, WithPayloadInterface, WithVector};
 use tempfile::Builder;
@@ -162,7 +162,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();
@@ -173,7 +173,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            CollectionAppliedHardwareAcc::new_unchecked(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use api::rest::SearchRequestInternal;
-use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::Collection;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -1,13 +1,20 @@
+#[cfg(any(debug_assertions, test))]
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+
+use serde::Serialize;
 
 use super::hardware_counter::HardwareCounterCell;
 
 /// A "slow" but thread-safe accumulator for measurement results of `HardwareCounterCell` values.
 /// This type is completely reference counted and clones of this type will read/write the same values as their origin structure.
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize)]
 pub struct HwMeasurementAcc {
     cpu_counter: Arc<AtomicUsize>,
+
+    #[cfg(any(debug_assertions, test))]
+    applied: Arc<AtomicBool>,
 }
 
 impl HwMeasurementAcc {
@@ -15,9 +22,21 @@ impl HwMeasurementAcc {
         Self::default()
     }
 
+    pub fn new_unchecked() -> Self {
+        Self {
+            cpu_counter: Arc::new(AtomicUsize::new(0)),
+
+            #[cfg(any(debug_assertions, test))]
+            applied: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
     pub fn new_with_values(cpu: usize) -> Self {
         Self {
             cpu_counter: Arc::new(AtomicUsize::new(cpu)),
+
+            #[cfg(any(debug_assertions, test))]
+            applied: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -26,9 +45,29 @@ impl HwMeasurementAcc {
     }
 
     pub fn clear(&self) {
-        let HwMeasurementAcc { cpu_counter } = self;
+        let HwMeasurementAcc {
+            cpu_counter,
+
+            #[cfg(any(debug_assertions, test))]
+                applied: _,
+        } = self;
 
         cpu_counter.store(0, Ordering::Relaxed);
+    }
+
+    /// Consumes and accumulates the values from `hw_counter_cell` into the accumulator.
+    pub fn merge(&self, hw_counter: Self) {
+        hw_counter.set_applied();
+
+        let Self {
+            ref cpu_counter,
+
+            #[cfg(any(debug_assertions, test))]
+                applied: _,
+        } = hw_counter;
+
+        self.cpu_counter
+            .fetch_add(cpu_counter.load(Ordering::Relaxed), Ordering::Relaxed);
     }
 
     /// Consumes and accumulates the values from `hw_counter_cell` into the accumulator.
@@ -38,12 +77,84 @@ impl HwMeasurementAcc {
         self.cpu_counter
             .fetch_add(cpu_counter.take(), Ordering::Relaxed);
     }
+
+    pub fn has_values(&self) -> bool {
+        let Self {
+            ref cpu_counter,
+
+            #[cfg(any(debug_assertions, test))]
+                applied: _,
+        } = self;
+        cpu_counter.load(Ordering::Relaxed) > 0
+    }
+
+    pub fn set_applied(&self) {
+        #[cfg(any(debug_assertions, test))]
+        self.applied.store(true, Ordering::Relaxed);
+    }
 }
 
 impl Default for HwMeasurementAcc {
     fn default() -> Self {
         Self {
             cpu_counter: Arc::new(AtomicUsize::new(0)),
+
+            #[cfg(any(debug_assertions, test))]
+            applied: Arc::new(AtomicBool::new(false)),
         }
+    }
+}
+
+impl Drop for HwMeasurementAcc {
+    fn drop(&mut self) {
+        #[cfg(any(debug_assertions, test))] // We want this to fail in both, release and debug tests
+        {
+            if !self.applied.load(Ordering::Relaxed)
+            && self.has_values()
+            // We don't create weak references so checking for strong count only is fine!
+            && Arc::strong_count(&self.cpu_counter) == 1
+            {
+                panic!("Hw Counter not applied")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_panic_hw_measurement_acc_applied_field() {
+        let HwMeasurementAcc {
+            cpu_counter: _,
+            applied, // In tests we need this field always to be available!
+        } = &HwMeasurementAcc::new_with_values(1);
+        assert!(!applied.load(Ordering::Relaxed));
+        applied.store(true, Ordering::Relaxed);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_panic_hw_measurement_acc() {
+        HwMeasurementAcc::new_with_values(1); // With a value, this will panic on drop
+    }
+
+    #[test]
+    fn test_panic_hw_measurement_acc_clone() {
+        let acc = HwMeasurementAcc::new_with_values(1);
+
+        let acc_clone = acc.clone();
+        let result = std::panic::catch_unwind(move || {
+            drop(acc_clone);
+        });
+        // No panic here, since it's a clone!
+        assert!(result.is_ok());
+
+        let result = std::panic::catch_unwind(move || {
+            drop(acc);
+        });
+        // Panic here as it's the "last" instance
+        assert!(result.is_err());
     }
 }

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -78,14 +78,14 @@ impl HwMeasurementAcc {
             .fetch_add(cpu_counter.take(), Ordering::Relaxed);
     }
 
-    pub fn has_values(&self) -> bool {
+    pub fn is_zero(&self) -> bool {
         let Self {
             ref cpu_counter,
 
             #[cfg(any(debug_assertions, test))]
                 applied: _,
         } = self;
-        cpu_counter.load(Ordering::Relaxed) > 0
+        cpu_counter.load(Ordering::Relaxed) == 0
     }
 
     pub fn set_applied(&self) {
@@ -119,7 +119,7 @@ impl Drop for HwMeasurementAcc {
         #[cfg(any(debug_assertions, test))] // Fail in both, release and debug tests.
         {
             if !self.applied.load(Ordering::Relaxed)
-            && self.has_values()
+            && !self.is_zero()
             // We don't create weak references so checking for strong count only is fine!
             && Arc::strong_count(&self.cpu_counter) == 1
             {

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::{
     CollectionSearchMatrixRequest, CollectionSearchMatrixResponse,
 };
@@ -13,7 +14,6 @@ use collection::operations::types::*;
 use collection::operations::universal_query::collection_query::CollectionQueryRequest;
 use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use collection::{discovery, recommendations};
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::stream::FuturesUnordered;
 use futures::TryStreamExt as _;
 use segment::data_types::facets::{FacetParams, FacetResponse};
@@ -43,7 +43,7 @@ impl TableOfContent {
         shard_selector: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<Vec<ScoredPoint>> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -78,7 +78,7 @@ impl TableOfContent {
         read_consistency: Option<ReadConsistency>,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for (request, _shard_selector) in &mut requests {
@@ -124,7 +124,7 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for request in &mut request.searches {
@@ -168,7 +168,7 @@ impl TableOfContent {
         timeout: Option<Duration>,
         shard_selection: ShardSelectorInternal,
         access: Access,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<CountResult> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -223,7 +223,7 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<GroupsResult> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -252,7 +252,7 @@ impl TableOfContent {
         shard_selector: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<Vec<ScoredPoint>> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -277,7 +277,7 @@ impl TableOfContent {
         read_consistency: Option<ReadConsistency>,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for (request, _shard_selector) in &mut requests {
@@ -337,7 +337,7 @@ impl TableOfContent {
         read_consistency: Option<ReadConsistency>,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for (request, _shard_selector) in &mut requests {
@@ -391,7 +391,7 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> Result<CollectionSearchMatrixResponse, StorageError> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -4,7 +4,7 @@ use collection::collection::distance_matrix::{
     CollectionSearchMatrixRequest, CollectionSearchMatrixResponse,
 };
 use collection::collection::Collection;
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::grouping::group_by::GroupRequest;
 use collection::grouping::GroupBy;
 use collection::operations::consistency_params::ReadConsistency;
@@ -43,7 +43,7 @@ impl TableOfContent {
         shard_selector: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<Vec<ScoredPoint>> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -78,7 +78,7 @@ impl TableOfContent {
         read_consistency: Option<ReadConsistency>,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for (request, _shard_selector) in &mut requests {
@@ -124,7 +124,7 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for request in &mut request.searches {
@@ -168,7 +168,7 @@ impl TableOfContent {
         timeout: Option<Duration>,
         shard_selection: ShardSelectorInternal,
         access: Access,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<CountResult> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -223,7 +223,7 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<GroupsResult> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -252,7 +252,7 @@ impl TableOfContent {
         shard_selector: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<Vec<ScoredPoint>> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
@@ -277,7 +277,7 @@ impl TableOfContent {
         read_consistency: Option<ReadConsistency>,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for (request, _shard_selector) in &mut requests {
@@ -337,7 +337,7 @@ impl TableOfContent {
         read_consistency: Option<ReadConsistency>,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<Vec<Vec<ScoredPoint>>> {
         let mut collection_pass = None;
         for (request, _shard_selector) in &mut requests {
@@ -391,7 +391,7 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         access: Access,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> Result<CollectionSearchMatrixResponse, StorageError> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
-use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::{
     CollectionSearchMatrixRequest, CollectionSearchMatrixResponse,
 };
 use collection::collection::Collection;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::grouping::group_by::GroupRequest;
 use collection::grouping::GroupBy;
 use collection::operations::consistency_params::ReadConsistency;

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::UpdateResult;
 use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -2,11 +2,11 @@
 
 use std::time::Duration;
 
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::UpdateResult;
 use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use collection::shards::shard::ShardId;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 
 use super::TableOfContent;
@@ -20,7 +20,7 @@ impl TableOfContent {
         requests: Vec<ShardQueryRequest>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
+        hw_measurement_acc: CollectionAppliedHardwareAcc,
     ) -> StorageResult<Vec<ShardQueryResponse>> {
         let collection = self.get_collection_unchecked(collection_name).await?;
 

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::UpdateResult;
 use collection::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
@@ -20,7 +20,7 @@ impl TableOfContent {
         requests: Vec<ShardQueryRequest>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
-        hw_measurement_acc: CollectionAppliedHardwareAcc,
+        hw_measurement_acc: RequestHardwareAcc,
     ) -> StorageResult<Vec<ShardQueryResponse>> {
         let collection = self.get_collection_unchecked(collection_name).await?;
 

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -1,8 +1,8 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::CountRequest;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use storage::content_manager::collection_verification::check_strict_mode;
 use storage::dispatcher::Dispatcher;
 use tokio::time::Instant;
@@ -46,7 +46,7 @@ async fn count_points(
         Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_count_points(
@@ -59,7 +59,7 @@ async fn count_points(
             access,
             hw_measurement_acc.clone(),
         ),
-        hw_measurement_acc,
+        hw_measurement_acc.into_hw_measurement_acc(),
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -59,7 +59,7 @@ async fn count_points(
             access,
             hw_measurement_acc.clone(),
         ),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -1,6 +1,6 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::CountRequest;
 use storage::content_manager::collection_verification::check_strict_mode;
@@ -46,7 +46,7 @@ async fn count_points(
         Some(shard_keys) => ShardSelectorInternal::from(shard_keys),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_count_points(

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -1,6 +1,6 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::CountRequest;
 use storage::content_manager::collection_verification::check_strict_mode;

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -1,6 +1,6 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{DiscoverRequest, DiscoverRequestBatch};
 use futures::TryFutureExt;
@@ -50,7 +50,7 @@ async fn discover_points(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new_unchecked();
+    let hw_measurement_acc = RequestHardwareAcc::new_unchecked();
 
     helpers::time_and_hardware_opt(
         dispatcher
@@ -100,7 +100,7 @@ async fn discover_batch_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_discover_batch_points(

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -1,6 +1,6 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{DiscoverRequest, DiscoverRequestBatch};
 use futures::TryFutureExt;

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -70,7 +70,7 @@ async fn discover_points(
                     .map(api::rest::ScoredPoint::from)
                     .collect_vec()
             }),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -123,7 +123,7 @@ async fn discover_batch_points(
                 })
                 .collect_vec()
         }),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -1,8 +1,8 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{DiscoverRequest, DiscoverRequestBatch};
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::TryFutureExt;
 use itertools::Itertools;
 use storage::content_manager::collection_verification::{
@@ -50,7 +50,7 @@ async fn discover_points(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new_unchecked();
 
     helpers::time_and_hardware_opt(
         dispatcher
@@ -70,7 +70,7 @@ async fn discover_points(
                     .map(api::rest::ScoredPoint::from)
                     .collect_vec()
             }),
-        hw_measurement_acc,
+        hw_measurement_acc.into_hw_measurement_acc(),
         service_config.hardware_reporting(),
     )
     .await
@@ -100,7 +100,7 @@ async fn discover_batch_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_discover_batch_points(
@@ -123,7 +123,7 @@ async fn discover_batch_points(
                 })
                 .collect_vec()
         }),
-        hw_measurement_acc,
+        hw_measurement_acc.into_hw_measurement_acc(),
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use actix_web::{post, web, Responder};
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CountRequestInternal, PointRequestInternal, ScrollRequestInternal,
 };
 use collection::operations::verification::{new_unchecked_verification_pass, VerificationPass};
 use collection::shards::shard::ShardId;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::{Condition, Filter};
 use storage::content_manager::collection_verification::check_strict_mode;
 use storage::content_manager::errors::{StorageError, StorageResult};
@@ -144,7 +144,7 @@ async fn count_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
 
     helpers::time_and_hardware_opt(
@@ -178,7 +178,7 @@ async fn count_points(
             )
             .await
         },
-        hw_measurement_acc,
+        hw_measurement_acc.into_hw_measurement_acc(),
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use actix_web::{post, web, Responder};
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CountRequestInternal, PointRequestInternal, ScrollRequestInternal,

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -178,7 +178,7 @@ async fn count_points(
             )
             .await
         },
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use actix_web::{post, web, Responder};
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CountRequestInternal, PointRequestInternal, ScrollRequestInternal,
@@ -144,7 +144,7 @@ async fn count_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
 
     helpers::time_and_hardware_opt(

--- a/src/actix/api/mod.rs
+++ b/src/actix/api/mod.rs
@@ -16,9 +16,12 @@ pub mod shards_api;
 pub mod snapshot_api;
 pub mod update_api;
 
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use common::validation::validate_collection_name;
 use serde::Deserialize;
 use validator::Validate;
+
+use crate::settings::ServiceConfig;
 
 /// A collection path with stricter validation
 ///
@@ -43,4 +46,14 @@ struct StrictCollectionPath {
 struct CollectionPath {
     #[validate(length(min = 1, max = 255))]
     name: String,
+}
+
+pub(crate) fn apply_hw_measurement_settings(
+    config: &ServiceConfig,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
+) -> Option<CollectionAppliedHardwareAcc> {
+    if !config.hardware_reporting() {
+        hw_measurement_acc.set_applied();
+    }
+    config.hardware_reporting().then_some(hw_measurement_acc)
 }

--- a/src/actix/api/mod.rs
+++ b/src/actix/api/mod.rs
@@ -16,7 +16,7 @@ pub mod shards_api;
 pub mod snapshot_api;
 pub mod update_api;
 
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use common::validation::validate_collection_name;
 use serde::Deserialize;
 use validator::Validate;
@@ -50,8 +50,8 @@ struct CollectionPath {
 
 pub(crate) fn apply_hw_measurement_settings(
     config: &ServiceConfig,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
-) -> Option<CollectionAppliedHardwareAcc> {
+    hw_measurement_acc: RequestHardwareAcc,
+) -> Option<RequestHardwareAcc> {
     if !config.hardware_reporting() {
         hw_measurement_acc.set_applied();
     }

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -80,7 +80,7 @@ async fn query_points(
 
             Ok(QueryResponse { points })
         },
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -151,7 +151,7 @@ async fn query_points_batch(
                 .collect_vec();
             Ok(res)
         },
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -209,7 +209,7 @@ async fn query_points_groups(
             )
             .await
         },
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -1,7 +1,7 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse};
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use itertools::Itertools;
 use storage::content_manager::collection_verification::{

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -1,8 +1,8 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse};
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use storage::content_manager::collection_verification::{
     check_strict_mode, check_strict_mode_batch,
@@ -48,7 +48,7 @@ async fn query_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new_unchecked();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
     helpers::time_and_hardware_opt(
         async move {
@@ -80,7 +80,7 @@ async fn query_points(
 
             Ok(QueryResponse { points })
         },
-        hw_measurement_acc,
+        hw_measurement_acc.into_hw_measurement_acc(),
         service_config.hardware_reporting(),
     )
     .await
@@ -110,7 +110,7 @@ async fn query_points_batch(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new_unchecked();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
     helpers::time_and_hardware_opt(
         async move {
@@ -151,7 +151,7 @@ async fn query_points_batch(
                 .collect_vec();
             Ok(res)
         },
-        hw_measurement_acc,
+        hw_measurement_acc.into_hw_measurement_acc(),
         service_config.hardware_reporting(),
     )
     .await
@@ -184,7 +184,7 @@ async fn query_points_groups(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
 
     helpers::time_and_hardware_opt(
@@ -209,7 +209,7 @@ async fn query_points_groups(
             )
             .await
         },
-        hw_measurement_acc,
+        hw_measurement_acc.into_hw_measurement_acc(),
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -1,7 +1,7 @@
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{QueryGroupsRequest, QueryRequest, QueryRequestBatch, QueryResponse};
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use itertools::Itertools;
 use storage::content_manager::collection_verification::{
@@ -48,7 +48,7 @@ async fn query_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new_unchecked();
+    let hw_measurement_acc = RequestHardwareAcc::new_unchecked();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
     helpers::time_and_hardware_opt(
         async move {
@@ -110,7 +110,7 @@ async fn query_points_batch(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new_unchecked();
+    let hw_measurement_acc = RequestHardwareAcc::new_unchecked();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
     helpers::time_and_hardware_opt(
         async move {
@@ -184,7 +184,7 @@ async fn query_points_groups(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let hw_measurement_acc_clone = hw_measurement_acc.clone();
 
     helpers::time_and_hardware_opt(

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -78,7 +78,7 @@ async fn recommend_points(
                     .map(api::rest::ScoredPoint::from)
                     .collect_vec()
             }),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -162,7 +162,7 @@ async fn recommend_batch_points(
                 })
                 .collect_vec()
         }),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -212,7 +212,7 @@ async fn recommend_point_groups(
             params.timeout(),
             hw_measurement_acc.clone(),
         ),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
@@ -58,7 +58,7 @@ async fn recommend_points(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new_unchecked();
+    let hw_measurement_acc = RequestHardwareAcc::new_unchecked();
 
     helpers::time_and_hardware_opt(
         dispatcher
@@ -91,7 +91,7 @@ async fn do_recommend_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = request
         .searches
@@ -139,7 +139,7 @@ async fn recommend_batch_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_recommend_batch_points(
@@ -200,7 +200,7 @@ async fn recommend_point_groups(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     helpers::time_and_hardware_opt(
         crate::common::points::do_recommend_point_groups(
             dispatcher.toc(&access, &pass),

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -2,7 +2,7 @@ use actix_web::{post, web, HttpResponse, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{SearchMatrixOffsetsResponse, SearchMatrixPairsResponse, SearchMatrixRequest};
 use collection::collection::distance_matrix::CollectionSearchMatrixRequest;
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CoreSearchRequest, SearchGroupsRequest, SearchRequest, SearchRequestBatch,
@@ -57,7 +57,7 @@ async fn search_points(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_core_search_points(
@@ -123,7 +123,7 @@ async fn batch_search_points(
         Err(err) => return process_response_error(err, Instant::now()),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_search_batch_points(
@@ -184,7 +184,7 @@ async fn search_point_groups(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     helpers::time_and_hardware_opt(
         do_search_point_groups(
@@ -237,7 +237,7 @@ async fn search_points_matrix_pairs(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     let response = do_search_points_matrix(
         dispatcher.toc(&access, &pass),
@@ -291,7 +291,7 @@ async fn search_points_matrix_offsets(
         Some(shard_keys) => shard_keys.into(),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     let response = do_search_points_matrix(
         dispatcher.toc(&access, &pass),

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -75,7 +75,7 @@ async fn search_points(
                 .map(api::rest::ScoredPoint::from)
                 .collect_vec()
         }),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -145,7 +145,7 @@ async fn batch_search_points(
                 })
                 .collect_vec()
         }),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -196,7 +196,7 @@ async fn search_point_groups(
             params.timeout(),
             hw_measurement_acc.clone(),
         ),
-        hw_measurement_acc.into_hw_measurement_acc(),
+        hw_measurement_acc,
         service_config.hardware_reporting(),
     )
     .await
@@ -253,7 +253,7 @@ async fn search_points_matrix_pairs(
 
     let hw_measurements = service_config
         .hardware_reporting()
-        .then(|| hw_measurement_acc.into_hw_measurement_acc());
+        .then(|| hw_measurement_acc);
 
     process_response(response, timing, hw_measurements)
 }
@@ -309,7 +309,7 @@ async fn search_points_matrix_offsets(
 
     let hw_measurements = service_config
         .hardware_reporting()
-        .then(|| hw_measurement_acc.into_hw_measurement_acc());
+        .then(|| hw_measurement_acc);
 
     process_response(response, timing, hw_measurements)
 }

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -17,6 +17,7 @@ use tokio::time::Instant;
 
 use super::read_params::ReadParams;
 use super::CollectionPath;
+use crate::actix::api::apply_hw_measurement_settings;
 use crate::actix::auth::ActixAccess;
 use crate::actix::helpers::{self, process_response, process_response_error};
 use crate::common::points::{
@@ -251,9 +252,7 @@ async fn search_points_matrix_pairs(
     .await
     .map(SearchMatrixPairsResponse::from);
 
-    let hw_measurements = service_config
-        .hardware_reporting()
-        .then_some(hw_measurement_acc);
+    let hw_measurements = apply_hw_measurement_settings(&service_config, hw_measurement_acc);
 
     process_response(response, timing, hw_measurements)
 }
@@ -307,9 +306,7 @@ async fn search_points_matrix_offsets(
     .await
     .map(SearchMatrixOffsetsResponse::from);
 
-    let hw_measurements = service_config
-        .hardware_reporting()
-        .then_some(hw_measurement_acc);
+    let hw_measurements = apply_hw_measurement_settings(&service_config, hw_measurement_acc);
 
     process_response(response, timing, hw_measurements)
 }

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -1,8 +1,8 @@
 use actix_web::{post, web, HttpResponse, Responder};
 use actix_web_validator::{Json, Path, Query};
 use api::rest::{SearchMatrixOffsetsResponse, SearchMatrixPairsResponse, SearchMatrixRequest};
-use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::CollectionSearchMatrixRequest;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CoreSearchRequest, SearchGroupsRequest, SearchRequest, SearchRequestBatch,

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -253,7 +253,7 @@ async fn search_points_matrix_pairs(
 
     let hw_measurements = service_config
         .hardware_reporting()
-        .then(|| hw_measurement_acc);
+        .then_some(hw_measurement_acc);
 
     process_response(response, timing, hw_measurements)
 }
@@ -309,7 +309,7 @@ async fn search_points_matrix_offsets(
 
     let hw_measurements = service_config
         .hardware_reporting()
-        .then(|| hw_measurement_acc);
+        .then_some(hw_measurement_acc);
 
     process_response(response, timing, hw_measurements)
 }

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use actix_web::rt::time::Instant;
 use actix_web::{http, HttpResponse, ResponseError};
 use api::grpc::models::{ApiResponse, ApiStatus, HardwareUsage};
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::types::CollectionError;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use serde::Serialize;
@@ -22,7 +22,7 @@ pub fn accepted_response(timing: Instant) -> HttpResponse {
 pub fn process_response<T>(
     response: Result<T, StorageError>,
     timing: Instant,
-    hw_measurement_acc: Option<CollectionAppliedHardwareAcc>,
+    hw_measurement_acc: Option<RequestHardwareAcc>,
 ) -> HttpResponse
 where
     T: Serialize,
@@ -42,7 +42,7 @@ where
     }
 }
 
-fn hardware_accumulator_to_api(acc: CollectionAppliedHardwareAcc) -> HardwareUsage {
+fn hardware_accumulator_to_api(acc: RequestHardwareAcc) -> HardwareUsage {
     let acc = HwMeasurementAcc::from(acc);
     HardwareUsage { cpu: acc.get_cpu() }
 }
@@ -67,7 +67,7 @@ pub fn process_response_error(err: StorageError, timing: Instant) -> HttpRespons
 /// Future must be cancel safe.
 pub async fn time_and_hardware_opt<T, Fut>(
     future: Fut,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
     enabled: bool,
 ) -> HttpResponse
 where
@@ -146,7 +146,7 @@ where
 /// Future must be cancel safe.
 async fn time_and_hardware_impl<T, Fut>(
     future: Fut,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> HttpResponse
 where
     Fut: Future<Output = Result<Option<T>, StorageError>>,

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -71,6 +71,7 @@ where
     Fut: Future<Output = Result<T, StorageError>>,
     T: serde::Serialize,
 {
+    hw_measurement_acc.set_applied();
     if enabled {
         time_and_hardware_impl(async { future.await.map(Some) }, hw_measurement_acc).await
     } else {

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -27,6 +27,10 @@ pub fn process_response<T>(
 where
     T: Serialize,
 {
+    if let Some(hw_measurements) = hw_measurement_acc.as_ref() {
+        hw_measurements.set_applied();
+    }
+
     match response {
         Ok(res) => HttpResponse::Ok().json(ApiResponse {
             result: Some(res),
@@ -40,7 +44,6 @@ where
 
 fn hardware_accumulator_to_api(acc: CollectionAppliedHardwareAcc) -> HardwareUsage {
     let acc = HwMeasurementAcc::from(acc);
-    acc.set_applied();
     HardwareUsage { cpu: acc.get_cpu() }
 }
 
@@ -72,6 +75,7 @@ where
     T: serde::Serialize,
 {
     hw_measurement_acc.set_applied();
+
     if enabled {
         time_and_hardware_impl(async { future.await.map(Some) }, hw_measurement_acc).await
     } else {

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -3,12 +3,12 @@ use std::time::Duration;
 
 use api::rest::schema::{PointInsertOperations, PointsBatch, PointsList};
 use api::rest::{SearchGroupsRequestInternal, ShardKeySelector, UpdateVectors};
-use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::{
     CollectionSearchMatrixRequest, CollectionSearchMatrixResponse,
 };
 use collection::collection::Collection;
 use collection::common::batching::batch_requests;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::grouping::group_by::GroupRequest;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -8,7 +8,7 @@ use collection::collection::distance_matrix::{
 };
 use collection::collection::Collection;
 use collection::common::batching::batch_requests;
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::grouping::group_by::GroupRequest;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{
@@ -844,7 +844,7 @@ pub async fn do_core_search_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let batch_res = do_core_search_batch_points(
         toc,
@@ -872,7 +872,7 @@ pub async fn do_search_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = batch_requests::<
         (CoreSearchRequest, ShardSelectorInternal),
@@ -923,7 +923,7 @@ pub async fn do_core_search_batch_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.core_search_batch(
         collection_name,
@@ -946,7 +946,7 @@ pub async fn do_search_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -969,7 +969,7 @@ pub async fn do_recommend_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -990,7 +990,7 @@ pub async fn do_discover_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = request
         .searches
@@ -1025,7 +1025,7 @@ pub async fn do_count_points(
     timeout: Option<Duration>,
     shard_selection: ShardSelectorInternal,
     access: Access,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<CountResult, StorageError> {
     toc.count(
         collection_name,
@@ -1088,7 +1088,7 @@ pub async fn do_query_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let requests = vec![(request, shard_selection)];
     let batch_res = toc
@@ -1115,7 +1115,7 @@ pub async fn do_query_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.query_batch(
         collection_name,
@@ -1137,7 +1137,7 @@ pub async fn do_query_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -1160,7 +1160,7 @@ pub async fn do_search_points_matrix(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<CollectionSearchMatrixResponse, StorageError> {
     toc.search_points_matrix(
         collection_name,

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use api::rest::schema::{PointInsertOperations, PointsBatch, PointsList};
 use api::rest::{SearchGroupsRequestInternal, ShardKeySelector, UpdateVectors};
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::{
     CollectionSearchMatrixRequest, CollectionSearchMatrixResponse,
 };
@@ -34,7 +35,6 @@ use collection::operations::{
     ClockTag, CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
 use collection::shards::shard::ShardId;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use schemars::JsonSchema;
 use segment::json_path::JsonPath;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, ScoredPoint, StrictModeConfig};
@@ -844,7 +844,7 @@ pub async fn do_core_search_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let batch_res = do_core_search_batch_points(
         toc,
@@ -872,7 +872,7 @@ pub async fn do_search_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = batch_requests::<
         (CoreSearchRequest, ShardSelectorInternal),
@@ -923,7 +923,7 @@ pub async fn do_core_search_batch_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.core_search_batch(
         collection_name,
@@ -946,7 +946,7 @@ pub async fn do_search_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -969,7 +969,7 @@ pub async fn do_recommend_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -990,7 +990,7 @@ pub async fn do_discover_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = request
         .searches
@@ -1025,7 +1025,7 @@ pub async fn do_count_points(
     timeout: Option<Duration>,
     shard_selection: ShardSelectorInternal,
     access: Access,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<CountResult, StorageError> {
     toc.count(
         collection_name,
@@ -1088,7 +1088,7 @@ pub async fn do_query_points(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let requests = vec![(request, shard_selection)];
     let batch_res = toc
@@ -1115,7 +1115,7 @@ pub async fn do_query_batch_points(
     read_consistency: Option<ReadConsistency>,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.query_batch(
         collection_name,
@@ -1137,7 +1137,7 @@ pub async fn do_query_point_groups(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
         collection_name,
@@ -1160,7 +1160,7 @@ pub async fn do_search_points_matrix(
     shard_selection: ShardSelectorInternal,
     access: Access,
     timeout: Option<Duration>,
-    hw_measurement_acc: HwMeasurementAcc,
+    hw_measurement_acc: CollectionAppliedHardwareAcc,
 ) -> Result<CollectionSearchMatrixResponse, StorageError> {
     toc.search_points_matrix(
         collection_name,

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -47,6 +47,15 @@ impl PointsService {
             service_config,
         }
     }
+
+    /// Converts `CollectionAppliedHardwareAcc` to `HardwareUsage` by respecting the configuration in ServiceConfig,
+    /// returning `None` if hardware reporting is disabled.
+    fn convert_api_hardware_usage_opt(
+        &self,
+        hw_measurements: CollectionAppliedHardwareAcc,
+    ) -> Option<HardwareUsage> {
+        super::points_common::convert_api_hardware_usage_opt(&self.service_config, hw_measurements)
+    }
 }
 
 #[tonic::async_trait]
@@ -568,10 +577,7 @@ impl Points for PointsService {
         let pairs_response = SearchMatrixPairsResponse {
             result: Some(SearchMatrixPairs::from(search_matrix_response)),
             time: timing.elapsed().as_secs_f64(),
-            usage: self
-                .service_config
-                .hardware_reporting()
-                .then(|| HardwareUsage::from(hw_measurement_acc.into_hw_measurement_acc())),
+            usage: self.convert_api_hardware_usage_opt(hw_measurement_acc),
         };
         Ok(Response::new(pairs_response))
     }
@@ -594,10 +600,7 @@ impl Points for PointsService {
         let offsets_response = SearchMatrixOffsetsResponse {
             result: Some(SearchMatrixOffsets::from(search_matrix_response)),
             time: timing.elapsed().as_secs_f64(),
-            usage: self
-                .service_config
-                .hardware_reporting()
-                .then(|| HardwareUsage::from(hw_measurement_acc.into_hw_measurement_acc())),
+            usage: self.convert_api_hardware_usage_opt(hw_measurement_acc),
         };
         Ok(Response::new(offsets_response))
     }

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -15,7 +15,7 @@ use api::grpc::qdrant::{
     SearchPointGroups, SearchPoints, SearchResponse, SetPayloadPoints, UpdateBatchPoints,
     UpdateBatchResponse, UpdatePointVectors, UpsertPoints,
 };
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::types::CoreSearchRequest;
 use collection::operations::verification::new_unchecked_verification_pass;
 use storage::dispatcher::Dispatcher;

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -15,9 +15,9 @@ use api::grpc::qdrant::{
     SearchPointGroups, SearchPoints, SearchResponse, SetPayloadPoints, UpdateBatchPoints,
     UpdateBatchResponse, UpdatePointVectors, UpsertPoints,
 };
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::types::CoreSearchRequest;
 use collection::operations::verification::new_unchecked_verification_pass;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status};
 
@@ -557,7 +557,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
         let timing = Instant::now();
-        let hw_measurement_acc = HwMeasurementAcc::new();
+        let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
         let search_matrix_response = search_points_matrix(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
             request.into_inner(),
@@ -571,7 +571,7 @@ impl Points for PointsService {
             usage: self
                 .service_config
                 .hardware_reporting()
-                .then(|| HardwareUsage::from(hw_measurement_acc)),
+                .then(|| HardwareUsage::from(hw_measurement_acc.into_hw_measurement_acc())),
         };
         Ok(Response::new(pairs_response))
     }
@@ -583,7 +583,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
         let timing = Instant::now();
-        let hw_measurement_acc = HwMeasurementAcc::new();
+        let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
         let search_matrix_response = search_points_matrix(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
             request.into_inner(),
@@ -597,7 +597,7 @@ impl Points for PointsService {
             usage: self
                 .service_config
                 .hardware_reporting()
-                .then(|| HardwareUsage::from(hw_measurement_acc)),
+                .then(|| HardwareUsage::from(hw_measurement_acc.into_hw_measurement_acc())),
         };
         Ok(Response::new(offsets_response))
     }

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -15,7 +15,7 @@ use api::grpc::qdrant::{
     SearchPointGroups, SearchPoints, SearchResponse, SetPayloadPoints, UpdateBatchPoints,
     UpdateBatchResponse, UpdatePointVectors, UpsertPoints,
 };
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::types::CoreSearchRequest;
 use collection::operations::verification::new_unchecked_verification_pass;
 use storage::dispatcher::Dispatcher;
@@ -52,7 +52,7 @@ impl PointsService {
     /// returning `None` if hardware reporting is disabled.
     fn convert_api_hardware_usage_opt(
         &self,
-        hw_measurements: CollectionAppliedHardwareAcc,
+        hw_measurements: RequestHardwareAcc,
     ) -> Option<HardwareUsage> {
         super::points_common::convert_api_hardware_usage_opt(&self.service_config, hw_measurements)
     }
@@ -566,7 +566,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
         let timing = Instant::now();
-        let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+        let hw_measurement_acc = RequestHardwareAcc::new();
         let search_matrix_response = search_points_matrix(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
             request.into_inner(),
@@ -589,7 +589,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
         let timing = Instant::now();
-        let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+        let hw_measurement_acc = RequestHardwareAcc::new();
         let search_matrix_response = search_points_matrix(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
             request.into_inner(),

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -2066,6 +2066,7 @@ pub(crate) fn convert_api_hardware_usage_opt(
     service_config: &ServiceConfig,
     hw_measurements: CollectionAppliedHardwareAcc,
 ) -> Option<HardwareUsage> {
+    hw_measurements.set_applied();
     service_config
         .hardware_reporting()
         .then_some(HardwareUsage::from(HwMeasurementAcc::from(hw_measurements)))

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -21,10 +21,10 @@ use api::rest::schema::{PointInsertOperations, PointsList};
 use api::rest::{
     OrderByInterface, PointStruct, PointVectors, ShardKeySelector, UpdateVectors, VectorStruct,
 };
-use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::collection::distance_matrix::{
     CollectionSearchMatrixRequest, CollectionSearchMatrixResponse,
 };
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::conversions::{
     try_discover_request_from_grpc, try_points_selector_from_grpc, write_ordering_from_proto,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -2068,5 +2068,5 @@ pub(crate) fn convert_api_hardware_usage_opt(
 ) -> Option<HardwareUsage> {
     service_config
         .hardware_reporting()
-        .then(|| HardwareUsage::from(HwMeasurementAcc::from(hw_measurements)))
+        .then_some(HardwareUsage::from(HwMeasurementAcc::from(hw_measurements)))
 }

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -24,7 +24,7 @@ use api::rest::{
 use collection::collection::distance_matrix::{
     CollectionSearchMatrixRequest, CollectionSearchMatrixResponse,
 };
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::conversions::{
     try_discover_request_from_grpc, try_points_selector_from_grpc, write_ordering_from_proto,
@@ -1058,7 +1058,7 @@ pub async fn search(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     let timing = Instant::now();
     let scored_points = do_core_search_points(
@@ -1106,7 +1106,7 @@ pub async fn core_search_batch(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let timing = Instant::now();
 
     let scored_points = do_search_batch_points(
@@ -1166,7 +1166,7 @@ pub async fn core_search_list(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let scored_points = toc
         .core_search_batch(
             &collection_name,
@@ -1223,7 +1223,7 @@ pub async fn search_groups(
 
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     let timing = Instant::now();
     let groups_result = crate::common::points::do_search_point_groups(
@@ -1330,7 +1330,7 @@ pub async fn recommend(
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
     let timeout = timeout.map(Duration::from_secs);
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let timing = Instant::now();
     let recommended_points = toc
         .recommend(
@@ -1387,7 +1387,7 @@ pub async fn recommend_batch(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let timing = Instant::now();
     let scored_points = toc
         .recommend_batch(
@@ -1443,7 +1443,7 @@ pub async fn recommend_groups(
 
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     let timing = Instant::now();
     let groups_result = crate::common::points::do_recommend_point_groups(
@@ -1490,7 +1490,7 @@ pub async fn discover(
 
     let timing = Instant::now();
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
 
     let discovered_points = toc
@@ -1547,7 +1547,7 @@ pub async fn discover_batch(
         )
         .await?;
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let timing = Instant::now();
     let scored_points = toc
         .discover_batch(
@@ -1686,7 +1686,7 @@ pub async fn count(
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
 
     let timing = Instant::now();
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     let count_result = do_count_points(
         toc,
@@ -1800,7 +1800,7 @@ pub async fn query(
 
     let timeout = timeout.map(Duration::from_secs);
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let timing = Instant::now();
     let scored_points = do_query_points(
         toc,
@@ -1854,7 +1854,7 @@ pub async fn query_batch(
         )
         .await?;
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let timing = Instant::now();
     let scored_points = do_query_batch_points(
         toc,
@@ -1911,7 +1911,7 @@ pub async fn query_groups(
     let timeout = timeout.map(Duration::from_secs);
     let timing = Instant::now();
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
     let groups_result = do_query_point_groups(
         toc,
         &collection_name,
@@ -2003,7 +2003,7 @@ pub async fn search_points_matrix(
     toc_provider: impl CheckedTocProvider,
     search_matrix_points: SearchMatrixPoints,
     access: Access,
-    hw_measurement_acc: CollectionAppliedHardwareAcc,
+    hw_measurement_acc: RequestHardwareAcc,
 ) -> Result<CollectionSearchMatrixResponse, Status> {
     let SearchMatrixPoints {
         collection_name,
@@ -2064,7 +2064,7 @@ pub async fn search_points_matrix(
 /// returning `None` if hardware reporting is disabled.
 pub(crate) fn convert_api_hardware_usage_opt(
     service_config: &ServiceConfig,
-    hw_measurements: CollectionAppliedHardwareAcc,
+    hw_measurements: RequestHardwareAcc,
 ) -> Option<HardwareUsage> {
     hw_measurements.set_applied();
     service_config

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -13,7 +13,7 @@ use api::grpc::qdrant::{
     ScrollPointsInternal, ScrollResponse, SearchBatchResponse, SetPayloadPointsInternal,
     SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
 };
-use collection::collection::common::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use collection::shards::shard::ShardId;

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -7,7 +7,7 @@ use api::grpc::qdrant::{
     ClearPayloadPointsInternal, CoreSearchBatchPointsInternal, CountPointsInternal, CountResponse,
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
     DeletePayloadPointsInternal, DeletePointsInternal, DeleteVectorsInternal, FacetCountsInternal,
-    FacetResponseInternal, GetPointsInternal, GetResponse, HardwareUsage, IntermediateResult,
+    FacetResponseInternal, GetPointsInternal, GetResponse, IntermediateResult,
     PointsOperationResponseInternal, QueryBatchPointsInternal, QueryBatchResponseInternal,
     QueryResultInternal, QueryShardPoints, RecommendPointsInternal, RecommendResponse,
     ScrollPointsInternal, ScrollResponse, SearchBatchResponse, SetPayloadPointsInternal,
@@ -25,7 +25,7 @@ use storage::content_manager::toc::TableOfContent;
 use storage::rbac::Access;
 use tonic::{Request, Response, Status};
 
-use super::points_common::{core_search_list, scroll};
+use super::points_common::{convert_api_hardware_usage_opt, core_search_list, scroll};
 use super::validate_and_log;
 use crate::settings::ServiceConfig;
 use crate::tonic::api::points_common::{
@@ -102,9 +102,7 @@ pub async fn query_batch_internal(
             })
             .collect(),
         time: timing.elapsed().as_secs_f64(),
-        usage: service_config
-            .hardware_reporting()
-            .then(|| HardwareUsage::from(hw_measurement_acc.into_hw_measurement_acc())),
+        usage: convert_api_hardware_usage_opt(service_config, hw_measurement_acc),
     };
 
     Ok(Response::new(response))

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -13,7 +13,7 @@ use api::grpc::qdrant::{
     ScrollPointsInternal, ScrollResponse, SearchBatchResponse, SetPayloadPointsInternal,
     SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
 };
-use collection::common::hardware_counting::CollectionAppliedHardwareAcc;
+use collection::common::hardware_counting::RequestHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use collection::shards::shard::ShardId;
@@ -77,7 +77,7 @@ pub async fn query_batch_internal(
         Some(shard_id) => ShardSelectorInternal::ShardId(shard_id),
     };
 
-    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
+    let hw_measurement_acc = RequestHardwareAcc::new();
 
     let batch_response = toc
         .query_batch_internal(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -13,10 +13,10 @@ use api::grpc::qdrant::{
     ScrollPointsInternal, ScrollResponse, SearchBatchResponse, SetPayloadPointsInternal,
     SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
 };
+use collection::collection::common::CollectionAppliedHardwareAcc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::universal_query::shard_query::ShardQueryRequest;
 use collection::shards::shard::ShardId;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::json_path::JsonPath;
@@ -77,7 +77,7 @@ pub async fn query_batch_internal(
         Some(shard_id) => ShardSelectorInternal::ShardId(shard_id),
     };
 
-    let hw_measurement_acc = HwMeasurementAcc::new();
+    let hw_measurement_acc = CollectionAppliedHardwareAcc::new();
 
     let batch_response = toc
         .query_batch_internal(
@@ -104,7 +104,7 @@ pub async fn query_batch_internal(
         time: timing.elapsed().as_secs_f64(),
         usage: service_config
             .hardware_reporting()
-            .then(|| HardwareUsage::from(hw_measurement_acc)),
+            .then(|| HardwareUsage::from(hw_measurement_acc.into_hw_measurement_acc())),
     };
 
     Ok(Response::new(response))


### PR DESCRIPTION
Aggregate hardware measurements in the corresponding `Collection` for all measured operations.

Design choices:
  - Utilizes a new wrapper proving by design that no measurements can be dropped without noticing.
  - `HwMeasurementAcc` now also has checks when dropping values in test+debug builds with zero overhead in release, thanks to being completely conditionally compiled.