### PR TITLE
Make `default_on_disk_payload` consistent with config file

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,6 +33,8 @@ storage:
   # It will be read from the disk every time it is requested.
   # This setting saves RAM by (slightly) increasing the response time.
   # Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+  # 
+  # Default: true
   on_disk_payload: true
 
   # Maximum number of concurrent updates to shard replicas

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6724,8 +6724,8 @@
             "nullable": true
           },
           "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
-            "default": false,
+            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.\n\nDefault: true",
+            "default": true,
             "type": "boolean"
           },
           "sparse_vectors": {
@@ -9186,7 +9186,7 @@
             "nullable": true
           },
           "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
+            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.\n\nDefault: true",
             "default": null,
             "type": "boolean",
             "nullable": true

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -100,6 +100,8 @@ pub struct CollectionParams {
     /// It will be read from the disk every time it is requested.
     /// This setting saves RAM by (slightly) increasing the response time.
     /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+    ///
+    /// Default: true
     #[serde(default = "default_on_disk_payload")]
     pub on_disk_payload: bool,
     /// Configuration of the sparse vector storage
@@ -193,8 +195,8 @@ pub fn default_write_consistency_factor() -> NonZeroU32 {
     NonZeroU32::new(default_write_consistency_factor_const()).unwrap()
 }
 
-const fn default_on_disk_payload() -> bool {
-    false
+pub const fn default_on_disk_payload() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -359,7 +359,7 @@ mod tests {
 
         assert_eq!(new_params.replication_factor.get(), 1);
         assert_eq!(new_params.write_consistency_factor.get(), 2);
-        assert!(!new_params.on_disk_payload);
+        assert!(new_params.on_disk_payload);
     }
 
     #[test]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -758,9 +758,9 @@ impl Default for Indexes {
 #[serde(tag = "type", content = "options", rename_all = "snake_case")]
 pub enum PayloadStorageType {
     // Store payload in memory and use persistence storage only if vectors are changed
-    #[default]
     InMemory,
     // Store payload on disk only, read each time it is requested
+    #[default]
     OnDisk,
 }
 

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -146,6 +146,8 @@ pub struct CreateCollection {
     /// It will be read from the disk every time it is requested.
     /// This setting saves RAM by (slightly) increasing the response time.
     /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+    ///
+    /// Default: true
     #[serde(default)]
     pub on_disk_payload: Option<bool>,
     /// Custom params for HNSW index. If none - values from service configuration file are used.

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -125,7 +125,7 @@ fn default_snapshots_path() -> String {
 }
 
 const fn default_on_disk_payload() -> bool {
-    false
+    true
 }
 
 const fn default_mmap_advice() -> madvise::Advice {

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use collection::common::snapshots_manager::SnapShotsConfig;
-use collection::config::WalConfig;
+use collection::config::{default_on_disk_payload, WalConfig};
 use collection::operations::config_diff::OptimizersConfigDiff;
 use collection::operations::shared_storage_config::{
     SharedStorageConfig, DEFAULT_IO_SHARD_TRANSFER_LIMIT, DEFAULT_SNAPSHOTS_PATH,
@@ -122,10 +122,6 @@ impl StorageConfig {
 
 fn default_snapshots_path() -> String {
     DEFAULT_SNAPSHOTS_PATH.to_string()
-}
-
-const fn default_on_disk_payload() -> bool {
-    true
 }
 
 const fn default_mmap_advice() -> madvise::Advice {


### PR DESCRIPTION
We currently have our code to interpret a missing `on_disk_payload` as `false`, but it does not usually get exercised because the default config file for storage sets it to true:

https://github.com/qdrant/qdrant/blob/dev/config/config.yaml#L36

This PR:
- makes the default `on_disk_payload` to `true`, to match the default config value
- changes the default `PayloadStorageType` to `OnDisk`
- removes duplicate `default_on_disk_payload` implementation
