### PR TITLE
Compute facets by streaming shard results

### DIFF
--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -1,5 +1,4 @@
 use std::cmp::Reverse;
-use std::collections::HashMap;
 use std::hash::Hash;
 
 use schemars::JsonSchema;
@@ -86,16 +85,6 @@ impl<T: FacetValueTrait> PartialOrd for FacetHit<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
-}
-
-pub fn aggregate_facet_hits<T: FacetValueTrait>(
-    hits: impl IntoIterator<Item = FacetHit<T>>,
-) -> HashMap<T, usize> {
-    hits.into_iter()
-        .fold(HashMap::new(), |mut map, FacetHit { value, count }| {
-            *map.entry(value).or_insert(0) += count;
-            map
-        })
 }
 
 impl From<FacetValue> for ValueVariants {


### PR DESCRIPTION
Similar to https://github.com/qdrant/qdrant/pull/5505 but for facets.

Do not wait for all shards to start aggregating results as soon as available.

- Do not wait idle for slow shards.
- Use less memory by avoiding to hold all responses in memory at once.