### PR TITLE
Do not pass PointOffsetType by reference

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_posting_list.rs
@@ -41,7 +41,7 @@ impl CompressedPostingList {
         )
     }
 
-    pub fn contains(&self, val: &PointOffsetType) -> bool {
+    pub fn contains(&self, val: PointOffsetType) -> bool {
         self.reader().contains(val)
     }
 
@@ -94,7 +94,7 @@ mod tests {
             let (compressed_posting_list, set) =
                 CompressedPostingList::generate_compressed_posting_list_fixture(step);
             for i in 0..step * 1000 {
-                assert_eq!(compressed_posting_list.contains(&i), set.contains(&i));
+                assert_eq!(compressed_posting_list.contains(i), set.contains(&i));
             }
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -93,7 +93,7 @@ impl InvertedIndex for ImmutableInvertedIndex {
             .tokens
             .iter()
             // unwrap crash safety: all tokens exist in the vocabulary if it passes the above check
-            .all(|query_token| self.postings[query_token.unwrap() as usize].contains(&point_id))
+            .all(|query_token| self.postings[query_token.unwrap() as usize].contains(point_id))
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -48,7 +48,7 @@ impl ImmutableFullTextIndex {
 
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         if self.inverted_index.remove_document(id) {
-            let db_doc_id = FullTextIndex::store_key(&id);
+            let db_doc_id = FullTextIndex::store_key(id);
             self.db_wrapper.remove(db_doc_id)?;
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -268,11 +268,11 @@ mod tests {
 
                 let new_contains_orig = orig_posting
                     .iter()
-                    .all(|point_id| new_posting.contains(&point_id));
+                    .all(|point_id| new_posting.contains(point_id));
 
                 let orig_contains_new = new_posting
                     .iter()
-                    .all(|point_id| orig_posting.contains(&point_id));
+                    .all(|point_id| orig_posting.contains(point_id));
 
                 new_contains_orig && orig_contains_new
             })
@@ -306,7 +306,7 @@ mod tests {
             let chunk_reader = mmap.postings.get(token_id as u32).unwrap();
 
             for point_id in posting.iter() {
-                assert!(chunk_reader.contains(&point_id));
+                assert!(chunk_reader.contains(point_id));
             }
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -222,7 +222,7 @@ impl InvertedIndex for MmapInvertedIndex {
                 self.postings
                     .get(query_token.unwrap())
                     .unwrap()
-                    .contains(&point_id)
+                    .contains(point_id)
             })
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -62,7 +62,7 @@ impl MutableFullTextIndex {
         let document = self.inverted_index.document_from_tokens(&tokens);
         self.inverted_index.index_document(idx, document)?;
 
-        let db_idx = FullTextIndex::store_key(&idx);
+        let db_idx = FullTextIndex::store_key(idx);
         let db_document = FullTextIndex::serialize_document_tokens(tokens)?;
 
         self.db_wrapper.put(db_idx, db_document)?;
@@ -72,7 +72,7 @@ impl MutableFullTextIndex {
 
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         if self.inverted_index.remove_document(id) {
-            let db_doc_id = FullTextIndex::store_key(&id);
+            let db_doc_id = FullTextIndex::store_key(id);
             self.db_wrapper.remove(db_doc_id)?;
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/posting_list.rs
@@ -33,8 +33,8 @@ impl PostingList {
         self.list.len()
     }
 
-    pub fn contains(&self, val: &PointOffsetType) -> bool {
-        self.list.binary_search(val).is_ok()
+    pub fn contains(&self, val: PointOffsetType) -> bool {
+        self.list.binary_search(&val).is_ok()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = PointOffsetType> + '_ {

--- a/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
@@ -18,7 +18,7 @@ pub fn intersect_postings_iterator<'a>(
 
     let and_iter = smallest_posting
         .iter()
-        .filter(move |doc_id| postings.iter().all(|posting| posting.contains(doc_id)));
+        .filter(move |doc_id| postings.iter().all(|posting| posting.contains(*doc_id)));
 
     Box::new(and_iter)
 }
@@ -47,7 +47,7 @@ pub fn intersect_compressed_postings_iterator<'a>(
         .filter(move |doc_id| {
             posting_visitors
                 .iter_mut()
-                .all(|posting_visitor| posting_visitor.contains_next_and_advance(doc_id))
+                .all(|posting_visitor| posting_visitor.contains_next_and_advance(*doc_id))
         });
 
     Box::new(and_iter)

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -159,7 +159,7 @@ impl FullTextIndex {
         }
     }
 
-    pub(super) fn store_key(id: &PointOffsetType) -> Vec<u8> {
+    pub(super) fn store_key(id: PointOffsetType) -> Vec<u8> {
         bincode::serialize(&id).unwrap()
     }
 

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -41,8 +41,8 @@ impl SimplePayloadStorage {
         })
     }
 
-    pub(crate) fn update_storage(&self, point_id: &PointOffsetType) -> OperationResult<()> {
-        match self.payload.get(point_id) {
+    pub(crate) fn update_storage(&self, point_id: PointOffsetType) -> OperationResult<()> {
+        match self.payload.get(&point_id) {
             None => self
                 .db_wrapper
                 .remove(serde_cbor::to_vec(&point_id).unwrap()),

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -14,7 +14,7 @@ use crate::types::{Payload, PayloadKeyTypeRef};
 impl PayloadStorage for SimplePayloadStorage {
     fn overwrite(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         self.payload.insert(point_id, payload.to_owned());
-        self.update_storage(&point_id)?;
+        self.update_storage(point_id)?;
         Ok(())
     }
 
@@ -26,7 +26,7 @@ impl PayloadStorage for SimplePayloadStorage {
             }
         }
 
-        self.update_storage(&point_id)?;
+        self.update_storage(point_id)?;
 
         Ok(())
     }
@@ -64,7 +64,7 @@ impl PayloadStorage for SimplePayloadStorage {
             Some(payload) => {
                 let res = payload.remove(key);
                 if !res.is_empty() {
-                    self.update_storage(&point_id)?;
+                    self.update_storage(point_id)?;
                 }
                 Ok(res)
             }
@@ -74,7 +74,7 @@ impl PayloadStorage for SimplePayloadStorage {
 
     fn clear(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
         let res = self.payload.remove(&point_id);
-        self.update_storage(&point_id)?;
+        self.update_storage(point_id)?;
         Ok(res)
     }
 


### PR DESCRIPTION
This PR changes a bunch of functions to accept `PointOffsetType` by value instead of by reference.

Passed as value `PointOffsetType` is taking 4 bytes (u32).
Passed as a reference on a 64bits system, it takes 8 bytes to pass an address.

Discovered with Clippy pedantic lints.

```
warning: this argument (4 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
``` 