### PR TITLE
Prefer vector index for `size_of_available_vectors_in_bytes`

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -68,8 +68,12 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
         self.vectors.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<VectorElementType>()
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
+        Some(
+            self.available_vector_count()
+                * self.vector_dim()
+                * std::mem::size_of::<VectorElementType>(),
+        )
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -68,14 +68,6 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
         self.vectors.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        Some(
-            self.available_vector_count()
-                * self.vector_dim()
-                * std::mem::size_of::<VectorElementType>(),
-        )
-    }
-
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         self.get_vector_opt(key).expect("vector not found")
     }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -163,7 +163,6 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 let available_vectors = vector_storage.available_vector_count();
                 let full_scan_threshold = vector_storage
                     .size_of_available_vectors_in_bytes()
-                    .expect("Dense vector storages always know their size")
                     .checked_div(available_vectors)
                     .and_then(|avg_vector_size| {
                         hnsw_config
@@ -268,7 +267,6 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
         let full_scan_threshold = vector_storage
             .size_of_available_vectors_in_bytes()
-            .expect("Dense vector storages always know their size")
             .checked_div(total_vector_count)
             .and_then(|avg_vector_size| {
                 hnsw_config
@@ -1328,9 +1326,10 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             .unwrap_or_else(|| self.graph.num_points())
     }
 
-    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize> {
-        // get the size from the vector storage
-        None
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
+        self.vector_storage
+            .borrow()
+            .size_of_available_vectors_in_bytes()
     }
 
     fn update_vector(

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -163,6 +163,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 let available_vectors = vector_storage.available_vector_count();
                 let full_scan_threshold = vector_storage
                     .size_of_available_vectors_in_bytes()
+                    .expect("Dense vector storages always know their size")
                     .checked_div(available_vectors)
                     .and_then(|avg_vector_size| {
                         hnsw_config
@@ -267,6 +268,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
         let full_scan_threshold = vector_storage
             .size_of_available_vectors_in_bytes()
+            .expect("Dense vector storages always know their size")
             .checked_div(total_vector_count)
             .and_then(|avg_vector_size| {
                 hnsw_config
@@ -1324,6 +1326,11 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             .indexed_vector_count
             // If indexed vector count is unknown, fall back to number of points
             .unwrap_or_else(|| self.graph.num_points())
+    }
+
+    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize> {
+        // get the size from the vector storage
+        None
     }
 
     fn update_vector(

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -172,6 +172,12 @@ impl VectorIndex for PlainVectorIndex {
         0
     }
 
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
+        self.vector_storage
+            .borrow()
+            .size_of_available_vectors_in_bytes()
+    }
+
     fn update_vector(
         &mut self,
         id: PointOffsetType,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -565,8 +565,8 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         self.inverted_index.vector_count()
     }
 
-    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize> {
-        Some(self.inverted_index.total_sparse_vectors_size())
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
+        self.inverted_index.total_sparse_vectors_size()
     }
 
     fn update_vector(

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -176,6 +176,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         // Simple migration mechanism for 0.1.0.
         let old_path = path.join(OLD_INDEX_FILE_NAME);
         if TInvertedIndex::Version::current() == Version::new(0, 1, 0) && old_path.exists() {
+            // Didn't have a version file, but uses 0.1.0 index. Create a version file.
             rename(old_path, path.join(INDEX_FILE_NAME))?;
             TInvertedIndex::Version::save(path)?;
             stored_version = Some(TInvertedIndex::Version::current());

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -564,6 +564,10 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         self.inverted_index.vector_count()
     }
 
+    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize> {
+        Some(self.inverted_index.total_sparse_vectors_size())
+    }
+
     fn update_vector(
         &mut self,
         id: PointOffsetType,

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -39,8 +39,8 @@ pub trait VectorIndex {
     /// The number of indexed vectors, currently accessible
     fn indexed_vector_count(&self) -> usize;
 
-    /// Total size of all searchable vectors in bytes, if known.
-    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize>;
+    /// Total size of all searchable vectors in bytes.
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize;
 
     /// Update index for a single vector
     ///
@@ -216,7 +216,7 @@ impl VectorIndex for VectorIndexEnum {
         }
     }
 
-    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize> {
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
         match self {
             Self::Plain(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::HnswRam(index) => index.size_of_searchable_vectors_in_bytes(),

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -39,6 +39,9 @@ pub trait VectorIndex {
     /// The number of indexed vectors, currently accessible
     fn indexed_vector_count(&self) -> usize;
 
+    /// Total size of all searchable vectors in bytes, if known.
+    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize>;
+
     /// Update index for a single vector
     ///
     /// # Arguments
@@ -210,6 +213,29 @@ impl VectorIndex for VectorIndexEnum {
             Self::SparseCompressedMmapF32(index) => index.indexed_vector_count(),
             Self::SparseCompressedMmapF16(index) => index.indexed_vector_count(),
             Self::SparseCompressedMmapU8(index) => index.indexed_vector_count(),
+        }
+    }
+
+    fn size_of_searchable_vectors_in_bytes(&self) -> Option<usize> {
+        match self {
+            Self::Plain(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::HnswRam(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::HnswMmap(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseRam(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseImmutableRam(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseMmap(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.size_of_searchable_vectors_in_bytes()
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.size_of_searchable_vectors_in_bytes()
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.size_of_searchable_vectors_in_bytes()
+            }
+            Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
         }
     }
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -10,7 +10,7 @@ use common::types::TelemetryDetail;
 use io::storage_version::VERSION_FILE;
 use uuid::Uuid;
 
-use super::Segment;
+use super::{Segment, VectorData};
 use crate::common::operation_error::OperationError::TypeInferenceError;
 use crate::common::operation_error::{OperationError, OperationResult, SegmentFailedState};
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
@@ -389,10 +389,12 @@ impl SegmentEntry for Segment {
 
     fn available_vectors_size_in_bytes(&self, vector_name: &str) -> OperationResult<usize> {
         check_vector_name(vector_name, &self.segment_config)?;
-        Ok(self.vector_data[vector_name]
-            .vector_storage
-            .borrow()
-            .size_of_available_vectors_in_bytes())
+        let vector_data = &self.vector_data[vector_name];
+        let size = VectorData::size_of_available_vectors_in_bytes(
+            &vector_data.vector_storage.borrow(),
+            &vector_data.vector_index.borrow(),
+        );
+        Ok(size)
     }
 
     fn estimate_point_count<'a>(&'a self, filter: Option<&'a Filter>) -> CardinalityEstimation {
@@ -453,7 +455,8 @@ impl SegmentEntry for Segment {
                 let is_indexed = vector_index.is_index();
 
                 let average_vector_size_bytes = if num_vectors > 0 {
-                    vector_storage.size_of_available_vectors_in_bytes() / num_vectors
+                    VectorData::size_of_available_vectors_in_bytes(&vector_storage, &vector_index)
+                        / num_vectors
                 } else {
                     0
                 };

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -10,7 +10,7 @@ use common::types::TelemetryDetail;
 use io::storage_version::VERSION_FILE;
 use uuid::Uuid;
 
-use super::{Segment, VectorData};
+use super::Segment;
 use crate::common::operation_error::OperationError::TypeInferenceError;
 use crate::common::operation_error::{OperationError, OperationResult, SegmentFailedState};
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
@@ -390,10 +390,10 @@ impl SegmentEntry for Segment {
     fn available_vectors_size_in_bytes(&self, vector_name: &str) -> OperationResult<usize> {
         check_vector_name(vector_name, &self.segment_config)?;
         let vector_data = &self.vector_data[vector_name];
-        let size = VectorData::size_of_available_vectors_in_bytes(
-            &vector_data.vector_storage.borrow(),
-            &vector_data.vector_index.borrow(),
-        );
+        let size = vector_data
+            .vector_index
+            .borrow()
+            .size_of_searchable_vectors_in_bytes();
         Ok(size)
     }
 
@@ -455,8 +455,7 @@ impl SegmentEntry for Segment {
                 let is_indexed = vector_index.is_index();
 
                 let average_vector_size_bytes = if num_vectors > 0 {
-                    VectorData::size_of_available_vectors_in_bytes(&vector_storage, &vector_index)
-                        / num_vectors
+                    vector_index.size_of_searchable_vectors_in_bytes() / num_vectors
                 } else {
                     0
                 };

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -110,10 +110,13 @@ impl VectorData {
         storage: &VectorStorageEnum,
         index: &VectorIndexEnum,
     ) -> usize {
-        storage
+        let size = storage
             .size_of_available_vectors_in_bytes()
-            .or_else(|| index.size_of_searchable_vectors_in_bytes())
-            .unwrap_or(0)
+            .or_else(|| index.size_of_searchable_vectors_in_bytes());
+
+        debug_assert!(size.is_some());
+
+        size.unwrap_or(0)
     }
 }
 

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -24,11 +24,11 @@ use rocksdb::DB;
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::{VectorIndex, VectorIndexEnum};
+use crate::index::VectorIndexEnum;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::types::{SegmentConfig, SegmentType, SeqNumberType, VectorName};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::VectorStorageEnum;
 
 pub const SEGMENT_STATE_FILE: &str = "segment.json";
 
@@ -104,19 +104,6 @@ impl VectorData {
         };
 
         index_task.into_iter().chain(storage_task)
-    }
-
-    pub fn size_of_available_vectors_in_bytes(
-        storage: &VectorStorageEnum,
-        index: &VectorIndexEnum,
-    ) -> usize {
-        let size = storage
-            .size_of_available_vectors_in_bytes()
-            .or_else(|| index.size_of_searchable_vectors_in_bytes());
-
-        debug_assert!(size.is_some());
-
-        size.unwrap_or(0)
     }
 }
 

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -24,11 +24,11 @@ use rocksdb::DB;
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::VectorIndexEnum;
+use crate::index::{VectorIndex, VectorIndexEnum};
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::types::{SegmentConfig, SegmentType, SeqNumberType, VectorName};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::VectorStorageEnum;
+use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 pub const SEGMENT_STATE_FILE: &str = "segment.json";
 
@@ -104,6 +104,16 @@ impl VectorData {
         };
 
         index_task.into_iter().chain(storage_task)
+    }
+
+    pub fn size_of_available_vectors_in_bytes(
+        storage: &VectorStorageEnum,
+        index: &VectorIndexEnum,
+    ) -> usize {
+        storage
+            .size_of_available_vectors_in_bytes()
+            .or_else(|| index.size_of_searchable_vectors_in_bytes())
+            .unwrap_or(0)
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -99,10 +99,6 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
         self.vectors.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        Some(self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>())
-    }
-
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         self.get_vector_opt(key).expect("vector not found")
     }

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -99,8 +99,8 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
         self.vectors.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
+        Some(self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>())
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -162,10 +162,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         self.mmap_store.as_ref().unwrap().num_vectors
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        Some(self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>())
-    }
-
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         self.get_vector_opt(key).expect("vector not found")
     }

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -162,8 +162,8 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         self.mmap_store.as_ref().unwrap().num_vectors
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
+        Some(self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>())
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -209,8 +209,8 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         self.vectors.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
+        Some(self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>())
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -209,10 +209,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         self.vectors.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        Some(self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>())
-    }
-
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         self.get_vector_opt(key).expect("vector not found")
     }

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -135,6 +135,16 @@ impl<
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }
+
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count() > 0 {
+            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
+            (total_size as u128 * self.available_vector_count() as u128
+                / self.total_vector_count() as u128) as usize
+        } else {
+            0
+        }
+    }
 }
 
 impl<
@@ -157,18 +167,6 @@ impl<
 
     fn total_vector_count(&self) -> usize {
         self.offsets.len()
-    }
-
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        let size = if self.total_vector_count() > 0 {
-            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
-            (total_size as u128 * self.available_vector_count() as u128
-                / self.total_vector_count() as u128) as usize
-        } else {
-            0
-        };
-
-        Some(size)
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -159,14 +159,16 @@ impl<
         self.offsets.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        if self.total_vector_count() > 0 {
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
+        let size = if self.total_vector_count() > 0 {
             let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
             (total_size as u128 * self.available_vector_count() as u128
                 / self.total_vector_count() as u128) as usize
         } else {
             0
-        }
+        };
+
+        Some(size)
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -323,6 +323,16 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }
+
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count() > 0 {
+            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
+            (total_size as u128 * self.available_vector_count() as u128
+                / self.total_vector_count() as u128) as usize
+        } else {
+            0
+        }
+    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<T> {
@@ -340,18 +350,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
 
     fn total_vector_count(&self) -> usize {
         self.vectors_metadata.len()
-    }
-
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        let size = if self.total_vector_count() > 0 {
-            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
-            (total_size as u128 * self.available_vector_count() as u128
-                / self.total_vector_count() as u128) as usize
-        } else {
-            0
-        };
-
-        Some(size)
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -342,14 +342,16 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
         self.vectors_metadata.len()
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        if self.total_vector_count() > 0 {
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
+        let size = if self.total_vector_count() > 0 {
             let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
             (total_size as u128 * self.available_vector_count() as u128
                 / self.total_vector_count() as u128) as usize
         } else {
             0
-        }
+        };
+
+        Some(size)
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -149,11 +149,6 @@ impl VectorStorage for MmapSparseVectorStorage {
         self.next_point_offset
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        // get from sparse index instead
-        None
-    }
-
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         let vector = self.get_vector_opt(key);
         vector.unwrap_or_else(CowVector::default_sparse)

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -10,7 +10,6 @@ use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use sparse::common::sparse_vector::SparseVector;
-use sparse::common::types::{DimId, DimWeight};
 
 use super::simple_sparse_vector_storage::SPARSE_VECTOR_DISTANCE;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -30,8 +29,6 @@ pub struct MmapSparseVectorStorage {
     deleted_count: usize,
     /// Maximum point offset in the storage + 1. This also means the total amount of point offsets
     next_point_offset: usize,
-    /// Total number of non-zero elements in all vectors. Used to estimate average vector size.
-    total_sparse_size: usize,
 }
 
 impl MmapSparseVectorStorage {
@@ -51,14 +48,11 @@ impl MmapSparseVectorStorage {
         let mut deleted = BitVec::new();
         let mut deleted_count = 0;
         let mut next_point_offset = 0;
-        let mut total_sparse_size = 0;
         const CHECK_STOP_INTERVAL: usize = 100;
 
         storage
             .for_each_unfiltered(|point_id, opt_vector| {
-                if let Some(vector) = opt_vector {
-                    total_sparse_size += vector.values.len();
-                } else {
+                if opt_vector.is_none() {
                     // Propagate deleted flag
                     bitvec_set_deleted(&mut deleted, point_id, true);
                     deleted_count += 1;
@@ -81,7 +75,6 @@ impl MmapSparseVectorStorage {
             deleted,
             deleted_count,
             next_point_offset,
-            total_sparse_size,
         })
     }
 
@@ -108,24 +101,12 @@ impl MmapSparseVectorStorage {
         let mut storage_guard = self.storage.write();
         if let Some(vector) = vector {
             // upsert vector
-            if let Some(old_vector) = storage_guard.get_value(key) {
-                // it is an update
-                self.total_sparse_size = self
-                    .total_sparse_size
-                    .saturating_sub(old_vector.values.len());
-            }
-
-            self.total_sparse_size += vector.values.len();
             storage_guard
                 .put_value(key, vector)
                 .map_err(OperationError::service_error)?;
         } else {
             // delete vector
-            if let Some(old_vector) = storage_guard.delete_value(key) {
-                self.total_sparse_size = self
-                    .total_sparse_size
-                    .saturating_sub(old_vector.values.len());
-            }
+            storage_guard.delete_value(key);
         }
 
         self.next_point_offset = std::cmp::max(self.next_point_offset, key as usize + 1);
@@ -168,14 +149,9 @@ impl VectorStorage for MmapSparseVectorStorage {
         self.next_point_offset
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        if self.next_point_offset == 0 {
-            return 0;
-        }
-        let available_fraction =
-            (self.next_point_offset - self.deleted_count) as f32 / self.next_point_offset as f32;
-        let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
-        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
+        // get from sparse index instead
+        None
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -167,14 +167,14 @@ impl VectorStorage for SimpleSparseVectorStorage {
         self.total_vector_count
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
         if self.total_vector_count == 0 {
-            return 0;
+            return Some(0);
         }
         let available_fraction =
             (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
         let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
-        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
+        Some(available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>()))
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -119,6 +119,16 @@ impl SimpleSparseVectorStorage {
 
         Ok(())
     }
+
+    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count == 0 {
+            return 0;
+        }
+        let available_fraction =
+            (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
+        let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
+        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
+    }
 }
 
 impl SparseVectorStorage for SimpleSparseVectorStorage {
@@ -165,16 +175,6 @@ impl VectorStorage for SimpleSparseVectorStorage {
 
     fn total_vector_count(&self) -> usize {
         self.total_vector_count
-    }
-
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        if self.total_vector_count == 0 {
-            return Some(0);
-        }
-        let available_fraction =
-            (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
-        let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
-        Some(available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>()))
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -225,7 +225,6 @@ fn do_test_persistance(open: impl Fn(&Path) -> VectorStorageEnum) {
 
     let deleted_vector_count = storage.deleted_vector_count();
     let available_vector_count = storage.available_vector_count();
-    let size_of_available_vectors_in_bytes = storage.size_of_available_vectors_in_bytes();
 
     drop(storage);
 
@@ -250,10 +249,6 @@ fn do_test_persistance(open: impl Fn(&Path) -> VectorStorageEnum) {
 
     assert_eq!(storage.deleted_vector_count(), deleted_vector_count);
     assert_eq!(storage.available_vector_count(), available_vector_count);
-    assert_eq!(
-        storage.size_of_available_vectors_in_bytes(),
-        size_of_available_vectors_in_bytes
-    );
 }
 
 #[test]

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -54,12 +54,6 @@ pub trait VectorStorage {
             .saturating_sub(self.deleted_vector_count())
     }
 
-    /// Get the total size of available vectors in bytes, if it is known.
-    /// Returns `None` if the size is not known.
-    ///
-    /// This should be a cheap operation.
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize>;
-
     /// Get the vector by the given key
     fn get_vector(&self, key: PointOffsetType) -> CowVector;
 
@@ -121,6 +115,10 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
             vectors[idx] = self.get_dense(*key);
         }
     }
+
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    }
 }
 
 pub trait SparseVectorStorage: VectorStorage {
@@ -139,6 +137,8 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     );
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send;
     fn multi_vector_config(&self) -> &MultiVectorConfig;
+
+    fn size_of_available_vectors_in_bytes(&self) -> usize;
 }
 
 #[derive(Debug)]
@@ -352,6 +352,58 @@ impl VectorStorageEnum {
             }
         }
     }
+
+    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
+        match self {
+            VectorStorageEnum::DenseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmap(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmapByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::DenseAppendableInRam(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseAppendableInRamByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::DenseAppendableInRamHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::SparseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::SparseMmap(_v) => {
+                unreachable!(
+                    "Mmap sparse storage does not know its total size, get from index instead"
+                )
+            }
+            VectorStorageEnum::MultiDenseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableInRam(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+        }
+    }
 }
 
 impl VectorStorage for VectorStorageEnum {
@@ -464,54 +516,6 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::MultiDenseAppendableInRam(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseAppendableInRamByte(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => v.total_vector_count(),
-        }
-    }
-
-    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
-        match self {
-            VectorStorageEnum::DenseSimple(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseMemmap(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseMemmapByte(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::DenseAppendableInRam(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseAppendableInRamByte(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::DenseAppendableInRamHalf(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::SparseSimple(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::SparseMmap(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::MultiDenseSimple(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::MultiDenseAppendableInRam(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
         }
     }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -54,7 +54,11 @@ pub trait VectorStorage {
             .saturating_sub(self.deleted_vector_count())
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize;
+    /// Get the total size of available vectors in bytes, if it is known.
+    /// Returns `None` if the size is not known.
+    ///
+    /// This should be a cheap operation.
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize>;
 
     /// Get the vector by the given key
     fn get_vector(&self, key: PointOffsetType) -> CowVector;
@@ -463,7 +467,7 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
+    fn size_of_available_vectors_in_bytes(&self) -> Option<usize> {
         match self {
             VectorStorageEnum::DenseSimple(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -112,6 +112,10 @@ impl RemappedSparseVector {
     pub fn len(&self) -> usize {
         self.indices.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl SparseVector {

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -107,6 +107,11 @@ impl RemappedSparseVector {
         debug_assert!(other.is_sorted());
         score_vectors(&self.indices, &self.values, &other.indices, &other.values)
     }
+
+    pub fn size_in_bytes(&self) -> usize {
+        self.indices.len() * std::mem::size_of::<DimOffset>()
+            + self.values.len() * std::mem::size_of::<DimWeight>()
+    }
 }
 
 impl SparseVector {

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -108,9 +108,9 @@ impl RemappedSparseVector {
         score_vectors(&self.indices, &self.values, &other.indices, &other.values)
     }
 
-    pub fn size_in_bytes(&self) -> usize {
-        self.indices.len() * std::mem::size_of::<DimOffset>()
-            + self.values.len() * std::mem::size_of::<DimWeight>()
+    /// Returns the number of elements in the vector.
+    pub fn len(&self) -> usize {
+        self.indices.len()
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -17,6 +17,7 @@ use crate::index::posting_list_common::PostingListIter as _;
 pub struct InvertedIndexCompressedImmutableRam<W: Weight> {
     pub(super) postings: Vec<CompressedPostingList<W>>,
     pub(super) vector_count: usize,
+    pub(super) total_sparse_size: usize,
 }
 
 impl<W: Weight> InvertedIndexCompressedImmutableRam<W> {
@@ -35,6 +36,7 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
         let mut inverted_index = InvertedIndexCompressedImmutableRam {
             postings: Vec::with_capacity(mmap_inverted_index.file_header.posting_count),
             vector_count: mmap_inverted_index.file_header.vector_count,
+            total_sparse_size: mmap_inverted_index.file_header.total_sparse_size,
         };
 
         for i in 0..mmap_inverted_index.file_header.posting_count as DimId {
@@ -101,11 +103,16 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
         Ok(InvertedIndexCompressedImmutableRam {
             postings,
             vector_count: ram_index.vector_count,
+            total_sparse_size: ram_index.total_sparse_size,
         })
     }
 
     fn vector_count(&self) -> usize {
         self.vector_count
+    }
+
+    fn total_sparse_vectors_size(&self) -> usize {
+        self.total_sparse_size
     }
 
     fn max_index(&self) -> Option<DimOffset> {

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -100,10 +100,13 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
             }
             postings.push(new_posting_list.build());
         }
+
+        let total_sparse_size = postings.iter().map(|p| p.view().store_size().total).sum();
+
         Ok(InvertedIndexCompressedImmutableRam {
             postings,
             vector_count: ram_index.vector_count,
-            total_sparse_size: ram_index.total_sparse_size,
+            total_sparse_size,
         })
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -36,7 +36,7 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
         let mut inverted_index = InvertedIndexCompressedImmutableRam {
             postings: Vec::with_capacity(mmap_inverted_index.file_header.posting_count),
             vector_count: mmap_inverted_index.file_header.vector_count,
-            total_sparse_size: mmap_inverted_index.file_header.total_sparse_size,
+            total_sparse_size: mmap_inverted_index.total_sparse_vectors_size(),
         };
 
         for i in 0..mmap_inverted_index.file_header.posting_count as DimId {

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -44,7 +44,10 @@ pub struct InvertedIndexFileHeader {
     /// Number of unique vectors indexed
     pub vector_count: usize,
     /// Total size of all searchable sparse vectors in bytes
-    pub total_sparse_size: usize,
+    // This is an option because earlier versions of the index did not store this information.
+    // In case it is not present, it will be calculated on load.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_sparse_size: Option<usize>,
 }
 
 /// Inverted flatten index from dimension id to posting list
@@ -136,7 +139,11 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedMmap<W> {
     }
 
     fn total_sparse_vectors_size(&self) -> usize {
-        self.file_header.total_sparse_size
+        debug_assert!(
+            self.file_header.total_sparse_size.is_some(),
+            "The field should be populated from the file, or on load"
+        );
+        self.file_header.total_sparse_size.unwrap_or(0)
     }
 
     fn max_index(&self) -> Option<DimId> {
@@ -261,7 +268,7 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
         let file_header = InvertedIndexFileHeader {
             posting_count: index.postings.as_slice().len(),
             vector_count: index.vector_count,
-            total_sparse_size: index.total_sparse_size,
+            total_sparse_size: Some(index.total_sparse_size),
         };
         atomic_save_json(&Self::index_config_file_path(path.as_ref()), &file_header)?;
 
@@ -289,12 +296,26 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
             AdviceSetting::from(Advice::Normal),
             false,
         )?;
-        Ok(Self {
+
+        let mut index = Self {
             path: path.as_ref().to_owned(),
             mmap: Arc::new(mmap),
             file_header,
             _phantom: PhantomData,
-        })
+        };
+
+        if index.file_header.total_sparse_size.is_none() {
+            index.file_header.total_sparse_size = Some(index.calculate_total_sparse_size());
+            atomic_save_json(&config_file_path, &index.file_header)?;
+        }
+
+        Ok(index)
+    }
+
+    fn calculate_total_sparse_size(&self) -> usize {
+        (0..self.file_header.posting_count as DimId)
+            .filter_map(|id| self.get(&id).map(|posting| posting.store_size().total))
+            .sum()
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -271,7 +271,9 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
             total_sparse_size: Some(index.total_sparse_size),
         };
 
-        let mut compressed_index = Self {
+        atomic_save_json(&Self::index_config_file_path(path.as_ref()), &file_header)?;
+
+        Ok(Self {
             path: path.as_ref().to_owned(),
             mmap: Arc::new(open_read_mmap(
                 file_path.as_ref(),
@@ -280,18 +282,7 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
             )?),
             file_header,
             _phantom: PhantomData,
-        };
-
-        // total_sparse_size is recalculated because now it is compressed
-        compressed_index.file_header.total_sparse_size =
-            Some(compressed_index.calculate_total_sparse_size());
-
-        atomic_save_json(
-            &Self::index_config_file_path(path.as_ref()),
-            &compressed_index.file_header,
-        )?;
-
-        Ok(compressed_index)
+        })
     }
 
     pub fn load<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -39,8 +39,12 @@ impl StorageVersion for Version {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct InvertedIndexFileHeader {
-    pub posting_count: usize, // number of posting lists
-    pub vector_count: usize,  // number of unique vectors indexed
+    /// Number of posting lists
+    pub posting_count: usize,
+    /// Number of unique vectors indexed
+    pub vector_count: usize,
+    /// Total size of all searchable sparse vectors in bytes
+    pub total_sparse_size: usize,
 }
 
 /// Inverted flatten index from dimension id to posting list
@@ -129,6 +133,10 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedMmap<W> {
 
     fn vector_count(&self) -> usize {
         self.file_header.vector_count
+    }
+
+    fn total_sparse_vectors_size(&self) -> usize {
+        self.file_header.total_sparse_size
     }
 
     fn max_index(&self) -> Option<DimId> {
@@ -253,6 +261,7 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
         let file_header = InvertedIndexFileHeader {
             posting_count: index.postings.as_slice().len(),
             vector_count: index.vector_count,
+            total_sparse_size: index.total_sparse_size,
         };
         atomic_save_json(&Self::index_config_file_path(path.as_ref()), &file_header)?;
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
@@ -28,6 +28,7 @@ impl InvertedIndex for InvertedIndexImmutableRam {
         let mut inverted_index = InvertedIndexRam {
             postings: Default::default(),
             vector_count: mmap_inverted_index.file_header.vector_count,
+            // Calculated after reading mmap
             total_sparse_size: 0,
         };
 
@@ -42,6 +43,8 @@ impl InvertedIndex for InvertedIndexImmutableRam {
                 elements: posting_list.to_owned(),
             });
         }
+
+        inverted_index.total_sparse_size = inverted_index.total_posting_elements_size();
 
         Ok(InvertedIndexImmutableRam {
             inner: inverted_index,

--- a/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
@@ -12,6 +12,7 @@ use crate::index::posting_list::{PostingList, PostingListIterator};
 
 /// A wrapper around [`InvertedIndexRam`].
 /// Will be replaced with the new compressed implementation eventually.
+// TODO: Remove this inverted index implementation, it is no longer used
 #[derive(Debug, Clone, PartialEq)]
 pub struct InvertedIndexImmutableRam {
     inner: InvertedIndexRam,
@@ -27,7 +28,7 @@ impl InvertedIndex for InvertedIndexImmutableRam {
         let mut inverted_index = InvertedIndexRam {
             postings: Default::default(),
             vector_count: mmap_inverted_index.file_header.vector_count,
-            total_sparse_size: mmap_inverted_index.file_header.total_sparse_size,
+            total_sparse_size: 0,
         };
 
         for i in 0..mmap_inverted_index.file_header.posting_count as DimId {

--- a/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_immutable_ram.rs
@@ -27,6 +27,7 @@ impl InvertedIndex for InvertedIndexImmutableRam {
         let mut inverted_index = InvertedIndexRam {
             postings: Default::default(),
             vector_count: mmap_inverted_index.file_header.vector_count,
+            total_sparse_size: mmap_inverted_index.file_header.total_sparse_size,
         };
 
         for i in 0..mmap_inverted_index.file_header.posting_count as DimId {
@@ -91,6 +92,10 @@ impl InvertedIndex for InvertedIndexImmutableRam {
 
     fn vector_count(&self) -> usize {
         self.inner.vector_count()
+    }
+
+    fn total_sparse_vectors_size(&self) -> usize {
+        self.inner.total_sparse_vectors_size()
     }
 
     fn max_index(&self) -> Option<DimOffset> {

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -161,7 +161,7 @@ impl InvertedIndexMmap {
         path: P,
     ) -> std::io::Result<Self> {
         let total_posting_headers_size = Self::total_posting_headers_size(inverted_index_ram);
-        let total_posting_elements_size = Self::total_posting_elements_size(inverted_index_ram);
+        let total_posting_elements_size = inverted_index_ram.total_posting_elements_size();
 
         let file_length = total_posting_headers_size + total_posting_elements_size;
         let file_path = Self::index_file_path(path.as_ref());
@@ -220,15 +220,6 @@ impl InvertedIndexMmap {
 
     fn total_posting_headers_size(inverted_index_ram: &InvertedIndexRam) -> usize {
         inverted_index_ram.postings.len() * POSTING_HEADER_SIZE
-    }
-
-    fn total_posting_elements_size(inverted_index_ram: &InvertedIndexRam) -> usize {
-        let mut total_posting_elements_size = 0;
-        for posting in &inverted_index_ram.postings {
-            total_posting_elements_size += posting.elements.len() * size_of::<PostingElementEx>();
-        }
-
-        total_posting_elements_size
     }
 
     fn save_posting_headers(

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -39,8 +39,6 @@ pub struct InvertedIndexFileHeader {
     pub posting_count: usize,
     /// Number of unique vectors indexed
     pub vector_count: usize,
-    /// Total size of all searchable sparse vectors in bytes
-    pub total_sparse_size: usize,
 }
 
 /// Inverted flatten index from dimension id to posting list
@@ -123,7 +121,8 @@ impl InvertedIndex for InvertedIndexMmap {
     }
 
     fn total_sparse_vectors_size(&self) -> usize {
-        self.file_header.total_sparse_size
+        debug_assert!(false, "This index is already substituted by the compressed version, no need to maintain new features");
+        0
     }
 
     fn max_index(&self) -> Option<DimId> {
@@ -184,13 +183,11 @@ impl InvertedIndexMmap {
         // save header properties
         let posting_count = inverted_index_ram.postings.len();
         let vector_count = inverted_index_ram.vector_count();
-        let total_sparse_size = inverted_index_ram.total_sparse_vectors_size();
 
         // finalize data with index file.
         let file_header = InvertedIndexFileHeader {
             posting_count,
             vector_count,
-            total_sparse_size,
         };
         let config_file_path = Self::index_config_file_path(path.as_ref());
         atomic_save_json(&config_file_path, &file_header)?;

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -27,6 +27,8 @@ pub struct InvertedIndexRam {
     /// Number of unique indexed vectors
     /// pre-computed on build and upsert to avoid having to traverse the posting lists.
     pub vector_count: usize,
+    /// Total size of all searchable sparse vectors in bytes
+    pub total_sparse_size: usize,
 }
 
 impl InvertedIndex for InvertedIndexRam {
@@ -59,6 +61,7 @@ impl InvertedIndex for InvertedIndexRam {
     }
 
     fn remove(&mut self, id: PointOffsetType, old_vector: RemappedSparseVector) {
+        let old_vector_size = old_vector.size_in_bytes();
         for dim_id in old_vector.indices {
             if let Some(posting) = self.postings.get_mut(dim_id as usize) {
                 posting.delete(id);
@@ -67,6 +70,7 @@ impl InvertedIndex for InvertedIndexRam {
             }
         }
 
+        self.total_sparse_size = self.total_sparse_size.saturating_sub(old_vector_size);
         self.vector_count = self.vector_count.saturating_sub(1);
     }
 
@@ -90,6 +94,10 @@ impl InvertedIndex for InvertedIndexRam {
         self.vector_count
     }
 
+    fn total_sparse_vectors_size(&self) -> usize {
+        self.total_sparse_size
+    }
+
     fn max_index(&self) -> Option<DimId> {
         match self.postings.len() {
             0 => None,
@@ -104,6 +112,7 @@ impl InvertedIndexRam {
         InvertedIndexRam {
             postings: Vec::new(),
             vector_count: 0,
+            total_sparse_size: 0,
         }
     }
 
@@ -135,6 +144,8 @@ impl InvertedIndexRam {
             }
         }
 
+        let new_vector_size = vector.size_in_bytes();
+
         for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
             match self.postings.get_mut(dim_id) {
@@ -151,9 +162,13 @@ impl InvertedIndexRam {
                 }
             }
         }
-        if old_vector.is_none() {
+        if let Some(old) = old_vector {
+            self.total_sparse_size = self.total_sparse_size.saturating_sub(old.size_in_bytes());
+        } else {
             self.vector_count += 1;
         }
+
+        self.total_sparse_size += new_vector_size
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -10,6 +10,7 @@ use crate::index::posting_list::PostingBuilder;
 pub struct InvertedIndexBuilder {
     pub posting_builders: Vec<PostingBuilder>,
     pub vector_count: usize,
+    pub total_sparse_size: usize,
 }
 
 impl Default for InvertedIndexBuilder {
@@ -23,11 +24,13 @@ impl InvertedIndexBuilder {
         InvertedIndexBuilder {
             posting_builders: Vec::new(),
             vector_count: 0,
+            total_sparse_size: 0,
         }
     }
 
     /// Add a vector to the inverted index builder
     pub fn add(&mut self, id: PointOffsetType, vector: RemappedSparseVector) {
+        let sparse_size = vector.size_in_bytes();
         for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
             self.posting_builders.resize_with(
@@ -37,6 +40,7 @@ impl InvertedIndexBuilder {
             self.posting_builders[dim_id].add(id, weight);
         }
         self.vector_count += 1;
+        self.total_sparse_size = self.total_sparse_size.saturating_add(sparse_size);
     }
 
     /// Consumes the builder and returns an InvertedIndexRam
@@ -47,9 +51,11 @@ impl InvertedIndexBuilder {
         }
 
         let vector_count = self.vector_count;
+        let total_sparse_size = self.total_sparse_size;
         InvertedIndexRam {
             postings,
             vector_count,
+            total_sparse_size,
         }
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -5,6 +5,7 @@ use common::types::PointOffsetType;
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::posting_list::PostingBuilder;
+use crate::index::posting_list_common::PostingElementEx;
 
 /// Builder for InvertedIndexRam
 pub struct InvertedIndexBuilder {
@@ -30,7 +31,7 @@ impl InvertedIndexBuilder {
 
     /// Add a vector to the inverted index builder
     pub fn add(&mut self, id: PointOffsetType, vector: RemappedSparseVector) {
-        let sparse_size = vector.size_in_bytes();
+        let sparse_size = vector.len() * size_of::<PostingElementEx>();
         for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
             self.posting_builders.resize_with(

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -69,6 +69,9 @@ pub trait InvertedIndex: Sized + Debug + 'static {
     /// Number of indexed vectors
     fn vector_count(&self) -> usize;
 
-    // Get max existed index
+    /// Total size of all the sparse vectors in bytes
+    fn total_sparse_vectors_size(&self) -> usize;
+
+    /// Get max existed index
     fn max_index(&self) -> Option<DimOffset>;
 }

--- a/lib/sparse/src/index/loaders.rs
+++ b/lib/sparse/src/index/loaders.rs
@@ -11,7 +11,7 @@ use validator::ValidationErrors;
 
 use crate::common::sparse_vector::SparseVector;
 
-/// Compressed Sparse Row matrix, baked by memory-mapped file.
+/// Compressed Sparse Row matrix, backed by memory-mapped file.
 ///
 /// The layout of the memory-mapped file is as follows:
 ///


### PR DESCRIPTION
In #5533 we realized that calculating `total_sparse_vectors_size` on load was inevitable, but we don't want it, reason is:
- to compute it on load, we need to scan the whole storage, which we want to avoid for a mmap storage.
- if we put it in a mmapped file, replayed operations are not idempotent, which leads to a counter which we can't trust.

To solve this, we add `VectorIndex::size_of_searchable_vectors_in_bytes` as a primary source for `VectorStorage::size_of_available_vectors_in_bytes`. All indices have access to the vector storage, so it is easy to use the storage as a fallback if the index does not know it.

Regarding the precision of making this number come from the sparse index, a mutable segment will return an up-to-date number. For the immutable counterpart, we will rely on the vacuum optimizer, but it should still be representative of the work it takes to search through the all the vectors.

This will allow us to load the mmap sparse vector storage quicker.