### PR TITLE
Better `QueryInterface` untagged enum message

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -435,6 +435,7 @@ pub struct QueryResponse {
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
+#[serde(expecting = "Expected some form of vector, id, or a type of query")]
 pub enum QueryInterface {
     Nearest(VectorInput),
     Query(Query),


### PR DESCRIPTION
Previously: 
`"Format error in JSON body: data did not match any variant of untagged enum QueryInterface at line 1 column 16"`

Now:
`"Format error in JSON body: Expected some form of vector, id, or a type of query at line 1 column 16"`


I did try to use `strum` crate to list the exact variants that are allowed, but `#[serde(expecting = "...")]` only allows string literals, so even when I could construct a `const &str` which was descriptive enough, I could not use it without reimplementing `Deserialize` for the type.