### PR TITLE
Drop `GraphLayersBackwardCompatibility`

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoredPointOffset};
-use io::file_operations::{atomic_save_bin, read_bin, FileStorageError};
+use io::file_operations::{atomic_save_bin, read_bin};
 use itertools::Itertools;
 use memory::mmap_ops;
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,6 @@ use super::graph_links::{GraphLinks, GraphLinksMmap};
 use crate::common::operation_error::OperationResult;
 use crate::common::utils::rev_range;
 use crate::index::hnsw_index::entry_points::EntryPoints;
-use crate::index::hnsw_index::graph_links::GraphLinksConverter;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::search_context::SearchContext;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
@@ -32,17 +31,6 @@ struct GraphLayerData<'a> {
     m0: usize,
     ef_construct: usize,
     entry_points: Cow<'a, EntryPoints>,
-}
-
-/// Contents of the `graph.bin` file (Qdrant 0.8.4).
-#[derive(Deserialize, Serialize, Debug)]
-struct GraphLayersBackwardCompatibility {
-    max_level: usize,
-    m: usize,
-    m0: usize,
-    ef_construct: usize,
-    links_layers: Vec<LayersContainer>,
-    entry_points: EntryPoints,
 }
 
 #[derive(Debug)]
@@ -246,50 +234,15 @@ where
     TGraphLinks: GraphLinks,
 {
     pub fn load(graph_path: &Path, links_path: &Path) -> OperationResult<Self> {
-        let try_data: Result<GraphLayerData, FileStorageError> = if links_path.exists() {
-            read_bin(graph_path)
-        } else {
-            Err(FileStorageError::generic(format!(
-                "Links file does not exists: {links_path:?}"
-            )))
-        };
-
-        match try_data {
-            Ok(data) => {
-                let links = TGraphLinks::load_from_file(links_path)?;
-                Ok(Self {
-                    m: data.m,
-                    m0: data.m0,
-                    ef_construct: data.ef_construct,
-                    links,
-                    entry_points: data.entry_points.into_owned(),
-                    visited_pool: VisitedPool::new(),
-                })
-            }
-            Err(err) => {
-                let try_legacy: Result<GraphLayersBackwardCompatibility, _> = read_bin(graph_path);
-                if let Ok(legacy) = try_legacy {
-                    log::debug!("Converting legacy graph to new format");
-
-                    let mut converter = GraphLinksConverter::new(legacy.links_layers);
-                    converter.save_as(links_path)?;
-
-                    let links = TGraphLinks::from_converter(converter)?;
-                    let slf = Self {
-                        m: legacy.m,
-                        m0: legacy.m0,
-                        ef_construct: legacy.ef_construct,
-                        links,
-                        entry_points: legacy.entry_points,
-                        visited_pool: VisitedPool::new(),
-                    };
-                    slf.save(graph_path)?;
-                    Ok(slf)
-                } else {
-                    Err(err)?
-                }
-            }
-        }
+        let graph_data: GraphLayerData = read_bin(graph_path)?;
+        Ok(Self {
+            m: graph_data.m,
+            m0: graph_data.m0,
+            ef_construct: graph_data.ef_construct,
+            links: TGraphLinks::load_from_file(links_path)?,
+            entry_points: graph_data.entry_points.into_owned(),
+            visited_pool: VisitedPool::new(),
+        })
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
@@ -327,7 +280,7 @@ mod tests {
     use crate::fixtures::index_fixtures::{
         random_vector, FakeFilterContext, TestRawScorerProducer,
     };
-    use crate::index::hnsw_index::graph_links::GraphLinksRam;
+    use crate::index::hnsw_index::graph_links::{GraphLinksConverter, GraphLinksRam};
     use crate::index::hnsw_index::tests::create_graph_layer_fixture;
     use crate::spaces::metric::Metric;
     use crate::spaces::simple::{CosineMetric, DotProductMetric};


### PR DESCRIPTION
This PR drops the support for reading/converting of the old `graph.bin` file format used before Qdrant 0.8.4.
This old format stores everything in a single `graph.bin` file while newer versions of qdrant store the graph in two files, `graph.bin`+`links.bin`.