### PR TITLE
Use references for less cloning when possible

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -221,7 +221,7 @@ impl Collection {
 
             let all_nodes_cancel_transfers = self
                 .channel_service
-                .all_peers_at_version(ABORT_TRANSFERS_ON_SHARD_DROP_FROM_VERSION.clone());
+                .all_peers_at_version(&ABORT_TRANSFERS_ON_SHARD_DROP_FROM_VERSION);
             if all_nodes_cancel_transfers {
                 // Collect shard transfers related to removed shard...
                 let transfers = shard_holder

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -670,7 +670,7 @@ impl Collection {
                 .unwrap_or_else(|| {
                     let all_support_wal_delta = self
                         .channel_service
-                        .all_peers_at_version(Version::new(1, 8, 0));
+                        .all_peers_at_version(&Version::new(1, 8, 0));
                     if all_support_wal_delta {
                         ShardTransferMethod::WalDelta
                     } else {

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -170,14 +170,14 @@ impl Collection {
         Ok(())
     }
 
-    pub async fn commit_read_hashring(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
+    pub async fn commit_read_hashring(&self, resharding_key: &ReshardKey) -> CollectionResult<()> {
         self.shards_holder
             .write()
             .await
             .commit_read_hashring(resharding_key)
     }
 
-    pub async fn commit_write_hashring(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
+    pub async fn commit_write_hashring(&self, resharding_key: &ReshardKey) -> CollectionResult<()> {
         self.shards_holder
             .write()
             .await

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -30,7 +30,7 @@ use crate::shards::shard_versioning;
 
 impl Collection {
     pub fn get_snapshots_storage_manager(&self) -> CollectionResult<SnapshotStorageManager> {
-        SnapshotStorageManager::new(self.shared_storage_config.snapshots_config.clone())
+        SnapshotStorageManager::new(&self.shared_storage_config.snapshots_config)
     }
 
     pub async fn list_snapshots(&self) -> CollectionResult<Vec<SnapshotDescription>> {

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -77,7 +77,7 @@ impl SegmentsSearcher {
     pub(crate) fn process_search_result_step1(
         search_result: BatchSearchResult,
         limits: Vec<usize>,
-        further_results: Vec<Vec<bool>>,
+        further_results: &[Vec<bool>],
     ) -> (
         BatchResultAggregator,
         HashMap<SegmentOffset, Vec<BatchOffset>>,
@@ -294,7 +294,7 @@ impl SegmentsSearcher {
                 .iter()
                 .map(|request| request.limit + request.offset)
                 .collect(),
-            further_results,
+            &further_results,
         );
         // The second step of the search is to re-run the search without sampling on some segments
         // Expected that this stage will be executed rarely

--- a/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
+++ b/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
@@ -84,7 +84,7 @@ fn test_aggregation_of_batch_search_results() {
     let (aggregator, re_request) = SegmentsSearcher::process_search_result_step1(
         search_results,
         result_limits,
-        further_results,
+        &further_results,
     );
 
     // ------------Segment----------batch---

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -53,7 +53,7 @@ pub enum SnapshotStorageManager {
 }
 
 impl SnapshotStorageManager {
-    pub fn new(snapshots_config: SnapShotsConfig) -> CollectionResult<Self> {
+    pub fn new(snapshots_config: &SnapShotsConfig) -> CollectionResult<Self> {
         match snapshots_config.snapshots_storage {
             SnapshotsStorageConfig::Local => {
                 Ok(SnapshotStorageManager::LocalFS(SnapshotStorageLocalFS))

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -338,7 +338,7 @@ pub async fn group_by(
         // Construct filter to exclude already found groups
         let full_groups = aggregator.keys_of_filled_groups();
         if !full_groups.is_empty() {
-            let except_any = except_on(&request.group_by, full_groups);
+            let except_any = except_on(&request.group_by, &full_groups);
             if !except_any.is_empty() {
                 let exclude_groups = Filter {
                     must: Some(except_any),
@@ -402,7 +402,7 @@ pub async fn group_by(
 
             // Construct filter to only include unsatisfied groups
             let unsatisfied_groups = aggregator.keys_of_unfilled_best_groups();
-            let match_any = match_on(&request.group_by, unsatisfied_groups);
+            let match_any = match_on(&request.group_by, &unsatisfied_groups);
             if !match_any.is_empty() {
                 let include_groups = Filter {
                     must: Some(match_any),
@@ -493,7 +493,7 @@ pub async fn group_by(
 }
 
 /// Uses the set of values to create Match::Except's, if possible
-fn except_on(path: &JsonPath, values: Vec<Value>) -> Vec<Condition> {
+fn except_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
     values_to_any_variants(values)
         .into_iter()
         .map(|v| {
@@ -506,7 +506,7 @@ fn except_on(path: &JsonPath, values: Vec<Value>) -> Vec<Condition> {
 }
 
 /// Uses the set of values to create Match::Any's, if possible
-fn match_on(path: &JsonPath, values: Vec<Value>) -> Vec<Condition> {
+fn match_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
     values_to_any_variants(values)
         .into_iter()
         .map(|any_variants| {
@@ -518,7 +518,7 @@ fn match_on(path: &JsonPath, values: Vec<Value>) -> Vec<Condition> {
         .collect()
 }
 
-fn values_to_any_variants(values: Vec<Value>) -> Vec<AnyVariants> {
+fn values_to_any_variants(values: &[Value]) -> Vec<AnyVariants> {
     let mut any_variants = Vec::new();
 
     // gather int values

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -110,7 +110,7 @@ impl PlannedQuery {
                     &mut self.scrolls,
                     prefetches,
                     offset,
-                    filter,
+                    &filter,
                     Some((with_payload, with_vector)),
                 )?;
 
@@ -126,7 +126,7 @@ impl PlannedQuery {
                     &mut self.scrolls,
                     prefetches,
                     offset,
-                    filter,
+                    &filter,
                     None,
                 )?;
 
@@ -232,7 +232,7 @@ fn recurse_prefetches(
     scrolls: &mut Vec<QueryScrollRequestInternal>,
     prefetches: Vec<ShardPrefetch>,
     root_offset: usize, // Offset is added to all prefetches, so we make sure we have enough
-    propagate_filter: Option<Filter>, // Global filter to apply to all prefetches
+    propagate_filter: &Option<Filter>, // Global filter to apply to all prefetches
     // Top-level fusion requests won't be merged on shard level, so we pass these params down one level to fetch on the sources.
     // Otherwise we would miss to fetch the payload and vector.
     with_payload_and_vector: Option<(WithPayloadInterface, WithVector)>,
@@ -265,7 +265,7 @@ fn recurse_prefetches(
                 scrolls,
                 prefetches,
                 root_offset,
-                filter,
+                &filter,
                 None,
             )?;
 

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -162,7 +162,7 @@ impl ChannelService {
     ///
     /// If the version is not known for any peer, this returns `false`.
     /// Peer versions are known since 1.9 and up.
-    pub fn all_peers_at_version(&self, version: Version) -> bool {
+    pub fn all_peers_at_version(&self, version: &Version) -> bool {
         let id_to_address = self.id_to_address.read();
         let id_to_metadata = self.id_to_metadata.read();
 
@@ -173,18 +173,18 @@ impl ChannelService {
 
         id_to_metadata
             .values()
-            .all(|metadata| metadata.version >= version)
+            .all(|metadata| &metadata.version >= version)
     }
 
     /// Check whether the specified peer is running at least the given version
     ///
     /// If the version is not known for the peer, this returns `false`.
     /// Peer versions are known since 1.9 and up.
-    pub fn peer_is_at_version(&self, peer_id: PeerId, version: Version) -> bool {
+    pub fn peer_is_at_version(&self, peer_id: PeerId, version: &Version) -> bool {
         self.id_to_metadata
             .read()
             .get(&peer_id)
-            .map_or(false, |metadata| metadata.version >= version)
+            .map_or(false, |metadata| &metadata.version >= version)
     }
 
     /// Get the REST address for the current peer.

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -993,7 +993,7 @@ impl ShardReplicaSet {
     }
 
     pub(crate) fn get_snapshots_storage_manager(&self) -> CollectionResult<SnapshotStorageManager> {
-        SnapshotStorageManager::new(self.shared_storage_config.snapshots_config.clone())
+        SnapshotStorageManager::new(&self.shared_storage_config.snapshots_config)
     }
 
     pub(crate) async fn trigger_optimizers(&self) -> bool {

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -121,8 +121,8 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn commit_read_hashring(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
-        self.check_resharding(&resharding_key, check_stage(ReshardStage::MigratingPoints))?;
+    pub fn commit_read_hashring(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
+        self.check_resharding(resharding_key, check_stage(ReshardStage::MigratingPoints))?;
 
         self.resharding_state.write(|state| {
             let Some(state) = state else {
@@ -135,9 +135,9 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn commit_write_hashring(&mut self, resharding_key: ReshardKey) -> CollectionResult<()> {
+    pub fn commit_write_hashring(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
         self.check_resharding(
-            &resharding_key,
+            resharding_key,
             check_stage(ReshardStage::ReadHashRingCommitted),
         )?;
 

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -218,7 +218,7 @@ pub fn suggest_transfer_source(
 /// 2. Peer should have minimal number of active transfers
 pub fn suggest_peer_to_add_replica(
     shard_id: ShardId,
-    shard_distribution: HashMap<ShardId, HashSet<PeerId>>,
+    shard_distribution: &HashMap<ShardId, HashSet<PeerId>>,
 ) -> Option<PeerId> {
     let mut peer_loads: HashMap<PeerId, usize> = HashMap::new();
     for peers in shard_distribution.values() {

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -194,7 +194,7 @@ pub(super) async fn transfer_snapshot(
 
     // The ability to read streaming snapshot format is introduced in 1.12 (#5179).
     let use_streaming_endpoint =
-        channel_service.peer_is_at_version(remote_peer_id, Version::new(1, 12, 0));
+        channel_service.peer_is_at_version(remote_peer_id, &Version::new(1, 12, 0));
 
     let mut snapshot_temp_paths = Vec::new();
     let mut shard_download_url = local_rest_address;

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -73,9 +73,8 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         )?;
 
         // finally, encode data
-        #[allow(clippy::redundant_clone)]
         Self::encode_storage(
-            data.clone(),
+            data,
             &mut storage_builder,
             &vector_division,
             &centroids,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -159,7 +159,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 &vector_storage.borrow(),
                 &quantized_vectors.borrow(),
                 &payload_index.borrow(),
-                hnsw_config,
+                &hnsw_config,
                 num_cpus,
                 stopped,
             )?;
@@ -205,7 +205,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         vector_storage: &VectorStorageEnum,
         quantized_vectors: &Option<QuantizedVectors>,
         payload_index: &StructPayloadIndex,
-        hnsw_config: HnswConfig,
+        hnsw_config: &HnswConfig,
         num_cpus: usize,
         stopped: &AtomicBool,
     ) -> OperationResult<(HnswGraphConfig, GraphLayers<TGraphLinks>)> {

--- a/lib/segment/src/index/query_optimization/optimizer.rs
+++ b/lib/segment/src/index/query_optimization/optimizer.rs
@@ -88,7 +88,7 @@ impl StructPayloadIndex {
             must_not: filter.must_not.as_ref().and_then(|conditions| {
                 if !conditions.is_empty() {
                     let (optimized_conditions, estimation) =
-                        self.optimize_must_not(conditions, payload_provider.clone(), total);
+                        self.optimize_must_not(conditions, payload_provider, total);
                     filter_estimations.push(estimation);
                     Some(optimized_conditions)
                 } else {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -111,8 +111,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             // RAM mutable case - build inverted index from scratch and use provided config
             create_dir_all(path)?;
             let (inverted_index, indices_tracker) = Self::build_inverted_index(
-                id_tracker.clone(),
-                vector_storage.clone(),
+                &id_tracker,
+                &vector_storage,
                 path,
                 stopped,
                 tick_progress,
@@ -130,8 +130,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 create_dir_all(path)?;
 
                 let (inverted_index, indices_tracker) = Self::build_inverted_index(
-                    id_tracker.clone(),
-                    vector_storage.clone(),
+                    &id_tracker,
+                    &vector_storage,
                     path,
                     stopped,
                     tick_progress,
@@ -196,8 +196,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     }
 
     fn build_inverted_index(
-        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+        id_tracker: &AtomicRefCell<IdTrackerSS>,
+        vector_storage: &AtomicRefCell<VectorStorageEnum>,
         path: &Path,
         stopped: &AtomicBool,
         mut tick_progress: impl FnMut(),

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -96,10 +96,10 @@ impl SegmentEntry for Segment {
         let stored_internal_point = self.id_tracker.borrow().internal_id(point_id);
         self.handle_point_version_and_failure(op_num, stored_internal_point, |segment| {
             if let Some(existing_internal_id) = stored_internal_point {
-                segment.replace_all_vectors(existing_internal_id, vectors)?;
+                segment.replace_all_vectors(existing_internal_id, &vectors)?;
                 Ok((true, Some(existing_internal_id)))
             } else {
-                let new_index = segment.insert_new_vectors(point_id, vectors)?;
+                let new_index = segment.insert_new_vectors(point_id, &vectors)?;
                 Ok((false, Some(new_index)))
             }
         })

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -47,10 +47,10 @@ impl Segment {
     pub(super) fn replace_all_vectors(
         &mut self,
         internal_id: PointOffsetType,
-        vectors: NamedVectors,
+        vectors: &NamedVectors,
     ) -> OperationResult<()> {
         debug_assert!(self.is_appendable());
-        check_named_vectors(&vectors, &self.segment_config)?;
+        check_named_vectors(vectors, &self.segment_config)?;
         for (vector_name, vector_data) in self.vector_data.iter_mut() {
             let vector = vectors.get(vector_name);
             let mut vector_index = vector_data.vector_index.borrow_mut();
@@ -95,10 +95,10 @@ impl Segment {
     pub(super) fn insert_new_vectors(
         &mut self,
         point_id: PointIdType,
-        vectors: NamedVectors,
+        vectors: &NamedVectors,
     ) -> OperationResult<PointOffsetType> {
         debug_assert!(self.is_appendable());
-        check_named_vectors(&vectors, &self.segment_config)?;
+        check_named_vectors(vectors, &self.segment_config)?;
         let new_index = self.id_tracker.borrow().total_point_count() as PointOffsetType;
         for (vector_name, vector_data) in self.vector_data.iter_mut() {
             let vector_opt = vectors.get(vector_name);

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -599,7 +599,7 @@ fn test_point_vector_count_multivec() {
     segment
         .replace_all_vectors(
             internal_8,
-            NamedVectors::from_pairs([("a".into(), vec![0.1])]),
+            &NamedVectors::from_pairs([("a".into(), vec![0.1])]),
         )
         .unwrap();
     let segment_info = segment.info();
@@ -610,7 +610,7 @@ fn test_point_vector_count_multivec() {
     segment
         .replace_all_vectors(
             internal_8,
-            NamedVectors::from_pairs([("a".into(), vec![0.1]), ("b".into(), vec![0.1])]),
+            &NamedVectors::from_pairs([("a".into(), vec![0.1]), ("b".into(), vec![0.1])]),
         )
         .unwrap();
     let segment_info = segment.info();
@@ -762,11 +762,11 @@ fn test_vector_compatibility_checks() {
             .err()
             .unwrap();
         segment
-            .insert_new_vectors(point_id, vectors.clone())
+            .insert_new_vectors(point_id, &vectors)
             .err()
             .unwrap();
         segment
-            .replace_all_vectors(internal_id, vectors.clone())
+            .replace_all_vectors(internal_id, &vectors)
             .err()
             .unwrap();
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -55,7 +55,7 @@ where
     }
 
     pub fn new_multi(
-        raw_query: MultiDenseVectorInternal,
+        raw_query: &MultiDenseVectorInternal,
         quantized_data: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
     ) -> Self {

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -214,7 +214,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
         match query {
             QueryVector::Nearest(vector) => {
                 let query_scorer = QuantizedQueryScorer::<TElement, TMetric, _, _>::new_multi(
-                    MultiDenseVectorInternal::try_from(vector)?,
+                    &MultiDenseVectorInternal::try_from(vector)?,
                     quantized_storage,
                     quantization_config,
                 );

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -32,7 +32,7 @@ impl<
         TVectorStorage: MultiVectorStorage<TElement>,
     > MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
-    pub fn new(query: MultiDenseVectorInternal, vector_storage: &'a TVectorStorage) -> Self {
+    pub fn new(query: &MultiDenseVectorInternal, vector_storage: &'a TVectorStorage) -> Self {
         let slices = query.multi_vectors();
         let preprocessed: DenseVector = slices
             .into_iter()

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -603,7 +603,7 @@ fn new_multi_scorer_with_metric<
     match query {
         QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
             MultiMetricQueryScorer::<VectorElementType, TMetric, _>::new(
-                vector.try_into()?,
+                &vector.try_into()?,
                 vector_storage,
             ),
             point_deleted,
@@ -699,7 +699,7 @@ fn new_multi_scorer_byte_with_metric<
     match query {
         QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
             MultiMetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
-                vector.try_into()?,
+                &vector.try_into()?,
                 vector_storage,
             ),
             point_deleted,
@@ -795,7 +795,7 @@ fn new_multi_scorer_half_with_metric<
     match query {
         QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
             MultiMetricQueryScorer::<VectorElementTypeHalf, TMetric, _>::new(
-                vector.try_into()?,
+                &vector.try_into()?,
                 vector_storage,
             ),
             point_deleted,

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -47,11 +47,11 @@ impl AliasPersistence {
         Ok(data_path)
     }
 
-    pub fn open(dir_path: PathBuf) -> Result<Self, StorageError> {
+    pub fn open(dir_path: &Path) -> Result<Self, StorageError> {
         if !dir_path.exists() {
-            fs::create_dir_all(&dir_path)?;
+            fs::create_dir_all(dir_path)?;
         }
-        let data_path = Self::init_file(&dir_path)?;
+        let data_path = Self::init_file(dir_path)?;
         let alias_mapping = AliasMapping::load(&data_path)?;
         Ok(AliasPersistence {
             data_path,

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -171,14 +171,13 @@ impl Persistent {
     }
 
     pub fn insert_peer(&mut self, peer_id: PeerId, address: Uri) -> Result<(), StorageError> {
-        if let Some(prev_peer_address) = self
-            .peer_address_by_id
-            .write()
-            .insert(peer_id, address.clone())
-        {
-            log::warn!("Replaced address of peer {peer_id} from {prev_peer_address} to {address}");
+        let address_display = address.to_string();
+        if let Some(prev_peer_address) = self.peer_address_by_id.write().insert(peer_id, address) {
+            log::warn!(
+                "Replaced address of peer {peer_id} from {prev_peer_address} to {address_display}"
+            );
         } else {
-            log::debug!("Added peer with id {peer_id} and address {address}")
+            log::debug!("Added peer with id {peer_id} and address {address_display}")
         }
         self.save()
     }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -336,11 +336,11 @@ impl TableOfContent {
             }
 
             ReshardingOperation::CommitRead(key) => {
-                collection.commit_read_hashring(key).await?;
+                collection.commit_read_hashring(&key).await?;
             }
 
             ReshardingOperation::CommitWrite(key) => {
-                collection.commit_write_hashring(key).await?;
+                collection.commit_write_hashring(&key).await?;
             }
 
             ReshardingOperation::Finish(key) => {

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -159,8 +159,8 @@ impl TableOfContent {
             collections.insert(collection_name, collection);
         }
         let alias_path = Path::new(&storage_config.storage_path).join(ALIASES_PATH);
-        let alias_persistence =
-            AliasPersistence::open(alias_path).expect("Can't open database by the provided config");
+        let alias_persistence = AliasPersistence::open(&alias_path)
+            .expect("Can't open database by the provided config");
 
         let rate_limiter = match storage_config.performance.update_rate_limit {
             Some(limit) => Some(Semaphore::new(limit)),

--- a/lib/storage/src/content_manager/toc/snapshots.rs
+++ b/lib/storage/src/content_manager/toc/snapshots.rs
@@ -14,7 +14,7 @@ use crate::rbac::CollectionPass;
 
 impl TableOfContent {
     pub fn get_snapshots_storage_manager(&self) -> Result<SnapshotStorageManager, StorageError> {
-        SnapshotStorageManager::new(self.storage_config.snapshots_config.clone()).map_err(|err| {
+        SnapshotStorageManager::new(&self.storage_config.snapshots_config).map_err(|err| {
             StorageError::service_error(format!(
                 "Can't create snapshot storage manager. Error: {err}"
             ))

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -41,7 +41,7 @@ impl HealthChecker {
     pub fn spawn(
         toc: Arc<TableOfContent>,
         consensus_state: ConsensusStateRef,
-        runtime: runtime::Handle,
+        runtime: &runtime::Handle,
         wait_for_bootstrap: bool,
     ) -> Self {
         let task = Task {

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -125,10 +125,11 @@ static INFERENCE_SERVICE: RwLock<Option<Arc<InferenceService>>> = RwLock::new(No
 
 impl InferenceService {
     pub fn new(config: InferenceConfig) -> Self {
+        let timeout = Duration::from_secs(config.timeout);
         Self {
-            config: config.clone(),
+            config,
             client: Client::builder()
-                .timeout(Duration::from_secs(config.timeout))
+                .timeout(timeout)
                 .build()
                 .expect("Invalid timeout value for HTTP client"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,7 @@ fn main() -> anyhow::Result<()> {
         let health_checker = Arc::new(common::health::HealthChecker::spawn(
             toc_arc.clone(),
             consensus_state.clone(),
-            runtime_handle.clone(),
+            &runtime_handle,
             // NOTE: `wait_for_bootstrap` should be calculated *before* starting `Consensus` thread
             consensus_state.is_new_deployment() && args.bootstrap.is_some(),
         ));

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -127,7 +127,7 @@ pub fn recover_full_snapshot(
 
     let alias_path = Path::new(storage_dir).join(ALIASES_PATH);
     let mut alias_persistence =
-        AliasPersistence::open(alias_path).expect("Can't open database by the provided config");
+        AliasPersistence::open(&alias_path).expect("Can't open database by the provided config");
     for (alias, collection_name) in config_json.collections_aliases {
         if alias_persistence.get(&alias).is_some() && !force {
             panic!("Alias {alias} already exists. Use --force-snapshot to overwrite it.");


### PR DESCRIPTION
Miscellaneous changes to decrease memory usages.

- avoid unnecessary cloning
- pass arguments by reference when the function does not consume it (and size larger of address)