### PR TITLE
Compatibility for mmap sparse vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6381,7 +6381,9 @@ dependencies = [
 name = "sparse"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "bitpacking",
+ "blob_store",
  "common",
  "criterion",
  "dataset",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11527,6 +11527,9 @@
         "properties": {
           "index": {
             "$ref": "#/components/schemas/SparseIndexConfig"
+          },
+          "storage_type": {
+            "$ref": "#/components/schemas/SparseVectorStorageType"
           }
         }
       },
@@ -11582,6 +11585,24 @@
             "type": "string",
             "enum": [
               "Mmap"
+            ]
+          }
+        ]
+      },
+      "SparseVectorStorageType": {
+        "oneOf": [
+          {
+            "description": "Storage on disk",
+            "type": "string",
+            "enum": [
+              "on_disk"
+            ]
+          },
+          {
+            "description": "Storage in memory maps",
+            "type": "string",
+            "enum": [
+              "mmap"
             ]
           }
         ]

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -86,7 +86,7 @@ impl<V: Blob> BlobStore<V> {
         } else {
             // create folder if it does not exist
             std::fs::create_dir_all(&base_path)
-                .map_err(|_| "Failed to create mmap sparse vector storage directory")?;
+                .map_err(|err| format!("Failed to create blob_store storage directory: {err}"))?;
             Self::new(base_path, options)
         }
     }

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -114,6 +114,13 @@ impl<V: Blob> BlobStore<V> {
     /// Open an existing storage at the given path
     /// Returns None if the storage does not exist
     pub fn open(path: PathBuf) -> Result<Self> {
+        if !path.exists() {
+            return Err(format!("Path '{path:?}' does not exist"));
+        }
+        if !path.is_dir() {
+            return Err(format!("Path '{path:?}' is not a directory"));
+        }
+
         // read config file first
         let config_path = path.join(CONFIG_FILENAME);
         let config_file = std::fs::File::open(&config_path).map_err(|err| err.to_string())?;

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -78,7 +78,7 @@ impl<V: Blob> BlobStore<V> {
 
     /// Opens an existing storage, or initializes a new one.
     ///
-    /// Depends on the existance of the config file at the `base_path`.
+    /// Depends on the existence of the config file at the `base_path`.
     pub fn open_or_create(base_path: PathBuf, options: StorageOptions) -> Result<Self> {
         let config_path = base_path.join(CONFIG_FILENAME);
         if config_path.exists() {

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -76,6 +76,21 @@ impl<V: Blob> BlobStore<V> {
         self.tracker.read().pointer_count()
     }
 
+    /// Opens an existing storage, or initializes a new one.
+    ///
+    /// Depends on the existance of the config file at the `base_path`.
+    pub fn open_or_create(base_path: PathBuf, options: StorageOptions) -> Result<Self> {
+        let config_path = base_path.join(CONFIG_FILENAME);
+        if config_path.exists() {
+            Self::open(base_path)
+        } else {
+            // create folder if it does not exist
+            std::fs::create_dir_all(&base_path)
+                .map_err(|_| "Failed to create mmap sparse vector storage directory")?;
+            Self::new(base_path, options)
+        }
+    }
+
     /// Initializes a new storage with a single empty page.
     ///
     /// `base_path` is the directory where the storage files will be stored.

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -77,9 +77,10 @@ impl<V: Blob> BlobStore<V> {
     }
 
     /// Opens an existing storage, or initializes a new one.
-    ///
     /// Depends on the existence of the config file at the `base_path`.
-    pub fn open_or_create(base_path: PathBuf, options: StorageOptions) -> Result<Self> {
+    ///
+    /// In case of opening, it ignores the `create_options` parameter.
+    pub fn open_or_create(base_path: PathBuf, create_options: StorageOptions) -> Result<Self> {
         let config_path = base_path.join(CONFIG_FILENAME);
         if config_path.exists() {
             Self::open(base_path)
@@ -87,7 +88,7 @@ impl<V: Blob> BlobStore<V> {
             // create folder if it does not exist
             std::fs::create_dir_all(&base_path)
                 .map_err(|err| format!("Failed to create blob_store storage directory: {err}"))?;
-            Self::new(base_path, options)
+            Self::new(base_path, create_options)
         }
     }
 

--- a/lib/blob_store/src/tracker.rs
+++ b/lib/blob_store/src/tracker.rs
@@ -295,6 +295,7 @@ impl Tracker {
             self.pending_updates
                 .insert(point_offset, PointerUpdate::Unset(pointer));
         }
+        self.next_pointer_offset = self.next_pointer_offset.max(point_offset + 1);
 
         pointer_opt
     }

--- a/lib/blob_store/src/tracker.rs
+++ b/lib/blob_store/src/tracker.rs
@@ -244,9 +244,7 @@ impl Tracker {
     }
 
     /// Iterate over the pointers in the tracker
-    pub fn iter_pointers<'a>(
-        &'a self,
-    ) -> impl Iterator<Item = (PointOffset, Option<ValuePointer>)> + 'a {
+    pub fn iter_pointers(&self) -> impl Iterator<Item = (PointOffset, Option<ValuePointer>)> + '_ {
         (0..self.next_pointer_offset).map(move |i| (i, self.get(i as PointOffset)))
     }
 

--- a/lib/blob_store/src/tracker.rs
+++ b/lib/blob_store/src/tracker.rs
@@ -244,8 +244,10 @@ impl Tracker {
     }
 
     /// Iterate over the pointers in the tracker
-    pub fn iter_pointers(&self) -> impl Iterator<Item = Option<(PointOffset, ValuePointer)>> + '_ {
-        (0..self.next_pointer_offset).map(move |i| self.get(i as PointOffset).map(|p| (i, p)))
+    pub fn iter_pointers<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = (PointOffset, Option<ValuePointer>)> + 'a {
+        (0..self.next_pointer_offset).map(move |i| (i, self.get(i as PointOffset)))
     }
 
     /// Get the raw value at the given point offset

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -13,7 +13,7 @@ use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, Spars
 use segment::types::{
     default_replication_factor_const, default_shard_number_const,
     default_write_consistency_factor_const, Distance, HnswConfig, Indexes, PayloadStorageType,
-    QuantizationConfig, SparseVectorDataConfig, SparseVectorStorageType, StrictModeConfig,
+    QuantizationConfig, SparseVectorDataConfig, StrictModeConfig,
     VectorDataConfig, VectorStorageDatatype, VectorStorageType,
 };
 use serde::{Deserialize, Serialize};
@@ -109,6 +109,9 @@ pub struct CollectionParams {
     // TODO: remove this setting after integration is finished
     #[serde(skip)]
     pub on_disk_payload_uses_mmap: bool,
+    // TODO: remove this setting after integration is finished
+    #[serde(skip)]
+    pub on_disk_sparse_vectors_uses_mmap: bool,
     /// Configuration of the sparse vector storage
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
@@ -137,6 +140,7 @@ impl CollectionParams {
             read_fan_out_factor: _, // May be changed
             on_disk_payload: _, // May be changed
             on_disk_payload_uses_mmap: _, // Temporary
+            on_disk_sparse_vectors_uses_mmap: _, // Temporary
             sparse_vectors,  // Parameters may be changes, but not the structure
         } = other;
 
@@ -188,6 +192,7 @@ impl Anonymize for CollectionParams {
             read_fan_out_factor: self.read_fan_out_factor,
             on_disk_payload: self.on_disk_payload,
             on_disk_payload_uses_mmap: self.on_disk_payload_uses_mmap,
+            on_disk_sparse_vectors_uses_mmap: self.on_disk_sparse_vectors_uses_mmap,
             sparse_vectors: self.sparse_vectors.anonymize(),
         }
     }
@@ -274,6 +279,7 @@ impl CollectionParams {
             read_fan_out_factor: None,
             on_disk_payload: default_on_disk_payload(),
             on_disk_payload_uses_mmap: false,
+            on_disk_sparse_vectors_uses_mmap: false,
             sparse_vectors: None,
         }
     }
@@ -501,7 +507,7 @@ impl CollectionParams {
                                     .map(VectorStorageDatatype::from),
                             },
                             // Not configurable by user (at this point). When we switch the default, it will be switched here too.
-                            storage_type: SparseVectorStorageType::default(),
+                            storage_type: params.storage_type(self.on_disk_sparse_vectors_uses_mmap),
                         },
                     ))
                 })

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -13,8 +13,8 @@ use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, Spars
 use segment::types::{
     default_replication_factor_const, default_shard_number_const,
     default_write_consistency_factor_const, Distance, HnswConfig, Indexes, PayloadStorageType,
-    QuantizationConfig, SparseVectorDataConfig, StrictModeConfig,
-    VectorDataConfig, VectorStorageDatatype, VectorStorageType,
+    QuantizationConfig, SparseVectorDataConfig, StrictModeConfig, VectorDataConfig,
+    VectorStorageDatatype, VectorStorageType,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -507,7 +507,8 @@ impl CollectionParams {
                                     .map(VectorStorageDatatype::from),
                             },
                             // Not configurable by user (at this point). When we switch the default, it will be switched here too.
-                            storage_type: params.storage_type(self.on_disk_sparse_vectors_uses_mmap),
+                            storage_type: params
+                                .storage_type(self.on_disk_sparse_vectors_uses_mmap),
                         },
                     ))
                 })

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -13,8 +13,8 @@ use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, Spars
 use segment::types::{
     default_replication_factor_const, default_shard_number_const,
     default_write_consistency_factor_const, Distance, HnswConfig, Indexes, PayloadStorageType,
-    QuantizationConfig, SparseVectorDataConfig, StrictModeConfig, VectorDataConfig,
-    VectorStorageDatatype, VectorStorageType,
+    QuantizationConfig, SparseVectorDataConfig, SparseVectorStorageType, StrictModeConfig,
+    VectorDataConfig, VectorStorageDatatype, VectorStorageType,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -500,6 +500,8 @@ impl CollectionParams {
                                     .and_then(|index| index.datatype)
                                     .map(VectorStorageDatatype::from),
                             },
+                            // Not configurable by user (at this point). When we switch the default, it will be switched here too.
+                            storage_type: SparseVectorStorageType::default(),
                         },
                     ))
                 })

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1788,6 +1788,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                         .map(sharding_method_from_proto)
                         .transpose()?,
                     on_disk_payload_uses_mmap: false,
+                    on_disk_sparse_vectors_uses_mmap: false,
                 },
             },
             hnsw_config: match config.hnsw_config {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -27,7 +27,10 @@ use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStructInternal, DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
-    Distance, Filter, HnswConfig, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey, SparseVectorStorageType, StrictModeConfig, VectorStorageDatatype, WithPayloadInterface, WithVector
+    Distance, Filter, HnswConfig, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType,
+    PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey,
+    SparseVectorStorageType, StrictModeConfig, VectorStorageDatatype, WithPayloadInterface,
+    WithVector,
 };
 use semver::Version;
 use serde;

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -27,9 +27,7 @@ use segment::data_types::vectors::{
     DenseVector, QueryVector, VectorRef, VectorStructInternal, DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
-    Distance, Filter, HnswConfig, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType,
-    PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey, StrictModeConfig,
-    VectorStorageDatatype, WithPayloadInterface, WithVector,
+    Distance, Filter, HnswConfig, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey, SparseVectorStorageType, StrictModeConfig, VectorStorageDatatype, WithPayloadInterface, WithVector
 };
 use semver::Version;
 use serde;
@@ -1495,6 +1493,16 @@ pub struct SparseVectorParams {
     /// Default: none
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub modifier: Option<Modifier>,
+}
+
+impl SparseVectorParams {
+    pub fn storage_type(&self, use_new_storage: bool) -> SparseVectorStorageType {
+        if use_new_storage {
+            SparseVectorStorageType::Mmap
+        } else {
+            SparseVectorStorageType::default()
+        }
+    }
 }
 
 impl Anonymize for SparseVectorParams {

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -344,6 +344,9 @@ impl GpuVectorStorage {
             VectorStorageEnum::SparseSimple(_) => Err(OperationError::from(
                 gpu::GpuError::NotSupported("Sparse vectors are not supported on GPU".to_string()),
             )),
+            VectorStorageEnum::SparseMmap(_) => Err(OperationError::from(
+                gpu::GpuError::NotSupported("Sparse vectors are not supported on GPU".to_string()),
+            )),
             VectorStorageEnum::MultiDenseSimple(vector_storage) => Self::new_multi_f32(
                 device.clone(),
                 vector_storage,

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -152,7 +152,7 @@ impl PayloadStorage for MmapPayloadStorage {
     fn flusher(&self) -> Flusher {
         let storage = self.storage.clone();
         Box::new(move || {
-            storage.write().flush().map_err(|err| {
+            storage.read().flush().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to flush mmap payload storage: {err}"
                 ))

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -96,14 +96,12 @@ impl SegmentBuilder {
             vector_storages.insert(vector_name.to_owned(), vector_storage);
         }
 
-        #[allow(clippy::for_kv_map)]
         for (vector_name, sparse_vector_config) in &segment_config.sparse_vector_data {
-            // `_sparse_vector_config` should be used, once we are able to initialize storage with
-            // different datatypes
+            let vector_storage_path = get_vector_storage_path(temp_dir.path(), vector_name);
 
             let vector_storage = create_sparse_vector_storage(
                 database.clone(),
-                segment_path,
+                &vector_storage_path,
                 vector_name,
                 &sparse_vector_config.storage_type,
                 &stopped,

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -97,12 +97,18 @@ impl SegmentBuilder {
         }
 
         #[allow(clippy::for_kv_map)]
-        for (vector_name, _sparse_vector_config) in &segment_config.sparse_vector_data {
+        for (vector_name, sparse_vector_config) in &segment_config.sparse_vector_data {
             // `_sparse_vector_config` should be used, once we are able to initialize storage with
             // different datatypes
 
-            let vector_storage =
-                create_sparse_vector_storage(database.clone(), vector_name, &stopped)?;
+            let vector_storage = create_sparse_vector_storage(
+                database.clone(),
+                segment_path,
+                vector_name,
+                &sparse_vector_config.storage_type,
+                &stopped,
+            )?;
+
             vector_storages.insert(vector_name.to_owned(), vector_storage);
         }
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -521,11 +521,12 @@ fn create_segment(
     }
 
     for (vector_name, sparse_config) in config.sparse_vector_data.iter() {
-        // Select suitable vector storage type based on configuration
+        let vector_storage_path = get_vector_storage_path(segment_path, vector_name);
 
+        // Select suitable sparse vector storage type based on configuration
         let vector_storage = sp(create_sparse_vector_storage(
             database.clone(),
-            segment_path,
+            &vector_storage_path,
             vector_name,
             &sparse_config.storage_type,
             stopped,

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -143,6 +143,7 @@ impl Anonymize for SparseVectorDataConfig {
     fn anonymize(&self) -> Self {
         SparseVectorDataConfig {
             index: self.index.anonymize(),
+            storage_type: self.storage_type,
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -950,12 +950,27 @@ impl VectorDataConfig {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SparseVectorStorageType {
+    /// Storage on disk
+    // (rocksdb storage)
+    #[default]
+    OnDisk,
+    /// Storage in memory maps
+    // (blob_store storage)
+    Mmap,
+}
+
 /// Config of single sparse vector data storage
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct SparseVectorDataConfig {
     /// Sparse inverted index config
     pub index: SparseIndexConfig,
+
+    /// Type of storage this sparse vector uses
+    pub storage_type: SparseVectorStorageType,
 }
 
 impl SparseVectorDataConfig {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -970,7 +970,13 @@ pub struct SparseVectorDataConfig {
     pub index: SparseIndexConfig,
 
     /// Type of storage this sparse vector uses
+    #[serde(default = "default_sparse_vector_storage_type_when_not_in_config")]
     pub storage_type: SparseVectorStorageType,
+}
+
+/// If the storage type is not in config, it means it is the OnDisk variant
+const fn default_sparse_vector_storage_type_when_not_in_config() -> SparseVectorStorageType {
+    SparseVectorStorageType::OnDisk
 }
 
 impl SparseVectorDataConfig {

--- a/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
@@ -152,7 +152,7 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
         key: PointOffsetType,
     ) -> crate::common::operation_error::OperationResult<SparseVector> {
         self.get_sparse_opt(key)?
-            .ok_or_else(|| OperationError::service_error(format!("Key {} not found", key)))
+            .ok_or_else(|| OperationError::service_error(format!("Key {key} not found")))
     }
 
     fn get_sparse_opt(

--- a/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
@@ -23,7 +23,8 @@ use crate::types::VectorStorageDatatype;
 
 const STORAGE_PATH: &str = "sparse_vector_storage";
 
-struct MmapSparseVectorStorage {
+#[derive(Debug)]
+pub struct MmapSparseVectorStorage {
     storage: Arc<RwLock<BlobStore<SparseVector>>>,
     /// BitVec for deleted flags. Grows dynamically upto last set flag.
     deleted: BitVec,

--- a/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
@@ -21,8 +21,6 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::VectorStorageDatatype;
 
-const STORAGE_PATH: &str = "sparse_vector_storage";
-
 /// Memory-mapped mutable sparse vector storage.
 #[derive(Debug)]
 pub struct MmapSparseVectorStorage {
@@ -31,14 +29,14 @@ pub struct MmapSparseVectorStorage {
     deleted: BitVec,
     /// Current number of deleted vectors.
     deleted_count: usize,
-    total_vector_count: usize,
+    max_point_offset: usize,
     /// Total number of non-zero elements in all vectors. Used to estimate average vector size.
     total_sparse_size: usize,
 }
 
 impl MmapSparseVectorStorage {
     pub fn open_or_create(path: &Path, stopped: &AtomicBool) -> OperationResult<Self> {
-        let path = path.join(STORAGE_PATH);
+        let path = path.to_path_buf();
         if path.exists() {
             Self::open(path, stopped)
         } else {
@@ -61,7 +59,7 @@ impl MmapSparseVectorStorage {
 
         let mut deleted = BitVec::new();
         let mut deleted_count = 0;
-        let mut total_vector_count = 0;
+        let mut max_point_offset = 0;
         let mut total_sparse_size = 0;
         let mut last_read_id = 0;
         const CHECK_STOP_INTERVAL: usize = 100;
@@ -77,10 +75,10 @@ impl MmapSparseVectorStorage {
             }
             last_read_id = point_id;
 
-            total_vector_count = total_vector_count.max(point_id as usize + 1);
+            max_point_offset = max_point_offset.max(point_id as usize + 1);
             total_sparse_size += vector.values.len();
 
-            if total_vector_count % CHECK_STOP_INTERVAL == 0 && stopped.load(Ordering::Relaxed) {
+            if max_point_offset % CHECK_STOP_INTERVAL == 0 && stopped.load(Ordering::Relaxed) {
                 return Err(std::io::Error::other("Process cancelled"));
             }
 
@@ -93,7 +91,7 @@ impl MmapSparseVectorStorage {
             storage,
             deleted,
             deleted_count,
-            total_vector_count,
+            max_point_offset,
             total_sparse_size,
         })
     }
@@ -107,25 +105,24 @@ impl MmapSparseVectorStorage {
             storage,
             deleted: BitVec::new(),
             deleted_count: 0,
-            total_vector_count: 0,
+            max_point_offset: 0,
             total_sparse_size: 0,
         })
     }
 
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
-        if key as usize >= self.total_vector_count {
+        if key as usize >= self.max_point_offset {
             return false;
         }
-        let was_deleted = bitvec_set_deleted(&mut self.deleted, key, deleted);
-        if was_deleted != deleted {
-            if !was_deleted {
-                self.deleted_count += 1;
-            } else {
-                self.deleted_count = self.deleted_count.saturating_sub(1);
-            }
+        let previously_deleted = bitvec_set_deleted(&mut self.deleted, key, deleted);
+        // update deleted_count if it changed
+        match (previously_deleted, deleted) {
+            (false, true) => self.deleted_count += 1,
+            (true, false) => self.deleted_count = self.deleted_count.saturating_sub(1),
+            _ => {}
         }
-        was_deleted
+        previously_deleted
     }
 
     fn update_stored(
@@ -155,6 +152,8 @@ impl MmapSparseVectorStorage {
                     .saturating_sub(old_vector.values.len());
             }
         }
+
+        self.max_point_offset = std::cmp::max(self.max_point_offset, key as usize + 1);
 
         Ok(())
     }
@@ -191,15 +190,15 @@ impl VectorStorage for MmapSparseVectorStorage {
     }
 
     fn total_vector_count(&self) -> usize {
-        self.total_vector_count
+        self.max_point_offset
     }
 
     fn size_of_available_vectors_in_bytes(&self) -> usize {
-        if self.total_vector_count == 0 {
+        if self.max_point_offset == 0 {
             return 0;
         }
         let available_fraction =
-            (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
+            (self.max_point_offset - self.deleted_count) as f32 / self.max_point_offset as f32;
         let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
         available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
     }
@@ -222,7 +221,6 @@ impl VectorStorage for MmapSparseVectorStorage {
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
         let vector = <&SparseVector>::try_from(vector)?;
         debug_assert!(vector.is_sorted());
-        self.total_vector_count = std::cmp::max(self.total_vector_count, key as usize + 1);
         self.set_deleted(key, false);
         self.update_stored(key, Some(vector))?;
         Ok(())
@@ -233,22 +231,20 @@ impl VectorStorage for MmapSparseVectorStorage {
         other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
-        let start_index = self.total_vector_count as PointOffsetType;
+        let start_index = self.max_point_offset as PointOffsetType;
         for (other_vector, other_deleted) in
             other_vectors.check_stop(|| stopped.load(Ordering::Relaxed))
         {
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = other_vector.as_vec_ref().try_into()?;
-            let new_id = self.total_vector_count as PointOffsetType;
-            self.total_vector_count += 1;
+            let new_id = self.max_point_offset as PointOffsetType;
+            self.max_point_offset += 1;
             self.set_deleted(new_id, other_deleted);
-            if other_deleted {
-                self.update_stored(new_id, None)?;
-            } else {
-                self.update_stored(new_id, Some(other_vector))?;
-            }
+
+            let vector = (!other_deleted).then_some(other_vector);
+            self.update_stored(new_id, vector)?;
         }
-        Ok(start_index..self.total_vector_count as PointOffsetType)
+        Ok(start_index..self.max_point_offset as PointOffsetType)
     }
 
     fn flusher(&self) -> crate::common::Flusher {

--- a/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/mmap_sparse_vector_storage.rs
@@ -1,0 +1,278 @@
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use bitvec::slice::BitSlice;
+use bitvec::vec::BitVec;
+use blob_store::config::StorageOptions;
+use blob_store::BlobStore;
+use common::iterator_ext::IteratorExt;
+use common::types::PointOffsetType;
+use parking_lot::RwLock;
+use sparse::common::sparse_vector::SparseVector;
+use sparse::common::types::{DimId, DimWeight};
+
+use super::bitvec::bitvec_set_deleted;
+use super::simple_sparse_vector_storage::SPARSE_VECTOR_DISTANCE;
+use super::{SparseVectorStorage, VectorStorage};
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::named_vectors::CowVector;
+use crate::data_types::vectors::VectorRef;
+use crate::types::VectorStorageDatatype;
+
+const STORAGE_PATH: &str = "sparse_vector_storage";
+
+struct MmapSparseVectorStorage {
+    storage: Arc<RwLock<BlobStore<SparseVector>>>,
+    /// BitVec for deleted flags. Grows dynamically upto last set flag.
+    deleted: BitVec,
+    /// Current number of deleted vectors.
+    deleted_count: usize,
+    total_vector_count: usize,
+    /// Total number of non-zero elements in all vectors. Used to estimate average vector size.
+    total_sparse_size: usize,
+}
+
+impl MmapSparseVectorStorage {
+    pub fn open_or_create(path: &Path) -> OperationResult<Self> {
+        let path = path.join(STORAGE_PATH);
+        if path.exists() {
+            Self::open(path)
+        } else {
+            // create folder if it does not exist
+            std::fs::create_dir_all(&path).map_err(|_| {
+                OperationError::service_error(
+                    "Failed to create mmap sparse vector storage directory",
+                )
+            })?;
+            Ok(Self::new(path)?)
+        }
+    }
+
+    fn open(path: PathBuf) -> OperationResult<Self> {
+        let storage: BlobStore<SparseVector> = BlobStore::open(path).map_err(|err| {
+            OperationError::service_error(format!(
+                "Failed to open mmap sparse vector storage: {err}"
+            ))
+        })?;
+
+        let mut deleted = BitVec::new();
+        let mut deleted_count = 0;
+        let mut total_vector_count = 0;
+        let mut total_sparse_size = 0;
+        let mut last_read_id = 0;
+
+        storage.iter(|point_id, vector| {
+            // Propagate deleted flag
+            if point_id - last_read_id > 1 {
+                // Some vectors are missing in the sequence
+                for deleted_id in last_read_id + 1..point_id {
+                    bitvec_set_deleted(&mut deleted, deleted_id, true);
+                    deleted_count += 1;
+                }
+            }
+            last_read_id = point_id;
+
+            total_vector_count = total_vector_count.max(point_id as usize + 1);
+            total_sparse_size += vector.values.len();
+            Ok(true)
+        })?;
+
+        let storage = Arc::new(RwLock::new(storage));
+
+        Ok(Self {
+            storage,
+            deleted,
+            deleted_count,
+            total_vector_count,
+            total_sparse_size,
+        })
+    }
+
+    fn new(path: PathBuf) -> OperationResult<Self> {
+        let storage = BlobStore::new(path, StorageOptions::default())
+            .map_err(OperationError::service_error)?;
+        let storage = Arc::new(RwLock::new(storage));
+
+        Ok(Self {
+            storage,
+            deleted: BitVec::new(),
+            deleted_count: 0,
+            total_vector_count: 0,
+            total_sparse_size: 0,
+        })
+    }
+
+    #[inline]
+    fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
+        if key as usize >= self.total_vector_count {
+            return false;
+        }
+        let was_deleted = bitvec_set_deleted(&mut self.deleted, key, deleted);
+        if was_deleted != deleted {
+            if !was_deleted {
+                self.deleted_count += 1;
+            } else {
+                self.deleted_count = self.deleted_count.saturating_sub(1);
+            }
+        }
+        was_deleted
+    }
+
+    fn update_stored(
+        &mut self,
+        key: PointOffsetType,
+        vector: Option<&SparseVector>,
+    ) -> OperationResult<()> {
+        // Write vector state to buffer record
+        if let Some(vector) = vector {
+            self.total_sparse_size += vector.values.len();
+            self.storage
+                .write()
+                .put_value(key, vector)
+                .map_err(OperationError::service_error)?;
+        } else {
+            // is deleting
+            if let Some(old_vector) = self.storage.write().delete_value(key) {
+                self.total_sparse_size = self
+                    .total_sparse_size
+                    .saturating_sub(old_vector.values.len());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SparseVectorStorage for MmapSparseVectorStorage {
+    fn get_sparse(
+        &self,
+        key: PointOffsetType,
+    ) -> crate::common::operation_error::OperationResult<SparseVector> {
+        self.get_sparse_opt(key)?
+            .ok_or_else(|| OperationError::service_error(format!("Key {} not found", key)))
+    }
+
+    fn get_sparse_opt(
+        &self,
+        key: PointOffsetType,
+    ) -> crate::common::operation_error::OperationResult<Option<SparseVector>> {
+        Ok(self.storage.read().get_value(key))
+    }
+}
+
+impl VectorStorage for MmapSparseVectorStorage {
+    fn distance(&self) -> crate::types::Distance {
+        SPARSE_VECTOR_DISTANCE
+    }
+
+    fn datatype(&self) -> crate::types::VectorStorageDatatype {
+        VectorStorageDatatype::Float32
+    }
+
+    fn is_on_disk(&self) -> bool {
+        true
+    }
+
+    fn total_vector_count(&self) -> usize {
+        self.total_vector_count
+    }
+
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count == 0 {
+            return 0;
+        }
+        let available_fraction =
+            (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
+        let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
+        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
+    }
+
+    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+        let vector = self.get_vector_opt(key);
+        debug_assert!(vector.is_some());
+        vector.unwrap_or_else(CowVector::default_sparse)
+    }
+
+    /// Get vector by key, if it exists.
+    ///
+    /// Ignore any error
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        match self.get_sparse_opt(key) {
+            Ok(Some(vector)) => Some(CowVector::from(vector)),
+            _ => None,
+        }
+    }
+
+    fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
+        let vector = <&SparseVector>::try_from(vector)?;
+        debug_assert!(vector.is_sorted());
+        self.total_vector_count = std::cmp::max(self.total_vector_count, key as usize + 1);
+        self.set_deleted(key, false);
+        self.update_stored(key, Some(vector))?;
+        Ok(())
+    }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let start_index = self.total_vector_count as PointOffsetType;
+        for (other_vector, other_deleted) in
+            other_vectors.check_stop(|| stopped.load(Ordering::Relaxed))
+        {
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = other_vector.as_vec_ref().try_into()?;
+            let new_id = self.total_vector_count as PointOffsetType;
+            self.total_vector_count += 1;
+            self.set_deleted(new_id, other_deleted);
+            if other_deleted {
+                self.update_stored(new_id, None)?;
+            } else {
+                self.update_stored(new_id, Some(other_vector))?;
+            }
+        }
+        Ok(start_index..self.total_vector_count as PointOffsetType)
+    }
+
+    fn flusher(&self) -> crate::common::Flusher {
+        let storage = self.storage.clone();
+        Box::new(move || {
+            storage.read().flush().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to flush mmap sparse vector storage: {err}"
+                ))
+            })?;
+            Ok(())
+        })
+    }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        self.storage.read().files()
+    }
+
+    fn delete_vector(
+        &mut self,
+        key: common::types::PointOffsetType,
+    ) -> crate::common::operation_error::OperationResult<bool> {
+        let is_deleted = !self.set_deleted(key, true);
+        if is_deleted {
+            self.update_stored(key, None)?;
+        }
+        Ok(is_deleted)
+    }
+
+    fn is_deleted_vector(&self, key: common::types::PointOffsetType) -> bool {
+        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
+    }
+}

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -17,6 +17,7 @@ pub mod chunked_vector_storage;
 pub mod common;
 pub mod dense;
 mod in_ram_persisted_vectors;
+pub mod mmap_sparse_vector_storage;
 pub mod multi_dense;
 pub mod query;
 mod query_scorer;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -256,6 +256,7 @@ impl QuantizedVectors {
                 Self::create_impl(v.as_ref(), quantization_config, path, max_threads, stopped)
             }
             VectorStorageEnum::SparseSimple(_) => Err(OperationError::WrongSparse),
+            VectorStorageEnum::SparseMmap(_) => Err(OperationError::WrongSparse),
             VectorStorageEnum::MultiDenseSimple(v) => {
                 Self::create_multi_impl(v, quantization_config, path, max_threads, stopped)
             }

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -175,6 +175,9 @@ pub fn new_stoppable_raw_scorer<'a>(
         VectorStorageEnum::SparseSimple(vs) => {
             raw_sparse_scorer_impl(query, vs, point_deleted, is_stopped)
         }
+        VectorStorageEnum::SparseMmap(vs) => {
+            raw_sparse_scorer_impl(query, vs, point_deleted, is_stopped)
+        }
         VectorStorageEnum::MultiDenseSimple(vs) => {
             raw_multi_scorer_impl(query, vs, point_deleted, is_stopped)
         }

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -58,9 +58,10 @@ pub fn open_simple_sparse_vector_storage(
         if stored_record.deleted {
             bitvec_set_deleted(&mut deleted, point_id, true);
             deleted_count += 1;
+        } else {
+            total_vector_count = total_vector_count.max(point_id as usize + 1);
+            total_sparse_size += stored_record.vector.values.len();
         }
-        total_vector_count = std::cmp::max(total_vector_count, point_id as usize + 1);
-        total_sparse_size += stored_record.vector.values.len();
 
         check_process_stopped(stopped)?;
     }
@@ -136,10 +137,14 @@ impl SparseVectorStorage for SimpleSparseVectorStorage {
         let bin_key = bincode::serialize(&key)
             .map_err(|_| OperationError::service_error("Cannot serialize sparse vector key"))?;
         if let Some(data) = self.db_wrapper.get_opt(bin_key)? {
-            let record: StoredSparseVector = bincode::deserialize(&data).map_err(|_| {
-                OperationError::service_error("Cannot deserialize sparse vector from db")
-            })?;
-            Ok(Some(record.vector))
+            let StoredSparseVector { deleted, vector } =
+                bincode::deserialize(&data).map_err(|_| {
+                    OperationError::service_error("Cannot deserialize sparse vector from db")
+                })?;
+            if deleted {
+                return Ok(None);
+            }
+            Ok(Some(vector))
         } else {
             Ok(None)
         }
@@ -227,7 +232,8 @@ impl VectorStorage for SimpleSparseVectorStorage {
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         let is_deleted = !self.set_deleted(key, true);
         if is_deleted {
-            self.update_stored(key, true, None)?;
+            let old_vector = self.get_sparse_opt(key).ok().flatten();
+            self.update_stored(key, true, old_vector.as_ref())?;
         }
         Ok(is_deleted)
     }

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -180,7 +180,6 @@ impl VectorStorage for SimpleSparseVectorStorage {
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         let vector = self.get_vector_opt(key);
-        debug_assert!(vector.is_some());
         vector.unwrap_or_else(CowVector::default_sparse)
     }
 

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -7,7 +7,7 @@ use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
 use sparse::common::sparse_vector::SparseVector;
-use sparse::common::types::DimWeight;
+use sparse::common::types::{DimId, DimWeight};
 
 use super::SparseVectorStorage;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
@@ -170,7 +170,7 @@ impl VectorStorage for SimpleSparseVectorStorage {
         let available_fraction =
             (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
         let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
-        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<PointOffsetType>())
+        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -59,9 +59,9 @@ pub fn open_simple_sparse_vector_storage(
             bitvec_set_deleted(&mut deleted, point_id, true);
             deleted_count += 1;
         } else {
-            total_vector_count = total_vector_count.max(point_id as usize + 1);
             total_sparse_size += stored_record.vector.values.len();
         }
+        total_vector_count = total_vector_count.max(point_id as usize + 1);
 
         check_process_stopped(stopped)?;
     }

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -80,6 +80,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
             VectorStorageEnum::DenseAppendableMemmapByte(_) => unreachable!(),
             VectorStorageEnum::DenseAppendableMemmapHalf(_) => unreachable!(),
             VectorStorageEnum::SparseSimple(_) => unreachable!(),
+            VectorStorageEnum::SparseMmap(_) => unreachable!(),
             VectorStorageEnum::MultiDenseSimple(v) => {
                 for (orig, vec) in orig_iter.zip(v.iterate_inner_vectors()) {
                     assert_eq!(orig, vec);

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -10,6 +11,7 @@ use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
+use crate::vector_storage::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use crate::vector_storage::query::RecoQuery;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
@@ -197,6 +199,65 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
     );
 }
 
+fn do_test_persistance(open: impl Fn(&Path) -> VectorStorageEnum) {
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let mut storage = open(dir.path());
+
+    let points = vec![
+        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)],
+        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)],
+        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)],
+        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)],
+        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)],
+    ]
+    .into_iter()
+    .map(|v| v.try_into().unwrap())
+    .collect::<Vec<SparseVector>>();
+
+    points.iter().enumerate().for_each(|(i, vec)| {
+        storage
+            .insert_vector(i as PointOffsetType, vec.into())
+            .unwrap();
+    });
+
+    // Delete selective vectors
+    storage.delete_vector(1).unwrap();
+    storage.delete_vector(3).unwrap();
+    storage.flusher()().unwrap();
+
+    let deleted_vector_count = storage.deleted_vector_count();
+    let available_vector_count = storage.available_vector_count();
+    let size_of_available_vectors_in_bytes = storage.size_of_available_vectors_in_bytes();
+
+    drop(storage);
+
+    // Re-open storage and verify state
+    let storage = open(dir.path());
+
+    // Check deleted vectors are still marked as deleted
+    assert!(storage.is_deleted_vector(1));
+    assert!(storage.get_vector_opt(1).is_none());
+
+    assert!(storage.is_deleted_vector(3));
+    assert!(storage.get_vector_opt(3).is_none());
+
+    // Check non-deleted vectors still have correct data
+    let verify_idx = [0, 2, 4];
+    for idx in verify_idx {
+        let stored = storage.get_vector(idx);
+        let sparse: &SparseVector = stored.as_vec_ref().try_into().unwrap();
+        assert_eq!(sparse, &points[idx as usize]);
+    }
+    assert_eq!(storage.deleted_vector_count(), 2);
+
+    assert_eq!(storage.deleted_vector_count(), deleted_vector_count);
+    assert_eq!(storage.available_vector_count(), available_vector_count);
+    assert_eq!(
+        storage.size_of_available_vectors_in_bytes(),
+        size_of_available_vectors_in_bytes
+    );
+}
+
 #[test]
 fn test_delete_points_in_simple_sparse_vector_storage() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
@@ -214,6 +275,20 @@ fn test_delete_points_in_simple_sparse_vector_storage() {
 }
 
 #[test]
+fn test_delete_points_in_mmap_sparse_vector_storage() {
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let mut storage =
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
+    do_test_delete_points(&mut storage);
+
+    storage.flusher()().unwrap();
+
+    drop(storage);
+
+    let _storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+}
+
+#[test]
 fn test_update_from_delete_points_simple_sparse_vector_storage() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
@@ -227,4 +302,35 @@ fn test_update_from_delete_points_simple_sparse_vector_storage() {
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
     let _storage =
         open_simple_sparse_vector_storage(db, DB_VECTOR_CF, &AtomicBool::new(false)).unwrap();
+}
+
+#[test]
+fn test_update_from_delete_points_mmap_sparse_vector_storage() {
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+
+    let mut storage =
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
+
+    do_test_update_from_delete_points(&mut storage);
+    storage.flusher()().unwrap();
+
+    drop(storage);
+
+    let mut _storage =
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
+}
+
+#[test]
+fn test_persistance_in_mmap_sparse_vector_storage() {
+    do_test_persistance(|path| {
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(path).unwrap())
+    });
+}
+
+#[test]
+fn test_persistance_in_simple_sparse_vector_storage() {
+    do_test_persistance(|path| {
+        let db = open_db(path, &[DB_VECTOR_CF]).unwrap();
+        open_simple_sparse_vector_storage(db, DB_VECTOR_CF, &AtomicBool::new(false)).unwrap()
+    });
 }

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -277,15 +277,17 @@ fn test_delete_points_in_simple_sparse_vector_storage() {
 #[test]
 fn test_delete_points_in_mmap_sparse_vector_storage() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
-    let mut storage =
-        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
+    let mut storage = VectorStorageEnum::SparseMmap(
+        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap(),
+    );
     do_test_delete_points(&mut storage);
 
     storage.flusher()().unwrap();
 
     drop(storage);
 
-    let _storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+    let _storage =
+        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap();
 }
 
 #[test]
@@ -308,22 +310,26 @@ fn test_update_from_delete_points_simple_sparse_vector_storage() {
 fn test_update_from_delete_points_mmap_sparse_vector_storage() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
-    let mut storage =
-        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
+    let mut storage = VectorStorageEnum::SparseMmap(
+        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap(),
+    );
 
     do_test_update_from_delete_points(&mut storage);
     storage.flusher()().unwrap();
 
     drop(storage);
 
-    let mut _storage =
-        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
+    let mut _storage = VectorStorageEnum::SparseMmap(
+        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap(),
+    );
 }
 
 #[test]
 fn test_persistance_in_mmap_sparse_vector_storage() {
     do_test_persistance(|path| {
-        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(path).unwrap())
+        VectorStorageEnum::SparseMmap(
+            MmapSparseVectorStorage::open_or_create(path, &Default::default()).unwrap(),
+        )
     });
 }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -8,6 +8,7 @@ use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::memmap_dense_vector_storage::MemmapDenseVectorStorage;
 use super::dense::simple_dense_vector_storage::SimpleDenseVectorStorage;
+use super::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use super::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, MultivectorMmapOffset,
 };
@@ -193,6 +194,7 @@ pub enum VectorStorageEnum {
         >,
     ),
     SparseSimple(SimpleSparseVectorStorage),
+    SparseMmap(MmapSparseVectorStorage),
     MultiDenseSimple(SimpleMultiDenseVectorStorage<VectorElementType>),
     MultiDenseSimpleByte(SimpleMultiDenseVectorStorage<VectorElementTypeByte>),
     MultiDenseSimpleHalf(SimpleMultiDenseVectorStorage<VectorElementTypeHalf>),
@@ -268,6 +270,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(_) => None,
             VectorStorageEnum::DenseAppendableInRamHalf(_) => None,
             VectorStorageEnum::SparseSimple(_) => None,
+            VectorStorageEnum::SparseMmap(_) => None,
             VectorStorageEnum::MultiDenseSimple(s) => Some(s.multi_vector_config()),
             VectorStorageEnum::MultiDenseSimpleByte(s) => Some(s.multi_vector_config()),
             VectorStorageEnum::MultiDenseSimpleHalf(s) => Some(s.multi_vector_config()),
@@ -315,6 +318,7 @@ impl VectorStorageEnum {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
             VectorStorageEnum::SparseSimple(_) => VectorInternal::from(SparseVector::default()),
+            VectorStorageEnum::SparseMmap(_) => VectorInternal::from(SparseVector::default()),
             VectorStorageEnum::MultiDenseSimple(v) => {
                 VectorInternal::from(MultiDenseVectorInternal::placeholder(v.vector_dim()))
             }
@@ -362,6 +366,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.distance(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.distance(),
             VectorStorageEnum::SparseSimple(v) => v.distance(),
+            VectorStorageEnum::SparseMmap(v) => v.distance(),
             VectorStorageEnum::MultiDenseSimple(v) => v.distance(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.distance(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.distance(),
@@ -389,6 +394,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.datatype(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.datatype(),
             VectorStorageEnum::SparseSimple(v) => v.datatype(),
+            VectorStorageEnum::SparseMmap(v) => v.datatype(),
             VectorStorageEnum::MultiDenseSimple(v) => v.datatype(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.datatype(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.datatype(),
@@ -416,6 +422,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.is_on_disk(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.is_on_disk(),
             VectorStorageEnum::SparseSimple(v) => v.is_on_disk(),
+            VectorStorageEnum::SparseMmap(v) => v.is_on_disk(),
             VectorStorageEnum::MultiDenseSimple(v) => v.is_on_disk(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_on_disk(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.is_on_disk(),
@@ -443,6 +450,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.total_vector_count(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.total_vector_count(),
             VectorStorageEnum::SparseSimple(v) => v.total_vector_count(),
+            VectorStorageEnum::SparseMmap(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseSimple(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.total_vector_count(),
@@ -478,6 +486,7 @@ impl VectorStorage for VectorStorageEnum {
                 v.size_of_available_vectors_in_bytes()
             }
             VectorStorageEnum::SparseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::SparseMmap(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::MultiDenseSimple(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
@@ -517,6 +526,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.get_vector(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.get_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.get_vector(key),
+            VectorStorageEnum::SparseMmap(v) => v.get_vector(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector(key),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector(key),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector(key),
@@ -544,6 +554,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.get_vector_opt(key),
             VectorStorageEnum::SparseSimple(v) => v.get_vector_opt(key),
+            VectorStorageEnum::SparseMmap(v) => v.get_vector_opt(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector_opt(key),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector_opt(key),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector_opt(key),
@@ -571,6 +582,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.insert_vector(key, vector),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.insert_vector(key, vector),
             VectorStorageEnum::SparseSimple(v) => v.insert_vector(key, vector),
+            VectorStorageEnum::SparseMmap(v) => v.insert_vector(key, vector),
             VectorStorageEnum::MultiDenseSimple(v) => v.insert_vector(key, vector),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.insert_vector(key, vector),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.insert_vector(key, vector),
@@ -602,6 +614,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.update_from(other_ids, stopped),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.update_from(other_ids, stopped),
             VectorStorageEnum::SparseSimple(v) => v.update_from(other_ids, stopped),
+            VectorStorageEnum::SparseMmap(v) => v.update_from(other_ids, stopped),
             VectorStorageEnum::MultiDenseSimple(v) => v.update_from(other_ids, stopped),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.update_from(other_ids, stopped),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.update_from(other_ids, stopped),
@@ -637,6 +650,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.flusher(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.flusher(),
             VectorStorageEnum::SparseSimple(v) => v.flusher(),
+            VectorStorageEnum::SparseMmap(v) => v.flusher(),
             VectorStorageEnum::MultiDenseSimple(v) => v.flusher(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.flusher(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.flusher(),
@@ -664,6 +678,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.files(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.files(),
             VectorStorageEnum::SparseSimple(v) => v.files(),
+            VectorStorageEnum::SparseMmap(v) => v.files(),
             VectorStorageEnum::MultiDenseSimple(v) => v.files(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.files(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.files(),
@@ -691,6 +706,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.delete_vector(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.delete_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.delete_vector(key),
+            VectorStorageEnum::SparseMmap(v) => v.delete_vector(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.delete_vector(key),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.delete_vector(key),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.delete_vector(key),
@@ -718,6 +734,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.is_deleted_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::SparseMmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.is_deleted_vector(key),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.is_deleted_vector(key),
@@ -745,6 +762,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.deleted_vector_count(),
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_count(),
+            VectorStorageEnum::SparseMmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_count(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.deleted_vector_count(),
@@ -772,6 +790,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::SparseMmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.deleted_vector_bitslice(),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -65,7 +65,7 @@ pub trait VectorStorage {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>>;
 

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -9,7 +9,8 @@ use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
-    Distance, Indexes, SegmentConfig, SparseVectorDataConfig, VectorDataConfig, VectorStorageType,
+    Distance, Indexes, SegmentConfig, SparseVectorDataConfig, SparseVectorStorageType,
+    VectorDataConfig, VectorStorageType,
 };
 use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
@@ -253,6 +254,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
                 "sparse".to_owned(),
                 SparseVectorDataConfig {
                     index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
+                    storage_type: SparseVectorStorageType::default(),
                 },
             )]),
             payload_storage_type: Default::default(),
@@ -337,6 +339,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
                 "sparse".to_owned(),
                 SparseVectorDataConfig {
                     index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
+                    storage_type: SparseVectorStorageType::default(),
                 },
             )]),
             payload_storage_type: Default::default(),

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -16,8 +16,8 @@ use segment::index::VectorIndex;
 use segment::segment_constructor::{build_segment, create_sparse_vector_index_test};
 use segment::types::{
     Condition, Distance, ExtendedPointId, Filter, HasIdCondition, Indexes, PointIdType,
-    SegmentConfig, SeqNumberType, SparseVectorDataConfig, VectorDataConfig, VectorStorageDatatype,
-    VectorStorageType, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
+    SegmentConfig, SeqNumberType, SparseVectorDataConfig, SparseVectorStorageType,
+    VectorDataConfig, VectorStorageDatatype, VectorStorageType, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use sparse::common::sparse_vector::SparseVector;
@@ -123,6 +123,7 @@ fn sparse_index_discover_test() {
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),
                 },
+                storage_type: SparseVectorStorageType::default(),
             },
         )]),
         payload_storage_type: Default::default(),
@@ -269,6 +270,7 @@ fn sparse_index_hardware_measurement_test() {
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),
                 },
+                storage_type: SparseVectorStorageType::default(),
             },
         )]),
         payload_storage_type: Default::default(),

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -27,7 +27,8 @@ use segment::types::PayloadFieldSchema::FieldType;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
     Condition, FieldCondition, Filter, Payload, ScoredPoint, SegmentConfig, SeqNumberType,
-    SparseVectorDataConfig, VectorStorageDatatype, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
+    SparseVectorDataConfig, SparseVectorStorageType, VectorStorageDatatype,
+    DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
 use segment::vector_storage::VectorStorage;
 use serde_json::json;
@@ -579,6 +580,7 @@ fn sparse_vector_index_persistence_test() {
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),
                 },
+                storage_type: SparseVectorStorageType::default(),
             },
         )]),
         payload_storage_type: Default::default(),
@@ -747,6 +749,7 @@ fn sparse_vector_test_large_index() {
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),
                 },
+                storage_type: SparseVectorStorageType::OnDisk,
             },
         )]),
         payload_storage_type: Default::default(),

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -16,6 +16,8 @@ testing = []
 
 [dependencies]
 bitpacking = "0.9.2"
+blob_store = { git = "https://github.com/qdrant/mmap-payload-storage", rev = "75a9f44bfd5bac60b8baf4d4ad7e6194abedef80" }
+bincode = "1.3"
 common = { path = "../common/common" }
 half = { workspace = true }
 io = { path = "../common/io" }

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -16,7 +16,7 @@ testing = []
 
 [dependencies]
 bitpacking = "0.9.2"
-blob_store = { git = "https://github.com/qdrant/mmap-payload-storage", rev = "75a9f44bfd5bac60b8baf4d4ad7e6194abedef80" }
+blob_store = { path = "../blob_store" }
 bincode = "1.3"
 common = { path = "../common/common" }
 half = { workspace = true }

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::hash::Hash;
 
+use blob_store::Blob;
 use common::types::ScoreType;
 use itertools::Itertools;
 use schemars::JsonSchema;
@@ -233,6 +234,16 @@ impl TryFrom<Vec<(u32, f32)>> for SparseVector {
     fn try_from(tuples: Vec<(u32, f32)>) -> Result<Self, Self::Error> {
         let (indices, values): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
         SparseVector::new(indices, values)
+    }
+}
+
+impl Blob for SparseVector {
+    fn to_bytes(&self) -> Vec<u8> {
+        bincode::serialize(&self).expect("Sparse vector serialization should not fail")
+    }
+
+    fn from_bytes(data: &[u8]) -> Self {
+        bincode::deserialize(data).expect("Sparse vector deserialization should not fail")
     }
 }
 

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -140,6 +140,7 @@ impl TableOfContent {
             sharding_method,
             on_disk_payload: on_disk_payload.unwrap_or(self.storage_config.on_disk_payload),
             on_disk_payload_uses_mmap: self.storage_config.on_disk_payload_uses_mmap,
+            on_disk_sparse_vectors_uses_mmap: self.storage_config.on_disk_sparse_vectors_uses_mmap,
             replication_factor: NonZeroU32::new(replication_factor).ok_or_else(|| {
                 StorageError::BadInput {
                     description: "`replication_factor` cannot be 0".to_string(),

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -69,6 +69,9 @@ pub struct StorageConfig {
     // TODO: remove this field after integration is finished
     #[serde(default)]
     pub on_disk_payload_uses_mmap: bool,
+    // TODO: remove this field after integration is finished
+    #[serde(default)]
+    pub on_disk_sparse_vectors_uses_mmap: bool,
     #[validate(nested)]
     pub optimizers: OptimizersConfig,
     #[validate(nested)]

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -38,6 +38,7 @@ fn test_alias_operation() {
         temp_path: None,
         on_disk_payload: false,
         on_disk_payload_uses_mmap: false,
+        on_disk_sparse_vectors_uses_mmap: false,
         optimizers: OptimizersConfig {
             deleted_threshold: 0.5,
             vacuum_min_vector_number: 100,

--- a/tests/storage-compat/gen_storage_compat_data.sh
+++ b/tests/storage-compat/gen_storage_compat_data.sh
@@ -91,4 +91,4 @@ tar -cvf "./compatibility-${QDRANT_VERSION}.tar" "storage.tar.bz2" "full-snapsho
 cd -
 
 echo "Compatibility data saved to ${SCRIPT_DIR}/compatibility-${QDRANT_VERSION}.tar"
-echo "Upload it to "qdrant-backward-compatibility" gcs bucket (requires access rights)"
+echo "Upload it to 'qdrant-backward-compatibility' gcs bucket (requires access rights)"

--- a/tests/storage-compat/populate_db.py
+++ b/tests/storage-compat/populate_db.py
@@ -3,7 +3,7 @@
 import os
 import random
 import uuid
-from typing import List
+from typing import List, Optional
 
 import requests
 
@@ -18,7 +18,7 @@ def drop_collection(name: str):
     requests.delete(f"http://{QDRANT_HOST}/collections/{name}")
 
 
-def create_collection(name: str, memmap_threshold_kb: int, on_disk: bool, quantization_config: dict = None):
+def create_collection(name: str, memmap_threshold_kb: int, on_disk: bool, quantization_config: Optional[dict] = None):
     # create collection with a lower `indexing_threshold_kb` to generate the HNSW index
     response = requests.put(
         f"http://{QDRANT_HOST}/collections/{name}",
@@ -260,7 +260,7 @@ def basic_retrieve(name: str):
 # There are two ways to configure the usage of memmap storage:
 # - `memmap_threshold_kb` - the threshold for the indexer to use memmap storage
 # - `on_disk` - to store vectors immediately on disk
-def populate_collection(name: str, on_disk: bool, quantization_config: dict = None, memmap_threshold: bool = False, on_disk_payload_index: bool = False):
+def populate_collection(name: str, on_disk: bool, quantization_config: Optional[dict] = None, memmap_threshold: bool = False, on_disk_payload_index: bool = False):
     drop_collection(name)
     memmap_threshold_kb = 0
     if memmap_threshold:
@@ -276,10 +276,10 @@ if __name__ == "__main__":
     populate_collection("test_collection_vector_memory", on_disk=False)
     populate_collection("test_collection_vector_on_disk", on_disk=True)
     populate_collection("test_collection_vector_on_disk_threshold", on_disk=False, memmap_threshold=True)
-    populate_collection("test_collection_scalar_int8", False, {"scalar": {"type": "int8"}})
-    populate_collection("test_collection_product_x64", False, {"product": {"compression": "x64"}})
-    populate_collection("test_collection_product_x32", False, {"product": {"compression": "x32"}})
-    populate_collection("test_collection_product_x16", False, {"product": {"compression": "x16"}})
-    populate_collection("test_collection_product_x8", False, {"product": {"compression": "x8"}})
-    populate_collection("test_collection_binary", False, {"binary": {"always_ram": True}})
+    populate_collection("test_collection_scalar_int8", on_disk=False, quantization_config={"scalar": {"type": "int8"}})
+    populate_collection("test_collection_product_x64", on_disk=False, quantization_config={"product": {"compression": "x64"}})
+    populate_collection("test_collection_product_x32", on_disk=False, quantization_config={"product": {"compression": "x32"}})
+    populate_collection("test_collection_product_x16", on_disk=False, quantization_config={"product": {"compression": "x16"}})
+    populate_collection("test_collection_product_x8", on_disk=False, quantization_config={"product": {"compression": "x8"}})
+    populate_collection("test_collection_binary", on_disk=False, quantization_config={"binary": {"always_ram": True}})
     populate_collection("test_collection_mmap_field_index", on_disk=True, on_disk_payload_index=True)

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -123,3 +123,6 @@ test_version $PREV_PATCH_QDRANT_VERSION
 
 # Test previous minor version
 test_version $PREV_MINOR_QDRANT_VERSION
+
+# Test that it can read both rocksdb and blob_store
+test_version 'v1.12.4-rocksdb+blob_store'


### PR DESCRIPTION
Adds the infrastructure to integrate `blob_store` as a new mmap storage for sparse vectors. 

This PR does not yet create segments with this storage, but should be able to read it.

There are some additional changes to the `simple` storage, specifically:
- better calculation for `total_sparse_vector_size`:
  - when deleting, the old vector gets subtracted before adding the new vector size 
- deleted vectors are considered `None` when reading the storage

Edits for `blob_store`:
- Setting a trailing point id to a `None` value (deleting a point above the range of the storage) now updates the `next_pointer_offset`
- new `for_each_unfiltered` function which iterates through the ALL the storage with a callback, including deleted points
- new `open_or_create` function which does a better check to choose between opening or creating a storage

### TODO
- [x] test implementation
- [x] hidden setting to enable mmap sparse vector storage
- [x] read segment config for mmap
  - [x] fix reading old config
- [x] compatibility test