### PR TITLE
Fix rate limiting of internal update operations

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -179,9 +179,9 @@ impl Collection {
         // update collection config
         self.collection_config.read().await.save(&self.path)?;
         // apply config change to all shards
-        let shard_holder = self.shards_holder.read().await;
+        let mut shard_holder = self.shards_holder.write().await;
         let updates = shard_holder
-            .all_shards()
+            .all_shards_mut()
             .map(|replica_set| replica_set.on_strict_mode_config_update());
         future::try_join_all(updates).await?;
         Ok(())

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -126,6 +126,7 @@ impl ForwardProxyShard {
         debug_assert!(batch_size > 0);
         let limit = batch_size + 1;
         let _update_lock = self.update_lock.lock().await;
+        // TODO(ratelimits) this scroll should *not* be rate limited
         let mut batch = self
             .wrapped_shard
             .scroll_by(

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -101,7 +101,6 @@ pub struct LocalShard {
     pub(super) search_runtime: Handle,
     disk_usage_watcher: DiskUsageWatcher,
     read_rate_limiter: ParkingMutex<Option<RateLimiter>>,
-    write_rate_limiter: ParkingMutex<Option<RateLimiter>>,
 }
 
 /// Shard holds information about segments and WAL.
@@ -206,13 +205,6 @@ impl LocalShard {
             .and_then(|strict_mode| strict_mode.read_rate_limit.map(RateLimiter::new_per_minute));
         let read_rate_limiter = ParkingMutex::new(read_rate_limiter);
 
-        let write_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
-            strict_mode
-                .write_rate_limit
-                .map(RateLimiter::new_per_minute)
-        });
-        let write_rate_limiter = ParkingMutex::new(write_rate_limiter);
-
         drop(config); // release `shared_config` from borrow checker
 
         Self {
@@ -232,7 +224,6 @@ impl LocalShard {
             total_optimized_points,
             disk_usage_watcher,
             read_rate_limiter,
-            write_rate_limiter,
         }
     }
 
@@ -770,13 +761,6 @@ impl LocalShard {
                 read_rate_limiter_guard
                     .replace(RateLimiter::new_per_minute(read_rate_limit_per_sec));
             }
-
-            // update write rate limiter
-            if let Some(write_rate_limit_per_sec) = strict_mode_config.write_rate_limit {
-                let mut write_rate_limiter_guard = self.write_rate_limiter.lock();
-                write_rate_limiter_guard
-                    .replace(RateLimiter::new_per_minute(write_rate_limit_per_sec));
-            }
         }
     }
 
@@ -1140,20 +1124,6 @@ impl LocalShard {
     /// This also updates the highest seen clocks.
     pub async fn update_cutoff(&self, cutoff: &RecoveryPoint) {
         self.wal.update_cutoff(cutoff).await
-    }
-
-    /// Check if the write rate limiter allows the operation to proceed
-    ///
-    /// Returns an error if the rate limit is exceeded.
-    fn check_write_rate_limiter(&self) -> CollectionResult<()> {
-        if let Some(rate_limiter) = self.write_rate_limiter.lock().as_mut() {
-            if !rate_limiter.check() {
-                return Err(CollectionError::RateLimitExceeded {
-                    description: "Write rate limit exceeded, retry later".to_string(),
-                });
-            }
-        }
-        Ok(())
     }
 
     /// Check if the read rate limiter allows the operation to proceed

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1131,7 +1131,7 @@ impl LocalShard {
     /// Returns an error if the rate limit is exceeded.
     fn check_read_rate_limiter(&self) -> CollectionResult<()> {
         if let Some(rate_limiter) = self.read_rate_limiter.lock().as_mut() {
-            if !rate_limiter.check() {
+            if !rate_limiter.check_and_update() {
                 return Err(CollectionError::RateLimitExceeded {
                     description: "Read rate limit exceeded, retry later".to_string(),
                 });

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -39,9 +39,6 @@ impl ShardOperation for LocalShard {
         mut operation: OperationWithClockTag,
         wait: bool,
     ) -> CollectionResult<UpdateResult> {
-        // Check write rate limiter before proceeding
-        self.check_write_rate_limiter()?;
-
         // `LocalShard::update` only has a single cancel safe `await`, WAL operations are blocking,
         // and update is applied by a separate task, so, surprisingly, this method is cancel safe. :D
 

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -312,6 +312,7 @@ async fn drive_down(
             })?;
 
             // Take batch of points, if full, pop the last entry as next batch offset
+            // TODO(ratelimits) this scroll should *not* be rate limited
             let mut points = source_replica_set
                 .scroll_by(
                     offset,

--- a/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
+++ b/lib/collection/src/shards/resharding/stage_propagate_deletes.rs
@@ -62,6 +62,7 @@ pub(super) async fn drive(
             })?;
 
             // Take batch of points, if full, pop the last entry as next batch offset
+            // TODO(ratelimits) this scroll should *not* be rate limited
             let mut points = replica_set
                 .scroll_by(
                     offset,

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -289,6 +289,10 @@ impl ShardHolder {
         self.shards.values()
     }
 
+    pub fn all_shards_mut(&mut self) -> impl Iterator<Item = &mut ShardReplicaSet> {
+        self.shards.values_mut()
+    }
+
     pub fn split_by_shard<O: SplitByShard + Clone>(
         &self,
         operation: O,

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -29,7 +29,7 @@ impl RateLimiter {
     }
 
     /// Attempt to consume a token. Returns `true` if allowed, `false` otherwise.
-    pub fn check(&mut self) -> bool {
+    pub fn check_and_update(&mut self) -> bool {
         let now = Instant::now();
         let elapsed = now.duration_since(self.last_check);
         self.last_check = now;
@@ -67,11 +67,11 @@ mod tests {
         assert_eq_floats(limiter.tokens_per_sec, 0.016, 0.001);
         assert_eq!(limiter.tokens, 1.0);
 
-        assert!(limiter.check());
+        assert!(limiter.check_and_update());
         assert_eq!(limiter.tokens, 0.0);
 
         // rate limit reached
-        assert!(!limiter.check());
+        assert!(!limiter.check_and_update());
     }
 
     #[test]
@@ -81,7 +81,7 @@ mod tests {
         assert_eq!(limiter.tokens_per_sec, 10.0);
         assert_eq!(limiter.tokens, 600.0);
 
-        assert!(limiter.check());
+        assert!(limiter.check_and_update());
         assert_eq!(limiter.tokens, 599.0);
     }
 }

--- a/tests/consensus_tests/test_shard_transfer_rate_limiting.py
+++ b/tests/consensus_tests/test_shard_transfer_rate_limiting.py
@@ -1,0 +1,245 @@
+import pathlib
+from time import sleep
+
+from .utils import *
+from .assertions import assert_http_ok
+
+N_PEERS = 2
+N_SHARDS = 2
+N_REPLICA = 1
+
+
+def test_shard_transfer_rate_limiting(tmp_path: pathlib.Path):
+    assert_project_root()
+    peer_dirs = make_peer_folders(tmp_path, N_PEERS)
+
+    # Gathers REST API uris
+    peer_api_uris = []
+
+    # Start bootstrap
+    (bootstrap_api_uri, bootstrap_uri) = start_first_peer(
+        peer_dirs[0], "peer_0_0.log")
+    peer_api_uris.append(bootstrap_api_uri)
+
+    # Wait for leader
+    leader = wait_peer_added(bootstrap_api_uri)
+
+    # Start other peers
+    for i in range(1, len(peer_dirs)):
+        peer_api_uris.append(start_peer(
+            peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
+
+    # Wait for cluster
+    wait_for_uniform_cluster_status(peer_api_uris, leader)
+
+    # Check that there are no collections on all peers
+    for uri in peer_api_uris:
+        r = requests.get(f"{uri}/collections")
+        assert_http_ok(r)
+        assert len(r.json()["result"]["collections"]) == 0
+
+    # Create collection in first peer
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection", json={
+            "vectors": {
+                "size": 4,
+                "distance": "Dot"
+            },
+            "shard_number": N_SHARDS,
+            "replication_factor": N_REPLICA,
+        })
+    assert_http_ok(r)
+
+    # Check that it exists on all peers
+    wait_collection_exists_and_active_on_all_peers(collection_name="test_collection", peer_api_uris=peer_api_uris)
+
+    # Check collection's cluster info
+    collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], "test_collection")
+    assert collection_cluster_info["shard_count"] == N_SHARDS
+
+    # Create points in first peer's collection
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection/points?wait=true", json={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76, 0.74],
+                    "payload": {
+                        "city": "Berlin",
+                        "country": "Germany",
+                        "count": 1000000,
+                        "square": 12.5,
+                        "coords": {"lat": 1.0, "lon": 2.0}
+                    }
+                },
+                {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11],
+                 "payload": {"city": ["Berlin", "London"]}},
+                {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94],
+                 "payload": {"city": ["Berlin", "Moscow"]}},
+                {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80],
+                 "payload": {"city": ["London", "Moscow"]}},
+                {"id": 5, "vector": [0.24, 0.18, 0.22, 0.44],
+                 "payload": {"count": [0]}},
+                {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
+            ]
+        })
+    assert_http_ok(r)
+
+    # Check that 'search' returns the same results on all peers
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/test_collection/points/search", json={
+                "vector": [0.2, 0.1, 0.9, 0.7],
+                "top": 3,
+            }
+        )
+        assert_http_ok(r)
+        assert r.json()["result"][0]["id"] == 4
+        assert r.json()["result"][1]["id"] == 1
+        assert r.json()["result"][2]["id"] == 3
+
+    # Extract current collection cluster info
+    collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], "test_collection")
+    target_peer_id = collection_cluster_info["remote_shards"][0]["peer_id"]
+    source_uri = peer_api_uris[0]
+    target_uri = peer_api_uris[1]
+
+    target_collection_cluster_info = get_collection_cluster_info(target_uri, "test_collection")
+    target_before_local_shard_count = len(target_collection_cluster_info["local_shards"])
+
+    before_local_shard_count = len(collection_cluster_info["local_shards"])
+    shard_id = collection_cluster_info["local_shards"][0]["shard_id"]
+    source_peer_id = collection_cluster_info["peer_id"]
+
+    # set rate limiting
+    r = requests.patch(
+        f"{source_uri}/collections/test_collection", json={
+            "strict_mode_config": {
+                "enabled": True,
+                "write_rate_limit": 1,
+                # TODO(ratelimit) validate read limits as well "read_rate_limit": 1
+            }
+        })
+    assert_http_ok(r)
+
+    # Exhaust write rate limit on target shard
+    rate_limited = False
+    for _ in range(100):
+        r = requests.put(
+            f"{target_uri}/collections/test_collection/points?wait=true", json={
+                "points": [
+                    {
+                        "id": 1,
+                        "vector": [0.05, 0.61, 0.76, 0.74],
+                        "payload": {
+                            "city": "Berlin",
+                            "country": "Germany",
+                            "count": 1000000,
+                            "square": 12.5,
+                            "coords": {"lat": 1.0, "lon": 2.0}
+                        }
+                    },
+                ]
+            })
+        if not r.ok:
+            rate_limited = True
+            assert r.status_code == 429, f"Failure body {r.json()}"
+            assert "Rate limiting exceeded: Write rate limit exceeded, retry later" in r.json()['status']['error']
+            break
+
+    assert rate_limited, "Expected write rate limit to be reached"
+
+    # Move shard `shard_id` to peer `target_peer_id` without write budget
+    r = requests.post(
+        f"{source_uri}/collections/test_collection/cluster", json={
+            "move_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": source_peer_id,
+                "to_peer_id": target_peer_id
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(source_uri, "test_collection", 0)
+
+    # Check the number of local shards goes down by 1
+    assert check_collection_local_shards_count(source_uri, "test_collection", before_local_shard_count - 1)
+    assert check_collection_local_shards_count(target_uri, "test_collection", target_before_local_shard_count + 1)
+
+    # Check that 'search' returns the same results on all peers
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/test_collection/points/search", json={
+                "vector": [0.2, 0.1, 0.9, 0.7],
+                "top": 3,
+            }
+        )
+        assert_http_ok(r)
+        assert r.json()["result"][0]["id"] == 4
+        assert r.json()["result"][1]["id"] == 1
+        assert r.json()["result"][2]["id"] == 3
+
+    # Replicate shards back to the source peer
+    r = requests.post(
+        f"{source_uri}/collections/test_collection/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": target_peer_id,
+                "to_peer_id": source_peer_id
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(source_uri, "test_collection", 0)
+
+    # Check that the number of local shard goes back to the original value
+    assert check_collection_local_shards_count(source_uri, "test_collection", before_local_shard_count)
+    assert check_collection_local_shards_count(target_uri, "test_collection", target_before_local_shard_count + 1)
+
+    # Check that 'search' returns the same results on all peers
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/test_collection/points/search", json={
+                "vector": [0.2, 0.1, 0.9, 0.7],
+                "top": 3,
+            }
+        )
+        assert_http_ok(r)
+        assert r.json()["result"][0]["id"] == 4
+        assert r.json()["result"][1]["id"] == 1
+        assert r.json()["result"][2]["id"] == 3
+
+    # Perform a replication for the second time with the target node active
+    r = requests.post(
+        f"{source_uri}/collections/test_collection/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": target_peer_id,
+                "to_peer_id": source_peer_id
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(source_uri, "test_collection", 0)
+
+    # Check that the number of local shard is still the same
+    assert check_collection_local_shards_count(source_uri, "test_collection", before_local_shard_count)
+    assert check_collection_local_shards_count(target_uri, "test_collection", target_before_local_shard_count + 1)
+
+    # Check that 'search' returns the same results on all peers
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/test_collection/points/search", json={
+                "vector": [0.2, 0.1, 0.9, 0.7],
+                "top": 3,
+            }
+        )
+        assert_http_ok(r)
+        assert r.json()["result"][0]["id"] == 4
+        assert r.json()["result"][1]["id"] == 1
+        assert r.json()["result"][2]["id"] == 3
+
+

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -695,3 +695,14 @@ def create_shard_key(shard_key, peer_url, collection="test_collection", placemen
         },
     )
     assert_http_ok(r_batch)
+
+def move_shard(source_uri, collection_name, shard_id, source_peer_id, target_peer_id):
+    r = requests.post(
+        f"{source_uri}/collections/{collection_name}/cluster", json={
+            "move_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": source_peer_id,
+                "to_peer_id": target_peer_id
+            }
+        })
+    assert_http_ok(r)

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -643,6 +643,23 @@ def test_strict_mode_read_rate_limiting(collection_name):
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
 
+    # TODO(ratelimite) test read limit can be disabled
+    # set_strict_mode(collection_name, {
+    #     "enabled": False,
+    # })
+    #
+    # for _ in range(10):
+    #     response = request_with_validation(
+    #         api='/collections/{collection_name}/points/search',
+    #         method="POST",
+    #         path_params={'collection_name': collection_name},
+    #         body={
+    #             "vector": [0.2, 0.1, 0.9, 0.7],
+    #             "limit": 4
+    #         }
+    #     )
+    #     assert response.ok, "Rate limiting should be disabled now"
+
 
 def test_strict_mode_max_collection_payload_size_upsert(collection_name):
     # TODO: Update this test when payload rocksDB storage has been replaced by mmap payload storage!
@@ -814,3 +831,26 @@ def test_strict_mode_write_rate_limiting(collection_name):
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
+
+    # Disable rate limiting
+    set_strict_mode(collection_name, {
+        "enabled": False,
+    })
+
+    for _ in range(10):
+        response = request_with_validation(
+            api='/collections/{collection_name}/points',
+            method="PUT",
+            path_params={'collection_name': collection_name},
+            query_params={'wait': 'true'},
+            body={
+                "points": [
+                    {
+                        "id": 1,
+                        "vector": [0.05, 0.61, 0.76, 0.74],
+                    },
+                ]
+            }
+        )
+
+        assert response.ok, "Rate limiting should be disabled now"

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -643,7 +643,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
 
-    # TODO(ratelimite) test read limit can be disabled
+    # TODO(ratelimiting) test read limit can be disabled
     # set_strict_mode(collection_name, {
     #     "enabled": False,
     # })


### PR DESCRIPTION
This PR ensures that we do not rate limit internal update operations used during transfers.

This is achieved by lifting the write rate limiter up from local shard to the replica set.
This new location has access to the replica state to decide whether the update should be rate limited.

I have added an integration tests to demonstrate that a shard can be transferred when the write limiting budget is used up.

Interestingly I found a couple of spots where read requests involved in shard transfers are wrongly rate limited.
I have annotated those for a future PR. 