### PR TITLE
use 64-bit dim-id for storing sparse vectors

### DIFF
--- a/lib/blob_store/src/config.rs
+++ b/lib/blob_store/src/config.rs
@@ -9,6 +9,15 @@ pub const DEFAULT_PAGE_SIZE_BYTES: usize = 32 * 1024 * 1024; // 32MB
 
 pub const DEFAULT_REGION_SIZE_BLOCKS: usize = 8_192;
 
+pub const DEFAULT_USE_COMPRESSION: bool = true;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub enum Compression {
+    None,
+    #[default]
+    LZ4,
+}
+
 /// Configuration options for the storage
 #[derive(Debug, Default)]
 pub struct StorageOptions {
@@ -26,6 +35,11 @@ pub struct StorageOptions {
     ///
     /// Default is 8192 blocks
     pub region_size_blocks: Option<u16>,
+
+    /// Use compression
+    ///
+    /// Default is LZ4
+    pub compression: Option<Compression>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,6 +58,12 @@ pub(crate) struct StorageConfig {
     ///
     /// Default is 8192 blocks
     pub region_size_blocks: usize,
+
+    /// Use compression
+    ///
+    /// Default is true
+    #[serde(default)]
+    pub compression: Compression,
 }
 
 impl TryFrom<StorageOptions> for StorageConfig {
@@ -83,6 +103,7 @@ impl TryFrom<StorageOptions> for StorageConfig {
             page_size_bytes,
             block_size_bytes,
             region_size_blocks,
+            compression: options.compression.unwrap_or_default(),
         })
     }
 }

--- a/lib/common/common/src/delta_pack.rs
+++ b/lib/common/common/src/delta_pack.rs
@@ -1,0 +1,167 @@
+use crate::bitpacking::{packed_bits, BitReader, BitWriter};
+
+/// To simplify value counting, each value should be at least one byte.
+/// Otherwise, the count would be ambiguous, e.g., a 2-byte slice of 5-bit
+/// values could contain either 2 or 3 values.
+const MIN_BITS_PER_VALUE: u8 = u8::BITS as u8;
+
+/// How many bits required to store a value in range
+/// `MIN_BITS_PER_VALUE..=u64::BITS`.
+const HEADER_BITS: u8 = 6;
+
+/// Pack sequence of u64 into a delta encoded byte array, and then bitpack it
+///
+/// Max length of the input: 2**32
+/// Assume that the input is sorted
+/// Output contains 4 bytes of the length of the input, followed by the packed data.
+pub fn delta_pack(data: &[u64]) -> Vec<u8> {
+    let mut deltas = Vec::with_capacity(data.len());
+    let mut prev = 0;
+    for &value in data {
+        deltas.push(value - prev);
+        prev = value;
+    }
+
+    compress_sequence(&deltas)
+}
+
+/// Pack sequence of u64 into a delta encoded byte array, and then bitpack it
+///
+/// Max length of the input: 2**32
+/// DO NOT Assume that the input is sorted
+/// Output contains 4 bytes of the length of the input, followed by the packed data.
+pub fn compress_sequence(data: &[u64]) -> Vec<u8> {
+    let length = data.len() as u32;
+    let mut output = Vec::with_capacity(4);
+
+    if length == 0 {
+        return output;
+    }
+
+    let max_value = *data.iter().max().unwrap();
+    let bits_per_value = packed_bits(max_value).max(MIN_BITS_PER_VALUE);
+
+    let mut writer = BitWriter::new(&mut output);
+
+    writer.write(bits_per_value - MIN_BITS_PER_VALUE, HEADER_BITS);
+
+    for &value in data {
+        writer.write(value, bits_per_value);
+    }
+
+    writer.finish();
+
+    output
+}
+
+pub fn decompress_sequence(data: &[u8]) -> Vec<u64> {
+    if data.is_empty() {
+        return Vec::new();
+    }
+
+    let mut result = Vec::new();
+
+    let mut reader = BitReader::new(data);
+    let mut remaining_bits = data.len() * u8::BITS as usize;
+
+    reader.set_bits(HEADER_BITS);
+    let bits_per_value = reader.read::<u8>() + MIN_BITS_PER_VALUE;
+    remaining_bits -= HEADER_BITS as usize;
+
+    reader.set_bits(bits_per_value);
+
+    // It might be possible, that some bits are left after reading the header,
+    // but it is always less than 1 byte and less than bits_per_value
+    while remaining_bits >= bits_per_value as usize {
+        result.push(reader.read::<u64>());
+        remaining_bits -= bits_per_value as usize;
+    }
+
+    result
+}
+
+pub fn delta_unpack(data: &[u8]) -> Vec<u64> {
+    let mut sequence = decompress_sequence(data);
+
+    let mut prev = 0;
+    for value in sequence.iter_mut() {
+        *value += prev;
+        prev = *value;
+    }
+
+    sequence
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::*;
+
+    #[test]
+    fn pack_and_unpack_sorted_data() {
+        let data = vec![1, 2, 3, 4, 5];
+        let packed = delta_pack(&data);
+        let unpacked = delta_unpack(&packed);
+        assert_eq!(data, unpacked);
+    }
+
+    #[test]
+    fn pack_and_unpack_unsorted_data() {
+        let data = vec![5, 3, 1, 4, 2];
+        let packed = compress_sequence(&data);
+        let unpacked = decompress_sequence(&packed);
+        assert_eq!(data, unpacked);
+    }
+
+    #[test]
+    fn pack_and_unpack_empty_data() {
+        let data: Vec<u64> = Vec::new();
+        let packed = delta_pack(&data);
+        let unpacked = delta_unpack(&packed);
+        assert_eq!(data, unpacked);
+    }
+
+    #[test]
+    fn pack_and_unpack_single_element() {
+        let data = vec![42];
+        let packed = delta_pack(&data);
+        let unpacked = delta_unpack(&packed);
+        assert_eq!(data, unpacked);
+    }
+
+    #[test]
+    fn pack_and_unpack_large_numbers() {
+        let data = vec![u64::MAX - 2, u64::MAX - 1, u64::MAX, u64::MAX];
+        let packed = delta_pack(&data);
+        let unpacked = delta_unpack(&packed);
+        assert_eq!(data, unpacked);
+    }
+
+    #[test]
+    fn pack_and_unpack_large_numbers_unsorted() {
+        let data = vec![u64::MAX - 2, u64::MAX, u64::MAX, u64::MAX - 1];
+        let packed = compress_sequence(&data);
+        let unpacked = decompress_sequence(&packed);
+        assert_eq!(data, unpacked);
+    }
+
+    #[test]
+    fn pack_and_unpack_random_data() {
+        let num_iterations = 100;
+        let max_length = 100;
+
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..num_iterations {
+            let length = rng.gen_range(0..max_length);
+            let mut data = (0..length)
+                .map(|_| rng.gen_range(0..u64::MAX))
+                .collect::<Vec<_>>();
+            data.sort();
+            let packed = delta_pack(&data);
+            let unpacked = delta_unpack(&packed);
+            assert_eq!(data, unpacked);
+        }
+    }
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bitpacking_ordered;
 pub mod counter;
 pub mod cpu;
 pub mod defaults;
+pub mod delta_pack;
 pub mod disk;
 pub mod ext;
 pub mod fixed_length_priority_queue;

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -172,6 +172,10 @@ name = "sparse_index_build"
 harness = false
 
 [[bench]]
+name = "sparse_vector_storage"
+harness = false
+
+[[bench]]
 name = "multi_vector_search"
 harness = false
 

--- a/lib/segment/benches/sparse_vector_storage.rs
+++ b/lib/segment/benches/sparse_vector_storage.rs
@@ -1,0 +1,96 @@
+#[cfg(not(target_os = "windows"))]
+mod prof;
+
+use std::sync::atomic::AtomicBool;
+
+use common::types::PointOffsetType;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
+use segment::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
+use segment::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use segment::vector_storage::VectorStorage;
+use sparse::common::sparse_vector_fixture::random_sparse_vector;
+use tempfile::Builder;
+
+const NUM_VECTORS: usize = 10_000;
+const MAX_SPARSE_DIM: usize = 1_000;
+
+fn sparse_vector_storage_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse-vector-storage-group");
+
+    let stopped = AtomicBool::new(false);
+    let mut rnd = StdRng::seed_from_u64(42);
+    let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let db = open_db(storage_dir.path(), &[DB_VECTOR_CF]).unwrap();
+
+    let mut rocksdb_sparse_vector_storage =
+        open_simple_sparse_vector_storage(db, DB_VECTOR_CF, &stopped).unwrap();
+
+    group.bench_function("insert-rocksdb", |b| {
+        b.iter(|| {
+            for idx in 0..NUM_VECTORS {
+                let vec = &random_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
+                rocksdb_sparse_vector_storage
+                    .insert_vector(idx as PointOffsetType, vec.into())
+                    .unwrap();
+            }
+        })
+    });
+
+    group.bench_function("read-rocksdb", |b| {
+        b.iter(|| {
+            for idx in 0..NUM_VECTORS {
+                let vec = rocksdb_sparse_vector_storage.get_vector_opt(idx as PointOffsetType);
+                assert!(vec.is_some());
+            }
+        })
+    });
+
+    drop(rocksdb_sparse_vector_storage);
+
+    let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let mut mmap_sparse_vector_storage =
+        MmapSparseVectorStorage::open_or_create(storage_dir.path()).unwrap();
+
+    group.bench_function("insert-mmap-compression", |b| {
+        b.iter(|| {
+            for idx in 0..NUM_VECTORS {
+                let vec = &random_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
+                mmap_sparse_vector_storage
+                    .insert_vector(idx as PointOffsetType, vec.into())
+                    .unwrap();
+            }
+        })
+    });
+
+    group.bench_function("read-mmap-compression", |b| {
+        b.iter(|| {
+            for idx in 0..NUM_VECTORS {
+                let vec = mmap_sparse_vector_storage.get_vector_opt(idx as PointOffsetType);
+                assert!(vec.is_some());
+            }
+        })
+    });
+
+    drop(mmap_sparse_vector_storage);
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
+    targets = sparse_vector_storage_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = sparse_vector_storage_benchmark,
+}
+
+criterion_main!(benches);

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use bitvec::slice::BitSlice;
+use blob_store::config::{Compression, StorageOptions};
 use blob_store::BlobStore;
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
@@ -84,7 +85,13 @@ impl MmapSparseVectorStorage {
         // Storage
         let storage_dir = path.join(STORAGE_DIRNAME);
         std::fs::create_dir_all(&storage_dir)?;
-        let storage = BlobStore::new(storage_dir, Default::default()).map_err(|err| {
+        let storage_config = StorageOptions {
+            // Don't use built-in compression, as we will use bitpacking instead
+            compression: Some(Compression::None),
+            ..Default::default()
+        };
+
+        let storage = BlobStore::new(storage_dir, storage_config).map_err(|err| {
             OperationError::service_error(format!(
                 "Failed to create storage for mmap sparse vectors: {err}"
             ))

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -163,18 +163,12 @@ impl MmapSparseVectorStorage {
 }
 
 impl SparseVectorStorage for MmapSparseVectorStorage {
-    fn get_sparse(
-        &self,
-        key: PointOffsetType,
-    ) -> crate::common::operation_error::OperationResult<SparseVector> {
+    fn get_sparse(&self, key: PointOffsetType) -> OperationResult<SparseVector> {
         self.get_sparse_opt(key)?
             .ok_or_else(|| OperationError::service_error(format!("Key {key} not found")))
     }
 
-    fn get_sparse_opt(
-        &self,
-        key: PointOffsetType,
-    ) -> crate::common::operation_error::OperationResult<Option<SparseVector>> {
+    fn get_sparse_opt(&self, key: PointOffsetType) -> OperationResult<Option<SparseVector>> {
         self.storage
             .read()
             .get_value(key)

--- a/lib/segment/src/vector_storage/sparse/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/mod.rs
@@ -1,2 +1,3 @@
 pub mod mmap_sparse_vector_storage;
 pub mod simple_sparse_vector_storage;
+mod stored_sparse_vectors;

--- a/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
+++ b/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
@@ -1,0 +1,51 @@
+use blob_store::Blob;
+use serde::{Deserialize, Serialize};
+use sparse::common::sparse_vector::SparseVector;
+use sparse::common::types::{DimId, DimId64, DimWeight};
+
+use crate::common::operation_error::OperationError;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct StoredSparseVector {
+    /// Indices must be unique, explicitly use 64-bit integers for further interface extension
+    pub indices: Vec<DimId64>,
+    /// Values and indices must be the same length
+    pub values: Vec<DimWeight>,
+}
+
+impl From<&SparseVector> for StoredSparseVector {
+    fn from(vector: &SparseVector) -> Self {
+        Self {
+            indices: vector.indices.iter().copied().map(DimId64::from).collect(),
+            values: vector.values.clone(),
+        }
+    }
+}
+
+impl TryFrom<StoredSparseVector> for SparseVector {
+    type Error = OperationError;
+
+    fn try_from(value: StoredSparseVector) -> Result<Self, Self::Error> {
+        Ok(SparseVector {
+            indices: value
+                .indices
+                .into_iter()
+                .map(DimId::try_from)
+                .collect::<Result<_, _>>()
+                .map_err(|err| {
+                    OperationError::service_error(format!("Failed to convert indices: {err}"))
+                })?,
+            values: value.values,
+        })
+    }
+}
+
+impl Blob for StoredSparseVector {
+    fn to_bytes(&self) -> Vec<u8> {
+        bincode::serialize(&self).expect("Sparse vector serialization should not fail")
+    }
+
+    fn from_bytes(data: &[u8]) -> Self {
+        bincode::deserialize(data).expect("Sparse vector deserialization should not fail")
+    }
+}

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -197,7 +197,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
     );
 }
 
-fn do_test_persistance(open: impl Fn(&Path) -> VectorStorageEnum) {
+fn do_test_persistence(open: impl Fn(&Path) -> VectorStorageEnum) {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let mut storage = open(dir.path());
 
@@ -309,20 +309,20 @@ fn test_update_from_delete_points_mmap_sparse_vector_storage() {
 
     drop(storage);
 
-    let mut _storage =
+    let _storage =
         VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(dir.path()).unwrap());
 }
 
 #[test]
-fn test_persistance_in_mmap_sparse_vector_storage() {
-    do_test_persistance(|path| {
+fn test_persistence_in_mmap_sparse_vector_storage() {
+    do_test_persistence(|path| {
         VectorStorageEnum::SparseMmap(MmapSparseVectorStorage::open_or_create(path).unwrap())
     });
 }
 
 #[test]
-fn test_persistance_in_simple_sparse_vector_storage() {
-    do_test_persistance(|path| {
+fn test_persistence_in_simple_sparse_vector_storage() {
+    do_test_persistence(|path| {
         let db = open_db(path, &[DB_VECTOR_CF]).unwrap();
         open_simple_sparse_vector_storage(db, DB_VECTOR_CF, &AtomicBool::new(false)).unwrap()
     });

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -31,7 +31,7 @@ pub struct RemappedSparseVector {
 }
 
 /// Sort two arrays by the first array.
-fn double_sort<T: Ord + Copy, V: Copy>(indices: &mut [T], values: &mut [V]) {
+pub fn double_sort<T: Ord + Copy, V: Copy>(indices: &mut [T], values: &mut [V]) {
     // Check if the indices are already sorted
     if indices.windows(2).all(|w| w[0] < w[1]) {
         return;

--- a/lib/sparse/src/common/types.rs
+++ b/lib/sparse/src/common/types.rs
@@ -5,6 +5,7 @@ use itertools::{Itertools, MinMaxResult};
 
 pub type DimOffset = u32;
 pub type DimId = u32;
+pub type DimId64 = u64;
 pub type DimWeight = f32;
 
 pub trait Weight: PartialEq + Copy + Debug + 'static {

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -125,4 +125,4 @@ test_version $PREV_PATCH_QDRANT_VERSION
 test_version $PREV_MINOR_QDRANT_VERSION
 
 # Test that it can read both rocksdb and blob_store
-test_version 'v1.12.5-rocksdb+blob_store'
+test_version 'v1.12.6-rocksdb+blob_store-pre_release'


### PR DESCRIPTION
Eventually we want to allow 64bit `DimId` for sparse vectors. This is one of the steps towards.