### PR TITLE
Leverage ahash in search results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "actix-files",
  "actix-web",
  "actix-web-validator",
+ "ahash",
  "api",
  "approx",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ used_underscore_binding = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [workspace.dependencies]
+ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"
 bytes = "1.8.0"
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -30,7 +30,7 @@ pprof = { workspace = true }
 
 [dependencies]
 parking_lot = { workspace = true }
-
+ahash = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/lib/collection/src/collection_manager/search_result_aggregator.rs
+++ b/lib/collection/src/collection_manager/search_result_aggregator.rs
@@ -1,20 +1,20 @@
 use std::cmp::max;
-use std::collections::{HashMap, HashSet};
 
+use ahash::{AHashMap, AHashSet};
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::ScoreType;
 use segment::types::{PointIdType, ScoredPoint, SeqNumberType};
 
 pub struct SearchResultAggregator {
     queue: FixedLengthPriorityQueue<ScoredPoint>,
-    seen: HashSet<PointIdType>, // Point ids seen
+    seen: AHashSet<PointIdType>, // Point ids seen
 }
 
 impl SearchResultAggregator {
     pub fn new(limit: usize) -> Self {
         SearchResultAggregator {
             queue: FixedLengthPriorityQueue::new(limit),
-            seen: HashSet::new(),
+            seen: AHashSet::with_capacity(limit),
         }
     }
 
@@ -39,7 +39,7 @@ pub struct BatchResultAggregator {
     // result aggregators for each batched request
     batch_aggregators: Vec<SearchResultAggregator>,
     // Store max version for each point id to exclude outdated points from the result
-    point_versions: HashMap<PointIdType, SeqNumberType>,
+    point_versions: AHashMap<PointIdType, SeqNumberType>,
 }
 
 impl BatchResultAggregator {
@@ -51,7 +51,7 @@ impl BatchResultAggregator {
 
         BatchResultAggregator {
             batch_aggregators: merged_results_per_batch,
-            point_versions: HashMap::new(),
+            point_versions: AHashMap::new(),
         }
     }
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -126,7 +126,7 @@ impl SegmentsSearcher {
         let mut searches_to_rerun: HashMap<SegmentOffset, Vec<BatchOffset>> = HashMap::new();
 
         // Check if we want to re-run the search without sampling on some segments
-        for (batch_id, required_limit) in limits.iter().copied().enumerate() {
+        for (batch_id, required_limit) in limits.into_iter().enumerate() {
             let lowest_batch_score_opt = result_aggregator.batch_lowest_scores(batch_id);
 
             // If there are no results, we do not need to re-run the search

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -76,7 +76,7 @@ chrono = { workspace = true }
 smol_str = { version = "0.3.2", features = ["serde"] }
 fnv = { workspace = true }
 indexmap = { workspace = true }
-ahash = { version = "0.8.11", features = ["serde"] }
+ahash = {  workspace = true }
 http = "1.0.0"
 sha2 = { workspace = true }
 smallvec = "1.13.2"


### PR DESCRIPTION
On large result sets, the SIP hasher shows up in profiling when combining search results from different segments & shards.

This PR replaces the default hasher with `Ahash` which is more efficient on smaller input like ids.
After the change, hashing does not appear in profiling anymore.