### PR TITLE
Rate limit local shard operations

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use common::cpu::CpuBudget;
+use common::rate_limiting::RateLimiter;
 use common::types::TelemetryDetail;
 use common::{panic, tar_ext};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -95,6 +96,8 @@ pub struct LocalShard {
     update_runtime: Handle,
     pub(super) search_runtime: Handle,
     disk_usage_watcher: DiskUsageWatcher,
+    read_rate_limiter: Option<ParkingMutex<RateLimiter>>,
+    write_rate_limiter: Option<ParkingMutex<RateLimiter>>,
 }
 
 /// Shard holds information about segments and WAL.
@@ -211,6 +214,8 @@ impl LocalShard {
             optimizers_log,
             total_optimized_points,
             disk_usage_watcher,
+            read_rate_limiter: None, // TODO initialize rate limiter from config
+            write_rate_limiter: None, // TODO initialize rate limiter from config
         }
     }
 
@@ -1090,6 +1095,34 @@ impl LocalShard {
     /// This also updates the highest seen clocks.
     pub async fn update_cutoff(&self, cutoff: &RecoveryPoint) {
         self.wal.update_cutoff(cutoff).await
+    }
+
+    /// Check if the write rate limiter allows the operation to proceed
+    ///
+    /// Returns an error if the rate limit is exceeded.
+    fn check_write_rate_limiter(&self) -> CollectionResult<()> {
+        if let Some(rate_limiter) = &self.write_rate_limiter {
+            if !rate_limiter.lock().check() {
+                return Err(CollectionError::RateLimitExceeded {
+                    description: "Write rate limit exceeded, retry later".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Check if the read rate limiter allows the operation to proceed
+    ///
+    /// Returns an error if the rate limit is exceeded.
+    fn check_read_rate_limiter(&self) -> CollectionResult<()> {
+        if let Some(rate_limiter) = &self.read_rate_limiter {
+            if !rate_limiter.lock().check() {
+                return Err(CollectionError::RateLimitExceeded {
+                    description: "Read rate limit exceeded, retry later".to_string(),
+                });
+            }
+        }
+        Ok(())
     }
 }
 

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod iterator_ext;
 pub mod math;
 pub mod mmap_hashmap;
 pub mod panic;
+pub mod rate_limiting;
 pub mod tar_ext;
 pub mod tempfile_ext;
 pub mod top_k;

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -1,0 +1,101 @@
+use std::time::{Duration, Instant};
+
+/// A rate of requests per time period.
+#[derive(Debug)]
+pub struct Rate {
+    requests_num: u64,
+    period: Duration,
+}
+
+impl Rate {
+    /// Create a new rate.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `requests_num` or `period` is 0.
+    pub const fn new(requests_num: u64, period: Duration) -> Self {
+        assert!(requests_num > 0);
+        assert!(period.as_nanos() > 0);
+
+        Rate {
+            requests_num,
+            period,
+        }
+    }
+
+    pub(crate) fn requests_num(&self) -> u64 {
+        self.requests_num
+    }
+
+    pub(crate) fn period(&self) -> Duration {
+        self.period
+    }
+}
+
+/// A rate limiter based on the token bucket algorithm.
+#[derive(Debug)]
+pub struct RateLimiter {
+    // Maximum tokens the bucket can hold.
+    capacity: u64,
+    // Tokens added per second.
+    tokens_per_sec: f64,
+    // Current tokens in the bucket.
+    tokens: f64,
+    // Last time tokens were updated.
+    last_check: Instant,
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter.
+    pub fn new(rate: Rate) -> Self {
+        let tokens_per_sec = rate.requests_num() as f64 / rate.period().as_secs_f64();
+        let capacity = rate.requests_num;
+        RateLimiter {
+            capacity,
+            tokens_per_sec,
+            tokens: capacity as f64, // Start with a full bucket.
+            last_check: Instant::now(),
+        }
+    }
+
+    /// Attempt to consume a token. Returns `true` if allowed, `false` otherwise.
+    pub fn check(&mut self) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_check);
+        self.last_check = now;
+
+        // Refill tokens based on elapsed time.
+        self.tokens += self.tokens_per_sec * elapsed.as_secs_f64();
+        if self.tokens > self.capacity as f64 {
+            self.tokens = self.capacity as f64;
+        }
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0; // Consume one token.
+            true // Request allowed.
+        } else {
+            false // Request denied.
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rate_limiter() {
+        let rate = Rate::new(2, Duration::from_secs(1));
+        let mut limiter = RateLimiter::new(rate);
+
+        assert!(limiter.check());
+        assert!(limiter.check());
+        assert!(!limiter.check());
+
+        std::thread::sleep(Duration::from_secs(1));
+
+        assert!(limiter.check());
+        assert!(limiter.check());
+        assert!(!limiter.check());
+    }
+}

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -98,27 +98,4 @@ mod tests {
         assert!(limiter.check());
         assert!(!limiter.check());
     }
-
-    #[test]
-    fn test_constant_rate() {
-        let rate = Rate::new(1, Duration::from_millis(10));
-        let mut limiter = RateLimiter::new(rate);
-        let mut success = 0;
-        let mut fail = 0;
-
-        for _ in 0..100 {
-            if limiter.check() {
-                success += 1;
-            } else {
-                fail += 1;
-            }
-            std::thread::sleep(Duration::from_millis(5));
-        }
-
-        // expected time = 100 * 5 milliseconds = 500 milliseconds
-        // expected success = 500 / 10 = 50
-        // expected fail = 100 - 50 = 50
-        assert_eq!(fail, 50);
-        assert_eq!(success, 50);
-    }
 }

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -98,4 +98,27 @@ mod tests {
         assert!(limiter.check());
         assert!(!limiter.check());
     }
+
+    #[test]
+    fn test_constant_rate() {
+        let rate = Rate::new(1, Duration::from_millis(10));
+        let mut limiter = RateLimiter::new(rate);
+        let mut success = 0;
+        let mut fail = 0;
+
+        for _ in 0..100 {
+            if limiter.check() {
+                success += 1;
+            } else {
+                fail += 1;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        // expected time = 100 * 5 milliseconds = 500 milliseconds
+        // expected success = 500 / 10 = 50
+        // expected fail = 100 - 50 = 50
+        assert_eq!(fail, 50);
+        assert_eq!(success, 50);
+    }
 }


### PR DESCRIPTION
This PR adds rate limiting to read and write operations on the local shard.

The rate limiters use the token based algorithm to allow burst of requests.
In case of exceeded capacity, we return the newly introduced error in https://github.com/qdrant/qdrant/pull/5538

The rate limiters will be initialized properly from configuration in a future PR.
