### PR TITLE
Bump version to v1.12.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "api"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "chrono",
  "common",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.12.4"
+version = "1.12.5"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.12.4"
+version = "1.12.5"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.12.4";
+pub const QDRANT_VERSION_STRING: &str = "1.12.5";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=9d83ef2a6d24cfc5b8c5a504d71710fecabfc7fe
+IGNORE_UPTO=9ab212aac566cdb33ca0f17095cd382a38fb6e63
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Release PR for Qdrant 1.12.5.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/5461/>.