### PR TITLE
Use TLS when registering node with TLS server config

### DIFF
--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -16,13 +16,19 @@ use crate::consensus;
 pub struct RaftService {
     message_sender: Sender<consensus::Message>,
     consensus_state: ConsensusStateRef,
+    use_tls: bool,
 }
 
 impl RaftService {
-    pub fn new(sender: Sender<consensus::Message>, consensus_state: ConsensusStateRef) -> Self {
+    pub fn new(
+        sender: Sender<consensus::Message>,
+        consensus_state: ConsensusStateRef,
+        use_tls: bool,
+    ) -> Self {
         Self {
             message_sender: sender,
             consensus_state,
+            use_tls,
         }
     }
 }
@@ -73,7 +79,11 @@ impl Raft for RaftService {
             let port = peer
                 .port
                 .ok_or_else(|| Status::invalid_argument("URI or port should be supplied"))?;
-            format!("http://{ip}:{port}")
+            if self.use_tls {
+                format!("https://{ip}:{port}")
+            } else {
+                format!("http://{ip}:{port}")
+            }
         };
         let uri: Uri = uri_string
             .parse()

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -282,7 +282,8 @@ pub fn init_internal(
                 QdrantInternalService::new(settings, consensus_state.clone());
             let collections_internal_service = CollectionsInternalService::new(toc.clone());
             let shard_snapshots_service = ShardSnapshotsService::new(toc.clone(), http_client);
-            let raft_service = RaftService::new(to_consensus, consensus_state);
+            let raft_service =
+                RaftService::new(to_consensus, consensus_state, tls_config.is_some());
 
             log::debug!("Qdrant internal gRPC listening on {}", internal_grpc_port);
 


### PR DESCRIPTION
This PR forces the usage of TLS when a node is joining a cluster but no URL is provided.

In that case we build manually a peer URI which will be used by raft.rs as peer address.

The following patch makes sure that we use `https` in the peer address if a TLS server config is set up.