### PR TITLE
Expose storage size of RocksDB payload storage

### DIFF
--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -114,6 +114,10 @@ impl DatabaseColumnScheduledDeleteWrapper {
     pub fn remove_column_family(&self) -> OperationResult<()> {
         self.db.remove_column_family()
     }
+
+    pub fn get_storage_size_bytes(&self) -> OperationResult<u64> {
+        self.db.get_storage_size_bytes()
+    }
 }
 
 pub struct LockedDatabaseColumnScheduledDeleteWrapper<'a> {

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -272,6 +272,16 @@ impl DatabaseColumnWrapper {
     pub fn get_column_name(&self) -> &str {
         &self.column_name
     }
+
+    /// Get the size of the storage in bytes
+    ///
+    /// The size of this column family in bytes, which is equal to the sum of the file size of its "levels"
+    pub fn get_storage_size_bytes(&self) -> OperationResult<u64> {
+        let db = self.database.read();
+        let cf_handle = self.get_column_family(&db)?;
+        let size = db.get_column_family_metadata_cf(cf_handle).size;
+        Ok(size)
+    }
 }
 
 impl<'a> LockedDatabaseColumnWrapper<'a> {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -287,7 +287,8 @@ mod tests {
         // needs a flush to impact the storage size
         storage.flusher()().unwrap();
         // large value contains initial cost of infra (SSTable, etc.), not stable across different OS
-        assert!(storage.get_storage_size_bytes().unwrap() > 1100);
+        let storage_size = storage.get_storage_size_bytes().unwrap();
+        assert!(storage_size > 1000, "storage_size = {storage_size}");
 
         // check how it scales
         for _ in 1..=100 {
@@ -296,6 +297,7 @@ mod tests {
 
         storage.flusher()().unwrap();
         // loose assertion because value not stable across different OS
-        assert!(storage.get_storage_size_bytes().unwrap() > 2200);
+        let storage_size = storage.get_storage_size_bytes().unwrap();
+        assert!(storage_size > 2000, "storage_size = {storage_size}");
     }
 }

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -286,7 +286,8 @@ mod tests {
 
         // needs a flush to impact the storage size
         storage.flusher()().unwrap();
-        assert!(storage.get_storage_size_bytes().unwrap() > 1100); // contains initial cost of infra (SSTable, etc.)
+        // large value contains initial cost of infra (SSTable, etc.), not stable across different OS
+        assert!(storage.get_storage_size_bytes().unwrap() > 1100);
 
         // check how it scales
         for _ in 1..=100 {
@@ -294,6 +295,7 @@ mod tests {
         }
 
         storage.flusher()().unwrap();
-        assert_eq!(storage.get_storage_size_bytes().unwrap(), 2206);
+        // loose assertion because value not stable across different OS
+        assert!(storage.get_storage_size_bytes().unwrap() > 2200);
     }
 }

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -286,7 +286,7 @@ mod tests {
 
         // needs a flush to impact the storage size
         storage.flusher()().unwrap();
-        assert_eq!(storage.get_storage_size_bytes().unwrap(), 1103); // contains initial cost of infra (SSTable, etc.)
+        assert!(storage.get_storage_size_bytes().unwrap() > 1100); // contains initial cost of infra (SSTable, etc.)
 
         // check how it scales
         for _ in 1..=100 {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -288,7 +288,10 @@ mod tests {
         storage.flusher()().unwrap();
         // large value contains initial cost of infra (SSTable, etc.), not stable across different OS
         let storage_size = storage.get_storage_size_bytes().unwrap();
-        assert!(storage_size > 1000, "storage_size = {storage_size}");
+        assert!(
+            storage_size > 1000 && storage_size < 1300,
+            "storage_size = {storage_size}"
+        );
 
         // check how it scales
         for _ in 1..=100 {
@@ -298,6 +301,9 @@ mod tests {
         storage.flusher()().unwrap();
         // loose assertion because value not stable across different OS
         let storage_size = storage.get_storage_size_bytes().unwrap();
-        assert!(storage_size > 2000, "storage_size = {storage_size}");
+        assert!(
+            storage_size > 2000 && storage_size < 2300,
+            "storage_size = {storage_size}"
+        );
     }
 }

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -56,4 +56,8 @@ impl SimplePayloadStorage {
     pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
         self.payload.get(&point_id)
     }
+
+    pub fn get_storage_size_bytes(&self) -> OperationResult<u64> {
+        self.db_wrapper.get_storage_size_bytes()
+    }
 }


### PR DESCRIPTION
Introduces a new feature to retrieve the RocksDB storage size of a given column family.

I tried various approach before settling on this one, it seems to give a good proxy for what is being persisted.

This function is introduced mostly for consistency sake as we want to support this feature on the payload storage trait.
It is unlikely that it will be used meaningfully in practice.