### PR TITLE
Read rate limiter handles batched search requests

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1021,8 +1021,8 @@ pub enum CollectionError {
 }
 
 impl CollectionError {
-    pub fn timeout(timeout_sec: usize, operation: impl Into<String>) -> CollectionError {
-        CollectionError::Timeout {
+    pub fn timeout(timeout_sec: usize, operation: impl Into<String>) -> Self {
+        Self::Timeout {
             description: format!(
                 "Operation '{}' timed out after {timeout_sec} seconds",
                 operation.into()
@@ -1030,35 +1030,35 @@ impl CollectionError {
         }
     }
 
-    pub fn service_error(error: impl Into<String>) -> CollectionError {
-        CollectionError::ServiceError {
+    pub fn service_error(error: impl Into<String>) -> Self {
+        Self::ServiceError {
             error: error.into(),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
 
-    pub fn bad_input(description: impl Into<String>) -> CollectionError {
-        CollectionError::BadInput {
+    pub fn bad_input(description: impl Into<String>) -> Self {
+        Self::BadInput {
             description: description.into(),
         }
     }
 
-    pub fn not_found(what: impl Into<String>) -> CollectionError {
-        CollectionError::NotFound { what: what.into() }
+    pub fn not_found(what: impl Into<String>) -> Self {
+        Self::NotFound { what: what.into() }
     }
 
-    pub fn bad_request(description: impl Into<String>) -> CollectionError {
-        CollectionError::BadRequest {
+    pub fn bad_request(description: impl Into<String>) -> Self {
+        Self::BadRequest {
             description: description.into(),
         }
     }
 
-    pub fn bad_shard_selection(description: String) -> CollectionError {
-        CollectionError::BadShardSelection { description }
+    pub fn bad_shard_selection(description: String) -> Self {
+        Self::BadShardSelection { description }
     }
 
-    pub fn object_storage_error(what: impl Into<String>) -> CollectionError {
-        CollectionError::ObjectStoreError { what: what.into() }
+    pub fn object_storage_error(what: impl Into<String>) -> Self {
+        Self::ObjectStoreError { what: what.into() }
     }
 
     pub fn forward_proxy_error(peer_id: PeerId, error: impl Into<Self>) -> Self {
@@ -1075,19 +1075,19 @@ impl CollectionError {
         }
     }
 
-    pub fn shard_key_not_found(shard_key: &Option<ShardKey>) -> CollectionError {
+    pub fn shard_key_not_found(shard_key: &Option<ShardKey>) -> Self {
         match shard_key {
-            Some(shard_key) => CollectionError::NotFound {
+            Some(shard_key) => Self::NotFound {
                 what: format!("Shard key {shard_key} not found"),
             },
-            None => CollectionError::NotFound {
+            None => Self::NotFound {
                 what: "Shard expected, but not provided".to_string(),
             },
         }
     }
 
-    pub fn pre_condition_failed(description: impl Into<String>) -> CollectionError {
-        CollectionError::PreConditionFailed {
+    pub fn pre_condition_failed(description: impl Into<String>) -> Self {
+        Self::PreConditionFailed {
             description: description.into(),
         }
     }
@@ -1095,6 +1095,12 @@ impl CollectionError {
     pub fn strict_mode(error: impl Into<String>, solution: impl Into<String>) -> Self {
         let description = format!("{}. Help: {}", error.into(), solution.into());
         Self::StrictMode { description }
+    }
+
+    pub fn rate_limit_exceeded(description: impl Into<String>) -> Self {
+        Self::RateLimitExceeded {
+            description: description.into(),
+        }
     }
 
     /// Returns true if the error is transient and the operation can be retried.
@@ -1128,8 +1134,8 @@ impl CollectionError {
 
     pub fn is_missing_point(&self) -> bool {
         match self {
-            CollectionError::NotFound { what } => what.contains("No point with id"),
-            CollectionError::PointNotFound { .. } => true,
+            Self::NotFound { what } => what.contains("No point with id"),
+            Self::PointNotFound { .. } => true,
             _ => false,
         }
     }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1142,14 +1142,14 @@ impl LocalShard {
             match rate_limiter.lock().try_consume(cost as f64) {
                 Ok(true) => {}
                 Ok(false) => {
-                    return Err(CollectionError::RateLimitExceeded {
-                        description: "Read rate limit exceeded, retry later".to_string(),
-                    });
+                    return Err(CollectionError::rate_limit_exceeded(
+                        "Read rate limit exceeded, retry later",
+                    ));
                 }
-                Err(err) => {
-                    return Err(CollectionError::RateLimitExceeded {
-                        description: err.to_string(),
-                    });
+                Err(msg) => {
+                    return Err(CollectionError::rate_limit_exceeded(format!(
+                        "Read rate limit exceeded, {msg}",
+                    )));
                 }
             }
         }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1134,11 +1134,12 @@ impl LocalShard {
     }
 
     /// Check if the read rate limiter allows the operation to proceed
+    /// - cost: the cost of the operation
     ///
     /// Returns an error if the rate limit is exceeded.
-    fn check_read_rate_limiter(&self) -> CollectionResult<()> {
+    fn check_read_rate_limiter(&self, cost: usize) -> CollectionResult<()> {
         if let Some(rate_limiter) = &self.read_rate_limiter {
-            if !rate_limiter.lock().check_and_update() {
+            if !rate_limiter.lock().try_consume(cost as f64) {
                 return Err(CollectionError::RateLimitExceeded {
                     description: "Read rate limit exceeded, retry later".to_string(),
                 });

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -120,7 +120,7 @@ impl ShardOperation for LocalShard {
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<RecordInternal>> {
         // Check read rate limiter before proceeding
-        self.check_read_rate_limiter()?;
+        self.check_read_rate_limiter(1)?;
         match order_by {
             None => {
                 self.scroll_by_id(
@@ -175,7 +175,7 @@ impl ShardOperation for LocalShard {
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         // Check read rate limiter before proceeding
-        self.check_read_rate_limiter()?;
+        self.check_read_rate_limiter(request.searches.len())?;
         self.do_search(request, search_runtime_handle, timeout, hw_measurement_acc)
             .await
     }
@@ -188,7 +188,7 @@ impl ShardOperation for LocalShard {
         _hw_measurement_acc: HwMeasurementAcc, // TODO: measure hardware when counting
     ) -> CollectionResult<CountResult> {
         // Check read rate limiter before proceeding
-        self.check_read_rate_limiter()?;
+        self.check_read_rate_limiter(1)?;
         let total_count = if request.exact {
             let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
             let all_points = tokio::time::timeout(
@@ -215,7 +215,7 @@ impl ShardOperation for LocalShard {
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<RecordInternal>> {
         // Check read rate limiter before proceeding
-        self.check_read_rate_limiter()?;
+        self.check_read_rate_limiter(1)?;
         let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
         let records_map = tokio::time::timeout(
             timeout,
@@ -247,7 +247,7 @@ impl ShardOperation for LocalShard {
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         // Check read rate limiter before proceeding
-        self.check_read_rate_limiter()?;
+        self.check_read_rate_limiter(requests.len())?;
         let planned_query = PlannedQuery::try_from(requests.as_ref().to_owned())?;
 
         self.do_planned_query(
@@ -266,7 +266,7 @@ impl ShardOperation for LocalShard {
         timeout: Option<Duration>,
     ) -> CollectionResult<FacetResponse> {
         // Check read rate limiter before proceeding
-        self.check_read_rate_limiter()?;
+        self.check_read_rate_limiter(1)?;
         let hits = if request.exact {
             self.exact_facet(request, search_runtime_handle, timeout)
                 .await?

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -785,11 +785,12 @@ impl ShardReplicaSet {
     }
 
     /// Check if the write rate limiter allows the operation to proceed
+    /// - cost: the cost of the operation
     ///
     /// Returns an error if the rate limit is exceeded.
-    fn check_write_rate_limiter(&self) -> CollectionResult<()> {
+    fn check_write_rate_limiter(&self, cost: usize) -> CollectionResult<()> {
         if let Some(rate_limiter) = &self.write_rate_limiter {
-            if !rate_limiter.lock().check_and_update() {
+            if !rate_limiter.lock().try_consume(cost as f64) {
                 return Err(CollectionError::RateLimitExceeded {
                     description: "Write rate limit exceeded, retry later".to_string(),
                 });

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -793,14 +793,14 @@ impl ShardReplicaSet {
             match rate_limiter.lock().try_consume(cost as f64) {
                 Ok(true) => {}
                 Ok(false) => {
-                    return Err(CollectionError::RateLimitExceeded {
-                        description: "Write rate limit exceeded, retry later".to_string(),
-                    });
+                    return Err(CollectionError::rate_limit_exceeded(
+                        "Write rate limit exceeded, retry later",
+                    ));
                 }
-                Err(err) => {
-                    return Err(CollectionError::RateLimitExceeded {
-                        description: err.to_string(),
-                    });
+                Err(msg) => {
+                    return Err(CollectionError::rate_limit_exceeded(format!(
+                        "Write rate limit exceeded, {msg}",
+                    )));
                 }
             }
         }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -790,10 +790,18 @@ impl ShardReplicaSet {
     /// Returns an error if the rate limit is exceeded.
     fn check_write_rate_limiter(&self, cost: usize) -> CollectionResult<()> {
         if let Some(rate_limiter) = &self.write_rate_limiter {
-            if !rate_limiter.lock().try_consume(cost as f64) {
-                return Err(CollectionError::RateLimitExceeded {
-                    description: "Write rate limit exceeded, retry later".to_string(),
-                });
+            match rate_limiter.lock().try_consume(cost as f64) {
+                Ok(true) => {}
+                Ok(false) => {
+                    return Err(CollectionError::RateLimitExceeded {
+                        description: "Write rate limit exceeded, retry later".to_string(),
+                    });
+                }
+                Err(err) => {
+                    return Err(CollectionError::RateLimitExceeded {
+                        description: err.to_string(),
+                    });
+                }
             }
         }
         Ok(())

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -40,7 +40,8 @@ impl ShardReplicaSet {
             match self.peer_state(self.this_peer_id()) {
                 Some(ReplicaState::Active) => {
                     // Rate limit update operations on Active replica
-                    self.check_write_rate_limiter()?;
+                    // TODO(ratelimits) determine cost of update based on operation
+                    self.check_write_rate_limiter(1)?;
                     Ok(Some(local_shard.get().update(operation, wait).await?))
                 }
                 Some(
@@ -255,7 +256,8 @@ impl ShardReplicaSet {
 
                 if self.peer_is_active(this_peer_id) {
                     // Check write rate limiter before proceeding if replica active
-                    self.check_write_rate_limiter()?;
+                    // TODO(ratelimits) determine cost of update based on operation
+                    self.check_write_rate_limiter(1)?;
                 }
 
                 let operation = operation.clone();

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -28,8 +28,10 @@ impl RateLimiter {
         }
     }
 
-    /// Attempt to consume a token. Returns `true` if allowed, `false` otherwise.
-    pub fn check_and_update(&mut self) -> bool {
+    /// Attempt to consume a given number of tokens.
+    ///
+    /// Returns `true` if allowed and consumes the tokens, `false` otherwise.
+    pub fn try_consume(&mut self, tokens: f64) -> bool {
         let now = Instant::now();
         let elapsed = now.duration_since(self.last_check);
         self.last_check = now;
@@ -40,8 +42,8 @@ impl RateLimiter {
             self.tokens = self.capacity_per_minute as f64;
         }
 
-        if self.tokens >= 1.0 {
-            self.tokens -= 1.0; // Consume one token.
+        if self.tokens >= tokens {
+            self.tokens -= tokens; // Consume `cost` tokens.
             true // Request allowed.
         } else {
             false // Request denied.
@@ -67,11 +69,11 @@ mod tests {
         assert_eq_floats(limiter.tokens_per_sec, 0.016, 0.001);
         assert_eq!(limiter.tokens, 1.0);
 
-        assert!(limiter.check_and_update());
+        assert!(limiter.try_consume(1.0));
         assert_eq!(limiter.tokens, 0.0);
 
         // rate limit reached
-        assert!(!limiter.check_and_update());
+        assert!(!limiter.try_consume(1.0));
     }
 
     #[test]
@@ -81,7 +83,10 @@ mod tests {
         assert_eq!(limiter.tokens_per_sec, 10.0);
         assert_eq!(limiter.tokens, 600.0);
 
-        assert!(limiter.check_and_update());
+        assert!(limiter.try_consume(1.0));
         assert_eq!(limiter.tokens, 599.0);
+
+        assert!(limiter.try_consume(10.0));
+        assert_eq_floats(limiter.tokens, 589.0, 0.001);
     }
 }

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -37,7 +37,9 @@ impl RateLimiter {
     pub fn try_consume(&mut self, tokens: f64) -> Result<bool, &'static str> {
         // Consumer wants more than maximum capacity, that's impossible
         if tokens > self.capacity_per_minute as f64 {
-            return Err("Request too big for rate limiter, please try to split your request");
+            return Err(
+                "request larger than than rate limiter capacity, please try to split your request",
+            );
         }
 
         let now = Instant::now();

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -30,8 +30,16 @@ impl RateLimiter {
 
     /// Attempt to consume a given number of tokens.
     ///
-    /// Returns `true` if allowed and consumes the tokens, `false` otherwise.
-    pub fn try_consume(&mut self, tokens: f64) -> bool {
+    /// Returns:
+    /// - `Some(true)` if allowed and consumes the tokens.
+    /// - `Some(false)` if denied because tokens are exhausted, the user can try again later.
+    /// - `Err(_)` if denied because requested more tokens than max capacity, request will never go through.
+    pub fn try_consume(&mut self, tokens: f64) -> Result<bool, &'static str> {
+        // Consumer wants more than maximum capacity, that's impossible
+        if tokens > self.capacity_per_minute as f64 {
+            return Err("Request too big for rate limiter, please try to split your request");
+        }
+
         let now = Instant::now();
         let elapsed = now.duration_since(self.last_check);
         self.last_check = now;
@@ -44,9 +52,9 @@ impl RateLimiter {
 
         if self.tokens >= tokens {
             self.tokens -= tokens; // Consume `cost` tokens.
-            true // Request allowed.
+            Ok(true) // Request allowed.
         } else {
-            false // Request denied.
+            Ok(false) // Request denied.
         }
     }
 }
@@ -69,11 +77,11 @@ mod tests {
         assert_eq_floats(limiter.tokens_per_sec, 0.016, 0.001);
         assert_eq!(limiter.tokens, 1.0);
 
-        assert!(limiter.try_consume(1.0));
+        assert_eq!(limiter.try_consume(1.0), Ok(true));
         assert_eq!(limiter.tokens, 0.0);
 
         // rate limit reached
-        assert!(!limiter.try_consume(1.0));
+        assert_eq!(limiter.try_consume(1.0), Ok(false));
     }
 
     #[test]
@@ -83,10 +91,18 @@ mod tests {
         assert_eq!(limiter.tokens_per_sec, 10.0);
         assert_eq!(limiter.tokens, 600.0);
 
-        assert!(limiter.try_consume(1.0));
+        assert_eq!(limiter.try_consume(1.0), Ok(true));
         assert_eq!(limiter.tokens, 599.0);
 
-        assert!(limiter.try_consume(10.0));
+        assert_eq!(limiter.try_consume(10.0), Ok(true));
         assert_eq_floats(limiter.tokens, 589.0, 0.001);
+    }
+
+    #[test]
+    fn test_rate_huge_request() {
+        let mut limiter = RateLimiter::new_per_minute(100);
+
+        // request too large to ever pass the rate limiter
+        assert!(limiter.try_consume(99999.0).is_err());
     }
 }


### PR DESCRIPTION
This PR makes the read rate limiter consume more tokens in case of batched search.

Exactly 1 token per batched request.

This prevents users from sending very large requests without really impacting the request budget.

A similar PR can be applied later to the updates with a similar logic.