### PR TITLE
[Strict Mode] Max collection size in distributed setup

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7293,7 +7293,7 @@
             "nullable": true
           },
           "max_collection_vector_size_bytes": {
-            "description": "Max size of a collections vector storage in bytes",
+            "description": "Max size of a collections vector storage in bytes, ignoring replicas.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -83,7 +83,7 @@ pub struct Collection {
     // Search runtime handle.
     search_runtime: Handle,
     optimizer_cpu_budget: CpuBudget,
-    // Cached statistics of collection size, may be outdatetd.
+    // Cached statistics of collection size, may be outdated.
     collection_stats_cache: CollectionSizeStatsCache,
 }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -27,8 +27,10 @@ use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
 
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_state::{ShardInfo, State};
+use crate::common::collection_size_stats::{
+    CollectionSizeAtomicStats, CollectionSizeStats, CollectionSizeStatsCache,
+};
 use crate::common::is_ready::IsReady;
-use crate::common::local_data_stats::{LocalDataAtomicStats, LocalDataStats, LocalDataStatsCache};
 use crate::config::CollectionConfigInternal;
 use crate::operations::config_diff::{DiffConfig, OptimizersConfigDiff};
 use crate::operations::shared_storage_config::SharedStorageConfig;
@@ -81,8 +83,8 @@ pub struct Collection {
     // Search runtime handle.
     search_runtime: Handle,
     optimizer_cpu_budget: CpuBudget,
-    // Cached stats over all local shards used in strict mode, may be outdated
-    local_stats_cache: LocalDataStatsCache,
+    // Cached statistics of collection size, may be outdatetd.
+    collection_stats_cache: CollectionSizeStatsCache,
 }
 
 pub type RequestShardTransfer = Arc<dyn Fn(ShardTransfer) + Send + Sync>;
@@ -153,8 +155,8 @@ impl Collection {
 
         let locked_shard_holder = Arc::new(LockedShardHolder::new(shard_holder));
 
-        let local_stats_cache = LocalDataStatsCache::new_with_values(
-            Self::calculate_local_shards_stats(&locked_shard_holder).await,
+        let collection_stats_cache = CollectionSizeStatsCache::new_with_values(
+            Self::estimate_collection_size_stats(&locked_shard_holder).await,
         );
 
         // Once the config is persisted - the collection is considered to be successfully created.
@@ -183,7 +185,7 @@ impl Collection {
             update_runtime: update_runtime.unwrap_or_else(Handle::current),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
             optimizer_cpu_budget,
-            local_stats_cache,
+            collection_stats_cache,
         })
     }
 
@@ -271,8 +273,8 @@ impl Collection {
 
         let locked_shard_holder = Arc::new(LockedShardHolder::new(shard_holder));
 
-        let local_stats_cache = LocalDataStatsCache::new_with_values(
-            Self::calculate_local_shards_stats(&locked_shard_holder).await,
+        let collection_stats_cache = CollectionSizeStatsCache::new_with_values(
+            Self::estimate_collection_size_stats(&locked_shard_holder).await,
         );
 
         Self {
@@ -297,7 +299,7 @@ impl Collection {
             update_runtime: update_runtime.unwrap_or_else(Handle::current),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
             optimizer_cpu_budget,
-            local_stats_cache,
+            collection_stats_cache,
         }
     }
 
@@ -798,18 +800,18 @@ impl Collection {
         self.shards_holder.read().await.trigger_optimizers().await;
     }
 
-    async fn calculate_local_shards_stats(
+    async fn estimate_collection_size_stats(
         shards_holder: &Arc<RwLock<ShardHolder>>,
-    ) -> LocalDataStats {
+    ) -> Option<CollectionSizeStats> {
         let shard_lock = shards_holder.read().await;
-        shard_lock.calculate_local_shards_stats().await
+        shard_lock.estimate_collection_size_stats().await
     }
 
-    /// Returns estimations of local shards statistics. This values are cached and might be not 100% up to date.
+    /// Returns estimations of collection sizes. This values are cached and might be not 100% up to date.
     /// The cache gets updated every 32 calls.
-    pub async fn local_stats_estimations(&self) -> &LocalDataAtomicStats {
-        self.local_stats_cache
-            .get_or_update_cache(|| Self::calculate_local_shards_stats(&self.shards_holder))
+    pub(crate) async fn estimated_collection_stats(&self) -> Option<&CollectionSizeAtomicStats> {
+        self.collection_stats_cache
+            .get_or_update_cache(|| Self::estimate_collection_size_stats(&self.shards_holder))
             .await
     }
 }

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -1,9 +1,9 @@
 pub mod batching;
+pub mod collection_size_stats;
 pub mod eta_calculator;
 pub mod fetch_vectors;
 pub mod file_utils;
 pub mod is_ready;
-pub mod local_data_stats;
 pub mod retrieve_request_trait;
 pub mod sha_256;
 pub mod snapshot_stream;

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -17,7 +17,7 @@ use crate::collection::Collection;
 
 // Creates a new `VerificationPass` without actually verifying anything.
 // This is useful in situations where we don't need to check for strict mode, but still
-// want to be able to access `TableOfContents` using `.toc()`.
+// want to be able to access `TableOfContent` using `.toc()`.
 // If you're not implementing a new point-api endpoint for which a strict mode check
 // is required, this is safe to use.
 pub fn new_unchecked_verification_pass() -> VerificationPass {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use common::cpu::CpuBudget;
 use common::tar_ext::BuilderExt;
-use futures::{Future, TryStreamExt as _};
+use futures::{stream, Future, StreamExt, TryStreamExt as _};
 use itertools::Itertools;
 use segment::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use segment::types::{ShardKey, SnapshotFormat};
@@ -23,7 +23,7 @@ use super::resharding::tasks_pool::ReshardTasksPool;
 use super::resharding::{ReshardStage, ReshardState};
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
-use crate::common::local_data_stats::LocalDataStats;
+use crate::common::collection_size_stats::CollectionSizeStats;
 use crate::common::snapshot_stream::SnapshotStream;
 use crate::config::{CollectionConfigInternal, ShardingMethod};
 use crate::hash_ring::HashRingRouter;
@@ -1119,13 +1119,37 @@ impl ShardHolder {
         Ok(())
     }
 
-    /// Queries and accumulates the statistics for local data, uncached.
-    pub async fn calculate_local_shards_stats(&self) -> LocalDataStats {
-        let mut stats = LocalDataStats::default();
-        for shard in self.shards.iter() {
-            stats.accumulate_from(&shard.1.calculate_local_shards_stats().await)
+    /// Estimates the collections size based on local shard data. Returns `None` if no shard for the collection was found locally.
+    pub async fn estimate_collection_size_stats(&self) -> Option<CollectionSizeStats> {
+        if self.is_distributed().await {
+            // In distributed, we estimate the whole collection size by using a single local shard and multiply by amount of shards in the collection.
+            for shard in self.shards.iter() {
+                if let Some(shard_stats) = shard.1.calculate_local_shard_stats().await {
+                    // Project the single shards size to the full collection.
+                    let collection_estimate = shard_stats.multiplied_with(self.shards.len());
+                    return Some(collection_estimate);
+                }
+            }
+
+            return None;
         }
-        stats
+
+        // Local mode: return collection size estimations using all shards.
+        let mut stats = CollectionSizeStats::default();
+        for shard in self.shards.iter() {
+            if let Some(shard_stats) = shard.1.calculate_local_shard_stats().await {
+                stats.accumulate_metrics_from(&shard_stats);
+            }
+        }
+
+        Some(stats)
+    }
+
+    /// Returns `true` if the collection is distributed across multiple nodes.
+    async fn is_distributed(&self) -> bool {
+        stream::iter(self.shards.iter())
+            .any(|i| async { i.1.has_remote_shard().await })
+            .await
     }
 }
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1125,6 +1125,7 @@ impl ShardHolder {
             // In distributed, we estimate the whole collection size by using a single local shard and multiply by amount of shards in the collection.
             for shard in self.shards.iter() {
                 if let Some(shard_stats) = shard.1.calculate_local_shard_stats().await {
+                    // TODO(resharding) take into account the ongoing resharding and exclude shards that are being filled from multiplication.
                     // Project the single shards size to the full collection.
                     let collection_estimate = shard_stats.multiplied_with(self.shards.len());
                     return Some(collection_estimate);

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -708,7 +708,7 @@ pub struct StrictModeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upsert_max_batchsize: Option<usize>,
 
-    /// Max size of a collections vector storage in bytes
+    /// Max size of a collections vector storage in bytes, ignoring replicas.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_collection_vector_size_bytes: Option<usize>,
 

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -35,7 +35,7 @@ use crate::tonic::api::points_common::{
     delete_payload, delete_vectors, get, overwrite_payload, recommend, set_payload, sync,
     update_vectors, upsert,
 };
-use crate::tonic::verification::UncheckedTocProvider;
+use crate::tonic::verification::{StrictModeCheckedInternalTocProvider, UncheckedTocProvider};
 
 const FULL_ACCESS: Access = Access::full("Internal API");
 
@@ -195,7 +195,7 @@ impl PointsInternal for PointsInternalService {
             upsert_points.ok_or_else(|| Status::invalid_argument("UpsertPoints is missing"))?;
 
         upsert(
-            UncheckedTocProvider::new_unchecked(&self.toc),
+            StrictModeCheckedInternalTocProvider::new(&self.toc),
             upsert_points,
             clock_tag.map(Into::into),
             shard_id,

--- a/src/tonic/verification.rs
+++ b/src/tonic/verification.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use collection::operations::verification::StrictModeVerification;
 use storage::content_manager::collection_verification::{
-    check_strict_mode, check_strict_mode_batch,
+    check_strict_mode, check_strict_mode_batch, check_strict_mode_toc, check_strict_mode_toc_batch,
 };
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
@@ -114,5 +114,54 @@ impl CheckedTocProvider for StrictModeCheckedTocProvider<'_> {
         )
         .await?;
         Ok(self.dispatcher.toc(access, &pass))
+    }
+}
+
+/// TableOfContent "Provider" for internal API. The `CheckedTocProvider` usually is designed to provide TOC by checking strictmode.
+/// However this is not possible in the internal API as it requires `Dispatcher` which we don't have in this case.
+///
+/// Note: Only use this if you only have access to `TableOfContent` and not `Dispatcher`!
+pub(crate) struct StrictModeCheckedInternalTocProvider<'a> {
+    toc: &'a Arc<TableOfContent>,
+}
+
+impl<'a> StrictModeCheckedInternalTocProvider<'a> {
+    pub fn new(toc: &'a Arc<TableOfContent>) -> Self {
+        Self { toc }
+    }
+}
+
+impl CheckedTocProvider for StrictModeCheckedInternalTocProvider<'_> {
+    async fn check_strict_mode(
+        &self,
+        request: &impl StrictModeVerification,
+        collection_name: &str,
+        timeout: Option<usize>,
+        access: &Access,
+    ) -> Result<&Arc<TableOfContent>, Status> {
+        check_strict_mode_toc(request, timeout, collection_name, self.toc, access).await?;
+        Ok(self.toc)
+    }
+
+    async fn check_strict_mode_batch<'b, I, R>(
+        &'b self,
+        requests: &[I],
+        conv: impl Fn(&I) -> &R,
+        collection_name: &str,
+        timeout: Option<usize>,
+        access: &Access,
+    ) -> Result<&'b Arc<TableOfContent>, Status>
+    where
+        R: StrictModeVerification,
+    {
+        check_strict_mode_toc_batch(
+            requests.iter().map(conv),
+            timeout,
+            collection_name,
+            self.toc,
+            access,
+        )
+        .await?;
+        Ok(self.toc)
     }
 }

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -177,3 +177,12 @@ def count_counts(peer_url, collection="test_collection"):
     )
     assert_http_ok(r_search)
     return r_search.json()["result"]["count"]
+
+
+def set_strict_mode(peer_id, collection_name, strict_mode_config):
+    requests.patch(
+        f"{peer_id}/collections/{collection_name}",
+        json={
+            "strict_mode_config": strict_mode_config,
+        },
+    ).raise_for_status()

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -28,6 +28,24 @@ def random_sparse_vector():
     return {"indices": indices, "values": values}
 
 
+def upsert_points(
+        peer_url,
+        points,
+        collection_name="test_collection",
+        wait="true",
+        ordering="weak",
+        shard_key=None,
+        headers={},
+) -> requests.Response:
+    return requests.put(
+        f"{peer_url}/collections/{collection_name}/points?wait={wait}&ordering={ordering}",
+        json={
+            "points": points,
+            "shard_key": shard_key,
+        },
+        headers=headers,
+    )
+
 def upsert_random_points(
     peer_url,
     num,
@@ -87,6 +105,7 @@ def create_collection(
     sharding_method=None,
     indexing_threshold=20000,
     headers={},
+    strict_mode=None,
 ):
     # Create collection in peer_url
     r_batch = requests.put(
@@ -101,6 +120,7 @@ def create_collection(
             "optimizers_config": {
                 "indexing_threshold": indexing_threshold,
             },
+            "strict_mode_config": strict_mode,
         },
         headers=headers,
     )

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -1,0 +1,95 @@
+import logging
+import pathlib
+import time
+
+from .fixtures import create_collection, upsert_random_points, upsert_points, random_dense_vector, drop_collection
+from .utils import *
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger()
+
+N_PEERS = 2
+N_SHARDS = 1
+N_REPLICAS = 1
+COLLECTION_NAME = "test_collection_strict_mode"
+
+
+def test_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
+    peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_urls[0], collection=COLLECTION_NAME, shard_number=N_SHARDS, replication_factor=N_REPLICAS, sharding_method="custom")
+
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_urls)
+
+    collection_info = get_cluster_info(peer_urls[0])
+    non_leader = 0
+    for peer_id, peer_info in collection_info['peers'].items():
+        peer_id = int(peer_id)
+        if peer_id != int(collection_info['peer_id']):
+            non_leader = peer_id
+            break
+
+    create_shard_key("non_leader", peer_urls[0], collection=COLLECTION_NAME, placement=[non_leader])
+
+    for _ in range(32):
+        point = {"id": 1, "payload": {}, "vector": random_dense_vector()}
+        upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()
+
+    set_strict_mode(peer_urls[0], COLLECTION_NAME, {
+        "enabled": True,
+        "max_collection_vector_size_bytes": 30,
+    })
+
+    for _ in range(32):
+        point = {"id": 1, "payload": {}, "vector": random_dense_vector()}
+        upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()
+
+    for _ in range(32):
+        point = {"id": 2, "payload": {}, "vector": random_dense_vector()}
+        res = upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader")
+        if not res.ok:
+            assert "Max vector storage size" in res.json()['status']['error']
+            assert not res.ok
+            return
+
+    assert False, "Should have blocked upsert but didn't"
+
+
+def test_strict_mode_upsert_local_shard(tmp_path: pathlib.Path):
+    peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_urls[0], collection=COLLECTION_NAME, shard_number=N_SHARDS, replication_factor=N_REPLICAS)
+
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_urls)
+
+    for _ in range(32):
+        point = {"id": 1, "payload": {}, "vector": random_dense_vector()}
+        upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME).raise_for_status()
+
+    set_strict_mode(peer_urls[0], COLLECTION_NAME, {
+        "enabled": True,
+        "max_collection_vector_size_bytes": 30,
+    })
+
+    for _ in range(32):
+        point = {"id": 1, "payload": {}, "vector": random_dense_vector()}
+        upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME).raise_for_status()
+
+    for _ in range(32):
+        point = {"id": 2, "payload": {}, "vector": random_dense_vector()}
+        res = upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME)
+        if not res.ok:
+            assert "Max vector storage size" in res.json()['status']['error']
+            assert not res.ok
+            return
+
+    assert False, "Should have blocked upsert but didn't"
+
+
+def set_strict_mode(peer_id, collection_name, strict_mode_config):
+    requests.patch(
+        f"{peer_id}/collections/{collection_name}",
+        json={
+            "strict_mode_config": strict_mode_config,
+        },
+    ).raise_for_status()

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -13,8 +13,6 @@ N_SHARDS = 1
 N_REPLICAS = 1
 COLLECTION_NAME = "test_collection_strict_mode"
 
-UPSERT_REQUEST_DELAY = 0.7
-
 
 def test_strict_mode_upsert(tmp_path: pathlib.Path):
     peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, 4)
@@ -63,21 +61,15 @@ def test_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
     for _ in range(32):
         point = {"id": 1, "payload": {}, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()
-        time.sleep(UPSERT_REQUEST_DELAY)  # Give qdrant some time to update shard statistics
 
     set_strict_mode(peer_urls[0], COLLECTION_NAME, {
         "enabled": True,
         "max_collection_vector_size_bytes": 33,
     })
 
-    time.sleep(10)
-
     for _ in range(32):
         point = {"id": 2, "payload": {}, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()
-        time.sleep(UPSERT_REQUEST_DELAY)
-
-    time.sleep(10)
 
     for _ in range(32):
         point = {"id": 3, "payload": {}, "vector": random_dense_vector()}
@@ -86,7 +78,6 @@ def test_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
             assert "Max vector storage size" in res.json()['status']['error']
             assert not res.ok
             return
-        time.sleep(UPSERT_REQUEST_DELAY)
 
     assert False, "Should have blocked upsert but didn't"
 
@@ -101,7 +92,6 @@ def test_strict_mode_upsert_local_shard(tmp_path: pathlib.Path):
     for _ in range(32):
         point = {"id": 1, "payload": {}, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME).raise_for_status()
-        time.sleep(UPSERT_REQUEST_DELAY)  # Give qdrant some time to update shard statistics
 
     set_strict_mode(peer_urls[0], COLLECTION_NAME, {
         "enabled": True,
@@ -113,7 +103,6 @@ def test_strict_mode_upsert_local_shard(tmp_path: pathlib.Path):
     for _ in range(32):
         point = {"id": 2, "payload": {}, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME).raise_for_status()
-        time.sleep(UPSERT_REQUEST_DELAY)
 
     for _ in range(32):
         point = {"id": 3, "payload": {}, "vector": random_dense_vector()}
@@ -122,7 +111,6 @@ def test_strict_mode_upsert_local_shard(tmp_path: pathlib.Path):
             assert "Max vector storage size" in res.json()['status']['error']
             assert not res.ok
             return
-        time.sleep(UPSERT_REQUEST_DELAY)
 
     assert False, "Should have blocked upsert but didn't"
 

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import time
 
 from .fixtures import create_collection, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode
 from .utils import *
@@ -12,7 +13,7 @@ N_SHARDS = 1
 N_REPLICAS = 1
 COLLECTION_NAME = "test_collection_strict_mode"
 
-UPSERT_REQUEST_DELAY = 0.3
+UPSERT_REQUEST_DELAY = 0.7
 
 
 def test_strict_mode_upsert(tmp_path: pathlib.Path):
@@ -69,10 +70,14 @@ def test_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
         "max_collection_vector_size_bytes": 33,
     })
 
+    time.sleep(10)
+
     for _ in range(32):
         point = {"id": 2, "payload": {}, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()
-        time.sleep(0.3)
+        time.sleep(UPSERT_REQUEST_DELAY)
+
+    time.sleep(10)
 
     for _ in range(32):
         point = {"id": 3, "payload": {}, "vector": random_dense_vector()}

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -108,6 +108,8 @@ def test_strict_mode_upsert_local_shard(tmp_path: pathlib.Path):
         "max_collection_vector_size_bytes": 33,
     })
 
+    wait_for_strict_mode_enabled(peer_urls[1], COLLECTION_NAME)
+
     for _ in range(32):
         point = {"id": 2, "payload": {}, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME).raise_for_status()

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -67,6 +67,8 @@ def test_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
         "max_collection_vector_size_bytes": 33,
     })
 
+    wait_for_strict_mode_enabled(peer_urls[1], COLLECTION_NAME)
+
     for _ in range(32):
         point = {"id": 2, "payload": {}, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -483,7 +483,6 @@ def check_collection_cluster(peer_url, collection_name):
 
 def check_strict_mode_enabled(peer_api_uri: str, collection_name: str) -> bool:
     collection_info = get_collection_info(peer_api_uri, collection_name)
-    print(collection_info)
     strict_mode_enabled = collection_info["config"]["strict_mode_config"]["enabled"]
     return strict_mode_enabled == True
 

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -481,6 +481,13 @@ def check_collection_cluster(peer_url, collection_name):
     return res.json()["result"]['local_shards'][0]
 
 
+def check_strict_mode_enabled(peer_api_uri: str, collection_name: str) -> bool:
+    collection_info = get_collection_info(peer_api_uri, collection_name)
+    print(collection_info)
+    strict_mode_enabled = collection_info["config"]["strict_mode_config"]["enabled"]
+    return strict_mode_enabled == True
+
+
 def wait_peer_added(peer_api_uri: str, expected_size: int = 1, headers={}) -> str:
     wait_for(check_cluster_size, peer_api_uri, expected_size, headers=headers)
     wait_for(leader_is_defined, peer_api_uri, headers=headers)
@@ -594,6 +601,14 @@ def wait_for_collection_resharding_operation_stage(peer_api_uri: str, collection
 def wait_for_collection_local_shards_count(peer_api_uri: str, collection_name: str, expected_local_shard_count: int):
     try:
         wait_for(check_collection_local_shards_count, peer_api_uri, collection_name, expected_local_shard_count)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name)
+        raise e
+
+
+def wait_for_strict_mode_enabled(peer_api_uri: str, collection_name: str):
+    try:
+        wait_for(check_strict_mode_enabled, peer_api_uri, collection_name)
     except Exception as e:
         print_collection_cluster_info(peer_api_uri, collection_name)
         raise e

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -670,3 +670,14 @@ def wait_collection_exists_and_active_on_all_peers(collection_name: str, peer_ap
     for peer_uri in peer_api_uris:
         # Collection is active on all peers
         wait_for_all_replicas_active(collection_name=collection_name, peer_api_uri=peer_uri, headers=headers)
+
+
+def create_shard_key(shard_key, peer_url, collection="test_collection", placement=None):
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}/shards",
+        json={
+            "shard_key": shard_key,
+            "placement": placement,
+        },
+    )
+    assert_http_ok(r_batch)


### PR DESCRIPTION
Depends on #5588

Allows limiting collection size (vector and payload storage separately) in distributed setups with strict mode.
