### PR TITLE
RocksDB buffers use Ahash

### DIFF
--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
 use std::mem;
 use std::sync::Arc;
 
+use ahash::AHashSet;
 use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
 
@@ -19,7 +19,7 @@ use crate::common::Flusher;
 #[derive(Debug)]
 pub struct DatabaseColumnScheduledDeleteWrapper {
     db: DatabaseColumnWrapper,
-    deleted_pending_persistence: Arc<Mutex<HashSet<Vec<u8>>>>,
+    deleted_pending_persistence: Arc<Mutex<AHashSet<Vec<u8>>>>,
 }
 
 impl Clone for DatabaseColumnScheduledDeleteWrapper {
@@ -35,7 +35,7 @@ impl DatabaseColumnScheduledDeleteWrapper {
     pub fn new(db: DatabaseColumnWrapper) -> Self {
         Self {
             db,
-            deleted_pending_persistence: Arc::new(Mutex::new(HashSet::new())),
+            deleted_pending_persistence: Arc::new(Mutex::new(AHashSet::new())),
         }
     }
 
@@ -118,7 +118,7 @@ impl DatabaseColumnScheduledDeleteWrapper {
 
 pub struct LockedDatabaseColumnScheduledDeleteWrapper<'a> {
     base: LockedDatabaseColumnWrapper<'a>,
-    deleted_pending_persistence: &'a Mutex<HashSet<Vec<u8>>>,
+    deleted_pending_persistence: &'a Mutex<AHashSet<Vec<u8>>>,
 }
 
 impl LockedDatabaseColumnScheduledDeleteWrapper<'_> {
@@ -132,7 +132,7 @@ impl LockedDatabaseColumnScheduledDeleteWrapper<'_> {
 
 pub struct DatabaseColumnScheduledDeleteIterator<'a> {
     base: DatabaseColumnIterator<'a>,
-    deleted_pending_persistence: &'a Mutex<HashSet<Vec<u8>>>,
+    deleted_pending_persistence: &'a Mutex<AHashSet<Vec<u8>>>,
 }
 
 impl<'a> Iterator for DatabaseColumnScheduledDeleteIterator<'a> {

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, HashSet};
 use std::mem;
 
+use ahash::{AHashMap, AHashSet};
 use parking_lot::Mutex;
 
 use crate::common::operation_error::OperationResult;
@@ -16,16 +16,16 @@ use crate::common::Flusher;
 #[derive(Debug)]
 pub struct DatabaseColumnScheduledUpdateWrapper {
     db: DatabaseColumnWrapper,
-    deleted_pending_persistence: Mutex<HashSet<Vec<u8>>>,
-    insert_pending_persistence: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
+    deleted_pending_persistence: Mutex<AHashSet<Vec<u8>>>,
+    insert_pending_persistence: Mutex<AHashMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl DatabaseColumnScheduledUpdateWrapper {
     pub fn new(db: DatabaseColumnWrapper) -> Self {
         Self {
             db,
-            deleted_pending_persistence: Mutex::new(HashSet::new()),
-            insert_pending_persistence: Mutex::new(HashMap::new()),
+            deleted_pending_persistence: Mutex::new(AHashSet::new()),
+            insert_pending_persistence: Mutex::new(AHashMap::new()),
         }
     }
 


### PR DESCRIPTION
The RocksDB's buffering is hashing ids using the SIP hasher.

![sipping](https://github.com/user-attachments/assets/19e8fad1-235f-4d61-8d06-378e0a01a190)

This PR changes to Ahash which is better for small inputs.