### PR TITLE
HardwareCounterCell::drop: avoid nested panic

### DIFF
--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -129,7 +129,7 @@ impl Drop for HwMeasurementAcc {
 
         #[cfg(any(debug_assertions, test))] // Fail in both, release and debug tests.
         {
-            if !self.is_zero() {
+            if !self.is_zero() && !std::thread::panicking() {
                 panic!(
                     "HwMeasurementAcc dropped while still holding values! Drain: {:?}",
                     self.drain.is_some()

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -75,10 +75,12 @@ impl HardwareCounterCell {
 impl Drop for HardwareCounterCell {
     fn drop(&mut self) {
         if self.has_values() {
-            #[cfg(any(debug_assertions, test))] // We want this to fail in both, release and debug tests
-            panic!("Checked HardwareCounterCell dropped without consuming all values!");
+            // We want this to fail in both, release and debug tests
+            #[cfg(any(debug_assertions, test))]
+            if !std::thread::panicking() {
+                panic!("Checked HardwareCounterCell dropped without consuming all values!");
+            }
 
-            #[cfg(not(any(debug_assertions, test)))]
             log::warn!("Hardware measurements not processed!")
         }
     }


### PR DESCRIPTION
Nested panics caused by `HardwareCounterCell::drop()` abort the program which is inconvenient when debugging failed tests.
To avoid this, this PR adds a check suggested in the Rust docs: https://doc.rust-lang.org/std/ops/trait.Drop.html#panics.