### PR TITLE
Expose payload storage size in segment info

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11253,6 +11253,7 @@
           "num_indexed_vectors",
           "num_points",
           "num_vectors",
+          "payloads_size_bytes",
           "ram_usage_bytes",
           "segment_type",
           "vector_data",
@@ -11284,6 +11285,12 @@
           },
           "vectors_size_bytes": {
             "description": "An ESTIMATION of effective amount of bytes used for vectors Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "payloads_size_bytes": {
+            "description": "An estimation of the effective amount of bytes used for payloads",
             "type": "integer",
             "format": "uint",
             "minimum": 0

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -950,6 +950,7 @@ impl SegmentEntry for ProxySegment {
             num_points: self.available_point_count(),
             num_deleted_vectors: write_info.num_deleted_vectors,
             vectors_size_bytes: wrapped_info.vectors_size_bytes, //  + write_info.vectors_size_bytes,
+            payloads_size_bytes: wrapped_info.payloads_size_bytes,
             ram_usage_bytes: wrapped_info.ram_usage_bytes + write_info.ram_usage_bytes,
             disk_usage_bytes: wrapped_info.disk_usage_bytes + write_info.disk_usage_bytes,
             is_appendable: false,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -491,14 +491,22 @@ impl SegmentEntry for Segment {
 
         let vectors_size_bytes = total_average_vectors_size_bytes * num_points;
 
+        // Unwrap and default to 0 here because the RocksDB storage is the only faillible one, and we will remove it eventually.
+        let payloads_size_bytes = self
+            .payload_storage
+            .borrow()
+            .get_storage_size_bytes()
+            .unwrap_or(0);
+
         SegmentInfo {
             segment_type: self.segment_type,
             num_vectors,
             num_indexed_vectors,
             num_points: self.available_point_count(),
             num_deleted_vectors: self.deleted_point_count(),
-            vectors_size_bytes, // Considers vector storage, but not payload or indices
-            ram_usage_bytes: 0, // ToDo: Implement
+            vectors_size_bytes,  // Considers vector storage, but not indices
+            payloads_size_bytes, // Considers payload storage, but not indices
+            ram_usage_bytes: 0,  // ToDo: Implement
             disk_usage_bytes: 0, // ToDo: Implement
             is_appendable: self.appendable_flag,
             index_schema: schema,

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -86,6 +86,7 @@ impl Anonymize for SegmentInfo {
             num_indexed_vectors: self.num_indexed_vectors.anonymize(),
             num_deleted_vectors: self.num_deleted_vectors.anonymize(),
             vectors_size_bytes: self.vectors_size_bytes.anonymize(),
+            payloads_size_bytes: self.payloads_size_bytes.anonymize(),
             ram_usage_bytes: self.ram_usage_bytes.anonymize(),
             disk_usage_bytes: self.disk_usage_bytes.anonymize(),
             is_appendable: self.is_appendable,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -327,6 +327,8 @@ pub struct SegmentInfo {
     /// An ESTIMATION of effective amount of bytes used for vectors
     /// Do NOT rely on this number unless you know what you are doing
     pub vectors_size_bytes: usize,
+    /// An estimation of the effective amount of bytes used for payloads
+    pub payloads_size_bytes: usize,
     pub ram_usage_bytes: usize,
     pub disk_usage_bytes: usize,
     pub is_appendable: bool,


### PR DESCRIPTION
Adding the payload storage size at the segment info makes it visible in the telemetry.

Tested manually

e.g.

- empty segment

```json
  "num_vectors": 0,
  "num_points": 0,
  "num_indexed_vectors": 0,
  "num_deleted_vectors": 0,
  "vectors_size_bytes": 0,
  "payloads_size_bytes": 0,
  "ram_usage_bytes": 0,
  "disk_usage_bytes": 0,
```

- non empty

```json
  "num_vectors": 6,
  "num_points": 6,
  "num_indexed_vectors": 0,
  "num_deleted_vectors": 0,
  "vectors_size_bytes": 96,
  "payloads_size_bytes": 1183,
  "ram_usage_bytes": 0,
  "disk_usage_bytes": 0,
```