### PR TITLE
[vector storages] Don't skip marking as deleted

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -37,7 +37,7 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> AppendableMmapDenseV
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> OperationResult<bool> {
-        if self.vectors.len() <= key as usize {
+        if !deleted && self.vectors.len() <= key as usize {
             return Ok(false);
         }
 

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -169,11 +169,8 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
         }
     }
 
+    /// Marks the key as deleted, return s
     pub fn delete(&mut self, key: PointOffsetType) -> bool {
-        if self.num_vectors <= key as usize {
-            return false;
-        }
-
         let is_deleted = !self.deleted.replace(key as usize, true);
         if is_deleted {
             self.deleted_count += 1;

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -169,7 +169,9 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
         }
     }
 
-    /// Marks the key as deleted, return s
+    /// Marks the key as deleted.
+    ///
+    /// Returns true if the key was not deleted before, and it is now deleted.
     pub fn delete(&mut self, key: PointOffsetType) -> bool {
         let is_deleted = !self.deleted.replace(key as usize, true);
         if is_deleted {

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -145,7 +145,7 @@ impl<T: PrimitiveVectorElement> SimpleDenseVectorStorage<T> {
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
-        if key as usize >= self.vectors.len() {
+        if !deleted && key as usize >= self.vectors.len() {
             return false;
         }
         let was_deleted = bitvec_set_deleted(&mut self.deleted, key, deleted);

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -55,7 +55,7 @@ impl<
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> OperationResult<bool> {
-        if self.vectors.len() <= key as usize {
+        if !deleted && self.vectors.len() <= key as usize {
             return Ok(false);
         }
 

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -184,7 +184,7 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
-        if key as usize >= self.vectors.len() {
+        if !deleted && key as usize >= self.vectors.len() {
             return false;
         }
         let was_deleted = bitvec_set_deleted(&mut self.deleted, key, deleted);

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -78,7 +78,7 @@ impl SimpleSparseVectorStorage {
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
-        if key as usize >= self.total_vector_count {
+        if !deleted && key as usize >= self.total_vector_count {
             return false;
         }
         let was_deleted = bitvec_set_deleted(&mut self.deleted, key, deleted);

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -106,18 +106,19 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
 }
 
 fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
-    let points: Vec<SparseVector> = vec![
-        vec![(0, 1.0), (2, 1.0), (3, 1.0)],
-        vec![(0, 1.0), (2, 1.0)],
-        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)],
-        vec![(0, 1.0), (1, 1.0), (3, 1.0)],
-        vec![(0, 1.0)],
+    let points: Vec<Option<SparseVector>> = vec![
+        Some(vec![(0, 1.0), (2, 1.0), (3, 1.0)]),
+        Some(vec![(0, 1.0), (2, 1.0)]),
+        None,
+        None,
+        Some(vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)]),
+        Some(vec![(0, 1.0), (1, 1.0), (3, 1.0)]),
+        None,
     ]
     .into_iter()
-    .map(|v| v.try_into().unwrap())
+    .map(|opt| opt.map(|v| v.try_into().unwrap()))
     .collect();
 
-    let delete_mask = [false, false, true, true, false];
     let id_tracker: Arc<AtomicRefCell<IdTrackerSS>> =
         Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
 
@@ -127,16 +128,17 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
         let mut storage2 =
             open_simple_sparse_vector_storage(db, DB_VECTOR_CF, &AtomicBool::new(false)).unwrap();
-        {
-            points.iter().enumerate().for_each(|(i, vec)| {
+
+        points.iter().enumerate().for_each(|(i, opt_vec)| {
+            if let Some(vec) = opt_vec {
                 storage2
                     .insert_vector(i as PointOffsetType, vec.into())
                     .unwrap();
-                if delete_mask[i] {
-                    storage2.delete_vector(i as PointOffsetType).unwrap();
-                }
-            });
-        }
+            } else {
+                storage2.delete_vector(i as PointOffsetType).unwrap();
+            }
+        });
+
         let mut iter = (0..points.len()).map(|i| {
             let i = i as PointOffsetType;
             let vec = storage2.get_vector(i);
@@ -148,8 +150,8 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
 
     assert_eq!(
         storage.deleted_vector_count(),
-        2,
-        "2 vectors must be deleted from other storage"
+        3,
+        "3 vectors must be deleted from other storage"
     );
 
     // Check that deleted points are deleted through raw scorer
@@ -169,21 +171,28 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap();
-    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4, 5].iter().cloned(), 5);
     scorer.take_hardware_counter().discard_results();
     drop(scorer);
-    assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
-    assert_eq!(closest[0].idx, 0);
-    assert_eq!(closest[1].idx, 1);
-    assert_eq!(closest[2].idx, 4);
+
+    assert_eq!(
+        closest.len(),
+        4,
+        "must have 4 vectors, 3 are deleted. closest = {closest:?}"
+    );
+    assert_eq!(closest[0].idx, 4);
+    assert_eq!(closest[1].idx, 0);
+    assert_eq!(closest[2].idx, 5);
+    assert_eq!(closest[3].idx, 1);
 
     // Delete all
     storage.delete_vector(0 as PointOffsetType).unwrap();
     storage.delete_vector(1 as PointOffsetType).unwrap();
     storage.delete_vector(4 as PointOffsetType).unwrap();
+    storage.delete_vector(5 as PointOffsetType).unwrap();
     assert_eq!(
         storage.deleted_vector_count(),
-        5,
+        7,
         "all vectors must be deleted"
     );
 }


### PR DESCRIPTION
In the vector storages, we usually have a `deleted_bitvec` which marks the vectors as deleted. 

However, there was a shortcut, which would skip marking as deleted, if the point offset exceeded the current length of the storage. This is incorrect and should be only applied when setting `deleted=false`.

This PR fixes those cases and adds (modifies) a test which would fail on `dev` branch, but now passes