### PR TITLE
Fixup for VisitedListHandle::check_and_update_visited

### DIFF
--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -65,8 +65,12 @@ impl<'a> VisitedListHandle<'a> {
     /// Updates visited list
     /// return `true` if point was visited before
     pub fn check_and_update_visited(&mut self, point_id: PointOffsetType) -> bool {
+        let idx = point_id as usize;
+        if idx >= self.visited_list.visit_counters.len() {
+            self.visited_list.visit_counters.resize(idx + 1, 0);
+        }
         std::mem::replace(
-            &mut self.visited_list.visit_counters[point_id as usize],
+            &mut self.visited_list.visit_counters[idx],
             self.visited_list.current_iter,
         ) == self.visited_list.current_iter
     }


### PR DESCRIPTION
Fixup for #5336. In #5336, I made an assumption that the `num_points` provided to `VisitedPool::get()` is always accurate and removed bounds check from `VisitedListHandle::check_and_update_visited`.

```rust
let mut visited_list = visited_pool.get(num_points);
visited_list.check_and_update_visited(point_id); // assumption: point_id < num_points
```

But it seems that it's not true. Chaos testing shows that it crashes in the following code:
https://github.com/qdrant/qdrant/blob/ac54ad4074cc0240bb2e01f91804e857d720b756/lib/segment/src/index/struct_payload_index.rs#L381-L399

Perhaps the offending ids could come from `PrimaryCondition::Ids`/WAL/field_index? This PR restores the check.