### PR TITLE
Fixes for rescoring param usage and HNSW

### DIFF
--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use segment::data_types::vectors::{
     DenseVector, Named, NamedQuery, NamedVectorStruct, VectorInternal,
 };

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1,7 +1,7 @@
 use std::backtrace::Backtrace;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error as _;
-use std::fmt::Write as _;
+use std::fmt::{Debug, Write as _};
 use std::iter;
 use std::num::NonZeroU64;
 use std::time::SystemTimeError;

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -1,7 +1,7 @@
 //! Types used within `LocalShard` to represent a planned `ShardQueryRequest`
 
 use common::types::ScoreType;
-use segment::types::{Filter, WithPayloadInterface, WithVector};
+use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
 
 use super::shard_query::{SampleInternal, ScoringQuery, ShardPrefetch, ShardQueryRequest};
 use crate::operations::types::{
@@ -44,6 +44,9 @@ pub struct RescoreParams {
 
     /// The payload to return
     pub with_payload: WithPayloadInterface,
+
+    /// Parameters for the rescore search request
+    pub params: Option<SearchParams>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -138,6 +141,7 @@ impl PlannedQuery {
                         score_threshold,
                         with_vector,
                         with_payload,
+                        params,
                     }),
                 }
             }
@@ -281,6 +285,7 @@ fn recurse_prefetches(
                     score_threshold,
                     with_vector: with_vector.clone(),
                     with_payload: with_payload.clone(),
+                    params,
                 }),
             };
 
@@ -441,7 +446,10 @@ mod tests {
             score_threshold: None,
             limit: 10,
             offset: 0,
-            params: None,
+            params: Some(SearchParams {
+                exact: true,
+                ..Default::default()
+            }),
             with_vector: WithVector::Bool(true),
             with_payload: WithPayloadInterface::Bool(true),
         };
@@ -485,6 +493,7 @@ mod tests {
                         score_threshold: None,
                         with_vector: WithVector::Bool(false),
                         with_payload: WithPayloadInterface::Bool(false),
+                        params: None,
                     })
                 })],
                 rescore_params: Some(RescoreParams {
@@ -500,6 +509,10 @@ mod tests {
                     score_threshold: None,
                     with_vector: WithVector::Bool(true),
                     with_payload: WithPayloadInterface::Bool(true),
+                    params: Some(SearchParams {
+                        exact: true,
+                        ..Default::default()
+                    })
                 })
             }]
         );
@@ -966,6 +979,7 @@ mod tests {
                                 score_threshold: None,
                                 with_vector: WithVector::Bool(true),
                                 with_payload: WithPayloadInterface::Bool(true),
+                                params: None,
                             }),
                         }),
                         Source::ScrollsIdx(1),

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -58,7 +58,7 @@ pub enum Source {
     ScrollsIdx(usize),
 
     /// A nested prefetch
-    Prefetch(MergePlan),
+    Prefetch(Box<MergePlan>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -289,7 +289,7 @@ fn recurse_prefetches(
                 }),
             };
 
-            Source::Prefetch(merge_plan)
+            Source::Prefetch(Box::new(merge_plan))
         } else {
             // This is a leaf prefetch. Fetch this info from the segments
             match query {
@@ -480,7 +480,7 @@ mod tests {
         assert_eq!(
             planned_query.root_plans,
             vec![MergePlan {
-                sources: vec![Source::Prefetch(MergePlan {
+                sources: vec![Source::Prefetch(Box::from(MergePlan {
                     sources: vec![Source::SearchesIdx(0)],
                     rescore_params: Some(RescoreParams {
                         rescore: ScoringQuery::Vector(QueryEnum::Nearest(
@@ -495,7 +495,7 @@ mod tests {
                         with_payload: WithPayloadInterface::Bool(false),
                         params: None,
                     })
-                })],
+                }))],
                 rescore_params: Some(RescoreParams {
                     rescore: ScoringQuery::Vector(QueryEnum::Nearest(
                         NamedVectorStruct::new_from_vector(
@@ -971,7 +971,7 @@ mod tests {
                 },
                 MergePlan {
                     sources: vec![
-                        Source::Prefetch(MergePlan {
+                        Source::Prefetch(Box::from(MergePlan {
                             sources: vec![Source::SearchesIdx(1), Source::SearchesIdx(2),],
                             rescore_params: Some(RescoreParams {
                                 rescore: ScoringQuery::Fusion(FusionInternal::Rrf),
@@ -981,7 +981,7 @@ mod tests {
                                 with_payload: WithPayloadInterface::Bool(true),
                                 params: None,
                             }),
-                        }),
+                        })),
                         Source::ScrollsIdx(1),
                     ],
                     rescore_params: None,

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -232,6 +232,7 @@ impl LocalShard {
             limit,
             with_vector,
             with_payload,
+            params,
         } = rescore_params;
 
         match rescore {
@@ -281,14 +282,13 @@ impl LocalShard {
                 let search_request = CoreSearchRequest {
                     query: query_enum,
                     filter: Some(filter),
-                    params: None,
+                    params,
                     limit,
                     offset: 0,
                     with_payload: Some(with_payload),
                     with_vector: Some(with_vector),
                     score_threshold,
                 };
-
                 let rescoring_core_search_request = CoreSearchRequestBatch {
                     searches: vec![search_request],
                 };

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -177,7 +177,7 @@ impl LocalShard {
                     Source::Prefetch(prefetch) => {
                         let merged = self
                             .recurse_prefetch(
-                                prefetch,
+                                *prefetch,
                                 prefetch_holder,
                                 search_runtime_handle,
                                 timeout,


### PR DESCRIPTION
This PR contains 2 improvement, which when combined, make usage of the colpali models a bit less miserable.

1. Propagate search parameters to re-scoring search.

Previously, if we were using re-scoring (query + prefetch), the re-scoring request was used with empty param, assuming that since we had fixed list of elements to re-score, we would always do a full-scan. 
This is, however, not true for ColPali vectors, where only ~20 vectors overwhelm  full-scan threshold and force us to use HNSW (which is not efficient at this stage)

Additionally, empty parameter forced us to ignore quantization, while sometimes it might be useful. Now params from the query are fully propagated.

2. Detection if the HNSW is disabled. 

Since ColPali vectors are enormous, building HNSW for them barely makes sense. Comparing 2 multi-vectors require (1030 ** 2) vector comparisons. Instead full-size vectors should be used only for re-scoring. Therefore, HNSW should be disabled. We, however, previously ignored disabled HNSW and continued to search in HNSW graph even if it is not built.

This PR explicitly checks if HNSW is enabled and falls back to full scan (with quantization) if it is.

Those changes might be useful not only for colpali models.