### PR TITLE
Fix handling of rate limiting error for CollectionError

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1301,7 +1301,18 @@ impl From<tonic::Status> for CollectionError {
             tonic::Code::FailedPrecondition => CollectionError::PreConditionFailed {
                 description: format!("{err}"),
             },
-            _other => CollectionError::ServiceError {
+            tonic::Code::ResourceExhausted => CollectionError::RateLimitExceeded {
+                description: format!("{err}"),
+            },
+            tonic::Code::Ok
+            | tonic::Code::Unknown
+            | tonic::Code::PermissionDenied
+            | tonic::Code::Aborted
+            | tonic::Code::OutOfRange
+            | tonic::Code::Unimplemented
+            | tonic::Code::Unavailable
+            | tonic::Code::DataLoss
+            | tonic::Code::Unauthenticated => CollectionError::ServiceError {
                 error: format!("Tonic status error: {err}"),
                 backtrace: Some(Backtrace::force_capture().to_string()),
             },


### PR DESCRIPTION
I forgot to handle properly the Tonic rate limiting error (introduced in https://github.com/qdrant/qdrant/pull/5538) because of the match all approach.

This PR fixes the missing error handling and switch to an exhaustive match to avoid this kind of error in the future.