### PR TITLE
Expose shard keys in telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11126,6 +11126,16 @@
             "format": "uint32",
             "minimum": 0
           },
+          "key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKey"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "local": {
             "anyOf": [
               {

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -122,8 +122,10 @@ impl Collection {
                     optimizers_overwrite.update(&effective_optimizers_config)?;
             }
 
+            let shard_key = None;
             let replica_set = ShardReplicaSet::build(
                 shard_id,
+                shard_key.clone(),
                 name.clone(),
                 this_peer_id,
                 is_local,
@@ -143,7 +145,7 @@ impl Collection {
             )
             .await?;
 
-            shard_holder.add_shard(shard_id, replica_set, None)?;
+            shard_holder.add_shard(shard_id, replica_set, shard_key)?;
         }
 
         let locked_shard_holder = Arc::new(LockedShardHolder::new(shard_holder));

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -45,6 +45,7 @@ impl Collection {
                 let replica_set = self
                     .create_replica_set(
                         resharding_key.shard_id,
+                        resharding_key.shard_key.clone(),
                         &[resharding_key.peer_id],
                         Some(ReplicaState::Resharding),
                     )

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -15,6 +15,7 @@ impl Collection {
     pub async fn create_replica_set(
         &self,
         shard_id: ShardId,
+        shard_key: Option<ShardKey>,
         replicas: &[PeerId],
         init_state: Option<ReplicaState>,
     ) -> Result<ShardReplicaSet, CollectionError> {
@@ -30,6 +31,7 @@ impl Collection {
 
         ShardReplicaSet::build(
             shard_id,
+            shard_key,
             self.name(),
             self.this_peer_id,
             is_local,
@@ -102,7 +104,12 @@ impl Collection {
             let shard_id = max_shard_id + idx as ShardId + 1;
 
             let replica_set = self
-                .create_replica_set(shard_id, shard_replicas_placement, None)
+                .create_replica_set(
+                    shard_id,
+                    Some(shard_key.clone()),
+                    shard_replicas_placement,
+                    None,
+                )
                 .await?;
 
             for (field_name, field_schema) in payload_schema.iter() {

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -170,9 +170,13 @@ impl Collection {
             match self.shards_holder.read().await.get_shard(shard_id) {
                 Some(replica_set) => replica_set.apply_state(shard_info.replicas).await?,
                 None => {
+                    let shard_key = shards_key_mapping
+                        .iter()
+                        .find(|(_, ids)| ids.contains(&shard_id))
+                        .map(|(key, _)| key.clone());
                     let shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
                     let replica_set = self
-                        .create_replica_set(shard_id, &shard_replicas, None)
+                        .create_replica_set(shard_id, shard_key, &shard_replicas, None)
                         .await?;
                     replica_set.apply_state(shard_info.replicas).await?;
                     extra_shards.insert(shard_id, replica_set);

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use common::cpu::CpuBudget;
 use common::types::TelemetryDetail;
 use schemars::JsonSchema;
-use segment::types::{ExtendedPointId, Filter};
+use segment::types::{ExtendedPointId, Filter, ShardKey};
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
@@ -94,6 +94,7 @@ pub struct ShardReplicaSet {
     locally_disabled_peers: parking_lot::RwLock<locally_disabled_peers::Registry>,
     pub(crate) shard_path: PathBuf,
     pub(crate) shard_id: ShardId,
+    shard_key: Option<ShardKey>,
     notify_peer_failure_cb: ChangePeerFromState,
     abort_shard_transfer_cb: AbortShardTransfer,
     channel_service: ChannelService,
@@ -122,6 +123,7 @@ impl ShardReplicaSet {
     #[allow(clippy::too_many_arguments)]
     pub async fn build(
         shard_id: ShardId,
+        shard_key: Option<ShardKey>,
         collection_id: CollectionId,
         this_peer_id: PeerId,
         local: bool,
@@ -187,6 +189,7 @@ impl ShardReplicaSet {
 
         Ok(Self {
             shard_id,
+            shard_key,
             local: RwLock::new(local),
             remotes: RwLock::new(remote_shards),
             replica_state: replica_state.into(),
@@ -216,6 +219,7 @@ impl ShardReplicaSet {
     #[allow(clippy::too_many_arguments)]
     pub async fn load(
         shard_id: ShardId,
+        shard_key: Option<ShardKey>,
         collection_id: CollectionId,
         shard_path: &Path,
         collection_config: Arc<RwLock<CollectionConfigInternal>>,
@@ -304,6 +308,7 @@ impl ShardReplicaSet {
 
         let replica_set = Self {
             shard_id,
+            shard_key,
             local: RwLock::new(local),
             remotes: RwLock::new(remote_shards),
             replica_state: replica_state.into(),

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -769,6 +769,7 @@ impl ShardReplicaSet {
 
         ReplicaSetTelemetry {
             id: self.shard_id,
+            key: self.shard_key.clone(),
             local: local_telemetry,
             remote: self
                 .remotes

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -644,6 +644,7 @@ mod tests {
         let remotes = HashSet::from([2, 3, 4, 5]);
         ShardReplicaSet::build(
             1,
+            None,
             "test_collection".to_string(),
             1,
             false,

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -603,11 +603,14 @@ impl ShardHolder {
 
         // ToDo: remove after version 0.11.0
         for shard_id in shard_ids_list {
+            let shard_key = self.get_shard_id_to_key_mapping().get(&shard_id).cloned();
+
             for (path, _shard_version, shard_type) in
                 latest_shard_paths(collection_path, shard_id).await.unwrap()
             {
                 let replica_set = ShardReplicaSet::load(
                     shard_id,
+                    shard_key.clone(),
                     collection_id.clone(),
                     &path,
                     collection_config.clone(),

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::common::operation_time_statistics::OperationDurationStatistics;
 use segment::telemetry::SegmentTelemetry;
+use segment::types::ShardKey;
 use serde::Serialize;
 
 use crate::collection_manager::optimizers::TrackerTelemetry;
@@ -14,6 +15,7 @@ use crate::shards::shard::{PeerId, ShardId};
 #[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct ReplicaSetTelemetry {
     pub id: ShardId,
+    pub key: Option<ShardKey>,
     pub local: Option<LocalShardTelemetry>,
     pub remote: Vec<RemoteShardTelemetry>,
     pub replicate_states: HashMap<PeerId, ReplicaState>,
@@ -96,6 +98,7 @@ impl Anonymize for ReplicaSetTelemetry {
     fn anonymize(&self) -> Self {
         ReplicaSetTelemetry {
             id: self.id,
+            key: self.key.clone(),
             local: self.local.anonymize(),
             remote: self.remote.anonymize(),
             replicate_states: Default::default(),

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -467,8 +467,8 @@ pub async fn do_update_collection_cluster(
             if !shard_keys_mapping.contains_key(&drop_sharding_key.shard_key) {
                 return Err(StorageError::BadRequest {
                     description: format!(
-                        "Sharding key {} does not exists for collection {}",
-                        drop_sharding_key.shard_key, collection_name
+                        "Sharding key {} does not exist for collection {collection_name}",
+                        drop_sharding_key.shard_key,
                     ),
                 });
             }
@@ -540,7 +540,7 @@ pub async fn do_update_collection_cluster(
             if let Some(shard_key) = &shard_key {
                 if !collection_state.shards_key_mapping.contains_key(shard_key) {
                     return Err(StorageError::bad_request(format!(
-                        "sharding key {shard_key} does not exists for collection {collection_name}"
+                        "sharding key {shard_key} does not exist for collection {collection_name}",
                     )));
                 }
             }


### PR DESCRIPTION
Expose shard keys for each shard in telemetry. This is necessary for resharding.

Rather than listing the key mapping, this lists the assigned key in each shard instead. I think that is a better interface to work with. Because of it I've copied the shard key into the replica set struct.

See `"key": "test"`:

```json
{
  "collections": {
    "number_of_collections": 1,
    "collections": [
      {
        "id": "benchmark",
        "init_time_ms": 800,
        "config": { ... },
        "shards": [
          {
            "id": 1,
            "key": "test",
            "local": { ... },
            "remote": [],
            "replicate_states": {
              "6469369128247073": "Active"
            }
          }
        ],
        "transfers": [],
        "resharding": []
      }
    ]
  }
}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?