### PR TITLE
Enforce clippy needless_pass_by_ref_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ unnecessary_wraps = "warn"
 unused_self = "warn"
 used_underscore_binding = "warn"
 match_wildcard_for_single_variants = "warn"
+needless_pass_by_ref_mut = "warn"
 
 [workspace.lints.rust]
 # https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -375,7 +375,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                         continue;
                     }
                     // ToDo: reuse graph layer for same payload
-                    let mut additional_graph = GraphLayersBuilder::new_with_params(
+                    let additional_graph = GraphLayersBuilder::new_with_params(
                         total_vector_count,
                         payload_m,
                         config.payload_m0.unwrap_or(config.m0),
@@ -391,7 +391,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                         payload_index,
                         &pool,
                         stopped,
-                        &mut additional_graph,
+                        &additional_graph,
                         payload_block.condition,
                         &mut block_filter_list,
                         &mut indexed_vectors_set,
@@ -438,7 +438,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         payload_index: &StructPayloadIndex,
         pool: &ThreadPool,
         stopped: &AtomicBool,
-        graph_layers_builder: &mut GraphLayersBuilder,
+        graph_layers_builder: &GraphLayersBuilder,
         condition: FieldCondition,
         block_filter_list: &mut VisitedListHandle,
         indexed_vectors_set: &mut BitVec,

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -72,6 +72,7 @@ impl Segment {
     /// # Warning
     ///
     /// Available for appendable segments only.
+    #[allow(clippy::needless_pass_by_ref_mut)] // ensure single access to AtomicRefCell vector_index
     pub(super) fn update_vectors(
         &mut self,
         internal_id: PointOffsetType,

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -199,7 +199,7 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
     }
 
     fn update_stored(
-        &mut self,
+        &self,
         key: PointOffsetType,
         deleted: bool,
         vector: Option<TypedMultiDenseVectorRef<T>>,

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -114,7 +114,7 @@ pub struct Task {
 }
 
 impl Task {
-    pub async fn exec(mut self) {
+    pub async fn exec(self) {
         while let Err(err) = self.exec_catch_unwind().await {
             let message = common::panic::downcast_str(&err).unwrap_or("");
             let separator = if !message.is_empty() { ": " } else { "" };
@@ -123,17 +123,17 @@ impl Task {
         }
     }
 
-    async fn exec_catch_unwind(&mut self) -> thread::Result<()> {
+    async fn exec_catch_unwind(&self) -> thread::Result<()> {
         panic::AssertUnwindSafe(self.exec_cancel())
             .catch_unwind()
             .await
     }
 
-    async fn exec_cancel(&mut self) {
+    async fn exec_cancel(&self) {
         let _ = cancel::future::cancel_on_token(self.cancel.clone(), self.exec_impl()).await;
     }
 
-    async fn exec_impl(&mut self) {
+    async fn exec_impl(&self) {
         // Wait until node joins cluster for the first time
         //
         // If this is a new deployment and `--bootstrap` CLI parameter was specified...

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -704,7 +704,7 @@ impl Consensus {
         Ok(())
     }
 
-    fn try_sync_local_state(&mut self) -> anyhow::Result<()> {
+    fn try_sync_local_state(&self) -> anyhow::Result<()> {
         if !self.node.has_ready() {
             // No updates to process
             let store = self.node.store();
@@ -1242,7 +1242,7 @@ impl RaftMessageSender {
         }
     }
 
-    async fn send(&mut self, message: &RaftMessage) {
+    async fn send(&self, message: &RaftMessage) {
         if let Err(err) = self.try_send(message).await {
             let peer_id = message.to;
 
@@ -1254,7 +1254,7 @@ impl RaftMessageSender {
         }
     }
 
-    async fn try_send(&mut self, message: &RaftMessage) -> anyhow::Result<()> {
+    async fn try_send(&self, message: &RaftMessage) -> anyhow::Result<()> {
         let peer_id = message.to;
 
         let uri = self.uri(peer_id).await?;
@@ -1316,7 +1316,7 @@ impl RaftMessageSender {
         Ok(())
     }
 
-    async fn uri(&mut self, peer_id: PeerId) -> anyhow::Result<Uri> {
+    async fn uri(&self, peer_id: PeerId) -> anyhow::Result<Uri> {
         let uri = self
             .consensus_state
             .peer_address_by_id()
@@ -1329,7 +1329,7 @@ impl RaftMessageSender {
         }
     }
 
-    async fn who_is(&mut self, peer_id: PeerId) -> anyhow::Result<Uri> {
+    async fn who_is(&self, peer_id: PeerId) -> anyhow::Result<Uri> {
         let bootstrap_uri = self
             .bootstrap_uri
             .clone()


### PR DESCRIPTION
This PR fixes and enforces clippy [needless_pass_by_ref_mut](https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut)