### PR TITLE
Bump wal f42e853

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ dependencies = [
  "criterion",
  "env_logger",
  "fnv",
- "fs4 0.11.0",
+ "fs4",
  "fs_extra",
  "futures",
  "hashring",
@@ -2068,16 +2068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs4"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c6b3bd49c37d2aa3f3f2220233b29a7cd23f79d1fe70e5337d25fb390793de"
-dependencies = [
- "rustix 0.38.37",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7367,19 +7357,19 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=7c9202d0874b719212e6eacedaa795bfdf43199c#7c9202d0874b719212e6eacedaa795bfdf43199c"
+source = "git+https://github.com/qdrant/wal.git?rev=f42e853debf22a3a746de444d625bb8cc1d2e61e#f42e853debf22a3a746de444d625bb8cc1d2e61e"
 dependencies = [
  "byteorder",
  "crc32c",
  "crossbeam-channel",
  "docopt",
  "env_logger",
- "fs4 0.9.1",
+ "fs4",
  "log",
  "memmap2 0.9.5",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.38.37",
+ "rustix 0.37.27",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,7 @@ tonic-reflection = "0.11.0"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 validator = { version = "0.18.1", features = ["derive"] }
-wal = { git = "https://github.com/qdrant/wal.git", rev = "7c9202d0874b719212e6eacedaa795bfdf43199c" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "f42e853debf22a3a746de444d625bb8cc1d2e61e" }
 zerocopy = { version = "0.7.34", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"


### PR DESCRIPTION
We can align our `fs4` versions and stop compiling an old one.

ref https://github.com/qdrant/wal/pull/78