### PR TITLE
Log debug message on operation rejection for missing force flag

### DIFF
--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -160,12 +160,12 @@ impl CollectionUpdateOperations {
         )
     }
 
-    pub fn point_ids(&self) -> Vec<PointIdType> {
+    pub fn point_ids(&self) -> Option<Vec<PointIdType>> {
         match self {
             Self::PointOperation(op) => op.point_ids(),
             Self::VectorOperation(op) => op.point_ids(),
             Self::PayloadOperation(op) => op.point_ids(),
-            Self::FieldIndexOperation(_) => Vec::new(),
+            Self::FieldIndexOperation(_) => None,
         }
     }
 

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -161,13 +161,13 @@ impl PayloadOps {
         }
     }
 
-    pub fn point_ids(&self) -> Vec<PointIdType> {
+    pub fn point_ids(&self) -> Option<Vec<PointIdType>> {
         match self {
-            Self::SetPayload(op) => op.points.clone().unwrap_or(Vec::new()),
-            Self::DeletePayload(op) => op.points.clone().unwrap_or(Vec::new()),
-            Self::ClearPayload { points } => points.clone(),
-            Self::ClearPayloadByFilter(_) => Vec::new(),
-            Self::OverwritePayload(op) => op.points.clone().unwrap_or(Vec::new()),
+            Self::SetPayload(op) => op.points.clone(),
+            Self::DeletePayload(op) => op.points.clone(),
+            Self::ClearPayload { points } => Some(points.clone()),
+            Self::ClearPayloadByFilter(_) => None,
+            Self::OverwritePayload(op) => op.points.clone(),
         }
     }
 

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -633,12 +633,12 @@ impl PointOperations {
         }
     }
 
-    pub fn point_ids(&self) -> Vec<PointIdType> {
+    pub fn point_ids(&self) -> Option<Vec<PointIdType>> {
         match self {
-            Self::UpsertPoints(op) => op.point_ids(),
-            Self::DeletePoints { ids } => ids.clone(),
-            Self::DeletePointsByFilter(_) => Vec::new(),
-            Self::SyncPoints(op) => op.points.iter().map(|point| point.id).collect(),
+            Self::UpsertPoints(op) => Some(op.point_ids()),
+            Self::DeletePoints { ids } => Some(ids.clone()),
+            Self::DeletePointsByFilter(_) => None,
+            Self::SyncPoints(op) => Some(op.points.iter().map(|point| point.id).collect()),
         }
     }
 

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -61,11 +61,11 @@ impl VectorOperations {
         }
     }
 
-    pub fn point_ids(&self) -> Vec<PointIdType> {
+    pub fn point_ids(&self) -> Option<Vec<PointIdType>> {
         match self {
-            Self::UpdateVectors(op) => op.points.iter().map(|point| point.id).collect(),
-            Self::DeleteVectors(points, _) => points.points.clone(),
-            Self::DeleteVectorsByFilter(_, _) => Vec::new(),
+            Self::UpdateVectors(op) => Some(op.points.iter().map(|point| point.id).collect()),
+            Self::DeleteVectors(points, _) => Some(points.points.clone()),
+            Self::DeleteVectorsByFilter(_, _) => None,
         }
     }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -53,10 +53,11 @@ impl ShardReplicaSet {
                 {
                     Ok(Some(local_shard.get().update(operation, wait).await?))
                 }
-                Some(
-                    ReplicaState::PartialSnapshot | ReplicaState::Recovery | ReplicaState::Dead,
-                )
-                | None => Ok(None),
+                Some(ReplicaState::PartialSnapshot | ReplicaState::Recovery) => {
+                    log::debug!("Operation {operation:?} rejected on this peer, force flag required in recovery state");
+                    Ok(None)
+                }
+                Some(ReplicaState::Dead) | None => Ok(None),
             }
         } else {
             Ok(None)

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -56,11 +56,10 @@ impl ShardReplicaSet {
                 // In recovery state, log rejected operations without clock tag
                 Some(ReplicaState::PartialSnapshot | ReplicaState::Recovery) => {
                     if log::log_enabled!(log::Level::Debug) {
-                        let ids = operation.operation.point_ids();
-                        if ids.is_empty() {
-                            log::debug!("Operation {operation:?} rejected on this peer, force flag required in recovery state");
-                        } else {
+                        if let Some(ids) = operation.operation.point_ids() {
                             log::debug!("Operation affecting point IDs {ids:?} rejected on this peer, force flag required in recovery state");
+                        } else {
+                            log::debug!("Operation {operation:?} rejected on this peer, force flag required in recovery state");
                         }
                     }
                     Ok(None)
@@ -181,15 +180,14 @@ impl ShardReplicaSet {
             // Log a warning, if operation was rejected... but only if operation had a non-0 tick,
             // because operations with tick 0 should *always* be rejected and rejection is *expected*.
             if is_non_zero_tick && log::log_enabled!(log::Level::Warn) {
-                let ids = operation.point_ids();
-                if ids.is_empty() {
+                if let Some(ids) = operation.point_ids() {
                     log::warn!(
-                        "Operation {operation:?} was rejected by some node(s), retrying... \
+                        "Operation affecting point IDs {ids:?} was rejected by some node(s), retrying... \
                          (attempt {attempt}/{UPDATE_MAX_CLOCK_REJECTED_RETRIES})"
                     );
                 } else {
                     log::warn!(
-                        "Operation affecting point IDs {ids:?} was rejected by some node(s), retrying... \
+                        "Operation {operation:?} was rejected by some node(s), retrying... \
                          (attempt {attempt}/{UPDATE_MAX_CLOCK_REJECTED_RETRIES})"
                     );
                 }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -490,11 +490,10 @@ impl ShardHolder {
             return OperationsByMode::from(operation);
         };
 
-        let point_ids = operation.point_ids();
-
-        if point_ids.is_empty() {
-            return OperationsByMode::from(operation);
-        }
+        let point_ids = match operation.point_ids() {
+            Some(ids) if !ids.is_empty() => ids,
+            Some(_) | None => return OperationsByMode::from(operation),
+        };
 
         let target_point_ids: HashSet<_> = point_ids
             .iter()


### PR DESCRIPTION
An operation may be rejected on a replica in `Recovery` state if no `force` flag is provided.

This now shows a debug message when that happens.

For rejections caused by old clocks we already have a warning and automatic retry in place here: https://github.com/qdrant/qdrant/blob/d6f266a4ddbf3f57a3d308b6dce1fed83b867917/lib/collection/src/shards/replica_set/update.rs#L175-L178

I expect this debug message to be a bit noisy if a lot of replica state changes are happening. Let's see how it behaves and revert if needed. This will at least allow us to detect rejections on chaos testing for the time being.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?