### PR TITLE
Atomic save chunked mmap config

### DIFF
--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -105,8 +105,14 @@ impl<T: Sized + Copy + 'static> ChunkedMmapVectors<T> {
 
     fn load_config(config_file: &Path) -> Option<ChunkedMmapConfig> {
         if config_file.exists() {
-            let file = std::fs::File::open(config_file).ok()?;
-            let config: ChunkedMmapConfig = serde_json::from_reader(file).ok()?;
+            let file = std::fs::File::open(config_file)
+                .inspect_err(|e| log::error!("Failed to open config file {config_file:?}: {e}"))
+                .ok()?;
+            let config: ChunkedMmapConfig = serde_json::from_reader(file)
+                .inspect_err(|e| {
+                    log::error!("Failed to deserialize config file {config_file:?}: {e}")
+                })
+                .ok()?;
             Some(config)
         } else {
             None

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -105,7 +105,7 @@ impl<T: Sized + Copy + 'static> ChunkedMmapVectors<T> {
 
     fn load_config(config_file: &Path) -> Option<ChunkedMmapConfig> {
         if config_file.exists() {
-            let file = std::fs::File::open(&config_file).ok()?;
+            let file = std::fs::File::open(config_file).ok()?;
             let config: ChunkedMmapConfig = serde_json::from_reader(file).ok()?;
             Some(config)
         } else {


### PR DESCRIPTION
Save chunked mmap config atomically.
Just flush is not enough because it doesn't guarantee presence on disk. This situation was caught on a real cluster.

Also, this file can be generated from another config. Do it if loading fails.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
