### PR TITLE
Refactor `GraphLinksConverter`

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -46,6 +46,8 @@ for lvl > 0:
 links offset = level_offsets[level] + offsets[reindex[point_id]]
 */
 
+const HEADER_SIZE: usize = 64;
+
 #[derive(Clone, Debug, Default)]
 struct GraphLinksFileHeader {
     pub point_count: u64,
@@ -115,7 +117,7 @@ impl GraphLinksFileHeader {
     pub fn get_level_offsets_range(&self) -> Range<usize> {
         // level offsets are stored after header
         // but we might want to have some extra space for future changes
-        let start = max(64, Self::raw_size());
+        let start = max(HEADER_SIZE, Self::raw_size());
         start..start + self.levels_count as usize * size_of::<u64>()
     }
 


### PR DESCRIPTION
This PR refactors `GraphLinksConverter` in preparation for adding support for compressing.

- `GraphLinksFileHeader` is split into `GraphLinksFileHeader` (on-disk representation) and `GraphLinksFileInfo` (in-memory, all offsets are calculated).
- Replaced usages of `mmap_ops::transmute_from_u8_to_slice` with equivalents from the `transmute` crate (as I find it to be more sound).
- Now, it serializes into `impl Write` sequentially rather than into `&mut [u8]`.
- The serialization code now looks much simpler. It will extended later to support writing in a compressed format.