### PR TITLE
Pass inference API token from request to inference service

### DIFF
--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -443,7 +443,6 @@ impl TableOfContent {
     /// # Cancel safety
     ///
     /// This method is cancel safe.
-    #[allow(clippy::too_many_arguments)]
     pub async fn update(
         &self,
         collection_name: &str,

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -443,6 +443,7 @@ impl TableOfContent {
     /// # Cancel safety
     ///
     /// This method is cancel safe.
+    #[allow(clippy::too_many_arguments)]
     pub async fn update(
         &self,
         collection_name: &str,
@@ -451,6 +452,7 @@ impl TableOfContent {
         ordering: WriteOrdering,
         shard_selector: ShardSelectorInternal,
         access: Access,
+        _inference_token: Option<String>,
     ) -> StorageResult<UpdateResult> {
         let collection_pass = access.check_point_op(collection_name, &mut operation.operation)?;
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -452,7 +452,6 @@ impl TableOfContent {
         ordering: WriteOrdering,
         shard_selector: ShardSelectorInternal,
         access: Access,
-        _inference_token: Option<String>,
     ) -> StorageResult<UpdateResult> {
         let collection_pass = access.check_point_op(collection_name, &mut operation.operation)?;
 

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -209,8 +209,7 @@ async fn query_points_groups(
             Some(shard_keys) => shard_keys.into(),
         };
         let query_group_request =
-            convert_query_groups_request_from_rest(search_group_request, inference_token.clone())
-                .await?;
+            convert_query_groups_request_from_rest(search_group_request, inference_token).await?;
 
         do_query_point_groups(
             dispatcher.toc(&access, &pass),

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -63,7 +63,7 @@ async fn query_points(
     let hw_measurement_acc = request_hw_counter.get_counter();
     let result = async move {
         let request =
-            convert_query_request_from_rest(query_request, Some(inference_token.clone())).await?;
+            convert_query_request_from_rest(query_request, inference_token.clone()).await?;
 
         let points = dispatcher
             .toc(&access, &pass)
@@ -133,7 +133,7 @@ async fn query_points_batch(
             } = request;
 
             let request =
-                convert_query_request_from_rest(internal, Some(inference_token.clone())).await?;
+                convert_query_request_from_rest(internal, inference_token.clone()).await?;
             let shard_selection = match shard_key {
                 None => ShardSelectorInternal::All,
                 Some(shard_keys) => shard_keys.into(),
@@ -209,11 +209,9 @@ async fn query_points_groups(
             None => ShardSelectorInternal::All,
             Some(shard_keys) => shard_keys.into(),
         };
-        let query_group_request = convert_query_groups_request_from_rest(
-            search_group_request,
-            Some(inference_token.clone()),
-        )
-        .await?;
+        let query_group_request =
+            convert_query_groups_request_from_rest(search_group_request, inference_token.clone())
+                .await?;
 
         do_query_point_groups(
             dispatcher.toc(&access, &pass),

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -62,7 +62,7 @@ async fn query_points(
     };
     let hw_measurement_acc = request_hw_counter.get_counter();
     let result = async move {
-        let request = convert_query_request_from_rest(query_request, inference_token).await?;
+        let request = convert_query_request_from_rest(query_request, &inference_token).await?;
 
         let points = dispatcher
             .toc(&access, &pass)
@@ -131,8 +131,7 @@ async fn query_points_batch(
                 shard_key,
             } = request;
 
-            let request =
-                convert_query_request_from_rest(internal, inference_token.clone()).await?;
+            let request = convert_query_request_from_rest(internal, &inference_token).await?;
             let shard_selection = match shard_key {
                 None => ShardSelectorInternal::All,
                 Some(shard_keys) => shard_keys.into(),

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -62,8 +62,7 @@ async fn query_points(
     };
     let hw_measurement_acc = request_hw_counter.get_counter();
     let result = async move {
-        let request =
-            convert_query_request_from_rest(query_request, inference_token.clone()).await?;
+        let request = convert_query_request_from_rest(query_request, inference_token).await?;
 
         let points = dispatcher
             .toc(&access, &pass)

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -17,6 +17,7 @@ use validator::Validate;
 use super::CollectionPath;
 use crate::actix::auth::ActixAccess;
 use crate::actix::helpers::{self, process_response, process_response_error};
+use crate::common::inference::InferenceToken;
 use crate::common::points::{
     do_batch_update_points, do_clear_payload, do_create_index, do_delete_index, do_delete_payload,
     do_delete_points, do_delete_vectors, do_overwrite_payload, do_set_payload, do_update_vectors,
@@ -42,6 +43,7 @@ async fn upsert_points(
     operation: Json<PointInsertOperations>,
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
+    inference_token: Option<InferenceToken>,
 ) -> impl Responder {
     let pass =
         match check_strict_mode(&operation.0, None, &collection.name, &dispatcher, &access).await {
@@ -62,6 +64,7 @@ async fn upsert_points(
         wait,
         ordering,
         access,
+        inference_token,
     ))
     .await
 }
@@ -73,6 +76,7 @@ async fn delete_points(
     operation: Json<PointsSelector>,
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
+    inference_token: Option<InferenceToken>,
 ) -> impl Responder {
     let operation = operation.into_inner();
     let pass =
@@ -93,6 +97,7 @@ async fn delete_points(
         wait,
         ordering,
         access,
+        inference_token,
     ))
     .await
 }
@@ -292,6 +297,7 @@ async fn update_batch(
     operations: Json<UpdateOperations>,
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
+    inference_token: Option<InferenceToken>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operations = operations.into_inner();
@@ -324,6 +330,7 @@ async fn update_batch(
         wait,
         ordering,
         access,
+        inference_token,
     )
     .await;
     process_response(response, timing, None)

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -43,7 +43,7 @@ async fn upsert_points(
     operation: Json<PointInsertOperations>,
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> impl Responder {
     let pass =
         match check_strict_mode(&operation.0, None, &collection.name, &dispatcher, &access).await {
@@ -76,7 +76,7 @@ async fn delete_points(
     operation: Json<PointsSelector>,
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> impl Responder {
     let operation = operation.into_inner();
     let pass =
@@ -109,6 +109,7 @@ async fn update_vectors(
     operation: Json<UpdateVectors>,
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
+    inference_token: InferenceToken,
 ) -> impl Responder {
     let operation = operation.into_inner();
     let wait = params.wait.unwrap_or(false);
@@ -129,6 +130,7 @@ async fn update_vectors(
         wait,
         ordering,
         access,
+        inference_token,
     ))
     .await
 }
@@ -297,7 +299,7 @@ async fn update_batch(
     operations: Json<UpdateOperations>,
     params: Query<UpdateParam>,
     ActixAccess(access): ActixAccess,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> impl Responder {
     let timing = Instant::now();
     let operations = operations.into_inner();

--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -9,7 +9,7 @@ use futures_util::future::LocalBoxFuture;
 use storage::rbac::Access;
 
 use super::helpers::HttpError;
-use crate::common::auth::{AuthError, AuthKeys};
+use crate::common::auth::{ApiKey, AuthError, AuthKeys};
 
 pub struct Auth {
     auth_keys: AuthKeys,
@@ -122,7 +122,7 @@ where
             {
                 Ok((access, api_key)) => {
                     let previous = req.extensions_mut().insert::<Access>(access);
-                    req.extensions_mut().insert(api_key.to_string());
+                    req.extensions_mut().insert(ApiKey::new(api_key));
                     debug_assert!(
                         previous.is_none(),
                         "Previous access object should not exist in the request"

--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -109,7 +109,6 @@ where
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let path = req.path();
-
         if self.is_path_whitelisted(path) {
             return Box::pin(self.service.call(req));
         }
@@ -121,8 +120,9 @@ where
                 .validate_request(|key| req.headers().get(key).and_then(|val| val.to_str().ok()))
                 .await
             {
-                Ok(access) => {
+                Ok((access, api_key)) => {
                     let previous = req.extensions_mut().insert::<Access>(access);
+                    req.extensions_mut().insert(api_key.to_string());
                     debug_assert!(
                         previous.is_none(),
                         "Previous access object should not exist in the request"

--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -9,7 +9,8 @@ use futures_util::future::LocalBoxFuture;
 use storage::rbac::Access;
 
 use super::helpers::HttpError;
-use crate::common::auth::{ApiKey, AuthError, AuthKeys};
+use crate::common::auth::{AuthError, AuthKeys};
+use crate::common::inference::InferenceToken;
 
 pub struct Auth {
     auth_keys: AuthKeys,
@@ -122,7 +123,8 @@ where
             {
                 Ok((access, api_key)) => {
                     let previous = req.extensions_mut().insert::<Access>(access);
-                    req.extensions_mut().insert(ApiKey::new(api_key));
+                    req.extensions_mut()
+                        .insert(InferenceToken::new(api_key.to_string()));
                     debug_assert!(
                         previous.is_none(),
                         "Previous access object should not exist in the request"

--- a/src/common/auth/claims.rs
+++ b/src/common/auth/claims.rs
@@ -6,6 +6,8 @@ use validator::{Validate, ValidationErrors};
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Claims {
+    pub sub: Option<String>,
+
     /// Expiration time (seconds since UNIX epoch)
     pub exp: Option<u64>,
 

--- a/src/common/auth/claims.rs
+++ b/src/common/auth/claims.rs
@@ -6,6 +6,7 @@ use validator::{Validate, ValidationErrors};
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Claims {
+    /// The subject ID; can be a subscription ID, cluster ID, or user ID
     pub sub: Option<String>,
 
     /// Expiration time (seconds since UNIX epoch)

--- a/src/common/auth/jwt_parser.rs
+++ b/src/common/auth/jwt_parser.rs
@@ -76,6 +76,7 @@ mod tests {
             .expect("Time went backwards")
             .as_secs();
         let claims = Claims {
+            sub: None,
             exp: Some(exp),
             access: Access::Collection(CollectionAccessList(vec![CollectionAccess {
                 collection: "collection".to_string(),
@@ -113,6 +114,7 @@ mod tests {
             - 31; // 31 seconds in the past, bigger than the 30 seconds leeway
 
         let mut claims = Claims {
+            sub: None,
             exp: Some(exp),
             access: Access::Global(GlobalAccessMode::Read),
             value_exists: None,
@@ -139,6 +141,7 @@ mod tests {
     #[test]
     fn test_invalid_token() {
         let claims = Claims {
+            sub: None,
             exp: None,
             access: Access::Global(GlobalAccessMode::Read),
             value_exists: None,

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::sync::Arc;
 
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
@@ -11,32 +10,12 @@ use storage::rbac::Access;
 use self::claims::{Claims, ValueExists};
 use self::jwt_parser::JwtParser;
 use super::strings::ct_eq;
+use crate::common::inference::InferenceToken;
 use crate::settings::ServiceConfig;
 pub mod claims;
 pub mod jwt_parser;
 
 pub const HTTP_HEADER_API_KEY: &str = "api-key";
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct ApiKey(pub String);
-
-impl ApiKey {
-    #[allow(dead_code)]
-    pub fn new(key: ApiKey) -> Self {
-        ApiKey(key.to_string())
-    }
-
-    #[allow(dead_code)]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl fmt::Display for ApiKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 /// The API keys used for auth
 #[derive(Clone)]
@@ -95,7 +74,7 @@ impl AuthKeys {
     pub async fn validate_request<'a>(
         &self,
         get_header: impl Fn(&'a str) -> Option<&'a str>,
-    ) -> Result<(Access, ApiKey), AuthError> {
+    ) -> Result<(Access, InferenceToken), AuthError> {
         let Some(key) = get_header(HTTP_HEADER_API_KEY)
             .or_else(|| get_header("authorization").and_then(|v| v.strip_prefix("Bearer ")))
         else {
@@ -107,14 +86,14 @@ impl AuthKeys {
         if self.can_write(key) {
             return Ok((
                 Access::full("Read-write access by key"),
-                ApiKey(key.to_string()),
+                InferenceToken(key.to_string()),
             ));
         }
 
         if self.can_read(key) {
             return Ok((
                 Access::full_ro("Read-only access by key"),
-                ApiKey(key.to_string()),
+                InferenceToken(key.to_string()),
             ));
         }
 
@@ -129,7 +108,7 @@ impl AuthKeys {
                 self.validate_value_exists(&value_exists).await?;
             }
 
-            return Ok((access, ApiKey(key.to_string())));
+            return Ok((access, InferenceToken(key.to_string())));
         }
 
         Err(AuthError::Unauthorized(

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -86,19 +86,20 @@ impl AuthKeys {
         if self.can_write(key) {
             return Ok((
                 Access::full("Read-write access by key"),
-                InferenceToken(Some(key.to_string())),
+                InferenceToken(None),
             ));
         }
 
         if self.can_read(key) {
             return Ok((
                 Access::full_ro("Read-only access by key"),
-                InferenceToken(Some(key.to_string())),
+                InferenceToken(None),
             ));
         }
 
         if let Some(claims) = self.jwt_parser.as_ref().and_then(|p| p.decode(key)) {
             let Claims {
+                sub,
                 exp: _, // already validated on decoding
                 access,
                 value_exists,
@@ -108,7 +109,7 @@ impl AuthKeys {
                 self.validate_value_exists(&value_exists).await?;
             }
 
-            return Ok((access, InferenceToken(Some(key.to_string()))));
+            return Ok((access, InferenceToken(sub)));
         }
 
         Err(AuthError::Unauthorized(

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -86,14 +86,14 @@ impl AuthKeys {
         if self.can_write(key) {
             return Ok((
                 Access::full("Read-write access by key"),
-                InferenceToken(key.to_string()),
+                InferenceToken(Some(key.to_string())),
             ));
         }
 
         if self.can_read(key) {
             return Ok((
                 Access::full_ro("Read-only access by key"),
-                InferenceToken(key.to_string()),
+                InferenceToken(Some(key.to_string())),
             ));
         }
 
@@ -108,7 +108,7 @@ impl AuthKeys {
                 self.validate_value_exists(&value_exists).await?;
             }
 
-            return Ok((access, InferenceToken(key.to_string())));
+            return Ok((access, InferenceToken(Some(key.to_string()))));
         }
 
         Err(AuthError::Unauthorized(

--- a/src/common/inference/infer_processing.rs
+++ b/src/common/inference/infer_processing.rs
@@ -63,10 +63,10 @@ impl BatchAccumInferred {
     pub async fn from_batch_accum(
         batch: BatchAccum,
         inference_type: InferenceType,
-        inference_token: InferenceToken,
+        inference_token: &InferenceToken,
     ) -> Result<Self, StorageError> {
         let BatchAccum { objects } = batch;
-        Self::from_objects(objects, inference_type, inference_token).await
+        Self::from_objects(objects, inference_type, inference_token.clone()).await
     }
 
     pub fn get_vector(&self, data: &InferenceData) -> Option<&VectorPersisted> {

--- a/src/common/inference/infer_processing.rs
+++ b/src/common/inference/infer_processing.rs
@@ -5,6 +5,7 @@ use storage::content_manager::errors::StorageError;
 
 use super::batch_processing::BatchAccum;
 use super::service::{InferenceData, InferenceInput, InferenceService, InferenceType};
+use crate::common::inference::InferenceToken;
 
 pub struct BatchAccumInferred {
     pub(crate) objects: HashMap<InferenceData, VectorPersisted>,
@@ -20,6 +21,7 @@ impl BatchAccumInferred {
     pub async fn from_objects(
         objects: HashSet<InferenceData>,
         inference_type: InferenceType,
+        inference_token: InferenceToken,
     ) -> Result<Self, StorageError> {
         if objects.is_empty() {
             return Ok(Self::new());
@@ -41,7 +43,7 @@ impl BatchAccumInferred {
             .collect();
 
         let vectors = service
-            .infer(inference_inputs, inference_type)
+            .infer(inference_inputs, inference_type, inference_token)
             .await
             .map_err(|e| StorageError::service_error(
                 format!("Inference request failed. Check if inference service is running and properly configured: {e}")
@@ -61,9 +63,10 @@ impl BatchAccumInferred {
     pub async fn from_batch_accum(
         batch: BatchAccum,
         inference_type: InferenceType,
+        inference_token: InferenceToken,
     ) -> Result<Self, StorageError> {
         let BatchAccum { objects } = batch;
-        Self::from_objects(objects, inference_type).await
+        Self::from_objects(objects, inference_type, inference_token).await
     }
 
     pub fn get_vector(&self, data: &InferenceData) -> Option<&VectorPersisted> {

--- a/src/common/inference/mod.rs
+++ b/src/common/inference/mod.rs
@@ -1,3 +1,9 @@
+use std::convert::Infallible;
+use std::fmt;
+use std::future::{ready, Ready};
+
+use actix_web::{FromRequest, HttpMessage};
+
 mod batch_processing;
 mod batch_processing_grpc;
 pub(crate) mod config;
@@ -6,3 +12,39 @@ pub mod query_requests_grpc;
 pub mod query_requests_rest;
 pub mod service;
 pub mod update_requests;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InferenceToken(pub String);
+
+impl InferenceToken {
+    pub fn new(key: String) -> Self {
+        InferenceToken(key)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromRequest for InferenceToken {
+    type Error = Infallible;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(
+        req: &actix_web::HttpRequest,
+        _payload: &mut actix_web::dev::Payload,
+    ) -> Self::Future {
+        let api_key = req.extensions().get::<InferenceToken>().cloned();
+        ready(Ok(api_key.unwrap_or_else(|| InferenceToken("".to_string()))))
+    }
+}
+
+impl fmt::Display for InferenceToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub fn extract_token<R>(req: &mut tonic::Request<R>) -> Option<InferenceToken> {
+    req.extensions_mut().get::<InferenceToken>().cloned()
+}

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -19,10 +19,12 @@ use crate::common::inference::batch_processing_grpc::{
 };
 use crate::common::inference::infer_processing::BatchAccumInferred;
 use crate::common::inference::service::{InferenceData, InferenceType};
+use crate::common::inference::InferenceToken;
 
 /// ToDo: this function is supposed to call an inference endpoint internally
 pub async fn convert_query_point_groups_from_grpc(
     query: grpc::QueryPointGroups,
+    inference_token: InferenceToken,
 ) -> Result<CollectionQueryGroupsRequest, Status> {
     let grpc::QueryPointGroups {
         collection_name: _,
@@ -56,9 +58,10 @@ pub async fn convert_query_point_groups_from_grpc(
 
     let BatchAccumGrpc { objects } = batch;
 
-    let inferred = BatchAccumInferred::from_objects(objects, InferenceType::Search)
-        .await
-        .map_err(|e| Status::internal(format!("Inference error: {e}")))?;
+    let inferred =
+        BatchAccumInferred::from_objects(objects, InferenceType::Search, inference_token)
+            .await
+            .map_err(|e| Status::internal(format!("Inference error: {e}")))?;
 
     let query = if let Some(q) = query {
         Some(convert_query_with_inferred(q, &inferred)?)
@@ -102,6 +105,7 @@ pub async fn convert_query_point_groups_from_grpc(
 /// ToDo: this function is supposed to call an inference endpoint internally
 pub async fn convert_query_points_from_grpc(
     query: grpc::QueryPoints,
+    inference_token: InferenceToken,
 ) -> Result<CollectionQueryRequest, Status> {
     let grpc::QueryPoints {
         collection_name: _,
@@ -133,9 +137,10 @@ pub async fn convert_query_points_from_grpc(
 
     let BatchAccumGrpc { objects } = batch;
 
-    let inferred = BatchAccumInferred::from_objects(objects, InferenceType::Search)
-        .await
-        .map_err(|e| Status::internal(format!("Inference error: {e}")))?;
+    let inferred =
+        BatchAccumInferred::from_objects(objects, InferenceType::Search, inference_token)
+            .await
+            .map_err(|e| Status::internal(format!("Inference error: {e}")))?;
 
     let prefetch = prefetch
         .into_iter()

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -19,7 +19,7 @@ use crate::common::inference::InferenceToken;
 
 pub async fn convert_query_groups_request_from_rest(
     request: rest::QueryGroupsRequestInternal,
-    inference_key: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<CollectionQueryGroupsRequest, StorageError> {
     let batch = collect_query_groups_request(&request);
     let rest::QueryGroupsRequestInternal {
@@ -34,9 +34,9 @@ pub async fn convert_query_groups_request_from_rest(
         lookup_from,
         group_request,
     } = request;
-    println!("InferenceKey (convert_query_groups_request_from_rest) >> {inference_key:?}",);
 
-    let inferred = BatchAccumInferred::from_batch_accum(batch, InferenceType::Search).await?;
+    let inferred =
+        BatchAccumInferred::from_batch_accum(batch, InferenceType::Search, inference_token).await?;
     let query = query
         .map(|q| convert_query_with_inferred(q, &inferred))
         .transpose()?;
@@ -74,10 +74,11 @@ pub async fn convert_query_groups_request_from_rest(
 
 pub async fn convert_query_request_from_rest(
     request: rest::QueryRequestInternal,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<CollectionQueryRequest, StorageError> {
     let batch = collect_query_request(&request);
-    let inferred = BatchAccumInferred::from_batch_accum(batch, InferenceType::Search).await?;
+    let inferred =
+        BatchAccumInferred::from_batch_accum(batch, InferenceType::Search, inference_token).await?;
     let rest::QueryRequestInternal {
         prefetch,
         query,
@@ -91,8 +92,6 @@ pub async fn convert_query_request_from_rest(
         with_payload,
         lookup_from,
     } = request;
-
-    println!("InferenceKey >> {inference_token:?}");
 
     let prefetch = prefetch
         .map(|prefetches| {

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -10,6 +10,7 @@ use segment::data_types::vectors::{MultiDenseVectorInternal, VectorInternal, DEF
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use storage::content_manager::errors::StorageError;
 
+use crate::common::auth::ApiKey;
 use crate::common::inference::batch_processing::{
     collect_query_groups_request, collect_query_request,
 };
@@ -18,6 +19,7 @@ use crate::common::inference::service::{InferenceData, InferenceType};
 
 pub async fn convert_query_groups_request_from_rest(
     request: rest::QueryGroupsRequestInternal,
+    _api_key: Option<ApiKey>,
 ) -> Result<CollectionQueryGroupsRequest, StorageError> {
     let batch = collect_query_groups_request(&request);
     let rest::QueryGroupsRequestInternal {
@@ -71,6 +73,7 @@ pub async fn convert_query_groups_request_from_rest(
 
 pub async fn convert_query_request_from_rest(
     request: rest::QueryRequestInternal,
+    _api_key: Option<ApiKey>,
 ) -> Result<CollectionQueryRequest, StorageError> {
     let batch = collect_query_request(&request);
     let inferred = BatchAccumInferred::from_batch_accum(batch, InferenceType::Search).await?;

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -36,7 +36,8 @@ pub async fn convert_query_groups_request_from_rest(
     } = request;
 
     let inferred =
-        BatchAccumInferred::from_batch_accum(batch, InferenceType::Search, inference_token).await?;
+        BatchAccumInferred::from_batch_accum(batch, InferenceType::Search, &inference_token)
+            .await?;
     let query = query
         .map(|q| convert_query_with_inferred(q, &inferred))
         .transpose()?;
@@ -74,7 +75,7 @@ pub async fn convert_query_groups_request_from_rest(
 
 pub async fn convert_query_request_from_rest(
     request: rest::QueryRequestInternal,
-    inference_token: InferenceToken,
+    inference_token: &InferenceToken,
 ) -> Result<CollectionQueryRequest, StorageError> {
     let batch = collect_query_request(&request);
     let inferred =

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -10,16 +10,16 @@ use segment::data_types::vectors::{MultiDenseVectorInternal, VectorInternal, DEF
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use storage::content_manager::errors::StorageError;
 
-use crate::common::auth::ApiKey;
 use crate::common::inference::batch_processing::{
     collect_query_groups_request, collect_query_request,
 };
 use crate::common::inference::infer_processing::BatchAccumInferred;
 use crate::common::inference::service::{InferenceData, InferenceType};
+use crate::common::inference::InferenceToken;
 
 pub async fn convert_query_groups_request_from_rest(
     request: rest::QueryGroupsRequestInternal,
-    _api_key: Option<ApiKey>,
+    inference_key: Option<InferenceToken>,
 ) -> Result<CollectionQueryGroupsRequest, StorageError> {
     let batch = collect_query_groups_request(&request);
     let rest::QueryGroupsRequestInternal {
@@ -34,6 +34,7 @@ pub async fn convert_query_groups_request_from_rest(
         lookup_from,
         group_request,
     } = request;
+    println!("InferenceKey (convert_query_groups_request_from_rest) >> {inference_key:?}",);
 
     let inferred = BatchAccumInferred::from_batch_accum(batch, InferenceType::Search).await?;
     let query = query
@@ -73,7 +74,7 @@ pub async fn convert_query_groups_request_from_rest(
 
 pub async fn convert_query_request_from_rest(
     request: rest::QueryRequestInternal,
-    _api_key: Option<ApiKey>,
+    inference_token: Option<InferenceToken>,
 ) -> Result<CollectionQueryRequest, StorageError> {
     let batch = collect_query_request(&request);
     let inferred = BatchAccumInferred::from_batch_accum(batch, InferenceType::Search).await?;
@@ -90,6 +91,8 @@ pub async fn convert_query_request_from_rest(
         with_payload,
         lookup_from,
     } = request;
+
+    println!("InferenceKey >> {inference_token:?}");
 
     let prefetch = prefetch
         .map(|prefetches| {

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -173,14 +173,16 @@ impl InferenceService {
         inference_type: InferenceType,
         inference_token: InferenceToken,
     ) -> Result<Vec<VectorPersisted>, StorageError> {
-        let token = inference_token
-            .0
-            .unwrap_or_else(|| self.config.token.clone().unwrap_or_default());
+        // Assume that either:
+        // - User doesn't have access to generating random JWT tokens (like in serverless)
+        // - Inference server checks validity of the tokens.
+
+        let token = inference_token.0.or_else(|| self.config.token.clone());
 
         let request = InferenceRequest {
             inputs: inference_inputs,
             inference: Some(inference_type),
-            token: Some(token),
+            token,
         };
 
         let url = self.config.address.as_ref().ok_or_else(|| {

--- a/src/common/inference/update_requests.rs
+++ b/src/common/inference/update_requests.rs
@@ -11,12 +11,16 @@ use storage::content_manager::errors::StorageError;
 use crate::common::inference::batch_processing::BatchAccum;
 use crate::common::inference::infer_processing::BatchAccumInferred;
 use crate::common::inference::service::{InferenceData, InferenceType};
+use crate::common::inference::InferenceToken;
 
 pub async fn convert_point_struct(
     point_structs: Vec<PointStruct>,
     inference_type: InferenceType,
+    inference_token: Option<InferenceToken>,
 ) -> Result<Vec<PointStructPersisted>, StorageError> {
     let mut batch_accum = BatchAccum::new();
+
+    println!("InferenceToken {inference_token:?}");
 
     for point_struct in &point_structs {
         match &point_struct.vector {
@@ -143,12 +147,17 @@ pub async fn convert_point_struct(
     Ok(converted_points)
 }
 
-pub async fn convert_batch(batch: Batch) -> Result<BatchPersisted, StorageError> {
+pub async fn convert_batch(
+    batch: Batch,
+    inference_token: Option<InferenceToken>,
+) -> Result<BatchPersisted, StorageError> {
     let Batch {
         ids,
         vectors,
         payloads,
     } = batch;
+
+    println!("InferenceToken {inference_token:?}",);
 
     let batch_persisted = BatchPersisted {
         ids,

--- a/src/common/inference/update_requests.rs
+++ b/src/common/inference/update_requests.rs
@@ -43,7 +43,7 @@ pub async fn convert_point_struct(
 
     let inferred = if !batch_accum.objects.is_empty() {
         Some(
-            BatchAccumInferred::from_batch_accum(batch_accum, inference_type, inference_token)
+            BatchAccumInferred::from_batch_accum(batch_accum, inference_type, &inference_token)
                 .await?,
         )
     } else {
@@ -220,7 +220,7 @@ pub async fn convert_point_vectors(
 
     let inferred = if !batch_accum.objects.is_empty() {
         Some(
-            BatchAccumInferred::from_batch_accum(batch_accum, inference_type, inference_token)
+            BatchAccumInferred::from_batch_accum(batch_accum, inference_type, &inference_token)
                 .await?,
         )
     } else {
@@ -370,7 +370,7 @@ pub async fn convert_vectors(
 
     let inferred = if !batch_accum.objects.is_empty() {
         Some(
-            BatchAccumInferred::from_batch_accum(batch_accum, inference_type, inference_token)
+            BatchAccumInferred::from_batch_accum(batch_accum, inference_type, &inference_token)
                 .await?,
         )
     } else {

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -263,7 +263,7 @@ pub async fn do_upsert_points(
     wait: bool,
     ordering: WriteOrdering,
     access: Access,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<UpdateResult, StorageError> {
     let (shard_key, operation) = match operation {
         PointInsertOperations::PointsBatch(PointsBatch { batch, shard_key }) => (
@@ -292,7 +292,6 @@ pub async fn do_upsert_points(
         ordering,
         shard_selector,
         access,
-        None,
     )
     .await
 }
@@ -307,7 +306,7 @@ pub async fn do_delete_points(
     wait: bool,
     ordering: WriteOrdering,
     access: Access,
-    _inference_token: Option<InferenceToken>,
+    _inference_token: InferenceToken,
 ) -> Result<UpdateResult, StorageError> {
     let (point_operation, shard_key) = match points {
         PointsSelector::PointIdsSelector(PointIdsList { points, shard_key }) => {
@@ -327,7 +326,6 @@ pub async fn do_delete_points(
         ordering,
         shard_selector,
         access,
-        None,
     )
     .await
 }
@@ -342,10 +340,12 @@ pub async fn do_update_vectors(
     wait: bool,
     ordering: WriteOrdering,
     access: Access,
+    inference_token: InferenceToken,
 ) -> Result<UpdateResult, StorageError> {
     let UpdateVectors { points, shard_key } = operation;
 
-    let persisted_points = convert_point_vectors(points, InferenceType::Update).await?;
+    let persisted_points =
+        convert_point_vectors(points, InferenceType::Update, inference_token).await?;
 
     let collection_operation = CollectionUpdateOperations::VectorOperation(
         VectorOperations::UpdateVectors(UpdateVectorsOp {
@@ -362,7 +362,6 @@ pub async fn do_update_vectors(
         ordering,
         shard_selector,
         access,
-        None,
     )
     .await
 }
@@ -406,7 +405,6 @@ pub async fn do_delete_vectors(
                 ordering,
                 shard_selector.clone(),
                 access.clone(),
-                None,
             )
             .await?,
         );
@@ -423,7 +421,6 @@ pub async fn do_delete_vectors(
                 ordering,
                 shard_selector,
                 access,
-                None,
             )
             .await?,
         );
@@ -468,7 +465,6 @@ pub async fn do_set_payload(
         ordering,
         shard_selector,
         access,
-        None,
     )
     .await
 }
@@ -510,7 +506,6 @@ pub async fn do_overwrite_payload(
         ordering,
         shard_selector,
         access,
-        None,
     )
     .await
 }
@@ -549,7 +544,6 @@ pub async fn do_delete_payload(
         ordering,
         shard_selector,
         access,
-        None,
     )
     .await
 }
@@ -585,7 +579,6 @@ pub async fn do_clear_payload(
         ordering,
         shard_selector,
         access,
-        None,
     )
     .await
 }
@@ -600,7 +593,7 @@ pub async fn do_batch_update_points(
     wait: bool,
     ordering: WriteOrdering,
     access: Access,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<Vec<UpdateResult>, StorageError> {
     let mut results = Vec::with_capacity(operations.len());
     for operation in operations {
@@ -695,6 +688,7 @@ pub async fn do_batch_update_points(
                     wait,
                     ordering,
                     access.clone(),
+                    inference_token.clone(),
                 )
                 .await
             }
@@ -748,7 +742,6 @@ pub async fn do_create_index_internal(
         ordering,
         shard_selector,
         Access::full("Internal API"),
-        None,
     )
     .await
 }
@@ -835,7 +828,6 @@ pub async fn do_delete_index_internal(
         ordering,
         shard_selector,
         Access::full("Internal API"),
-        None,
     )
     .await
 }

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -26,6 +26,7 @@ use super::points_common::{
     recommend_groups, scroll, search_groups, search_points_matrix, update_batch, update_vectors,
 };
 use super::validate;
+use crate::common::inference::extract_token;
 use crate::settings::ServiceConfig;
 use crate::tonic::api::points_common::{
     clear_payload, convert_shard_selector_for_read, core_search_batch, count, create_field_index,
@@ -66,6 +67,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
 
         let access = extract_access(&mut request);
+        let inference_token = extract_token(&mut request);
 
         upsert(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
@@ -73,6 +75,7 @@ impl Points for PointsService {
             None,
             None,
             access,
+            inference_token,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -85,6 +88,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
 
         let access = extract_access(&mut request);
+        let inference_token = extract_token(&mut request);
 
         delete(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
@@ -92,6 +96,7 @@ impl Points for PointsService {
             None,
             None,
             access,
+            inference_token,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -234,8 +239,17 @@ impl Points for PointsService {
         validate(request.get_ref())?;
 
         let access = extract_access(&mut request);
+        let inference_token = extract_token(&mut request);
 
-        update_batch(&self.dispatcher, request.into_inner(), None, None, access).await
+        update_batch(
+            &self.dispatcher,
+            request.into_inner(),
+            None,
+            None,
+            access,
+            inference_token,
+        )
+        .await
     }
 
     async fn create_field_index(

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -67,7 +67,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
 
         let access = extract_access(&mut request);
-        let inference_token = extract_token(&mut request);
+        let inference_token = extract_token(&request);
 
         upsert(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
@@ -88,7 +88,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
 
         let access = extract_access(&mut request);
-        let inference_token = extract_token(&mut request);
+        let inference_token = extract_token(&request);
 
         delete(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
@@ -125,6 +125,7 @@ impl Points for PointsService {
         // Nothing to verify here.
 
         let access = extract_access(&mut request);
+        let inference_token = extract_token(&request);
 
         update_vectors(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
@@ -132,6 +133,7 @@ impl Points for PointsService {
             None,
             None,
             access,
+            inference_token,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -239,7 +241,7 @@ impl Points for PointsService {
         validate(request.get_ref())?;
 
         let access = extract_access(&mut request);
-        let inference_token = extract_token(&mut request);
+        let inference_token = extract_token(&request);
 
         update_batch(
             &self.dispatcher,
@@ -534,6 +536,7 @@ impl Points for PointsService {
     ) -> Result<Response<QueryResponse>, Status> {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
+        let inference_token = extract_token(&request);
         let collection_name = request.get_ref().collection_name.clone();
         let hw_metrics = self.get_request_collection_hw_usage_counter(collection_name);
 
@@ -543,6 +546,7 @@ impl Points for PointsService {
             None,
             access,
             hw_metrics,
+            inference_token,
         )
         .await?;
 
@@ -555,6 +559,7 @@ impl Points for PointsService {
     ) -> Result<Response<QueryBatchResponse>, Status> {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
+        let inference_token = extract_token(&request);
         let request = request.into_inner();
         let QueryBatchPoints {
             collection_name,
@@ -572,6 +577,7 @@ impl Points for PointsService {
             access,
             timeout,
             hw_metrics,
+            inference_token,
         )
         .await?;
 
@@ -583,6 +589,7 @@ impl Points for PointsService {
         mut request: Request<QueryPointGroups>,
     ) -> Result<Response<QueryGroupsResponse>, Status> {
         let access = extract_access(&mut request);
+        let inference_token = extract_token(&request);
         let collection_name = request.get_ref().collection_name.clone();
         let hw_metrics = self.get_request_collection_hw_usage_counter(collection_name);
 
@@ -592,6 +599,7 @@ impl Points for PointsService {
             None,
             access,
             hw_metrics,
+            inference_token,
         )
         .await?;
 

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -117,7 +117,7 @@ pub async fn upsert(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let UpsertPoints {
         collection_name,
@@ -162,7 +162,7 @@ pub async fn sync(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let SyncPoints {
         collection_name,
@@ -205,7 +205,6 @@ pub async fn sync(
             write_ordering_from_proto(ordering)?,
             shard_selector,
             access,
-            None,
         )
         .await?;
 
@@ -219,7 +218,7 @@ pub async fn delete(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeletePoints {
         collection_name,
@@ -262,6 +261,7 @@ pub async fn update_vectors(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
+    inference_token: InferenceToken,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let UpdatePointVectors {
         collection_name,
@@ -304,6 +304,7 @@ pub async fn update_vectors(
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
         access,
+        inference_token,
     )
     .await?;
 
@@ -550,7 +551,7 @@ pub async fn update_batch(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
-    inference_token: Option<InferenceToken>,
+    inference_token: InferenceToken,
 ) -> Result<Response<UpdateBatchResponse>, Status> {
     let UpdateBatchPoints {
         collection_name,
@@ -716,6 +717,7 @@ pub async fn update_batch(
                     clock_tag,
                     shard_selection,
                     access.clone(),
+                    inference_token.clone(),
                 )
                 .await
             }
@@ -1779,6 +1781,7 @@ pub async fn query(
     shard_selection: Option<ShardId>,
     access: Access,
     request_hw_counter: RequestHwCounter,
+    inference_token: InferenceToken,
 ) -> Result<Response<QueryResponse>, Status> {
     let shard_key_selector = query_points.shard_key_selector.clone();
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
@@ -1789,7 +1792,7 @@ pub async fn query(
         .transpose()?;
     let collection_name = query_points.collection_name.clone();
     let timeout = query_points.timeout;
-    let request = convert_query_points_from_grpc(query_points).await?;
+    let request = convert_query_points_from_grpc(query_points, inference_token).await?;
 
     let toc = toc_provider
         .check_strict_mode(
@@ -1827,6 +1830,7 @@ pub async fn query(
     Ok(Response::new(response))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn query_batch(
     toc_provider: impl CheckedTocProvider,
     collection_name: &str,
@@ -1835,13 +1839,14 @@ pub async fn query_batch(
     access: Access,
     timeout: Option<Duration>,
     request_hw_counter: RequestHwCounter,
+    inference_token: InferenceToken,
 ) -> Result<Response<QueryBatchResponse>, Status> {
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
     let mut requests = Vec::with_capacity(points.len());
     for query_points in points {
         let shard_key_selector = query_points.shard_key_selector.clone();
         let shard_selector = convert_shard_selector_for_read(None, shard_key_selector);
-        let request = convert_query_points_from_grpc(query_points).await?;
+        let request = convert_query_points_from_grpc(query_points, inference_token.clone()).await?;
         requests.push((request, shard_selector));
     }
 
@@ -1887,6 +1892,7 @@ pub async fn query_groups(
     shard_selection: Option<ShardId>,
     access: Access,
     request_hw_counter: RequestHwCounter,
+    inference_token: InferenceToken,
 ) -> Result<Response<QueryGroupsResponse>, Status> {
     let shard_key_selector = query_points.shard_key_selector.clone();
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
@@ -1897,7 +1903,7 @@ pub async fn query_groups(
         .transpose()?;
     let timeout = query_points.timeout;
     let collection_name = query_points.collection_name.clone();
-    let request = convert_query_point_groups_from_grpc(query_points).await?;
+    let request = convert_query_point_groups_from_grpc(query_points, inference_token).await?;
 
     let toc = toc_provider
         .check_strict_mode(

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -58,6 +58,7 @@ use crate::common::inference::query_requests_grpc::{
 };
 use crate::common::inference::service::InferenceType;
 use crate::common::inference::update_requests::convert_point_struct;
+use crate::common::inference::InferenceToken;
 use crate::common::points::{
     do_clear_payload, do_core_search_points, do_count_points, do_create_index,
     do_create_index_internal, do_delete_index, do_delete_index_internal, do_delete_payload,
@@ -116,6 +117,7 @@ pub async fn upsert(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
+    inference_token: Option<InferenceToken>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let UpsertPoints {
         collection_name,
@@ -146,6 +148,7 @@ pub async fn upsert(
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
         access,
+        inference_token,
     )
     .await?;
 
@@ -159,6 +162,7 @@ pub async fn sync(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
+    inference_token: Option<InferenceToken>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let SyncPoints {
         collection_name,
@@ -175,7 +179,8 @@ pub async fn sync(
 
     // No actual inference should happen here, as we are just syncing existing points
     // So this function is used for consistency only
-    let points = convert_point_struct(point_structs?, InferenceType::Update).await?;
+    let points =
+        convert_point_struct(point_structs?, InferenceType::Update, inference_token).await?;
 
     let operation = PointSyncOperation {
         points,
@@ -200,6 +205,7 @@ pub async fn sync(
             write_ordering_from_proto(ordering)?,
             shard_selector,
             access,
+            None,
         )
         .await?;
 
@@ -213,6 +219,7 @@ pub async fn delete(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
+    inference_token: Option<InferenceToken>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeletePoints {
         collection_name,
@@ -241,6 +248,7 @@ pub async fn delete(
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
         access,
+        inference_token,
     )
     .await?;
 
@@ -542,6 +550,7 @@ pub async fn update_batch(
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     access: Access,
+    inference_token: Option<InferenceToken>,
 ) -> Result<Response<UpdateBatchResponse>, Status> {
     let UpdateBatchPoints {
         collection_name,
@@ -575,6 +584,7 @@ pub async fn update_batch(
                     clock_tag,
                     shard_selection,
                     access.clone(),
+                    inference_token.clone(),
                 )
                 .await
             }
@@ -591,6 +601,7 @@ pub async fn update_batch(
                     clock_tag,
                     shard_selection,
                     access.clone(),
+                    inference_token.clone(),
                 )
                 .await
             }
@@ -763,6 +774,7 @@ pub async fn update_batch(
                     clock_tag,
                     shard_selection,
                     access.clone(),
+                    inference_token.clone(),
                 )
                 .await
             }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -28,6 +28,7 @@ use tonic::{Request, Response, Status};
 
 use super::points_common::{core_search_list, scroll};
 use super::validate_and_log;
+use crate::common::inference::InferenceToken;
 use crate::settings::ServiceConfig;
 use crate::tonic::api::points_common::{
     clear_payload, count, create_field_index_internal, delete, delete_field_index_internal,
@@ -177,6 +178,8 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
+        let inference_token = request.extensions().get::<InferenceToken>().cloned();
+
         let UpsertPointsInternal {
             upsert_points,
             shard_id,
@@ -192,6 +195,7 @@ impl PointsInternal for PointsInternalService {
             clock_tag.map(Into::into),
             shard_id,
             FULL_ACCESS.clone(),
+            inference_token,
         )
         .await
     }
@@ -201,6 +205,8 @@ impl PointsInternal for PointsInternalService {
         request: Request<DeletePointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let inference_token = request.extensions().get::<InferenceToken>().cloned();
 
         let DeletePointsInternal {
             delete_points,
@@ -217,6 +223,7 @@ impl PointsInternal for PointsInternalService {
             clock_tag.map(Into::into),
             shard_id,
             FULL_ACCESS.clone(),
+            inference_token,
         )
         .await
     }
@@ -570,6 +577,7 @@ impl PointsInternal for PointsInternalService {
         request: Request<SyncPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+        let inference_token = request.extensions().get::<InferenceToken>().cloned();
 
         let SyncPointsInternal {
             sync_points,
@@ -585,6 +593,7 @@ impl PointsInternal for PointsInternalService {
             clock_tag.map(Into::into),
             shard_id,
             FULL_ACCESS.clone(),
+            inference_token,
         )
         .await
     }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -178,7 +178,11 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
-        let inference_token = request.extensions().get::<InferenceToken>().cloned();
+        let inference_token = request
+            .extensions()
+            .get::<InferenceToken>()
+            .cloned()
+            .unwrap_or(InferenceToken(None));
 
         let UpsertPointsInternal {
             upsert_points,
@@ -206,7 +210,11 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
-        let inference_token = request.extensions().get::<InferenceToken>().cloned();
+        let inference_token = request
+            .extensions()
+            .get::<InferenceToken>()
+            .cloned()
+            .unwrap_or(InferenceToken(None));
 
         let DeletePointsInternal {
             delete_points,
@@ -234,6 +242,11 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
+        let inference_token = request
+            .extensions()
+            .get::<InferenceToken>()
+            .cloned()
+            .unwrap_or(InferenceToken(None));
         let request = request.into_inner();
 
         let shard_id = request.shard_id;
@@ -249,6 +262,7 @@ impl PointsInternal for PointsInternalService {
             clock_tag.map(Into::into),
             shard_id,
             FULL_ACCESS.clone(),
+            inference_token,
         )
         .await
     }
@@ -577,7 +591,11 @@ impl PointsInternal for PointsInternalService {
         request: Request<SyncPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-        let inference_token = request.extensions().get::<InferenceToken>().cloned();
+        let inference_token = request
+            .extensions()
+            .get::<InferenceToken>()
+            .cloned()
+            .unwrap_or(InferenceToken(None));
 
         let SyncPointsInternal {
             sync_points,

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -7,7 +7,7 @@ use tonic::body::BoxBody;
 use tonic::Status;
 use tower::{Layer, Service};
 
-use crate::common::auth::{AuthError, AuthKeys};
+use crate::common::auth::{ApiKey, AuthError, AuthKeys};
 
 type Request = tonic::codegen::http::Request<tonic::transport::Body>;
 type Response = tonic::codegen::http::Response<BoxBody>;
@@ -29,7 +29,7 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
         })?;
 
     let previous = req.extensions_mut().insert::<Access>(access);
-    req.extensions_mut().insert(api_key);
+    req.extensions_mut().insert(ApiKey::new(api_key));
     debug_assert!(
         previous.is_none(),
         "Previous access object should not exist in the request"

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -36,8 +36,14 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
         "Previous access object should not exist in the request"
     );
 
-    req.extensions_mut()
+    let previous_token = req
+        .extensions_mut()
         .insert(InferenceToken::new(api_key.to_string()));
+
+    debug_assert!(
+        previous_token.is_none(),
+        "Previous inference token should not exist in the request"
+    );
 
     Ok(req)
 }

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -7,7 +7,8 @@ use tonic::body::BoxBody;
 use tonic::Status;
 use tower::{Layer, Service};
 
-use crate::common::auth::{ApiKey, AuthError, AuthKeys};
+use crate::common::auth::{AuthError, AuthKeys};
+use crate::common::inference::InferenceToken;
 
 type Request = tonic::codegen::http::Request<tonic::transport::Body>;
 type Response = tonic::codegen::http::Response<BoxBody>;
@@ -29,7 +30,8 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
         })?;
 
     let previous = req.extensions_mut().insert::<Access>(access);
-    req.extensions_mut().insert(ApiKey::new(api_key));
+    req.extensions_mut()
+        .insert(InferenceToken::new(api_key.to_string()));
     debug_assert!(
         previous.is_none(),
         "Previous access object should not exist in the request"

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -19,7 +19,7 @@ pub struct AuthMiddleware<S> {
 }
 
 async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, Status> {
-    let access = auth_keys
+    let (access, api_key) = auth_keys
         .validate_request(|key| req.headers().get(key).and_then(|val| val.to_str().ok()))
         .await
         .map_err(|e| match e {
@@ -29,6 +29,7 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
         })?;
 
     let previous = req.extensions_mut().insert::<Access>(access);
+    req.extensions_mut().insert(api_key);
     debug_assert!(
         previous.is_none(),
         "Previous access object should not exist in the request"

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -30,12 +30,14 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
         })?;
 
     let previous = req.extensions_mut().insert::<Access>(access);
-    req.extensions_mut()
-        .insert(InferenceToken::new(api_key.to_string()));
+
     debug_assert!(
         previous.is_none(),
         "Previous access object should not exist in the request"
     );
+
+    req.extensions_mut()
+        .insert(InferenceToken::new(api_key.to_string()));
 
     Ok(req)
 }


### PR DESCRIPTION
This change enables dynamic token propagation from API requests to the inference service. 
Key changes:

- Add InferenceToken type to hold API tokens from requests
- Modify auth middleware to extract and propagate tokens from request headers 
- Update inference service to accept tokens per-request (when possible)
- Remove requirement for token in config (now optional)
- Thread token through query and update operations
- Fall back to config token if request token is not provided

The main goal is to allow per-request inference tracking with the user specific token rather than using a single global token. 

Technical details:
- Inference token is extracted during auth and stored in request extensions
- Token is propagated through all operations that need inference (queries, updates, etc)
- InferenceService.infer() now accepts a token parameter
- Default to config token if no request token is provided