### PR TITLE
Fix missing flush on proxy segment if sharing write segment

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -20,7 +20,9 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
-use segment::types::{Payload, PointIdType, SegmentConfig, SeqNumberType, SnapshotFormat};
+use segment::types::{
+    Payload, PointIdType, SegmentConfig, SegmentType, SeqNumberType, SnapshotFormat,
+};
 
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
@@ -776,6 +778,7 @@ impl<'s> SegmentHolder {
         let mut max_persisted_version: SeqNumberType = SeqNumberType::MIN;
         let mut min_unsaved_version: SeqNumberType = SeqNumberType::MAX;
         let mut has_unsaved = false;
+        let mut proxy_segments = vec![];
 
         // Flush and release each segment
         for read_segment in segment_reads {
@@ -789,9 +792,17 @@ impl<'s> SegmentHolder {
 
             max_persisted_version = max(max_persisted_version, segment_persisted_version);
 
-            // Release read-lock immediately after flush, explicit to make this more clear
-            drop(read_segment);
+            // Release segment read-lock right away now or keep it until the end
+            match read_segment.segment_type() {
+                // Regular segment: release now to allow new writes
+                SegmentType::Plain | SegmentType::Indexed => drop(read_segment),
+                // Proxy segment: release at the end, proxy segments may share the write segment
+                // Prevent new updates from changing write segment on yet-to-be-flushed proxies
+                SegmentType::Special => proxy_segments.push(read_segment),
+            }
         }
+
+        drop(proxy_segments);
 
         if has_unsaved {
             Ok(min_unsaved_version)


### PR DESCRIPTION
Fix a problem where we could potentially miss flushing deletes on segments wrapped in a proxy.

Imagine the following events:
- flush proxy A
- reinsert point into proxy A
- flush proxy B

If proxy A and B share the same write segment, this write segment will be updated even though proxy B is yet to be flushed. The write segment affects the segment version of the proxy, so the version of proxy B is bumped even though it's still pending flush. We normally don't expect this to happen as we hold a read lock on proxy B.

Also, in our flush logic we normally acknowledge the highest version we've seen to the write ahead log.

If we add versions to the above actions, the problem becomes visible:
- flush proxy A (version 10)
- reinsert point into proxy A (version 11)
- flush proxy B (version 11)

We did not flush the new change having version 11 in proxy A because we flushed before the update came in. We do acknowledge version 11 in the WAL because it was the highest as reported by proxy B which does include the new version (through proxy A). If we crash now, the WAL won't fix this for us because it'll only start replaying from version 12 onward since version 11 was already acknowledged.

As far as I can see this can only cause us missing flushing deletes. Nor should it cause major issues because we already take point versions into account everywhere. Still I think it's better to prevent this scenario from happening to make our storage more robust.

The key problem here is that we can have multiple proxy segments sharing the same write segment. They are flushed at different times and individually release immediately after flushing. Because of it we can affect a segment we still have a read-lock on.

Note that it's fine to write into non-proxy segments that have just been flushed, even if other segments are still pending flush. The reason is that writing into these will not affect the segment version of the segments pending flush.

To fix the problem from happening I delay releasing the lock for all proxy segments until all segments have been flushed. This will prevent access to shared segments if some part is already flushed.

A potential downside can be that accepting a write takes longer if all segments are proxified. I don't see this as real issue though.

This one is hard to explain, let me know if I need to elaborate further.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?