### PR TITLE
Fix broken replication factor in gRPC create shard key

### DIFF
--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1616,7 +1616,7 @@ impl TryFrom<api::grpc::qdrant::CreateShardKey> for CreateShardingKey {
                     Status::invalid_argument(format!("Replication factor cannot be zero: {err}"))
                 })?,
             replication_factor: op
-                .shards_number
+                .replication_factor
                 .map(NonZeroU32::try_from)
                 .transpose()
                 .map_err(|err| {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1613,7 +1613,7 @@ impl TryFrom<api::grpc::qdrant::CreateShardKey> for CreateShardingKey {
                 .map(NonZeroU32::try_from)
                 .transpose()
                 .map_err(|err| {
-                    Status::invalid_argument(format!("Shard number factor cannot be zero: {err}"))
+                    Status::invalid_argument(format!("Shard number cannot be zero: {err}"))
                 })?,
             replication_factor: op
                 .replication_factor

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1613,7 +1613,7 @@ impl TryFrom<api::grpc::qdrant::CreateShardKey> for CreateShardingKey {
                 .map(NonZeroU32::try_from)
                 .transpose()
                 .map_err(|err| {
-                    Status::invalid_argument(format!("Replication factor cannot be zero: {err}"))
+                    Status::invalid_argument(format!("Shard number factor cannot be zero: {err}"))
                 })?,
             replication_factor: op
                 .replication_factor
@@ -1622,11 +1622,7 @@ impl TryFrom<api::grpc::qdrant::CreateShardKey> for CreateShardingKey {
                 .map_err(|err| {
                     Status::invalid_argument(format!("Replication factor cannot be zero: {err}"))
                 })?,
-            placement: if op.placement.is_empty() {
-                None
-            } else {
-                Some(op.placement)
-            },
+            placement: (!op.placement.is_empty()).then_some(op.placement),
         };
         Ok(res)
     }


### PR DESCRIPTION
The gRPC interface for creating a new shard key appeared to be broken. Internally it would replace the specified replication factor with the specified number of shards.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?