### PR TITLE
No useless async

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -679,7 +679,7 @@ impl Collection {
                 });
 
             // Try to find a replica to transfer from
-            for replica_id in replica_set.active_remote_shards().await {
+            for replica_id in replica_set.active_remote_shards() {
                 let transfer = ShardTransfer {
                     from: replica_id,
                     to: this_peer_id,

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -329,6 +329,5 @@ impl Collection {
             .read()
             .await
             .assert_shard_exists(shard_id)
-            .await
     }
 }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -156,12 +156,12 @@ impl SnapshotStorageManager {
         snapshot_name: &str,
     ) -> CollectionResult<PathBuf> {
         match self {
-            SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl.get_snapshot_path(snapshots_path, snapshot_name)
+            SnapshotStorageManager::LocalFS(_storage_impl) => {
+                SnapshotStorageLocalFS::get_snapshot_path(snapshots_path, snapshot_name)
             }
-            SnapshotStorageManager::S3(storage_impl) => {
-                storage_impl.get_snapshot_path(snapshots_path, snapshot_name)
-            }
+            SnapshotStorageManager::S3(_storage_impl) => Ok(
+                SnapshotStorageCloud::get_snapshot_path(snapshots_path, snapshot_name),
+            ),
         }
     }
 
@@ -171,12 +171,12 @@ impl SnapshotStorageManager {
         snapshot_name: &str,
     ) -> CollectionResult<PathBuf> {
         match self {
-            SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl.get_full_snapshot_path(snapshots_path, snapshot_name)
+            SnapshotStorageManager::LocalFS(_storage_impl) => {
+                SnapshotStorageLocalFS::get_full_snapshot_path(snapshots_path, snapshot_name)
             }
-            SnapshotStorageManager::S3(storage_impl) => {
-                storage_impl.get_full_snapshot_path(snapshots_path, snapshot_name)
-            }
+            SnapshotStorageManager::S3(_storage_impl) => Ok(
+                SnapshotStorageCloud::get_full_snapshot_path(snapshots_path, snapshot_name),
+            ),
         }
     }
 
@@ -186,8 +186,8 @@ impl SnapshotStorageManager {
         temp_dir: &Path,
     ) -> CollectionResult<MaybeTempPath> {
         match self {
-            SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl.get_snapshot_file(snapshot_path, temp_dir)
+            SnapshotStorageManager::LocalFS(_storage_impl) => {
+                SnapshotStorageLocalFS::get_snapshot_file(snapshot_path, temp_dir)
             }
             SnapshotStorageManager::S3(storage_impl) => {
                 storage_impl
@@ -202,8 +202,8 @@ impl SnapshotStorageManager {
         snapshot_path: &Path,
     ) -> CollectionResult<SnapshotStream> {
         match self {
-            SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl.get_snapshot_stream(snapshot_path)
+            SnapshotStorageManager::LocalFS(_storage_impl) => {
+                Ok(SnapshotStorageLocalFS::get_snapshot_stream(snapshot_path))
             }
             SnapshotStorageManager::S3(storage_impl) => {
                 storage_impl.get_snapshot_stream(snapshot_path).await
@@ -313,7 +313,6 @@ impl SnapshotStorageLocalFS {
     ///
     /// This enforces the file to be inside the snapshots directory
     fn get_full_snapshot_path(
-        &self,
         snapshots_path: &str,
         snapshot_name: &str,
     ) -> CollectionResult<PathBuf> {
@@ -344,11 +343,7 @@ impl SnapshotStorageLocalFS {
     /// Get absolute file path for a collection snapshot by name
     ///
     /// This enforces the file to be inside the snapshots directory
-    fn get_snapshot_path(
-        &self,
-        snapshots_path: &Path,
-        snapshot_name: &str,
-    ) -> CollectionResult<PathBuf> {
+    fn get_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> CollectionResult<PathBuf> {
         let absolute_snapshot_dir = snapshots_path.canonicalize().map_err(|_| {
             CollectionError::not_found(format!("Snapshot directory: {}", snapshots_path.display()))
         })?;
@@ -374,7 +369,6 @@ impl SnapshotStorageLocalFS {
     }
 
     fn get_snapshot_file(
-        &self,
         snapshot_path: &Path,
         _temp_dir: &Path,
     ) -> CollectionResult<MaybeTempPath> {
@@ -386,10 +380,10 @@ impl SnapshotStorageLocalFS {
         Ok(MaybeTempPath::Persistent(snapshot_path.to_path_buf()))
     }
 
-    fn get_snapshot_stream(&self, snapshot_path: &Path) -> CollectionResult<SnapshotStream> {
-        Ok(SnapshotStream::LocalFS(SnapShotStreamLocalFS {
+    fn get_snapshot_stream(snapshot_path: &Path) -> SnapshotStream {
+        SnapshotStream::LocalFS(SnapShotStreamLocalFS {
             snapshot_path: snapshot_path.to_path_buf(),
-        }))
+        })
     }
 }
 
@@ -429,24 +423,14 @@ impl SnapshotStorageCloud {
         Ok(())
     }
 
-    fn get_snapshot_path(
-        &self,
-        snapshots_path: &Path,
-        snapshot_name: &str,
-    ) -> CollectionResult<PathBuf> {
+    fn get_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> PathBuf {
         let absolute_snapshot_dir = snapshots_path;
-        let absolute_snapshot_path = absolute_snapshot_dir.join(snapshot_name);
-        Ok(absolute_snapshot_path)
+        absolute_snapshot_dir.join(snapshot_name)
     }
 
-    fn get_full_snapshot_path(
-        &self,
-        snapshots_path: &str,
-        snapshot_name: &str,
-    ) -> CollectionResult<PathBuf> {
+    fn get_full_snapshot_path(snapshots_path: &str, snapshot_name: &str) -> PathBuf {
         let absolute_snapshot_dir = PathBuf::from(snapshots_path);
-        let absolute_snapshot_path = absolute_snapshot_dir.join(snapshot_name);
-        Ok(absolute_snapshot_path)
+        absolute_snapshot_dir.join(snapshot_name)
     }
 
     async fn get_snapshot_file(

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -150,40 +150,32 @@ impl SnapshotStorageManager {
         }
     }
 
-    pub async fn get_snapshot_path(
+    pub fn get_snapshot_path(
         &self,
         snapshots_path: &Path,
         snapshot_name: &str,
     ) -> CollectionResult<PathBuf> {
         match self {
             SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl
-                    .get_snapshot_path(snapshots_path, snapshot_name)
-                    .await
+                storage_impl.get_snapshot_path(snapshots_path, snapshot_name)
             }
             SnapshotStorageManager::S3(storage_impl) => {
-                storage_impl
-                    .get_snapshot_path(snapshots_path, snapshot_name)
-                    .await
+                storage_impl.get_snapshot_path(snapshots_path, snapshot_name)
             }
         }
     }
 
-    pub async fn get_full_snapshot_path(
+    pub fn get_full_snapshot_path(
         &self,
         snapshots_path: &str,
         snapshot_name: &str,
     ) -> CollectionResult<PathBuf> {
         match self {
             SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl
-                    .get_full_snapshot_path(snapshots_path, snapshot_name)
-                    .await
+                storage_impl.get_full_snapshot_path(snapshots_path, snapshot_name)
             }
             SnapshotStorageManager::S3(storage_impl) => {
-                storage_impl
-                    .get_full_snapshot_path(snapshots_path, snapshot_name)
-                    .await
+                storage_impl.get_full_snapshot_path(snapshots_path, snapshot_name)
             }
         }
     }
@@ -195,9 +187,7 @@ impl SnapshotStorageManager {
     ) -> CollectionResult<MaybeTempPath> {
         match self {
             SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl
-                    .get_snapshot_file(snapshot_path, temp_dir)
-                    .await
+                storage_impl.get_snapshot_file(snapshot_path, temp_dir)
             }
             SnapshotStorageManager::S3(storage_impl) => {
                 storage_impl
@@ -213,7 +203,7 @@ impl SnapshotStorageManager {
     ) -> CollectionResult<SnapshotStream> {
         match self {
             SnapshotStorageManager::LocalFS(storage_impl) => {
-                storage_impl.get_snapshot_stream(snapshot_path).await
+                storage_impl.get_snapshot_stream(snapshot_path)
             }
             SnapshotStorageManager::S3(storage_impl) => {
                 storage_impl.get_snapshot_stream(snapshot_path).await
@@ -322,7 +312,7 @@ impl SnapshotStorageLocalFS {
     /// Get absolute file path for a full snapshot by name
     ///
     /// This enforces the file to be inside the snapshots directory
-    async fn get_full_snapshot_path(
+    fn get_full_snapshot_path(
         &self,
         snapshots_path: &str,
         snapshot_name: &str,
@@ -354,7 +344,7 @@ impl SnapshotStorageLocalFS {
     /// Get absolute file path for a collection snapshot by name
     ///
     /// This enforces the file to be inside the snapshots directory
-    async fn get_snapshot_path(
+    fn get_snapshot_path(
         &self,
         snapshots_path: &Path,
         snapshot_name: &str,
@@ -383,7 +373,7 @@ impl SnapshotStorageLocalFS {
         Ok(absolute_snapshot_path)
     }
 
-    async fn get_snapshot_file(
+    fn get_snapshot_file(
         &self,
         snapshot_path: &Path,
         _temp_dir: &Path,
@@ -396,7 +386,7 @@ impl SnapshotStorageLocalFS {
         Ok(MaybeTempPath::Persistent(snapshot_path.to_path_buf()))
     }
 
-    async fn get_snapshot_stream(&self, snapshot_path: &Path) -> CollectionResult<SnapshotStream> {
+    fn get_snapshot_stream(&self, snapshot_path: &Path) -> CollectionResult<SnapshotStream> {
         Ok(SnapshotStream::LocalFS(SnapShotStreamLocalFS {
             snapshot_path: snapshot_path.to_path_buf(),
         }))
@@ -439,7 +429,7 @@ impl SnapshotStorageCloud {
         Ok(())
     }
 
-    async fn get_snapshot_path(
+    fn get_snapshot_path(
         &self,
         snapshots_path: &Path,
         snapshot_name: &str,
@@ -449,7 +439,7 @@ impl SnapshotStorageCloud {
         Ok(absolute_snapshot_path)
     }
 
-    async fn get_full_snapshot_path(
+    fn get_full_snapshot_path(
         &self,
         snapshots_path: &str,
         snapshot_name: &str,

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -325,7 +325,7 @@ impl ShardReplicaSet {
             clock_set: Default::default(),
         };
 
-        if local_load_failure && replica_set.active_remote_shards().await.is_empty() {
+        if local_load_failure && replica_set.active_remote_shards().is_empty() {
             replica_set
                 .locally_disabled_peers
                 .write()
@@ -372,7 +372,7 @@ impl ShardReplicaSet {
     }
 
     /// List the peer IDs on which this shard is active, both the local and remote peers.
-    pub async fn active_shards(&self) -> Vec<PeerId> {
+    pub fn active_shards(&self) -> Vec<PeerId> {
         let replica_state = self.replica_state.read();
         replica_state
             .active_peers()
@@ -382,7 +382,7 @@ impl ShardReplicaSet {
     }
 
     /// List the remote peer IDs on which this shard is active, excludes the local peer ID.
-    pub async fn active_remote_shards(&self) -> Vec<PeerId> {
+    pub fn active_remote_shards(&self) -> Vec<PeerId> {
         let replica_state = self.replica_state.read();
         let this_peer_id = replica_state.this_peer_id;
         replica_state
@@ -1001,7 +1001,7 @@ impl ShardReplicaSet {
         let Some(shard) = shard.as_ref() else {
             return false;
         };
-        shard.trigger_optimizers().await;
+        shard.trigger_optimizers();
         true
     }
 }

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -141,7 +141,7 @@ impl ShardReplicaSet {
                 // TODO: Handle single-node mode!? (How!? 😰)
 
                 // Mark this peer as "locally disabled"...
-                let has_other_active_peers = self.active_remote_shards().await.is_empty();
+                let has_other_active_peers = self.active_remote_shards().is_empty();
 
                 // ...if this peer is *not* the last active replica
                 if has_other_active_peers {

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -138,7 +138,7 @@ async fn drive_up(
                         ))
                     })?;
 
-                    let active_peer_ids = replica_set.active_shards().await;
+                    let active_peer_ids = replica_set.active_shards();
                     if active_peer_ids.is_empty() {
                         return Err(CollectionError::service_error(format!(
                             "No peer with shard {source_shard_id} in active state for resharding",

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -130,7 +130,7 @@ impl Shard {
         }
     }
 
-    pub async fn trigger_optimizers(&self) {
+    pub fn trigger_optimizers(&self) {
         match self {
             Shard::Local(local_shard) => local_shard.trigger_optimizers(),
             Shard::Proxy(proxy_shard) => proxy_shard.trigger_optimizers(),

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -714,7 +714,7 @@ impl ShardHolder {
         }
     }
 
-    pub async fn assert_shard_exists(&self, shard_id: ShardId) -> CollectionResult<()> {
+    pub fn assert_shard_exists(&self, shard_id: ShardId) -> CollectionResult<()> {
         match self.get_shard(shard_id) {
             Some(_) => Ok(()),
             None => Err(shard_not_found_error(shard_id)),

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -240,7 +240,7 @@ impl UpdateHandler {
 
     /// Checks if there are any failed operations.
     /// If so - attempts to re-apply all failed operations.
-    async fn try_recover(segments: LockedSegmentHolder, wal: LockedWal) -> CollectionResult<usize> {
+    fn try_recover(segments: LockedSegmentHolder, wal: LockedWal) -> CollectionResult<usize> {
         // Try to re-apply everything starting from the first failed operation
         let first_failed_operation_option = segments.read().failed_operation.iter().cloned().min();
         match first_failed_operation_option {
@@ -604,10 +604,7 @@ impl UpdateHandler {
                 continue;
             }
 
-            if Self::try_recover(segments.clone(), wal.clone())
-                .await
-                .is_err()
-            {
+            if Self::try_recover(segments.clone(), wal.clone()).is_err() {
                 continue;
             }
 

--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -10,10 +10,7 @@ pub type Collections = HashMap<CollectionId, Collection>;
 pub trait Checker {
     fn collection_exists(&self, collection_name: &str) -> bool;
 
-    async fn validate_collection_not_exists(
-        &self,
-        collection_name: &str,
-    ) -> Result<(), StorageError> {
+    fn validate_collection_not_exists(&self, collection_name: &str) -> Result<(), StorageError> {
         if self.collection_exists(collection_name) {
             return Err(StorageError::AlreadyExists {
                 description: format!("Collection `{collection_name}` already exists!"),
@@ -22,7 +19,7 @@ pub trait Checker {
         Ok(())
     }
 
-    async fn validate_collection_exists(&self, collection_name: &str) -> Result<(), StorageError> {
+    fn validate_collection_exists(&self, collection_name: &str) -> Result<(), StorageError> {
         if !self.collection_exists(collection_name) {
             return Err(StorageError::NotFound {
                 description: format!("Collection `{collection_name}` doesn't exist!"),

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -38,9 +38,8 @@ pub async fn do_delete_full_snapshot(
     let toc = dispatcher.toc(&access, &pass);
 
     let snapshot_manager = toc.get_snapshots_storage_manager()?;
-    let snapshot_dir = snapshot_manager
-        .get_full_snapshot_path(toc.snapshots_path(), snapshot_name)
-        .await?;
+    let snapshot_dir =
+        snapshot_manager.get_full_snapshot_path(toc.snapshots_path(), snapshot_name)?;
 
     let res = tokio::spawn(async move {
         log::info!("Deleting full storage snapshot {:?}", snapshot_dir);
@@ -68,9 +67,8 @@ pub async fn do_delete_collection_snapshot(
     let snapshot_name = snapshot_name.to_string();
     let collection = toc.get_collection(&collection_pass).await?;
     let snapshot_manager = toc.get_snapshots_storage_manager()?;
-    let file_name = snapshot_manager
-        .get_snapshot_path(collection.snapshots_path(), &snapshot_name)
-        .await?;
+    let file_name =
+        snapshot_manager.get_snapshot_path(collection.snapshots_path(), &snapshot_name)?;
 
     let res = tokio::spawn(async move {
         log::info!("Deleting collection snapshot {:?}", file_name);

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -189,7 +189,7 @@ impl TableOfContent {
                         self.storage_config.optimizers_overwrite.clone(),
                     )
                     .await?;
-                    collections.validate_collection_not_exists(id).await?;
+                    collections.validate_collection_not_exists(id)?;
                     collections.insert(id.to_string(), collection);
                 }
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -259,12 +259,8 @@ impl TableOfContent {
                             alias_name,
                         },
                 }) => {
-                    collection_lock
-                        .validate_collection_exists(&collection_name)
-                        .await?;
-                    collection_lock
-                        .validate_collection_not_exists(&alias_name)
-                        .await?;
+                    collection_lock.validate_collection_exists(&collection_name)?;
+                    collection_lock.validate_collection_not_exists(&alias_name)?;
 
                     alias_lock.insert(alias_name, collection_name)?;
                 }

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -50,8 +50,7 @@ impl TableOfContent {
         self.collections
             .read()
             .await
-            .validate_collection_not_exists(collection_name)
-            .await?;
+            .validate_collection_not_exists(collection_name)?;
 
         if self
             .alias_persistence
@@ -240,9 +239,7 @@ impl TableOfContent {
 
         {
             let mut write_collections = self.collections.write().await;
-            write_collections
-                .validate_collection_not_exists(collection_name)
-                .await?;
+            write_collections.validate_collection_not_exists(collection_name)?;
             write_collections.insert(collection_name.to_string(), collection);
         }
 

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -243,7 +243,7 @@ impl TableOfContent {
 
         let real_collection_name = {
             let alias_persistence = self.alias_persistence.read().await;
-            Self::resolve_name(collection_name, &read_collection, &alias_persistence).await?
+            Self::resolve_name(collection_name, &read_collection, &alias_persistence)?
         };
         // resolve_name already checked collection existence, unwrap is safe here
         Ok(RwLockReadGuard::map(read_collection, |collection| {
@@ -278,7 +278,7 @@ impl TableOfContent {
     /// If the collection exists - return its name
     /// If alias exists - returns the original collection name
     /// If neither exists - returns [`StorageError`]
-    async fn resolve_name(
+    fn resolve_name(
         collection_name: &str,
         collections: &Collections,
         aliases: &AliasPersistence,
@@ -289,9 +289,7 @@ impl TableOfContent {
             None => collection_name.to_string(),
             Some(resolved_alias) => resolved_alias,
         };
-        collections
-            .validate_collection_exists(&resolved_name)
-            .await?;
+        collections.validate_collection_exists(&resolved_name)?;
         Ok(resolved_name)
     }
 
@@ -333,7 +331,7 @@ impl TableOfContent {
         Ok(aliases)
     }
 
-    pub async fn suggest_shard_distribution(
+    pub fn suggest_shard_distribution(
         &self,
         op: &CreateCollectionOperation,
         suggested_shard_number: NonZeroU32,

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -87,14 +87,11 @@ impl Dispatcher {
 
                                 let suggested_shard_nr = number_of_peers as u32 * shard_nr_per_node;
 
-                                let shard_distribution = self
-                                    .toc
-                                    .suggest_shard_distribution(
-                                        &op,
-                                        NonZeroU32::new(suggested_shard_nr)
-                                            .expect("Peer count should be always >= 1"),
-                                    )
-                                    .await;
+                                let shard_distribution = self.toc.suggest_shard_distribution(
+                                    &op,
+                                    NonZeroU32::new(suggested_shard_nr)
+                                        .expect("Peer count should be always >= 1"),
+                                );
 
                                 // Expect all replicas to become active eventually
                                 for (shard_id, peer_ids) in &shard_distribution.distribution {

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -146,12 +146,12 @@ fn get_stacktrace(ActixAccess(access): ActixAccess) -> impl Future<Output = Http
 
 #[get("/healthz")]
 async fn healthz() -> impl Responder {
-    kubernetes_healthz().await
+    kubernetes_healthz()
 }
 
 #[get("/livez")]
 async fn livez() -> impl Responder {
-    kubernetes_healthz().await
+    kubernetes_healthz()
 }
 
 #[get("/readyz")]
@@ -173,7 +173,7 @@ async fn readyz(health_checker: web::Data<Option<Arc<health::HealthChecker>>>) -
 }
 
 /// Basic Kubernetes healthz endpoint
-async fn kubernetes_healthz() -> impl Responder {
+fn kubernetes_healthz() -> impl Responder {
     HttpResponse::Ok()
         .content_type(ContentType::plaintext())
         .body("healthz check passed")

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -64,9 +64,8 @@ pub async fn do_get_full_snapshot(
 ) -> Result<SnapshotStream, HttpError> {
     access.check_global_access(AccessRequirements::new())?;
     let snapshots_storage_manager = toc.get_snapshots_storage_manager()?;
-    let snapshot_path = snapshots_storage_manager
-        .get_full_snapshot_path(toc.snapshots_path(), snapshot_name)
-        .await?;
+    let snapshot_path =
+        snapshots_storage_manager.get_full_snapshot_path(toc.snapshots_path(), snapshot_name)?;
     let snapshot_stream = snapshots_storage_manager
         .get_snapshot_stream(&snapshot_path)
         .await?;
@@ -127,9 +126,8 @@ pub async fn do_get_snapshot(
     let collection: tokio::sync::RwLockReadGuard<collection::collection::Collection> =
         toc.get_collection(&collection_pass).await?;
     let snapshot_storage_manager = collection.get_snapshots_storage_manager()?;
-    let snapshot_path = snapshot_storage_manager
-        .get_snapshot_path(collection.snapshots_path(), snapshot_name)
-        .await?;
+    let snapshot_path =
+        snapshot_storage_manager.get_snapshot_path(collection.snapshots_path(), snapshot_name)?;
     let snapshot_stream = snapshot_storage_manager
         .get_snapshot_stream(&snapshot_path)
         .await?;

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -72,7 +72,7 @@ impl HealthChecker {
             return true;
         }
 
-        self.notify_task().await;
+        self.notify_task();
         self.wait_ready().await
     }
 
@@ -80,7 +80,7 @@ impl HealthChecker {
         self.is_ready.load(atomic::Ordering::Relaxed)
     }
 
-    pub async fn notify_task(&self) {
+    pub fn notify_task(&self) {
         self.check_ready_signal.notify_one();
     }
 

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -100,7 +100,7 @@ pub async fn convert_query_point_groups_from_grpc(
 }
 
 /// ToDo: this function is supposed to call an inference endpoint internally
-pub async fn convert_query_points_from_grpc(
+pub fn convert_query_points_from_grpc(
     query: grpc::QueryPoints,
 ) -> Result<CollectionQueryRequest, Status> {
     let grpc::QueryPoints {

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1806,7 +1806,7 @@ pub async fn query(
         .transpose()?;
     let collection_name = query_points.collection_name.clone();
     let timeout = query_points.timeout;
-    let request = convert_query_points_from_grpc(query_points).await?;
+    let request = convert_query_points_from_grpc(query_points)?;
 
     let toc = toc_provider
         .check_strict_mode(
@@ -1861,7 +1861,7 @@ pub async fn query_batch(
     for query_points in points {
         let shard_key_selector = query_points.shard_key_selector.clone();
         let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
-        let request = convert_query_points_from_grpc(query_points).await?;
+        let request = convert_query_points_from_grpc(query_points)?;
         requests.push((request, shard_selector));
     }
 


### PR DESCRIPTION
Remove all unnecessary `async/await` definitions which I found with the pedantic mode of Clippy.

An additional clippy pass was necessary afterwards as removing async triggered further simplifications.