### PR TITLE
Abort scale-down resharding on update error

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1849,7 +1849,8 @@ Note: 1kB = 1 vector of size 256. |
 | Listener | 4 | A shard which receives data, but is not used for search; Useful for backup shards |
 | PartialSnapshot | 5 | Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard |
 | Recovery | 6 | Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true |
-| Resharding | 7 | Points are being migrated to this shard as part of resharding |
+| Resharding | 7 | Points are being migrated to this shard as part of scale-up resharding |
+| ReshardingScaleDown | 8 | Points are being migrated to this shard as part of scale-down resharding |
 
 
 

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -552,7 +552,8 @@ enum ReplicaState {
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
   PartialSnapshot = 5; // Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
   Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
-  Resharding = 7; // Points are being migrated to this shard as part of resharding
+  Resharding = 7; // Points are being migrated to this shard as part of scale-up resharding
+  ReshardingScaleDown = 8; // Points are being migrated to this shard as part of scale-down resharding
 }
 
 message ShardKey {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1670,8 +1670,10 @@ pub enum ReplicaState {
     PartialSnapshot = 5,
     /// Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
     Recovery = 6,
-    /// Points are being migrated to this shard as part of resharding
+    /// Points are being migrated to this shard as part of scale-up resharding
     Resharding = 7,
+    /// Points are being migrated to this shard as part of scale-down resharding
+    ReshardingScaleDown = 8,
 }
 impl ReplicaState {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1688,6 +1690,7 @@ impl ReplicaState {
             ReplicaState::PartialSnapshot => "PartialSnapshot",
             ReplicaState::Recovery => "Recovery",
             ReplicaState::Resharding => "Resharding",
+            ReplicaState::ReshardingScaleDown => "ReshardingScaleDown",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1701,6 +1704,7 @@ impl ReplicaState {
             "PartialSnapshot" => Some(Self::PartialSnapshot),
             "Recovery" => Some(Self::Recovery),
             "Resharding" => Some(Self::Resharding),
+            "ReshardingScaleDown" => Some(Self::ReshardingScaleDown),
             _ => None,
         }
     }

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -219,7 +219,9 @@ impl Collection {
                 });
             }
 
-            // Check that we are not removing the
+            // Check that we are not removing the last active replica
+            //
+            // `is_last_active_replica` counts both `Active` and `ReshardingScaleDown` replicas!
             if replica_set.is_last_active_replica(peer_id) {
                 return Err(CollectionError::BadRequest {
                     description: format!("Shard {shard_id} must have at least one active replica after removing {peer_id}"),

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -421,7 +421,7 @@ impl Collection {
         // 3. Do not deactivate the last active replica
         //
         // `is_last_active_replica` counts both `Active` and `ReshardingScaleDown` replicas!
-        if replica_set.is_last_active_replica(peer_id) && new_state.is_active() {
+        if replica_set.is_last_active_replica(peer_id) && !new_state.is_active() {
             return Err(CollectionError::bad_input(format!(
                 "Cannot deactivate the last active replica {peer_id} of shard {shard_id}"
             )));

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -7,6 +7,7 @@ use common::defaults;
 use parking_lot::Mutex;
 
 use super::Collection;
+use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::local_shard::LocalShard;
 use crate::shards::replica_set::ReplicaState;
@@ -80,10 +81,21 @@ impl Collection {
 
             let initial_state = match shard_transfer.method.unwrap_or_default() {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,
+
                 ShardTransferMethod::Snapshot | ShardTransferMethod::WalDelta => {
                     ReplicaState::Recovery
                 }
-                ShardTransferMethod::ReshardingStreamRecords => ReplicaState::Resharding,
+
+                ShardTransferMethod::ReshardingStreamRecords => {
+                    let resharding_direction =
+                        self.resharding_state().await.map(|state| state.direction);
+
+                    match resharding_direction {
+                        Some(ReshardingDirection::Up) => ReplicaState::Resharding,
+                        Some(ReshardingDirection::Down) => ReplicaState::ReshardingScaleDown,
+                        None => return Err(CollectionError::bad_input("can't start resharding transfer, because resharding is not in progress")),
+                    }
+                }
             };
 
             // Create local shard if it does not exist on receiver, or simply set replica state otherwise
@@ -218,7 +230,21 @@ impl Collection {
                 //     *explicitly* when all transfers are finished
 
                 let state = if is_resharding_transfer {
-                    ReplicaState::Resharding
+                    let resharding_direction =
+                        self.resharding_state().await.map(|state| state.direction);
+
+                    match resharding_direction {
+                        Some(ReshardingDirection::Up) => ReplicaState::Resharding,
+                        Some(ReshardingDirection::Down) => ReplicaState::ReshardingScaleDown,
+                        None => {
+                            log::error!(
+                                "Can't finish resharding shard transfer correctly, \
+                                 because resharding is not in progress anymore!",
+                            );
+
+                            ReplicaState::Dead
+                        }
+                    }
                 } else {
                     ReplicaState::Active
                 };

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -229,6 +229,10 @@ impl Collection {
                 //   - resharding requires multiple transfers, so destination shard is promoted
                 //     *explicitly* when all transfers are finished
 
+                // TODO(resharding): Do not change replica state at all, when finishing resharding transfer?
+                //
+                // We switch replica into correct state when *starting* resharding transfer, and
+                // we want to *keep* it in the same state *after* resharding transfer is finished...
                 let state = if is_resharding_transfer {
                     let resharding_direction =
                         self.resharding_state().await.map(|state| state.direction);

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1228,6 +1228,7 @@ impl From<api::grpc::qdrant::ReplicaState> for ReplicaState {
             api::grpc::qdrant::ReplicaState::PartialSnapshot => Self::PartialSnapshot,
             api::grpc::qdrant::ReplicaState::Recovery => Self::Recovery,
             api::grpc::qdrant::ReplicaState::Resharding => Self::Resharding,
+            api::grpc::qdrant::ReplicaState::ReshardingScaleDown => Self::ReshardingScaleDown,
         }
     }
 }
@@ -1243,6 +1244,7 @@ impl From<ReplicaState> for api::grpc::qdrant::ReplicaState {
             ReplicaState::PartialSnapshot => Self::PartialSnapshot,
             ReplicaState::Recovery => Self::Recovery,
             ReplicaState::Resharding => Self::Resharding,
+            ReplicaState::ReshardingScaleDown => Self::ReshardingScaleDown,
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -355,6 +355,7 @@ impl ShardReplicaSet {
             write_rate_limiter,
         };
 
+        // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!
         if local_load_failure && replica_set.active_remote_shards().is_empty() {
             replica_set
                 .locally_disabled_peers
@@ -397,6 +398,7 @@ impl ShardReplicaSet {
     }
 
     pub fn is_last_active_replica(&self, peer_id: PeerId) -> bool {
+        // This includes `Active` and `ReshardingScaleDown` replicas!
         let active_peers = self.replica_state.read().active_peers();
         active_peers.len() == 1 && active_peers.contains(&peer_id)
     }
@@ -409,6 +411,7 @@ impl ShardReplicaSet {
     pub fn active_shards(&self) -> Vec<PeerId> {
         let replica_state = self.replica_state.read();
         replica_state
+            // This is a part of deprecated built-in resharding implementaiton, so we don't care
             .active_peers()
             .into_iter()
             .filter(|&peer_id| !self.is_locally_disabled(peer_id))
@@ -420,7 +423,7 @@ impl ShardReplicaSet {
         let replica_state = self.replica_state.read();
         let this_peer_id = replica_state.this_peer_id;
         replica_state
-            .active_peers()
+            .active_peers() // This includes `Active` and `ReshardingScaleDown` replicas!
             .into_iter()
             .filter(|&peer_id| !self.is_locally_disabled(peer_id) && peer_id != this_peer_id)
             .collect()
@@ -716,8 +719,11 @@ impl ShardReplicaSet {
                     self.optimizers_config.clone(),
                 )
                 .await?;
+
                 match state {
-                    ReplicaState::Active | ReplicaState::Listener => {
+                    ReplicaState::Active
+                    | ReplicaState::Listener
+                    | ReplicaState::ReshardingScaleDown => {
                         // No way we can provide up-to-date replica right away at this point,
                         // so we report a failure to consensus
                         self.set_local(local_shard, Some(state)).await?;
@@ -733,6 +739,7 @@ impl ShardReplicaSet {
                         self.set_local(local_shard, Some(state)).await?;
                     }
                 }
+
                 continue;
             }
 
@@ -962,13 +969,22 @@ impl ShardReplicaSet {
     /// Check whether a peer is registered as `active`.
     /// Unknown peers are not active.
     fn peer_is_active(&self, peer_id: PeerId) -> bool {
-        self.peer_state(peer_id) == Some(ReplicaState::Active) && !self.is_locally_disabled(peer_id)
+        // This is used *exclusively* during `execute_*_read_operation`, and so it *should* consider
+        // `ReshardingScaleDown` replicas
+        let is_active = matches!(
+            self.peer_state(peer_id),
+            Some(ReplicaState::Active | ReplicaState::ReshardingScaleDown)
+        );
+
+        is_active && !self.is_locally_disabled(peer_id)
     }
 
     fn peer_is_active_or_resharding(&self, peer_id: PeerId) -> bool {
         let is_active_or_resharding = matches!(
             self.peer_state(peer_id),
-            Some(ReplicaState::Active | ReplicaState::Resharding)
+            Some(
+                ReplicaState::Active | ReplicaState::Resharding | ReplicaState::ReshardingScaleDown
+            )
         );
 
         let is_locally_disabled = self.is_locally_disabled(peer_id);
@@ -1150,14 +1166,23 @@ impl ReplicaSetState {
         self.peers
             .iter()
             .filter_map(|(peer_id, state)| {
-                matches!(state, ReplicaState::Active).then_some(*peer_id)
+                // We consider `ReshardingScaleDown` to be `Active`!
+                matches!(
+                    state,
+                    ReplicaState::Active | ReplicaState::ReshardingScaleDown
+                )
+                .then_some(*peer_id)
             })
             .collect()
     }
 
     pub fn active_or_resharding_peers(&self) -> impl Iterator<Item = PeerId> + '_ {
         self.peers.iter().filter_map(|(peer_id, state)| {
-            matches!(state, ReplicaState::Active | ReplicaState::Resharding).then_some(*peer_id)
+            matches!(
+                state,
+                ReplicaState::Active | ReplicaState::Resharding | ReplicaState::ReshardingScaleDown
+            )
+            .then_some(*peer_id)
         })
     }
 
@@ -1190,16 +1215,22 @@ pub enum ReplicaState {
     // Shard is undergoing recovery by an external node
     // Normally rejects updates, accepts updates if force is true
     Recovery,
-    // Points are being migrated to this shard as part of resharding
+    // Points are being migrated to this shard as part of resharding up
     #[schemars(skip)]
     Resharding,
+    // Points are being migrated to this shard as part of resharding down
+    #[schemars(skip)]
+    ReshardingScaleDown,
 }
 
 impl ReplicaState {
     /// Check whether the replica state is active or listener or resharding.
     pub fn is_active_or_listener_or_resharding(self) -> bool {
         match self {
-            ReplicaState::Active | ReplicaState::Listener | ReplicaState::Resharding => true,
+            ReplicaState::Active
+            | ReplicaState::Listener
+            | ReplicaState::Resharding
+            | ReplicaState::ReshardingScaleDown => true,
 
             ReplicaState::Dead
             | ReplicaState::Initializing
@@ -1217,7 +1248,8 @@ impl ReplicaState {
             ReplicaState::Partial
             | ReplicaState::PartialSnapshot
             | ReplicaState::Recovery
-            | ReplicaState::Resharding => true,
+            | ReplicaState::Resharding
+            | ReplicaState::ReshardingScaleDown => true,
 
             ReplicaState::Active
             | ReplicaState::Dead

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -411,7 +411,7 @@ impl ShardReplicaSet {
     pub fn active_shards(&self) -> Vec<PeerId> {
         let replica_state = self.replica_state.read();
         replica_state
-            // This is a part of deprecated built-in resharding implementaiton, so we don't care
+            // This is a part of deprecated built-in resharding implementation, so we don't care
             .active_peers()
             .into_iter()
             .filter(|&peer_id| !self.is_locally_disabled(peer_id))

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1224,6 +1224,22 @@ pub enum ReplicaState {
 }
 
 impl ReplicaState {
+    /// Check if replica state is active
+    pub fn is_active(self) -> bool {
+        match self {
+            ReplicaState::Active => true,
+            ReplicaState::ReshardingScaleDown => true,
+
+            ReplicaState::Dead => false,
+            ReplicaState::Partial => false,
+            ReplicaState::Initializing => false,
+            ReplicaState::Listener => false,
+            ReplicaState::PartialSnapshot => false,
+            ReplicaState::Recovery => false,
+            ReplicaState::Resharding => false,
+        }
+    }
+
     /// Check whether the replica state is active or listener or resharding.
     pub fn is_active_or_listener_or_resharding(self) -> bool {
         match self {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1243,6 +1243,8 @@ impl ReplicaState {
     /// Check whether the replica state is partial or partial-like.
     ///
     /// In other words: is the state related to shard transfers?
+    //
+    // TODO(resharding): What's the best way to handle `ReshardingScaleDown` properly!?
     pub fn is_partial_or_recovery(self) -> bool {
         match self {
             ReplicaState::Partial

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -141,6 +141,8 @@ impl ShardReplicaSet {
                 // TODO: Handle single-node mode!? (How!? 😰)
 
                 // Mark this peer as "locally disabled"...
+                //
+                // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!
                 let has_other_active_peers = self.active_remote_shards().is_empty();
 
                 // ...if this peer is *not* the last active replica

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -36,42 +36,53 @@ impl ShardReplicaSet {
 
         let local = self.local.read().await;
 
-        if let Some(local_shard) = local.deref() {
-            match self.peer_state(self.this_peer_id()) {
-                Some(ReplicaState::Active) => {
-                    // Rate limit update operations on Active replica
-                    // TODO(ratelimits) determine cost of update based on operation
-                    self.check_write_rate_limiter(1)?;
-                    Ok(Some(local_shard.get().update(operation, wait).await?))
-                }
-                Some(
-                    ReplicaState::Partial | ReplicaState::Initializing | ReplicaState::Resharding,
-                ) => Ok(Some(local_shard.get().update(operation, wait).await?)),
-                Some(ReplicaState::Listener) => {
-                    Ok(Some(local_shard.get().update(operation, false).await?))
-                }
-                // In recovery state, only allow operations with force flag
-                Some(ReplicaState::PartialSnapshot | ReplicaState::Recovery)
-                    if operation.clock_tag.is_some_and(|tag| tag.force) =>
-                {
-                    Ok(Some(local_shard.get().update(operation, wait).await?))
-                }
-                // In recovery state, log rejected operations without clock tag
-                Some(ReplicaState::PartialSnapshot | ReplicaState::Recovery) => {
-                    if log::log_enabled!(log::Level::Debug) {
-                        if let Some(ids) = operation.operation.point_ids() {
-                            log::debug!("Operation affecting point IDs {ids:?} rejected on this peer, force flag required in recovery state");
-                        } else {
-                            log::debug!("Operation {operation:?} rejected on this peer, force flag required in recovery state");
-                        }
-                    }
-                    Ok(None)
-                }
-                Some(ReplicaState::Dead) | None => Ok(None),
+        let Some(local) = local.deref() else {
+            return Ok(None);
+        };
+
+        let Some(state) = self.peer_state(self.this_peer_id()) else {
+            return Ok(None);
+        };
+
+        let result = match state {
+            ReplicaState::Active => {
+                // Rate limit update operations on Active replica
+                // TODO(ratelimits) determine cost of update based on operation
+                self.check_write_rate_limiter(1)?;
+                local.get().update(operation, wait).await
             }
-        } else {
-            Ok(None)
-        }
+
+            ReplicaState::Partial
+            | ReplicaState::Initializing
+            | ReplicaState::Resharding
+            | ReplicaState::ReshardingScaleDown => local.get().update(operation, wait).await,
+
+            ReplicaState::Listener => local.get().update(operation, false).await,
+
+            ReplicaState::PartialSnapshot | ReplicaState::Recovery
+                if operation.clock_tag.is_some_and(|tag| tag.force) =>
+            {
+                local.get().update(operation, wait).await
+            }
+
+            ReplicaState::PartialSnapshot | ReplicaState::Recovery => {
+                if log::log_enabled!(log::Level::Debug) {
+                    if let Some(ids) = operation.operation.point_ids() {
+                        log::debug!("Operation affecting point IDs {ids:?} rejected on this peer, force flag required in recovery state");
+                    } else {
+                        log::debug!("Operation {operation:?} rejected on this peer, force flag required in recovery state");
+                    }
+                }
+
+                return Ok(None);
+            }
+
+            ReplicaState::Dead => {
+                return Ok(None);
+            }
+        };
+
+        result.map(Some)
     }
 
     /// # Cancel safety
@@ -254,12 +265,6 @@ impl ShardReplicaSet {
                     wait
                 };
 
-                if self.peer_is_active(this_peer_id) {
-                    // Check write rate limiter before proceeding if replica active
-                    // TODO(ratelimits) determine cost of update based on operation
-                    self.check_write_rate_limiter(1)?;
-                }
-
                 let operation = operation.clone();
 
                 let local_update = async move {
@@ -416,7 +421,18 @@ impl ShardReplicaSet {
                             |state| {
                                 peer_ids.iter().all(|peer_id| {
                                     // Not found means that peer is dead
-                                    state.peers.get(peer_id) != Some(&ReplicaState::Active)
+
+                                    // Wait for replica deactivation.
+                                    let is_active = matches!(
+                                        state.peers.get(peer_id),
+                                        Some(
+                                            ReplicaState::Active
+                                                | ReplicaState::Resharding
+                                                | ReplicaState::ReshardingScaleDown
+                                        )
+                                    );
+
+                                    !is_active
                                 })
                             },
                             timeout,
@@ -480,23 +496,30 @@ impl ShardReplicaSet {
     ///
     /// A peer in dead state, or a locally disabled peer, will not accept updates.
     fn is_peer_updatable(&self, peer_id: PeerId) -> bool {
-        let res = match self.peer_state(peer_id) {
-            Some(ReplicaState::Active) => true,
-            Some(ReplicaState::Partial) => true,
-            Some(ReplicaState::Initializing) => true,
-            Some(ReplicaState::Listener) => true,
-            // We must not send updates to replicas in recovery state.
-            // If we do we might create gaps in WAL clock tags.
-            Some(ReplicaState::Recovery | ReplicaState::PartialSnapshot) => false,
-            Some(ReplicaState::Resharding) => true,
-            Some(ReplicaState::Dead) | None => false,
+        let Some(state) = self.peer_state(peer_id) else {
+            return false;
         };
+
+        let res = match state {
+            ReplicaState::Active => true,
+            ReplicaState::Partial => true,
+            ReplicaState::Initializing => true,
+            ReplicaState::Listener => true,
+            ReplicaState::Recovery | ReplicaState::PartialSnapshot => false,
+            ReplicaState::Resharding | ReplicaState::ReshardingScaleDown => true,
+            ReplicaState::Dead => false,
+        };
+
         res && !self.is_locally_disabled(peer_id)
     }
 
     fn peer_is_resharding(&self, peer_id: PeerId) -> bool {
-        self.peer_state(peer_id) == Some(ReplicaState::Resharding)
-            && !self.is_locally_disabled(peer_id)
+        let is_resharding = matches!(
+            self.peer_state(peer_id),
+            Some(ReplicaState::Resharding | ReplicaState::ReshardingScaleDown)
+        );
+
+        is_resharding && !self.is_locally_disabled(peer_id)
     }
 
     fn handle_failed_replicas<'a>(
@@ -520,7 +543,8 @@ impl ShardReplicaSet {
                 | ReplicaState::Partial
                 | ReplicaState::Recovery
                 | ReplicaState::PartialSnapshot
-                | ReplicaState::Resharding => (),
+                | ReplicaState::Resharding
+                | ReplicaState::ReshardingScaleDown => (),
             }
 
             // Handle a special case where transfer receiver is not in the expected replica state yet.

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -45,16 +45,17 @@ impl ShardReplicaSet {
         };
 
         let result = match state {
-            ReplicaState::Active | ReplicaState::ReshardingScaleDown => {
+            ReplicaState::Active => {
                 // Rate limit update operations on Active replica
                 // TODO(ratelimits) determine cost of update based on operation
                 self.check_write_rate_limiter(1)?;
                 local.get().update(operation, wait).await
             }
 
-            ReplicaState::Partial | ReplicaState::Initializing | ReplicaState::Resharding => {
-                local.get().update(operation, wait).await
-            }
+            ReplicaState::Partial
+            | ReplicaState::Initializing
+            | ReplicaState::Resharding
+            | ReplicaState::ReshardingScaleDown => local.get().update(operation, wait).await,
 
             ReplicaState::Listener => local.get().update(operation, false).await,
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -265,6 +265,12 @@ impl ShardReplicaSet {
                     wait
                 };
 
+                if self.peer_is_active(this_peer_id) {
+                    // Check write rate limiter before proceeding if replica active
+                    // TODO(ratelimits) determine cost of update based on operation
+                    self.check_write_rate_limiter(1)?;
+                }
+
                 let operation = operation.clone();
 
                 let local_update = async move {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -45,17 +45,16 @@ impl ShardReplicaSet {
         };
 
         let result = match state {
-            ReplicaState::Active => {
+            ReplicaState::Active | ReplicaState::ReshardingScaleDown => {
                 // Rate limit update operations on Active replica
                 // TODO(ratelimits) determine cost of update based on operation
                 self.check_write_rate_limiter(1)?;
                 local.get().update(operation, wait).await
             }
 
-            ReplicaState::Partial
-            | ReplicaState::Initializing
-            | ReplicaState::Resharding
-            | ReplicaState::ReshardingScaleDown => local.get().update(operation, wait).await,
+            ReplicaState::Partial | ReplicaState::Initializing | ReplicaState::Resharding => {
+                local.get().update(operation, wait).await
+            }
 
             ReplicaState::Listener => local.get().update(operation, false).await,
 

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -138,6 +138,7 @@ async fn drive_up(
                         ))
                     })?;
 
+                    // This is a part of deprecated built-in resharding implementaiton, so we don't care
                     let active_peer_ids = replica_set.active_shards();
                     if active_peer_ids.is_empty() {
                         return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/shards/resharding/stage_migrate_points.rs
+++ b/lib/collection/src/shards/resharding/stage_migrate_points.rs
@@ -138,7 +138,7 @@ async fn drive_up(
                         ))
                     })?;
 
-                    // This is a part of deprecated built-in resharding implementaiton, so we don't care
+                    // This is a part of deprecated built-in resharding implementation, so we don't care
                     let active_peer_ids = replica_set.active_shards();
                     if active_peer_ids.is_empty() {
                         return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -309,7 +309,9 @@ impl ShardHolder {
 
                 // Revert replicas in `Resharding` state back into `Active` state
                 for (peer, state) in shard.peers() {
-                    if state == ReplicaState::Resharding {
+                    if state == ReplicaState::Resharding
+                        || state == ReplicaState::ReshardingScaleDown
+                    {
                         shard.set_replica_state(peer, ReplicaState::Active)?;
                     }
                 }

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -205,7 +205,7 @@ pub fn suggest_transfer_source(
     let currently_transferring = current_transfers
         .iter()
         .filter(|transfer| transfer.shard_id == shard_id)
-        .map(|transfer| transfer.from)
+        .flat_map(|transfer| [transfer.from, transfer.to])
         .collect::<HashSet<PeerId>>();
 
     candidates = candidates

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -31,6 +31,8 @@ async fn get_local_source_shards(
 ) -> CollectionResult<Vec<ShardId>> {
     let collection_state = source.state().await;
 
+    // TODO: Check that resharding is *not* in progress for `source` collection?
+
     let mut local_responsible_shards = Vec::new();
 
     // Find max replica peer id for each shard
@@ -38,17 +40,18 @@ async fn get_local_source_shards(
         let responsible_shard_opt = shard_info
             .replicas
             .iter()
-            .filter(|(_, replica_state)| **replica_state == ReplicaState::Active)
+            .filter(|&(_, &replica_state)| {
+                // It's much easier to only select among `Active` (but not `ReshardingScaleDown`) shards here.
+                // Also, don't initialize-from during resharding... 🙄
+                replica_state == ReplicaState::Active
+            })
             .max_by_key(|(peer_id, _)| *peer_id)
             .map(|(peer_id, _)| *peer_id);
 
-        let responsible_shard = match responsible_shard_opt {
-            None => {
-                return Err(CollectionError::service_error(format!(
-                    "No active replica for shard {shard_id}, collection initialization is cancelled"
-                )));
-            }
-            Some(responsible_shard) => responsible_shard,
+        let Some(responsible_shard) = responsible_shard_opt else {
+            return Err(CollectionError::service_error(format!(
+                "No active replica for shard {shard_id}, collection initialization is cancelled"
+            )));
         };
 
         if responsible_shard == this_peer_id {

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -31,7 +31,13 @@ async fn get_local_source_shards(
 ) -> CollectionResult<Vec<ShardId>> {
     let collection_state = source.state().await;
 
-    // TODO: Check that resharding is *not* in progress for `source` collection?
+    if source.resharding_state().await.is_some() {
+        return Err(CollectionError::bad_input(format!(
+            "can't initialize new collection from collection {source}, \
+             because resharding is in progress for collection {source}",
+            source = source.name(),
+        )));
+    }
 
     let mut local_responsible_shards = Vec::new();
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -470,7 +470,13 @@ impl TableOfContent {
                     .keys()
                     .cloned()
                     .collect();
-                let shard_state = shards.get(&transfer.shard_id).map(|info| &info.replicas);
+
+                let source_replicas = shards.get(&transfer.shard_id).map(|info| &info.replicas);
+
+                let destination_replicas = transfer
+                    .to_shard_id
+                    .and_then(|to_shard_id| shards.get(&to_shard_id))
+                    .map(|info| &info.replicas);
 
                 // Valid transfer:
                 // All peers: 123, 321, 111, 222, 333
@@ -485,7 +491,8 @@ impl TableOfContent {
                 transfer::helpers::validate_transfer(
                     &transfer,
                     &all_peers,
-                    shard_state,
+                    source_replicas,
+                    destination_replicas,
                     &transfers,
                     &shards_key_mapping,
                 )?;

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -715,6 +715,11 @@ pub async fn do_update_collection_cluster(
                 }
             };
 
+            let from_state = match state.direction {
+                ReshardingDirection::Up => replica_set::ReplicaState::Resharding,
+                ReshardingDirection::Down => replica_set::ReplicaState::ReshardingScaleDown,
+            };
+
             dispatcher
                 .submit_collection_meta_op(
                     CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
@@ -722,7 +727,7 @@ pub async fn do_update_collection_cluster(
                         shard_id,
                         peer_id,
                         state: replica_set::ReplicaState::Active,
-                        from_state: Some(replica_set::ReplicaState::Resharding),
+                        from_state: Some(from_state),
                     }),
                     access,
                     wait_timeout,

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -237,7 +237,17 @@ pub async fn recover_shard_snapshot_impl(
         .replicas
         .iter()
         .map(|(&peer, &state)| (peer, state))
-        .filter(|&(peer, state)| peer != toc.this_peer_id && state == ReplicaState::Active)
+        .filter(|&(peer, state)| {
+            // Check if there are *other* active replicas, after recovering shard snapshot.
+            // This should include `ReshardingScaleDown` replicas.
+
+            let is_active = matches!(
+                state,
+                ReplicaState::Active | ReplicaState::ReshardingScaleDown
+            );
+
+            peer != toc.this_peer_id && is_active
+        })
         .collect();
 
     if other_active_replicas.is_empty() {


### PR DESCRIPTION
This PR adds `ReshardingScaleDown` replica state (might be renamed into something more sane before merge) and aborts resharding when switching from `ReshardingScaleDown` into `Dead`.

`ReshardingScaleDown` is treated equivalent to `Active` state in most places, because `ReshardingScaleDown` state is sort of a "superset" of `Active` state: `ReshardingScaleDown` replica contains all the same points (and some *additional* points on top) and serves all read and write requests the same way as an `Active` replica.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
