### PR TITLE
[mmap payload storage] Add hidden config to use mmap storage

### DIFF
--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -102,6 +102,10 @@ pub struct CollectionParams {
     /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
     #[serde(default = "default_on_disk_payload")]
     pub on_disk_payload: bool,
+    /// Temporary setting to enable/disable the use of mmap for on-disk payload storage.
+    // TODO: remove this setting after integration is finished
+    #[serde(skip)]
+    pub on_disk_payload_uses_mmap: bool,
     /// Configuration of the sparse vector storage
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
@@ -111,6 +115,9 @@ pub struct CollectionParams {
 impl CollectionParams {
     pub fn payload_storage_type(&self) -> PayloadStorageType {
         if self.on_disk_payload {
+            if self.on_disk_payload_uses_mmap {
+                return PayloadStorageType::Mmap;
+            }
             PayloadStorageType::OnDisk
         } else {
             PayloadStorageType::InMemory
@@ -126,6 +133,7 @@ impl CollectionParams {
             write_consistency_factor: _, // May be changed
             read_fan_out_factor: _, // May be changed
             on_disk_payload: _, // May be changed
+            on_disk_payload_uses_mmap: _, // Temporary
             sparse_vectors,  // Parameters may be changes, but not the structure
         } = other;
 
@@ -176,6 +184,7 @@ impl Anonymize for CollectionParams {
             write_consistency_factor: self.write_consistency_factor,
             read_fan_out_factor: self.read_fan_out_factor,
             on_disk_payload: self.on_disk_payload,
+            on_disk_payload_uses_mmap: self.on_disk_payload_uses_mmap,
             sparse_vectors: self.sparse_vectors.anonymize(),
         }
     }
@@ -261,6 +270,7 @@ impl CollectionParams {
             write_consistency_factor: default_write_consistency_factor(),
             read_fan_out_factor: None,
             on_disk_payload: default_on_disk_payload(),
+            on_disk_payload_uses_mmap: false,
             sparse_vectors: None,
         }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -733,6 +733,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                     shard_number: NonZeroU32::new(params.shard_number)
                         .ok_or_else(|| Status::invalid_argument("`shard_number` cannot be zero"))?,
                     on_disk_payload: params.on_disk_payload,
+                    on_disk_payload_uses_mmap: false,
                     replication_factor: NonZeroU32::new(
                         params
                             .replication_factor

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -140,6 +140,7 @@ impl TableOfContent {
             })?,
             sharding_method,
             on_disk_payload: on_disk_payload.unwrap_or(self.storage_config.on_disk_payload),
+            on_disk_payload_uses_mmap: self.storage_config.on_disk_payload_uses_mmap,
             replication_factor: NonZeroU32::new(replication_factor).ok_or_else(|| {
                 StorageError::BadInput {
                     description: "`replication_factor` cannot be 0".to_string(),

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -64,6 +64,9 @@ pub struct StorageConfig {
     pub temp_path: Option<String>,
     #[serde(default = "default_on_disk_payload")]
     pub on_disk_payload: bool,
+    // TODO: remove this field after integration is finished
+    #[serde(default)]
+    pub on_disk_payload_uses_mmap: bool,
     #[validate(nested)]
     pub optimizers: OptimizersConfig,
     #[validate(nested)]

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -37,6 +37,7 @@ fn test_alias_operation() {
         snapshots_config: Default::default(),
         temp_path: None,
         on_disk_payload: false,
+        on_disk_payload_uses_mmap: false,
         optimizers: OptimizersConfig {
             deleted_threshold: 0.5,
             vacuum_min_vector_number: 100,


### PR DESCRIPTION
Adds a temporary `storage.on_disk_payload_uses_mmap` setting to enable the use of the new mmap storage before actually integrating it as a default storage.