### PR TITLE
Fix Debian package release build

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -51,7 +51,7 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           cargo install cargo-deb
-          cargo deb --no-strip --target ${{ matrix.target }}
+          cargo deb --no-strip --target ${{ matrix.target }} -- --features=service_debug
       - name: Upload Debian package
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Building a Debian package on release [current](https://github.com/qdrant/qdrant/actions/runs/12238399544/) fails since <https://github.com/qdrant/qdrant/pull/5479>.

This patches the release logic to fix the build in future releases.

`cargo deb` does not have many toggles, and providing `--features=service_debug` to bypass the error seems to be the best approach here. I do prefer to keep that explicit feature flag to speed up other builds as described in the [PR](<https://github.com/qdrant/qdrant/pull/5479>) that implemented it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?