### PR TITLE
Remove leftover TODO

### DIFF
--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -56,9 +56,6 @@ impl RecoverableWal {
     ) -> crate::wal::Result<(u64, ParkingMutexGuard<'a, SerdeWal<OperationWithClockTag>>)> {
         // Update last seen clock map and correct clock tag if necessary
         if let Some(clock_tag) = &mut operation.clock_tag {
-            // TODO: Do not manually advance here!
-            //
-            // TODO: What does the above `TODO` mean? "Make sure to call `advance_clock_and_correct_tag`, but not `advance_clock`?"
             let operation_accepted = self
                 .newest_clocks
                 .lock()


### PR DESCRIPTION
I believe we accidentally left the TODO behind and it does not have a real purpose anymore.

As far as I understand it had to do with a suggested change for when we'd accept all clocks no matter their tick value during the implementation phase.

This is where it first appeared: https://github.com/qdrant/qdrant/commit/42b80f454346b39c2fba09e38c8c6c8e578080c6#diff-4c0b7eece99d62a4a61db5090e46cc181bacb1c0b4211c84fb5210fe34154416R33-R38

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?