### PR TITLE
Fix large result size in consensus loop

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1080,7 +1080,7 @@ impl RaftMessageBroker {
                 );
             };
 
-            match sender.send(message) {
+            match sender.send(message).map_err(|err| *err) {
                 Ok(()) => (),
 
                 Err(tokio::sync::mpsc::error::TrySendError::Full((_, message))) => {
@@ -1136,14 +1136,15 @@ struct RaftMessageSenderHandle {
 }
 
 impl RaftMessageSenderHandle {
-    #[allow(clippy::result_large_err)]
-    pub fn send(&mut self, message: RaftMessage) -> RaftMessageSenderResult<()> {
+    fn send(&mut self, message: RaftMessage) -> RaftMessageSenderResult<()> {
         if !is_heartbeat(&message) {
-            self.messages.try_send((self.index, message))?;
+            self.messages
+                .try_send((self.index, message))
+                .map_err(|send_error| Box::new(send_error))?;
         } else {
             self.heartbeat.send((self.index, message)).map_err(
-                |tokio::sync::watch::error::SendError(message)| {
-                    tokio::sync::mpsc::error::TrySendError::Closed(message)
+                |watch::error::SendError(message)| {
+                    Box::new(tokio::sync::mpsc::error::TrySendError::Closed(message))
                 },
             )?;
         }
@@ -1155,7 +1156,7 @@ impl RaftMessageSenderHandle {
 }
 
 type RaftMessageSenderResult<T, E = RaftMessageSenderError> = Result<T, E>;
-type RaftMessageSenderError = tokio::sync::mpsc::error::TrySendError<(usize, RaftMessage)>;
+type RaftMessageSenderError = Box<tokio::sync::mpsc::error::TrySendError<(usize, RaftMessage)>>;
 
 struct RaftMessageSender {
     messages: Receiver<(usize, RaftMessage)>,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1140,7 +1140,7 @@ impl RaftMessageSenderHandle {
         if !is_heartbeat(&message) {
             self.messages
                 .try_send((self.index, message))
-                .map_err(|send_error| Box::new(send_error))?;
+                .map_err(Box::new)?;
         } else {
             self.heartbeat.send((self.index, message)).map_err(
                 |watch::error::SendError(message)| {


### PR DESCRIPTION
In the steady state, there is no consensus error so we should not pay any price for successful sent messages.

Returning `Ok(())` should be as cheap as possible and not 304 bytes.

```console
error: the `Err`-variant returned from this function is very large
    --> src/consensus.rs:1139:53
     |
1139 |     pub fn send(&mut self, message: RaftMessage) -> RaftMessageSenderResult<()> {
     |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 304 bytes
     |
     = help: try reducing the size of `tokio::sync::mpsc::error::TrySendError<(usize, raft::prelude::Message)>`, for example by boxing large elements or replacing it with `Box<tokio::sync::mpsc::error::TrySendError<(usize, raft::prelude::Message)>>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
     = note: `-D clippy::result-large-err` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::result_large_err)]`
```