### PR TITLE
Deduplicate point IDs returned from proxy segment

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -680,6 +680,7 @@ impl SegmentEntry for ProxySegment {
             .read_filtered(offset, limit, filter, is_stopped);
         read_points.append(&mut write_segment_points);
         read_points.sort_unstable();
+        read_points.dedup();
         read_points
     }
 
@@ -713,6 +714,7 @@ impl SegmentEntry for ProxySegment {
             .read_ordered_filtered(limit, filter, order_by, is_stopped)?;
         read_points.append(&mut write_segment_points);
         read_points.sort_unstable();
+        read_points.dedup();
         Ok(read_points)
     }
 
@@ -743,6 +745,8 @@ impl SegmentEntry for ProxySegment {
             .read()
             .read_random_filtered(limit, filter, is_stopped);
         read_points.append(&mut write_segment_points);
+        read_points.sort_unstable();
+        read_points.dedup();
         read_points
     }
 
@@ -756,6 +760,7 @@ impl SegmentEntry for ProxySegment {
         let mut write_segment_points = self.write_segment.get().read().read_range(from, to);
         read_points.append(&mut write_segment_points);
         read_points.sort_unstable();
+        read_points.dedup();
         read_points
     }
 


### PR DESCRIPTION
In case of a proxy segment, the functions that return available point IDs may include duplicates. That's especially true when the write segment is shared across multiple proxies.

In some places we derive point count based on the returned list, which would double count any duplicates.

I think it's best to deduplicate to prevent this from happening.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?