### PR TITLE
Bump version to 1.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "api"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "chrono",
  "common",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.12.1"
+version = "1.12.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.12.1"
+version = "1.12.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.12.1";
+pub const QDRANT_VERSION_STRING: &str = "1.12.2";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=bcd9bfd5ac3826b5682a5e65c19a1e84d04f1e32
+IGNORE_UPTO=f81b119ce057936705251915abd332d59e392cd9
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Patch release of Qdrant 1.12.2.

This contains some critical fixes, most notably:
- https://github.com/qdrant/qdrant/pull/5346
- https://github.com/qdrant/qdrant/pull/5211