### PR TITLE
Rate limit requests per minute

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1432,8 +1432,8 @@ Note: 1kB = 1 vector of size 256. |
 | search_max_oversampling | [float](#float) | optional |  |
 | upsert_max_batchsize | [uint64](#uint64) | optional |  |
 | max_collection_vector_size_bytes | [uint64](#uint64) | optional |  |
-| read_rate_limit_per_sec | [uint32](#uint32) | optional |  |
-| write_rate_limit_per_sec | [uint32](#uint32) | optional |  |
+| read_rate_limit_per_minute | [uint32](#uint32) | optional |  |
+| write_rate_limit_per_minute | [uint32](#uint32) | optional |  |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1432,8 +1432,8 @@ Note: 1kB = 1 vector of size 256. |
 | search_max_oversampling | [float](#float) | optional |  |
 | upsert_max_batchsize | [uint64](#uint64) | optional |  |
 | max_collection_vector_size_bytes | [uint64](#uint64) | optional |  |
-| read_rate_limit_per_minute | [uint32](#uint32) | optional |  |
-| write_rate_limit_per_minute | [uint32](#uint32) | optional |  |
+| read_rate_limit | [uint32](#uint32) | optional | Max number of read operations per minute per replica |
+| write_rate_limit | [uint32](#uint32) | optional | Max number of write operations per minute per replica |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7299,18 +7299,18 @@
             "minimum": 0,
             "nullable": true
           },
-          "read_rate_limit_per_sec": {
-            "description": "Max number of read operations per second per shard per peer",
+          "read_rate_limit_per_minute": {
+            "description": "Max number of read operations per minute per replica",
             "type": "integer",
             "format": "uint",
-            "minimum": 0,
+            "minimum": 1,
             "nullable": true
           },
-          "write_rate_limit_per_sec": {
-            "description": "Max number of write operations per second per shard per peer",
+          "write_rate_limit_per_minute": {
+            "description": "Max number of write operations per minute per replica",
             "type": "integer",
             "format": "uint",
-            "minimum": 0,
+            "minimum": 1,
             "nullable": true
           }
         }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7299,14 +7299,14 @@
             "minimum": 0,
             "nullable": true
           },
-          "read_rate_limit_per_minute": {
+          "read_rate_limit": {
             "description": "Max number of read operations per minute per replica",
             "type": "integer",
             "format": "uint",
             "minimum": 1,
             "nullable": true
           },
-          "write_rate_limit_per_minute": {
+          "write_rate_limit": {
             "description": "Max number of write operations per minute per replica",
             "type": "integer",
             "format": "uint",

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -161,6 +161,8 @@ fn configure_validation(builder: Builder) -> Builder {
             ("UpdateCollectionClusterSetupRequest.operation", ""),
             ("StrictModeConfig.max_query_limit", "range(min = 1)"),
             ("StrictModeConfig.max_timeout", "range(min = 1)"),
+            ("StrictModeConfig.read_rate_limit_per_minute", "range(min = 1)"),
+            ("StrictModeConfig.write_rate_limit_per_minute", "range(min = 1)"),
         ], &[
             "ListCollectionsRequest",
             "CollectionParamsDiff",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1635,8 +1635,8 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
             max_collection_vector_size_bytes: value
                 .max_collection_vector_size_bytes
                 .map(|i| i as usize),
-            read_rate_limit_per_minute: value.read_rate_limit_per_minute.map(|i| i as usize),
-            write_rate_limit_per_minute: value.read_rate_limit_per_minute.map(|i| i as usize),
+            read_rate_limit: value.read_rate_limit.map(|i| i as usize),
+            write_rate_limit: value.read_rate_limit.map(|i| i as usize),
         }
     }
 }
@@ -1656,8 +1656,8 @@ impl From<segment::types::StrictModeConfig> for StrictModeConfig {
             max_collection_vector_size_bytes: value
                 .max_collection_vector_size_bytes
                 .map(|i| i as u64),
-            read_rate_limit_per_minute: value.read_rate_limit_per_minute.map(|i| i as u32),
-            write_rate_limit_per_minute: value.write_rate_limit_per_minute.map(|i| i as u32),
+            read_rate_limit: value.read_rate_limit.map(|i| i as u32),
+            write_rate_limit: value.write_rate_limit.map(|i| i as u32),
         }
     }
 }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1635,8 +1635,8 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
             max_collection_vector_size_bytes: value
                 .max_collection_vector_size_bytes
                 .map(|i| i as usize),
-            read_rate_limit_per_sec: value.read_rate_limit_per_sec.map(|i| i as usize),
-            write_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as usize),
+            read_rate_limit_per_minute: value.read_rate_limit_per_minute.map(|i| i as usize),
+            write_rate_limit_per_minute: value.read_rate_limit_per_minute.map(|i| i as usize),
         }
     }
 }
@@ -1656,8 +1656,8 @@ impl From<segment::types::StrictModeConfig> for StrictModeConfig {
             max_collection_vector_size_bytes: value
                 .max_collection_vector_size_bytes
                 .map(|i| i as u64),
-            read_rate_limit_per_sec: value.read_rate_limit_per_sec.map(|i| i as u32),
-            write_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as u32),
+            read_rate_limit_per_minute: value.read_rate_limit_per_minute.map(|i| i as u32),
+            write_rate_limit_per_minute: value.write_rate_limit_per_minute.map(|i| i as u32),
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -322,8 +322,8 @@ message StrictModeConfig {
   optional float search_max_oversampling  = 8;
   optional uint64 upsert_max_batchsize  = 9;
   optional uint64 max_collection_vector_size_bytes  = 10;
-  optional uint32 read_rate_limit_per_sec = 11;
-  optional uint32 write_rate_limit_per_sec = 12;
+  optional uint32 read_rate_limit_per_minute = 11;
+  optional uint32 write_rate_limit_per_minute = 12;
 }
 
 message CreateCollection {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -322,8 +322,8 @@ message StrictModeConfig {
   optional float search_max_oversampling  = 8;
   optional uint64 upsert_max_batchsize  = 9;
   optional uint64 max_collection_vector_size_bytes  = 10;
-  optional uint32 read_rate_limit_per_minute = 11;
-  optional uint32 write_rate_limit_per_minute = 12;
+  optional uint32 read_rate_limit = 11; // Max number of read operations per minute per replica
+  optional uint32 write_rate_limit = 12; // Max number of write operations per minute per replica
 }
 
 message CreateCollection {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -456,12 +456,12 @@ pub struct StrictModeConfig {
     pub upsert_max_batchsize: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "10")]
     pub max_collection_vector_size_bytes: ::core::option::Option<u64>,
+    /// Max number of read operations per minute per replica
     #[prost(uint32, optional, tag = "11")]
-    #[validate(range(min = 1))]
-    pub read_rate_limit_per_minute: ::core::option::Option<u32>,
+    pub read_rate_limit: ::core::option::Option<u32>,
+    /// Max number of write operations per minute per replica
     #[prost(uint32, optional, tag = "12")]
-    #[validate(range(min = 1))]
-    pub write_rate_limit_per_minute: ::core::option::Option<u32>,
+    pub write_rate_limit: ::core::option::Option<u32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -457,9 +457,11 @@ pub struct StrictModeConfig {
     #[prost(uint64, optional, tag = "10")]
     pub max_collection_vector_size_bytes: ::core::option::Option<u64>,
     #[prost(uint32, optional, tag = "11")]
-    pub read_rate_limit_per_sec: ::core::option::Option<u32>,
+    #[validate(range(min = 1))]
+    pub read_rate_limit_per_minute: ::core::option::Option<u32>,
     #[prost(uint32, optional, tag = "12")]
-    pub write_rate_limit_per_sec: ::core::option::Option<u32>,
+    #[validate(range(min = 1))]
+    pub write_rate_limit_per_minute: ::core::option::Option<u32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -409,8 +409,8 @@ mod test {
             search_max_oversampling: Some(0.2),
             upsert_max_batchsize: None,
             max_collection_vector_size_bytes: None,
-            read_rate_limit_per_sec: None,
-            write_rate_limit_per_sec: None,
+            read_rate_limit_per_minute: None,
+            write_rate_limit_per_minute: None,
         };
 
         fixture_collection(&strict_mode_config).await

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -409,8 +409,8 @@ mod test {
             search_max_oversampling: Some(0.2),
             upsert_max_batchsize: None,
             max_collection_vector_size_bytes: None,
-            read_rate_limit_per_minute: None,
-            write_rate_limit_per_minute: None,
+            read_rate_limit: None,
+            write_rate_limit: None,
         };
 
         fixture_collection(&strict_mode_config).await

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -196,16 +196,15 @@ impl LocalShard {
 
         let update_tracker = segment_holder.read().update_tracker();
 
-        let read_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
-            strict_mode
-                .read_rate_limit_per_minute
-                .map(RateLimiter::new_per_minute)
-        });
+        let read_rate_limiter = config
+            .strict_mode_config
+            .as_ref()
+            .and_then(|strict_mode| strict_mode.read_rate_limit.map(RateLimiter::new_per_minute));
         let read_rate_limiter = ParkingMutex::new(read_rate_limiter);
 
         let write_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
             strict_mode
-                .write_rate_limit_per_minute
+                .write_rate_limit
                 .map(RateLimiter::new_per_minute)
         });
         let write_rate_limiter = ParkingMutex::new(write_rate_limiter);
@@ -762,14 +761,14 @@ impl LocalShard {
 
         if let Some(strict_mode_config) = &config.strict_mode_config {
             // Update read rate limiter
-            if let Some(read_rate_limit_per_sec) = strict_mode_config.read_rate_limit_per_minute {
+            if let Some(read_rate_limit_per_sec) = strict_mode_config.read_rate_limit {
                 let mut read_rate_limiter_guard = self.read_rate_limiter.lock();
                 read_rate_limiter_guard
                     .replace(RateLimiter::new_per_minute(read_rate_limit_per_sec));
             }
 
             // update write rate limiter
-            if let Some(write_rate_limit_per_sec) = strict_mode_config.write_rate_limit_per_minute {
+            if let Some(write_rate_limit_per_sec) = strict_mode_config.write_rate_limit {
                 let mut write_rate_limiter_guard = self.write_rate_limiter.lock();
                 write_rate_limiter_guard
                     .replace(RateLimiter::new_per_minute(write_rate_limit_per_sec));

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -198,15 +198,15 @@ impl LocalShard {
 
         let read_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
             strict_mode
-                .read_rate_limit_per_sec
-                .map(RateLimiter::with_rate_per_sec)
+                .read_rate_limit_per_minute
+                .map(RateLimiter::new_per_minute)
         });
         let read_rate_limiter = ParkingMutex::new(read_rate_limiter);
 
         let write_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
             strict_mode
-                .write_rate_limit_per_sec
-                .map(RateLimiter::with_rate_per_sec)
+                .write_rate_limit_per_minute
+                .map(RateLimiter::new_per_minute)
         });
         let write_rate_limiter = ParkingMutex::new(write_rate_limiter);
 
@@ -762,17 +762,17 @@ impl LocalShard {
 
         if let Some(strict_mode_config) = &config.strict_mode_config {
             // Update read rate limiter
-            if let Some(read_rate_limit_per_sec) = strict_mode_config.read_rate_limit_per_sec {
+            if let Some(read_rate_limit_per_sec) = strict_mode_config.read_rate_limit_per_minute {
                 let mut read_rate_limiter_guard = self.read_rate_limiter.lock();
                 read_rate_limiter_guard
-                    .replace(RateLimiter::with_rate_per_sec(read_rate_limit_per_sec));
+                    .replace(RateLimiter::new_per_minute(read_rate_limit_per_sec));
             }
 
             // update write rate limiter
-            if let Some(write_rate_limit_per_sec) = strict_mode_config.write_rate_limit_per_sec {
+            if let Some(write_rate_limit_per_sec) = strict_mode_config.write_rate_limit_per_minute {
                 let mut write_rate_limiter_guard = self.write_rate_limiter.lock();
                 write_rate_limiter_guard
-                    .replace(RateLimiter::with_rate_per_sec(write_rate_limit_per_sec));
+                    .replace(RateLimiter::new_per_minute(write_rate_limit_per_sec));
             }
         }
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -715,12 +715,12 @@ pub struct StrictModeConfig {
     /// Max number of read operations per minute per replica
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
-    pub read_rate_limit_per_minute: Option<usize>,
+    pub read_rate_limit: Option<usize>,
 
     /// Max number of write operations per minute per replica
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
-    pub write_rate_limit_per_minute: Option<usize>,
+    pub write_rate_limit: Option<usize>,
 }
 
 impl Eq for StrictModeConfig {}
@@ -739,8 +739,8 @@ impl Hash for StrictModeConfig {
             search_max_oversampling: _,
             upsert_max_batchsize,
             max_collection_vector_size_bytes,
-            read_rate_limit_per_minute,
-            write_rate_limit_per_minute,
+            read_rate_limit: read_rate_limit_per_minute,
+            write_rate_limit: write_rate_limit_per_minute,
         } = self;
         (
             enabled,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -712,13 +712,15 @@ pub struct StrictModeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_collection_vector_size_bytes: Option<usize>,
 
-    /// Max number of read operations per second per shard per peer
+    /// Max number of read operations per minute per replica
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub read_rate_limit_per_sec: Option<usize>,
+    #[validate(range(min = 1))]
+    pub read_rate_limit_per_minute: Option<usize>,
 
-    /// Max number of write operations per second per shard per peer
+    /// Max number of write operations per minute per replica
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub write_rate_limit_per_sec: Option<usize>,
+    #[validate(range(min = 1))]
+    pub write_rate_limit_per_minute: Option<usize>,
 }
 
 impl Eq for StrictModeConfig {}
@@ -737,8 +739,8 @@ impl Hash for StrictModeConfig {
             search_max_oversampling: _,
             upsert_max_batchsize,
             max_collection_vector_size_bytes,
-            read_rate_limit_per_sec,
-            write_rate_limit_per_sec,
+            read_rate_limit_per_minute,
+            write_rate_limit_per_minute,
         } = self;
         (
             enabled,
@@ -750,8 +752,8 @@ impl Hash for StrictModeConfig {
             search_allow_exact,
             upsert_max_batchsize,
             max_collection_vector_size_bytes,
-            read_rate_limit_per_sec,
-            write_rate_limit_per_sec,
+            read_rate_limit_per_minute,
+            write_rate_limit_per_minute,
         )
             .hash(state);
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -89,8 +89,8 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
         max_collection_vector_size_bytes: value
             .max_collection_vector_size_bytes
             .map(|i| i as usize),
-        read_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as usize),
-        write_rate_limit_per_sec: value.write_rate_limit_per_sec.map(|i| i as usize),
+        read_rate_limit_per_minute: value.write_rate_limit_per_minute.map(|i| i as usize),
+        write_rate_limit_per_minute: value.write_rate_limit_per_minute.map(|i| i as usize),
     }
 }
 

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -89,8 +89,8 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
         max_collection_vector_size_bytes: value
             .max_collection_vector_size_bytes
             .map(|i| i as usize),
-        read_rate_limit_per_minute: value.write_rate_limit_per_minute.map(|i| i as usize),
-        write_rate_limit_per_minute: value.write_rate_limit_per_minute.map(|i| i as usize),
+        read_rate_limit: value.write_rate_limit.map(|i| i as usize),
+        write_rate_limit: value.write_rate_limit.map(|i| i as usize),
     }
 }
 

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -607,7 +607,7 @@ def test_strict_mode_max_collection_size_upsert_batch(collection_name):
 def test_strict_mode_read_rate_limiting(collection_name):
     set_strict_mode(collection_name, {
         "enabled": True,
-        "read_rate_limit_per_minute": 1,
+        "read_rate_limit": 1,
     })
 
     response = request_with_validation(
@@ -619,7 +619,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
     assert response.ok
     new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
     assert new_strict_mode_config['enabled']
-    assert new_strict_mode_config['read_rate_limit_per_minute'] == 1
+    assert new_strict_mode_config['read_rate_limit'] == 1
 
     failed_count = 0
 
@@ -645,7 +645,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
 def test_strict_mode_write_rate_limiting(collection_name):
     set_strict_mode(collection_name, {
         "enabled": True,
-        "write_rate_limit_per_minute": 1,
+        "write_rate_limit": 1,
     })
 
     response = request_with_validation(
@@ -657,7 +657,7 @@ def test_strict_mode_write_rate_limiting(collection_name):
     assert response.ok
     new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
     assert new_strict_mode_config['enabled']
-    assert new_strict_mode_config['write_rate_limit_per_minute'] == 1
+    assert new_strict_mode_config['write_rate_limit'] == 1
 
     failed_count = 0
 

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -607,7 +607,7 @@ def test_strict_mode_max_collection_size_upsert_batch(collection_name):
 def test_strict_mode_read_rate_limiting(collection_name):
     set_strict_mode(collection_name, {
         "enabled": True,
-        "read_rate_limit_per_sec": 1,
+        "read_rate_limit_per_minute": 1,
     })
 
     response = request_with_validation(
@@ -619,7 +619,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
     assert response.ok
     new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
     assert new_strict_mode_config['enabled']
-    assert new_strict_mode_config['read_rate_limit_per_sec'] == 1
+    assert new_strict_mode_config['read_rate_limit_per_minute'] == 1
 
     failed_count = 0
 
@@ -645,7 +645,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
 def test_strict_mode_write_rate_limiting(collection_name):
     set_strict_mode(collection_name, {
         "enabled": True,
-        "write_rate_limit_per_sec": 1,
+        "write_rate_limit_per_minute": 1,
     })
 
     response = request_with_validation(
@@ -657,7 +657,7 @@ def test_strict_mode_write_rate_limiting(collection_name):
     assert response.ok
     new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
     assert new_strict_mode_config['enabled']
-    assert new_strict_mode_config['write_rate_limit_per_sec'] == 1
+    assert new_strict_mode_config['write_rate_limit_per_minute'] == 1
 
     failed_count = 0
 


### PR DESCRIPTION
Adjust rate limiter to make it work on a per minute basis.

The main goal is to enable larger burst values.

I took this opportunity to add the missing API validation.

Double checked again with end to end testing for 1000 req/minute

```http
PUT collections/benchmark
{
  "vectors": {
    "size": 4,
    "distance": "Dot"
  },
  "strict_mode_config": {
    "enabled": true,
    "read_rate_limit": 1000
  }
}
```

Shoot with [oha](https://github.com/hatoo/oha) with 10 concurrent workers for 10 minutes

```bash
oha -m POST  \
 -d "{ \"vector\": [0.2, 0.1, 0.9, 0.7], \"limit\": 4 }" \
 -T application/json \
 -A application/json  \
 -z 10m \
 -c 10 \
 http://127.0.0.1:6333/collections/benchmark/points/search
```

```Status code distribution:
  [429] 1641485 responses
  [200] 10108 responses
```