### PR TITLE
Do not build schema_generator by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ name = "schema_generator"
 path = "src/schema_generator.rs"
 test = false
 bench = false
+required-features = ["service_debug"]
 
 [[bin]]
 name = "wal_inspector"

--- a/tools/generate_openapi_models.sh
+++ b/tools/generate_openapi_models.sh
@@ -33,7 +33,7 @@ sh_with_ytt '
 '
 
 # Generates models from internal service structures
-cargo run --package qdrant --bin schema_generator > ./openapi/schemas/AllDefinitions.json
+cargo run --package qdrant --features="service_debug" --bin schema_generator > ./openapi/schemas/AllDefinitions.json
 
 docker build tools/schema2openapi --tag schema2openapi
 


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/5479.

Same reasoning, that binary is even larger `1010M schema_generator-a1b487c3b49c0bdd`

It is only used through `tools/generate_openapi_models.sh` where it is enabled explicitly.