### PR TITLE
bump version to v1.12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "api"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "chrono",
  "common",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.12.3"
+version = "1.12.4"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.12.3"
+version = "1.12.4"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.12.3";
+pub const QDRANT_VERSION_STRING: &str = "1.12.4";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=48c02b29c738c59a7ec22165ad9a134170c3eeb5
+IGNORE_UPTO=9d83ef2a6d24cfc5b8c5a504d71710fecabfc7fe
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
```
# Change log

## Improvements

* https://github.com/qdrant/qdrant/pull/5440 - :sparkles: Optimize mmap sequential access for full-scan segments and reading of large vectors
* https://github.com/qdrant/qdrant/pull/5428 - Leverage ahash in search results
* https://github.com/qdrant/qdrant/pull/5414 - Improvements for update clocks to improve updates consistency
* https://github.com/qdrant/qdrant/pull/5448 - Sync consensus at the end of stream records transfer
* https://github.com/qdrant/qdrant/pull/5378 - Introduce a unique identifier for collections for easier consensus snapshots resolution


## Bug fixes

* https://github.com/qdrant/qdrant/pull/5457 - :sparkles: Fixes for rescoring param usage and usage of disabled HNSW
* https://github.com/qdrant/qdrant/pull/5439 - Fix the file name too long error during collection deletion
```