### PR TITLE
Bump dev version to 1.12.4-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "api"
-version = "1.12.3-dev"
+version = "1.12.4-dev"
 dependencies = [
  "chrono",
  "common",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.12.3-dev"
+version = "1.12.4-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.12.3-dev"
+version = "1.12.4-dev"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.12.3-dev"
+version = "1.12.4-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.12.3-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.12.4-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to `1.12.4-dev`.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/5407>.