### PR TITLE
Clippy 1.83

### DIFF
--- a/lib/collection/benches/prof.rs
+++ b/lib/collection/benches/prof.rs
@@ -45,7 +45,7 @@ pub struct FlamegraphProfiler<'a> {
     active_profiler: Option<ProfilerGuard<'a>>,
 }
 
-impl<'a> FlamegraphProfiler<'a> {
+impl FlamegraphProfiler<'_> {
     #[allow(dead_code)]
     pub fn new(frequency: c_int) -> Self {
         FlamegraphProfiler {
@@ -55,7 +55,7 @@ impl<'a> FlamegraphProfiler<'a> {
     }
 }
 
-impl<'a> Profiler for FlamegraphProfiler<'a> {
+impl Profiler for FlamegraphProfiler<'_> {
     fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
         self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
     }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -197,9 +197,7 @@ impl Collection {
             None => shard_holder_guard.insert(self.shards_holder.read().await),
         };
 
-        let is_resharding_transfer = transfer
-            .method
-            .map_or(false, |method| method.is_resharding());
+        let is_resharding_transfer = transfer.method.is_some_and(|method| method.is_resharding());
 
         // Handle *destination* replica
         let mut is_dest_replica_active = false;
@@ -298,9 +296,7 @@ impl Collection {
             return Ok(());
         };
 
-        let is_resharding_transfer = transfer
-            .method
-            .map_or(false, |method| method.is_resharding());
+        let is_resharding_transfer = transfer.method.is_some_and(|method| method.is_resharding());
 
         let shard_id = transfer_key.to_shard_id.unwrap_or(transfer_key.shard_id);
 
@@ -411,7 +407,7 @@ impl Collection {
                         |state| {
                             state
                                 .get_peer_state(this_peer_id)
-                                .map_or(false, |peer_state| peer_state.is_partial_or_recovery())
+                                .is_some_and(|peer_state| peer_state.is_partial_or_recovery())
                         },
                         defaults::CONSENSUS_META_OP_WAIT,
                     )
@@ -445,12 +441,12 @@ impl Collection {
         let incoming_shard_transfer_limit_reached = self
             .shared_storage_config
             .incoming_shard_transfers_limit
-            .map_or(false, |limit| incoming >= limit);
+            .is_some_and(|limit| incoming >= limit);
 
         let outgoing_shard_transfer_limit_reached = self
             .shared_storage_config
             .outgoing_shard_transfers_limit
-            .map_or(false, |limit| outgoing >= limit);
+            .is_some_and(|limit| outgoing >= limit);
 
         incoming_shard_transfer_limit_reached || outgoing_shard_transfer_limit_reached
     }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -156,7 +156,7 @@ impl<'s> SegmentHolder {
     /// Iterate over all segments with their IDs
     ///
     /// Appendable first, then non-appendable.
-    pub fn iter(&'s self) -> impl Iterator<Item = (&SegmentId, &LockedSegment)> + 's {
+    pub fn iter(&'s self) -> impl Iterator<Item = (&'s SegmentId, &'s LockedSegment)> + 's {
         self.appendable_segments
             .iter()
             .chain(self.non_appendable_segments.iter())

--- a/lib/collection/src/common/eta_calculator.rs
+++ b/lib/collection/src/common/eta_calculator.rs
@@ -30,7 +30,7 @@ impl EtaCalculator {
     }
 
     fn set_progress_raw(&mut self, now: Instant, current_progress: usize) {
-        if self.0.back().map_or(false, |(_, l)| current_progress < *l) {
+        if self.0.back().is_some_and(|(_, l)| current_progress < *l) {
             // Progress went backwards, reset the state.
             *self = Self::new();
         }

--- a/lib/collection/src/common/retrieve_request_trait.rs
+++ b/lib/collection/src/common/retrieve_request_trait.rs
@@ -105,7 +105,7 @@ impl RetrieveRequest for DiscoverRequestInternal {
     }
 }
 
-impl<'a> RetrieveRequest for CollectionQueryResolveRequest<'a> {
+impl RetrieveRequest for CollectionQueryResolveRequest<'_> {
     fn get_lookup_collection(&self) -> Option<&String> {
         self.lookup_from.as_ref().map(|x| &x.collection)
     }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -246,7 +246,7 @@ impl SnapshotStorageLocalFS {
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
 
-            if !path.is_dir() && path.extension().map_or(false, |ext| ext == "snapshot") {
+            if !path.is_dir() && path.extension().is_some_and(|ext| ext == "snapshot") {
                 snapshots.push(get_snapshot_description(&path).await?);
             }
         }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -239,7 +239,7 @@ impl TryFrom<VectorStructPersisted> for VectorStructInternal {
     }
 }
 
-impl<'a> From<VectorStructPersisted> for NamedVectors<'a> {
+impl From<VectorStructPersisted> for NamedVectors<'_> {
     fn from(value: VectorStructPersisted) -> Self {
         match value {
             VectorStructPersisted::Single(vector) => {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1612,7 +1612,7 @@ impl VectorsConfig {
     /// Iterate over the named vector parameters.
     ///
     /// If this is `Single` it iterates over a single parameter named [`DEFAULT_VECTOR_NAME`].
-    pub fn params_iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&str, &VectorParams)> + 'a> {
+    pub fn params_iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&'a str, &'a VectorParams)> + 'a> {
         match self {
             VectorsConfig::Single(p) => Box::new(std::iter::once((DEFAULT_VECTOR_NAME, p))),
             VectorsConfig::Multi(p) => Box::new(p.iter().map(|(n, p)| (n.as_str(), p))),

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -184,7 +184,7 @@ impl ChannelService {
         self.id_to_metadata
             .read()
             .get(&peer_id)
-            .map_or(false, |metadata| &metadata.version >= version)
+            .is_some_and(|metadata| &metadata.version >= version)
     }
 
     /// Get the REST address for the current peer.

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -262,7 +262,7 @@ impl RecoveryPoint {
             other
                 .clocks
                 .get(key)
-                .map_or(false, |&(other_tick, _token)| tick < other_tick)
+                .is_some_and(|&(other_tick, _token)| tick < other_tick)
         })
     }
 

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -218,7 +218,7 @@ impl LocalShard {
     }
 
     /// Rescore list of scored points
-    async fn rescore<'a>(
+    async fn rescore(
         &self,
         sources: Vec<Vec<ScoredPoint>>,
         rescore_params: RescoreParams,
@@ -340,7 +340,7 @@ impl LocalShard {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn fusion_rescore<'a>(
+    async fn fusion_rescore(
         &self,
         sources: impl Iterator<Item = Vec<ScoredPoint>>,
         fusion: FusionInternal,

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -789,7 +789,7 @@ impl ShardOperation for RemoteShard {
                 let is_payload_required = request
                     .with_payload
                     .as_ref()
-                    .map_or(false, |with_payload| with_payload.is_required());
+                    .is_some_and(|with_payload| with_payload.is_required());
 
                 batch_result
                     .result

--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -147,7 +147,7 @@ impl ShardReplicaSet {
                 let is_local_ready = local
                     .deref()
                     .as_ref()
-                    .map_or(false, |local| !local.is_update_in_progress());
+                    .is_some_and(|local| !local.is_update_in_progress());
 
                 (
                     future::ready(local).left_future(),

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -366,7 +366,7 @@ struct ResolverRecord<'a, T> {
     count: usize,
 }
 
-impl<'a, T> Default for ResolverRecord<'a, T> {
+impl<T> Default for ResolverRecord<'_, T> {
     fn default() -> Self {
         Self {
             item: None,

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -144,7 +144,7 @@ impl Shard {
 
     pub fn is_update_in_progress(&self) -> bool {
         self.update_tracker()
-            .map_or(false, UpdateTracker::is_update_in_progress)
+            .is_some_and(UpdateTracker::is_update_in_progress)
     }
 
     pub fn watch_for_update(&self) -> impl Future<Output = ()> {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -495,7 +495,7 @@ impl ShardHolder {
     pub fn select_shards<'a>(
         &'a self,
         shard_selector: &'a ShardSelectorInternal,
-    ) -> CollectionResult<Vec<(&ShardReplicaSet, Option<&ShardKey>)>> {
+    ) -> CollectionResult<Vec<(&'a ShardReplicaSet, Option<&'a ShardKey>)>> {
         let mut res = Vec::new();
 
         match shard_selector {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -507,7 +507,7 @@ impl ShardHolder {
                     // Ignore a new resharding shard until it completed point migration
                     // The shard will be marked as active at the end of the migration stage
                     let resharding_migrating_up =
-                        self.resharding_state.read().clone().map_or(false, |state| {
+                        self.resharding_state.read().clone().is_some_and(|state| {
                             state.direction == ReshardingDirection::Up
                                 && state.shard_id == shard_id
                                 && state.stage < ReshardStage::ReadHashRingCommitted

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -395,7 +395,7 @@ impl ShardHolder {
                 debug_assert!(
                     state
                         .as_ref()
-                        .map_or(false, |state| state.matches(&resharding_key)),
+                        .is_some_and(|state| state.matches(&resharding_key)),
                     "resharding {resharding_key} is not in progress:\n{state:#?}"
                 );
 

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -148,7 +148,7 @@ pub async fn transfer_shard_fallback_default(
 ) -> CollectionResult<bool> {
     // Do not attempt to fall back to the same method
     let old_method = transfer_config.method;
-    if old_method.map_or(false, |method| method == fallback_method) {
+    if old_method.is_some_and(|method| method == fallback_method) {
         log::warn!("Failed shard transfer fallback, because it would use the same transfer method: {fallback_method:?}");
         return Ok(false);
     }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -615,7 +615,7 @@ impl UpdateHandler {
             if !optimizer_cpu_budget.has_budget(desired_cpus) {
                 let trigger_active = cpu_available_trigger
                     .as_ref()
-                    .map_or(false, |t| !t.is_finished());
+                    .is_some_and(|t| !t.is_finished());
                 if !trigger_active {
                     cpu_available_trigger.replace(trigger_optimizers_on_cpu_budget(
                         optimizer_cpu_budget.clone(),

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1667,7 +1667,7 @@ mod tests {
                 // If we don't allow gaps, we only remove this exact tick from the beginning
                 // If we do allow gaps, we remove this tick and all lower ones from the beginning
                 while {
-                    must_see_ticks.front().map_or(false, |&tick| {
+                    must_see_ticks.front().is_some_and(|&tick| {
                         if allow_gaps {
                             tick <= newer.clock_tick
                         } else {

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -114,7 +114,7 @@ pub fn validate_shard_different_peers(
     }
 
     // If source and target shard is different, we do allow transferring from/to the same peer
-    if to_shard_id.map_or(false, |to_shard_id| to_shard_id != shard_id) {
+    if to_shard_id.is_some_and(|to_shard_id| to_shard_id != shard_id) {
         return Ok(());
     }
 

--- a/lib/segment/benches/prof.rs
+++ b/lib/segment/benches/prof.rs
@@ -45,7 +45,7 @@ pub struct FlamegraphProfiler<'a> {
     active_profiler: Option<ProfilerGuard<'a>>,
 }
 
-impl<'a> FlamegraphProfiler<'a> {
+impl FlamegraphProfiler<'_> {
     #[allow(dead_code)]
     pub fn new(frequency: c_int) -> Self {
         FlamegraphProfiler {
@@ -55,7 +55,7 @@ impl<'a> FlamegraphProfiler<'a> {
     }
 }
 
-impl<'a> Profiler for FlamegraphProfiler<'a> {
+impl Profiler for FlamegraphProfiler<'_> {
     fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
         self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
     }

--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -139,7 +139,7 @@ pub struct DatabaseColumnScheduledDeleteIterator<'a> {
     deleted_pending_persistence: &'a Mutex<HashSet<Vec<u8>>>,
 }
 
-impl<'a> Iterator for DatabaseColumnScheduledDeleteIterator<'a> {
+impl Iterator for DatabaseColumnScheduledDeleteIterator<'_> {
     type Item = (Box<[u8]>, Box<[u8]>);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -284,7 +284,7 @@ impl DatabaseColumnWrapper {
     }
 }
 
-impl<'a> LockedDatabaseColumnWrapper<'a> {
+impl LockedDatabaseColumnWrapper<'_> {
     pub fn iter(&self) -> OperationResult<DatabaseColumnIterator> {
         DatabaseColumnIterator::new(&self.guard, self.column_name)
     }
@@ -303,7 +303,7 @@ impl<'a> DatabaseColumnIterator<'a> {
     }
 }
 
-impl<'a> Iterator for DatabaseColumnIterator<'a> {
+impl Iterator for DatabaseColumnIterator<'_> {
     type Item = (Box<[u8]>, Box<[u8]>);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -33,7 +33,7 @@ pub enum FacetValueRef<'a> {
     Bool(bool),
 }
 
-impl<'a> FacetValueRef<'a> {
+impl FacetValueRef<'_> {
     pub fn to_owned(&self) -> FacetValue {
         match self {
             FacetValueRef::Keyword(s) => FacetValue::Keyword((*s).to_string()),

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -29,7 +29,7 @@ pub enum CowVector<'a> {
     MultiDense(CowMultiVector<'a, VectorElementType>),
 }
 
-impl<'a> Default for CowVector<'a> {
+impl Default for CowVector<'_> {
     fn default() -> Self {
         CowVector::Dense(Cow::Owned(Vec::new()))
     }
@@ -61,7 +61,7 @@ impl<'a, TElement: PrimitiveVectorElement> CowMultiVector<'a, TElement> {
     }
 }
 
-impl<'a> CowVector<'a> {
+impl CowVector<'_> {
     pub fn default_sparse() -> Self {
         CowVector::Sparse(Cow::Owned(SparseVector::default()))
     }
@@ -92,7 +92,7 @@ impl<'a> From<Cow<'a, [VectorElementType]>> for CowVector<'a> {
     }
 }
 
-impl<'a> From<VectorInternal> for CowVector<'a> {
+impl From<VectorInternal> for CowVector<'_> {
     fn from(v: VectorInternal) -> Self {
         match v {
             VectorInternal::Dense(v) => CowVector::Dense(Cow::Owned(v)),
@@ -102,19 +102,19 @@ impl<'a> From<VectorInternal> for CowVector<'a> {
     }
 }
 
-impl<'a> From<SparseVector> for CowVector<'a> {
+impl From<SparseVector> for CowVector<'_> {
     fn from(v: SparseVector) -> Self {
         CowVector::Sparse(Cow::Owned(v))
     }
 }
 
-impl<'a> From<DenseVector> for CowVector<'a> {
+impl From<DenseVector> for CowVector<'_> {
     fn from(v: DenseVector) -> Self {
         CowVector::Dense(Cow::Owned(v))
     }
 }
 
-impl<'a> From<MultiDenseVectorInternal> for CowVector<'a> {
+impl From<MultiDenseVectorInternal> for CowVector<'_> {
     fn from(v: MultiDenseVectorInternal) -> Self {
         CowVector::MultiDense(CowMultiVector::Owned(v))
     }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -166,7 +166,7 @@ pub enum SimpleCow<'a, T> {
     Owned(T),
 }
 
-impl<'a, T> Deref for SimpleCow<'a, T> {
+impl<T> Deref for SimpleCow<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -379,7 +379,7 @@ impl TryFrom<Vec<DenseVector>> for VectorInternal {
     }
 }
 
-impl<'a> VectorRef<'a> {
+impl VectorRef<'_> {
     // Cannot use `ToOwned` trait because of `Borrow` implementation for `Vector`
     pub fn to_owned(self) -> VectorInternal {
         match self {
@@ -470,7 +470,7 @@ impl From<&[VectorElementType]> for VectorStructInternal {
     }
 }
 
-impl<'a> From<NamedVectors<'a>> for VectorStructInternal {
+impl From<NamedVectors<'_>> for VectorStructInternal {
     fn from(v: NamedVectors) -> Self {
         if v.len() == 1 && v.contains_key(DEFAULT_VECTOR_NAME) {
             let vector_ref = v.get(DEFAULT_VECTOR_NAME).unwrap();

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -79,7 +79,7 @@ pub trait IdTracker: fmt::Debug {
     fn iter_ids_excluding<'a>(
         &'a self,
         exclude_bitslice: &'a BitSlice,
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         Box::new(self.iter_ids().filter(|point| {
             !exclude_bitslice
                 .get(*point as usize)
@@ -128,7 +128,7 @@ pub trait IdTracker: fmt::Debug {
     fn sample_ids<'a>(
         &'a self,
         deleted_vector_bitslice: Option<&'a BitSlice>,
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         // Use seeded randomness, prevents 'inconsistencies' in search results with sampling
         let mut rng = StdRng::seed_from_u64(SEED);
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -185,7 +185,6 @@ impl ImmutableIdTracker {
     /// +-----------------+-----------------------+------------------+
     /// A single entry is thus either 1+8+4=13 or 1+16+4=21 bytes in size depending
     /// on the PointIdType.
-
     fn store_mapping<W: Write>(mappings: &PointMappings, mut writer: W) -> OperationResult<()> {
         let number_of_entries = mappings.total_point_count();
 

--- a/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_posting_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_posting_iterator.rs
@@ -13,7 +13,7 @@ impl<'a> CompressedPostingIterator<'a> {
     }
 }
 
-impl<'a> Iterator for CompressedPostingIterator<'a> {
+impl Iterator for CompressedPostingIterator<'_> {
     type Item = PointOffsetType;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -40,7 +40,7 @@ pub struct IndexSelectorOnDisk<'a> {
     pub dir: &'a Path,
 }
 
-impl<'a> IndexSelector<'a> {
+impl IndexSelector<'_> {
     /// Selects index type based on field type.
     pub fn new_index(
         &self,

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -158,7 +158,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         self.deleted
             .get(idx as usize)
             .filter(|b| !b)
-            .map_or(false, |_| {
+            .is_some_and(|_| {
                 self.point_to_values
                     .check_values_any(idx, |v| check_fn(N::from_referenced(&v)))
             })

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -138,7 +138,7 @@ impl MmapValue for str {
     type Referenced<'a> = &'a str;
 
     fn mmapped_size(value: &str) -> usize {
-        value.as_bytes().len() + std::mem::size_of::<u32>()
+        value.len() + std::mem::size_of::<u32>()
     }
 
     fn read_from_mmap(bytes: &[u8]) -> Option<&str> {

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -108,7 +108,7 @@ impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
     }
 }
 
-impl<'a, T: Encodable + Numericable> Iterator for NumericKeySortedVecIterator<'a, T> {
+impl<T: Encodable + Numericable> Iterator for NumericKeySortedVecIterator<'_, T> {
     type Item = Point<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -131,7 +131,7 @@ impl<'a, T: Encodable + Numericable> Iterator for NumericKeySortedVecIterator<'a
     }
 }
 
-impl<'a, T: Encodable + Numericable> DoubleEndedIterator for NumericKeySortedVecIterator<'a, T> {
+impl<T: Encodable + Numericable> DoubleEndedIterator for NumericKeySortedVecIterator<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.set.data[self.end_index - 1].clone();

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -45,7 +45,7 @@ pub(super) struct NumericIndexPairsIterator<'a, T: Encodable + Numericable> {
     end_index: usize,
 }
 
-impl<'a, T: Encodable + Numericable> Iterator for NumericIndexPairsIterator<'a, T> {
+impl<T: Encodable + Numericable> Iterator for NumericIndexPairsIterator<'_, T> {
     type Item = Point<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -62,7 +62,7 @@ impl<'a, T: Encodable + Numericable> Iterator for NumericIndexPairsIterator<'a, 
     }
 }
 
-impl<'a, T: Encodable + Numericable> DoubleEndedIterator for NumericIndexPairsIterator<'a, T> {
+impl<T: Encodable + Numericable> DoubleEndedIterator for NumericIndexPairsIterator<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.pairs[self.end_index - 1].clone();

--- a/lib/segment/src/index/hnsw_index/build_condition_checker.rs
+++ b/lib/segment/src/index/hnsw_index/build_condition_checker.rs
@@ -8,7 +8,7 @@ pub struct BuildConditionChecker<'a> {
     pub current_point: PointOffsetType,
 }
 
-impl<'a> FilterContext for BuildConditionChecker<'a> {
+impl FilterContext for BuildConditionChecker<'_> {
     fn check(&self, point_id: PointOffsetType) -> bool {
         if point_id == self.current_point {
             return false; // Do not match current point while inserting it (second time)

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -404,7 +404,7 @@ pub struct PlainFilterContext<'a> {
     filter: &'a Filter,
 }
 
-impl<'a> FilterContext for PlainFilterContext<'a> {
+impl FilterContext for PlainFilterContext<'_> {
     fn check(&self, point_id: PointOffsetType) -> bool {
         self.condition_checker.check(point_id, self.filter)
     }

--- a/lib/segment/src/index/struct_filter_context.rs
+++ b/lib/segment/src/index/struct_filter_context.rs
@@ -13,7 +13,7 @@ impl<'a> StructFilterContext<'a> {
     }
 }
 
-impl<'a> FilterContext for StructFilterContext<'a> {
+impl FilterContext for StructFilterContext<'_> {
     fn check(&self, point_id: PointOffsetType) -> bool {
         check_optimized_filter(&self.optimized_filter, point_id)
     }

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -39,7 +39,7 @@ impl VisitedList {
     }
 }
 
-impl<'a> Drop for VisitedListHandle<'a> {
+impl Drop for VisitedListHandle<'_> {
     fn drop(&mut self) {
         self.pool
             .return_back(std::mem::take(&mut self.visited_list));

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -59,7 +59,7 @@ impl<'a> VisitedListHandle<'a> {
         self.visited_list
             .visit_counters
             .get(point_id as usize)
-            .map_or(false, |x| *x == self.visited_list.current_iter)
+            .is_some_and(|x| *x == self.visited_list.current_iter)
     }
 
     /// Updates visited list

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -130,7 +130,7 @@ where
         Condition::IsNull(is_null) => check_is_null_condition(is_null, get_payload().deref()),
         Condition::HasId(has_id) => id_tracker
             .and_then(|id_tracker| id_tracker.external_id(point_id))
-            .map_or(false, |id| has_id.has_id.contains(&id)),
+            .is_some_and(|id| has_id.has_id.contains(&id)),
         Condition::HasVector(has_vector) => {
             if let Some(vector_storage) = vector_storages.get(&has_vector.has_vector) {
                 !vector_storage.borrow().is_deleted_vector(point_id)
@@ -159,7 +159,7 @@ where
 
         Condition::CustomIdChecker(cond) => id_tracker
             .and_then(|id_tracker| id_tracker.external_id(point_id))
-            .map_or(false, |point_id| cond.check(point_id)),
+            .is_some_and(|point_id| cond.check(point_id)),
 
         Condition::Filter(_) => unreachable!(),
     };

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -277,7 +277,7 @@ impl Segment {
                 .id_tracker
                 .borrow()
                 .internal_version(point_offset)
-                .map_or(false, |current_version| current_version > op_num)
+                .is_some_and(|current_version| current_version > op_num)
             {
                 return Ok(false);
             }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1100,7 +1100,7 @@ impl PayloadContainer for Payload {
     }
 }
 
-impl<'a> PayloadContainer for OwnedPayloadRef<'a> {
+impl PayloadContainer for OwnedPayloadRef<'_> {
     fn get_value(&self, path: &JsonPath) -> MultiValue<&Value> {
         path.value_get(self.as_ref())
     }
@@ -1142,7 +1142,7 @@ pub enum OwnedPayloadRef<'a> {
     Owned(Rc<Map<String, Value>>),
 }
 
-impl<'a> Deref for OwnedPayloadRef<'a> {
+impl Deref for OwnedPayloadRef<'_> {
     type Target = Map<String, Value>;
 
     fn deref(&self) -> &Self::Target {
@@ -1153,7 +1153,7 @@ impl<'a> Deref for OwnedPayloadRef<'a> {
     }
 }
 
-impl<'a> AsRef<Map<String, Value>> for OwnedPayloadRef<'a> {
+impl AsRef<Map<String, Value>> for OwnedPayloadRef<'_> {
     fn as_ref(&self) -> &Map<String, Value> {
         match self {
             OwnedPayloadRef::Ref(reference) => reference,
@@ -1162,13 +1162,13 @@ impl<'a> AsRef<Map<String, Value>> for OwnedPayloadRef<'a> {
     }
 }
 
-impl<'a> From<Payload> for OwnedPayloadRef<'a> {
+impl From<Payload> for OwnedPayloadRef<'_> {
     fn from(payload: Payload) -> Self {
         OwnedPayloadRef::Owned(Rc::new(payload.0))
     }
 }
 
-impl<'a> From<Map<String, Value>> for OwnedPayloadRef<'a> {
+impl From<Map<String, Value>> for OwnedPayloadRef<'_> {
     fn from(payload: Map<String, Value>) -> Self {
         OwnedPayloadRef::Owned(Rc::new(payload))
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -153,10 +153,7 @@ impl<'de> serde::Deserialize<'de> for ExtendedPointId {
     where
         D: serde::Deserializer<'de>,
     {
-        let value = match serde_value::Value::deserialize(deserializer) {
-            Ok(val) => val,
-            Err(err) => return Err(err),
-        };
+        let value = serde_value::Value::deserialize(deserializer)?;
 
         if let Ok(num) = value.clone().deserialize_into() {
             return Ok(ExtendedPointId::NumId(num));

--- a/lib/segment/src/utils/fmt.rs
+++ b/lib/segment/src/utils/fmt.rs
@@ -3,7 +3,7 @@ use std::fmt;
 #[derive(Copy, Clone, Debug)]
 pub struct SerdeValue<'a>(pub &'a serde_value::Value);
 
-impl<'a> fmt::Display for SerdeValue<'a> {
+impl fmt::Display for SerdeValue<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let val: &dyn fmt::Display = match &self.0 {
             serde_value::Value::Bool(val) => val,

--- a/lib/segment/src/utils/scored_point_ties.rs
+++ b/lib/segment/src/utils/scored_point_ties.rs
@@ -11,7 +11,7 @@ impl<'a> From<&'a ScoredPoint> for ScoredPointTies<'a> {
     }
 }
 
-impl<'a> Ord for ScoredPointTies<'a> {
+impl Ord for ScoredPointTies<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.0
             .cmp(other.0)
@@ -20,15 +20,15 @@ impl<'a> Ord for ScoredPointTies<'a> {
     }
 }
 
-impl<'a> PartialOrd for ScoredPointTies<'a> {
+impl PartialOrd for ScoredPointTies<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'a> Eq for ScoredPointTies<'a> {}
+impl Eq for ScoredPointTies<'_> {}
 
-impl<'a> PartialEq for ScoredPointTies<'a> {
+impl PartialEq for ScoredPointTies<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -63,7 +63,7 @@ where
     }
 }
 
-impl<'a, TQueryScorer> RawScorer for AsyncRawScorerImpl<'a, TQueryScorer>
+impl<TQueryScorer> RawScorer for AsyncRawScorerImpl<'_, TQueryScorer>
 where
     TQueryScorer: QueryScorer<[VectorElementType]>,
 {

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -63,13 +63,12 @@ impl<
 }
 
 impl<
-        'a,
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement>,
         TVectorStorage: DenseVectorStorage<TElement>,
         TInputQuery: Query<DenseVector>,
         TStoredQuery: Query<TypedDenseVector<TElement>>,
-    > CustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TInputQuery, TStoredQuery>
+    > CustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TInputQuery, TStoredQuery>
 {
     fn hardware_counter_finalized(&self) -> HardwareCounterCell {
         let mut counter = self.hardware_counter.take();
@@ -84,14 +83,13 @@ impl<
 }
 
 impl<
-        'a,
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement>,
         TVectorStorage: DenseVectorStorage<TElement>,
         TInputQuery: Query<DenseVector>,
         TStoredQuery: Query<TypedDenseVector<TElement>>,
     > QueryScorer<[TElement]>
-    for CustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TInputQuery, TStoredQuery>
+    for CustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TInputQuery, TStoredQuery>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -61,11 +61,10 @@ impl<
 }
 
 impl<
-        'a,
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement>,
         TVectorStorage: DenseVectorStorage<TElement>,
-    > QueryScorer<[TElement]> for MetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
+    > QueryScorer<[TElement]> for MetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -73,13 +73,12 @@ impl<
 }
 
 impl<
-        'a,
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement>,
         TVectorStorage: MultiVectorStorage<TElement>,
         TQuery: Query<TypedMultiDenseVector<TElement>>,
         TInputQuery: Query<MultiDenseVectorInternal>,
-    > MultiCustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TQuery, TInputQuery>
+    > MultiCustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TQuery, TInputQuery>
 {
     fn hardware_counter_finalized(&self) -> HardwareCounterCell {
         let mut counter = self.hardware_counter.take();
@@ -111,14 +110,13 @@ impl<
 }
 
 impl<
-        'a,
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement>,
         TVectorStorage: MultiVectorStorage<TElement>,
         TQuery: Query<TypedMultiDenseVector<TElement>>,
         TInputQuery: Query<MultiDenseVectorInternal>,
     > QueryScorer<TypedMultiDenseVector<TElement>>
-    for MultiCustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TQuery, TInputQuery>
+    for MultiCustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TQuery, TInputQuery>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -71,11 +71,10 @@ impl<
 }
 
 impl<
-        'a,
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement>,
         TVectorStorage: MultiVectorStorage<TElement>,
-    > MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
+    > MultiMetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
     fn hardware_counter_finalized(&self) -> HardwareCounterCell {
         let mut counter = self.hardware_counter.take();
@@ -90,12 +89,11 @@ impl<
 }
 
 impl<
-        'a,
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement>,
         TVectorStorage: MultiVectorStorage<TElement>,
     > QueryScorer<TypedMultiDenseVector<TElement>>
-    for MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
+    for MultiMetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -38,8 +38,8 @@ impl<
     }
 }
 
-impl<'a, TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScorer<SparseVector>
-    for SparseCustomQueryScorer<'a, TVectorStorage, TQuery>
+impl<TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScorer<SparseVector>
+    for SparseCustomQueryScorer<'_, TVectorStorage, TQuery>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -845,7 +845,7 @@ fn new_multi_scorer_half_with_metric<
     }
 }
 
-impl<'a, TVector, TQueryScorer> RawScorer for RawScorerImpl<'a, TVector, TQueryScorer>
+impl<TVector, TQueryScorer> RawScorer for RawScorerImpl<'_, TVector, TQueryScorer>
 where
     TVector: ?Sized,
     TQueryScorer: QueryScorer<TVector>,

--- a/lib/sparse/benches/prof.rs
+++ b/lib/sparse/benches/prof.rs
@@ -45,7 +45,7 @@ pub struct FlamegraphProfiler<'a> {
     active_profiler: Option<ProfilerGuard<'a>>,
 }
 
-impl<'a> FlamegraphProfiler<'a> {
+impl FlamegraphProfiler<'_> {
     #[allow(dead_code)]
     pub fn new(frequency: c_int) -> Self {
         FlamegraphProfiler {
@@ -55,7 +55,7 @@ impl<'a> FlamegraphProfiler<'a> {
     }
 }
 
-impl<'a> Profiler for FlamegraphProfiler<'a> {
+impl Profiler for FlamegraphProfiler<'_> {
     fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
         self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
     }

--- a/lib/sparse/src/common/scores_memory_pool.rs
+++ b/lib/sparse/src/common/scores_memory_pool.rs
@@ -16,7 +16,7 @@ impl<'a> PooledScoresHandle<'a> {
     }
 }
 
-impl<'a> Drop for PooledScoresHandle<'a> {
+impl Drop for PooledScoresHandle<'_> {
     fn drop(&mut self) {
         self.pool.return_back(std::mem::take(&mut self.scores));
     }

--- a/lib/sparse/src/index/compressed_posting_list.rs
+++ b/lib/sparse/src/index/compressed_posting_list.rs
@@ -327,7 +327,7 @@ impl<'a, W: Weight> CompressedPostingListIterator<'a, W> {
     }
 }
 
-impl<'a, W: Weight> PostingListIter for CompressedPostingListIterator<'a, W> {
+impl<W: Weight> PostingListIter for CompressedPostingListIterator<'_, W> {
     #[inline]
     fn peek(&mut self) -> Option<PostingElementEx> {
         let pos = self.pos;

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -176,9 +176,7 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
 
         if remainders_end
             .checked_sub(remainders_start)
-            .map_or(false, |len| {
-                len % size_of::<GenericPostingElement<W>>() as u64 != 0
-            })
+            .is_some_and(|len| len % size_of::<GenericPostingElement<W>>() as u64 != 0)
         {
             return None;
         }

--- a/lib/sparse/src/index/loaders.rs
+++ b/lib/sparse/src/index/loaders.rs
@@ -105,7 +105,7 @@ pub struct CsrIter<'a> {
     row: usize,
 }
 
-impl<'a> Iterator for CsrIter<'a> {
+impl Iterator for CsrIter<'_> {
     type Item = Result<SparseVector, ValidationErrors>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -117,7 +117,7 @@ impl<'a> Iterator for CsrIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for CsrIter<'a> {
+impl ExactSizeIterator for CsrIter<'_> {
     fn len(&self) -> usize {
         self.csr.nrow - self.row
     }

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -173,7 +173,7 @@ pub struct PostingListIterator<'a> {
     pub current_index: usize,
 }
 
-impl<'a> PostingListIter for PostingListIterator<'a> {
+impl PostingListIter for PostingListIterator<'_> {
     #[inline]
     fn peek(&mut self) -> Option<PostingElementEx> {
         self.elements.get(self.current_index).cloned()

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -1,3 +1,5 @@
+//! Handlers for transferring data from one collection into another within single cluster
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,8 +20,6 @@ use crate::content_manager::collections_ops::Collections;
 
 const MIGRATION_BATCH_SIZE: usize = 1000;
 const COLLECTION_INITIATION_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Handlers for transferring data from one collection into another within single cluster
 
 /// Get a list of local shards, which can be used for migration
 ///

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -258,9 +258,9 @@ impl TableOfContent {
         }))
     }
 
-    pub async fn get_collection<'a>(
+    pub async fn get_collection(
         &self,
-        collection: &CollectionPass<'a>,
+        collection: &CollectionPass<'_>,
     ) -> Result<RwLockReadGuard<Collection>, StorageError> {
         self.get_collection_unchecked(collection.name()).await
     }

--- a/lib/storage/src/content_manager/toc/snapshots.rs
+++ b/lib/storage/src/content_manager/toc/snapshots.rs
@@ -52,9 +52,9 @@ impl TableOfContent {
         Ok(snapshots_path)
     }
 
-    pub async fn create_snapshot<'a>(
+    pub async fn create_snapshot(
         &self,
-        collection: &CollectionPass<'a>,
+        collection: &CollectionPass<'_>,
     ) -> Result<SnapshotDescription, StorageError> {
         let collection = self.get_collection(collection).await?;
         // We want to use temp dir inside the temp_path (storage if not specified), because it is possible, that

--- a/lib/storage/src/rbac/mod.rs
+++ b/lib/storage/src/rbac/mod.rs
@@ -137,7 +137,7 @@ struct CollectionAccessView<'a> {
     pub payload: &'a Option<PayloadConstraint>,
 }
 
-impl<'a> CollectionAccessView<'a> {
+impl CollectionAccessView<'_> {
     pub(self) fn check_whole_access(&self) -> Result<(), StorageError> {
         if self.payload.is_some() {
             return incompatible_with_payload_constraint(self.collection);

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -112,7 +112,7 @@ impl CollectionAccessList {
     }
 }
 
-impl<'a> CollectionAccessView<'a> {
+impl CollectionAccessView<'_> {
     fn apply_filter(&self, filter: &mut Option<Filter>) {
         if let Some(payload) = &self.payload {
             let f = filter.get_or_insert_with(Default::default);

--- a/src/tonic/verification.rs
+++ b/src/tonic/verification.rs
@@ -42,7 +42,7 @@ impl<'a> UncheckedTocProvider<'a> {
     }
 }
 
-impl<'a> CheckedTocProvider for UncheckedTocProvider<'a> {
+impl CheckedTocProvider for UncheckedTocProvider<'_> {
     async fn check_strict_mode<'b>(
         &'b self,
         _request: &impl StrictModeVerification,
@@ -81,7 +81,7 @@ impl<'a> StrictModeCheckedTocProvider<'a> {
     }
 }
 
-impl<'a> CheckedTocProvider for StrictModeCheckedTocProvider<'a> {
+impl CheckedTocProvider for StrictModeCheckedTocProvider<'_> {
     async fn check_strict_mode(
         &self,
         request: &impl StrictModeVerification,


### PR DESCRIPTION
Rust 1.83 is being released on [November 28th, 2024](https://releases.rs/docs/1.83.0/).

This PR contains all the changes required to please Clippy in order to keep our CI happy.

Some changes may have slipped in from the next `1.84 beta` which I pulled today but nothing looks controversial IMO. 