### PR TITLE
Log all errors during replica set update

### DIFF
--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -355,6 +355,14 @@ impl ShardReplicaSet {
         };
 
         if !failures.is_empty() {
+            for (peer_id, err) in &failures {
+                log::warn!(
+                    "Failed to update shard {}:{} on peer {peer_id}, error: {err}",
+                    self.collection_id,
+                    self.shard_id,
+                );
+            }
+
             if successes.len() >= minimal_success_count {
                 // If there are enough successes, deactivate failed replicas
                 // Failed replicas will automatically recover from another replica ensuring consistency
@@ -473,12 +481,6 @@ impl ShardReplicaSet {
         let mut wait_for_deactivation = false;
 
         for (peer_id, err) in failures {
-            log::warn!(
-                "Failed to update shard {}:{} on peer {peer_id}, error: {err}",
-                self.collection_id,
-                self.shard_id,
-            );
-
             let Some(peer_state) = state.get_peer_state(*peer_id) else {
                 continue;
             };


### PR DESCRIPTION
For some reason, we did not always log errors for some code paths in `ShardReplicaSet::update_impl`. This PR restructures it a tiny bit, so that we *always* log all errors.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
