### PR TITLE
Friendlier untagged enum errors

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -405,6 +405,7 @@ pub struct QueryRequestInternal {
     pub offset: Option<usize>,
 
     /// Options for specifying which vectors to include into the response. Default is false.
+    #[serde(alias = "with_vectors")]
     pub with_vector: Option<WithVector>,
 
     /// Options for specifying which payload to include or not. Default is false.

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -238,6 +238,7 @@ pub struct Batch {
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(untagged)]
+#[serde(expecting = "Expected a string or an integer")]
 pub enum ShardKeySelector {
     ShardKey(ShardKey),
     ShardKeys(Vec<ShardKey>),
@@ -339,6 +340,7 @@ pub enum NamedVectorStruct {
 
 #[derive(Deserialize, Serialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(untagged)]
+#[serde(expecting = "Expected a string, or an object with a key, direction and/or start_from")]
 pub enum OrderByInterface {
     Key(JsonPath),
     Struct(OrderBy),

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2128,6 +2128,9 @@ impl NestedCondition {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
+#[serde(
+    expecting = "Expected some form of condition, which can be a field condition (like {\"key\": ..., \"match\": ... }), or some other mentioned in the documentation: https://qdrant.tech/documentation/concepts/filtering/#filtering-conditions"
+)]
 #[allow(clippy::large_enum_variant)]
 pub enum Condition {
     /// Check if field satisfies provided condition
@@ -2197,6 +2200,9 @@ pub trait CustomIdCheckerCondition: fmt::Debug {
 /// Options for specifying which payload to include or not
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(untagged, rename_all = "snake_case")]
+#[serde(
+    expecting = "Expected a boolean, an array of strings, or an object with an include/exclude field"
+)]
 pub enum WithPayloadInterface {
     /// If `true` - return all payload,
     /// If `false` - do not return payload
@@ -2222,6 +2228,7 @@ impl Default for WithPayloadInterface {
 /// Options for specifying which vector to include
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(untagged, rename_all = "snake_case")]
+#[serde(expecting = "Expected a boolean, or an array of strings")]
 pub enum WithVector {
     /// If `true` - return all vector,
     /// If `false` - do not return vector


### PR DESCRIPTION
Following the change done in #5546, this PR adds the same kind of messages to other untagged enums.

Additionally, it aliases `with_vectors` and `with_vector` in the query interface. We have documentation referencing both names, and it is easy to solve here.