### PR TITLE
Update hnsw_search_graph benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,6 +2999,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
+ "rayon",
  "unicode-width 0.2.0",
  "web-time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ futures-util = "0.3.30"
 generic-tests = "0.1.3"
 half = { version = "2.4.1", features = ["alloc", "serde", "num-traits"] }
 indexmap = { version = "2", features = ["serde"] }
-indicatif = "0.17.9"
+indicatif = { version = "0.17.9", features = ["rayon"] }
 itertools = "0.13.0"
 log = "0.4.22"
 memmap2 = "0.9.5"

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -361,16 +361,7 @@ pub fn convert_to_compressed(path: &Path, m: usize, m0: usize) -> OperationResul
         return Ok(());
     }
 
-    let edges = (0..links.num_points())
-        .map(|point_id| {
-            let num_levels = links.point_level(point_id as PointOffsetType) + 1;
-            (0..num_levels)
-                .map(|level| links.links_vec(point_id as PointOffsetType, level))
-                .collect::<Vec<_>>()
-        })
-        .collect();
-    drop(links);
-    let mut converter = GraphLinksConverter::new(edges, true, m, m0);
+    let mut converter = GraphLinksConverter::new(links.into_edges(), true, m, m0);
 
     let original_size = path.metadata()?.len();
     converter.save_as(path)?;
@@ -407,6 +398,21 @@ pub trait GraphLinks: Sized {
         let mut links = Vec::new();
         self.for_each_link(point_id, level, |link| links.push(link));
         links
+    }
+
+    /// Convert the graph links to a vector of edges, suitable for passing into
+    /// [`GraphLinksConverter::new`] or using in tests.
+    fn into_edges(self) -> Vec<Vec<Vec<PointOffsetType>>> {
+        let mut edges = Vec::new();
+        for point_id in 0..self.num_points() {
+            let num_levels = self.point_level(point_id as PointOffsetType) + 1;
+            let mut levels = Vec::with_capacity(num_levels);
+            for level in 0..num_levels {
+                levels.push(self.links_vec(point_id as PointOffsetType, level));
+            }
+            edges.push(levels);
+        }
+        edges
     }
 }
 
@@ -647,21 +653,6 @@ mod tests {
 
     use super::*;
 
-    fn to_vec<TGraphLinks: GraphLinks>(links: &TGraphLinks) -> Vec<Vec<Vec<PointOffsetType>>> {
-        let mut result = Vec::new();
-        let num_points = links.num_points();
-        for i in 0..num_points {
-            let mut layers = Vec::new();
-            let num_levels = links.point_level(i as PointOffsetType) + 1;
-            for level in 0..num_levels {
-                let links = links.links_vec(i as PointOffsetType, level);
-                layers.push(links);
-            }
-            result.push(layers);
-        }
-        result
-    }
-
     fn random_links(
         points_count: usize,
         max_levels_count: usize,
@@ -734,7 +725,7 @@ mod tests {
             let mut links_converter = GraphLinksConverter::new(links.clone(), compressed, m, m0);
             links_converter.save_as(&links_file).unwrap();
         }
-        let cmp_links = to_vec(&A::load_from_file(&links_file).unwrap());
+        let cmp_links = A::load_from_file(&links_file).unwrap().into_edges();
         compare_links(links, cmp_links, compressed, m, m0);
     }
 
@@ -749,15 +740,14 @@ mod tests {
                               m: usize,
                               m0: usize|
          -> Vec<Vec<Vec<PointOffsetType>>> {
-            to_vec(
-                &GraphLinksRam::from_converter(GraphLinksConverter::new(
-                    links.clone(),
-                    compressed,
-                    m,
-                    m0,
-                ))
-                .unwrap(),
-            )
+            GraphLinksRam::from_converter(GraphLinksConverter::new(
+                links.clone(),
+                compressed,
+                m,
+                m0,
+            ))
+            .unwrap()
+            .into_edges()
         };
 
         // no points


### PR DESCRIPTION
Depends on #5492. Review only the last two commits.

This PR updates `hnsw_search_graph` benchmark to make it convenient to benchmark changes in the compression implementation.

- Uncompressed HNSW links are cached and preserved across benchmark runs, so you don't have to wait each time you run the benchmark.
- Cache file name: `target/tmp/segment/hnsw_search_graph/1000000-64-16-100-true-Cosine.links`.
  - Since HNSW parameters are part of the file name, the index is properly invalidated if you change them.
  - Caveat: the vectors are not saved. So the results will be garbage if you change the vectors generation code or seed without manually cleaning the cache. Tho I believe that it will be changed rarely (or never).
- HNSW is built in parallel and the progress is shown using `indicatif` crate.
- Benchmarks are renamed, and a `compressed` benchmark is added.
  - Old names: `hnsw-index-search-group/{hnsw_search,plain_search}`.
  - New names: `hnsw-search-graph/{uncompressed,compressed,plain}`.
- `NUM_VECTORS` increased from `100_000` to `1_000_000` since wait times are not a problem now.