### PR TITLE
Fix apply points mixing point versions, only apply operation to latest

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -454,6 +454,11 @@ impl<'s> SegmentHolder {
     }
 
     /// Apply an operation `point_operation` to a set of points `ids`.
+    ///
+    /// Points can be in multiple segments having different versions. We must only apply the
+    /// operation to the latest point version, otherwise our copy on write mechanism may
+    /// repurpose old point data.
+    ///
     /// The `segment_data` function is called no more than once for each segment and its result is
     /// passed to `point_operation`.
     pub fn apply_points<T, O, D>(
@@ -473,22 +478,59 @@ impl<'s> SegmentHolder {
     {
         let _update_guard = self.update_tracker.update();
 
-        let mut applied_points = 0;
+        // Find in which segments latest point versions are located
+        let mut points: HashMap<PointIdType, (SeqNumberType, SegmentId)> =
+            HashMap::with_capacity(ids.len());
         for (idx, segment) in self.iter() {
-            // Collect affected points first, we want to lock segment for writing as rare as possible
             let segment_arc = segment.get();
-            let segment_lock = segment_arc.upgradable_read();
+            let segment_lock = segment_arc.read();
             let segment_points = Self::segment_points(ids, segment_lock.deref());
-            if !segment_points.is_empty() {
-                let mut write_segment = RwLockUpgradableReadGuard::upgrade(segment_lock);
-                let segment_data = segment_data(write_segment.deref());
-                for point_id in segment_points {
-                    let is_applied =
-                        point_operation(point_id, *idx, &mut write_segment, &segment_data)?;
-                    applied_points += usize::from(is_applied);
+            for segment_point in segment_points {
+                let point_version = segment_lock.point_version(segment_point).unwrap();
+
+                match points.entry(segment_point) {
+                    // First time we see the point, add it to the list
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert((point_version, *idx));
+                    }
+                    // Point we have seen before is older, replace it
+                    std::collections::hash_map::Entry::Occupied(mut entry)
+                        if entry.get().0 < point_version =>
+                    {
+                        entry.insert((point_version, *idx));
+                    }
+                    // Point we have seen before is newer, do nothing
+                    std::collections::hash_map::Entry::Occupied(_) => {}
                 }
             }
         }
+
+        // Map segment ID to points to update
+        let segment_count = self.len();
+        let mut segment_points: HashMap<SegmentId, Vec<PointIdType>> =
+            HashMap::with_capacity(self.len());
+        for (point_id, (_point_version, segment_id)) in points {
+            segment_points
+                .entry(segment_id)
+                .or_insert_with(|| Vec::with_capacity(ids.len() / segment_count))
+                .push(point_id);
+        }
+
+        // Apply point operations to segments in which we found latest point version
+        let mut applied_points = 0;
+        for (segment_id, point_ids) in segment_points {
+            let segment = self.get(segment_id).unwrap();
+            let segment_arc = segment.get();
+            let mut write_segment = segment_arc.write();
+            let segment_data = segment_data(write_segment.deref());
+
+            for point_id in point_ids {
+                let is_applied =
+                    point_operation(point_id, segment_id, &mut write_segment, &segment_data)?;
+                applied_points += usize::from(is_applied);
+            }
+        }
+
         Ok(applied_points)
     }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
+use ahash::AHashMap;
 use common::iterator_ext::IteratorExt;
 use common::tar_ext;
 use futures::future::try_join_all;
@@ -479,8 +480,8 @@ impl<'s> SegmentHolder {
         let _update_guard = self.update_tracker.update();
 
         // Find in which segments latest point versions are located
-        let mut points: HashMap<PointIdType, (SeqNumberType, SegmentId)> =
-            HashMap::with_capacity(ids.len());
+        let mut points: AHashMap<PointIdType, (SeqNumberType, SegmentId)> =
+            AHashMap::with_capacity(ids.len());
         for (idx, segment) in self.iter() {
             let segment_arc = segment.get();
             let segment_lock = segment_arc.read();
@@ -507,8 +508,8 @@ impl<'s> SegmentHolder {
 
         // Map segment ID to points to update
         let segment_count = self.len();
-        let mut segment_points: HashMap<SegmentId, Vec<PointIdType>> =
-            HashMap::with_capacity(self.len());
+        let mut segment_points: AHashMap<SegmentId, Vec<PointIdType>> =
+            AHashMap::with_capacity(self.len());
         for (point_id, (_point_version, segment_id)) in points {
             segment_points
                 .entry(segment_id)

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -260,8 +260,8 @@ fn test_proxy_shared_updates() {
     let old_vec = vec![1.0, 0.0, 0.0, 1.0];
     let new_vec = vec![1.0, 0.0, 1.0, 0.0];
 
-    let old_payload: Payload = json!({ "size": vec!["small".to_owned()] }).into();
-    let new_payload: Payload = json!({ "size": vec!["big".to_owned()] }).into();
+    let old_payload: Payload = json!({ "size": vec!["small"] }).into();
+    let new_payload: Payload = json!({ "size": vec!["big"] }).into();
     // let newest_vec = vec![1.0, 1.0, 0.0, 0.0];
 
     let write_segment = LockedSegment::new(empty_segment(dir.path()));
@@ -273,7 +273,6 @@ fn test_proxy_shared_updates() {
         .upsert_point(10, idx1, only_default_vector(&old_vec))
         .unwrap();
     segment1.set_payload(10, idx1, &old_payload, &None).unwrap();
-
     segment1
         .upsert_point(20, idx2, only_default_vector(&new_vec))
         .unwrap();
@@ -319,7 +318,7 @@ fn test_proxy_shared_updates() {
     holder.add_new(proxy_segment_1);
     holder.add_new(proxy_segment_2);
 
-    let payload: Payload = json!({ "color": vec!["yellow".to_owned()] }).into();
+    let payload: Payload = json!({ "color": vec!["yellow"] }).into();
 
     let ids = vec![idx1, idx2];
 
@@ -341,8 +340,7 @@ fn test_proxy_shared_updates() {
     )
     .unwrap();
 
-    let expected_payload: Payload =
-        json!({ "size": vec!["big".to_owned()], "color": vec!["yellow".to_owned()] }).into();
+    let expected_payload: Payload = json!({ "size": vec!["big"], "color": vec!["yellow"] }).into();
 
     for (point_id, record) in result {
         if let Some(payload) = record.payload {


### PR DESCRIPTION
Potential fix for <https://github.com/qdrant/qdrant/pull/5527>

Points can be in multiple segments having different versions. We must only apply the operation to the latest version of a point, otherwise our copy on write mechanism may repurpose old point data.

Using the latest point data is very important, because the copy on write operation will bump the version number. If old point data was used, we'll not be able to tell that anymore.

This problem can appear when applying an operation that depends on the current point data (such as set payload), while having a point in multiple segments. Having a point in multiple segments may happen because of optimizations and segment proxies.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?