### PR TITLE
 In proxy segment, apply proxied index changes with its operation version

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use bitvec::prelude::BitVec;
 use common::tar_ext;
 use common::types::{PointOffsetType, TelemetryDetail};
+use itertools::Itertools;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
 use segment::data_types::facets::{FacetParams, FacetValue};
@@ -27,8 +28,7 @@ use segment::types::{
 use crate::collection_manager::holders::segment_holder::LockedSegment;
 
 pub type LockedRmSet = Arc<RwLock<HashMap<PointIdType, ProxyDeletedPoint>>>;
-pub type LockedFieldsSet = Arc<RwLock<HashSet<PayloadKeyType>>>;
-pub type LockedFieldsMap = Arc<RwLock<HashMap<PayloadKeyType, PayloadFieldSchema>>>;
+pub type LockedIndexChanges = Arc<RwLock<HashMap<PayloadKeyType, ProxyIndexChange>>>;
 
 /// This object is a wrapper around read-only segment.
 ///
@@ -42,12 +42,11 @@ pub struct ProxySegment {
     /// Present if the wrapped segment is a plain segment
     /// Used for faster deletion checks
     deleted_mask: Option<BitVec>,
+    changed_indexes: LockedIndexChanges,
     /// Points which should no longer used from wrapped_segment
     /// May contain points which are not in wrapped_segment,
     /// because the set is shared among all proxy segments
     deleted_points: LockedRmSet,
-    created_indexes: LockedFieldsMap,
-    deleted_indexes: LockedFieldsSet,
     wrapped_config: SegmentConfig,
 }
 
@@ -56,8 +55,7 @@ impl ProxySegment {
         segment: LockedSegment,
         write_segment: LockedSegment,
         deleted_points: LockedRmSet,
-        created_indexes: LockedFieldsMap,
-        deleted_indexes: LockedFieldsSet,
+        changed_indexes: LockedIndexChanges,
     ) -> Self {
         let deleted_mask = match &segment {
             LockedSegment::Original(raw_segment) => {
@@ -72,9 +70,8 @@ impl ProxySegment {
             write_segment,
             wrapped_segment: segment,
             deleted_mask,
+            changed_indexes,
             deleted_points,
-            created_indexes,
-            deleted_indexes,
             wrapped_config,
         }
     }
@@ -253,6 +250,43 @@ impl ProxySegment {
         let mut wrapped_segment = wrapped_segment.upgradable_read();
         let op_num = wrapped_segment.version();
 
+        // Propagate index changes
+        // Ordering is important here and must match the flush function to prevent a deadlock
+        {
+            let changed_indexes = self.changed_indexes.upgradable_read();
+            if !changed_indexes.is_empty() {
+                wrapped_segment.with_upgraded(|wrapped_segment| {
+                    let changes = changed_indexes
+                        .iter()
+                        .sorted_by_key(|(_, change)| change.version())
+                        .collect::<Vec<_>>();
+                    for (field_name, change) in changes {
+                        // Change indexes here with their operation version, that'll bump the optimized
+                        // segment version and will ensure we flush the new changes
+                        debug_assert!(
+                            change.version() >= op_num,
+                            "proxied index change should have newer version than segment",
+                        );
+
+                        match change {
+                            ProxyIndexChange::Create(schema, version) => {
+                                wrapped_segment.create_field_index(
+                                    *version,
+                                    field_name,
+                                    Some(schema),
+                                )?;
+                            }
+                            ProxyIndexChange::Delete(version) => {
+                                wrapped_segment.delete_field_index(*version, field_name)?;
+                            }
+                        }
+                    }
+                    OperationResult::Ok(())
+                })?;
+                RwLockUpgradableReadGuard::upgrade(changed_indexes).clear();
+            }
+        }
+
         // Propagate deleted points
         // Ordering is important here and must match the flush function to prevent a deadlock
         {
@@ -275,38 +309,6 @@ impl ProxySegment {
                 // Note: We do not clear the deleted mask here, as it provides
                 // no performance advantage and does not affect the correctness of search.
                 // Points are still marked as deleted in two places, which is fine
-            }
-        }
-
-        let op_num = wrapped_segment.version();
-
-        // Propagate deleted indexes
-        // Ordering is important here and must match the flush function to prevent a deadlock
-        {
-            let deleted_indexes = self.deleted_indexes.upgradable_read();
-            if !deleted_indexes.is_empty() {
-                wrapped_segment.with_upgraded(|wrapped_segment| {
-                    for key in deleted_indexes.iter() {
-                        wrapped_segment.delete_field_index(op_num, key)?;
-                    }
-                    OperationResult::Ok(())
-                })?;
-                RwLockUpgradableReadGuard::upgrade(deleted_indexes).clear();
-            }
-        }
-
-        // Propagate created indexes
-        // Ordering is important here and must match the flush function to prevent a deadlock
-        {
-            let created_indexes = self.created_indexes.upgradable_read();
-            if !created_indexes.is_empty() {
-                wrapped_segment.with_upgraded(|wrapped_segment| {
-                    for (key, field_schema) in created_indexes.iter() {
-                        wrapped_segment.create_field_index(op_num, key, Some(field_schema))?;
-                    }
-                    OperationResult::Ok(())
-                })?;
-                RwLockUpgradableReadGuard::upgrade(created_indexes).clear();
             }
         }
 
@@ -1000,9 +1002,8 @@ impl SegmentEntry for ProxySegment {
     }
 
     fn flush(&self, sync: bool, force: bool) -> OperationResult<SeqNumberType> {
+        let changed_indexes_guard = self.changed_indexes.read();
         let deleted_points_guard = self.deleted_points.read();
-        let deleted_indexes_guard = self.deleted_indexes.read();
-        let created_indexes_guard = self.created_indexes.read();
 
         let (wrapped_version, wrapped_persisted_version) = {
             let wrapped_segment = self.wrapped_segment.get();
@@ -1019,9 +1020,7 @@ impl SegmentEntry for ProxySegment {
 
         // As soon as anything is written to the proxy, the max version of the proxy if fixed to
         // minimal of both versions. So we should never ack operation, which does copy-on-write.
-        let is_all_empty = deleted_points_guard.is_empty()
-            && deleted_indexes_guard.is_empty()
-            && created_indexes_guard.is_empty();
+        let is_all_empty = changed_indexes_guard.is_empty() && deleted_points_guard.is_empty();
 
         let flushed_version = if is_all_empty {
             // It might happen, that wrapped segment still has some data which is not flushed
@@ -1074,8 +1073,12 @@ impl SegmentEntry for ProxySegment {
         if self.version() > op_num {
             return Ok(false);
         }
-        self.deleted_indexes.write().insert(key.clone());
-        self.created_indexes.write().remove(key);
+
+        // Store index change to later propagate to optimized/wrapped segment
+        self.changed_indexes
+            .write()
+            .insert(key.clone(), ProxyIndexChange::Delete(op_num));
+
         self.write_segment
             .get()
             .write()
@@ -1118,27 +1121,29 @@ impl SegmentEntry for ProxySegment {
             return Ok(false);
         };
 
-        // Index was updated: mark as added and deleted
-        self.created_indexes
+        // Store index change to later propagate to optimized/wrapped segment
+        self.changed_indexes
             .write()
-            .insert(key.clone(), field_schema);
-        self.deleted_indexes.write().remove(&key);
+            .insert(key.clone(), ProxyIndexChange::Create(field_schema, op_num));
 
         Ok(true)
     }
 
     fn get_indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
-        let indexed_fields = self.wrapped_segment.get().read().get_indexed_fields();
+        let mut indexed_fields = self.wrapped_segment.get().read().get_indexed_fields();
+
+        for (field_name, change) in self.changed_indexes.read().iter() {
+            match change {
+                ProxyIndexChange::Create(schema, _) => {
+                    indexed_fields.insert(field_name.to_owned(), schema.to_owned());
+                }
+                ProxyIndexChange::Delete(_) => {
+                    indexed_fields.remove(field_name);
+                }
+            }
+        }
+
         indexed_fields
-            .into_iter()
-            .chain(
-                self.created_indexes
-                    .read()
-                    .iter()
-                    .map(|(k, v)| (k.to_owned(), v.to_owned())),
-            )
-            .filter(|(key, _)| !self.deleted_indexes.read().contains(key))
-            .collect()
     }
 
     fn check_error(&self) -> Option<SegmentFailedState> {
@@ -1254,6 +1259,21 @@ pub struct ProxyDeletedPoint {
     pub operation_version: SeqNumberType,
 }
 
+#[derive(Debug)]
+pub enum ProxyIndexChange {
+    Create(PayloadFieldSchema, SeqNumberType),
+    Delete(SeqNumberType),
+}
+
+impl ProxyIndexChange {
+    pub fn version(&self) -> SeqNumberType {
+        match self {
+            ProxyIndexChange::Create(_, version) => *version,
+            ProxyIndexChange::Delete(version) => *version,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs::File;
@@ -1278,8 +1298,7 @@ mod tests {
             original_segment,
             write_segment,
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -1339,8 +1358,7 @@ mod tests {
             original_segment,
             write_segment,
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -1403,8 +1421,7 @@ mod tests {
             original_segment,
             write_segment,
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         let query_vector = [1.0, 1.0, 1.0, 1.0].into();
@@ -1458,8 +1475,7 @@ mod tests {
             original_segment,
             write_segment,
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         let q1 = [1.0, 1.0, 1.0, 0.1];
@@ -1519,8 +1535,7 @@ mod tests {
             original_segment,
             write_segment,
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         )
     }
 
@@ -1607,8 +1622,7 @@ mod tests {
             original_segment.clone(),
             write_segment.clone(),
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         proxy_segment.replicate_field_indexes(0).unwrap();
@@ -1657,23 +1671,20 @@ mod tests {
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
         let deleted_points = LockedRmSet::default();
-        let created_indexes = LockedFieldsMap::default();
-        let deleted_indexes = LockedFieldsSet::default();
+        let changed_indexes = LockedIndexChanges::default();
 
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment.clone(),
             Arc::clone(&deleted_points),
-            Arc::clone(&created_indexes),
-            Arc::clone(&deleted_indexes),
+            Arc::clone(&changed_indexes),
         );
 
         let mut proxy_segment2 = ProxySegment::new(
             original_segment_2,
             write_segment,
             deleted_points,
-            created_indexes,
-            deleted_indexes,
+            changed_indexes,
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -1740,8 +1751,7 @@ mod tests {
             original_segment,
             write_segment,
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         // We have 5 points by default, assert counts
@@ -1833,8 +1843,7 @@ mod tests {
             original_segment,
             write_segment,
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         // Assert counts from original segment
@@ -1924,8 +1933,7 @@ mod tests {
             locked_wrapped_segment.clone(),
             locked_write_segment.clone(),
             LockedRmSet::default(),
-            LockedFieldsMap::default(),
-            LockedFieldsSet::default(),
+            LockedIndexChanges::default(),
         );
 
         // Unwrapped `LockedSegment`s for convenient access

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -257,13 +257,10 @@ impl ProxySegment {
             if !changed_indexes.is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for (field_name, change) in changed_indexes.iter_ordered() {
-                        // Change indexes here with their operation version, that'll bump the optimized
-                        // segment version and will ensure we flush the new changes
                         debug_assert!(
                             change.version() >= op_num,
                             "proxied index change should have newer version than segment",
                         );
-
                         match change {
                             ProxyIndexChange::Create(schema, version) => {
                                 wrapped_segment.create_field_index(

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1030,7 +1030,6 @@ impl<'s> SegmentHolder {
                 tmp_segment.clone(),
                 Default::default(),
                 Default::default(),
-                Default::default(),
             );
 
             // Write segment is fresh, so it has no operations

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -22,6 +22,7 @@ use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
 use segment::types::{Payload, PointIdType, SegmentConfig, SeqNumberType, SnapshotFormat};
 
+use super::proxy_segment::{LockedIndexChanges, LockedRmSet};
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::config::CollectionParams;
@@ -1028,8 +1029,8 @@ impl<'s> SegmentHolder {
             let mut proxy = ProxySegment::new(
                 segment.clone(),
                 tmp_segment.clone(),
-                Default::default(),
-                Default::default(),
+                LockedRmSet::default(),
+                LockedIndexChanges::default(),
             );
 
             // Write segment is fresh, so it has no operations

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -442,11 +442,7 @@ pub trait SegmentOptimizer {
 
         // Apply index changes to segment builder
         // Indexes are only used for defragmentation in segment builder, so versions are ignored
-        for (field_name, change) in proxy_changed_indexes
-            .read()
-            .iter()
-            .sorted_by_key(|(_, change)| change.version())
-        {
+        for (field_name, change) in proxy_changed_indexes.read().iter_ordered() {
             match change {
                 ProxyIndexChange::Create(schema, _) => {
                     segment_builder.add_indexed_field(field_name.to_owned(), schema.to_owned());
@@ -475,14 +471,10 @@ pub trait SegmentOptimizer {
                 .unwrap();
         }
 
-        for (field_name, change) in proxy_changed_indexes
-            .read()
-            .iter()
-            .sorted_by_key(|(_, change)| change.version())
-        {
+        for (field_name, change) in proxy_changed_indexes.read().iter_ordered() {
             match change {
                 ProxyIndexChange::Create(schema, version) => {
-                    optimized_segment.create_field_index(*version, field_name, Some(schema))?;
+                    optimized_segment.create_field_index(*version, field_name, Some(&schema))?;
                 }
                 ProxyIndexChange::Delete(version) => {
                     optimized_segment.delete_field_index(*version, field_name)?;
@@ -659,11 +651,7 @@ pub trait SegmentOptimizer {
                     .unwrap();
             }
 
-            for (field_name, change) in proxy_index_changes
-                .read()
-                .iter()
-                .sorted_by_key(|(_, change)| change.version())
-            {
+            for (field_name, change) in proxy_index_changes.read().iter_ordered() {
                 match change {
                     ProxyIndexChange::Create(schema, version) => {
                         optimized_segment.create_field_index(*version, field_name, Some(schema))?;

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -10,6 +10,7 @@ use segment::types::{Payload, PointIdType, WithPayload, WithVector};
 use serde_json::json;
 use tempfile::Builder;
 
+use super::holders::proxy_segment;
 use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::collection_manager::holders::segment_holder::{
@@ -18,8 +19,6 @@ use crate::collection_manager::holders::segment_holder::{
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::collection_manager::segments_updater::{set_payload, upsert_points};
 use crate::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
-
-use super::holders::proxy_segment;
 
 mod test_search_aggregation;
 


### PR DESCRIPTION
Same as <https://github.com/qdrant/qdrant/pull/5573>, but for the proxied index changes as described [here](https://github.com/qdrant/qdrant/pull/5573#discussion_r1867551360).

Index changes must be applied in order of their version, because low version changes will be rejected after a high version change. I've added a new struct holding all our index changes that ensures the changes are applied in correct order.

These changes are now also applied before point deletions. Point deletions also bump the segment version, so a point delete with a high version will reject an index change with a lower version if applied after.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
