### PR TITLE
Add unit test for segment builder bug mixing internal point IDs

### DIFF
--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -333,8 +333,10 @@ fn estimate_build_time(segment: &Segment, stop_delay_millis: Option<u64>) -> (u6
 }
 
 /// Unit test for a specific bug we caught before.
+///
+/// See: <https://github.com/qdrant/qdrant/pull/5614>
 #[test]
-fn test_building_new_segment_bug() {
+fn test_building_new_segment_bug_5614() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 


### PR DESCRIPTION
Add unit test for <https://github.com/qdrant/qdrant/pull/5543>.

This specifically tests internal point IDs are handled as we expect.

If you revert <https://github.com/qdrant/qdrant/pull/5543> that fixes this bug, the unit test fails with:

```
thread 'segment_builder_test::test_building_new_segment_bug' panicked at lib/segment/tests/integration/segment_builder_test.rs:387:5:
assertion `left == right` failed
  left: NamedVectors { map: TinyMap { list: [("", Dense([4.0, 4.0, 0.0, 0.0]))] } }
 right: NamedVectors { map: TinyMap { list: [("", Dense([3.0, 3.0, 0.0, 0.0]))] } }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?