### PR TITLE
Demote peer added with same adress to debug

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -172,10 +172,14 @@ impl Persistent {
 
     pub fn insert_peer(&mut self, peer_id: PeerId, address: Uri) -> Result<(), StorageError> {
         let address_display = address.to_string();
-        if let Some(prev_peer_address) = self.peer_address_by_id.write().insert(peer_id, address) {
-            log::warn!(
-                "Replaced address of peer {peer_id} from {prev_peer_address} to {address_display}"
-            );
+        if let Some(prev_peer_address) = self
+            .peer_address_by_id
+            .write()
+            .insert(peer_id, address.clone())
+        {
+            if prev_peer_address != address {
+                log::warn!("Replaced address of peer {peer_id} from {prev_peer_address} to {address_display}");
+            }
         } else {
             log::debug!("Added peer with id {peer_id} and address {address_display}")
         }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -172,16 +172,18 @@ impl Persistent {
 
     pub fn insert_peer(&mut self, peer_id: PeerId, address: Uri) -> Result<(), StorageError> {
         let address_display = address.to_string();
-        if let Some(prev_peer_address) = self
+        match self
             .peer_address_by_id
             .write()
             .insert(peer_id, address.clone())
         {
-            if prev_peer_address != address {
-                log::warn!("Replaced address of peer {peer_id} from {prev_peer_address} to {address_display}");
-            }
-        } else {
-            log::debug!("Added peer with id {peer_id} and address {address_display}")
+            Some(prev_address) if prev_address != address => log::warn!(
+                "Replaced address of peer {peer_id} from {prev_address} to {address_display}"
+            ),
+            Some(_) => log::debug!(
+                "Re-added peer with id {peer_id} with the same address {address_display}"
+            ),
+            None => log::debug!("Added peer with id {peer_id} and address {address_display}"),
         }
         self.save()
     }


### PR DESCRIPTION
Only show the following warning if the peer address actually changed.

```
# 2024-11-11T09:39:11.379867Z  WARN storage::content_manager::consensus::persistent: Replaced address of peer 5828499418624065 from http://qdrant-0.qdrant-headless:6335/ to http://qdrant-0.qdrant-headless:6335/
```

Until now it's not entirely clear in what situation this message would show up.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?