### PR TITLE
In proxy segment, apply proxied point delete with its operation version

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1273,19 +1273,13 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
 
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -1340,19 +1334,13 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
 
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -1410,19 +1398,13 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(random_segment(dir.path(), 100, 200, 4));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
 
         let proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         let query_vector = [1.0, 1.0, 1.0, 1.0].into();
@@ -1471,19 +1453,13 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(random_segment(dir.path(), 100, 200, 4));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
 
         let proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         let q1 = [1.0, 1.0, 1.0, 0.1];
@@ -1538,19 +1514,13 @@ mod tests {
 
     fn wrap_proxy(dir: &TempDir, original_segment: LockedSegment) -> ProxySegment {
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
 
         ProxySegment::new(
             original_segment,
             write_segment,
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         )
     }
 
@@ -1623,12 +1593,6 @@ mod tests {
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
-
         original_segment
             .get()
             .write()
@@ -1642,9 +1606,9 @@ mod tests {
         let mut proxy_segment = ProxySegment::new(
             original_segment.clone(),
             write_segment.clone(),
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         proxy_segment.replicate_field_indexes(0).unwrap();
@@ -1691,19 +1655,17 @@ mod tests {
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let original_segment_2 = LockedSegment::new(build_segment_2(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
 
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
+        let deleted_points = Default::default();
+        let deleted_indexes = Default::default();
+        let created_indexes = Default::default();
 
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment.clone(),
-            deleted_points.clone(),
-            created_indexes.clone(),
-            deleted_indexes.clone(),
+            Arc::clone(&deleted_points),
+            Arc::clone(&created_indexes),
+            Arc::clone(&deleted_indexes),
         );
 
         let mut proxy_segment2 = ProxySegment::new(
@@ -1773,19 +1735,13 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
 
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         // We have 5 points by default, assert counts
@@ -1872,19 +1828,13 @@ mod tests {
 
         let original_segment = LockedSegment::new(original_segment);
         let write_segment = LockedSegment::new(write_segment);
-        let deleted_points = Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-
-        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let created_indexes = Arc::new(RwLock::new(
-            HashMap::<PayloadKeyType, PayloadFieldSchema>::new(),
-        ));
 
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            deleted_points,
-            created_indexes,
-            deleted_indexes,
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         // Assert counts from original segment

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -46,8 +46,8 @@ pub struct ProxySegment {
     /// May contain points which are not in wrapped_segment,
     /// because the set is shared among all proxy segments
     deleted_points: LockedRmSet,
-    deleted_indexes: LockedFieldsSet,
     created_indexes: LockedFieldsMap,
+    deleted_indexes: LockedFieldsSet,
     wrapped_config: SegmentConfig,
 }
 
@@ -1277,9 +1277,9 @@ mod tests {
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -1338,9 +1338,9 @@ mod tests {
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -1402,9 +1402,9 @@ mod tests {
         let proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         let query_vector = [1.0, 1.0, 1.0, 1.0].into();
@@ -1457,9 +1457,9 @@ mod tests {
         let proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         let q1 = [1.0, 1.0, 1.0, 0.1];
@@ -1518,9 +1518,9 @@ mod tests {
         ProxySegment::new(
             original_segment,
             write_segment,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         )
     }
 
@@ -1606,9 +1606,9 @@ mod tests {
         let mut proxy_segment = ProxySegment::new(
             original_segment.clone(),
             write_segment.clone(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         proxy_segment.replicate_field_indexes(0).unwrap();
@@ -1656,9 +1656,9 @@ mod tests {
         let original_segment_2 = LockedSegment::new(build_segment_2(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
-        let deleted_points = Default::default();
-        let deleted_indexes = Default::default();
-        let created_indexes = Default::default();
+        let deleted_points = LockedRmSet::default();
+        let created_indexes = LockedFieldsMap::default();
+        let deleted_indexes = LockedFieldsSet::default();
 
         let mut proxy_segment = ProxySegment::new(
             original_segment,
@@ -1739,9 +1739,9 @@ mod tests {
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         // We have 5 points by default, assert counts
@@ -1832,9 +1832,9 @@ mod tests {
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         // Assert counts from original segment
@@ -1923,9 +1923,9 @@ mod tests {
         let mut proxy_segment = ProxySegment::new(
             locked_wrapped_segment.clone(),
             locked_write_segment.clone(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            LockedRmSet::default(),
+            LockedFieldsMap::default(),
+            LockedFieldsSet::default(),
         );
 
         // Unwrapped `LockedSegment`s for convenient access

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -459,13 +459,14 @@ pub trait SegmentOptimizer {
         // Second step - delete all the rest points with full write lock
         //
         // Use collection copy to prevent long time lock of `proxy_deleted_points`
-        let deleted_points_snapshot: Vec<PointIdType> =
-            proxy_deleted_points.read().keys().copied().collect();
+        let deleted_points_snapshot: Vec<(PointIdType, SeqNumberType)> = proxy_deleted_points
+            .read()
+            .iter()
+            .map(|(point_id, version)| (*point_id, *version))
+            .collect();
 
-        for &point_id in &deleted_points_snapshot {
-            optimized_segment
-                .delete_point(optimized_segment.version(), point_id)
-                .unwrap();
+        for &(point_id, version) in &deleted_points_snapshot {
+            optimized_segment.delete_point(version, point_id).unwrap();
         }
 
         let deleted_indexes = proxy_deleted_indexes.read().iter().cloned().collect_vec();

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -547,9 +547,9 @@ pub trait SegmentOptimizer {
         check_process_stopped(stopped)?;
 
         let tmp_segment = self.temp_segment(false)?;
-
-        let (proxy_deleted_points, proxy_deleted_indexes, proxy_created_indexes) =
-            Default::default();
+        let proxy_deleted_points = proxy_segment::LockedRmSet::default();
+        let proxy_created_indexes = proxy_segment::LockedFieldsMap::default();
+        let proxy_deleted_indexes = proxy_segment::LockedFieldsSet::default();
 
         let mut proxies = Vec::new();
         for sg in optimizing_segments.iter() {

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -8,7 +8,7 @@ use common::cpu::CpuPermit;
 use common::disk::dir_size;
 use io::storage_version::StorageVersion;
 use itertools::Itertools;
-use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
+use parking_lot::{Mutex, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{check_process_stopped, OperationResult};
 use segment::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
@@ -18,12 +18,9 @@ use segment::index::sparse_index::sparse_index_config::SparseIndexType;
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::{
-    HnswConfig, Indexes, PayloadFieldSchema, PayloadKeyType, PointIdType, QuantizationConfig,
-    SegmentConfig, SeqNumberType, VectorStorageType,
-};
+use segment::types::{HnswConfig, Indexes, QuantizationConfig, SegmentConfig, VectorStorageType};
 
-use crate::collection_manager::holders::proxy_segment::ProxySegment;
+use crate::collection_manager::holders::proxy_segment::{self, ProxySegment};
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
 };
@@ -399,9 +396,9 @@ pub trait SegmentOptimizer {
     fn build_new_segment(
         &self,
         optimizing_segments: &[LockedSegment],
-        proxy_deleted_points: Arc<RwLock<HashMap<PointIdType, SeqNumberType>>>,
-        proxy_deleted_indexes: Arc<RwLock<HashSet<PayloadKeyType>>>,
-        proxy_created_indexes: Arc<RwLock<HashMap<PayloadKeyType, PayloadFieldSchema>>>,
+        proxy_deleted_points: proxy_segment::LockedRmSet,
+        proxy_deleted_indexes: proxy_segment::LockedFieldsSet,
+        proxy_created_indexes: proxy_segment::LockedFieldsMap,
         permit: CpuPermit,
         stopped: &AtomicBool,
     ) -> CollectionResult<Segment> {
@@ -459,14 +456,16 @@ pub trait SegmentOptimizer {
         // Second step - delete all the rest points with full write lock
         //
         // Use collection copy to prevent long time lock of `proxy_deleted_points`
-        let deleted_points_snapshot: Vec<(PointIdType, SeqNumberType)> = proxy_deleted_points
+        let deleted_points_snapshot = proxy_deleted_points
             .read()
             .iter()
-            .map(|(point_id, version)| (*point_id, *version))
-            .collect();
+            .map(|(point_id, versions)| (*point_id, *versions))
+            .collect::<Vec<_>>();
 
-        for &(point_id, version) in &deleted_points_snapshot {
-            optimized_segment.delete_point(version, point_id).unwrap();
+        for (point_id, versions) in deleted_points_snapshot {
+            optimized_segment
+                .delete_point(versions.operation_version, point_id)
+                .unwrap();
         }
 
         let deleted_indexes = proxy_deleted_indexes.read().iter().cloned().collect_vec();
@@ -549,22 +548,17 @@ pub trait SegmentOptimizer {
 
         let tmp_segment = self.temp_segment(false)?;
 
-        let proxy_deleted_points =
-            Arc::new(RwLock::new(HashMap::<PointIdType, SeqNumberType>::new()));
-        let proxy_deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let proxy_created_indexes = Arc::new(RwLock::new(HashMap::<
-            PayloadKeyType,
-            PayloadFieldSchema,
-        >::new()));
+        let (proxy_deleted_points, proxy_deleted_indexes, proxy_created_indexes) =
+            Default::default();
 
         let mut proxies = Vec::new();
         for sg in optimizing_segments.iter() {
             let mut proxy = ProxySegment::new(
                 sg.clone(),
                 tmp_segment.clone(),
-                proxy_deleted_points.clone(),
-                proxy_created_indexes.clone(),
-                proxy_deleted_indexes.clone(),
+                Arc::clone(&proxy_deleted_points),
+                Arc::clone(&proxy_created_indexes),
+                Arc::clone(&proxy_deleted_indexes),
             );
             // Wrapped segment is fresh, so it has no operations
             // Operation with number 0 will be applied
@@ -607,9 +601,9 @@ pub trait SegmentOptimizer {
 
         let mut optimized_segment = match self.build_new_segment(
             &optimizing_segments,
-            proxy_deleted_points.clone(),
-            proxy_deleted_indexes.clone(),
-            proxy_created_indexes.clone(),
+            Arc::clone(&proxy_deleted_points),
+            Arc::clone(&proxy_deleted_indexes),
+            Arc::clone(&proxy_created_indexes),
             permit,
             stopped,
         ) {
@@ -650,14 +644,16 @@ pub trait SegmentOptimizer {
                 .iter()
                 .filter(|&(point_id, _version)| !already_remove_points.contains(point_id));
             let optimized_segment_version = optimized_segment.version();
-            for (&point_id, &version) in points_diff {
+            for (&point_id, &versions) in points_diff {
                 // Delete points here with their operation version, that'll bump the optimized
                 // segment version and will ensure we flush the new changes
                 debug_assert!(
-                    version >= optimized_segment_version,
+                    versions.operation_version >= optimized_segment_version,
                     "proxied point deletes should have newer version than segment",
                 );
-                optimized_segment.delete_point(version, point_id).unwrap();
+                optimized_segment
+                    .delete_point(versions.operation_version, point_id)
+                    .unwrap();
             }
 
             for deleted_field_name in proxy_deleted_indexes.read().iter() {


### PR DESCRIPTION
At the end of segment optimization, we apply all proxied point deletes to the optimized segment.

When applying these deletes we reused the current segment version on those operations before. The segment likely considers that version to already be persisted. Subsequent flushes will not write the deletes to disk because of it, the segment thinks there are no new changes.

I've changed this to apply the deletes with the operation version that caused the delete to happen. Those will bump the segment version and ensure proper flushing.

I've added a debug assertion to ensure the delete versions are always newer than the segment version.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?