### PR TITLE
Docs: Update the link of gRPC API documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ You can also download raw OpenAPI [definitions](https://github.com/qdrant/qdrant
 
 ### gRPC
 
-For faster production-tier searches, Qdrant also provides a gRPC interface. You can find gRPC documentation [here](https://qdrant.tech/documentation/quick-start/#grpc).
+For faster production-tier searches, Qdrant also provides a gRPC interface. You can find gRPC documentation [here](https://qdrant.tech/documentation/interfaces/#grpc-interface).
 
 ## Features
 


### PR DESCRIPTION
The gRPC API documentation on the website (https://qdrant.tech/documentation/interfaces/#grpc-interface) has been updated, but the README.md still points to the old address, causing trouble for those searching for it.

This PR only makes a cosmetic change that do not affect functionality.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
