### PR TITLE
Strict mode for payload storage

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1434,6 +1434,7 @@ Note: 1kB = 1 vector of size 256. |
 | max_collection_vector_size_bytes | [uint64](#uint64) | optional |  |
 | read_rate_limit | [uint32](#uint32) | optional | Max number of read operations per minute per replica |
 | write_rate_limit | [uint32](#uint32) | optional | Max number of write operations per minute per replica |
+| max_collection_payload_size_bytes | [uint64](#uint64) | optional |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7312,6 +7312,13 @@
             "format": "uint",
             "minimum": 1,
             "nullable": true
+          },
+          "max_collection_payload_size_bytes": {
+            "description": "Max size of a collections payload storage in bytes",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1637,6 +1637,9 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
                 .map(|i| i as usize),
             read_rate_limit: value.read_rate_limit.map(|i| i as usize),
             write_rate_limit: value.read_rate_limit.map(|i| i as usize),
+            max_collection_payload_size_bytes: value
+                .max_collection_payload_size_bytes
+                .map(|i| i as usize),
         }
     }
 }
@@ -1658,6 +1661,9 @@ impl From<segment::types::StrictModeConfig> for StrictModeConfig {
                 .map(|i| i as u64),
             read_rate_limit: value.read_rate_limit.map(|i| i as u32),
             write_rate_limit: value.write_rate_limit.map(|i| i as u32),
+            max_collection_payload_size_bytes: value
+                .max_collection_payload_size_bytes
+                .map(|i| i as u64),
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -324,6 +324,7 @@ message StrictModeConfig {
   optional uint64 max_collection_vector_size_bytes  = 10;
   optional uint32 read_rate_limit = 11; // Max number of read operations per minute per replica
   optional uint32 write_rate_limit = 12; // Max number of write operations per minute per replica
+  optional uint64 max_collection_payload_size_bytes  = 13;
 }
 
 message CreateCollection {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -324,7 +324,7 @@ message StrictModeConfig {
   optional uint64 max_collection_vector_size_bytes  = 10;
   optional uint32 read_rate_limit = 11; // Max number of read operations per minute per replica
   optional uint32 write_rate_limit = 12; // Max number of write operations per minute per replica
-  optional uint64 max_collection_payload_size_bytes  = 13;
+  optional uint64 max_collection_payload_size_bytes = 13;
 }
 
 message CreateCollection {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -462,6 +462,8 @@ pub struct StrictModeConfig {
     /// Max number of write operations per minute per replica
     #[prost(uint32, optional, tag = "12")]
     pub write_rate_limit: ::core::option::Option<u32>,
+    #[prost(uint64, optional, tag = "13")]
+    pub max_collection_payload_size_bytes: ::core::option::Option<u64>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -822,6 +822,14 @@ impl Collection {
         }
         self.local_stats_cache.get_vector_storage()
     }
+
+    /// Returns the estimated local payload storage size for this collection, cached and auto-updated.
+    pub async fn estimated_local_payload_storage_size(&self) -> usize {
+        if let Some(shard_stats) = self.check_and_update_local_size_stats().await {
+            return shard_stats.payload_storage_size;
+        }
+        self.local_stats_cache.get_payload_storage()
+    }
 }
 
 struct CollectionVersion;

--- a/lib/collection/src/common/local_data_stats.rs
+++ b/lib/collection/src/common/local_data_stats.rs
@@ -75,6 +75,7 @@ impl LocalDataAtomicStats {
             vector_storage_size,
             payload_storage_size,
         } = data;
+
         let vector_storage_size = AtomicUsize::new(vector_storage_size);
         let payload_storage_size = AtomicUsize::new(payload_storage_size);
         Self {

--- a/lib/collection/src/common/local_data_stats.rs
+++ b/lib/collection/src/common/local_data_stats.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Amount of requests that have to be done until the cached data gets updated.
@@ -6,22 +7,15 @@ const UPDATE_INTERVAL: usize = 32;
 /// A cache for `LocalDataStats` utilizing `AtomicUsize` for better performance.
 #[derive(Default)]
 pub(crate) struct LocalDataStatsCache {
-    vector_storage_size: AtomicUsize,
-    payload_storage_size: AtomicUsize,
+    stats: LocalDataAtomicStats,
     request_counter: AtomicUsize,
 }
 
 impl LocalDataStatsCache {
     pub fn new_with_values(stats: LocalDataStats) -> Self {
-        let LocalDataStats {
-            vector_storage_size,
-            payload_storage_size,
-        } = stats;
-        let vector_storage_size = AtomicUsize::new(vector_storage_size);
-        let payload_storage_size = AtomicUsize::new(payload_storage_size);
+        let stats = LocalDataAtomicStats::new(stats);
         Self {
-            vector_storage_size,
-            payload_storage_size,
+            stats,
             request_counter: AtomicUsize::new(1), // Prevent same data getting loaded a second time when doing the first request.
         }
     }
@@ -34,27 +28,71 @@ impl LocalDataStatsCache {
         req_counter % UPDATE_INTERVAL == 0
     }
 
+    /// Returns the cached values. Automatically updates the cache every 32 calls using the given `update` function.
+    pub async fn get_or_update_cache<U>(
+        &self,
+        update_fn: impl FnOnce() -> U,
+    ) -> &LocalDataAtomicStats
+    where
+        U: Future<Output = LocalDataStats>,
+    {
+        // Update if necessary
+        if self.check_need_update_and_increment() {
+            let updated = update_fn().await;
+            self.update(updated);
+        }
+
+        // Give caller access to cached (inner) values which are always updated if required
+        &self.stats
+    }
+
     /// Sets all cache values to `new_stats`.
     pub fn update(&self, new_stats: LocalDataStats) {
+        self.stats.update(new_stats)
+    }
+}
+
+/// Same as `LocalDataStats` but each value is atomic.
+#[derive(Default)]
+pub struct LocalDataAtomicStats {
+    vector_storage_size: AtomicUsize,
+    payload_storage_size: AtomicUsize,
+}
+
+impl LocalDataAtomicStats {
+    /// Get the vector storage size.
+    pub fn get_vector_storage_size(&self) -> usize {
+        self.vector_storage_size.load(Ordering::Relaxed)
+    }
+
+    /// Get the payload storage size.
+    pub fn get_payload_storage_size(&self) -> usize {
+        self.payload_storage_size.load(Ordering::Relaxed)
+    }
+
+    fn new(data: LocalDataStats) -> Self {
         let LocalDataStats {
             vector_storage_size,
             payload_storage_size,
-        } = new_stats;
+        } = data;
+        let vector_storage_size = AtomicUsize::new(vector_storage_size);
+        let payload_storage_size = AtomicUsize::new(payload_storage_size);
+        Self {
+            vector_storage_size,
+            payload_storage_size,
+        }
+    }
+
+    fn update(&self, new_values: LocalDataStats) {
+        let LocalDataStats {
+            vector_storage_size,
+            payload_storage_size,
+        } = new_values;
 
         self.vector_storage_size
             .store(vector_storage_size, Ordering::Relaxed);
         self.payload_storage_size
             .store(payload_storage_size, Ordering::Relaxed);
-    }
-
-    /// Returns cached vector storage size estimation.
-    pub fn get_vector_storage(&self) -> usize {
-        self.vector_storage_size.load(Ordering::Relaxed)
-    }
-
-    /// Returns cached payload storage size estimation.
-    pub fn get_payload_storage(&self) -> usize {
-        self.payload_storage_size.load(Ordering::Relaxed)
     }
 }
 

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -411,6 +411,7 @@ mod test {
             max_collection_vector_size_bytes: None,
             read_rate_limit: None,
             write_rate_limit: None,
+            max_collection_payload_size_bytes: None,
         };
 
         fixture_collection(&strict_mode_config).await

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -190,6 +190,7 @@ impl StrictModeVerification for UpdateVectors {
     }
 }
 
+/// Checks all collection size limits that are configured in strict mode.
 async fn check_collection_size_limit(
     collection: &Collection,
     strict_mode_config: &StrictModeConfig,
@@ -197,7 +198,7 @@ async fn check_collection_size_limit(
     let vector_limit = strict_mode_config.max_collection_vector_size_bytes;
     let payload_limit = strict_mode_config.max_collection_payload_size_bytes;
 
-    // All configs to test are disabled/unset so we don't need to check anything nor update cache!.
+    // If all configs are disabled/unset, don't need to check anything nor update cache for performance.
     if (vector_limit, payload_limit) == (None, None) {
         return Ok(());
     }
@@ -215,11 +216,13 @@ async fn check_collection_size_limit(
     Ok(())
 }
 
+/// Check collections vector storage size limit.
 fn check_collection_vector_size_limit(
     max_vec_storage_size_bytes: usize,
     stats: &LocalDataAtomicStats,
 ) -> Result<(), CollectionError> {
     let vec_storage_size_bytes = stats.get_vector_storage_size();
+
     if vec_storage_size_bytes >= max_vec_storage_size_bytes {
         let size_in_mb = max_vec_storage_size_bytes as f32 / (1024.0 * 1024.0);
         return Err(CollectionError::bad_request(format!(
@@ -230,11 +233,13 @@ fn check_collection_vector_size_limit(
     Ok(())
 }
 
+/// Check collections payload storage size limit.
 fn check_collection_payload_size_limit(
     max_payload_storage_size_bytes: usize,
     stats: &LocalDataAtomicStats,
 ) -> Result<(), CollectionError> {
     let payload_storage_size_bytes = stats.get_payload_storage_size();
+
     if payload_storage_size_bytes >= max_payload_storage_size_bytes {
         let size_in_mb = max_payload_storage_size_bytes as f32 / (1024.0 * 1024.0);
         return Err(CollectionError::bad_request(format!(

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1031,14 +1031,17 @@ impl ShardReplicaSet {
             .map(|i| match i {
                 Shard::Local(local) => {
                     let mut total_vector_size = 0;
+                    let mut total_payload_size = 0;
 
                     for segment in local.segments.read().iter() {
                         let size_info = segment.1.get().read().size_info();
                         total_vector_size += size_info.vectors_size_bytes;
+                        total_payload_size += size_info.payloads_size_bytes;
                     }
 
                     LocalDataStats {
                         vector_storage_size: total_vector_size,
+                        payload_storage_size: total_payload_size,
                     }
                 }
                 Shard::Proxy(_)

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1120,7 +1120,7 @@ impl ShardHolder {
     }
 
     /// Queries and accumulates the statistics for local data, uncached.
-    pub async fn calculate_local_segments_stats(&self) -> LocalDataStats {
+    pub async fn calculate_local_shards_stats(&self) -> LocalDataStats {
         let mut stats = LocalDataStats::default();
         for shard in self.shards.iter() {
             stats.accumulate_from(&shard.1.calculate_local_shards_stats().await)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -721,6 +721,10 @@ pub struct StrictModeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
     pub write_rate_limit: Option<usize>,
+
+    /// Max size of a collections payload storage in bytes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_collection_payload_size_bytes: Option<usize>,
 }
 
 impl Eq for StrictModeConfig {}
@@ -739,8 +743,9 @@ impl Hash for StrictModeConfig {
             search_max_oversampling: _,
             upsert_max_batchsize,
             max_collection_vector_size_bytes,
-            read_rate_limit: read_rate_limit_per_minute,
-            write_rate_limit: write_rate_limit_per_minute,
+            read_rate_limit,
+            write_rate_limit,
+            max_collection_payload_size_bytes,
         } = self;
         (
             enabled,
@@ -752,8 +757,9 @@ impl Hash for StrictModeConfig {
             search_allow_exact,
             upsert_max_batchsize,
             max_collection_vector_size_bytes,
-            read_rate_limit_per_minute,
-            write_rate_limit_per_minute,
+            read_rate_limit,
+            write_rate_limit,
+            max_collection_payload_size_bytes,
         )
             .hash(state);
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -91,6 +91,9 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
             .map(|i| i as usize),
         read_rate_limit: value.write_rate_limit.map(|i| i as usize),
         write_rate_limit: value.write_rate_limit.map(|i| i as usize),
+        max_collection_payload_size_bytes: value
+            .max_collection_payload_size_bytes
+            .map(|i| i as usize),
     }
 }
 

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 import random
 
@@ -640,6 +642,134 @@ def test_strict_mode_read_rate_limiting(collection_name):
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
+
+
+def test_strict_mode_max_collection_payload_size_upsert(collection_name):
+    # TODO: Update this function when payload rocksDB storage has been replaced by mmap payload storage!
+    # For now were just asserting a very loose condition to ensure it works at all.
+    # Every required change for the mmap migration has been marked with a "TODO"
+
+    basic_collection_setup(collection_name=collection_name, on_disk_payload=True)  # Clear collection to not depend on other tests
+
+    def upsert_points(ids: list[int]):
+        length = len(ids)
+        payloads = [{"city": "Berlin"} for _ in range(length)]
+        vectors = [[1, 2, 3, 5] for _ in range(length)]
+        return request_with_validation(
+            api='/collections/{collection_name}/points',
+            method="PUT",
+            path_params={'collection_name': collection_name},
+            query_params={'wait': 'true'},
+            body={
+                "batch": {
+                    "ids": ids,
+                    "payloads": payloads,
+                    "vectors": vectors
+                }
+            }
+        )
+
+    # Overwriting the same points to trigger cache refreshing
+    for _ in range(32):
+        upsert_points([1, 2, 3, 4, 5]).raise_for_status()
+
+    time.sleep(15)  # TODO: Remove
+
+    # TODO: Remove
+    # Check that we still can upsert (not needed for mmap)
+    for _ in range(32):
+        upsert_points([1, 2, 3, 4, 5]).raise_for_status()
+    time.sleep(15)  # TODO: Remove
+
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        # "max_collection_payload_size_bytes": 45000,  # TODO: Uncomment and replace the line below
+        "max_collection_payload_size_bytes": 1,
+    })
+
+    # TODO: Uncomment
+    # for _ in range(32):
+    #     upsert_points([6, 7, 8, 9, 10]).raise_for_status()
+
+    # Max limit has been reached and one of the next requests must fail. Due to cache it might not be the first call!
+    for i in range(32):
+        failed_upsert = upsert_points([12, 13, 14, 15, 16])
+        if failed_upsert.ok:
+            # TODO: Remove this if block
+            if i == 0:
+                time.sleep(15)
+            continue
+        assert "Max payload storage size" in failed_upsert.json()['status']['error']
+        assert not failed_upsert.ok
+        return
+
+    assert False, "Upserting should have failed but didn't"
+
+
+def test_strict_mode_max_collection_payload_size_upsert_batch(collection_name):
+    # TODO: Update this function when payload rocksDB storage has been replaced by mmap payload storage!
+    # For now were just asserting a very loose condition to ensure it works at all.
+    # Every required change for the mmap migration has been marked with a "TODO"
+
+    basic_collection_setup(collection_name=collection_name, on_disk_payload=True)  # Clear collection to not depend on other tests
+
+    def upsert_points(ids: list[int]):
+        length = len(ids)
+        payloads = [{"city": "Berlin"} for _ in range(length)]
+        vectors = [[1, 2, 3, 5] for _ in range(length)]
+        return request_with_validation(
+            api='/collections/{collection_name}/points/batch',
+            method="POST",
+            path_params={'collection_name': collection_name},
+            body={
+                "operations": [
+                    {
+                        "upsert": {
+                            "batch": {
+                                "ids": ids,
+                                "payloads": payloads,
+                                "vectors": vectors
+                            }
+                        }
+                    }
+                ]
+            }
+        )
+
+    for _ in range(32):
+        upsert_points([1, 2, 3, 4, 5]).raise_for_status()
+
+    time.sleep(15)  # TODO: Remove
+
+    # TODO: Remove
+    # Check that we still can upsert (not needed for mmap)
+    for _ in range(32):
+        upsert_points([1, 2, 3, 4, 5]).raise_for_status()
+    time.sleep(15)  # TODO: Remove
+
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        # "max_collection_payload_size_bytes": 45000,  # TODO: Uncomment and replace the line below
+        "max_collection_payload_size_bytes": 1,
+    })
+
+    # TODO: Uncomment
+    # for i in range(32):
+    #     upsert_points([6, 7, 8, 9, 10]).raise_for_status()
+
+    # Max limit has been reached and one of the next requests must fail. Due to cache it might not be the first call!
+    for i in range(32):
+        failed_upsert = upsert_points([12, 13, 14, 15, 16])
+        if failed_upsert.ok:
+            # TODO: Remove this if block
+            if i == 0:
+                time.sleep(15)
+            continue
+        assert "Max payload storage size" in failed_upsert.json()['status']['error']
+        assert not failed_upsert.ok
+        return
+
+    assert False, "Upserting should have failed but didn't"
 
 
 def test_strict_mode_write_rate_limiting(collection_name):

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -645,7 +645,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
 
 
 def test_strict_mode_max_collection_payload_size_upsert(collection_name):
-    # TODO: Update this function when payload rocksDB storage has been replaced by mmap payload storage!
+    # TODO: Update this test when payload rocksDB storage has been replaced by mmap payload storage!
     # For now were just asserting a very loose condition to ensure it works at all.
     # Every required change for the mmap migration has been marked with a "TODO"
 
@@ -707,7 +707,7 @@ def test_strict_mode_max_collection_payload_size_upsert(collection_name):
 
 
 def test_strict_mode_max_collection_payload_size_upsert_batch(collection_name):
-    # TODO: Update this function when payload rocksDB storage has been replaced by mmap payload storage!
+    # TODO: Update this test when payload rocksDB storage has been replaced by mmap payload storage!
     # For now were just asserting a very loose condition to ensure it works at all.
     # Every required change for the mmap migration has been marked with a "TODO"
 


### PR DESCRIPTION
Validate the payload storage size when using the strict mode the same way it was done for `max_collection_vector_size_bytes`.