### PR TITLE
Make model name field mandatory in inference structures

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2476,7 +2476,7 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | text | [string](#string) |  | Text of the document |
-| model | [string](#string) | optional | Model name |
+| model | [string](#string) |  | Model name |
 | options | [Document.OptionsEntry](#qdrant-Document-OptionsEntry) | repeated | Model options |
 
 
@@ -2814,7 +2814,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | image | [Value](#qdrant-Value) |  | Image data, either base64 encoded or URL |
-| model | [string](#string) | optional | Model name |
+| model | [string](#string) |  | Model name |
 | options | [Image.OptionsEntry](#qdrant-Image-OptionsEntry) | repeated | Model options |
 
 
@@ -2847,7 +2847,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | object | [Value](#qdrant-Value) |  | Object to infer |
-| model | [string](#string) | optional | Model name |
+| model | [string](#string) |  | Model name |
 | options | [InferenceObject.OptionsEntry](#qdrant-InferenceObject-OptionsEntry) | repeated | Model options |
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9943,6 +9943,7 @@
         "description": "WARN: Work-in-progress, unimplemented\n\nText document for embedding. Requires inference infrastructure, unimplemented.",
         "type": "object",
         "required": [
+          "model",
           "text"
         ],
         "properties": {
@@ -9952,8 +9953,7 @@
           },
           "model": {
             "description": "Name of the model used to generate the vector List of available models depends on a provider",
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "options": {
             "description": "Parameters for the model Values of the parameters are model-specific",
@@ -9967,7 +9967,8 @@
         "description": "WARN: Work-in-progress, unimplemented\n\nImage object for embedding. Requires inference infrastructure, unimplemented.",
         "type": "object",
         "required": [
-          "image"
+          "image",
+          "model"
         ],
         "properties": {
           "image": {
@@ -9975,8 +9976,7 @@
           },
           "model": {
             "description": "Name of the model used to generate the vector List of available models depends on a provider",
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "options": {
             "description": "Parameters for the model Values of the parameters are model-specific",
@@ -9990,6 +9990,7 @@
         "description": "WARN: Work-in-progress, unimplemented\n\nCustom object for embedding. Requires inference infrastructure, unimplemented.",
         "type": "object",
         "required": [
+          "model",
           "object"
         ],
         "properties": {
@@ -9998,8 +9999,7 @@
           },
           "model": {
             "description": "Name of the model used to generate the vector List of available models depends on a provider",
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "options": {
             "description": "Parameters for the model Values of the parameters are model-specific",

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -48,19 +48,19 @@ message SparseIndices {
 
 message Document {
   string text = 1; // Text of the document
-  optional string model = 3; // Model name
+  string model = 3; // Model name
   map<string, Value> options = 4; // Model options
 }
 
 message Image {
   Value image = 1; // Image data, either base64 encoded or URL
-  optional string model = 2; // Model name
+  string model = 2; // Model name
   map<string, Value> options = 3; // Model options
 }
 
 message InferenceObject {
   Value object = 1; // Object to infer
-  optional string model = 2; // Model name
+  string model = 2; // Model name
   map<string, Value> options = 3; // Model options
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3835,8 +3835,8 @@ pub struct Document {
     #[prost(string, tag = "1")]
     pub text: ::prost::alloc::string::String,
     /// Model name
-    #[prost(string, optional, tag = "3")]
-    pub model: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "3")]
+    pub model: ::prost::alloc::string::String,
     /// Model options
     #[prost(map = "string, message", tag = "4")]
     pub options: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
@@ -3849,8 +3849,8 @@ pub struct Image {
     #[prost(message, optional, tag = "1")]
     pub image: ::core::option::Option<Value>,
     /// Model name
-    #[prost(string, optional, tag = "2")]
-    pub model: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "2")]
+    pub model: ::prost::alloc::string::String,
     /// Model options
     #[prost(map = "string, message", tag = "3")]
     pub options: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
@@ -3863,8 +3863,8 @@ pub struct InferenceObject {
     #[prost(message, optional, tag = "1")]
     pub object: ::core::option::Option<Value>,
     /// Model name
-    #[prost(string, optional, tag = "2")]
-    pub model: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "2")]
+    pub model: ::prost::alloc::string::String,
     /// Model options
     #[prost(map = "string, message", tag = "3")]
     pub options: ::std::collections::HashMap<::prost::alloc::string::String, Value>,

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -171,7 +171,7 @@ pub struct Document {
     pub text: String,
     /// Name of the model used to generate the vector
     /// List of available models depends on a provider
-    pub model: Option<String>,
+    pub model: String,
     #[serde(flatten)]
     pub options: Options,
 }
@@ -185,7 +185,7 @@ pub struct Image {
     pub image: Value,
     /// Name of the model used to generate the vector
     /// List of available models depends on a provider
-    pub model: Option<String>,
+    pub model: String,
     /// Parameters for the model
     /// Values of the parameters are model-specific
     #[serde(flatten)]
@@ -202,7 +202,7 @@ pub struct InferenceObject {
     pub object: Value,
     /// Name of the model used to generate the vector
     /// List of available models depends on a provider
-    pub model: Option<String>,
+    pub model: String,
     /// Parameters for the model
     /// Values of the parameters are model-specific
     #[serde(flatten)]

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -172,7 +172,7 @@ mod tests {
     fn create_test_document(text: &str) -> Document {
         Document {
             text: text.to_string(),
-            model: Some("test-model".to_string()),
+            model: "test-model".to_string(),
             options: Default::default(),
         }
     }
@@ -180,7 +180,7 @@ mod tests {
     fn create_test_image(url: &str) -> Image {
         Image {
             image: json!({"data": url.to_string()}),
-            model: Some("test-model".to_string()),
+            model: "test-model".to_string(),
             options: Default::default(),
         }
     }
@@ -188,7 +188,7 @@ mod tests {
     fn create_test_object(data: &str) -> InferenceObject {
         InferenceObject {
             object: json!({"data": data}),
-            model: Some("test-model".to_string()),
+            model: "test-model".to_string(),
             options: Default::default(),
         }
     }

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -329,8 +329,8 @@ mod tests {
 
         let mut doc1 = create_test_document("same");
         let mut doc2 = create_test_document("same");
-        doc1.model = Some("model1".to_string());
-        doc2.model = Some("model2".to_string());
+        doc1.model = "model1".to_string();
+        doc2.model = "model2".to_string();
 
         batch.add(InferenceData::Document(doc1));
         batch.add(InferenceData::Document(doc2));

--- a/src/common/inference/batch_processing_grpc.rs
+++ b/src/common/inference/batch_processing_grpc.rs
@@ -273,7 +273,7 @@ mod tests {
     fn create_test_document(text: &str) -> Document {
         Document {
             text: text.to_string(),
-            model: Some("test-model".to_string()),
+            model: "test-model".to_string(),
             options: Default::default(),
         }
     }
@@ -281,7 +281,7 @@ mod tests {
     fn create_test_image(url: &str) -> Image {
         Image {
             image: json!({"data": url.to_string()}),
-            model: Some("test-model".to_string()),
+            model: "test-model".to_string(),
             options: Default::default(),
         }
     }
@@ -289,7 +289,7 @@ mod tests {
     fn create_test_object(data: &str) -> InferenceObject {
         InferenceObject {
             object: json!({"data": data}),
-            model: Some("test-model".to_string()),
+            model: "test-model".to_string(),
             options: Default::default(),
         }
     }

--- a/src/common/inference/batch_processing_grpc.rs
+++ b/src/common/inference/batch_processing_grpc.rs
@@ -341,8 +341,8 @@ mod tests {
 
         let mut doc1 = create_test_document("same");
         let mut doc2 = create_test_document("same");
-        doc1.model = Some("model1".to_string());
-        doc2.model = Some("model2".to_string());
+        doc1.model = "model1".to_string();
+        doc2.model = "model2".to_string();
 
         batch.add(InferenceData::Document(doc1));
         batch.add(InferenceData::Document(doc2));

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -82,7 +82,7 @@ impl From<InferenceData> for InferenceInput {
                 InferenceInput {
                     data: Value::String(text),
                     data_type: DOCUMENT_DATA_TYPE.to_string(),
-                    model: model.unwrap_or_default(),
+                    model: model.to_string(),
                     options: options.options,
                 }
             }
@@ -95,7 +95,7 @@ impl From<InferenceData> for InferenceInput {
                 InferenceInput {
                     data: image,
                     data_type: IMAGE_DATA_TYPE.to_string(),
-                    model: model.unwrap_or_default(),
+                    model: model.to_string(),
                     options: options.options,
                 }
             }
@@ -108,7 +108,7 @@ impl From<InferenceData> for InferenceInput {
                 InferenceInput {
                     data: object,
                     data_type: OBJECT_DATA_TYPE.to_string(),
-                    model: model.unwrap_or_default(),
+                    model: model.to_string(),
                     options: options.options,
                 }
             }


### PR DESCRIPTION
We currently don't have interfaces which allow to omit model name in inference structures.
There was an idea of having this field optional for web-ui, however, it has been rejected, since model name can be substituted in web-ui on.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
