### PR TITLE
Introduce facet index trait

### DIFF
--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -44,6 +44,24 @@ impl FacetValueRef<'_> {
     }
 }
 
+impl<'a> From<&'a str> for FacetValueRef<'a> {
+    fn from(s: &'a str) -> Self {
+        FacetValueRef::Keyword(s)
+    }
+}
+
+impl<'a> From<&'a IntPayloadType> for FacetValueRef<'a> {
+    fn from(i: &'a IntPayloadType) -> Self {
+        FacetValueRef::Int(i)
+    }
+}
+
+impl<'a> From<&'a UuidIntType> for FacetValueRef<'a> {
+    fn from(uuid: &'a UuidIntType) -> Self {
+        FacetValueRef::Uuid(uuid)
+    }
+}
+
 #[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Debug)]
 pub enum FacetValue {
     Keyword(String),

--- a/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
@@ -217,6 +217,16 @@ impl MmapBoolIndex {
         ]
         .into_iter()
     }
+
+    pub(crate) fn get_point_values(&self, point_id: u32) -> Vec<bool> {
+        [
+            self.trues_slice.get(point_id as usize).then_some(true),
+            self.falses_slice.get(point_id as usize).then_some(false),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
 }
 
 /// Set or insert a flag in the given flags. Returns previous value.

--- a/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
@@ -265,6 +265,11 @@ impl SimpleBoolIndex {
         ]
         .into_iter()
     }
+
+    pub(crate) fn get_point_values(&self, point_id: u32) -> Vec<bool> {
+        let boolean_item = self.memory.get(point_id);
+        vec![boolean_item.has_true(), boolean_item.has_false()]
+    }
 }
 
 pub struct BoolIndexBuilder(SimpleBoolIndex);

--- a/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
@@ -268,7 +268,13 @@ impl SimpleBoolIndex {
 
     pub(crate) fn get_point_values(&self, point_id: u32) -> Vec<bool> {
         let boolean_item = self.memory.get(point_id);
-        vec![boolean_item.has_true(), boolean_item.has_false()]
+        [
+            boolean_item.has_true().then_some(true),
+            boolean_item.has_false().then_some(false),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 }
 

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -2,150 +2,94 @@ use common::types::PointOffsetType;
 use itertools::Itertools;
 
 use super::bool_index::BoolIndex;
-use super::map_index::MapIndex;
+use super::map_index::{IdIter, MapIndex};
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::payload_storage::FilterContext;
 use crate::types::{IntPayloadType, UuidIntType};
 
-pub enum FacetIndex<'a> {
+pub trait FacetIndex {
+    /// Get all values for a point
+    fn get_point_values(
+        &self,
+        point_id: PointOffsetType,
+    ) -> impl Iterator<Item = FacetValueRef> + '_;
+
+    /// Get all values in the index
+    fn iter_values(&self) -> impl Iterator<Item = FacetValueRef<'_>> + '_;
+
+    /// Get all value->point_ids mappings
+    fn iter_values_map(&self) -> impl Iterator<Item = (FacetValueRef, IdIter<'_>)> + '_;
+
+    /// Get all value->count mappings
+    fn iter_counts_per_value(&self) -> impl Iterator<Item = FacetHit<FacetValueRef<'_>>> + '_;
+}
+
+pub enum FacetIndexEnum<'a> {
     Keyword(&'a MapIndex<str>),
     Int(&'a MapIndex<IntPayloadType>),
     Uuid(&'a MapIndex<UuidIntType>),
     Bool(&'a BoolIndex),
 }
 
-impl<'a> FacetIndex<'a> {
-    pub fn get_values(
+impl<'a> FacetIndexEnum<'a> {
+    pub fn get_point_values(
         &self,
         point_id: PointOffsetType,
     ) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
         match self {
-            FacetIndex::Keyword(index) => {
-                let iter = index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten() // flatten the Option
-                    .map(FacetValueRef::Keyword);
-
-                Box::new(iter)
+            FacetIndexEnum::Keyword(index) => {
+                Box::new(FacetIndex::get_point_values(*index, point_id))
             }
-            FacetIndex::Int(index) => {
-                let iter = index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten() // flatten the Option
-                    .map(FacetValueRef::Int);
-
-                Box::new(iter)
-            }
-            FacetIndex::Uuid(index) => {
-                let iter = index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten() // flatten the Option
-                    .map(FacetValueRef::Uuid);
-
-                Box::new(iter)
-            }
-            FacetIndex::Bool(index) => {
-                let iter = index.iter_values().map(FacetValueRef::Bool);
-
-                Box::new(iter)
-            }
+            FacetIndexEnum::Int(index) => Box::new(FacetIndex::get_point_values(*index, point_id)),
+            FacetIndexEnum::Uuid(index) => Box::new(FacetIndex::get_point_values(*index, point_id)),
+            FacetIndexEnum::Bool(index) => Box::new(FacetIndex::get_point_values(*index, point_id)),
         }
     }
 
     pub fn iter_values(&self) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
         match self {
-            FacetIndex::Keyword(index) => {
-                let iter = index.iter_values().map(FacetValueRef::Keyword);
-                Box::new(iter)
-            }
-            FacetIndex::Int(index) => {
-                let iter = index.iter_values().map(FacetValueRef::Int);
-                Box::new(iter)
-            }
-            FacetIndex::Uuid(index) => {
-                let iter = index.iter_values().map(FacetValueRef::Uuid);
-                Box::new(iter)
-            }
-            FacetIndex::Bool(index) => {
-                let iter = index.iter_values().map(FacetValueRef::Bool);
-                Box::new(iter)
-            }
+            FacetIndexEnum::Keyword(index) => Box::new(FacetIndex::iter_values(*index)),
+            FacetIndexEnum::Int(index) => Box::new(FacetIndex::iter_values(*index)),
+            FacetIndexEnum::Uuid(index) => Box::new(FacetIndex::iter_values(*index)),
+            FacetIndexEnum::Bool(index) => Box::new(FacetIndex::iter_values(*index)),
         }
     }
 
-    pub fn iter_filtered_counts_per_value(
-        &self,
-        context: &'a StructFilterContext,
-    ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a {
-        let iter: Box<dyn Iterator<Item = _>> = match self {
-            FacetIndex::Keyword(index) => {
-                let iter = index
-                    .iter_values_map()
-                    .map(|(value, ids_iter)| (FacetValueRef::Keyword(value), ids_iter));
-                Box::new(iter)
-            }
-            FacetIndex::Int(index) => {
-                let iter = index
-                    .iter_values_map()
-                    .map(|(value, ids_iter)| (FacetValueRef::Int(value), ids_iter));
-                Box::new(iter)
-            }
-            FacetIndex::Uuid(index) => {
-                let iter = index
-                    .iter_values_map()
-                    .map(|(value, ids_iter)| (FacetValueRef::Uuid(value), ids_iter));
-                Box::new(iter)
-            }
-            FacetIndex::Bool(index) => {
-                let iter = index
-                    .iter_values_map()
-                    .map(|(value, ids_iter)| (FacetValueRef::Bool(value), ids_iter));
-                Box::new(iter)
-            }
-        };
-
-        iter.map(|(value, internal_ids_iter)| FacetHit {
-            value,
-            count: internal_ids_iter
-                .unique()
-                .filter(|&point_id| context.check(point_id))
-                .count(),
-        })
+    fn iter_values_map(&self) -> Box<dyn Iterator<Item = (FacetValueRef, IdIter<'_>)> + '_> {
+        match self {
+            FacetIndexEnum::Keyword(index) => Box::new(FacetIndex::iter_values_map(*index)),
+            FacetIndexEnum::Int(index) => Box::new(FacetIndex::iter_values_map(*index)),
+            FacetIndexEnum::Uuid(index) => Box::new(FacetIndex::iter_values_map(*index)),
+            FacetIndexEnum::Bool(index) => Box::new(FacetIndex::iter_values_map(*index)),
+        }
     }
+
+    pub fn iter_filtered_counts_per_value<'c>(
+        &'a self,
+        context: &'c StructFilterContext,
+    ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'c
+    where
+        'a: 'c,
+    {
+        self.iter_values_map()
+            .map(|(value, internal_ids_iter)| FacetHit {
+                value,
+                count: internal_ids_iter
+                    .unique()
+                    .filter(|&point_id| context.check(point_id))
+                    .count(),
+            })
+    }
+
     pub fn iter_counts_per_value(
         &'a self,
-    ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a {
-        let iter: Box<dyn Iterator<Item = _>> = match self {
-            FacetIndex::Keyword(index) => {
-                let iter = index
-                    .iter_counts_per_value()
-                    .map(|(value, count)| (FacetValueRef::Keyword(value), count));
-                Box::new(iter)
-            }
-            FacetIndex::Int(index) => {
-                let iter = index
-                    .iter_counts_per_value()
-                    .map(|(value, count)| (FacetValueRef::Int(value), count));
-                Box::new(iter)
-            }
-            FacetIndex::Uuid(index) => {
-                let iter = index
-                    .iter_counts_per_value()
-                    .map(|(value, count)| (FacetValueRef::Uuid(value), count));
-                Box::new(iter)
-            }
-            FacetIndex::Bool(index) => {
-                let iter = index
-                    .iter_counts_per_value()
-                    .map(|(value, count)| (FacetValueRef::Bool(value), count));
-                Box::new(iter)
-            }
-        };
-
-        iter.map(|(value, count)| FacetHit { value, count })
+    ) -> Box<dyn Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'a> {
+        match self {
+            FacetIndexEnum::Keyword(index) => Box::new(FacetIndex::iter_counts_per_value(*index)),
+            FacetIndexEnum::Int(index) => Box::new(FacetIndex::iter_counts_per_value(*index)),
+            FacetIndexEnum::Uuid(index) => Box::new(FacetIndex::iter_counts_per_value(*index)),
+            FacetIndexEnum::Bool(index) => Box::new(FacetIndex::iter_counts_per_value(*index)),
+        }
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use super::bool_index::mmap_bool_index::MmapBoolIndexBuilder;
 use super::bool_index::simple_bool_index::BoolIndexBuilder;
 use super::bool_index::BoolIndex;
-use super::facet_index::FacetIndex;
+use super::facet_index::FacetIndexEnum;
 use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use super::full_text_index::text_index::{FullTextIndex, FullTextIndexBuilder};
 use super::geo_index::{GeoMapIndexBuilder, GeoMapIndexMmapBuilder};
@@ -369,12 +369,12 @@ impl FieldIndex {
         }
     }
 
-    pub fn as_facet_index(&self) -> Option<FacetIndex> {
+    pub fn as_facet_index(&self) -> Option<FacetIndexEnum> {
         match self {
-            FieldIndex::KeywordIndex(index) => Some(FacetIndex::Keyword(index)),
-            FieldIndex::IntMapIndex(index) => Some(FacetIndex::Int(index)),
-            FieldIndex::UuidMapIndex(index) => Some(FacetIndex::Uuid(index)),
-            FieldIndex::BoolIndex(index) => Some(FacetIndex::Bool(index)),
+            FieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::Keyword(index)),
+            FieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::Int(index)),
+            FieldIndex::UuidMapIndex(index) => Some(FacetIndexEnum::Uuid(index)),
+            FieldIndex::BoolIndex(index) => Some(FacetIndexEnum::Bool(index)),
             FieldIndex::UuidIndex(_)
             | FieldIndex::IntIndex(_)
             | FieldIndex::DatetimeIndex(_)

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -20,10 +20,12 @@ use uuid::Uuid;
 
 use self::immutable_map_index::ImmutableMapIndex;
 use self::mutable_map_index::MutableMapIndex;
+use super::facet_index::FacetIndex;
 use super::mmap_point_to_values::MmapValue;
 use super::FieldIndexBuilderTrait;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::Flusher;
+use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
@@ -929,6 +931,38 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                     cardinality: count,
                 }),
         )
+    }
+}
+
+impl<N> FacetIndex for MapIndex<N>
+where
+    N: MapIndexKey + ?Sized,
+    for<'a> N::Referenced<'a>: Into<FacetValueRef<'a>>,
+    for<'a> &'a N: Into<FacetValueRef<'a>>,
+{
+    fn get_point_values(
+        &self,
+        point_id: PointOffsetType,
+    ) -> impl Iterator<Item = FacetValueRef> + '_ {
+        MapIndex::get_values(&self, point_id)
+            .into_iter()
+            .flatten()
+            .map(Into::into)
+    }
+
+    fn iter_values(&self) -> impl Iterator<Item = FacetValueRef<'_>> + '_ {
+        self.iter_values().map(Into::into)
+    }
+
+    fn iter_values_map(&self) -> impl Iterator<Item = (FacetValueRef, IdIter<'_>)> + '_ {
+        self.iter_values_map().map(|(k, iter)| (k.into(), iter))
+    }
+
+    fn iter_counts_per_value(&self) -> impl Iterator<Item = FacetHit<FacetValueRef<'_>>> + '_ {
+        self.iter_counts_per_value().map(|(value, count)| FacetHit {
+            value: value.into(),
+            count,
+        })
     }
 }
 

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -944,7 +944,7 @@ where
         &self,
         point_id: PointOffsetType,
     ) -> impl Iterator<Item = FacetValueRef> + '_ {
-        MapIndex::get_values(&self, point_id)
+        MapIndex::get_values(self, point_id)
             .into_iter()
             .flatten()
             .map(Into::into)

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -11,7 +11,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
-use super::field_index::facet_index::FacetIndex;
+use super::field_index::facet_index::FacetIndexEnum;
 use super::field_index::index_selector::{
     IndexSelector, IndexSelectorOnDisk, IndexSelectorRocksDb,
 };
@@ -415,7 +415,7 @@ impl StructPayloadIndex {
         }
     }
 
-    pub fn get_facet_index(&self, key: &JsonPath) -> OperationResult<FacetIndex> {
+    pub fn get_facet_index(&self, key: &JsonPath) -> OperationResult<FacetIndexEnum> {
         self.field_indexes
             .get(key)
             .and_then(|index| index.iter().find_map(|index| index.as_facet_index()))

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -53,9 +53,12 @@ impl Segment {
                     .check_stop_every(STOP_CHECK_INTERVAL, || is_stopped.load(Ordering::Relaxed))
                     .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                     .fold(HashMap::new(), |mut map, point_id| {
-                        facet_index.get_values(point_id).unique().for_each(|value| {
-                            *map.entry(value).or_insert(0) += 1;
-                        });
+                        facet_index
+                            .get_point_values(point_id)
+                            .unique()
+                            .for_each(|value| {
+                                *map.entry(value).or_insert(0) += 1;
+                            });
                         map
                     })
                     .into_iter()
@@ -117,7 +120,7 @@ impl Segment {
                 .check_stop(|| is_stopped.load(Ordering::Relaxed))
                 .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                 .fold(BTreeSet::new(), |mut set, point_id| {
-                    set.extend(facet_index.get_values(point_id));
+                    set.extend(facet_index.get_point_values(point_id));
                     set
                 })
                 .into_iter()


### PR DESCRIPTION
Refactors the faceting infrastructure to make all facet-enabled indices implement the same trait.

This also fixes a bug introduced in #5571 ([failed test run](https://github.com/qdrant/qdrant-client/actions/runs/12373060583/job/34533583784?pr=866)) which would iterate over the whole index, instead of just a single point's values