### PR TITLE
Cancel all related shard transfers on start

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -19,11 +19,10 @@ use crate::shards::transfer::{
 };
 
 impl Collection {
-    pub async fn get_outgoing_transfers(&self, current_peer_id: PeerId) -> Vec<ShardTransfer> {
-        self.shards_holder
-            .read()
-            .await
-            .get_outgoing_transfers(current_peer_id)
+    pub async fn get_related_transfers(&self, current_peer_id: PeerId) -> Vec<ShardTransfer> {
+        self.shards_holder.read().await.get_transfers(|transfer| {
+            transfer.from == current_peer_id || transfer.to == current_peer_id
+        })
     }
 
     pub async fn check_transfer_exists(&self, transfer_key: &ShardTransferKey) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,14 +357,14 @@ fn main() -> anyhow::Result<()> {
         let _cancel_transfer_handle = runtime_handle.spawn(async move {
             consensus_state_clone.is_leader_established.await_ready();
             match toc_arc_clone
-                .cancel_outgoing_all_transfers("Source peer restarted")
+                .cancel_related_transfers("Source or target peer restarted")
                 .await
             {
                 Ok(_) => {
                     log::debug!("All transfers if any cancelled");
                 }
                 Err(err) => {
-                    log::error!("Can't cancel outgoing transfers: {}", err);
+                    log::error!("Can't cancel related transfers: {err}");
                 }
             }
         });


### PR DESCRIPTION
Instead of just cancelling the outgoing shard transfers on start, also cancel the incoming transfers.

Automatic shard recovery will follow after cancelling the transfer to bring it back into active state.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?