### PR TITLE
Rate limiting for shard operations

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1432,6 +1432,8 @@ Note: 1kB = 1 vector of size 256. |
 | search_max_oversampling | [float](#float) | optional |  |
 | upsert_max_batchsize | [uint64](#uint64) | optional |  |
 | max_collection_vector_size_bytes | [uint64](#uint64) | optional |  |
+| read_rate_limit_per_sec | [uint32](#uint32) | optional |  |
+| write_rate_limit_per_sec | [uint32](#uint32) | optional |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7300,14 +7300,14 @@
             "nullable": true
           },
           "read_rate_limit_per_sec": {
-            "description": "Max number of read operations per second",
+            "description": "Max number of read operations per second per shard per peer",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "write_rate_limit_per_sec": {
-            "description": "Max number of write operations per second",
+            "description": "Max number of write operations per second per shard per peer",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7298,6 +7298,20 @@
             "format": "uint",
             "minimum": 0,
             "nullable": true
+          },
+          "read_rate_limit_per_sec": {
+            "description": "Max number of read operations per second",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "write_rate_limit_per_sec": {
+            "description": "Max number of write operations per second",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1635,6 +1635,8 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
             max_collection_vector_size_bytes: value
                 .max_collection_vector_size_bytes
                 .map(|i| i as usize),
+            read_rate_limit_per_sec: value.read_rate_limit_per_sec.map(|i| i as usize),
+            write_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as usize),
         }
     }
 }
@@ -1654,6 +1656,8 @@ impl From<segment::types::StrictModeConfig> for StrictModeConfig {
             max_collection_vector_size_bytes: value
                 .max_collection_vector_size_bytes
                 .map(|i| i as u64),
+            read_rate_limit_per_sec: value.read_rate_limit_per_sec.map(|i| i as u32),
+            write_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as u32),
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -322,6 +322,8 @@ message StrictModeConfig {
   optional float search_max_oversampling  = 8;
   optional uint64 upsert_max_batchsize  = 9;
   optional uint64 max_collection_vector_size_bytes  = 10;
+  optional uint32 read_rate_limit_per_sec = 11;
+  optional uint32 write_rate_limit_per_sec = 12;
 }
 
 message CreateCollection {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -456,6 +456,10 @@ pub struct StrictModeConfig {
     pub upsert_max_batchsize: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "10")]
     pub max_collection_vector_size_bytes: ::core::option::Option<u64>,
+    #[prost(uint32, optional, tag = "11")]
+    pub read_rate_limit_per_sec: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "12")]
+    pub write_rate_limit_per_sec: ::core::option::Option<u32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1107,7 +1107,6 @@ impl CollectionError {
             Self::Cancelled { .. } => true,
             Self::OutOfMemory { .. } => true,
             Self::PreConditionFailed { .. } => true,
-            Self::RateLimitExceeded { .. } => true,
             // Not transient
             Self::BadInput { .. } => false,
             Self::NotFound { .. } => false,
@@ -1119,6 +1118,7 @@ impl CollectionError {
             Self::ObjectStoreError { .. } => false,
             Self::StrictMode { .. } => false,
             Self::InferenceError { .. } => false,
+            Self::RateLimitExceeded { .. } => false,
         }
     }
 

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -409,6 +409,8 @@ mod test {
             search_max_oversampling: Some(0.2),
             upsert_max_batchsize: None,
             max_collection_vector_size_bytes: None,
+            read_rate_limit_per_sec: None,
+            write_rate_limit_per_sec: None,
         };
 
         fixture_collection(&strict_mode_config).await

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -49,6 +49,8 @@ impl DummyShard {
         self.dummy()
     }
 
+    pub async fn on_strict_mode_config_update(&self) {}
+
     pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
         LocalShardTelemetry {
             variant_name: Some("dummy shard".into()),

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -206,6 +206,10 @@ impl ForwardProxyShard {
         self.wrapped_shard.on_optimizer_config_update().await
     }
 
+    pub async fn on_strict_mode_config_update(&self) {
+        self.wrapped_shard.on_strict_mode_config_update().await
+    }
+
     pub fn trigger_optimizers(&self) {
         self.wrapped_shard.trigger_optimizers();
     }

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -85,6 +85,10 @@ impl ProxyShard {
         self.wrapped_shard.on_optimizer_config_update().await
     }
 
+    pub async fn on_strict_mode_config_update(&self) {
+        self.wrapped_shard.on_strict_mode_config_update().await;
+    }
+
     pub fn trigger_optimizers(&self) {
         // TODO: we might want to defer this trigger until we unproxy
         self.wrapped_shard.trigger_optimizers();

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -159,6 +159,13 @@ impl QueueProxyShard {
             .await
     }
 
+    pub async fn on_strict_mode_config_update(&self) {
+        self.inner_unchecked()
+            .wrapped_shard
+            .on_strict_mode_config_update()
+            .await
+    }
+
     pub fn trigger_optimizers(&self) {
         self.inner_unchecked().wrapped_shard.trigger_optimizers();
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -730,7 +730,15 @@ impl ShardReplicaSet {
         }
     }
 
-    /// Check if the are any locally disabled peers
+    pub(crate) async fn on_strict_mode_config_update(&self) -> CollectionResult<()> {
+        let read_local = self.local.read().await;
+        if let Some(shard) = &*read_local {
+            shard.on_strict_mode_config_update().await
+        }
+        Ok(())
+    }
+
+    /// Check if there are any locally disabled peers
     /// And if so, report them to the consensus
     pub fn sync_local_state<F>(&self, get_shard_transfers: F) -> CollectionResult<()>
     where

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -130,6 +130,16 @@ impl Shard {
         }
     }
 
+    pub async fn on_strict_mode_config_update(&self) {
+        match self {
+            Shard::Local(local_shard) => local_shard.on_strict_mode_config_update().await,
+            Shard::Proxy(proxy_shard) => proxy_shard.on_strict_mode_config_update().await,
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.on_strict_mode_config_update().await,
+            Shard::QueueProxy(proxy_shard) => proxy_shard.on_strict_mode_config_update().await,
+            Shard::Dummy(dummy_shard) => dummy_shard.on_strict_mode_config_update().await,
+        }
+    }
+
     pub fn trigger_optimizers(&self) {
         match self {
             Shard::Local(local_shard) => local_shard.trigger_optimizers(),

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -58,6 +58,12 @@ impl RateLimiter {
         }
     }
 
+    /// Create a new rate limiter from a rate per second.
+    pub fn with_rate_per_sec(rate_per_sec: usize) -> Self {
+        let rate = Rate::new(rate_per_sec as u64, Duration::from_secs(1));
+        Self::new(rate)
+    }
+
     /// Attempt to consume a token. Returns `true` if allowed, `false` otherwise.
     pub fn check(&mut self) -> bool {
         let now = Instant::now();

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -712,11 +712,11 @@ pub struct StrictModeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_collection_vector_size_bytes: Option<usize>,
 
-    /// Max number of read operations per second
+    /// Max number of read operations per second per shard per peer
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_rate_limit_per_sec: Option<usize>,
 
-    /// Max number of write operations per second
+    /// Max number of write operations per second per shard per peer
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_rate_limit_per_sec: Option<usize>,
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -711,6 +711,14 @@ pub struct StrictModeConfig {
     /// Max size of a collections vector storage in bytes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_collection_vector_size_bytes: Option<usize>,
+
+    /// Max number of read operations per second
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_rate_limit_per_sec: Option<usize>,
+
+    /// Max number of write operations per second
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub write_rate_limit_per_sec: Option<usize>,
 }
 
 impl Eq for StrictModeConfig {}
@@ -729,6 +737,8 @@ impl Hash for StrictModeConfig {
             search_max_oversampling: _,
             upsert_max_batchsize,
             max_collection_vector_size_bytes,
+            read_rate_limit_per_sec,
+            write_rate_limit_per_sec,
         } = self;
         (
             enabled,
@@ -740,6 +750,8 @@ impl Hash for StrictModeConfig {
             search_allow_exact,
             upsert_max_batchsize,
             max_collection_vector_size_bytes,
+            read_rate_limit_per_sec,
+            write_rate_limit_per_sec,
         )
             .hash(state);
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -89,6 +89,8 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
         max_collection_vector_size_bytes: value
             .max_collection_vector_size_bytes
             .map(|i| i as usize),
+        read_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as usize),
+        write_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as usize),
     }
 }
 

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -603,3 +603,84 @@ def test_strict_mode_max_collection_size_upsert_batch(collection_name):
 
     assert False, "Upserting should have failed but didn't"
 
+
+def test_strict_mode_read_rate_limiting(collection_name):
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "read_rate_limit_per_sec": 1,
+    })
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+
+    assert response.ok
+    new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
+    assert new_strict_mode_config['enabled']
+    assert new_strict_mode_config['read_rate_limit_per_sec'] == 1
+
+    failed = False
+
+    for _ in range(10):
+        response = request_with_validation(
+            api='/collections/{collection_name}/points/search',
+            method="POST",
+            path_params={'collection_name': collection_name},
+            body={
+                "vector": [0.2, 0.1, 0.9, 0.7],
+                "limit": 4
+            }
+        )
+        if not response.ok:
+            assert response.status_code == 429
+            assert "Rate limiting exceeded: Read rate limit exceeded, retry later" in response.json()['status']['error']
+            failed = True
+            break
+
+    assert failed, "Rate limiting did not work"
+
+
+def test_strict_mode_write_rate_limiting(collection_name):
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "write_rate_limit_per_sec": 1,
+    })
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+
+    assert response.ok
+    new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
+    assert new_strict_mode_config['enabled']
+    assert new_strict_mode_config['write_rate_limit_per_sec'] == 1
+
+    failed = False
+
+    for _ in range(10):
+        response = request_with_validation(
+            api='/collections/{collection_name}/points',
+            method="PUT",
+            path_params={'collection_name': collection_name},
+            query_params={'wait': 'true'},
+            body={
+                "points": [
+                    {
+                        "id": 1,
+                        "vector": [0.05, 0.61, 0.76, 0.74],
+                    },
+                ]
+            }
+        )
+
+        if not response.ok:
+            assert response.status_code == 429
+            assert "Rate limiting exceeded: Write rate limit exceeded, retry later" in response.json()['status']['error']
+            failed = True
+            break
+
+    assert failed, "Rate limiting did not work"

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -621,7 +621,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
     assert new_strict_mode_config['enabled']
     assert new_strict_mode_config['read_rate_limit_per_sec'] == 1
 
-    failed = False
+    failed_count = 0
 
     for _ in range(10):
         response = request_with_validation(
@@ -634,12 +634,12 @@ def test_strict_mode_read_rate_limiting(collection_name):
             }
         )
         if not response.ok:
+            failed_count += 1
             assert response.status_code == 429
             assert "Rate limiting exceeded: Read rate limit exceeded, retry later" in response.json()['status']['error']
-            failed = True
-            break
 
-    assert failed, "Rate limiting did not work"
+    # loose check, as the rate limiting might not be exact
+    assert failed_count > 5, "Rate limiting did not work"
 
 
 def test_strict_mode_write_rate_limiting(collection_name):
@@ -659,7 +659,7 @@ def test_strict_mode_write_rate_limiting(collection_name):
     assert new_strict_mode_config['enabled']
     assert new_strict_mode_config['write_rate_limit_per_sec'] == 1
 
-    failed = False
+    failed_count = 0
 
     for _ in range(10):
         response = request_with_validation(
@@ -678,9 +678,9 @@ def test_strict_mode_write_rate_limiting(collection_name):
         )
 
         if not response.ok:
+            failed_count += 1
             assert response.status_code == 429
             assert "Rate limiting exceeded: Write rate limit exceeded, retry later" in response.json()['status']['error']
-            failed = True
-            break
 
-    assert failed, "Rate limiting did not work"
+    # loose check, as the rate limiting might not be exact
+    assert failed_count > 5, "Rate limiting did not work"


### PR DESCRIPTION
This PR enables rate limiting through strict mode for read and write requests.

Integration tests are present to validate the limit kicks in with the correct error message.

I validated the precision of the limit with an end to end example for 1000 search req/s.

```http
PUT collections/benchmark
{
  "vectors": {
    "size": 4,
    "distance": "Dot"
  },
  "strict_mode_config": {
    "enabled": true,
    "read_rate_limit_per_sec": 1000
  }
}
```

Shoot with [oha](https://github.com/hatoo/oha) with 10 concurrent workers for 1 minutes

```bash
oha -m POST  \
 -d "{ \"vector\": [0.2, 0.1, 0.9, 0.7], \"limit\": 4 }" \
 -T application/json \
 -A application/json  \
 -z 1m \
 -c 10 \
 http://127.0.0.1:6333/collections/benchmark/points/search
```

Expected results `1000 rps * 60s = 60k` valid responses per minute.

```
Status code distribution:
  [200] 60949 responses
  [429] 38885 responses
```