### PR TITLE
GPU HNSW integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5984,6 +5984,7 @@ dependencies = [
  "is_sorted",
  "issues",
  "itertools 0.13.0",
+ "lazy_static",
  "log",
  "macro_rules_attribute",
  "memmap2 0.9.5",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10913,6 +10913,7 @@
         "type": "object",
         "required": [
           "debug",
+          "gpu",
           "recovery_mode",
           "service_debug_feature",
           "web_feature"
@@ -10928,6 +10929,9 @@
             "type": "boolean"
           },
           "recovery_mode": {
+            "type": "boolean"
+          },
+          "gpu": {
             "type": "boolean"
           }
         }
@@ -10980,6 +10984,13 @@
                 "nullable": true
               }
             ]
+          },
+          "gpu_devices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GpuDeviceTelemetry"
+            },
+            "nullable": true
           }
         }
       },
@@ -10990,6 +11001,17 @@
           "big",
           "other"
         ]
+      },
+      "GpuDeviceTelemetry": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
       },
       "CollectionsTelemetry": {
         "type": "object",

--- a/lib/common/common/src/cpu.rs
+++ b/lib/common/common/src/cpu.rs
@@ -194,6 +194,17 @@ impl CpuPermit {
     pub fn release(&mut self) {
         self.permit.take();
     }
+
+    /// Partial release CPU permit, giving them back to the semaphore.
+    pub fn release_count(&mut self, release_count: u32) {
+        if self.num_cpus > release_count {
+            self.num_cpus -= release_count;
+            let permit = self.permit.take();
+            self.permit = permit.and_then(|mut permit| permit.split(self.num_cpus as usize));
+        } else {
+            self.release();
+        }
+    }
 }
 
 impl Drop for CpuPermit {

--- a/lib/gpu/src/device.rs
+++ b/lib/gpu/src/device.rs
@@ -16,6 +16,9 @@ pub struct Device {
     /// Native Vulkan device handle.
     vk_device: ash::Device,
 
+    /// Hardware device name.
+    name: String,
+
     /// GPU memory allocator from `gpu-allocator` crate.
     /// It's an Option because of drop order. We need to drop it before the device.
     /// But `Allocator` is destroyed by it's own drop.
@@ -303,6 +306,7 @@ impl Device {
             max_buffer_size,
             is_dynamic_subgroup_size,
             queue_index,
+            name: vk_physical_device.name.clone(),
         }))
     }
 
@@ -365,6 +369,10 @@ impl Device {
 
     pub fn compute_queue(&self) -> &Queue {
         &self.compute_queues[self.queue_index % self.compute_queues.len()]
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     fn check_extensions_list(

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -85,6 +85,7 @@ is_sorted = "0.1.1"
 strum = { workspace = true }
 byteorder = { workspace = true }
 zerocopy = { workspace = true }
+lazy_static = "1.5.0"
 
 sysinfo = "0.32"
 charabia = { version = "0.9.2", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -85,6 +85,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
         payload_index: segment.payload_index.clone(),
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/src/index/hnsw_index/gpu/batched_points.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/batched_points.rs
@@ -40,7 +40,7 @@ impl BatchedPoints {
     ) -> OperationResult<Self> {
         Self::sort_points_by_level(&level_fn, &mut ids);
 
-        let mut remap = vec![0; ids.len()];
+        let mut remap = vec![0; ids.iter().max().copied().unwrap_or_default() as usize + 1];
         for (remapped_id, id) in ids.iter().enumerate() {
             remap[*id as usize] = remapped_id as PointOffsetType;
         }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use itertools::Itertools;
 use parking_lot::{Mutex, MutexGuard};
 
 use crate::common::check_stopped;
@@ -30,38 +31,54 @@ impl<'a> LockedGpuDevice<'a> {
 impl GpuDevicesMaganer {
     pub fn new(
         filter: &str,
-        start_index: usize,
-        count: usize,
+        device_indexes: Option<&[usize]>,
         allow_integrated: bool,
         allow_emulated: bool,
         wait_free: bool,
         parallel_indexes: usize,
     ) -> OperationResult<Self> {
         let instance = gpu::Instance::new(None, None, false)?;
+
+        // Device filter is case-insensitive and comma-separated.
         let filter = filter.to_lowercase();
         let filter = filter
             .split(",")
             .map(|s| s.trim().to_owned())
             .collect::<Vec<_>>();
+
+        // Collect physical devices that match the filter.
+        let filtered_physical_devices = instance
+            .physical_devices()
+            .iter()
+            // Apply device name filter.
+            .filter(|device| {
+                let device_name = device.name.to_lowercase();
+                filter.iter().any(|filter| device_name.contains(filter))
+            })
+            // Filter out integrated and emulated devices.
+            .filter(|device| {
+                device.device_type == gpu::PhysicalDeviceType::Discrete
+                    || (allow_integrated
+                        && device.device_type == gpu::PhysicalDeviceType::Integrated)
+                    || (allow_emulated && device.device_type == gpu::PhysicalDeviceType::Other)
+            })
+            .collect::<Vec<_>>();
+
+        // Collect device indexes to use.
+        let device_indexes: Vec<_> = if let Some(device_indexes) = device_indexes {
+            device_indexes.iter().copied().unique().collect()
+        } else {
+            (0..filtered_physical_devices.len()).collect()
+        };
+
         let mut devices = Vec::new();
         for queue_index in 0..parallel_indexes {
             devices.extend(
-                instance
-                    .physical_devices()
+                device_indexes
                     .iter()
-                    .filter(|device| {
-                        let device_name = device.name.to_lowercase();
-                        filter.iter().any(|filter| device_name.contains(filter))
-                    })
-                    .filter(|device| {
-                        device.device_type == gpu::PhysicalDeviceType::Discrete
-                            || (allow_integrated
-                                && device.device_type == gpu::PhysicalDeviceType::Integrated)
-                            || (allow_emulated
-                                && device.device_type == gpu::PhysicalDeviceType::Other)
-                    })
-                    .skip(start_index)
-                    .take(count)
+                    // Get vk physical device. Filter out invalid device indexes.
+                    .filter_map(|&device_index| filtered_physical_devices.get(device_index))
+                    // Try to create a gpu device.
                     .filter_map(|physical_device| {
                         match gpu::Device::new_with_queue_index(
                             instance.clone(),
@@ -85,9 +102,11 @@ impl GpuDevicesMaganer {
             );
         }
 
-        let device_names = devices
+        // All found devices to include it to the telemetry.
+        let device_names = instance
+            .physical_devices()
             .iter()
-            .map(|device| device.lock().name().to_owned())
+            .map(|device| device.name.clone())
             .collect();
 
         Ok(Self {
@@ -117,7 +136,8 @@ impl GpuDevicesMaganer {
         }
     }
 
-    pub fn device_names(&self) -> Vec<String> {
+    /// Returns all found device names without filtering.
+    pub fn all_found_device_names(&self) -> Vec<String> {
         self.device_names.clone()
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -494,7 +494,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         payload_index: &StructPayloadIndex,
         pool: &ThreadPool,
         stopped: &AtomicBool,
-        graph_layers_builder: &mut GraphLayersBuilder,
+        #[allow(clippy::needless_pass_by_ref_mut)] graph_layers_builder: &mut GraphLayersBuilder,
         condition: FieldCondition,
         block_filter_list: &mut VisitedListHandle,
         indexed_vectors_set: &mut BitVec,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -429,7 +429,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                         continue;
                     }
                     // ToDo: reuse graph layer for same payload
-                    let additional_graph = GraphLayersBuilder::new_with_params(
+                    let mut additional_graph = GraphLayersBuilder::new_with_params(
                         total_vector_count,
                         payload_m,
                         config.payload_m0.unwrap_or(config.m0),
@@ -446,7 +446,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                         payload_index,
                         &pool,
                         stopped,
-                        &additional_graph,
+                        &mut additional_graph,
                         payload_block.condition,
                         &mut block_filter_list,
                         &mut indexed_vectors_set,
@@ -494,7 +494,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         payload_index: &StructPayloadIndex,
         pool: &ThreadPool,
         stopped: &AtomicBool,
-        graph_layers_builder: &GraphLayersBuilder,
+        graph_layers_builder: &mut GraphLayersBuilder,
         condition: FieldCondition,
         block_filter_list: &mut VisitedListHandle,
         indexed_vectors_set: &mut BitVec,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -20,6 +20,8 @@ use rand::thread_rng;
 use rayon::prelude::*;
 use rayon::ThreadPool;
 
+use super::gpu::gpu_devices_manager::LockedGpuDevice;
+use super::gpu::gpu_vector_storage::GpuVectorStorage;
 use super::graph_links::{GraphLinks, GraphLinksMmap};
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::operation_time_statistics::{
@@ -31,6 +33,8 @@ use crate::data_types::vectors::{QueryVector, VectorInternal, VectorRef};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::config::HnswGraphConfig;
+#[cfg(feature = "gpu")]
+use crate::index::hnsw_index::gpu::{get_gpu_groups_count, gpu_graph_builder::build_hnsw_on_gpu};
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
@@ -39,6 +43,8 @@ use crate::index::sample_estimation::sample_check_cardinality;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 use crate::index::{PayloadIndex, VectorIndex};
+#[cfg(feature = "gpu")]
+use crate::payload_storage::FilterContext;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::Condition::Field;
 use crate::types::{
@@ -52,6 +58,7 @@ use crate::vector_storage::{
 };
 
 const HNSW_USE_HEURISTIC: bool = true;
+const FINISH_MAIN_GRAPH_LOG_MESSAGE: &str = "Finish main graph in time";
 
 /// Build first N points in HNSW graph using only a single thread, to avoid
 /// disconnected components in the graph.
@@ -91,6 +98,7 @@ pub struct HnswIndexOpenArgs<'a> {
     pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     pub hnsw_config: HnswConfig,
     pub permit: Option<Arc<CpuPermit>>,
+    pub gpu_device: Option<&'a LockedGpuDevice<'a>>,
     pub stopped: &'a AtomicBool,
 }
 
@@ -104,6 +112,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             payload_index,
             hnsw_config,
             permit,
+            gpu_device,
             stopped,
         } = args;
 
@@ -162,6 +171,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 &payload_index.borrow(),
                 &hnsw_config,
                 num_cpus,
+                gpu_device,
                 stopped,
             )?;
 
@@ -209,6 +219,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         payload_index: &StructPayloadIndex,
         hnsw_config: &HnswConfig,
         num_cpus: usize,
+        #[allow(unused_variables)] gpu_device: Option<&LockedGpuDevice>,
         stopped: &AtomicBool,
     ) -> OperationResult<(HnswGraphConfig, GraphLayers<TGraphLinks>)> {
         let total_vector_count = vector_storage.total_vector_count();
@@ -237,20 +248,31 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let mut rng = thread_rng();
         let deleted_bitslice = vector_storage.deleted_vector_bitslice();
 
-        debug!("building HNSW for {total_vector_count} vectors with {num_cpus} CPUs");
+        #[cfg(feature = "gpu")]
+        let gpu_name_postfix = if let Some(gpu_device) = gpu_device {
+            format!(" and GPU {}", gpu_device.device().name())
+        } else {
+            Default::default()
+        };
+        #[cfg(not(feature = "gpu"))]
+        let gpu_name_postfix = "";
+        debug!(
+            "building HNSW for {total_vector_count} vectors with {num_cpus} CPUs{gpu_name_postfix}"
+        );
 
+        let num_entries = std::cmp::max(
+            1,
+            total_vector_count
+                .checked_div(full_scan_threshold)
+                .unwrap_or(0)
+                * 10,
+        );
         let mut graph_layers_builder = GraphLayersBuilder::new(
             total_vector_count,
             config.m,
             config.m0,
             config.ef_construct,
-            std::cmp::max(
-                1,
-                total_vector_count
-                    .checked_div(full_scan_threshold)
-                    .unwrap_or(0)
-                    * 10,
-            ),
+            num_entries,
             HNSW_USE_HEURISTIC,
         );
 
@@ -280,15 +302,51 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             })
             .build()?;
 
+        let mut indexed_vectors = 0;
         for vector_id in id_tracker.iter_ids_excluding(deleted_bitslice) {
             check_process_stopped(stopped)?;
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(vector_id, level);
+            indexed_vectors += 1;
         }
 
-        let mut indexed_vectors = 0;
+        #[allow(unused_mut)]
+        let mut build_main_graph = config.m > 0;
+        if !build_main_graph {
+            debug!("skip building main HNSW graph");
+        }
 
-        if config.m > 0 {
+        // Try to build the main graph on GPU if possible.
+        // Store created gpu vectors to reuse them for payload links.
+        #[cfg(feature = "gpu")]
+        let gpu_vectors = if build_main_graph {
+            let timer = std::time::Instant::now();
+            let gpu_vectors =
+                Self::create_gpu_vectors(gpu_device, vector_storage, quantized_vectors, stopped)?;
+            if let Some(gpu_constructed_graph) = Self::build_main_graph_on_gpu(
+                id_tracker,
+                vector_storage,
+                quantized_vectors,
+                gpu_vectors.as_ref(),
+                &graph_layers_builder,
+                deleted_bitslice,
+                num_entries,
+                stopped,
+            )? {
+                graph_layers_builder = gpu_constructed_graph;
+                build_main_graph = false;
+                debug!("{FINISH_MAIN_GRAPH_LOG_MESSAGE} {:?}", timer.elapsed());
+            }
+            gpu_vectors
+        } else {
+            None
+        };
+        #[cfg(not(feature = "gpu"))]
+        let gpu_vectors = None;
+
+        if build_main_graph {
+            let timer = std::time::Instant::now();
+
             let mut ids_iterator = id_tracker.iter_ids_excluding(deleted_bitslice);
 
             let first_few_ids: Vec<_> = ids_iterator
@@ -296,8 +354,6 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 .take(SINGLE_THREADED_HNSW_BUILD_THRESHOLD)
                 .collect();
             let ids: Vec<_> = ids_iterator.collect();
-
-            indexed_vectors = ids.len() + first_few_ids.len();
 
             let insert_point = |vector_id| {
                 check_process_stopped(stopped)?;
@@ -331,9 +387,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 pool.install(|| ids.into_par_iter().try_for_each(insert_point))?;
             }
 
-            debug!("finish main graph");
-        } else {
-            debug!("skip building main HNSW graph");
+            debug!("{FINISH_MAIN_GRAPH_LOG_MESSAGE} {:?}", timer.elapsed());
         }
 
         let visited_pool = VisitedPool::new();
@@ -388,6 +442,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                         id_tracker,
                         vector_storage,
                         quantized_vectors,
+                        gpu_vectors.as_ref(),
                         payload_index,
                         &pool,
                         stopped,
@@ -435,6 +490,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         id_tracker: &IdTrackerSS,
         vector_storage: &VectorStorageEnum,
         quantized_vectors: &Option<QuantizedVectors>,
+        #[allow(unused_variables)] gpu_vectors: Option<&GpuVectorStorage>,
         payload_index: &StructPayloadIndex,
         pool: &ThreadPool,
         stopped: &AtomicBool,
@@ -466,6 +522,22 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             if !indexed_vectors_set.is_empty() {
                 indexed_vectors_set.set(block_point_id as usize, true);
             }
+        }
+
+        #[cfg(feature = "gpu")]
+        if let Some(gpu_constructed_graph) = Self::build_filtered_graph_on_gpu(
+            id_tracker,
+            vector_storage,
+            quantized_vectors,
+            gpu_vectors,
+            graph_layers_builder,
+            block_filter_list,
+            &points_to_index,
+            deleted_bitslice,
+            stopped,
+        )? {
+            *graph_layers_builder = gpu_constructed_graph;
+            return Ok(());
         }
 
         let insert_points = |block_point_id| {
@@ -517,6 +589,164 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             })?;
         }
         Ok(())
+    }
+
+    #[cfg(feature = "gpu")]
+    #[allow(clippy::too_many_arguments)]
+    fn build_main_graph_on_gpu(
+        id_tracker: &IdTrackerSS,
+        vector_storage: &VectorStorageEnum,
+        quantized_vectors: &Option<QuantizedVectors>,
+        gpu_vectors: Option<&GpuVectorStorage>,
+        graph_layers_builder: &GraphLayersBuilder,
+        deleted_bitslice: &BitSlice,
+        entry_points_num: usize,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Option<GraphLayersBuilder>> {
+        let points_scorer_builder = |vector_id| {
+            let vector = vector_storage.get_vector(vector_id);
+            let vector = vector.as_vec_ref().into();
+            let raw_scorer = if let Some(quantized_storage) = quantized_vectors.as_ref() {
+                quantized_storage.raw_scorer(
+                    vector,
+                    id_tracker.deleted_point_bitslice(),
+                    vector_storage.deleted_vector_bitslice(),
+                    stopped,
+                )
+            } else {
+                new_raw_scorer(vector, vector_storage, id_tracker.deleted_point_bitslice())
+            }?;
+            Ok((raw_scorer, None))
+        };
+
+        Self::build_graph_on_gpu(
+            gpu_vectors,
+            graph_layers_builder,
+            id_tracker.iter_ids_excluding(deleted_bitslice),
+            entry_points_num,
+            points_scorer_builder,
+            stopped,
+        )
+    }
+
+    #[cfg(feature = "gpu")]
+    #[allow(clippy::too_many_arguments)]
+    fn build_filtered_graph_on_gpu(
+        id_tracker: &IdTrackerSS,
+        vector_storage: &VectorStorageEnum,
+        quantized_vectors: &Option<QuantizedVectors>,
+        gpu_vectors: Option<&GpuVectorStorage>,
+        graph_layers_builder: &GraphLayersBuilder,
+        block_filter_list: &VisitedListHandle,
+        points_to_index: &[PointOffsetType],
+        deleted_bitslice: &BitSlice,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Option<GraphLayersBuilder>> {
+        let points_scorer_builder = |block_point_id| -> OperationResult<_> {
+            let vector = vector_storage.get_vector(block_point_id);
+            let vector = vector.as_vec_ref().into();
+            let raw_scorer = match quantized_vectors.as_ref() {
+                Some(quantized_storage) => quantized_storage.raw_scorer(
+                    vector,
+                    id_tracker.deleted_point_bitslice(),
+                    deleted_bitslice,
+                    stopped,
+                ),
+                None => new_raw_scorer(vector, vector_storage, id_tracker.deleted_point_bitslice()),
+            }?;
+            let block_condition_checker: Box<dyn FilterContext> = Box::new(BuildConditionChecker {
+                filter_list: block_filter_list,
+                current_point: block_point_id,
+            });
+            Ok((raw_scorer, Some(block_condition_checker)))
+        };
+
+        Self::build_graph_on_gpu(
+            gpu_vectors,
+            graph_layers_builder,
+            points_to_index.iter().copied(),
+            1,
+            points_scorer_builder,
+            stopped,
+        )
+    }
+
+    #[cfg(feature = "gpu")]
+    #[allow(clippy::too_many_arguments)]
+    fn build_graph_on_gpu<'a>(
+        gpu_vectors: Option<&GpuVectorStorage>,
+        graph_layers_builder: &GraphLayersBuilder,
+        points_to_index: impl Iterator<Item = PointOffsetType>,
+        entry_points_num: usize,
+        points_scorer_builder: impl Fn(
+                PointOffsetType,
+            )
+                -> OperationResult<(Box<dyn RawScorer + 'a>, Option<Box<dyn FilterContext + 'a>>)>
+            + Send
+            + Sync,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Option<GraphLayersBuilder>> {
+        if let Some(gpu_vectors) = gpu_vectors {
+            let gpu_constructed_graph = build_hnsw_on_gpu(
+                gpu_vectors,
+                graph_layers_builder,
+                get_gpu_groups_count(),
+                entry_points_num,
+                SINGLE_THREADED_HNSW_BUILD_THRESHOLD,
+                false,
+                points_to_index.collect::<Vec<_>>(),
+                points_scorer_builder,
+                stopped,
+            );
+
+            // GPU construction does not return an error. If it fails, it will fall back to CPU.
+            // To cover stopping case, we need to check stopping flag here.
+            check_process_stopped(stopped)?;
+
+            match gpu_constructed_graph {
+                Ok(gpu_constructed_graph) => Ok(Some(gpu_constructed_graph)),
+                Err(gpu_error) => {
+                    log::warn!("Failed to build HNSW on GPU: {gpu_error}. Falling back to CPU.");
+                    Ok(None)
+                }
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    fn create_gpu_vectors(
+        gpu_device: Option<&LockedGpuDevice>,
+        vector_storage: &VectorStorageEnum,
+        quantized_vectors: &Option<QuantizedVectors>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Option<GpuVectorStorage>> {
+        use crate::index::hnsw_index::gpu::get_gpu_force_half_precision;
+
+        if let Some(gpu_device) = gpu_device {
+            let gpu_vectors = GpuVectorStorage::new(
+                gpu_device.device(),
+                vector_storage,
+                quantized_vectors.as_ref(),
+                get_gpu_force_half_precision(),
+                stopped,
+            );
+
+            // GPU construction does not return an error. If it fails, it will fall back to CPU.
+            // To cover stopping case, we need to check stopping flag here.
+            check_process_stopped(stopped)?;
+
+            match gpu_vectors {
+                Ok(gpu_vectors) => Ok(Some(gpu_vectors)),
+                Err(err) => {
+                    log::error!("Failed to create GPU vectors, use CPU instead. Error: {err}.");
+                    Ok(None)
+                }
+            }
+        } else {
+            Ok(None)
+        }
     }
 
     fn search_with_graph(

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -486,6 +486,8 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(unused_variables)]
+    #[allow(clippy::needless_pass_by_ref_mut)]
     fn build_filtered_graph(
         id_tracker: &IdTrackerSS,
         vector_storage: &VectorStorageEnum,
@@ -494,7 +496,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         payload_index: &StructPayloadIndex,
         pool: &ThreadPool,
         stopped: &AtomicBool,
-        #[allow(clippy::needless_pass_by_ref_mut)] graph_layers_builder: &mut GraphLayersBuilder,
+        graph_layers_builder: &mut GraphLayersBuilder,
         condition: FieldCondition,
         block_filter_list: &mut VisitedListHandle,
         indexed_vectors_set: &mut BitVec,

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -14,6 +14,22 @@ mod search_context;
 #[cfg(feature = "gpu")]
 pub mod gpu;
 
+/// Placeholders for GPU logic when the `gpu` feature is not enabled.
+#[cfg(not(feature = "gpu"))]
+pub mod gpu {
+    pub mod gpu_devices_manager {
+        /// Placeholder for GPU device to process indexing on.
+        pub struct LockedGpuDevice<'a> {
+            phantom: std::marker::PhantomData<&'a usize>,
+        }
+    }
+
+    pub mod gpu_vector_storage {
+        /// Placeholder for GPU vector storage.
+        pub struct GpuVectorStorage {}
+    }
+}
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -86,6 +86,7 @@ fn test_graph_connectivity() {
         payload_index: payload_index_ptr,
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -20,6 +20,7 @@ use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
+use crate::index::hnsw_index::gpu::gpu_devices_manager::LockedGpuDevice;
 use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use crate::index::plain_payload_index::PlainIndex;
 use crate::index::sparse_index::sparse_index_config::SparseIndexType;
@@ -371,6 +372,7 @@ pub(crate) fn create_vector_index(
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
     permit: Option<Arc<CpuPermit>>,
+    gpu_device: Option<&LockedGpuDevice>,
     stopped: &AtomicBool,
 ) -> OperationResult<VectorIndexEnum> {
     let vector_index = match &vector_config.index {
@@ -386,6 +388,7 @@ pub(crate) fn create_vector_index(
                 payload_index,
                 hnsw_config: vector_hnsw_config.clone(),
                 permit,
+                gpu_device,
                 stopped,
             };
             if vector_hnsw_config.on_disk == Some(true) {
@@ -580,6 +583,7 @@ fn create_segment(
             vector_storage.clone(),
             payload_index.clone(),
             quantized_vectors.clone(),
+            Default::default(),
             None,
             stopped,
         )?);

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -170,6 +170,7 @@ fn test_batch_and_single_request_equivalency() {
         payload_index: payload_index_ptr,
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -223,6 +223,7 @@ fn test_byte_storage_hnsw(
         payload_index: segment_byte.payload_index.clone(),
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -350,6 +350,7 @@ fn test_byte_storage_binary_quantization_hnsw(
         payload_index: segment_byte.payload_index.clone(),
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -200,6 +200,7 @@ fn _test_filterable_hnsw(
         payload_index: payload_index_ptr.clone(),
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -118,6 +118,7 @@ fn hnsw_discover_precision() {
         payload_index: payload_index_ptr,
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();
@@ -241,6 +242,7 @@ fn filtered_hnsw_discover_precision() {
         payload_index: payload_index_ptr,
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -141,6 +141,7 @@ fn hnsw_quantized_search_test(
         payload_index: segment.payload_index.clone(),
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -7,6 +7,8 @@ mod fail_recovery_test;
 mod filtering_context_check;
 mod filtrable_hnsw_test;
 mod fixtures;
+#[cfg(feature = "gpu")]
+mod gpu_hnsw_test;
 mod hnsw_discover_test;
 mod hnsw_quantized_search_test;
 mod multivector_filtrable_hnsw_test;

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -192,6 +192,7 @@ fn test_multi_filterable_hnsw(
         payload_index: payload_index_ptr,
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -150,6 +150,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         payload_index: segment.payload_index.clone(),
         hnsw_config: hnsw_config.clone(),
         permit: Some(permit.clone()),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();
@@ -164,6 +165,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         payload_index: segment.payload_index.clone(),
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -320,6 +320,7 @@ fn test_multivector_quantization_hnsw(
         payload_index: segment.payload_index.clone(),
         hnsw_config,
         permit: Some(permit),
+        gpu_device: None,
         stopped: &stopped,
     })
     .unwrap();

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -26,6 +26,7 @@ pub struct AppFeaturesTelemetry {
     pub web_feature: bool,
     pub service_debug_feature: bool,
     pub recovery_mode: bool,
+    pub gpu: bool,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema)]
@@ -39,6 +40,8 @@ pub struct RunningEnvironmentTelemetry {
     cpu_flags: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     cpu_endian: Option<CpuEndian>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_devices: Option<Vec<GpuDeviceTelemetry>>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema)]
@@ -70,6 +73,7 @@ impl AppBuildTelemetry {
                 web_feature: cfg!(feature = "web"),
                 service_debug_feature: cfg!(feature = "service_debug"),
                 recovery_mode: settings.storage.recovery_mode.is_some(),
+                gpu: cfg!(feature = "gpu"),
             }),
             system: (detail.level >= DetailsLevel::Level1).then(get_system_data),
             jwt_rbac: settings.service.jwt_rbac,
@@ -124,6 +128,22 @@ fn get_system_data() -> RunningEnvironmentTelemetry {
             cpu_flags.push("fp16");
         }
     }
+
+    #[cfg(feature = "gpu")]
+    let gpu_devices = segment::index::hnsw_index::gpu::GPU_DEVICES_MANAGER
+        .read()
+        .as_ref()
+        .map(|gpu_devices_manager| {
+            gpu_devices_manager
+                .device_names()
+                .iter()
+                .map(|name| GpuDeviceTelemetry { name: name.clone() })
+                .collect::<Vec<_>>()
+        });
+
+    #[cfg(not(feature = "gpu"))]
+    let gpu_devices = None;
+
     RunningEnvironmentTelemetry {
         distribution,
         distribution_version,
@@ -133,6 +153,7 @@ fn get_system_data() -> RunningEnvironmentTelemetry {
         disk_size: sys_info::disk_info().ok().map(|x| x.total as usize),
         cpu_flags: cpu_flags.join(","),
         cpu_endian: Some(CpuEndian::current()),
+        gpu_devices,
     }
 }
 
@@ -157,6 +178,19 @@ impl CpuEndian {
     }
 }
 
+#[derive(Serialize, Clone, Debug, JsonSchema)]
+pub struct GpuDeviceTelemetry {
+    pub name: String,
+}
+
+impl Anonymize for GpuDeviceTelemetry {
+    fn anonymize(&self) -> Self {
+        GpuDeviceTelemetry {
+            name: self.name.clone(),
+        }
+    }
+}
+
 impl Anonymize for AppFeaturesTelemetry {
     fn anonymize(&self) -> Self {
         AppFeaturesTelemetry {
@@ -164,6 +198,7 @@ impl Anonymize for AppFeaturesTelemetry {
             web_feature: self.web_feature,
             service_debug_feature: self.service_debug_feature,
             recovery_mode: self.recovery_mode,
+            gpu: self.gpu,
         }
     }
 }
@@ -193,6 +228,7 @@ impl Anonymize for RunningEnvironmentTelemetry {
             disk_size: self.disk_size.anonymize(),
             cpu_flags: self.cpu_flags.clone(),
             cpu_endian: self.cpu_endian,
+            gpu_devices: self.gpu_devices.anonymize(),
         }
     }
 }

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -135,7 +135,7 @@ fn get_system_data() -> RunningEnvironmentTelemetry {
         .as_ref()
         .map(|gpu_devices_manager| {
             gpu_devices_manager
-                .device_names()
+                .all_found_device_names()
                 .iter()
                 .map(|name| GpuDeviceTelemetry { name: name.clone() })
                 .collect::<Vec<_>>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,8 +183,7 @@ fn main() -> anyhow::Result<()> {
             let mut gpu_device_manager = GPU_DEVICES_MANAGER.write();
             *gpu_device_manager = match gpu_devices_manager::GpuDevicesMaganer::new(
                 &settings_gpu.device_filter,
-                settings_gpu.skip_devices.unwrap_or(0),
-                settings_gpu.devices_count.unwrap_or(usize::MAX),
+                settings_gpu.devices.as_deref(),
                 settings_gpu.allow_integrated,
                 settings_gpu.allow_emulated,
                 true, // Currently we always wait for the free gpu device.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ fn main() -> anyhow::Result<()> {
             let mut gpu_device_manager = GPU_DEVICES_MANAGER.write();
             *gpu_device_manager = match gpu_devices_manager::GpuDevicesMaganer::new(
                 &settings_gpu.device_filter,
-                settings_gpu.device_index.unwrap_or(0),
+                settings_gpu.skip_devices.unwrap_or(0),
                 settings_gpu.devices_count.unwrap_or(usize::MAX),
                 settings_gpu.allow_integrated,
                 settings_gpu.allow_emulated,

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,34 @@ fn main() -> anyhow::Result<()> {
             .unwrap_or_default(),
     );
 
+    #[cfg(feature = "gpu")]
+    if let Some(settings_gpu) = &settings.gpu {
+        use segment::index::hnsw_index::gpu::*;
+
+        // initialize GPU devices manager.
+        if settings_gpu.indexing {
+            set_gpu_force_half_precision(settings_gpu.force_half_precision);
+            set_gpu_groups_count(settings_gpu.groups_count);
+
+            let mut gpu_device_manager = GPU_DEVICES_MANAGER.write();
+            *gpu_device_manager = match gpu_devices_manager::GpuDevicesMaganer::new(
+                &settings_gpu.device_filter,
+                settings_gpu.device_index.unwrap_or(0),
+                settings_gpu.devices_count.unwrap_or(usize::MAX),
+                settings_gpu.allow_integrated,
+                settings_gpu.allow_emulated,
+                true, // Currently we always wait for the free gpu device.
+                settings_gpu.parallel_indexes.unwrap_or(1),
+            ) {
+                Ok(gpu_device_manager) => Some(gpu_device_manager),
+                Err(err) => {
+                    log::error!("Can't initialize GPU devices manager: {err}");
+                    None
+                }
+            }
+        }
+    }
+
     welcome(&settings);
 
     if let Some(recovery_warning) = &settings.storage.recovery_mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,8 @@ fn main() -> anyhow::Result<()> {
             .unwrap_or_default(),
     );
 
+    welcome(&settings);
+
     #[cfg(feature = "gpu")]
     if let Some(settings_gpu) = &settings.gpu {
         use segment::index::hnsw_index::gpu::*;
@@ -196,8 +198,6 @@ fn main() -> anyhow::Result<()> {
             }
         }
     }
-
-    welcome(&settings);
 
     if let Some(recovery_warning) = &settings.storage.recovery_mode {
         log::warn!("Qdrant is loaded in recovery mode: {}", recovery_warning);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -148,15 +148,21 @@ pub struct GpuConfig {
     #[serde(default)]
     pub indexing: bool,
     /// Force half precision for `f32` values while indexing.
+    /// `f16` conversion will take place only inside GPU memory and won't affect storage type.
     #[serde(default)]
     pub force_half_precision: bool,
-    /// Warps count for GPU.
-    /// In other words, how many parallel points can be indexed by GPU.
+    /// Used vulkan "groups" of GPU. In other words, how many parallel points can be indexed by GPU.
+    /// Optimal value might depend on the GPU model.
+    /// Proportional, but doesn't necessary equal to the physical number of warps.
+    /// Do not change this value unless you know what you are doing.
+    /// Default: 512
     #[serde(default)]
     #[validate(range(min = 1))]
     pub groups_count: Option<usize>,
-    /// Filter for GPU devices by hardware name.
+    /// Filter for GPU devices by hardware name. Case insensitive.
     /// Comma-separated list of substrings to match against the gpu device name.
+    /// Example: "nvidia"
+    /// Default: "" - all devices are accepted.
     #[serde(default)]
     pub device_filter: String,
     /// How many gpu devices to skip before starting to use them.
@@ -165,13 +171,16 @@ pub struct GpuConfig {
     /// How many gpu devices to use.
     #[serde(default)]
     pub devices_count: Option<usize>,
-    /// How many parallel indexes to run.
+    /// How many parallel indexing processes are allowed to run.
+    /// Default: 1
     #[serde(default)]
     pub parallel_indexes: Option<usize>,
     /// Allow to use integrated GPUs.
+    /// Default: false
     #[serde(default)]
     pub allow_integrated: bool,
     /// Allow to use emulated GPUs like LLVMpipe. Useful for CI.
+    /// Default: false
     #[serde(default)]
     pub allow_emulated: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -141,6 +141,41 @@ pub struct TlsConfig {
     pub cert_ttl: Option<u64>,
 }
 
+#[allow(dead_code)]
+#[derive(Clone, Debug, Deserialize, Validate)]
+pub struct GpuConfig {
+    /// Enable GPU indexing.
+    #[serde(default)]
+    pub indexing: bool,
+    /// Force half precision for `f32` values while indexing.
+    #[serde(default)]
+    pub force_half_precision: bool,
+    /// Warps count for GPU.
+    /// In other words, how many parallel points can be indexed by GPU.
+    #[serde(default)]
+    #[validate(range(min = 1))]
+    pub groups_count: Option<usize>,
+    /// Filter for GPU devices by hardware name.
+    /// Comma-separated list of substrings to match against the gpu device name.
+    #[serde(default)]
+    pub device_filter: String,
+    /// How many gpu devices to skip before starting to use them.
+    #[serde(default)]
+    pub device_index: Option<usize>,
+    /// How many gpu devices to use.
+    #[serde(default)]
+    pub devices_count: Option<usize>,
+    /// How many parallel indexes to run.
+    #[serde(default)]
+    pub parallel_indexes: Option<usize>,
+    /// Allow to use integrated GPUs.
+    #[serde(default)]
+    pub allow_integrated: bool,
+    /// Allow to use emulated GPUs like LLVMpipe. Useful for CI.
+    #[serde(default)]
+    pub allow_emulated: bool,
+}
+
 #[derive(Debug, Deserialize, Clone, Validate)]
 #[allow(dead_code)] // necessary because some field are only used in main.rs
 pub struct Settings {
@@ -168,6 +203,9 @@ pub struct Settings {
     pub load_errors: Vec<LogMsg>,
     #[serde(default)]
     pub inference: Option<InferenceConfig>,
+    #[serde(default)]
+    #[validate(nested)]
+    pub gpu: Option<GpuConfig>,
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -165,12 +165,13 @@ pub struct GpuConfig {
     /// Default: "" - all devices are accepted.
     #[serde(default)]
     pub device_filter: String,
-    /// How many gpu devices to skip before starting to use them.
+    /// List of explicit GPU devices to use.
+    /// If host has multiple GPUs, this option allows to select specific devices
+    /// by their index in the list of found devices.
+    /// If `device_filter` is set, indexes are applied after filtering.
+    /// By default, all devices are accepted.
     #[serde(default)]
-    pub skip_devices: Option<usize>,
-    /// How many gpu devices to use.
-    #[serde(default)]
-    pub devices_count: Option<usize>,
+    pub devices: Option<Vec<usize>>,
     /// How many parallel indexing processes are allowed to run.
     /// Default: 1
     #[serde(default)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -161,7 +161,7 @@ pub struct GpuConfig {
     pub device_filter: String,
     /// How many gpu devices to skip before starting to use them.
     #[serde(default)]
-    pub device_index: Option<usize>,
+    pub skip_devices: Option<usize>,
     /// How many gpu devices to use.
     #[serde(default)]
     pub devices_count: Option<usize>,


### PR DESCRIPTION
Integrate GPU HNSW into segment.

This PR contains:
1. Run GPU indexation in `hnsw.rs`. Main and filtered graph is indexed by GPU. If gpu error occurs, error is logged and construction is continued by CPU.
2. Unit test of filtered HNSW
3. Segment builder creates GPU device and provide it into HNSW. In the future we need to move this logic up to optimizer and define GPU permits. Changes in segment builder are temporary.
4. Telemetry with enabled feature and created devices.
5. QDrant GPU settings.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
