### PR TITLE
Fast loading of mmap sparse storage

### DIFF
--- a/lib/blob_store/src/tracker.rs
+++ b/lib/blob_store/src/tracker.rs
@@ -293,7 +293,6 @@ impl Tracker {
             self.pending_updates
                 .insert(point_offset, PointerUpdate::Unset(pointer));
         }
-        self.next_pointer_offset = self.next_pointer_offset.max(point_offset + 1);
 
         pointer_opt
     }

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -389,6 +389,38 @@ impl MmapBitSlice {
 
         Ok(())
     }
+
+    /// Reopens the mmap file with a larger size.
+    ///
+    /// # Arguments
+    /// - `path`: Path to the mmap file
+    /// - `total_capacity`: New total capacity of the bitslice, in amount of bits it should fit.
+    ///
+    /// # Safety
+    /// Marked unsafe because the path must be the same as the original mmap file.
+    pub unsafe fn extend(
+        &mut self,
+        path: &Path,
+        total_capacity: usize,
+        advice: AdviceSetting,
+        populate: bool,
+    ) -> Result<()> {
+        if total_capacity <= self.len() {
+            return Ok(());
+        }
+
+        let new_length = total_capacity
+            .div_ceil(u8::BITS as usize)
+            .next_multiple_of(u8::BITS as usize);
+        mmap_ops::create_and_ensure_length(path, new_length)?;
+        let mmap = mmap_ops::open_write_mmap(path, advice, populate)?;
+
+        *self = MmapBitSlice::try_from(mmap, 0)?;
+
+        debug_assert!(self.len() >= total_capacity);
+
+        Ok(())
+    }
 }
 
 impl Deref for MmapBitSlice {

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -389,38 +389,6 @@ impl MmapBitSlice {
 
         Ok(())
     }
-
-    /// Reopens the mmap file with a larger size.
-    ///
-    /// # Arguments
-    /// - `path`: Path to the mmap file
-    /// - `total_capacity`: New total capacity of the bitslice, in amount of bits it should fit.
-    ///
-    /// # Safety
-    /// Marked unsafe because the path must be the same as the original mmap file.
-    pub unsafe fn extend(
-        &mut self,
-        path: &Path,
-        total_capacity: usize,
-        advice: AdviceSetting,
-        populate: bool,
-    ) -> Result<()> {
-        if total_capacity <= self.len() {
-            return Ok(());
-        }
-
-        let new_length = total_capacity
-            .div_ceil(u8::BITS as usize)
-            .next_multiple_of(u8::BITS as usize);
-        mmap_ops::create_and_ensure_length(path, new_length)?;
-        let mmap = mmap_ops::open_write_mmap(path, advice, populate)?;
-
-        *self = MmapBitSlice::try_from(mmap, 0)?;
-
-        debug_assert!(self.len() >= total_capacity);
-
-        Ok(())
-    }
 }
 
 impl Deref for MmapBitSlice {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -474,7 +474,7 @@ pub(crate) fn create_sparse_vector_storage(
             open_simple_sparse_vector_storage(database, &db_column_name, stopped)
         }
         SparseVectorStorageType::Mmap => {
-            let mmap_storage = MmapSparseVectorStorage::open_or_create(path, stopped)?;
+            let mmap_storage = MmapSparseVectorStorage::open_or_create(path)?;
             Ok(VectorStorageEnum::SparseMmap(mmap_storage))
         }
     }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -1,5 +1,5 @@
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -18,7 +18,6 @@ use crate::types::VectorStorageDatatype;
 use crate::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
 use crate::vector_storage::{SparseVectorStorage, VectorStorage};
 
-const METADATA_FILENAME: &str = "metadata.dat";
 const DELETED_DIRNAME: &str = "deleted";
 const STORAGE_DIRNAME: &str = "store";
 
@@ -35,13 +34,12 @@ pub struct MmapSparseVectorStorage {
     deleted_count: usize,
     /// Maximum point offset in the storage + 1. This also means the total amount of point offsets
     next_point_offset: usize,
-    path: PathBuf,
 }
 
 impl MmapSparseVectorStorage {
     pub fn open_or_create(path: &Path) -> OperationResult<Self> {
-        let meta_path = path.join(METADATA_FILENAME);
-        if meta_path.is_file() {
+        let deleted_dir = path.join(DELETED_DIRNAME);
+        if deleted_dir.is_dir() {
             // Storage already exists, open it
             return Self::open(path);
         }
@@ -76,7 +74,6 @@ impl MmapSparseVectorStorage {
             deleted,
             deleted_count,
             next_point_offset,
-            path,
         })
     }
 
@@ -101,7 +98,6 @@ impl MmapSparseVectorStorage {
             deleted,
             deleted_count: 0,
             next_point_offset: 0,
-            path,
         })
     }
 
@@ -253,7 +249,6 @@ impl VectorStorage for MmapSparseVectorStorage {
     fn files(&self) -> Vec<std::path::PathBuf> {
         let mut files = self.storage.read().files();
         files.extend(self.deleted.files());
-        files.push(self.path.join(METADATA_FILENAME));
 
         files
     }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -132,15 +132,16 @@ impl MmapSparseVectorStorage {
 
     fn set_deleted_flag(&mut self, key: PointOffsetType, deleted: bool) -> OperationResult<bool> {
         if (key as usize) < self.deleted.len() {
-            return Ok(self.deleted.set(key as usize, deleted));
+            return Ok(self.deleted.set(key, deleted));
         }
 
         // Bitslice is too small; grow and set the deletion flag, but only if we need to set it to true.
         if deleted {
             self.deleted.set_len(key as usize + BITSLICE_GROWTH_SLACK)?;
+            return Ok(self.deleted.set(key, true));
         }
 
-        Ok(self.deleted.set(key as usize, deleted))
+        Ok(false)
     }
 
     #[inline]

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -302,12 +302,16 @@ impl VectorStorage for MmapSparseVectorStorage {
 
     fn flusher(&self) -> crate::common::Flusher {
         let storage = self.storage.clone();
+        let deleted_flusher = self.deleted.flusher();
+        let metadata_flusher = self.metadata.flusher();
         Box::new(move || {
             storage.read().flush().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to flush mmap sparse vector storage: {err}"
                 ))
             })?;
+            deleted_flusher()?;
+            metadata_flusher()?;
             Ok(())
         })
     }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -320,8 +320,6 @@ mod test {
 
         let storage_files = storage.files().into_iter().collect::<HashSet<_>>();
 
-        assert_eq!(storage_files.len(), 8);
-        assert!(storage_files.iter().all(|f| f.exists()));
         assert_eq!(storage_files, existing_files);
     }
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -270,17 +270,15 @@ fn test_delete_points_in_simple_sparse_vector_storage() {
 #[test]
 fn test_delete_points_in_mmap_sparse_vector_storage() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
-    let mut storage = VectorStorageEnum::SparseMmap(
-        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap(),
-    );
+    let mut storage =
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
     do_test_delete_points(&mut storage);
 
     storage.flusher()().unwrap();
 
     drop(storage);
 
-    let _storage =
-        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap();
+    let _storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
 }
 
 #[test]
@@ -303,26 +301,22 @@ fn test_update_from_delete_points_simple_sparse_vector_storage() {
 fn test_update_from_delete_points_mmap_sparse_vector_storage() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
-    let mut storage = VectorStorageEnum::SparseMmap(
-        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap(),
-    );
+    let mut storage =
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
 
     do_test_update_from_delete_points(&mut storage);
     storage.flusher()().unwrap();
 
     drop(storage);
 
-    let mut _storage = VectorStorageEnum::SparseMmap(
-        MmapSparseVectorStorage::open_or_create(dir.path(), &Default::default()).unwrap(),
-    );
+    let mut _storage =
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
 }
 
 #[test]
 fn test_persistance_in_mmap_sparse_vector_storage() {
     do_test_persistance(|path| {
-        VectorStorageEnum::SparseMmap(
-            MmapSparseVectorStorage::open_or_create(path, &Default::default()).unwrap(),
-        )
+        VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(path).unwrap())
     });
 }
 

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -125,4 +125,4 @@ test_version $PREV_PATCH_QDRANT_VERSION
 test_version $PREV_MINOR_QDRANT_VERSION
 
 # Test that it can read both rocksdb and blob_store
-test_version 'v1.12.4-rocksdb+blob_store'
+test_version 'v1.12.5-rocksdb+blob_store'


### PR DESCRIPTION
Addresses https://github.com/qdrant/qdrant/pull/5454#pullrequestreview-2465392680

We want mmap storages to not waste any extra time loading, so this PR refactors `MmapSparseVectorStorage` to get rid of loading and use `DynamicMmapFlags` for deleted flags