### PR TITLE
Allow telemetry endpoint for JWT-limited requests

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10839,10 +10839,8 @@
         "type": "object",
         "required": [
           "app",
-          "cluster",
           "collections",
-          "id",
-          "requests"
+          "id"
         ],
         "properties": {
           "id": {
@@ -10855,10 +10853,24 @@
             "$ref": "#/components/schemas/CollectionsTelemetry"
           },
           "cluster": {
-            "$ref": "#/components/schemas/ClusterTelemetry"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ClusterTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "requests": {
-            "$ref": "#/components/schemas/RequestsTelemetry"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RequestsTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "memory": {
             "anyOf": [

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -216,13 +216,30 @@ impl TableOfContent {
 
     /// List of all collections to which the user has access
     pub async fn all_collections(&self, access: &Access) -> Vec<CollectionPass<'static>> {
+        self.all_collections_with_access_requirements(access, AccessRequirements::new())
+            .await
+    }
+
+    pub async fn all_collections_whole_access(
+        &self,
+        access: &Access,
+    ) -> Vec<CollectionPass<'static>> {
+        self.all_collections_with_access_requirements(access, AccessRequirements::new().whole())
+            .await
+    }
+
+    async fn all_collections_with_access_requirements(
+        &self,
+        access: &Access,
+        access_requirements: AccessRequirements,
+    ) -> Vec<CollectionPass<'static>> {
         self.collections
             .read()
             .await
             .keys()
             .filter_map(|name| {
                 access
-                    .check_collection_access(name, AccessRequirements::new())
+                    .check_collection_access(name, access_requirements.clone())
                     .ok()
                     .map(|pass| pass.into_static())
             })
@@ -451,7 +468,7 @@ impl TableOfContent {
         access: &Access,
     ) -> Vec<CollectionTelemetry> {
         let mut result = Vec::new();
-        let all_collections = self.all_collections(access).await;
+        let all_collections = self.all_collections_whole_access(access).await;
         for collection_pass in &all_collections {
             if let Ok(collection) = self.get_collection(collection_pass).await {
                 result.push(collection.get_telemetry_data(detail).await);

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -239,7 +239,7 @@ impl TableOfContent {
             .keys()
             .filter_map(|name| {
                 access
-                    .check_collection_access(name, access_requirements.clone())
+                    .check_collection_access(name, access_requirements)
                     .ok()
                     .map(|pass| pass.into_static())
             })

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -39,7 +39,6 @@ fn telemetry(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        // access.check_global_access(AccessRequirements::new())?;
         let anonymize = params.anonymize.unwrap_or(false);
         let details_level = params
             .details_level

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -39,7 +39,7 @@ fn telemetry(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        access.check_global_access(AccessRequirements::new())?;
+        // access.check_global_access(AccessRequirements::new())?;
         let anonymize = params.anonymize.unwrap_or(false);
         let details_level = params
             .details_level

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -110,8 +110,12 @@ impl MetricsProvider for TelemetryData {
     fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
         self.app.add_metrics(metrics);
         self.collections.add_metrics(metrics);
-        self.cluster.add_metrics(metrics);
-        self.requests.add_metrics(metrics);
+        if let Some(cluster) = &self.cluster {
+            cluster.add_metrics(metrics);
+        }
+        if let Some(requests) = &self.requests {
+            requests.add_metrics(metrics);
+        }
         if let Some(hardware) = &self.hardware {
             hardware.add_metrics(metrics);
         }

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -79,7 +79,7 @@ impl ClusterTelemetry {
         settings: &Settings,
     ) -> Option<ClusterTelemetry> {
         let global_access = AccessRequirements::new().whole();
-        if !access.check_global_access(global_access).is_ok() {
+        if access.check_global_access(global_access).is_err() {
             return None;
         }
 

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::Serialize;
 use storage::dispatcher::Dispatcher;
+use storage::rbac::{Access, AccessRequirements};
 use storage::types::{ClusterStatus, ConsensusThreadStatus, PeerInfo, StateRole};
 
 use crate::settings::Settings;
@@ -72,11 +73,17 @@ pub struct ClusterTelemetry {
 
 impl ClusterTelemetry {
     pub fn collect(
+        access: &Access,
         detail: TelemetryDetail,
         dispatcher: &Dispatcher,
         settings: &Settings,
-    ) -> ClusterTelemetry {
-        ClusterTelemetry {
+    ) -> Option<ClusterTelemetry> {
+        let global_access = AccessRequirements::new().whole();
+        if !access.check_global_access(global_access).is_ok() {
+            return None;
+        }
+
+        Some(ClusterTelemetry {
             enabled: settings.cluster.enabled,
             status: (detail.level >= DetailsLevel::Level1)
                 .then(|| match dispatcher.cluster_status() {
@@ -109,7 +116,7 @@ impl ClusterTelemetry {
                         .filter(|metadata| !metadata.is_empty())
                 })
                 .flatten(),
-        }
+        })
     }
 }
 

--- a/src/common/telemetry_ops/hardware.rs
+++ b/src/common/telemetry_ops/hardware.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::Serialize;
 use storage::dispatcher::Dispatcher;
+use storage::rbac::{Access, AccessRequirements};
 
 #[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct HardwareTelemetry {
@@ -12,10 +13,26 @@ pub struct HardwareTelemetry {
 }
 
 impl HardwareTelemetry {
-    pub(crate) fn new(dispatcher: &Dispatcher) -> Self {
-        Self {
-            collection_data: dispatcher.all_hw_metrics(),
-        }
+    pub(crate) fn new(dispatcher: &Dispatcher, access: &Access) -> Self {
+        let mut all_hw_metrics = dispatcher.all_hw_metrics();
+
+        let collection_data = match access {
+            Access::Global(_) => all_hw_metrics,
+            Access::Collection(collection_access_list) => {
+                let required_access = AccessRequirements::new().whole();
+                let allowed_collections =
+                    collection_access_list.meeting_requirements(required_access);
+                let mut resolved_collection_data = HashMap::new();
+                for collection in allowed_collections {
+                    if let Some(hw_metrics) = all_hw_metrics.remove(collection) {
+                        resolved_collection_data.insert(collection.clone(), hw_metrics);
+                    }
+                }
+                resolved_collection_data
+            }
+        };
+
+        Self { collection_data }
     }
 }
 

--- a/tests/consensus_tests/auth_tests/test_jwt_access.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_access.py
@@ -559,7 +559,7 @@ ACTION_ACCESS = {
     "readyz": EndpointAccess(True, True, True, "GET /readyz", "grpc.health.v1.Health/Check"),
     "healthz": EndpointAccess(True, True, True, "GET /healthz", "grpc.health.v1.Health/Check"),
     "livez": EndpointAccess(True, True, True, "GET /livez", "grpc.health.v1.Health/Check"),
-    "telemetry": EndpointAccess(True, False, True, "GET /telemetry", coll_r=False),
+    "telemetry": EndpointAccess(True, True, True, "GET /telemetry"),
     "metrics": EndpointAccess(True, False, True, "GET /metrics", coll_r=False),
     "post_locks": EndpointAccess(False, False, True, "POST /locks"),
     "get_locks": EndpointAccess(True, False, True, "GET /locks", coll_r=False),


### PR DESCRIPTION
- **WIP: per-collection telemetry permissions**
- **upd telemetry**

Always answer something on `GET /telemetry` request. The difference now is that info inside telemetry will be filtered based on the JWT permissions.

Any form of global access can read everything

Collection level-access can only read related collections (collection stats + hardware usage), but can't read:

- requests data
- cluster info
- memory info

Collection level access with payload can't read collection info and hardware counters.