### PR TITLE
Bump version to 1.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "api"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "chrono",
  "common",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.12.2"
+version = "1.12.3"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.12.2"
+version = "1.12.3"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.12.2";
+pub const QDRANT_VERSION_STRING: &str = "1.12.3";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=f81b119ce057936705251915abd332d59e392cd9
+IGNORE_UPTO=48c02b29c738c59a7ec22165ad9a134170c3eeb5
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Patch release of Qdrant 1.12.3, follows the pattern of <https://github.com/qdrant/qdrant/pull/5404>.

This includes a critical patch causing panics during search: https://github.com/qdrant/qdrant/pull/5427