### PR TITLE
Fix clippy large variant for filter condition

### DIFF
--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -314,7 +314,7 @@ impl PayloadFieldIndex for BinaryIndex {
                 };
 
                 let estimation = CardinalityEstimation::exact(count)
-                    .with_primary_clause(PrimaryCondition::Condition(condition.clone()));
+                    .with_primary_clause(PrimaryCondition::Condition(Box::new(condition.clone())));
 
                 Some(estimation)
             }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -103,7 +103,7 @@ pub trait InvertedIndex {
         if posting_lengths.is_none() || points_count == 0 {
             // There are unseen tokens -> no matches
             return CardinalityEstimation {
-                primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+                primary_clauses: vec![PrimaryCondition::Condition(Box::new(condition.clone()))],
                 min: 0,
                 exp: 0,
                 max: 0,
@@ -113,7 +113,7 @@ pub trait InvertedIndex {
         if postings.is_empty() {
             // Empty request -> no matches
             return CardinalityEstimation {
-                primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+                primary_clauses: vec![PrimaryCondition::Condition(Box::new(condition.clone()))],
                 min: 0,
                 exp: 0,
                 max: 0,
@@ -122,9 +122,9 @@ pub trait InvertedIndex {
         // Smallest posting is the largest possible cardinality
         let smallest_posting = postings.iter().min().copied().unwrap();
 
-        return if postings.len() == 1 {
+        if postings.len() == 1 {
             CardinalityEstimation {
-                primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+                primary_clauses: vec![PrimaryCondition::Condition(Box::new(condition.clone()))],
                 min: smallest_posting,
                 exp: smallest_posting,
                 max: smallest_posting,
@@ -136,12 +136,12 @@ pub trait InvertedIndex {
                 .product();
             let exp = (expected_frac * points_count as f64) as usize;
             CardinalityEstimation {
-                primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+                primary_clauses: vec![PrimaryCondition::Condition(Box::new(condition.clone()))],
                 min: 0, // ToDo: make better estimation
                 exp,
                 max: smallest_posting,
             }
-        };
+        }
     }
 
     fn vocab_with_postings_len_iter(&self) -> impl Iterator<Item = (&str, usize)> + '_;

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -530,7 +530,7 @@ impl PayloadFieldIndex for GeoMapIndex {
             let mut estimation = self.match_cardinality(&geo_hashes);
             estimation
                 .primary_clauses
-                .push(PrimaryCondition::Condition(condition.clone()));
+                .push(PrimaryCondition::Condition(Box::new(condition.clone())));
             return Some(estimation);
         }
 
@@ -539,7 +539,7 @@ impl PayloadFieldIndex for GeoMapIndex {
             let mut estimation = self.match_cardinality(&geo_hashes);
             estimation
                 .primary_clauses
-                .push(PrimaryCondition::Condition(condition.clone()));
+                .push(PrimaryCondition::Condition(Box::new(condition.clone())));
             return Some(estimation);
         }
 
@@ -565,7 +565,7 @@ impl PayloadFieldIndex for GeoMapIndex {
 
             exterior_estimation
                 .primary_clauses
-                .push(PrimaryCondition::Condition(condition.clone()));
+                .push(PrimaryCondition::Condition(Box::new(condition.clone())));
             return Some(exterior_estimation);
         }
 

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -551,7 +551,7 @@ impl PayloadFieldIndex for MapIndex<str> {
                     let mut estimation = self.match_cardinality(keyword.as_str());
                     estimation
                         .primary_clauses
-                        .push(PrimaryCondition::Condition(condition.clone()));
+                        .push(PrimaryCondition::Condition(Box::new(condition.clone())));
                     Some(estimation)
                 }
                 ValueVariants::Integer(_) => None,
@@ -569,38 +569,35 @@ impl PayloadFieldIndex for MapIndex<str> {
                         combine_should_estimations(&estimations, self.get_indexed_points())
                     };
                     Some(
-                        estimation
-                            .with_primary_clause(PrimaryCondition::Condition(condition.clone())),
+                        estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
+                            condition.clone(),
+                        ))),
                     )
                 }
                 AnyVariants::Integers(integers) => {
                     if integers.is_empty() {
-                        Some(
-                            CardinalityEstimation::exact(0).with_primary_clause(
-                                PrimaryCondition::Condition(condition.clone()),
-                            ),
-                        )
+                        Some(CardinalityEstimation::exact(0).with_primary_clause(
+                            PrimaryCondition::Condition(Box::new(condition.clone())),
+                        ))
                     } else {
                         None
                     }
                 }
             },
-            Some(Match::Except(MatchExcept { except })) => {
-                match except {
-                    AnyVariants::Strings(keywords) => {
-                        Some(self.except_cardinality(keywords.iter().map(|k| k.as_str())))
-                    }
-                    AnyVariants::Integers(others) => {
-                        if others.is_empty() {
-                            Some(CardinalityEstimation::exact(0).with_primary_clause(
-                                PrimaryCondition::Condition(condition.clone()),
-                            ))
-                        } else {
-                            None
-                        }
+            Some(Match::Except(MatchExcept { except })) => match except {
+                AnyVariants::Strings(keywords) => {
+                    Some(self.except_cardinality(keywords.iter().map(|k| k.as_str())))
+                }
+                AnyVariants::Integers(others) => {
+                    if others.is_empty() {
+                        Some(CardinalityEstimation::exact(0).with_primary_clause(
+                            PrimaryCondition::Condition(Box::new(condition.clone())),
+                        ))
+                    } else {
+                        None
                     }
                 }
-            }
+            },
             _ => None,
         }
     }
@@ -715,7 +712,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
                     let mut estimation = self.match_cardinality(&uuid.as_u128());
                     estimation
                         .primary_clauses
-                        .push(PrimaryCondition::Condition(condition.clone()));
+                        .push(PrimaryCondition::Condition(Box::new(condition.clone())));
                     Some(estimation)
                 }
                 ValueVariants::Integer(_) => None,
@@ -740,45 +737,42 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
                         combine_should_estimations(&estimations, self.get_indexed_points())
                     };
                     Some(
-                        estimation
-                            .with_primary_clause(PrimaryCondition::Condition(condition.clone())),
+                        estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
+                            condition.clone(),
+                        ))),
                     )
                 }
                 AnyVariants::Integers(integers) => {
                     if integers.is_empty() {
-                        Some(
-                            CardinalityEstimation::exact(0).with_primary_clause(
-                                PrimaryCondition::Condition(condition.clone()),
-                            ),
-                        )
+                        Some(CardinalityEstimation::exact(0).with_primary_clause(
+                            PrimaryCondition::Condition(Box::new(condition.clone())),
+                        ))
                     } else {
                         None
                     }
                 }
             },
-            Some(Match::Except(MatchExcept { except })) => {
-                match except {
-                    AnyVariants::Strings(uuids_string) => {
-                        let uuids: Result<IndexSet<u128>, _> = uuids_string
-                            .iter()
-                            .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
-                            .collect();
+            Some(Match::Except(MatchExcept { except })) => match except {
+                AnyVariants::Strings(uuids_string) => {
+                    let uuids: Result<IndexSet<u128>, _> = uuids_string
+                        .iter()
+                        .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
+                        .collect();
 
-                        let excluded_uuids = uuids.ok()?;
+                    let excluded_uuids = uuids.ok()?;
 
-                        Some(self.except_cardinality(excluded_uuids.iter()))
-                    }
-                    AnyVariants::Integers(other) => {
-                        if other.is_empty() {
-                            Some(CardinalityEstimation::exact(0).with_primary_clause(
-                                PrimaryCondition::Condition(condition.clone()),
-                            ))
-                        } else {
-                            None
-                        }
+                    Some(self.except_cardinality(excluded_uuids.iter()))
+                }
+                AnyVariants::Integers(other) => {
+                    if other.is_empty() {
+                        Some(CardinalityEstimation::exact(0).with_primary_clause(
+                            PrimaryCondition::Condition(Box::new(condition.clone())),
+                        ))
+                    } else {
+                        None
                     }
                 }
-            }
+            },
             _ => None,
         }
     }
@@ -873,7 +867,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                     let mut estimation = self.match_cardinality(integer);
                     estimation
                         .primary_clauses
-                        .push(PrimaryCondition::Condition(condition.clone()));
+                        .push(PrimaryCondition::Condition(Box::new(condition.clone())));
                     Some(estimation)
                 }
                 ValueVariants::Bool(_) => None,
@@ -881,11 +875,9 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
             Some(Match::Any(MatchAny { any: any_variants })) => match any_variants {
                 AnyVariants::Strings(keywords) => {
                     if keywords.is_empty() {
-                        Some(
-                            CardinalityEstimation::exact(0).with_primary_clause(
-                                PrimaryCondition::Condition(condition.clone()),
-                            ),
-                        )
+                        Some(CardinalityEstimation::exact(0).with_primary_clause(
+                            PrimaryCondition::Condition(Box::new(condition.clone())),
+                        ))
                     } else {
                         None
                     }
@@ -901,19 +893,18 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                         combine_should_estimations(&estimations, self.get_indexed_points())
                     };
                     Some(
-                        estimation
-                            .with_primary_clause(PrimaryCondition::Condition(condition.clone())),
+                        estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
+                            condition.clone(),
+                        ))),
                     )
                 }
             },
             Some(Match::Except(MatchExcept { except })) => match except {
                 AnyVariants::Strings(others) => {
                     if others.is_empty() {
-                        Some(
-                            CardinalityEstimation::exact(0).with_primary_clause(
-                                PrimaryCondition::Condition(condition.clone()),
-                            ),
-                        )
+                        Some(CardinalityEstimation::exact(0).with_primary_clause(
+                            PrimaryCondition::Condition(Box::new(condition.clone())),
+                        ))
                     } else {
                         None
                     }

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -25,9 +25,8 @@ mod utils;
 pub use field_index_base::*;
 
 #[derive(Debug, Clone, PartialEq)]
-#[allow(clippy::large_enum_variant)]
 pub enum PrimaryCondition {
-    Condition(FieldCondition),
+    Condition(Box<FieldCondition>),
     IsEmpty(IsEmptyCondition),
     IsNull(IsNullCondition),
     Ids(HashSet<PointOffsetType>),

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -679,8 +679,9 @@ impl<T: Encodable + Numericable + MmapValue + Default> PayloadFieldIndex for Num
 
                 let estimated_count = self.estimate_points(&key);
                 return Some(
-                    CardinalityEstimation::exact(estimated_count)
-                        .with_primary_clause(PrimaryCondition::Condition(condition.clone())),
+                    CardinalityEstimation::exact(estimated_count).with_primary_clause(
+                        PrimaryCondition::Condition(Box::new(condition.clone())),
+                    ),
                 );
             }
         }
@@ -689,7 +690,7 @@ impl<T: Encodable + Numericable + MmapValue + Default> PayloadFieldIndex for Num
             let mut cardinality = self.range_cardinality(range);
             cardinality
                 .primary_clauses
-                .push(PrimaryCondition::Condition(condition.clone()));
+                .push(PrimaryCondition::Condition(Box::new(condition.clone())));
             cardinality
         })
     }

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -294,19 +294,19 @@ mod tests {
             Condition::CustomIdChecker(_) => panic!("unexpected CustomIdChecker"),
             Condition::Field(field) => match field.key.to_string().as_str() {
                 "color" => CardinalityEstimation {
-                    primary_clauses: vec![PrimaryCondition::Condition(field.clone())],
+                    primary_clauses: vec![PrimaryCondition::Condition(Box::new(field.clone()))],
                     min: 100,
                     exp: 200,
                     max: 300,
                 },
                 "size" => CardinalityEstimation {
-                    primary_clauses: vec![PrimaryCondition::Condition(field.clone())],
+                    primary_clauses: vec![PrimaryCondition::Condition(Box::new(field.clone()))],
                     min: 100,
                     exp: 100,
                     max: 100,
                 },
                 "price" => CardinalityEstimation {
-                    primary_clauses: vec![PrimaryCondition::Condition(field.clone())],
+                    primary_clauses: vec![PrimaryCondition::Condition(Box::new(field.clone()))],
                     min: 10,
                     exp: 15,
                     max: 20,

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -683,7 +683,7 @@ fn test_root_nested_array_filter_cardinality_estimation() {
 
     match primary_clause {
         PrimaryCondition::Condition(field_condition) => {
-            assert_eq!(field_condition, &expected_primary_clause);
+            assert_eq!(*field_condition, Box::new(expected_primary_clause));
         }
         o => panic!("unexpected primary clause: {o:?}"),
     }
@@ -746,7 +746,7 @@ fn test_nesting_nested_array_filter_cardinality_estimation() {
 
     match primary_clause {
         PrimaryCondition::Condition(field_condition) => {
-            assert_eq!(field_condition, &expected_primary_clause);
+            assert_eq!(*field_condition, Box::new(expected_primary_clause));
         }
         o => panic!("unexpected primary clause: {o:?}"),
     }
@@ -1150,7 +1150,7 @@ fn test_any_matcher_cardinality_estimation() {
 
         match clause {
             PrimaryCondition::Condition(field_condition) => {
-                assert_eq!(field_condition, &expected_primary_clause);
+                assert_eq!(*field_condition, Box::new(expected_primary_clause));
             }
             o => panic!("unexpected primary clause: {o:?}"),
         }


### PR DESCRIPTION
We are using too much memory to represent non `FieldCondition` variant.

https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant

```console
error: large size difference between variants
  --> lib/segment/src/index/field_index/mod.rs:28:1
   |
28 | / pub enum PrimaryCondition {
29 | |     Condition(FieldCondition),
   | |     ------------------------- the largest variant contains at least 368 bytes
30 | |     IsEmpty(IsEmptyCondition),
   | |     ------------------------- the second-largest variant contains at least 48 bytes
31 | |     IsNull(IsNullCondition),
32 | |     Ids(HashSet<PointOffsetType>),
33 | |     HasVector(String),
34 | | }
   | |_^ the entire enum is at least 368 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
help: consider boxing the large fields to reduce the total size of the enum
   |
29 |     Condition(Box<FieldCondition>),
   |               ~~~~~~~~~~~~~~~~~~~
```

I believe the `FieldCondition`variant  is used more often but the other variants are not insignificant. 