### PR TITLE
In resharding stream records, set earlier cutoff point

### DIFF
--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -31,6 +31,7 @@ pub(crate) async fn transfer_resharding_stream_records(
     collection_id: &CollectionId,
 ) -> CollectionResult<()> {
     let remote_peer_id = remote_shard.peer_id;
+    let cutoff;
     let hashring;
 
     log::debug!(
@@ -81,6 +82,9 @@ pub(crate) async fn transfer_resharding_stream_records(
         progress.lock().points_total = count_result.count;
 
         replica_set.transfer_indexes().await?;
+
+        // Take our last seen clocks as cutoff point right before doing content batch transfers
+        cutoff = replica_set.shard_recovery_point().await?;
     }
 
     // Transfer contents batch by batch
@@ -117,37 +121,20 @@ pub(crate) async fn transfer_resharding_stream_records(
         }
     }
 
-    // Update cutoff point on remote shard, disallow recovery before our current last seen
-    {
-        let shard_holder = shard_holder.read().await;
-        let Some(replica_set) = shard_holder.get_shard(shard_id) else {
-            // Forward proxy gone?!
-            // That would be a programming error.
-            return Err(CollectionError::service_error(format!(
-                "Shard {shard_id} is not found"
-            )));
-        };
-
-        let cutoff = replica_set.shard_recovery_point().await?;
-        let result = remote_shard
-            .update_shard_cutoff_point(collection_id, remote_shard.id, &cutoff)
-            .await;
-
-        // Warn and ignore if remote shard is running an older version, error otherwise
-        // TODO: this is fragile, improve this with stricter matches/checks
-        match result {
-            // This string match is fragile but there does not seem to be a better way
-            Err(err)
-                if err.to_string().starts_with(
-                    "Service internal error: Tonic status error: status: Unimplemented",
-                ) =>
-            {
-                log::warn!("Cannot update cutoff point on remote shard because it is running an older version, ignoring: {err}");
-            }
-            Err(err) => return Err(err),
-            Ok(()) => {}
-        }
-    }
+    // Update cutoff point on remote shard, disallow recovery before it
+    //
+    // We provide it our last seen clocks from just before transferrinmg the content batches, and
+    // not our current last seen clocks. We're sure that after the transfer the remote must have
+    // seen all point data for those clocks. While we cannot guarantee the remote has all point
+    // data for our current last seen clocks because some operations may still be in flight.
+    // This is a trade-off between being conservative and being too conservative.
+    //
+    // We must send a cutoff point to the remote so it can learn about all the clocks that exist.
+    // If we don't do this it is possible the remote will never see a clock, breaking all future
+    // WAL delta transfers.
+    remote_shard
+        .update_shard_cutoff_point(collection_id, remote_shard.id, &cutoff)
+        .await?;
 
     log::debug!(
         "Ending shard {shard_id} transfer to peer {remote_peer_id} by reshard streaming records"


### PR DESCRIPTION
Same as <https://github.com/qdrant/qdrant/pull/5414>, but in the stream records logic specialized for resharding.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?