### PR TITLE
Bump tracing-serde to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,9 +6992,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",


### PR DESCRIPTION
Fixes current `dev` builds:

```bash
error: failed to select a version for the requirement `tracing-serde = "^0.2.0"`
candidate versions found which didn't match: 0.1.3, 0.1.2, 0.1.1, ...
location searched: crates.io index
required by package `tracing-subscriber v0.3.19`
    ... which satisfies dependency `tracing-subscriber = "^0.3"` (locked to 0.3.19) of package `qdrant v1.12.6-dev (/home/timvisee/git/qdrant)`
```

Used:

```bash
cargo update tracing-subscriber tracing-serde
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
