### PR TITLE
Fix panic on query with huge limit

### DIFF
--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -86,7 +86,7 @@ impl Collection {
         let used_transfers = sum_limits;
 
         let is_required_transfer_large_enough =
-            require_transfers > used_transfers * PAYLOAD_TRANSFERS_FACTOR_THRESHOLD;
+            require_transfers > used_transfers.saturating_mul(PAYLOAD_TRANSFERS_FACTOR_THRESHOLD);
 
         if metadata_required && is_required_transfer_large_enough {
             // If there is a significant offset, we need to retrieve the whole result

--- a/lib/collection/src/collection_manager/search_result_aggregator.rs
+++ b/lib/collection/src/collection_manager/search_result_aggregator.rs
@@ -5,6 +5,9 @@ use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::ScoreType;
 use segment::types::{PointIdType, ScoredPoint, SeqNumberType};
 
+/// Avoid excessive memory allocation and allocation failures on huge limits
+const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
+
 pub struct SearchResultAggregator {
     queue: FixedLengthPriorityQueue<ScoredPoint>,
     seen: AHashSet<PointIdType>, // Point ids seen
@@ -14,7 +17,7 @@ impl SearchResultAggregator {
     pub fn new(limit: usize) -> Self {
         SearchResultAggregator {
             queue: FixedLengthPriorityQueue::new(limit),
-            seen: AHashSet::with_capacity(limit),
+            seen: AHashSet::with_capacity(limit.min(LARGEST_REASONABLE_ALLOCATION_SIZE)),
         }
     }
 

--- a/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
+++ b/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
@@ -118,3 +118,24 @@ fn test_aggregation_of_batch_search_results() {
     assert_eq!(top_results[1][2].version, 12);
     assert_eq!(top_results[1][2].score, 0.71);
 }
+
+// Ensure we don't panic if we search with a huge limit
+// See: <https://github.com/qdrant/qdrant/issues/5483>
+#[test]
+fn test_batch_search_aggregation_high_limit() {
+    let search_results = vec![
+        vec![search_result_b0_s0(), search_result_b1_s0()],
+        vec![search_result_b0_s1(), search_result_b1_s1()],
+        vec![search_result_b0_s2(), search_result_b1_s2()],
+    ];
+
+    let result_limits = vec![12, usize::MAX];
+
+    let further_results = vec![vec![true, true], vec![true, true], vec![false, true]];
+
+    let (_aggregator, _re_request) = SegmentsSearcher::process_search_result_step1(
+        search_results,
+        result_limits,
+        &further_results,
+    );
+}

--- a/lib/common/common/src/fixed_length_priority_queue.rs
+++ b/lib/common/common/src/fixed_length_priority_queue.rs
@@ -33,7 +33,11 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
     /// Creates a new queue with the given length
     /// Panics if length is 0
     pub fn new(length: usize) -> Self {
-        let heap = BinaryHeap::with_capacity((length + 1).min(LARGEST_REASONABLE_ALLOCATION_SIZE));
+        let heap = BinaryHeap::with_capacity(
+            length
+                .saturating_add(1)
+                .min(LARGEST_REASONABLE_ALLOCATION_SIZE),
+        );
         let length = NonZeroUsize::new(length).expect("length must be greater than zero");
         FixedLengthPriorityQueue::<T> { heap, length }
     }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/5483>

[Here](https://github.com/qdrant/qdrant/pull/5428/files#diff-9a15df0820bef38d5804ec1676101484e170367b109289cb02410109db341d2aR17) we started to preallocate memory in the search result aggregator based on the user provided limit. If a user provides a huge limit it will panic due to an allocation failure.

This PR fixes the problem by limiting the size of preallocating to one million items, exactly like `FixedLengthPriorityQueue` does. I'm not entirely sure if one million is reasonable here, and it might be too big. Lets discuss here what we think may be reasonable.

I've also fixed a limit overflow in `FixedLengthPriorityQueue` if a `limit` of `u64::MAX` is given, and an overflow in search.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?