### PR TITLE
Compute storage size for blobstore

### DIFF
--- a/lib/blob_store/benches/real_data_bench.rs
+++ b/lib/blob_store/benches/real_data_bench.rs
@@ -1,39 +1,105 @@
 use std::fs::File;
+use std::path::Path;
 
 use blob_store::fixtures::{empty_storage, Payload, HM_FIELDS};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use serde_json::Value;
 
+/// Insert CSV data into the storage
+fn insert_csv_data(
+    storage: &mut blob_store::BlobStore<Payload>,
+    csv_path: &Path,
+    expected_point_count: u32,
+) {
+    let csv_file = File::open(csv_path).expect("file should open");
+    let mut rdr = csv::Reader::from_reader(csv_file);
+    let mut point_offset = 0;
+    for result in rdr.records() {
+        let record = result.unwrap();
+        let mut payload = Payload::default();
+        for (i, &field) in HM_FIELDS.iter().enumerate() {
+            payload.0.insert(
+                field.to_string(),
+                Value::String(record.get(i).unwrap().to_string()),
+            );
+        }
+        storage.put_value(point_offset, &payload).unwrap();
+        point_offset += 1;
+    }
+    assert_eq!(point_offset, expected_point_count);
+}
+
+/// Recursively compute the size of a directory in megabytes
+fn compute_folder_size_mb<P: AsRef<Path>>(path: P) -> u64 {
+    let mut size = 0;
+    for entry in std::fs::read_dir(path).unwrap() {
+        let entry = entry.unwrap();
+        let metadata = entry.metadata().unwrap();
+
+        if metadata.is_dir() {
+            size += compute_folder_size_mb(entry.path());
+        } else {
+            size += metadata.len();
+        }
+    }
+    (size as f32 / 1_000_000.0).ceil() as u64
+}
+
 pub fn real_data_data_bench(c: &mut Criterion) {
-    let (_dir, mut storage) = empty_storage();
+    let (dir, mut storage) = empty_storage();
     let csv_path = dataset::Dataset::HMArticles
         .download()
         .expect("download should succeed");
 
+    // check source file size
+    let file_size_bytes = std::fs::metadata(csv_path.clone())
+        .expect("file should exist")
+        .len();
+    assert_eq!(file_size_bytes, 36_127_865); // 36MB
+
+    // the CSV file has 105_542 rows
     let expected_point_count = 105_542;
 
-    c.bench_function("write real payload", |b| {
-        b.iter(|| {
-            let csv_file = File::open(csv_path.clone()).expect("file should open");
-            let mut rdr = csv::Reader::from_reader(csv_file);
-            let mut point_offset = 0;
-            for result in rdr.records() {
-                let record = result.unwrap();
-                let mut payload = Payload::default();
-                for (i, &field) in HM_FIELDS.iter().enumerate() {
-                    payload.0.insert(
-                        field.to_string(),
-                        Value::String(record.get(i).unwrap().to_string()),
-                    );
-                }
-                storage.put_value(point_offset, &payload).unwrap();
-                point_offset += 1;
-            }
-            assert_eq!(point_offset, expected_point_count);
-        });
+    // insert data once
+    insert_csv_data(&mut storage, &csv_path, expected_point_count);
+
+    // flush to get a consistent bitmask
+    storage.flush().unwrap();
+
+    // sanity check of storage size
+    let storage_size = storage.get_storage_size_bytes();
+    assert_eq!(storage_size, 54_034_048); // 54MB
+
+    // check storage folder size
+    let file_size_mb = compute_folder_size_mb(dir.path());
+    assert_eq!(file_size_mb, 70); // 70MB (includes metadata)
+
+    c.bench_function("compute storage size", |b| {
+        b.iter(|| black_box(storage.get_storage_size_bytes()));
     });
 
     c.bench_function("read real payload", |b| {
+        b.iter(|| {
+            for i in 0..expected_point_count {
+                let res = storage.get_value(i).unwrap();
+                assert!(res.0.contains_key("article_id"));
+            }
+        });
+    });
+
+    // disclaimer: updating values creates a lot of pages due to copy-on-write
+    c.bench_function("upsert real payload", |b| {
+        b.iter(|| insert_csv_data(&mut storage, &csv_path, expected_point_count));
+    });
+
+    let inflated_storage_size = storage.get_storage_size_bytes();
+    assert_eq!(inflated_storage_size, 5_619_540_992); // 5.6GB!
+
+    c.bench_function("compute storage size (large storage)", |b| {
+        b.iter(|| black_box(storage.get_storage_size_bytes()));
+    });
+
+    c.bench_function("read real payload (large storage)", |b| {
         b.iter(|| {
             for i in 0..expected_point_count {
                 let res = storage.get_value(i).unwrap();

--- a/lib/blob_store/src/bitmask/gaps.rs
+++ b/lib/blob_store/src/bitmask/gaps.rs
@@ -58,6 +58,18 @@ impl RegionGaps {
             trailing: blocks,
         }
     }
+
+    /// Check if the region is completely empty.
+    /// That is a single large gap
+    pub fn is_empty(&self, region_size_blocks: u16) -> bool {
+        self.max == region_size_blocks
+    }
+
+    /// Check if the region is completely full.
+    /// That is no gaps in the region.
+    pub fn is_full(&self) -> bool {
+        self.max == 0
+    }
 }
 
 /// An overview of contiguous free blocks covered by the bitmask.

--- a/lib/blob_store/src/bitmask/mod.rs
+++ b/lib/blob_store/src/bitmask/mod.rs
@@ -127,6 +127,32 @@ impl Bitmask {
         Ok(())
     }
 
+    /// Compute the size of the storage in bytes.
+    /// Does not include the metadata information (e.g. the regions gaps, bitmask...).
+    pub fn get_storage_size_bytes(&self) -> usize {
+        let mut size = 0;
+        let region_size_blocks = self.config.region_size_blocks;
+        let bloc_size_bytes = self.config.block_size_bytes;
+        let region_size_bytes = region_size_blocks * bloc_size_bytes;
+        for (gap_id, gap) in self.regions_gaps.as_slice().iter().enumerate() {
+            // skip empty regions
+            if gap.is_empty(region_size_blocks as u16) {
+                continue;
+            }
+            // fast path for full regions
+            if gap.is_full() {
+                size += region_size_bytes;
+            } else {
+                // compute the size of the occupied blocks for the region
+                let gap_offset_start = gap_id * region_size_blocks;
+                let gap_offset_end = gap_offset_start + region_size_blocks;
+                let occupied_bloc = self.bitslice[gap_offset_start..gap_offset_end].count_ones();
+                size += occupied_bloc * bloc_size_bytes
+            }
+        }
+        size
+    }
+
     pub fn infer_num_pages(&self) -> usize {
         let bits = self.bitslice.len();
         let covered_bytes = bits * self.config.block_size_bytes;

--- a/lib/blob_store/src/bitmask/mod.rs
+++ b/lib/blob_store/src/bitmask/mod.rs
@@ -132,8 +132,8 @@ impl Bitmask {
     pub fn get_storage_size_bytes(&self) -> usize {
         let mut size = 0;
         let region_size_blocks = self.config.region_size_blocks;
-        let bloc_size_bytes = self.config.block_size_bytes;
-        let region_size_bytes = region_size_blocks * bloc_size_bytes;
+        let block_size_bytes = self.config.block_size_bytes;
+        let region_size_bytes = region_size_blocks * block_size_bytes;
         for (gap_id, gap) in self.regions_gaps.as_slice().iter().enumerate() {
             // skip empty regions
             if gap.is_empty(region_size_blocks as u16) {
@@ -146,8 +146,8 @@ impl Bitmask {
                 // compute the size of the occupied blocks for the region
                 let gap_offset_start = gap_id * region_size_blocks;
                 let gap_offset_end = gap_offset_start + region_size_blocks;
-                let occupied_bloc = self.bitslice[gap_offset_start..gap_offset_end].count_ones();
-                size += occupied_bloc * bloc_size_bytes
+                let occupied_blocks = self.bitslice[gap_offset_start..gap_offset_end].count_ones();
+                size += occupied_blocks * block_size_bytes
             }
         }
         size

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -394,6 +394,11 @@ impl<V: Blob> BlobStore<V> {
         }
         Ok(())
     }
+
+    /// Return the storage size in bytes
+    pub fn get_storage_size_bytes(&self) -> usize {
+        self.bitmask.read().get_storage_size_bytes()
+    }
 }
 
 impl<V> BlobStore<V> {
@@ -459,6 +464,7 @@ mod tests {
         let (_dir, storage) = empty_storage();
         let payload = storage.get_value(0);
         assert!(payload.is_none());
+        assert_eq!(storage.get_storage_size_bytes(), 0);
     }
 
     #[test]
@@ -474,6 +480,7 @@ mod tests {
         let stored_payload = storage.get_value(0);
         assert!(stored_payload.is_some());
         assert_eq!(stored_payload.unwrap(), Payload::default());
+        assert_eq!(storage.get_storage_size_bytes(), DEFAULT_BLOCK_SIZE_BYTES);
     }
 
     #[test]
@@ -497,6 +504,7 @@ mod tests {
         let stored_payload = storage.get_value(0);
         assert!(stored_payload.is_some());
         assert_eq!(stored_payload.unwrap(), payload);
+        assert_eq!(storage.get_storage_size_bytes(), DEFAULT_BLOCK_SIZE_BYTES);
     }
 
     #[test]
@@ -578,6 +586,7 @@ mod tests {
 
         let stored_payload = storage.get_value(0);
         assert_eq!(stored_payload, Some(payload));
+        assert_eq!(storage.get_storage_size_bytes(), DEFAULT_BLOCK_SIZE_BYTES);
 
         // delete payload
         let deleted = storage.delete_value(0);
@@ -587,6 +596,8 @@ mod tests {
         // get payload again
         let stored_payload = storage.get_value(0);
         assert!(stored_payload.is_none());
+        storage.flush().unwrap();
+        assert_eq!(storage.get_storage_size_bytes(), 0);
     }
 
     #[test]
@@ -726,13 +737,18 @@ mod tests {
             assert_eq!(stored_payload.as_ref(), model_payload);
         }
 
+        // flush data
+        storage.flush().unwrap();
+
+        let before_size = storage.get_storage_size_bytes();
         // drop storage
         drop(storage);
 
         // reopen storage
         let storage = BlobStore::<Payload>::open(dir.path().to_path_buf()).unwrap();
-
-        // asset same length
+        // assert same size
+        assert_eq!(storage.get_storage_size_bytes(), before_size);
+        // assert same length
         assert_eq!(storage.tracker.read().mapping_len(), model_hashmap.len());
 
         // validate storage and model_hashmap are the same

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -71,6 +71,10 @@ impl<V: Blob> BlobStore<V> {
         self.pages.len() as PageId
     }
 
+    pub fn max_point_id(&self) -> PointOffset {
+        self.tracker.read().pointer_count()
+    }
+
     /// Initializes a new storage with a single empty page.
     ///
     /// `base_path` is the directory where the storage files will be stored.

--- a/lib/blob_store/src/tracker.rs
+++ b/lib/blob_store/src/tracker.rs
@@ -177,7 +177,6 @@ impl Tracker {
         self.mmap.len()
     }
 
-    #[cfg(test)]
     pub fn pointer_count(&self) -> u32 {
         self.header.next_pointer_offset
     }


### PR DESCRIPTION
Introduces a new feature to compute the storage size of the blobstore.

It targets only the values stored on the behalf of the users, it does not include our technical metadata (gaps, bitmask ...).

The computation leverages the region gaps to fast path empty and full regions.

The benchmarks show that handles 5GB of data in 500us.

```console
cargo bench -p blob_store --bench real_data_bench

compute storage size    
                        time:   [5.3589 µs 5.3737 µs 5.3895 µs]
                       
read real payload
                        time:   [638.35 ms 639.51 ms 641.02 ms]

upsert real payload
                        time:   [1.3302 s 1.3809 s 1.4324 s]

compute storage size (large storage) <--- 5GB
                        time:   [497.03 µs 498.55 µs 499.94 µs]

read real payload (large storage)
                        time:   [613.18 ms 615.96 ms 619.53 ms]
```

I refactored the benchmark to draw the attention on the size of the underlying storage.