### PR TITLE
update Image.image type to Value instead of string

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2813,7 +2813,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| image | [string](#string) |  | Image data, either base64 encoded or URL |
+| image | [Value](#qdrant-Value) |  | Image data, either base64 encoded or URL |
 | model | [string](#string) | optional | Model name |
 | options | [Image.OptionsEntry](#qdrant-Image-OptionsEntry) | repeated | Model options |
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9971,8 +9971,7 @@
         ],
         "properties": {
           "image": {
-            "description": "Image data: base64 encoded image or an URL",
-            "type": "string"
+            "description": "Image data: base64 encoded image or an URL"
           },
           "model": {
             "description": "Name of the model used to generate the vector List of available models depends on a provider",

--- a/lib/api/src/conversions/inference.rs
+++ b/lib/api/src/conversions/inference.rs
@@ -35,7 +35,7 @@ impl TryFrom<grpc::Document> for rest::Document {
 impl From<rest::Image> for grpc::Image {
     fn from(image: rest::Image) -> Self {
         Self {
-            image: image.image,
+            image: Some(json_to_proto(image.image)),
             model: image.model,
             options: image.options.options.map(dict_to_proto).unwrap_or_default(),
         }
@@ -46,11 +46,20 @@ impl TryFrom<grpc::Image> for rest::Image {
     type Error = Status;
 
     fn try_from(image: grpc::Image) -> Result<Self, Self::Error> {
+        let grpc::Image {
+            image,
+            model,
+            options,
+        } = image;
+
+        let image =
+            image.ok_or_else(|| Status::invalid_argument("Empty image is not allowed"))?;
+
         Ok(Self {
-            image: image.image,
-            model: image.model,
+            image: proto_to_json(image)?,
+            model,
             options: Options {
-                options: Some(proto_dict_to_json(image.options)?),
+                options: Some(proto_dict_to_json(options)?),
             },
         })
     }

--- a/lib/api/src/conversions/inference.rs
+++ b/lib/api/src/conversions/inference.rs
@@ -52,8 +52,7 @@ impl TryFrom<grpc::Image> for rest::Image {
             options,
         } = image;
 
-        let image =
-            image.ok_or_else(|| Status::invalid_argument("Empty image is not allowed"))?;
+        let image = image.ok_or_else(|| Status::invalid_argument("Empty image is not allowed"))?;
 
         Ok(Self {
             image: proto_to_json(image)?,

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -53,7 +53,7 @@ message Document {
 }
 
 message Image {
-  string image = 1; // Image data, either base64 encoded or URL
+  Value image = 1; // Image data, either base64 encoded or URL
   optional string model = 2; // Model name
   map<string, Value> options = 3; // Model options
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3846,8 +3846,8 @@ pub struct Document {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Image {
     /// Image data, either base64 encoded or URL
-    #[prost(string, tag = "1")]
-    pub image: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "1")]
+    pub image: ::core::option::Option<Value>,
     /// Model name
     #[prost(string, optional, tag = "2")]
     pub model: ::core::option::Option<::prost::alloc::string::String>,

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -182,7 +182,7 @@ pub struct Document {
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, JsonSchema, Hash)]
 pub struct Image {
     /// Image data: base64 encoded image or an URL
-    pub image: String,
+    pub image: Value,
     /// Name of the model used to generate the vector
     /// List of available models depends on a provider
     pub model: Option<String>,

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -179,7 +179,7 @@ mod tests {
 
     fn create_test_image(url: &str) -> Image {
         Image {
-            image: url.to_string(),
+            image: json!({"data": url.to_string()}),
             model: Some("test-model".to_string()),
             options: Default::default(),
         }

--- a/src/common/inference/batch_processing_grpc.rs
+++ b/src/common/inference/batch_processing_grpc.rs
@@ -280,7 +280,7 @@ mod tests {
 
     fn create_test_image(url: &str) -> Image {
         Image {
-            image: url.to_string(),
+            image: json!({"data": url.to_string()}),
             model: Some("test-model".to_string()),
             options: Default::default(),
         }

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -93,7 +93,7 @@ impl From<InferenceData> for InferenceInput {
                     options,
                 } = img;
                 InferenceInput {
-                    data: Value::String(image),
+                    data: image,
                     data_type: IMAGE_DATA_TYPE.to_string(),
                     model: model.unwrap_or_default(),
                     options: options.options,


### PR DESCRIPTION
Just str type is not enough for local inference, since it does not cover all the types we'd like to support in local inference. This PR changes Image.image type to Value in order to support any value.
The decision to make it any was taken due to the desire to support objects which are not supported in openapi schema (e.g. `PIL.Image`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
