### PR TITLE
Add retrieving storage size to payload storage trait

### DIFF
--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -115,7 +115,7 @@ impl DatabaseColumnScheduledDeleteWrapper {
         self.db.remove_column_family()
     }
 
-    pub fn get_storage_size_bytes(&self) -> OperationResult<u64> {
+    pub fn get_storage_size_bytes(&self) -> OperationResult<usize> {
         self.db.get_storage_size_bytes()
     }
 }

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -276,11 +276,11 @@ impl DatabaseColumnWrapper {
     /// Get the size of the storage in bytes
     ///
     /// The size of this column family in bytes, which is equal to the sum of the file size of its "levels"
-    pub fn get_storage_size_bytes(&self) -> OperationResult<u64> {
+    pub fn get_storage_size_bytes(&self) -> OperationResult<usize> {
         let db = self.database.read();
         let cf_handle = self.get_column_family(&db)?;
         let size = db.get_column_family_metadata_cf(cf_handle).size;
-        Ok(size)
+        Ok(size as usize)
     }
 }
 

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -91,6 +91,19 @@ impl PayloadStorage for InMemoryPayloadStorage {
     fn files(&self) -> Vec<PathBuf> {
         vec![]
     }
+
+    fn get_storage_size_bytes(&self) -> OperationResult<usize> {
+        let mut estimated_size = 0;
+        for (_p_id, val) in self.payload.iter() {
+            // account for point_id
+            estimated_size += size_of::<PointOffsetType>();
+            for (key, val) in val.0.iter() {
+                // account for key and value
+                estimated_size += key.len() + serde_json::to_string(val).unwrap().len()
+            }
+        }
+        Ok(estimated_size)
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -179,4 +179,8 @@ impl PayloadStorage for MmapPayloadStorage {
     fn files(&self) -> Vec<PathBuf> {
         self.storage.read().files()
     }
+
+    fn get_storage_size_bytes(&self) -> OperationResult<usize> {
+        Ok(self.storage.read().get_storage_size_bytes())
+    }
 }

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -148,4 +148,8 @@ impl PayloadStorage for OnDiskPayloadStorage {
     fn files(&self) -> Vec<PathBuf> {
         vec![]
     }
+
+    fn get_storage_size_bytes(&self) -> OperationResult<usize> {
+        self.db_wrapper.get_storage_size_bytes()
+    }
 }

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -50,6 +50,9 @@ pub trait PayloadStorage {
     /// Return all files that are used by storage to include in snapshots.
     /// RocksDB storages are captured outside of this trait.
     fn files(&self) -> Vec<PathBuf>;
+
+    /// Return storage size in bytes
+    fn get_storage_size_bytes(&self) -> OperationResult<usize>;
 }
 
 pub trait ConditionChecker {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -156,6 +156,16 @@ impl PayloadStorage for PayloadStorageEnum {
             PayloadStorageEnum::MmapPayloadStorage(s) => s.files(),
         }
     }
+
+    fn get_storage_size_bytes(&self) -> OperationResult<usize> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.get_storage_size_bytes(),
+            PayloadStorageEnum::SimplePayloadStorage(s) => s.get_storage_size_bytes(),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.get_storage_size_bytes(),
+            PayloadStorageEnum::MmapPayloadStorage(s) => s.get_storage_size_bytes(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -56,8 +56,4 @@ impl SimplePayloadStorage {
     pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
         self.payload.get(&point_id)
     }
-
-    pub fn get_storage_size_bytes(&self) -> OperationResult<u64> {
-        self.db_wrapper.get_storage_size_bytes()
-    }
 }

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -103,6 +103,10 @@ impl PayloadStorage for SimplePayloadStorage {
     fn files(&self) -> Vec<PathBuf> {
         vec![]
     }
+
+    fn get_storage_size_bytes(&self) -> OperationResult<usize> {
+        self.db_wrapper.get_storage_size_bytes()
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/payload_storage/tests.rs
+++ b/lib/segment/src/payload_storage/tests.rs
@@ -13,6 +13,8 @@ fn test_trait_impl<S: PayloadStorage>(open: impl Fn(&Path) -> S) {
     let dir = tempfile::tempdir().unwrap();
     let mut storage = open(dir.path());
 
+    assert_eq!(storage.get_storage_size_bytes().unwrap(), 0);
+
     let payload: Payload = json!({
         "a": "some text",
     })
@@ -114,6 +116,8 @@ fn test_trait_impl<S: PayloadStorage>(open: impl Fn(&Path) -> S) {
     // check if the data is still there
     assert_payloads(&storage);
     eprintln!("storage is correct after drop");
+
+    assert!(storage.get_storage_size_bytes().unwrap() > 0);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds `get_storage_size_bytes` to the payload storage trait for us to leverage later on the serverless infra.