### PR TITLE
Keep temporary segment if not empty

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -832,6 +832,10 @@ impl SegmentEntry for ProxySegment {
         };
     }
 
+    fn is_empty(&self) -> bool {
+        self.wrapped_segment.get().read().is_empty() && self.write_segment.get().read().is_empty()
+    }
+
     fn available_point_count(&self) -> usize {
         let deleted_points_count = self.deleted_points.read().len();
         let wrapped_segment_count = self.wrapped_segment.get().read().available_point_count();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1174,10 +1174,11 @@ impl<'s> SegmentHolder {
 
         // Finalize temporary segment we proxied writes to
         // Append a temp segment to collection if it is not empty or there is no other appendable segment
-        let available_points = tmp_segment.get().read().available_point_count();
-        let has_appendable_segment = write_segments.has_appendable_segment();
-        if available_points > 0 || !has_appendable_segment {
-            log::trace!("Keeping temporary segment with {available_points} points");
+        if !write_segments.has_appendable_segment() && !tmp_segment.get().read().is_empty() {
+            log::trace!(
+                "Keeping temporary segment with {} points",
+                tmp_segment.get().read().available_point_count(),
+            );
             write_segments.add_new_locked(tmp_segment);
         } else {
             log::trace!("Dropping temporary segment with no changes");

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -371,7 +371,7 @@ pub trait SegmentOptimizer {
         temp_segment: LockedSegment,
     ) -> OperationResult<()> {
         self.unwrap_proxy(segments, proxy_ids);
-        if temp_segment.get().read().available_point_count() > 0 {
+        if !temp_segment.get().read().is_empty() {
             let mut write_segments = segments.write();
             write_segments.add_new_locked(temp_segment);
         } else {
@@ -684,7 +684,7 @@ pub trait SegmentOptimizer {
             drop(optimizing_segments);
 
             // Append a temp segment to collection if it is not empty or there is no other appendable segment
-            if tmp_segment.get().read().available_point_count() > 0 || !has_appendable_segments {
+            if !tmp_segment.get().read().is_empty() || !has_appendable_segments {
                 write_segments_guard.add_new_locked(tmp_segment);
 
                 // unlock collection for search and updates

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -174,6 +174,15 @@ pub trait SegmentEntry {
 
     fn vector_names(&self) -> HashSet<String>;
 
+    /// Whether this segment is completely empty in terms of points
+    ///
+    /// The segment is considered to not be empty if it contains any points, even if deleted.
+    /// Deleted points still have a version which may be important at time of recovery. Deciding
+    /// this by just the reported point count is not reliable in case a proxy segment is used.
+    ///
+    /// Payload indices or type of storage are not considered here.
+    fn is_empty(&self) -> bool;
+
     /// Number of available points
     ///
     /// - excludes soft deleted points

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -375,6 +375,10 @@ impl SegmentEntry for Segment {
         self.id_tracker.borrow().internal_id(point_id).is_some()
     }
 
+    fn is_empty(&self) -> bool {
+        self.id_tracker.borrow().total_point_count() > 0
+    }
+
     fn available_point_count(&self) -> usize {
         self.id_tracker.borrow().available_point_count()
     }


### PR DESCRIPTION
Be a bit more explicit on when we keep the temporary write segment of a segment proxy.

This doesn't solve a clear issue but I think the improvement is worth it and may save us in the future.

We try to be smart about whether to keep it. The idea is that if there's nothing in it, we can throw it away to not bloat the segment holder. This happens after optimization, if cancelling an optimization, and after proxying all segments for taking a snapshot.

Before we relied on the available point count. That count is not very reliable however (especially with a proxy), which may be problematic. It also doesn't consider deleted points which we may actually want to keep for the recovery procedure because they still have a version attached.

This PR makes the decision more explicit by only throwing the temporary segment away if it's completely empty.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?