### PR TITLE
Enforce clippy match_wildcard_for_single_variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ uninlined_format_args = "warn"
 unnecessary_wraps = "warn"
 unused_self = "warn"
 used_underscore_binding = "warn"
+match_wildcard_for_single_variants = "warn"
 
 [workspace.lints.rust]
 # https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -285,7 +285,7 @@ impl IndexSelector<'_> {
     fn as_rocksdb(&self) -> OperationResult<&IndexSelectorRocksDb> {
         match self {
             IndexSelector::RocksDb(mode) => Ok(mode),
-            _ => Err(OperationError::service_error("Expected RocksDB mode")), // Should never happen
+            IndexSelector::OnDisk(_) => Err(OperationError::service_error("Expected RocksDB mode")), // Should never happen
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -363,7 +363,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                         );
                         stop_consensus
                     }
-                    ty => {
+                    ty @ EntryType::EntryConfChange => {
                         return Err(anyhow!("Unexpected entry type: {:?}", ty));
                     }
                 }

--- a/lib/storage/src/rbac/mod.rs
+++ b/lib/storage/src/rbac/mod.rs
@@ -87,7 +87,9 @@ impl Access {
     ) -> Result<CollectionMultipass, StorageError> {
         match self {
             Access::Global(mode) => mode.meets_requirements(requirements)?,
-            _ => return Err(StorageError::forbidden("Global access is required")),
+            Access::Collection(_) => {
+                return Err(StorageError::forbidden("Global access is required"))
+            }
         }
         Ok(CollectionMultipass)
     }

--- a/src/actix/api/read_params.rs
+++ b/src/actix/api/read_params.rs
@@ -41,9 +41,9 @@ where
     match Helper::deserialize(deserializer)? {
         Helper::ReadConsistency(read_consistency) => Ok(Some(read_consistency)),
         Helper::Str("") => Ok(None),
-        _ => Err(serde::de::Error::custom(
-            "failed to deserialize read consistency query parameter value",
-        )),
+        Helper::Str(x) => Err(serde::de::Error::custom(format!(
+            "failed to deserialize read consistency query parameter value '{x}'"
+        ))),
     }
 }
 


### PR DESCRIPTION
This PR fixes and enforces the Clippy lint [clippy::match_wildcard_for_single_variants](https://rust-lang.github.io/rust-clippy/master/index.html#/wildcard%20matches%20only).

This only checks the usage of wildcard enum matches for a single variant.
There is another lint for multiple matches but it would be pretty large to fix.