### PR TITLE
Extract plain vector index

### DIFF
--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -4,6 +4,7 @@ mod key_encoding;
 mod payload_config;
 mod payload_index_base;
 pub mod plain_payload_index;
+pub mod plain_vector_index;
 pub mod query_estimator;
 mod query_optimization;
 mod sample_estimation;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -4,31 +4,21 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
-use parking_lot::Mutex;
+use common::types::PointOffsetType;
 use schemars::_serde_json::Value;
 
 use super::field_index::FieldIndex;
 use crate::common::operation_error::OperationResult;
-use crate::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
-};
-use crate::common::{Flusher, BYTES_IN_KB};
-use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::common::Flusher;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
-use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::{PayloadIndex, VectorIndex};
+use crate::index::PayloadIndex;
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
-use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
-    SearchParams,
 };
-use crate::vector_storage::{new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
 ///
@@ -216,183 +206,6 @@ impl PayloadIndex for PlainPayloadIndex {
 
     fn files(&self) -> Vec<PathBuf> {
         vec![self.config_path()]
-    }
-}
-
-#[derive(Debug)]
-pub struct PlainIndex {
-    id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-    filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
-    unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
-}
-
-impl PlainIndex {
-    pub fn new(
-        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-    ) -> PlainIndex {
-        PlainIndex {
-            id_tracker,
-            vector_storage,
-            payload_index,
-            filtered_searches_telemetry: OperationDurationsAggregator::new(),
-            unfiltered_searches_telemetry: OperationDurationsAggregator::new(),
-        }
-    }
-
-    pub fn is_small_enough_for_unindexed_search(
-        &self,
-        search_optimized_threshold_kb: usize,
-        filter: Option<&Filter>,
-    ) -> bool {
-        let vector_storage = self.vector_storage.borrow();
-        let available_vector_count = vector_storage.available_vector_count();
-        if available_vector_count > 0 {
-            let vector_size_bytes =
-                vector_storage.size_of_available_vectors_in_bytes() / available_vector_count;
-            let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
-
-            if let Some(payload_filter) = filter {
-                let payload_index = self.payload_index.borrow();
-                let cardinality = payload_index.estimate_cardinality(payload_filter);
-                let scan_size = vector_size_bytes.saturating_mul(cardinality.max);
-                scan_size <= indexing_threshold_bytes
-            } else {
-                let vector_storage_size = vector_size_bytes.saturating_mul(available_vector_count);
-                vector_storage_size <= indexing_threshold_bytes
-            }
-        } else {
-            true
-        }
-    }
-}
-
-impl VectorIndex for PlainIndex {
-    fn search(
-        &self,
-        vectors: &[&QueryVector],
-        filter: Option<&Filter>,
-        top: usize,
-        params: Option<&SearchParams>,
-        query_context: &VectorQueryContext,
-    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let is_indexed_only = params.map(|p| p.indexed_only).unwrap_or(false);
-        if is_indexed_only
-            && !self.is_small_enough_for_unindexed_search(
-                query_context.search_optimized_threshold_kb(),
-                filter,
-            )
-        {
-            return Ok(vec![vec![]; vectors.len()]);
-        }
-
-        let is_stopped = query_context.is_stopped();
-
-        match filter {
-            Some(filter) => {
-                let _timer = ScopeDurationMeasurer::new(&self.filtered_searches_telemetry);
-                let id_tracker = self.id_tracker.borrow();
-                let payload_index = self.payload_index.borrow();
-                let vector_storage = self.vector_storage.borrow();
-                let filtered_ids_vec = payload_index.query_points(filter);
-                let deleted_points = query_context
-                    .deleted_points()
-                    .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
-                vectors
-                    .iter()
-                    .map(|&vector| {
-                        new_stoppable_raw_scorer(
-                            vector.to_owned(),
-                            &vector_storage,
-                            deleted_points,
-                            &is_stopped,
-                            query_context.hardware_counter(),
-                        )
-                        .map(|scorer| {
-                            let res =
-                                scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top);
-                            res
-                        })
-                    })
-                    .collect()
-            }
-            None => {
-                let _timer = ScopeDurationMeasurer::new(&self.unfiltered_searches_telemetry);
-                let vector_storage = self.vector_storage.borrow();
-                let id_tracker = self.id_tracker.borrow();
-                let deleted_points = query_context
-                    .deleted_points()
-                    .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
-                vectors
-                    .iter()
-                    .map(|&vector| {
-                        new_stoppable_raw_scorer(
-                            vector.to_owned(),
-                            &vector_storage,
-                            deleted_points,
-                            &is_stopped,
-                            query_context.hardware_counter(),
-                        )
-                        .map(|scorer| scorer.peek_top_all(top))
-                    })
-                    .collect()
-            }
-        }
-    }
-
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
-        VectorIndexSearchesTelemetry {
-            index_name: None,
-            unfiltered_plain: self
-                .unfiltered_searches_telemetry
-                .lock()
-                .get_statistics(detail),
-            filtered_plain: self
-                .filtered_searches_telemetry
-                .lock()
-                .get_statistics(detail),
-            unfiltered_hnsw: OperationDurationStatistics::default(),
-            filtered_small_cardinality: OperationDurationStatistics::default(),
-            filtered_large_cardinality: OperationDurationStatistics::default(),
-            filtered_exact: OperationDurationStatistics::default(),
-            filtered_sparse: Default::default(),
-            unfiltered_exact: OperationDurationStatistics::default(),
-            unfiltered_sparse: OperationDurationStatistics::default(),
-        }
-    }
-
-    fn files(&self) -> Vec<PathBuf> {
-        vec![]
-    }
-
-    fn indexed_vector_count(&self) -> usize {
-        0
-    }
-
-    fn update_vector(
-        &mut self,
-        id: PointOffsetType,
-        vector: Option<VectorRef>,
-    ) -> OperationResult<()> {
-        let mut vector_storage = self.vector_storage.borrow_mut();
-
-        if let Some(vector) = vector {
-            vector_storage.insert_vector(id, vector)?;
-        } else {
-            if id as usize >= vector_storage.total_vector_count() {
-                debug_assert!(id as usize == vector_storage.total_vector_count());
-                // Vector doesn't exist in the storage
-                // Insert default vector to keep the sequence
-                let default_vector = vector_storage.default_vector();
-                vector_storage.insert_vector(id, VectorRef::from(&default_vector))?;
-            }
-            vector_storage.delete_vector(id)?;
-        }
-
-        Ok(())
     }
 }
 

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -1,0 +1,197 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use parking_lot::Mutex;
+
+use crate::common::operation_error::OperationResult;
+use crate::common::operation_time_statistics::{
+    OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
+};
+use crate::common::BYTES_IN_KB;
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::id_tracker::IdTrackerSS;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::{PayloadIndex, VectorIndex};
+use crate::telemetry::VectorIndexSearchesTelemetry;
+use crate::types::{Filter, SearchParams};
+use crate::vector_storage::{new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum};
+
+#[derive(Debug)]
+pub struct PlainVectorIndex {
+    id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+    unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+}
+
+impl PlainVectorIndex {
+    pub fn new(
+        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    ) -> PlainVectorIndex {
+        PlainVectorIndex {
+            id_tracker,
+            vector_storage,
+            payload_index,
+            filtered_searches_telemetry: OperationDurationsAggregator::new(),
+            unfiltered_searches_telemetry: OperationDurationsAggregator::new(),
+        }
+    }
+
+    pub fn is_small_enough_for_unindexed_search(
+        &self,
+        search_optimized_threshold_kb: usize,
+        filter: Option<&Filter>,
+    ) -> bool {
+        let vector_storage = self.vector_storage.borrow();
+        let available_vector_count = vector_storage.available_vector_count();
+        if available_vector_count > 0 {
+            let vector_size_bytes =
+                vector_storage.size_of_available_vectors_in_bytes() / available_vector_count;
+            let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
+
+            if let Some(payload_filter) = filter {
+                let payload_index = self.payload_index.borrow();
+                let cardinality = payload_index.estimate_cardinality(payload_filter);
+                let scan_size = vector_size_bytes.saturating_mul(cardinality.max);
+                scan_size <= indexing_threshold_bytes
+            } else {
+                let vector_storage_size = vector_size_bytes.saturating_mul(available_vector_count);
+                vector_storage_size <= indexing_threshold_bytes
+            }
+        } else {
+            true
+        }
+    }
+}
+
+impl VectorIndex for PlainVectorIndex {
+    fn search(
+        &self,
+        vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        params: Option<&SearchParams>,
+        query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let is_indexed_only = params.map(|p| p.indexed_only).unwrap_or(false);
+        if is_indexed_only
+            && !self.is_small_enough_for_unindexed_search(
+                query_context.search_optimized_threshold_kb(),
+                filter,
+            )
+        {
+            return Ok(vec![vec![]; vectors.len()]);
+        }
+
+        let is_stopped = query_context.is_stopped();
+
+        match filter {
+            Some(filter) => {
+                let _timer = ScopeDurationMeasurer::new(&self.filtered_searches_telemetry);
+                let id_tracker = self.id_tracker.borrow();
+                let payload_index = self.payload_index.borrow();
+                let vector_storage = self.vector_storage.borrow();
+                let filtered_ids_vec = payload_index.query_points(filter);
+                let deleted_points = query_context
+                    .deleted_points()
+                    .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+                vectors
+                    .iter()
+                    .map(|&vector| {
+                        new_stoppable_raw_scorer(
+                            vector.to_owned(),
+                            &vector_storage,
+                            deleted_points,
+                            &is_stopped,
+                            query_context.hardware_counter(),
+                        )
+                        .map(|scorer| {
+                            let res =
+                                scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top);
+                            res
+                        })
+                    })
+                    .collect()
+            }
+            None => {
+                let _timer = ScopeDurationMeasurer::new(&self.unfiltered_searches_telemetry);
+                let vector_storage = self.vector_storage.borrow();
+                let id_tracker = self.id_tracker.borrow();
+                let deleted_points = query_context
+                    .deleted_points()
+                    .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+                vectors
+                    .iter()
+                    .map(|&vector| {
+                        new_stoppable_raw_scorer(
+                            vector.to_owned(),
+                            &vector_storage,
+                            deleted_points,
+                            &is_stopped,
+                            query_context.hardware_counter(),
+                        )
+                        .map(|scorer| scorer.peek_top_all(top))
+                    })
+                    .collect()
+            }
+        }
+    }
+
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        VectorIndexSearchesTelemetry {
+            index_name: None,
+            unfiltered_plain: self
+                .unfiltered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            filtered_plain: self
+                .filtered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            unfiltered_hnsw: OperationDurationStatistics::default(),
+            filtered_small_cardinality: OperationDurationStatistics::default(),
+            filtered_large_cardinality: OperationDurationStatistics::default(),
+            filtered_exact: OperationDurationStatistics::default(),
+            filtered_sparse: Default::default(),
+            unfiltered_exact: OperationDurationStatistics::default(),
+            unfiltered_sparse: OperationDurationStatistics::default(),
+        }
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn indexed_vector_count(&self) -> usize {
+        0
+    }
+
+    fn update_vector(
+        &mut self,
+        id: PointOffsetType,
+        vector: Option<VectorRef>,
+    ) -> OperationResult<()> {
+        let mut vector_storage = self.vector_storage.borrow_mut();
+
+        if let Some(vector) = vector {
+            vector_storage.insert_vector(id, vector)?;
+        } else {
+            if id as usize >= vector_storage.total_vector_count() {
+                debug_assert!(id as usize == vector_storage.total_vector_count());
+                // Vector doesn't exist in the storage
+                // Insert default vector to keep the sequence
+                let default_vector = vector_storage.default_vector();
+                vector_storage.insert_vector(id, VectorRef::from(&default_vector))?;
+            }
+            vector_storage.delete_vector(id)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -12,7 +12,7 @@ use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 
 use super::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
 use super::hnsw_index::hnsw::HNSWIndex;
-use super::plain_payload_index::PlainIndex;
+use super::plain_vector_index::PlainVectorIndex;
 use super::sparse_index::sparse_vector_index::SparseVectorIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
@@ -57,7 +57,7 @@ pub trait VectorIndex {
 
 #[derive(Debug)]
 pub enum VectorIndexEnum {
-    Plain(PlainIndex),
+    Plain(PlainVectorIndex),
     HnswRam(HNSWIndex<GraphLinksRam>),
     HnswMmap(HNSWIndex<GraphLinksMmap>),
     SparseRam(SparseVectorIndex<InvertedIndexRam>),

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -22,7 +22,7 @@ use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
 use crate::index::hnsw_index::gpu::gpu_devices_manager::LockedGpuDevice;
 use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
-use crate::index::plain_payload_index::PlainIndex;
+use crate::index::plain_vector_index::PlainVectorIndex;
 use crate::index::sparse_index::sparse_index_config::SparseIndexType;
 use crate::index::sparse_index::sparse_vector_index::{
     self, SparseVectorIndex, SparseVectorIndexOpenArgs,
@@ -376,9 +376,11 @@ pub(crate) fn create_vector_index(
     stopped: &AtomicBool,
 ) -> OperationResult<VectorIndexEnum> {
     let vector_index = match &vector_config.index {
-        Indexes::Plain {} => {
-            VectorIndexEnum::Plain(PlainIndex::new(id_tracker, vector_storage, payload_index))
-        }
+        Indexes::Plain {} => VectorIndexEnum::Plain(PlainVectorIndex::new(
+            id_tracker,
+            vector_storage,
+            payload_index,
+        )),
         Indexes::Hnsw(vector_hnsw_config) => {
             let args = HnswIndexOpenArgs {
                 path: vector_index_path,


### PR DESCRIPTION
This PR extracts the plain vector index into a dedicated module and renames it for clarity.

I am proposing this change because I got confused while reviewing https://github.com/qdrant/qdrant/pull/5587 when seeing changes in the `plain_payload_index.rs` file which were not related to payloads.
