### PR TITLE
Fix path to new payload storage for optimized segments

### DIFF
--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -54,13 +54,13 @@ pub struct SegmentBuilder {
     temp_dir: TempDir,
     indexed_fields: HashMap<PayloadKeyType, PayloadFieldSchema>,
 
-    // Payload key to deframent data to
+    // Payload key to defragment data to
     defragment_keys: Vec<PayloadKeyType>,
 }
 
 impl SegmentBuilder {
     pub fn new(
-        segment_path: &Path,
+        segments_path: &Path,
         temp_dir: &Path,
         segment_config: &SegmentConfig,
     ) -> OperationResult<Self> {
@@ -79,7 +79,7 @@ impl SegmentBuilder {
         };
 
         let payload_storage =
-            create_payload_storage(database.clone(), segment_config, segment_path)?;
+            create_payload_storage(database.clone(), segment_config, temp_dir.path())?;
 
         let mut vector_storages = HashMap::new();
 
@@ -106,7 +106,7 @@ impl SegmentBuilder {
             vector_storages.insert(vector_name.to_owned(), vector_storage);
         }
 
-        let destination_path = new_segment_path(segment_path);
+        let destination_path = new_segment_path(segments_path);
 
         Ok(SegmentBuilder {
             version: Default::default(), // default version is 0

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -5,7 +5,9 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::segment::Segment;
 use crate::segment_constructor::build_segment;
-use crate::types::{Distance, Indexes, SegmentConfig, VectorDataConfig, VectorStorageType};
+use crate::types::{
+    Distance, Indexes, PayloadStorageType, SegmentConfig, VectorDataConfig, VectorStorageType,
+};
 
 /// Build new segment with plain index in given directory
 ///
@@ -35,6 +37,34 @@ pub fn build_simple_segment(
             )]),
             sparse_vector_data: Default::default(),
             payload_storage_type: Default::default(),
+        },
+        true,
+    )
+}
+
+pub fn build_simple_segment_with_payload_storage(
+    path: &Path,
+    dim: usize,
+    distance: Distance,
+    payload_storage_type: PayloadStorageType,
+) -> OperationResult<Segment> {
+    build_segment(
+        path,
+        &SegmentConfig {
+            vector_data: HashMap::from([(
+                DEFAULT_VECTOR_NAME.to_owned(),
+                VectorDataConfig {
+                    size: dim,
+                    distance,
+                    storage_type: VectorStorageType::Memory,
+                    index: Indexes::Plain {},
+                    quantization_config: None,
+                    multivector_config: None,
+                    datatype: None,
+                },
+            )]),
+            sparse_vector_data: Default::default(),
+            payload_storage_type,
         },
         true,
     )

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -14,8 +14,10 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::json_path::JsonPath;
 use segment::segment::Segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment_with_payload_storage;
 use segment::types::{
-    Indexes, PayloadContainer, PayloadKeyType, SegmentConfig, VectorDataConfig, VectorStorageType,
+    Distance, Indexes, PayloadContainer, PayloadKeyType, PayloadStorageType, SegmentConfig,
+    VectorDataConfig, VectorStorageType,
 };
 use serde_json::Value;
 use sparse::common::sparse_vector::SparseVector;
@@ -384,4 +386,55 @@ fn test_building_cancellation() {
         time_fast < time_long,
         "time_early: {time_fast}, time_later: {time_long}, was_cancelled_later: {was_cancelled_later}",
     );
+}
+
+#[test]
+fn test_building_new_segment_with_mmap_payload() {
+    let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+    let stopped = AtomicBool::new(false);
+
+    let mut segment1 = build_simple_segment_with_payload_storage(
+        segment_dir.path(),
+        4,
+        Distance::Dot,
+        PayloadStorageType::Mmap,
+    )
+    .unwrap();
+
+    assert_eq!(
+        segment1.segment_config.payload_storage_type,
+        PayloadStorageType::Mmap
+    );
+
+    // add one point
+    segment1
+        .upsert_point(1, 1.into(), only_default_vector(&vec![1.0, 0.0, 1.0, 1.0]))
+        .unwrap();
+
+    let builder = SegmentBuilder::new(
+        segment_dir.path(),
+        temp_dir.path(),
+        &segment1.segment_config,
+    )
+    .unwrap();
+
+    let temp_segment_count = temp_dir.path().read_dir().unwrap().count();
+
+    assert_eq!(temp_segment_count, 1);
+
+    // Now we finalize building
+    let permit_cpu_count = num_rayon_threads(0);
+    let permit = CpuPermit::dummy(permit_cpu_count as u32);
+
+    let new_segment: Segment = builder.build(permit, &stopped).unwrap();
+    assert_eq!(
+        new_segment.segment_config.payload_storage_type,
+        PayloadStorageType::Mmap
+    );
+
+    let new_segment_count = segment_dir.path().read_dir().unwrap().count();
+
+    assert_eq!(new_segment_count, 2);
 }

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -410,7 +410,7 @@ fn test_building_new_segment_with_mmap_payload() {
 
     // add one point
     segment1
-        .upsert_point(1, 1.into(), only_default_vector(&vec![1.0, 0.0, 1.0, 1.0]))
+        .upsert_point(1, 1.into(), only_default_vector(&[1.0, 0.0, 1.0, 1.0]))
         .unwrap();
 
     let builder = SegmentBuilder::new(


### PR DESCRIPTION
Fix the path for the mmap payload storage in the segment builder.

Currently the storage is built at the level of `segments` and is not propagated properly.
We did not discover the issue earlier because we create the storage folder if it does not exist on load.

I added a simple making sure we do not add the folder at the wrong spot. 