### PR TITLE
Downgrade flush logging

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -784,7 +784,7 @@ impl<'s> SegmentHolder {
             let segment_version = read_segment.version();
             let segment_persisted_version = read_segment.flush(sync, force)?;
 
-            log::debug!(
+            log::trace!(
                 "Flushed segment {segment_id}:{:?} version: {segment_version} to persisted: {segment_persisted_version}", &read_segment.data_path()
             );
 
@@ -800,12 +800,12 @@ impl<'s> SegmentHolder {
         }
 
         if has_unsaved {
-            log::debug!(
+            log::trace!(
                 "Some segments have unsaved changes, lowest unsaved version: {min_unsaved_version}"
             );
             Ok(min_unsaved_version)
         } else {
-            log::debug!(
+            log::trace!(
                 "All segments flushed successfully, max persisted version: {max_persisted_version}"
             );
             Ok(max_persisted_version)


### PR DESCRIPTION
use tracing instead of debug to make it less noisy

WIP: merge after we confirm it is no longer needed for debugging