### PR TITLE
Retrieve points by streaming shard results

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -456,7 +456,8 @@ impl Collection {
             })
             .collect::<FuturesUnordered<_>>();
 
-        let mut covered_point_ids = HashMap::with_capacity(ids_len);
+        // pre-allocate hashmap with capped capacity to protect from malevolent input
+        let mut covered_point_ids = HashMap::with_capacity(ids_len.min(1024));
         while let Some(response) = all_shard_collection_requests.try_next().await? {
             for point in response {
                 // Add each point only once, deduplicate point IDs


### PR DESCRIPTION
Experimenting with streaming processing of results from shards.

## pros

- do not wait for all shards before processing points
- do not allocate all results eagerly
- pre-allocate result set