### PR TITLE
Improve point deduplication loop

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1285,8 +1285,8 @@ impl<'s> SegmentHolder {
             .map(|(segment_id, locked_segment)| (*segment_id, locked_segment.read()))
             .collect::<BTreeMap<_, _>>();
 
-        // Iterator produces segment:point tuples in order of point ID from all segments
-        let ordered_iter = locked_segments
+        // Iterator produces groups of points with the same point ID
+        let point_group_iter = locked_segments
             .iter()
             .map(|(&segment_id, locked_segment)| {
                 locked_segment
@@ -1297,15 +1297,13 @@ impl<'s> SegmentHolder {
                         version: None,
                     })
             })
-            .kmerge_by(|a, b| a.point_id < b.point_id);
-
-        // Iterator produces groups of point IDs
-        let chunked_iter = ordered_iter.chunk_by(|entry| entry.point_id);
+            .kmerge_by(|a, b| a.point_id < b.point_id)
+            .chunk_by(|entry| entry.point_id);
 
         let mut points = Vec::new();
         let mut points_to_remove: HashMap<SegmentId, Vec<PointIdType>> = HashMap::new();
 
-        for (point_id, group_iter) in &chunked_iter {
+        for (_, group_iter) in &point_group_iter {
             // Fill buffer with points of current chunk, need at least 2 points to deduplicate
             points.clear();
             points.extend(group_iter);

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1270,6 +1270,12 @@ impl<'s> SegmentHolder {
     }
 
     fn find_duplicated_points(&self) -> HashMap<SegmentId, Vec<PointIdType>> {
+        struct DedupPoint {
+            segment_id: SegmentId,
+            point_id: PointIdType,
+            version: Option<SeqNumberType>,
+        }
+
         let segments = self
             .iter()
             .map(|(&segment_id, locked_segment)| (segment_id, locked_segment.get()))
@@ -1285,52 +1291,53 @@ impl<'s> SegmentHolder {
             .map(|(&segment_id, locked_segment)| {
                 locked_segment
                     .iter_points()
-                    .map(move |point_id| (segment_id, point_id))
+                    .map(move |point_id| DedupPoint {
+                        segment_id,
+                        point_id,
+                        version: None,
+                    })
             })
-            .kmerge_by(|a, b| a.1 < b.1);
+            .kmerge_by(|a, b| a.point_id < b.point_id);
 
-        let mut last_point_id_opt = None;
-        let mut last_segment_id_opt = None;
-        let mut last_point_version_opt = None;
-        let mut points_to_remove: HashMap<SegmentId, Vec<PointIdType>> = Default::default();
+        // Iterator produces groups of point IDs
+        let chunked_iter = ordered_iter.chunk_by(|entry| entry.point_id);
 
-        for (segment_id, point_id) in ordered_iter {
-            if last_point_id_opt == Some(point_id) {
-                let last_segment_id = last_segment_id_opt.unwrap();
+        let mut points = Vec::new();
+        let mut points_to_remove: HashMap<SegmentId, Vec<PointIdType>> = HashMap::new();
 
-                let point_version = locked_segments[&segment_id].point_version(point_id);
-                let last_point_version = if let Some(last_point_version) = last_point_version_opt {
-                    last_point_version
-                } else {
-                    let version = locked_segments[&last_segment_id].point_version(point_id);
-                    last_point_version_opt = Some(version);
-                    version
-                };
+        for (point_id, group_iter) in &chunked_iter {
+            // Fill buffer with points of current chunk, need at least 2 points to deduplicate
+            points.clear();
+            points.extend(group_iter);
+            if points.len() < 2 {
+                continue;
+            }
 
-                // choose newer version between point_id and last_point_id
-                if point_version < last_point_version {
-                    log::debug!("Selected point {point_id} in segment {segment_id} for deduplication (version {point_version:?} versus {last_point_version:?} in segment {last_segment_id})");
+            // Attach point version to
+            for dedup_point in &mut points {
+                dedup_point.version =
+                    locked_segments[&dedup_point.segment_id].point_version(dedup_point.point_id);
+            }
 
-                    points_to_remove
-                        .entry(segment_id)
-                        .or_default()
-                        .push(point_id);
-                } else {
-                    log::debug!("Selected point {point_id} in segment {last_segment_id} for deduplication (version {last_point_version:?} versus {point_version:?} in segment {segment_id})");
+            // Sort points from highest to lowest version
+            points.sort_unstable_by(|a, b| b.version.cmp(&a.version));
 
-                    points_to_remove
-                        .entry(last_segment_id)
-                        .or_default()
-                        .push(point_id);
-
-                    last_point_id_opt = Some(point_id);
-                    last_segment_id_opt = Some(segment_id);
-                    last_point_version_opt = Some(point_version);
-                }
-            } else {
-                last_point_id_opt = Some(point_id);
-                last_segment_id_opt = Some(segment_id);
-                last_point_version_opt = None;
+            // Keep the first point, remove all others which are older
+            for &DedupPoint {
+                segment_id,
+                point_id,
+                version,
+            } in &points[1..]
+            {
+                log::debug!(
+                    "Selected point {point_id} in segment {segment_id} for deduplication (version {version:?} versus {:?} in segment {})",
+                    points[0].version,
+                    points[0].segment_id,
+                );
+                points_to_remove
+                    .entry(segment_id)
+                    .or_default()
+                    .push(point_id);
             }
         }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1,6 +1,6 @@
 use std::cmp::{max, min};
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -13,6 +13,7 @@ use common::iterator_ext::IteratorExt;
 use common::tar_ext;
 use futures::future::try_join_all;
 use io::storage_version::StorageVersion;
+use itertools::Itertools;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use rand::seq::SliceRandom;
 use segment::common::operation_error::{OperationError, OperationResult};
@@ -39,25 +40,6 @@ const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 pub enum LockedSegment {
     Original(Arc<RwLock<Segment>>),
     Proxy(Arc<RwLock<ProxySegment>>),
-}
-
-/// Internal structure for deduplication of points. Used for BinaryHeap
-#[derive(Eq, PartialEq)]
-struct DedupPoint {
-    point_id: PointIdType,
-    segment_id: SegmentId,
-}
-
-impl Ord for DedupPoint {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.point_id.cmp(&other.point_id).reverse()
-    }
-}
-
-impl PartialOrd for DedupPoint {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 fn try_unwrap_with_timeout<T>(
@@ -1296,37 +1278,23 @@ impl<'s> SegmentHolder {
             .iter()
             .map(|(segment_id, locked_segment)| (*segment_id, locked_segment.read()))
             .collect::<BTreeMap<_, _>>();
-        let mut iterators = locked_segments
-            .iter()
-            .map(|(segment_id, locked_segment)| (*segment_id, locked_segment.iter_points()))
-            .collect::<BTreeMap<_, _>>();
 
-        // heap contains the current iterable point id from each segment
-        let mut heap = iterators
-            .iter_mut()
-            .filter_map(|(&segment_id, iter)| {
-                iter.next().map(|point_id| DedupPoint {
-                    point_id,
-                    segment_id,
-                })
+        // Iterator produces segment:point tuples in order of point ID from all segments
+        let ordered_iter = locked_segments
+            .iter()
+            .map(|(&segment_id, locked_segment)| {
+                locked_segment
+                    .iter_points()
+                    .map(move |point_id| (segment_id, point_id))
             })
-            .collect::<BinaryHeap<_>>();
+            .kmerge_by(|a, b| a.1 < b.1);
 
         let mut last_point_id_opt = None;
         let mut last_segment_id_opt = None;
         let mut last_point_version_opt = None;
         let mut points_to_remove: HashMap<SegmentId, Vec<PointIdType>> = Default::default();
 
-        while let Some(entry) = heap.pop() {
-            let point_id = entry.point_id;
-            let segment_id = entry.segment_id;
-            if let Some(next_point_id) = iterators.get_mut(&segment_id).and_then(|i| i.next()) {
-                heap.push(DedupPoint {
-                    segment_id,
-                    point_id: next_point_id,
-                });
-            }
-
+        for (segment_id, point_id) in ordered_iter {
             if last_point_id_opt == Some(point_id) {
                 let last_segment_id = last_segment_id_opt.unwrap();
 


### PR DESCRIPTION
The logic for finding point duplicates was quite convoluted and was hard to understand. It even hid a significant bug for a long time (<https://github.com/qdrant/qdrant/pull/5585>)!

In this PR I attempt to simplify the loop to replace the error prone behavior we had before.

Note: this still needs a benchmark!

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?