### PR TITLE
Do not build wal_inspector by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,7 @@ name = "wal_inspector"
 path = "src/wal_inspector.rs"
 test = false
 bench = false
+required-features = ["service_debug"]
 
 [workspace]
 members = [


### PR DESCRIPTION
This PR prevents the `wal_inspector` binary to be built by default, it is now hidden behind the existing `service_debug` feature.

Why?

- The binary is used very rarely.

- It is rather large `979M wal_inspector-e63716334eafa7cb`.

- It takes a significant amount of time to build.

The `service_debug` feature is used in our integration tests so we should be able to catch a breakage early.