### PR TITLE
zerocopy: 0.7 -> 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ dependencies = [
  "thread-priority",
  "tokio",
  "validator",
- "zerocopy",
+ "zerocopy 0.8.13",
 ]
 
 [[package]]
@@ -5851,7 +5851,7 @@ dependencies = [
  "uuid",
  "validator",
  "walkdir",
- "zerocopy",
+ "zerocopy 0.8.13",
 ]
 
 [[package]]
@@ -7947,8 +7947,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
+dependencies = [
+ "zerocopy-derive 0.8.13",
 ]
 
 [[package]]
@@ -7956,6 +7964,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 validator = { version = "0.18.1", features = ["derive"] }
 wal = { git = "https://github.com/qdrant/wal.git", rev = "f42e853debf22a3a746de444d625bb8cc1d2e61e" }
-zerocopy = { version = "0.7.34", features = ["derive"] }
+zerocopy = { version = "0.8.13", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"
 thiserror = "1.0.69"

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -191,9 +191,8 @@ impl<K: Key + ?Sized, V: Sized + FromBytes + Immutable + IntoBytes + KnownLayout
         // See https://docs.rs/memmap2/latest/memmap2/struct.Mmap.html#safety
         let mmap = unsafe { Mmap::map(&file)? };
 
-        let header = Header::read_from_prefix(mmap.as_ref())
-            .map_err(|_| io::ErrorKind::InvalidData)?
-            .0;
+        let (header, _) =
+            Header::read_from_prefix(mmap.as_ref()).map_err(|_| io::ErrorKind::InvalidData)?;
 
         if header.key_type != K::NAME {
             return Err(io::Error::new(

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -14,7 +14,7 @@ use ph::fmph::Function;
 use rand::rngs::StdRng;
 #[cfg(any(test, feature = "testing"))]
 use rand::Rng as _;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::zeros::WriteZerosExt as _;
 
@@ -39,7 +39,7 @@ type ValuesLen = u32;
 /// | key   | values_len | padding | values |
 /// |-------|------------|---------|--------|
 /// | `i64` | `u32`      | `u8[]`  | `V[]`  |
-pub struct MmapHashMap<K: ?Sized, V: Sized + AsBytes + FromBytes> {
+pub struct MmapHashMap<K: ?Sized, V: Sized + FromBytes + Immutable + IntoBytes + KnownLayout> {
     mmap: Mmap,
     header: Header,
     phf: Function,
@@ -48,7 +48,7 @@ pub struct MmapHashMap<K: ?Sized, V: Sized + AsBytes + FromBytes> {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
+#[derive(Copy, Clone, Debug, FromBytes, Immutable, IntoBytes, KnownLayout)]
 struct Header {
     key_type: [u8; 8],
     buckets_pos: u64,
@@ -59,7 +59,9 @@ const PADDING_SIZE: usize = 4096;
 
 type BucketOffset = u64;
 
-impl<K: Key + ?Sized, V: Sized + AsBytes + FromBytes> MmapHashMap<K, V> {
+impl<K: Key + ?Sized, V: Sized + FromBytes + Immutable + IntoBytes + KnownLayout>
+    MmapHashMap<K, V>
+{
     /// Save `map` contents to `path`.
     pub fn create<'a>(
         path: &Path,
@@ -141,7 +143,7 @@ impl<K: Key + ?Sized, V: Sized + AsBytes + FromBytes> MmapHashMap<K, V> {
             bufw.write_all((values.len() as ValuesLen).as_bytes())?;
             bufw.write_zeros(Self::values_len_padding_bytes())?;
             for i in values {
-                bufw.write_all(AsBytes::as_bytes(&i))?;
+                bufw.write_all(i.as_bytes())?;
             }
         }
 
@@ -189,7 +191,9 @@ impl<K: Key + ?Sized, V: Sized + AsBytes + FromBytes> MmapHashMap<K, V> {
         // See https://docs.rs/memmap2/latest/memmap2/struct.Mmap.html#safety
         let mmap = unsafe { Mmap::map(&file)? };
 
-        let header = Header::read_from_prefix(mmap.as_ref()).ok_or(io::ErrorKind::InvalidData)?;
+        let header = Header::read_from_prefix(mmap.as_ref())
+            .map_err(|_| io::ErrorKind::InvalidData)?
+            .0;
 
         if header.key_type != K::NAME {
             return Err(io::Error::new(
@@ -272,15 +276,15 @@ impl<K: Key + ?Sized, V: Sized + AsBytes + FromBytes> MmapHashMap<K, V> {
             )
         })?;
 
-        let values_len = ValuesLen::read_from_prefix(entry).ok_or_else(|| {
+        let (values_len, _) = ValuesLen::read_from_prefix(entry).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Can't read values_len from mmap",
             )
-        })? as usize;
+        })?;
 
         let values_from = Self::values_len_size_with_padding();
-        let values_to = values_from + values_len * Self::VALUE_SIZE;
+        let values_to = values_from + values_len as usize * Self::VALUE_SIZE;
 
         let entry = entry.get(values_from..values_to).ok_or_else(|| {
             io::Error::new(
@@ -289,7 +293,7 @@ impl<K: Key + ?Sized, V: Sized + AsBytes + FromBytes> MmapHashMap<K, V> {
             )
         })?;
 
-        let result = V::slice_from(entry).ok_or_else(|| {
+        let result = <[V]>::ref_from_bytes(entry).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Can't convert mmap range into slice",
@@ -307,7 +311,7 @@ impl<K: Key + ?Sized, V: Sized + AsBytes + FromBytes> MmapHashMap<K, V> {
         let bucket_val = self
             .mmap
             .get(bucket_from..bucket_to)
-            .and_then(BucketOffset::slice_from)
+            .and_then(|b| <[BucketOffset]>::ref_from_bytes(b).ok())
             .and_then(|buckets| buckets.get(index).copied())
             .ok_or_else(|| {
                 io::Error::new(
@@ -389,7 +393,8 @@ impl Key for str {
         //    with 0xFF will always result in an invalid UTF-8 string. Such string could not be
         //    added to the index since we are adding only valid UTF-8 strings as Rust enforces the
         //    validity of `str`/`String` types.
-        buf.get(..self.len()) == Some(AsBytes::as_bytes(self)) && buf.get(self.len()) == Some(&0xFF)
+        buf.get(..self.len()) == Some(IntoBytes::as_bytes(self))
+            && buf.get(self.len()) == Some(&0xFF)
     }
 
     fn from_bytes(buf: &[u8]) -> Option<&Self> {
@@ -408,15 +413,15 @@ impl Key for i64 {
     }
 
     fn write(&self, buf: &mut impl Write) -> io::Result<()> {
-        buf.write_all(AsBytes::as_bytes(self))
+        buf.write_all(self.as_bytes())
     }
 
     fn matches(&self, buf: &[u8]) -> bool {
-        buf.get(..size_of::<i64>()) == Some(AsBytes::as_bytes(self))
+        buf.get(..size_of::<i64>()) == Some(self.as_bytes())
     }
 
     fn from_bytes(buf: &[u8]) -> Option<&Self> {
-        buf.get(..size_of::<i64>()).and_then(FromBytes::ref_from)
+        Some(i64::ref_from_prefix(buf).ok()?.0)
     }
 }
 
@@ -430,15 +435,15 @@ impl Key for u128 {
     }
 
     fn write(&self, buf: &mut impl Write) -> io::Result<()> {
-        buf.write_all(AsBytes::as_bytes(self))
+        buf.write_all(self.as_bytes())
     }
 
     fn matches(&self, buf: &[u8]) -> bool {
-        buf.get(..size_of::<u128>()) == Some(AsBytes::as_bytes(self))
+        buf.get(..size_of::<u128>()) == Some(self.as_bytes())
     }
 
     fn from_bytes(buf: &[u8]) -> Option<&Self> {
-        buf.get(..size_of::<u128>()).and_then(FromBytes::ref_from)
+        Some(u128::ref_from_prefix(buf).ok()?.0)
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_common.rs
+++ b/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_common.rs
@@ -1,10 +1,10 @@
 use bitpacking::BitPacker;
 use common::types::PointOffsetType;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub type BitPackerImpl = bitpacking::BitPacker4x;
 
-#[derive(Clone, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Debug, Default, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
 pub struct CompressedPostingChunksIndex {
     /// First document ID value in the compressed chunk

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -193,14 +193,12 @@ impl MmapPostings {
         let path = path.into();
         let mmap = open_read_mmap(&path, AdviceSetting::Advice(Advice::Normal), populate)?;
 
-        let header = PostingsHeader::read_from_prefix(&mmap)
-            .map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("Invalid header deserialization in {}", path.display()),
-                )
-            })?
-            .0;
+        let (header, _) = PostingsHeader::read_from_prefix(&mmap).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Invalid header deserialization in {}", path.display()),
+            )
+        })?;
 
         Ok(Self { path, mmap, header })
     }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -7,7 +7,7 @@ use common::zeros::WriteZerosExt;
 use memmap2::Mmap;
 use memory::madvise::{Advice, AdviceSetting};
 use memory::mmap_ops::open_read_mmap;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::index::field_index::full_text_index::compressed_posting::compressed_chunks_reader::ChunkReader;
 use crate::index::field_index::full_text_index::compressed_posting::compressed_common::CompressedPostingChunksIndex;
@@ -16,7 +16,7 @@ use crate::index::field_index::full_text_index::inverted_index::TokenId;
 
 const ALIGNMENT: usize = 4;
 
-#[derive(Debug, Default, Clone, AsBytes, FromBytes, FromZeroes)]
+#[derive(Debug, Default, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
 struct PostingsHeader {
     /// Number of posting lists. One posting list per term
@@ -26,7 +26,7 @@ struct PostingsHeader {
 
 /// This data structure should contain all the necessary information to
 /// construct `CompressedMmapPostingList` from the mmap file.
-#[derive(Debug, Default, Clone, AsBytes, FromBytes, FromZeroes)]
+#[derive(Debug, Default, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
 struct PostingListHeader {
     /// Offset in bytes from the start of the mmap file
@@ -74,11 +74,10 @@ impl MmapPostings {
 
         let header_offset =
             size_of::<PostingsHeader>() + token_id as usize * size_of::<PostingListHeader>();
-        let header_bytes = self
-            .mmap
-            .get(header_offset..header_offset + size_of::<PostingListHeader>())?;
 
-        PostingListHeader::ref_from(header_bytes)
+        PostingListHeader::ref_from_prefix(self.mmap.get(header_offset..)?)
+            .ok()
+            .map(|(header, _)| header)
     }
 
     /// Create ChunkReader from the given header
@@ -92,36 +91,17 @@ impl MmapPostings {
     /// * `remainder_postings: &'a [PointOffsetType],`
     /// ```
     fn get_reader(&self, header: &PostingListHeader) -> Option<ChunkReader<'_>> {
-        let offset = header.offset as usize;
-        let chunks_len = header.chunks_count as usize;
-        let data_len = header.data_bytes_count as usize;
-        let alignment_len = header.alignment_bytes_count as usize;
-        let remainder_len = header.remainder_count as usize;
-
-        let last_doc_id_bytes = size_of::<PointOffsetType>();
-        let chunks_size_bytes = chunks_len * size_of::<CompressedPostingChunksIndex>();
-        let data_size_bytes = data_len;
-        let alignment_size_bytes = alignment_len;
-        let remainder_size_bytes = remainder_len * size_of::<PointOffsetType>();
-
-        let last_doc_id_offset = offset;
-        let chunks_offset = last_doc_id_offset + last_doc_id_bytes;
-        let data_offset = chunks_offset + chunks_size_bytes;
-        let alignment_offset = data_offset + data_size_bytes;
-        let remainder_offset = alignment_offset + alignment_size_bytes;
-
-        let last_doc_id_mem = self.mmap.get(last_doc_id_offset..chunks_offset)?;
-        let last_doc_id = u32::read_from(last_doc_id_mem)?;
-
-        let chunks_mem = self.mmap.get(chunks_offset..data_offset)?;
-        let chunks = CompressedPostingChunksIndex::slice_from(chunks_mem)?;
-
-        let data = self.mmap.get(data_offset..alignment_offset)?;
-
-        let remainder_mem = self
-            .mmap
-            .get(remainder_offset..remainder_offset + remainder_size_bytes)?;
-        let remainder_postings = u32::slice_from(remainder_mem)?;
+        let bytes = self.mmap.get(header.offset as usize..)?;
+        let (last_doc_id, bytes) = PointOffsetType::read_from_prefix(bytes).ok()?;
+        let (chunks, bytes) = <[CompressedPostingChunksIndex]>::ref_from_prefix_with_elems(
+            bytes,
+            header.chunks_count as usize,
+        )
+        .ok()?;
+        let (data, bytes) = bytes.split_at(header.data_bytes_count as usize);
+        let bytes = bytes.get(header.alignment_bytes_count as usize..)?;
+        let (remainder_postings, _) =
+            <[u32]>::ref_from_prefix_with_elems(bytes, header.remainder_count as usize).ok()?;
 
         Some(ChunkReader::new(
             last_doc_id,
@@ -213,19 +193,14 @@ impl MmapPostings {
         let path = path.into();
         let mmap = open_read_mmap(&path, AdviceSetting::Advice(Advice::Normal), populate)?;
 
-        let header_bytes = mmap.get(0..size_of::<PostingsHeader>()).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Invalid header in {}", path.display()),
-            )
-        })?;
-
-        let header = PostingsHeader::read_from(header_bytes).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Invalid header deserialization in {}", path.display()),
-            )
-        })?;
+        let header = PostingsHeader::read_from_prefix(&mmap)
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Invalid header deserialization in {}", path.display()),
+                )
+            })?
+            .0;
 
         Ok(Self { path, mmap, header })
     }

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -4,7 +4,7 @@ use common::types::PointOffsetType;
 use memmap2::Mmap;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::types::{FloatPayloadType, GeoPoint, IntPayloadType, UuidIntType};
@@ -38,11 +38,11 @@ impl MmapValue for IntPayloadType {
     }
 
     fn read_from_mmap(bytes: &[u8]) -> Option<Self::Referenced<'_>> {
-        Self::ref_from_prefix(bytes)
+        Some(Self::ref_from_prefix(bytes).ok()?.0)
     }
 
     fn write_to_mmap(value: Self::Referenced<'_>, bytes: &mut [u8]) -> Option<()> {
-        value.write_to_prefix(bytes)
+        value.write_to_prefix(bytes).ok()
     }
 
     fn from_referenced<'a>(value: &'a Self::Referenced<'_>) -> &'a Self {
@@ -62,11 +62,11 @@ impl MmapValue for FloatPayloadType {
     }
 
     fn read_from_mmap(bytes: &[u8]) -> Option<Self> {
-        Self::read_from_prefix(bytes)
+        Some(*Self::ref_from_prefix(bytes).ok()?.0)
     }
 
     fn write_to_mmap(value: Self, bytes: &mut [u8]) -> Option<()> {
-        value.write_to_prefix(bytes)
+        value.write_to_prefix(bytes).ok()
     }
 
     fn from_referenced<'a>(value: &'a Self::Referenced<'_>) -> &'a Self {
@@ -86,11 +86,11 @@ impl MmapValue for UuidIntType {
     }
 
     fn read_from_mmap(bytes: &[u8]) -> Option<Self::Referenced<'_>> {
-        Self::ref_from_prefix(bytes)
+        Some(Self::ref_from_prefix(bytes).ok()?.0)
     }
 
     fn write_to_mmap(value: Self::Referenced<'_>, bytes: &mut [u8]) -> Option<()> {
-        value.write_to_prefix(bytes)
+        value.write_to_prefix(bytes).ok()
     }
 
     fn from_referenced<'a>(value: &'a Self::Referenced<'_>) -> &'a Self {
@@ -110,19 +110,16 @@ impl MmapValue for GeoPoint {
     }
 
     fn read_from_mmap(bytes: &[u8]) -> Option<Self> {
-        Some(Self {
-            lon: f64::read_from_prefix(bytes)?,
-            lat: bytes
-                .get(std::mem::size_of::<f64>()..)
-                .and_then(f64::read_from_prefix)?,
-        })
+        let (lon, bytes) = f64::read_from_prefix(bytes).ok()?;
+        let (lat, _) = f64::read_from_prefix(bytes).ok()?;
+        Some(Self { lon, lat })
     }
 
     fn write_to_mmap(value: Self, bytes: &mut [u8]) -> Option<()> {
-        value.lon.write_to_prefix(bytes)?;
+        value.lon.write_to_prefix(bytes).ok()?;
         bytes
             .get_mut(std::mem::size_of::<f64>()..)
-            .and_then(|bytes| value.lat.write_to_prefix(bytes))
+            .and_then(|bytes| value.lat.write_to_prefix(bytes).ok())
     }
 
     fn from_referenced<'a>(value: &'a Self::Referenced<'_>) -> &'a Self {
@@ -142,14 +139,13 @@ impl MmapValue for str {
     }
 
     fn read_from_mmap(bytes: &[u8]) -> Option<&str> {
-        let size = u32::read_from_prefix(bytes)? as usize;
-
-        let bytes = bytes.get(std::mem::size_of::<u32>()..std::mem::size_of::<u32>() + size)?;
+        let (size, bytes) = u32::read_from_prefix(bytes).ok()?;
+        let bytes = bytes.get(..size as usize)?;
         std::str::from_utf8(bytes).ok()
     }
 
     fn write_to_mmap(value: &str, bytes: &mut [u8]) -> Option<()> {
-        u32::write_to_prefix(&(value.len() as u32), bytes)?;
+        u32::write_to_prefix(&(value.len() as u32), bytes).ok()?;
         bytes
             .get_mut(std::mem::size_of::<u32>()..std::mem::size_of::<u32>() + value.len())?
             .copy_from_slice(value.as_bytes());
@@ -178,14 +174,14 @@ pub struct MmapPointToValues<T: MmapValue + ?Sized> {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Copy, Clone, Debug, Default, FromBytes, Immutable, IntoBytes, KnownLayout)]
 struct MmapRange {
     start: u64,
     count: u64,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
+#[derive(Copy, Clone, Debug, FromBytes, Immutable, IntoBytes, KnownLayout)]
 struct Header {
     ranges_start: u64,
     points_count: u64,
@@ -221,7 +217,7 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
         };
         header
             .write_to_prefix(mmap.as_mut())
-            .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?;
+            .map_err(|_| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?;
 
         // counter for values offset
         let mut point_values_offset = header.ranges_start as usize + ranges_size;
@@ -247,7 +243,7 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
                 header.ranges_start as usize
                     + point_id as usize * std::mem::size_of::<MmapRange>()..,
             )
-            .and_then(|bytes| range.write_to_prefix(bytes))
+            .and_then(|bytes| range.write_to_prefix(bytes).ok())
             .ok_or_else(|| OperationError::service_error(NOT_ENOUGHT_BYTES_ERROR_MESSAGE))?;
         }
 
@@ -263,11 +259,11 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
     pub fn open(path: &Path) -> OperationResult<Self> {
         let file_name = path.join(POINT_TO_VALUES_PATH);
         let mmap = open_write_mmap(&file_name, AdviceSetting::Global, false)?;
-        let header = Header::read_from_prefix(mmap.as_ref()).ok_or_else(|| {
-            OperationError::InconsistentStorage {
+        let header = Header::read_from_prefix(mmap.as_ref())
+            .map_err(|_| OperationError::InconsistentStorage {
                 description: NOT_ENOUGHT_BYTES_ERROR_MESSAGE.to_owned(),
-            }
-        })?;
+            })?
+            .0;
 
         Ok(Self {
             file_name,
@@ -351,9 +347,9 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
         if point_id < self.header.points_count as PointOffsetType {
             let range_offset = (self.header.ranges_start as usize)
                 + (point_id as usize) * std::mem::size_of::<MmapRange>();
-            self.mmap
-                .get(range_offset..range_offset + std::mem::size_of::<MmapRange>())
-                .and_then(MmapRange::read_from)
+            MmapRange::read_from_prefix(self.mmap.get(range_offset..)?)
+                .ok()
+                .map(|(range, _)| range)
         } else {
             None
         }

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -259,11 +259,11 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
     pub fn open(path: &Path) -> OperationResult<Self> {
         let file_name = path.join(POINT_TO_VALUES_PATH);
         let mmap = open_write_mmap(&file_name, AdviceSetting::Global, false)?;
-        let header = Header::read_from_prefix(mmap.as_ref())
-            .map_err(|_| OperationError::InconsistentStorage {
+        let (header, _) = Header::read_from_prefix(mmap.as_ref()).map_err(|_| {
+            OperationError::InconsistentStorage {
                 description: NOT_ENOUGHT_BYTES_ERROR_MESSAGE.to_owned(),
-            })?
-            .0;
+            }
+        })?;
 
         Ok(Self {
             file_name,

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -71,7 +71,7 @@ struct GraphLinksFileHeader {
 
 impl GraphLinksFileInfo {
     pub fn load(data: &[u8]) -> Option<GraphLinksFileInfo> {
-        let header = GraphLinksFileHeader::ref_from_prefix(data).ok()?.0;
+        let (header, _) = GraphLinksFileHeader::ref_from_prefix(data).ok()?;
 
         let reindex_start = HEADER_SIZE + header.levels_count as usize * size_of::<u64>();
         let links_start =

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -9,7 +9,7 @@ use common::types::PointOffsetType;
 use common::zeros::WriteZerosExt as _;
 use memmap2::Mmap;
 use memory::{madvise, mmap_ops};
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::vector_utils::TrySetCapacityExact;
@@ -59,7 +59,7 @@ struct GraphLinksFileInfo {
     offsets_end: usize,
 }
 
-#[derive(AsBytes, FromBytes, FromZeroes)]
+#[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
 struct GraphLinksFileHeader {
     point_count: u64,
@@ -71,7 +71,7 @@ struct GraphLinksFileHeader {
 
 impl GraphLinksFileInfo {
     pub fn load(data: &[u8]) -> Option<GraphLinksFileInfo> {
-        let header = GraphLinksFileHeader::ref_from_prefix(data)?;
+        let header = GraphLinksFileHeader::ref_from_prefix(data).ok()?.0;
 
         let reindex_start = HEADER_SIZE + header.levels_count as usize * size_of::<u64>();
         let links_start =
@@ -95,7 +95,7 @@ impl GraphLinksFileInfo {
     }
 
     pub fn get_level_offsets<'a>(&self, data: &'a [u8]) -> &'a [u64] {
-        u64::slice_from(&data[self.level_offsets()]).unwrap()
+        <[u64]>::ref_from_bytes(&data[self.level_offsets()]).unwrap()
     }
 
     pub fn reindex_range(&self) -> Range<usize> {
@@ -493,18 +493,18 @@ impl<'a> GraphLinksView<'a> {
     }
 
     fn get_links_range(&self, idx: usize) -> Range<usize> {
-        let offsets = u64::slice_from(&self.data[self.info.offsets_range()]).unwrap();
+        let offsets = <[u64]>::ref_from_bytes(&self.data[self.info.offsets_range()]).unwrap();
         offsets[idx] as usize..offsets[idx + 1] as usize
     }
 
     fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType {
         let idx = &self.data[self.info.reindex_range()];
-        PointOffsetType::slice_from(idx).unwrap()[point_id as usize]
+        <[PointOffsetType]>::ref_from_bytes(idx).unwrap()[point_id as usize]
     }
 
     fn get_links(&self, range: Range<usize>) -> &'a [PointOffsetType] {
         let idx = &self.data[self.info.links_range()];
-        PointOffsetType::slice_from(idx)
+        <[PointOffsetType]>::ref_from_bytes(idx)
             .unwrap()
             .get(range)
             .unwrap()


### PR DESCRIPTION
This PR bumps usage of `zerocopy` from `0.7` to `0.8`.

It's brings some incompatible changes to the API, but the new API neatly simplifies the code that reads items/slices in a sequential manner. Check the updated `MmapPostings::get_reader()`.

A list of changes and migration guide is listed here: https://github.com/google/zerocopy/discussions/1680.