### PR TITLE
Implement links compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ version = "0.0.0"
 dependencies = [
  "common",
  "criterion",
+ "itertools 0.13.0",
  "lazy_static",
  "log",
  "memmap2",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -35,6 +35,7 @@ log = { workspace = true }
 [dev-dependencies]
 common = { path = ".", features = ["testing"] }
 criterion = { workspace = true }
+itertools = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 thiserror = { workspace = true }

--- a/lib/common/common/benches/bitpacking.rs
+++ b/lib/common/common/benches/bitpacking.rs
@@ -43,6 +43,7 @@ pub fn bench_bitpacking(c: &mut Criterion) {
                 (bits, &data32[start..start + values])
             },
             |(bits, data)| {
+                out.clear();
                 let mut w = BitWriter::new(&mut out);
                 for &x in data {
                     w.write(x, bits);

--- a/lib/common/common/benches/bitpacking.rs
+++ b/lib/common/common/benches/bitpacking.rs
@@ -1,7 +1,9 @@
 use std::hint::black_box;
 
 use common::bitpacking::{BitReader, BitWriter};
+use common::bitpacking_links::{for_each_packed_link, pack_links};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use itertools::Itertools as _;
 use rand::rngs::StdRng;
 use rand::{Rng as _, SeedableRng as _};
 
@@ -56,10 +58,53 @@ pub fn bench_bitpacking(c: &mut Criterion) {
     });
 }
 
+pub fn bench_bitpacking_links(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bitpacking_links");
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut links = Vec::new();
+    let mut pos = vec![(0, 0, 0)];
+    while links.len() <= 64_000_000 {
+        let bits_per_unsorted = rng.gen_range(7..=32);
+        let sorted_count = rng.gen_range(0..100);
+        let unsorted_count = rng.gen_range(0..100);
+        if 1 << bits_per_unsorted < sorted_count + unsorted_count {
+            continue;
+        }
+
+        pack_links(
+            &mut links,
+            std::iter::repeat_with(|| rng.gen_range(0..1u64 << bits_per_unsorted) as u32)
+                .unique()
+                .take(sorted_count + unsorted_count)
+                .collect(),
+            bits_per_unsorted,
+            sorted_count,
+        );
+        pos.push((links.len(), bits_per_unsorted, sorted_count));
+    }
+
+    let mut rng = StdRng::seed_from_u64(42);
+    group.bench_function("read", |b| {
+        b.iter_batched(
+            || {
+                let idx = rng.gen_range(1..pos.len());
+                (&links[pos[idx - 1].0..pos[idx].0], pos[idx].1, pos[idx].2)
+            },
+            |(links, bits_per_unsorted, sorted_count)| {
+                for_each_packed_link(links, bits_per_unsorted, sorted_count, |x| {
+                    black_box(x);
+                });
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = bench_bitpacking
+    targets = bench_bitpacking, bench_bitpacking_links,
 }
 
 criterion_main!(benches);

--- a/lib/common/common/src/bitpacking.rs
+++ b/lib/common/common/src/bitpacking.rs
@@ -159,6 +159,12 @@ fn read_buf_and_advance(input: &mut &[u8]) -> Buf {
     buf
 }
 
+/// Minimum amount of bits required to store a value in the range
+/// `0..=max_value`.
+pub fn packed_bits(max_value: u32) -> u8 {
+    (u32::BITS - max_value.leading_zeros()) as u8
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter::zip;
@@ -234,5 +240,23 @@ mod tests {
                 assert_eq!(values, unpacked);
             }
         }
+    }
+
+    #[test]
+    fn test_packed_bits() {
+        assert_eq!(packed_bits(0), 0);
+
+        assert_eq!(packed_bits(1), 1);
+
+        assert_eq!(packed_bits(2), 2);
+        assert_eq!(packed_bits(3), 2);
+
+        assert_eq!(packed_bits(4), 3);
+        assert_eq!(packed_bits(7), 3);
+
+        assert_eq!(packed_bits(0x_7FFF_FFFF), 31);
+
+        assert_eq!(packed_bits(0x_8000_0000), 32);
+        assert_eq!(packed_bits(0x_FFFF_FFFF), 32);
     }
 }

--- a/lib/common/common/src/bitpacking.rs
+++ b/lib/common/common/src/bitpacking.rs
@@ -14,9 +14,9 @@ pub struct BitWriter<'a> {
 }
 
 impl<'a> BitWriter<'a> {
+    /// Create a new writer that appends bits to the `output`.
     #[inline]
     pub fn new(output: &'a mut Vec<u8>) -> Self {
-        output.clear();
         Self {
             output,
             buf: 0,
@@ -222,6 +222,7 @@ mod tests {
                     total_bits += u64::from(bits);
                 }
 
+                packed.clear();
                 let mut w = BitWriter::new(&mut packed);
                 for (&x, &bits) in zip(&values, &bits_per_value) {
                     w.write(x, bits);

--- a/lib/common/common/src/bitpacking_links.rs
+++ b/lib/common/common/src/bitpacking_links.rs
@@ -1,0 +1,147 @@
+use crate::bitpacking::{packed_bits, BitReader, BitWriter};
+
+/// To simplify value counting, each value should be at least one byte.
+/// Otherwise the count could would be ambiguous, e.g., a 2-byte slice of 5-bit
+/// values could contain either 2 or 3 values.
+pub const MIN_BITS_PER_VALUE: u8 = u8::BITS as u8;
+
+/// How many bits required to store a value in range
+/// `MIN_BITS_PER_VALUE..=u32::BITS`.
+const HEADER_BITS: u8 = 5;
+
+/// A specialized packer to pack HNSW graph links.
+///
+/// It assumes that the first `m` (or `m0`) values could be re-orderd for better
+/// compression.
+///
+/// Parameters:
+/// - `bits_per_unsorted` should be enough to store the maximum point ID
+///   (it should be the same for all nodes/links within a segment).
+/// - `sorted_count` is `m` (or `m0`) for this layer.
+pub fn pack_links(
+    links: &mut Vec<u8>,
+    mut raw_links: Vec<u32>,
+    bits_per_unsorted: u8,
+    sorted_count: usize,
+) {
+    if raw_links.is_empty() {
+        return;
+    }
+
+    // Sort and delta-encode the first `sorted_count` links.
+    let sorted_count = raw_links.len().min(sorted_count);
+    raw_links[..sorted_count].sort_unstable();
+    for i in (1..sorted_count).rev() {
+        raw_links[i] -= raw_links[i - 1];
+    }
+
+    let mut w = BitWriter::new(links);
+
+    if sorted_count != 0 {
+        // 1. Header.
+        let bits_per_sorted =
+            packed_bits(*raw_links[..sorted_count].iter().max().unwrap()).max(MIN_BITS_PER_VALUE);
+        w.write(u32::from(bits_per_sorted - MIN_BITS_PER_VALUE), HEADER_BITS);
+
+        // 2. First `sorted_count` values, sorted and delta-encoded.
+        //    The bit width is determined by the header.
+        for &value in &raw_links[..sorted_count] {
+            w.write(value, bits_per_sorted);
+        }
+    }
+
+    // 3. The rest of the values, unsorted.
+    for &value in &raw_links[sorted_count..] {
+        w.write(value, bits_per_unsorted);
+    }
+
+    w.finish();
+}
+
+/// Iterate over packed links and apply a function to each value.
+/// See [`pack_links`] for parameter descriptions.
+#[inline]
+pub fn for_each_packed_link(
+    links: &[u8],
+    bits_per_unsorted: u8,
+    sorted_count: usize,
+    mut f: impl FnMut(u32),
+) {
+    if links.is_empty() {
+        return;
+    }
+
+    let mut r = BitReader::new(links);
+
+    let mut remaining_bits = links.len() * u8::BITS as usize;
+    if sorted_count != 0 {
+        // 1. Header.
+        r.set_bits(HEADER_BITS);
+        let bits_per_sorted = r.read() as u8 + MIN_BITS_PER_VALUE;
+        remaining_bits -= HEADER_BITS as usize;
+
+        // 2. First `sorted_count` values, sorted and delta-encoded.
+        r.set_bits(bits_per_sorted);
+        let remaining_bits_target = remaining_bits
+            - sorted_count.min(remaining_bits / bits_per_sorted as usize)
+                * bits_per_sorted as usize;
+        let mut value = 0;
+        while remaining_bits > remaining_bits_target {
+            value += r.read();
+            f(value);
+            remaining_bits -= bits_per_sorted as usize;
+        }
+    }
+
+    // 3. The rest of the values, unsorted.
+    r.set_bits(bits_per_unsorted);
+    while remaining_bits >= bits_per_unsorted as usize {
+        f(r.read());
+        remaining_bits -= bits_per_unsorted as usize;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools as _;
+    use rand::rngs::StdRng;
+    use rand::{Rng as _, SeedableRng as _};
+
+    use super::*;
+
+    #[test]
+    fn test_random() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..100 {
+            let bits_per_unsorted = rng.gen_range(7..=32);
+            let sorted_count = rng.gen_range(0..100);
+            let unsorted_count = rng.gen_range(0..100);
+            if 1 << bits_per_unsorted < sorted_count + unsorted_count {
+                continue;
+            }
+
+            let mut raw_links =
+                std::iter::repeat_with(|| rng.gen_range(0..1u64 << bits_per_unsorted) as u32)
+                    .unique()
+                    .take(sorted_count + unsorted_count)
+                    .collect::<Vec<u32>>();
+
+            let mut links = Vec::new();
+            pack_links(
+                &mut links,
+                raw_links.clone(),
+                bits_per_unsorted,
+                sorted_count,
+            );
+
+            let mut unpacked = Vec::new();
+            for_each_packed_link(&links, bits_per_unsorted, sorted_count, |value| {
+                unpacked.push(value)
+            });
+
+            raw_links[..sorted_count].sort_unstable();
+            assert_eq!(raw_links, unpacked);
+        }
+    }
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bitpacking;
+pub mod bitpacking_links;
 pub mod counter;
 pub mod cpu;
 pub mod defaults;

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -10,7 +10,7 @@ use memory::mmap_ops;
 use serde::{Deserialize, Serialize};
 
 use super::entry_points::EntryPoint;
-use super::graph_links::{GraphLinks, GraphLinksMmap};
+use super::graph_links::{convert_to_compressed, GraphLinks, GraphLinksMmap};
 use crate::common::operation_error::OperationResult;
 use crate::common::utils::rev_range;
 use crate::index::hnsw_index::entry_points::EntryPoints;
@@ -270,7 +270,7 @@ where
         let graph_data: GraphLayerData = read_bin(graph_path)?;
 
         if convert {
-            // TODO: Implement conversion
+            convert_to_compressed(links_path, graph_data.m, graph_data.m0)?;
         }
 
         Ok(Self {


### PR DESCRIPTION
This PR add HNSW graph links compression implementation, both for reading and writing.

The integration is added in #5489: it's disabled by default unless `__QDRANT_COMPRESSED_LINKS` is set.

~Depends on #5486, #5487, #5489, #5490, #5491. Ignore all but the last commit during the review.~