### PR TITLE
GraphLinksConverter: take `m` and `compressed` arguments

### DIFF
--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -42,7 +42,7 @@ fn build_index<TMetric: Metric<VectorElementType>>(
     }
     (
         vector_holder,
-        graph_layers_builder.into_graph_layers(None).unwrap(),
+        graph_layers_builder.into_graph_layers(None, false).unwrap(),
     )
 }
 

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -38,7 +38,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
         graph_layers_builder.link_new_point(idx, scorer);
     }
     let graph_layers = graph_layers_builder
-        .into_graph_layers::<GraphLinksRam>(None)
+        .into_graph_layers::<GraphLinksRam>(None, false)
         .unwrap();
 
     group.bench_function("hnsw_search", |b| {

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -191,9 +191,11 @@ mod tests {
         ef: usize,
         accuracy: f32,
     ) {
-        let graph: GraphLayers<GraphLinksRam> = graph.into_graph_layers(None).unwrap();
-        let ref_graph: GraphLayers<GraphLinksRam> =
-            test.graph_layers_builder.into_graph_layers(None).unwrap();
+        let graph: GraphLayers<GraphLinksRam> = graph.into_graph_layers(None, false).unwrap();
+        let ref_graph: GraphLayers<GraphLinksRam> = test
+            .graph_layers_builder
+            .into_graph_layers(None, false)
+            .unwrap();
 
         let mut total_sames = 0;
         let total_top = top * test.search_vectors.len();

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -369,6 +369,7 @@ mod tests {
                 graph_links.clone(),
                 compressed,
                 m,
+                2 * m,
             ))
             .unwrap(),
             entry_points: EntryPoints::new(entry_points_num),

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -506,10 +506,9 @@ mod tests {
         assert_eq!(reference_top.into_vec(), graph_search);
     }
 
-    #[rstest]
-    #[case::uncompressed(false)]
-    #[case::compressed(true)]
-    fn test_draw_hnsw_graph(#[case] compressed: bool) {
+    #[test]
+    #[ignore]
+    fn test_draw_hnsw_graph() {
         let dim = 2;
         let num_vectors = 500;
 
@@ -519,7 +518,7 @@ mod tests {
             num_vectors,
             M,
             dim,
-            compressed,
+            true,
             true,
             &mut rng,
             None,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -78,6 +78,7 @@ impl GraphLayersBuilder {
     pub fn into_graph_layers<TGraphLinks: GraphLinks>(
         self,
         path: Option<&Path>,
+        compressed: bool,
     ) -> OperationResult<GraphLayers<TGraphLinks>> {
         let unlocker_links_layers = self
             .links_layers
@@ -85,7 +86,8 @@ impl GraphLayersBuilder {
             .map(|l| l.into_iter().map(|l| l.into_inner()).collect())
             .collect();
 
-        let mut links_converter = GraphLinksConverter::new(unlocker_links_layers);
+        let mut links_converter =
+            GraphLinksConverter::new(unlocker_links_layers, compressed, self.m);
         if let Some(path) = path {
             links_converter.save_as(path)?;
         }
@@ -511,13 +513,14 @@ mod tests {
     use rand::prelude::StdRng;
     use rand::seq::SliceRandom;
     use rand::SeedableRng;
+    use rstest::rstest;
 
     use super::*;
     use crate::data_types::vectors::{DenseVector, VectorElementType};
     use crate::fixtures::index_fixtures::{
         random_vector, FakeFilterContext, TestRawScorerProducer,
     };
-    use crate::index::hnsw_index::graph_links::GraphLinksRam;
+    use crate::index::hnsw_index::graph_links::{normalize_links, GraphLinksRam};
     use crate::index::hnsw_index::tests::create_graph_layer_fixture;
     use crate::spaces::metric::Metric;
     use crate::spaces::simple::{CosineMetric, EuclidMetric};
@@ -619,8 +622,10 @@ mod tests {
     }
 
     #[cfg(not(windows))] // https://github.com/qdrant/qdrant/issues/1452
-    #[test]
-    fn test_parallel_graph_build() {
+    #[rstest]
+    #[case::uncompressed(false)]
+    #[case::compressed(true)]
+    fn test_parallel_graph_build(#[case] compressed: bool) {
         let num_vectors = 1000;
         let dim = 8;
 
@@ -675,7 +680,7 @@ mod tests {
         }
 
         let graph = graph_layers_builder
-            .into_graph_layers::<GraphLinksRam>(None)
+            .into_graph_layers::<GraphLinksRam>(None, compressed)
             .unwrap();
 
         let fake_filter_context = FakeFilterContext {};
@@ -688,8 +693,10 @@ mod tests {
         assert_eq!(reference_top.into_vec(), graph_search);
     }
 
-    #[test]
-    fn test_add_points() {
+    #[rstest]
+    #[case::uncompressed(false)]
+    #[case::compressed(true)]
+    fn test_add_points(#[case] compressed: bool) {
         let num_vectors = 1000;
         let dim = 8;
 
@@ -701,8 +708,15 @@ mod tests {
         let (vector_holder, graph_layers_builder) =
             create_graph_layer::<M, _>(num_vectors, dim, false, &mut rng);
 
-        let (_vector_holder_orig, graph_layers_orig) =
-            create_graph_layer_fixture::<M, _>(num_vectors, M, dim, false, &mut rng2, None);
+        let (_vector_holder_orig, graph_layers_orig) = create_graph_layer_fixture::<M, _>(
+            num_vectors,
+            M,
+            dim,
+            compressed,
+            false,
+            &mut rng2,
+            None,
+        );
 
         // check is graph_layers_builder links are equal to graph_layers_orig
         let orig_len = graph_layers_orig.links.num_points();
@@ -714,7 +728,11 @@ mod tests {
             let links_orig = &graph_layers_orig.links.links_vec(idx as PointOffsetType, 0);
             let links_builder = graph_layers_builder.links_layers[idx][0].read();
             let link_container_from_builder = links_builder.iter().copied().collect::<Vec<_>>();
-            assert_eq!(links_orig, &link_container_from_builder);
+            let m = if compressed { M * 2 } else { 0 };
+            assert_eq!(
+                normalize_links(m, links_orig.clone()),
+                normalize_links(m, link_container_from_builder),
+            );
         }
 
         let main_entry = graph_layers_builder
@@ -759,7 +777,7 @@ mod tests {
         }
 
         let graph = graph_layers_builder
-            .into_graph_layers::<GraphLinksRam>(None)
+            .into_graph_layers::<GraphLinksRam>(None, compressed)
             .unwrap();
 
         let fake_filter_context = FakeFilterContext {};
@@ -771,9 +789,10 @@ mod tests {
         assert_eq!(reference_top.into_vec(), graph_search);
     }
 
-    #[test]
-    #[ignore]
-    fn test_hnsw_graph_properties() {
+    #[rstest]
+    #[case::uncompressed(false)]
+    #[case::compressed(true)]
+    fn test_hnsw_graph_properties(#[case] compressed: bool) {
         const NUM_VECTORS: usize = 5_000;
         const DIM: usize = 16;
         const M: usize = 16;
@@ -796,7 +815,7 @@ mod tests {
             raw_scorer.take_hardware_counter().discard_results();
         }
         let graph_layers = graph_layers_builder
-            .into_graph_layers::<GraphLinksRam>(None)
+            .into_graph_layers::<GraphLinksRam>(None, compressed)
             .unwrap();
 
         let num_points = graph_layers.links.num_points();

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -87,7 +87,7 @@ impl GraphLayersBuilder {
             .collect();
 
         let mut links_converter =
-            GraphLinksConverter::new(unlocker_links_layers, compressed, self.m);
+            GraphLinksConverter::new(unlocker_links_layers, compressed, self.m, self.m0);
         if let Some(path) = path {
             links_converter.save_as(path)?;
         }

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -123,7 +123,7 @@ pub struct GraphLinksConverter {
 }
 
 impl GraphLinksConverter {
-    pub fn new(edges: Vec<Vec<Vec<PointOffsetType>>>) -> Self {
+    pub fn new(edges: Vec<Vec<Vec<PointOffsetType>>>, _compressed: bool, _m: usize) -> Self {
         if edges.is_empty() {
             return Self {
                 edges,
@@ -505,9 +505,19 @@ impl<'a> GraphLinksView<'a> {
     }
 }
 
+/// Sort the first `m` values in `links` and return them. Used to compare stored
+/// links where the order of the first `m` links is not preserved.
+#[cfg(test)]
+pub(super) fn normalize_links(m: usize, mut links: Vec<PointOffsetType>) -> Vec<PointOffsetType> {
+    let first = links.len().min(m);
+    links[..first].sort_unstable();
+    links
+}
+
 #[cfg(test)]
 mod tests {
     use rand::Rng;
+    use rstest::rstest;
     use tempfile::Builder;
 
     use super::*;
@@ -530,6 +540,7 @@ mod tests {
     fn random_links(
         points_count: usize,
         max_levels_count: usize,
+        m: usize,
     ) -> Vec<Vec<Vec<PointOffsetType>>> {
         let mut rng = rand::thread_rng();
         (0..points_count)
@@ -537,7 +548,7 @@ mod tests {
                 let levels_count = rng.gen_range(1..max_levels_count);
                 (0..levels_count)
                     .map(|_| {
-                        let links_count = rng.gen_range(0..max_levels_count);
+                        let links_count = rng.gen_range(0..m * 4);
                         (0..links_count)
                             .map(|_| rng.gen_range(0..points_count) as PointOffsetType)
                             .collect()
@@ -547,44 +558,73 @@ mod tests {
             .collect()
     }
 
+    fn compare_links(
+        mut left: Vec<Vec<Vec<PointOffsetType>>>,
+        mut right: Vec<Vec<Vec<PointOffsetType>>>,
+        m: Option<usize>,
+    ) {
+        let m = m.unwrap_or(0);
+        for links in [&mut left, &mut right].iter_mut() {
+            links.iter_mut().for_each(|levels| {
+                levels
+                    .iter_mut()
+                    .enumerate()
+                    .for_each(|(level_idx, links)| {
+                        *links = normalize_links(
+                            if level_idx == 0 { m * 2 } else { m },
+                            std::mem::take(links),
+                        );
+                    })
+            });
+        }
+        assert_eq!(left, right);
+    }
+
     /// Test that random links can be saved by `GraphLinksConverter` and loaded correctly by a GraphLinks impl.
-    fn test_save_load<A>(points_count: usize, max_levels_count: usize)
+    fn test_save_load<A>(points_count: usize, max_levels_count: usize, compressed: bool, m: usize)
     where
         A: GraphLinks,
     {
         let path = Builder::new().prefix("graph_dir").tempdir().unwrap();
         let links_file = path.path().join("links.bin");
-        let links = random_links(points_count, max_levels_count);
+        let links = random_links(points_count, max_levels_count, m);
         {
-            let mut links_converter = GraphLinksConverter::new(links.clone());
+            let mut links_converter = GraphLinksConverter::new(links.clone(), compressed, m);
             links_converter.save_as(&links_file).unwrap();
         }
         let cmp_links = to_vec(&A::load_from_file(&links_file).unwrap());
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(m));
     }
 
-    #[test]
-    fn test_graph_links_construction() {
+    #[rstest]
+    #[case::uncompressed(false)]
+    #[case::compressed(true)]
+    fn test_graph_links_construction(#[case] compressed: bool) {
+        let m = 2;
+
         // no points
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![];
         let cmp_links = to_vec(
-            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone())).unwrap(),
+            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone(), compressed, m))
+                .unwrap(),
         );
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(m));
 
         // 2 points without any links
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![]], vec![vec![]]];
         let cmp_links = to_vec(
-            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone())).unwrap(),
+            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone(), compressed, m))
+                .unwrap(),
         );
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(m));
 
         // one link at level 0
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![1]], vec![vec![0]]];
         let cmp_links = to_vec(
-            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone())).unwrap(),
+            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone(), compressed, m))
+                .unwrap(),
         );
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(m));
 
         // 3 levels with no links at second level
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
@@ -593,9 +633,10 @@ mod tests {
             vec![vec![0, 1], vec![], vec![1]],
         ];
         let cmp_links = to_vec(
-            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone())).unwrap(),
+            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone(), compressed, m))
+                .unwrap(),
         );
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(m));
 
         // 3 levels with no links at last level
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
@@ -604,9 +645,10 @@ mod tests {
             vec![vec![0, 1]],
         ];
         let cmp_links = to_vec(
-            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone())).unwrap(),
+            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone(), compressed, m))
+                .unwrap(),
         );
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(m));
 
         // 4 levels with random nonexistent links
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
@@ -617,21 +659,25 @@ mod tests {
             vec![vec![0, 1, 9, 18], vec![1, 5, 6], vec![5], vec![9]],
         ];
         let cmp_links = to_vec(
-            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone())).unwrap(),
+            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone(), compressed, m))
+                .unwrap(),
         );
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(m));
 
         // fully random links
-        let links = random_links(100, 10);
+        let links = random_links(100, 10, 8);
         let cmp_links = to_vec(
-            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone())).unwrap(),
+            &GraphLinksRam::from_converter(GraphLinksConverter::new(links.clone(), compressed, 8))
+                .unwrap(),
         );
-        assert_eq!(links, cmp_links);
+        compare_links(links, cmp_links, compressed.then_some(8));
     }
 
     #[test]
     fn test_graph_links_mmap_ram_compatibility() {
-        test_save_load::<GraphLinksRam>(1000, 10);
-        test_save_load::<GraphLinksMmap>(1000, 10);
+        test_save_load::<GraphLinksRam>(1000, 10, true, 8);
+        test_save_load::<GraphLinksMmap>(1000, 10, true, 8);
+        test_save_load::<GraphLinksRam>(1000, 10, false, 8);
+        test_save_load::<GraphLinksMmap>(1000, 10, false, 8);
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -94,21 +94,36 @@ pub struct HnswIndexOpenArgs<'a> {
     pub stopped: &'a AtomicBool,
 }
 
-fn use_links_compression(existing: bool) -> bool {
-    let name = "__QDRANT_COMPRESSED_LINKS";
-    match std::env::var(name).as_deref() {
-        // 0: Only read compressed links, but never write.
-        Ok("0") | Err(std::env::VarError::NotPresent) => false,
-        // 1: Enable for newly created graphs.
-        Ok("1") => !existing,
-        // 2: Same as 1 + convert existing graphs.
-        Ok("2") => true,
-        _ => {
-            log::warn!(
-                "Unknown value for {name}={:?}, defaulting to 0",
-                std::env::var_os(name),
-            );
-            false
+struct LinkCompressionExperimentalSetting {
+    /// Whether newly created graphs should be written in the compressed format.
+    write_new: bool,
+    /// Whether to convert existing uncompressed graphs to the compressed format.
+    convert_existing: bool,
+}
+
+impl LinkCompressionExperimentalSetting {
+    /// Load the setting from an environment variable.
+    ///
+    /// This hidden setting exists for testing/benchmarking this particular
+    /// feature only. Later it could be removed and either made unconfigurable,
+    /// or moved to an appropriate place in the configuration.
+    fn from_env() -> Self {
+        let name = "__QDRANT_COMPRESSED_LINKS";
+        let (write_new, convert_existing) = match std::env::var(name).as_deref() {
+            Ok("0") | Err(std::env::VarError::NotPresent) => (false, false),
+            Ok("1") => (true, false),
+            Ok("2") => (true, true),
+            _ => {
+                log::warn!(
+                    "Unknown value for {name}={:?}, defaulting to 0",
+                    std::env::var_os(name),
+                );
+                (false, false)
+            }
+        };
+        Self {
+            write_new,
+            convert_existing,
         }
     }
 }
@@ -160,7 +175,11 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
             (
                 config,
-                GraphLayers::load(&graph_path, &graph_links_path, use_links_compression(true))?,
+                GraphLayers::load(
+                    &graph_path,
+                    &graph_links_path,
+                    LinkCompressionExperimentalSetting::from_env().convert_existing,
+                )?,
             )
         } else {
             let num_cpus = match permit {
@@ -434,8 +453,10 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         config.indexed_vector_count.replace(indexed_vectors);
 
         let graph_links_path = GraphLayers::<TGraphLinks>::get_links_path(path);
-        let graph: GraphLayers<TGraphLinks> = graph_layers_builder
-            .into_graph_layers(Some(&graph_links_path), use_links_compression(false))?;
+        let graph: GraphLayers<TGraphLinks> = graph_layers_builder.into_graph_layers(
+            Some(&graph_links_path),
+            LinkCompressionExperimentalSetting::from_env().write_new,
+        )?;
 
         #[cfg(debug_assertions)]
         {

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -57,6 +57,7 @@ pub(crate) fn create_graph_layer_fixture<TMetric: Metric<VectorElementType>, R>(
     num_vectors: usize,
     m: usize,
     dim: usize,
+    compressed: bool,
     use_heuristic: bool,
     rng: &mut R,
     links_path: Option<&Path>,
@@ -69,6 +70,8 @@ where
 
     (
         vector_holder,
-        graph_layers_builder.into_graph_layers(links_path).unwrap(),
+        graph_layers_builder
+            .into_graph_layers(links_path, compressed)
+            .unwrap(),
     )
 }

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -4,6 +4,7 @@ use common::types::ScoredPointOffset;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
+use rstest::rstest;
 
 use crate::fixtures::index_fixtures::random_vector;
 use crate::index::hnsw_index::graph_layers::GraphLayersBase;
@@ -38,9 +39,11 @@ fn search_in_builder(
     nearest.into_iter().take(top).collect_vec()
 }
 
-#[test]
 /// Check that HNSW index with raw and compacted links gives the same results
-fn test_compact_graph_layers() {
+#[rstest]
+#[case::uncompressed(false)]
+#[case::compressed(true)]
+fn test_compact_graph_layers(#[case] compressed: bool) {
     let num_vectors = 1000;
     let num_queries = 100;
     let m = 16;
@@ -69,7 +72,7 @@ fn test_compact_graph_layers() {
         .collect_vec();
 
     let graph_layers = graph_layers_builder
-        .into_graph_layers::<GraphLinksRam>(None)
+        .into_graph_layers::<GraphLinksRam>(None, compressed)
         .unwrap();
 
     let results = queries


### PR DESCRIPTION
This PR performs some integration work required for HNSW links compression.
- `GraphLinksConverter::new()` now takes `m: usize` and `compression: bool`. It is assumed that compression algorithm might sort the first `m`/`2*m` links for each node.
- This PR doesn't include the compression algorithm, so these parameters are ignored for now.
- Some unit tests are updated to test both compressed and uncompressed implementations.
- A new undocumented environment var is added: `__QDRANT_COMPRESSED_LINKS`. When set, it will enable creation of compressed graphs for testing/debugging purposes. By default it's disabled.

Assumption: `m0 == 2*m`.

Depends on #5486, ignore the first commit during review.