### PR TITLE
Fix division by zero in approximate facet API, shortcut instead

### DIFF
--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -22,6 +22,12 @@ impl Segment {
 
         let payload_index = self.payload_index.borrow();
 
+        // Shortcut if this segment has no points, prevent division by zero later
+        let available_points = self.available_point_count();
+        if available_points == 0 {
+            return Ok(HashMap::new());
+        }
+
         let facet_index = payload_index.get_facet_index(&request.key)?;
         let context;
 
@@ -29,8 +35,7 @@ impl Segment {
             let id_tracker = self.id_tracker.borrow();
             let filter_cardinality = payload_index.estimate_cardinality(filter);
 
-            let available = self.available_point_count();
-            let percentage_filtered = filter_cardinality.exp as f64 / available as f64;
+            let percentage_filtered = filter_cardinality.exp as f64 / available_points as f64;
 
             // TODO(facets): define a better estimate for this decision, the question is:
             // What is more expensive, to hash the same value excessively or to check with filter too many times?


### PR DESCRIPTION
Adjust the approximate facet interface to prevent a division by zero.

If a segment is empty, this will become infinite:
```rust
let percentage_filtered = filter_cardinality.exp as f64 / available_points as f64;
```

After which this is incorrectly (?) false:

```rust
let use_iterative_approach = percentage_filtered < 0.3;
```

I've adjusted this function to simply shortcut if the segment is empty. In that case there are no facet values to consider anyway. That also prevents the above problem.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?