### PR TITLE
Introduce rate limiting error types

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1016,6 +1016,8 @@ pub enum CollectionError {
     StrictMode { description: String },
     #[error("{description}")]
     InferenceError { description: String },
+    #[error("Rate limiting exceeded: {description}")]
+    RateLimitExceeded { description: String },
 }
 
 impl CollectionError {
@@ -1105,6 +1107,7 @@ impl CollectionError {
             Self::Cancelled { .. } => true,
             Self::OutOfMemory { .. } => true,
             Self::PreConditionFailed { .. } => true,
+            Self::RateLimitExceeded { .. } => true,
             // Not transient
             Self::BadInput { .. } => false,
             Self::NotFound { .. } => false,

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -28,8 +28,9 @@ impl From<StorageError> for tonic::Status {
             StorageError::Forbidden { .. } => tonic::Code::PermissionDenied,
             StorageError::PreconditionFailed { .. } => tonic::Code::FailedPrecondition,
             StorageError::InferenceError { .. } => tonic::Code::InvalidArgument,
+            StorageError::RateLimitExceeded { .. } => tonic::Code::ResourceExhausted,
         };
-        tonic::Status::new(error_code, format!("{error}"))
+        Status::new(error_code, format!("{error}"))
     }
 }
 

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -36,6 +36,8 @@ pub enum StorageError {
     PreconditionFailed { description: String }, // system is not in the state to perform the operation
     #[error("{description}")]
     InferenceError { description: String },
+    #[error("Rate limiting exceeded: {description}")]
+    RateLimitExceeded { description: String },
 }
 
 impl StorageError {
@@ -145,6 +147,9 @@ impl StorageError {
             CollectionError::InferenceError { description } => {
                 StorageError::InferenceError { description }
             }
+            CollectionError::RateLimitExceeded { description } => {
+                StorageError::RateLimitExceeded { description }
+            }
         }
     }
 }
@@ -196,6 +201,9 @@ impl From<CollectionError> for StorageError {
             CollectionError::StrictMode { description } => StorageError::Forbidden { description },
             CollectionError::InferenceError { description } => {
                 StorageError::InferenceError { description }
+            }
+            CollectionError::RateLimitExceeded { description } => {
+                StorageError::RateLimitExceeded { description }
             }
         }
     }

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -156,6 +156,7 @@ impl ResponseError for HttpError {
             StorageError::Forbidden { .. } => http::StatusCode::FORBIDDEN,
             StorageError::PreconditionFailed { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
             StorageError::InferenceError { .. } => http::StatusCode::BAD_REQUEST,
+            StorageError::RateLimitExceeded { .. } => http::StatusCode::TOO_MANY_REQUESTS,
         }
     }
 }


### PR DESCRIPTION
We are about to introduce rate limiting capabilities at the shard level very soon.

This PR takes the first step by defining the new error return in case of going over the limit.

There error travel through the layers and is mapped to the right specific protocol counter part.