### PR TITLE
Fix debug assertion for propagating segment proxy deletes

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -251,12 +251,12 @@ impl ProxySegment {
         // See: <https://github.com/qdrant/qdrant/pull/4206>
         let wrapped_segment = self.wrapped_segment.get();
         let mut wrapped_segment = wrapped_segment.upgradable_read();
-        let op_num = wrapped_segment.version();
 
         // Propagate index changes before point deletions
         // Point deletions bump the segment version, can cause index changes to be ignored
         // Lock ordering is important here and must match the flush function to prevent a deadlock
         {
+            let op_num = wrapped_segment.version();
             let changed_indexes = self.changed_indexes.upgradable_read();
             if !changed_indexes.is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
@@ -294,7 +294,8 @@ impl ProxySegment {
                         // Delete points here with their operation version, that'll bump the optimized
                         // segment version and will ensure we flush the new changes
                         debug_assert!(
-                            versions.operation_version >= op_num,
+                            versions.operation_version
+                                >= wrapped_segment.point_version(*point_id).unwrap_or(0),
                             "proxied point deletes should have newer version than segment",
                         );
                         wrapped_segment.delete_point(versions.operation_version, *point_id)?;

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -663,7 +663,8 @@ pub trait SegmentOptimizer {
                 // Delete points here with their operation version, that'll bump the optimized
                 // segment version and will ensure we flush the new changes
                 debug_assert!(
-                    versions.operation_version >= old_optimized_segment_version,
+                    versions.operation_version
+                        >= optimized_segment.point_version(point_id).unwrap_or(0),
                     "proxied point deletes should have newer version than segment",
                 );
                 optimized_segment


### PR DESCRIPTION
Fix the debug assertion panic causing flaky tests that were implemented in <https://github.com/qdrant/qdrant/pull/5573>.

Point delete operations don't have to be newer than the segment version, but they should not be older than the point version of the wrapped segment.

Example failures:
- > proxied point deletes should have newer version than segment
- https://github.com/qdrant/qdrant/actions/runs/12207755405/job/34059745505
- https://github.com/qdrant/qdrant/actions/runs/12254635448/job/34185980363

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?