### PR TITLE
Fix point deduplication

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1688,6 +1688,9 @@ mod tests {
         assert!(!holder.get(sid1).unwrap().get().read().has_point(5.into()));
     }
 
+    /// Unit test for a specific bug we caught before.
+    ///
+    /// See: <https://github.com/qdrant/qdrant/pull/5585>
     #[tokio::test]
     async fn test_points_deduplication_bug() {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1247,8 +1247,6 @@ impl<'s> SegmentHolder {
     /// Checks all segments and removes duplicated and outdated points.
     /// If two points have the same id, the point with the highest version is kept.
     /// If two points have the same id and version, one of them is kept.
-    ///
-    /// Deduplication works with plain segments only.
     pub async fn deduplicate_points(&self) -> OperationResult<usize> {
         let points_to_remove = self.find_duplicated_points();
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1786,9 +1786,9 @@ mod tests {
         ];
 
         // Insert points into all segments with random versions
-        let mut point_versions = HashMap::new();
+        let mut highest_point_version = HashMap::new();
         for id in 0..POINT_COUNT {
-            let mut versions = Vec::with_capacity(segments.len());
+            let mut max_version = 0;
             let point_id = PointIdType::from(id as u64);
 
             for segment in &mut segments {
@@ -1796,10 +1796,10 @@ mod tests {
                 segment
                     .upsert_point(version, point_id, vector.clone())
                     .unwrap();
-                versions.push(version);
+                max_version = version.max(max_version);
             }
 
-            point_versions.insert(id, versions);
+            highest_point_version.insert(id, max_version);
         }
 
         // Put segments into holder
@@ -1821,9 +1821,8 @@ mod tests {
 
         // Assert points after deduplication
         for id in 0..POINT_COUNT {
-            let versions = &point_versions[&id];
-            let max = *versions.iter().max().unwrap();
             let point_id = PointIdType::from(id as u64);
+            let max_version = highest_point_version[&id];
 
             let found_versions = segment_ids
                 .iter()
@@ -1844,7 +1843,7 @@ mod tests {
                 "point version must be maximum known version",
             );
             assert_eq!(
-                found_versions[0], max,
+                found_versions[0], max_version,
                 "point version must be maximum known version",
             );
         }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1364,6 +1364,7 @@ impl<'s> SegmentHolder {
             } else {
                 last_point_id_opt = Some(point_id);
                 last_segment_id_opt = Some(segment_id);
+                last_point_version_opt = None;
             }
         }
 


### PR DESCRIPTION
Fix a bug in point deduplication that caused mishandling of point versions.

The 'last point version' was not properly cleared when moving to the next point ID, meaning irrelevant point versions from the previous point leaked into the current one. Because of this it was possible we deleted newer point versions rather than old ones.

I've added two unit tests:
- the first tests this specific problem
- the second inserts random points into segments and asserts we always keep the highest point version

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?