### PR TITLE
Demote point deduplication logging from debug to trace

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1277,7 +1277,7 @@ impl<'s> SegmentHolder {
                         }
                     }
 
-                    log::debug!("Deleted {removed_points} points from segment {segment_id} to deduplicate: {points:?}");
+                    log::trace!("Deleted {removed_points} points from segment {segment_id} to deduplicate: {points:?}");
 
                     OperationResult::Ok(removed_points)
                 })
@@ -1352,14 +1352,14 @@ impl<'s> SegmentHolder {
 
                 // choose newer version between point_id and last_point_id
                 if point_version < last_point_version {
-                    log::debug!("Selected point {point_id} in segment {segment_id} for deduplication (version {point_version:?} versus {last_point_version:?} in segment {last_segment_id})");
+                    log::trace!("Selected point {point_id} in segment {segment_id} for deduplication (version {point_version:?} versus {last_point_version:?} in segment {last_segment_id})");
 
                     points_to_remove
                         .entry(segment_id)
                         .or_default()
                         .push(point_id);
                 } else {
-                    log::debug!("Selected point {point_id} in segment {last_segment_id} for deduplication (version {last_point_version:?} versus {point_version:?} in segment {segment_id})");
+                    log::trace!("Selected point {point_id} in segment {last_segment_id} for deduplication (version {last_point_version:?} versus {point_version:?} in segment {segment_id})");
 
                     points_to_remove
                         .entry(last_segment_id)


### PR DESCRIPTION
We added point deduplication logging in <https://github.com/qdrant/qdrant/pull/5577> for evaluating chaos testing. Now we want to demote these logs because they're quite noisy with normal usage.

Originally planned in <https://github.com/qdrant/qdrant/pull/5586> and mentioned again in <https://github.com/qdrant/qdrant/pull/5590#discussion_r1874073972>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?