### PR TITLE
Also limit the batch-size for vector updates

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1032,3 +1032,13 @@ impl Validate for PointInsertOperations {
         }
     }
 }
+
+impl PointInsertOperations {
+    /// Amonut of vectors in the operation request.
+    pub fn len(&self) -> usize {
+        match self {
+            PointInsertOperations::PointsBatch(batch) => batch.batch.ids.len(),
+            PointInsertOperations::PointsList(list) => list.points.len(),
+        }
+    }
+}

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -117,12 +117,8 @@ impl StrictModeVerification for PointInsertOperations {
         collection: &Collection,
         strict_mode_config: &StrictModeConfig,
     ) -> Result<(), CollectionError> {
-        let len = match self {
-            PointInsertOperations::PointsBatch(batch) => batch.batch.ids.len(),
-            PointInsertOperations::PointsList(list) => list.points.len(),
-        };
         check_limit_opt(
-            Some(len),
+            Some(self.len()),
             strict_mode_config.upsert_max_batchsize,
             "upsert limit",
         )?;
@@ -159,6 +155,12 @@ impl StrictModeVerification for UpdateVectors {
         collection: &Collection,
         strict_mode_config: &StrictModeConfig,
     ) -> Result<(), CollectionError> {
+        check_limit_opt(
+            Some(self.points.len()),
+            strict_mode_config.upsert_max_batchsize,
+            "update limit",
+        )?;
+
         check_collection_vector_size_limit(collection, strict_mode_config).await?;
         Ok(())
     }


### PR DESCRIPTION
Depends on #5501 

Also limit vector update operation with `upsert_max_batchsize` strict mode config.