### PR TITLE
Fix large variant for fulltext index

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -147,6 +147,6 @@ impl FieldIndexBuilderTrait for FullTextMmapIndexBuilder {
             config,
         };
 
-        Ok(FullTextIndex::Mmap(mmap_index))
+        Ok(FullTextIndex::Mmap(Box::new(mmap_index)))
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -25,11 +25,10 @@ use crate::index::field_index::{
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, PayloadKeyType};
 
-#[allow(clippy::large_enum_variant)]
 pub enum FullTextIndex {
     Mutable(MutableFullTextIndex),
     Immutable(ImmutableFullTextIndex),
-    Mmap(MmapFullTextIndex),
+    Mmap(Box<MmapFullTextIndex>),
 }
 
 impl FullTextIndex {
@@ -52,7 +51,7 @@ impl FullTextIndex {
     }
 
     pub fn new_mmap(path: PathBuf, config: TextIndexParams) -> OperationResult<Self> {
-        Ok(Self::Mmap(MmapFullTextIndex::open(path, config)?))
+        Ok(Self::Mmap(Box::new(MmapFullTextIndex::open(path, config)?)))
     }
 
     pub fn init(&mut self) -> OperationResult<()> {


### PR DESCRIPTION
I do not think we need to make an exception here for sizing the `FullTextIndex` enum.

```console
error: large size difference between variants
  --> lib/segment/src/index/field_index/full_text_index/text_index.rs:28:1
   |
28 | / pub enum FullTextIndex {
29 | |     Mutable(MutableFullTextIndex),
   | |     ----------------------------- the second-largest variant contains at least 0 bytes
30 | |     Immutable(ImmutableFullTextIndex),
31 | |     Mmap(MmapFullTextIndex),
   | |     ----------------------- the largest variant contains at least 352 bytes
32 | | }
   | |_^ the entire enum is at least 0 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
help: consider boxing the large fields to reduce the total size of the enum
   |
31 |     Mmap(Box<MmapFullTextIndex>),
   |          ~~~~~~~~~~~~~~~~~~~~~~
```