### PR TITLE
use more stable computation of vectors_size_bytes + refactoring

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11181,6 +11181,7 @@
             "minimum": 0
           },
           "vectors_size_bytes": {
+            "description": "An ESTIMATION of effective amount of bytes used for vectors Do NOT rely on this number unless you know what you are doing",
             "type": "integer",
             "format": "uint",
             "minimum": 0

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -916,7 +916,7 @@ impl SegmentEntry for ProxySegment {
             num_indexed_vectors,
             num_points: self.available_point_count(),
             num_deleted_vectors: write_info.num_deleted_vectors,
-            vectors_size_bytes: wrapped_info.vectors_size_bytes + write_info.vectors_size_bytes,
+            vectors_size_bytes: wrapped_info.vectors_size_bytes, //  + write_info.vectors_size_bytes,
             ram_usage_bytes: wrapped_info.ram_usage_bytes + write_info.ram_usage_bytes,
             disk_usage_bytes: wrapped_info.disk_usage_bytes + write_info.disk_usage_bytes,
             is_appendable: false,

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -67,7 +67,7 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
         self.vectors.len()
     }
 
-    fn size_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<VectorElementType>()
     }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -118,7 +118,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 let vector_storage = vector_storage.borrow();
                 let available_vectors = vector_storage.available_vector_count();
                 let full_scan_threshold = vector_storage
-                    .size_in_bytes()
+                    .size_of_available_vectors_in_bytes()
                     .checked_div(available_vectors)
                     .and_then(|avg_vector_size| {
                         hnsw_config
@@ -212,7 +212,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let total_vector_count = vector_storage.total_vector_count();
 
         let full_scan_threshold = vector_storage
-            .size_in_bytes()
+            .size_of_available_vectors_in_bytes()
             .checked_div(total_vector_count)
             .and_then(|avg_vector_size| {
                 hnsw_config

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -251,7 +251,8 @@ impl PlainIndex {
         let vector_storage = self.vector_storage.borrow();
         let available_vector_count = vector_storage.available_vector_count();
         if available_vector_count > 0 {
-            let vector_size_bytes = vector_storage.size_in_bytes() / available_vector_count;
+            let vector_size_bytes =
+                vector_storage.size_of_available_vectors_in_bytes() / available_vector_count;
             let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
 
             if let Some(payload_filter) = filter {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -327,6 +327,8 @@ pub struct SegmentInfo {
     pub num_points: usize,
     pub num_indexed_vectors: usize,
     pub num_deleted_vectors: usize,
+    /// An ESTIMATION of effective amount of bytes used for vectors
+    /// Do NOT rely on this number unless you know what you are doing
     pub vectors_size_bytes: usize,
     pub ram_usage_bytes: usize,
     pub disk_usage_bytes: usize,

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -86,7 +86,7 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
         self.vectors.len()
     }
 
-    fn size_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
 

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -153,7 +153,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         self.mmap_store.as_ref().unwrap().num_vectors
     }
 
-    fn size_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
 

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -209,7 +209,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         self.vectors.len()
     }
 
-    fn size_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -146,7 +146,7 @@ impl<
         self.offsets.len()
     }
 
-    fn size_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
         if self.total_vector_count() > 0 {
             let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
             (total_size as u128 * self.available_vector_count() as u128

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -329,7 +329,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
         self.vectors_metadata.len()
     }
 
-    fn size_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
         if self.total_vector_count() > 0 {
             let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
             (total_size as u128 * self.available_vector_count() as u128

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -53,7 +53,7 @@ pub trait VectorStorage {
             .saturating_sub(self.deleted_vector_count())
     }
 
-    fn size_in_bytes(&self) -> usize;
+    fn size_of_available_vectors_in_bytes(&self) -> usize;
 
     /// Get the vector by the given key
     fn get_vector(&self, key: PointOffsetType) -> CowVector;
@@ -441,30 +441,50 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn size_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
         match self {
-            VectorStorageEnum::DenseSimple(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseSimpleByte(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseSimpleHalf(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseMemmap(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseMemmapByte(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseAppendableInRam(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseAppendableInRamByte(v) => v.size_in_bytes(),
-            VectorStorageEnum::DenseAppendableInRamHalf(v) => v.size_in_bytes(),
-            VectorStorageEnum::SparseSimple(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseSimple(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableInRam(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => v.size_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => v.size_in_bytes(),
+            VectorStorageEnum::DenseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmap(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmapByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::DenseAppendableInRam(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseAppendableInRamByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::DenseAppendableInRamHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::SparseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableInRam(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
         }
     }
 


### PR DESCRIPTION
Current calculation of the `vectors_size_bytes` have some problems:

- It accumulates same vectors multiple times, if proxy segment is used
- It suffers from vectors not explicitly marked as deleted, even if the point is deleted

This PR fixes those shortcomings by changing the way we compute vector size:

1. We compute average size of all vectors
2. We estimate segment size by multiplying number of **points** to the average
3. We do not take temp segments into account


This PR also contains renaming for `size_in_bytes` -> `size_of_available_vectors_in_bytes` so the name is more explicit

+ bonus, PR makes sparse vector storage compute only size of available points.