### PR TITLE
Remove redundant check if point is in wrapped segment

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -150,11 +150,6 @@ impl ProxySegment {
 
             let wrapped_segment_guard = wrapped_segment.read();
 
-            if !wrapped_segment_guard.has_point(point_id) {
-                // Point is not in wrapped segment
-                return Ok(false);
-            }
-
             // Since `deleted_points` are shared between multiple ProxySegments,
             // It is possible that some other Proxy moved its point with different version already
             // If this is the case, there are multiple scenarios:


### PR DESCRIPTION
Here we check if a point is in the wrapped segment. But we actually do it twice.

The first checks if the point is there, the second gets the point version. Getting just the point version achieves the same as it'll be `None` if the point does not exist.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?