### PR TITLE
GraphLinks::for_each_link

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -160,9 +160,7 @@ impl<TGraphLinks: GraphLinks> GraphLayersBase for GraphLayers<TGraphLinks> {
     where
         F: FnMut(PointOffsetType),
     {
-        for link in self.links.links(point_id, level) {
-            f(link);
-        }
+        self.links.for_each_link(point_id, level, &mut f);
     }
 
     fn get_m(&self, level: usize) -> usize {
@@ -469,7 +467,7 @@ mod tests {
         assert_eq!(main_entry.level, num_levels);
 
         let total_links_0 = (0..num_vectors)
-            .map(|i| graph_layers.links.links(i as PointOffsetType, 0).count())
+            .map(|i| graph_layers.links.links_vec(i as PointOffsetType, 0).len())
             .sum::<usize>();
 
         eprintln!("total_links_0 = {total_links_0:#?}");

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -685,10 +685,7 @@ mod tests {
         assert_eq!(orig_len, builder_len);
 
         for idx in 0..builder_len {
-            let links_orig = &graph_layers_orig
-                .links
-                .links(idx as PointOffsetType, 0)
-                .collect_vec();
+            let links_orig = &graph_layers_orig.links.links_vec(idx as PointOffsetType, 0);
             let links_builder = graph_layers_builder.links_layers[idx][0].read();
             let link_container_from_builder = links_builder.iter().copied().collect::<Vec<_>>();
             assert_eq!(links_orig, &link_container_from_builder);
@@ -787,12 +784,12 @@ mod tests {
 
         let layers910 = graph_layers.links.point_level(910);
         let links910 = (0..layers910 + 1)
-            .map(|i| graph_layers.links.links(910, i).collect_vec())
+            .map(|i| graph_layers.links.links_vec(910, i))
             .collect::<Vec<_>>();
         eprintln!("graph_layers.links_layers[910] = {links910:#?}",);
 
         let total_edges: usize = (0..NUM_VECTORS)
-            .map(|i| graph_layers.links.links(i as PointOffsetType, 0).count())
+            .map(|i| graph_layers.links.links_vec(i as PointOffsetType, 0).len())
             .sum();
         let avg_connectivity = total_edges as f64 / NUM_VECTORS as f64;
         eprintln!("avg_connectivity = {avg_connectivity:#?}");

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -419,11 +419,9 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         {
             for (idx, deleted) in deleted_bitslice.iter().enumerate() {
                 if *deleted {
-                    debug_assert!(graph
-                        .links
-                        .links(idx as PointOffsetType, 0)
-                        .next()
-                        .is_none());
+                    graph.links.for_each_link(idx as PointOffsetType, 0, |_| {
+                        panic!("Deleted point in the graph");
+                    });
                 }
             }
         }

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -96,7 +96,7 @@ fn test_graph_connectivity() {
         let links = hnsw_index
             .graph()
             .links
-            .links(point_id as PointOffsetType, 0);
+            .links_vec(point_id as PointOffsetType, 0);
         for link in links {
             reverse_links[link as usize].push(point_id);
         }


### PR DESCRIPTION
This PR slightly updates the `GraphLinks` trait:
- Removed: `fn links()`; it was `iter()`-like, i.e. returns an iterator.
- Added instead: `fn for_each_link()`; it's `for_each()`-like, i.e. takes a closure.
- Also, added `#[cfg(test)] fn links_vec()`; returns a vector. Obliviously, it's slow, but it used only in tests.

The reason is that it would be easier for a compiler to generate inline-able code. (and the the subsequent PRs depend on this change)