### PR TITLE
bitpacking: make generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorz"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceb37c5798821e37369cb546f430f19da2f585e0364c9615ae340a9f2e6067b"
+dependencies = [
+ "supports-color",
+]
+
+[[package]]
 name = "common"
 version = "0.0.0"
 dependencies = [
@@ -1264,6 +1282,7 @@ dependencies = [
  "rand 0.8.5",
  "semver",
  "serde",
+ "tango-bench",
  "tap",
  "tar",
  "tempfile",
@@ -2363,6 +2382,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
+name = "goblin"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "gpu"
 version = "0.1.0"
 dependencies = [
@@ -3091,6 +3127,12 @@ dependencies = [
  "rustix 0.37.27",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_sorted"
@@ -4374,6 +4416,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -5706,6 +5754,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "sdd"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6354,6 +6422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
 name = "symbolic-common"
 version = "12.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6446,6 +6523,27 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows 0.57.0",
+]
+
+[[package]]
+name = "tango-bench"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257822358c6f206fed78bfe6369cf959063b0644d70f88df6b19f2dadc93423e"
+dependencies = [
+ "alloca",
+ "anyhow",
+ "clap",
+ "colorz",
+ "glob-match",
+ "goblin",
+ "libloading 0.8.5",
+ "log",
+ "num-traits",
+ "rand 0.8.5",
+ "scroll",
+ "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
+ "num-traits",
  "num_cpus",
  "ordered-float 4.5.0",
  "ph",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 testing = []
 
 [dependencies]
+num-traits = { workspace = true }
 num_cpus = "1.16"
 ordered-float = { workspace = true }
 ph = { workspace = true }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -36,6 +36,7 @@ log = { workspace = true }
 common = { path = ".", features = ["testing"] }
 criterion = { workspace = true }
 itertools = { workspace = true }
+tango-bench = "0.6.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 thiserror = { workspace = true }
@@ -43,6 +44,10 @@ thread-priority = "1.2"
 
 [[bench]]
 name = "bitpacking"
+harness = false
+
+[[bench]]
+name = "bitpacking_tango"
 harness = false
 
 [[bench]]

--- a/lib/common/common/benches/bitpacking.rs
+++ b/lib/common/common/benches/bitpacking.rs
@@ -27,7 +27,7 @@ pub fn bench_bitpacking(c: &mut Criterion) {
                 let mut r = BitReader::new(data);
                 r.set_bits(bits);
                 for _ in 0..(data.len() * u8::BITS as usize / bits as usize) {
-                    black_box(r.read());
+                    black_box(r.read::<u32>());
                 }
             },
             BatchSize::SmallInput,

--- a/lib/common/common/benches/bitpacking_tango.rs
+++ b/lib/common/common/benches/bitpacking_tango.rs
@@ -33,7 +33,7 @@ pub fn benchmarks_bitpacking() -> impl IntoBenchmarks {
                 let mut r = BitReader::new(data);
                 r.set_bits(bits);
                 for _ in 0..(data.len() * u8::BITS as usize / bits as usize) {
-                    black_box(r.read());
+                    black_box(r.read::<u32>());
                 }
             })
         }),

--- a/lib/common/common/benches/bitpacking_tango.rs
+++ b/lib/common/common/benches/bitpacking_tango.rs
@@ -1,0 +1,147 @@
+use std::cell::LazyCell;
+use std::hint::black_box;
+use std::rc::Rc;
+
+use common::bitpacking::{BitReader, BitWriter};
+use common::bitpacking_links::for_each_packed_link;
+use itertools::Itertools as _;
+use rand::rngs::StdRng;
+use rand::{Rng as _, SeedableRng as _};
+use tango_bench::{
+    benchmark_fn, tango_benchmarks, tango_main, Bencher, Benchmark, ErasedSampler, IntoBenchmarks,
+};
+
+pub fn benchmarks_bitpacking() -> impl IntoBenchmarks {
+    let data8 = StateBencher::new(move || {
+        let mut rng = StdRng::seed_from_u64(42);
+        (0..64_000_000).map(|_| rng.gen()).collect::<Vec<u8>>()
+    });
+    let data32 = StateBencher::new(move || {
+        let mut rng = StdRng::seed_from_u64(42);
+        (0..4_000_000).map(|_| rng.gen()).collect::<Vec<u32>>()
+    });
+
+    [
+        data8.benchmark_fn("bitpacking/read", move |b, data8| {
+            let mut rng = StdRng::seed_from_u64(42);
+            b.iter(move || {
+                let bits = rng.gen_range(1..=32);
+                let bytes = rng.gen_range(0..=16);
+                let start = rng.gen_range(0..data8.len() - bytes);
+                let data = &data8[start..start + bytes];
+
+                let mut r = BitReader::new(data);
+                r.set_bits(bits);
+                for _ in 0..(data.len() * u8::BITS as usize / bits as usize) {
+                    black_box(r.read());
+                }
+            })
+        }),
+        data32.benchmark_fn("bitpacking/write", move |b, data32| {
+            let mut rng = StdRng::seed_from_u64(42);
+            let mut out = Vec::new();
+            b.iter(move || {
+                let bits = rng.gen_range(1..=32);
+                let values = rng.gen_range(0..=16);
+                let start = rng.gen_range(0..data32.len() - values);
+                let data = &data32[start..start + values];
+
+                out.clear();
+                let mut w = BitWriter::new(&mut out);
+                for &x in data {
+                    w.write(x, bits);
+                }
+                w.finish();
+                black_box(&mut out);
+            })
+        }),
+    ]
+}
+
+fn benchmarks_bitpacking_links() -> impl IntoBenchmarks {
+    struct Item {
+        offset: usize,
+        bits_per_unsorted: u8,
+        sorted_count: usize,
+    }
+    struct State {
+        links: Vec<u8>,
+        items: Vec<Item>,
+    }
+
+    let b = StateBencher::new(move || {
+        Rc::new({
+            let mut rng = StdRng::seed_from_u64(42);
+            let mut links = Vec::new();
+            let mut pos = vec![Item {
+                offset: 0,
+                bits_per_unsorted: 0,
+                sorted_count: 0,
+            }];
+            while links.len() <= 64_000_000 {
+                let bits_per_unsorted = rng.gen_range(7..=32);
+                let sorted_count = rng.gen_range(0..100);
+                let unsorted_count = rng.gen_range(0..100);
+                if 1 << bits_per_unsorted < sorted_count + unsorted_count {
+                    continue;
+                }
+
+                common::bitpacking_links::pack_links(
+                    &mut links,
+                    std::iter::repeat_with(|| rng.gen_range(0..1u64 << bits_per_unsorted) as u32)
+                        .unique()
+                        .take(sorted_count + unsorted_count)
+                        .collect(),
+                    bits_per_unsorted,
+                    sorted_count,
+                );
+                pos.push(Item {
+                    offset: links.len(),
+                    bits_per_unsorted,
+                    sorted_count,
+                });
+            }
+
+            State { links, items: pos }
+        })
+    });
+
+    [b.benchmark_fn("bitpacking_links/read", move |b, state| {
+        let mut rng = rand::thread_rng();
+        b.iter(move || {
+            let idx = rng.gen_range(1..state.items.len());
+            for_each_packed_link(
+                &state.links[state.items[idx - 1].offset..state.items[idx].offset],
+                state.items[idx].bits_per_unsorted,
+                state.items[idx].sorted_count,
+                |x| {
+                    black_box(x);
+                },
+            );
+        })
+    })]
+}
+
+#[expect(clippy::type_complexity)]
+struct StateBencher<T>(Rc<LazyCell<Rc<T>, Box<dyn FnOnce() -> Rc<T>>>>);
+
+impl<T: 'static> StateBencher<T> {
+    fn new<F: FnOnce() -> T + 'static>(f: F) -> Self {
+        Self(Rc::new(LazyCell::new(Box::new(move || Rc::new(f())))))
+    }
+
+    pub fn benchmark_fn<F: FnMut(Bencher, Rc<T>) -> Box<dyn ErasedSampler> + 'static>(
+        &self,
+        name: impl Into<String>,
+        mut sampler_factory: F,
+    ) -> Benchmark {
+        let state = Rc::clone(&self.0);
+        benchmark_fn(name, move |b| {
+            let state = Rc::clone(LazyCell::force(&state));
+            sampler_factory(b, state)
+        })
+    }
+}
+
+tango_benchmarks!(benchmarks_bitpacking(), benchmarks_bitpacking_links());
+tango_main!();

--- a/lib/common/common/build.rs
+++ b/lib/common/common/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Required for tango benchmarks, see:
+    // https://github.com/bazhenov/tango/blob/v0.6.0/README.md#getting-started
+    println!("cargo:rustc-link-arg-benches=-rdynamic");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/lib/common/common/src/bitpacking.rs
+++ b/lib/common/common/src/bitpacking.rs
@@ -1,3 +1,7 @@
+use num_traits::{AsPrimitive, ConstOne, PrimInt, Unsigned};
+
+use crate::num_traits::ConstBits;
+
 /// The internal buffer type for [`BitWriter`] and [`BitReader`].
 /// Instead of writing/reading a single byte at a time, they write/read
 /// `size_of::<Buf>()` bytes at once, for a better performance.
@@ -29,11 +33,13 @@ impl<'a> BitWriter<'a> {
     /// The `bits` must be less than or equal to 32, and the `value` must fit in
     /// the `bits` bits.
     #[inline]
-    pub fn write(&mut self, value: u32, bits: u8) {
-        #[cfg(test)]
-        debug_assert!(bits <= 32 && u64::from(value) < 1 << bits);
+    pub fn write<T: ConstBits + Into<Buf>>(&mut self, value: T, bits: u8) {
+        let value = value.into();
 
-        self.buf |= Buf::from(value) << self.buf_bits;
+        #[cfg(test)]
+        debug_assert!(u32::from(bits) <= T::BITS && packed_bits(value) <= bits);
+
+        self.buf |= value << self.buf_bits;
         self.buf_bits += bits;
         if self.buf_bits >= Buf::BITS as u8 {
             // ┌──value───┐┌───initial self.buf────┐
@@ -41,7 +47,11 @@ impl<'a> BitWriter<'a> {
             // └[2]┘└─────────────[1]──────────────┘
             self.output.extend_from_slice(&self.buf.to_le_bytes()); // [1]
             self.buf_bits -= Buf::BITS as u8;
-            self.buf = Buf::from(value) >> (bits - self.buf_bits); // [2]
+            if bits - self.buf_bits == Buf::BITS as u8 {
+                self.buf = 0;
+            } else {
+                self.buf = value >> (bits - self.buf_bits); // [2]
+            }
         }
     }
 
@@ -88,10 +98,10 @@ impl<'a> BitReader<'a> {
     #[inline]
     pub fn set_bits(&mut self, bits: u8) {
         #[cfg(test)]
-        debug_assert!(bits <= 32);
+        debug_assert!(u32::from(bits) <= Buf::BITS);
 
         self.bits = bits;
-        self.mask = (1 << bits) - 1;
+        self.mask = make_bitmask(bits);
     }
 
     /// Read next `bits` bits from the input. The amount of bits must be set
@@ -102,10 +112,14 @@ impl<'a> BitReader<'a> {
     ///
     /// [`set_bits()`]: Self::set_bits
     #[inline]
-    pub fn read(&mut self) -> u32 {
+    pub fn read<T>(&mut self) -> T
+    where
+        T: 'static + Copy,
+        Buf: AsPrimitive<T>,
+    {
         if self.buf_bits >= self.bits {
             self.buf_bits -= self.bits;
-            let val = (self.buf & self.mask) as u32;
+            let val = (self.buf & self.mask).as_();
             self.buf >>= self.bits;
             val
         } else {
@@ -126,9 +140,13 @@ impl<'a> BitReader<'a> {
             // └──────────[3]──────────┘├─[2]─┘└───[1]────┤
             //                          └───────val───────┘
             let new_buf = read_buf_and_advance(&mut self.input);
-            let val = ((/*[1]*/self.buf) | (/*[2]*/new_buf << self.buf_bits) & self.mask) as u32;
+            let val = ((/*[1]*/self.buf) | (/*[2]*/new_buf << self.buf_bits) & self.mask).as_();
             self.buf_bits += Buf::BITS as u8 - self.bits;
-            self.buf = /*[3]*/ new_buf >> (Buf::BITS as u8 - self.buf_bits);
+            if self.buf_bits == 0 {
+                self.buf = 0;
+            } else {
+                self.buf = /*[3]*/ new_buf >> (Buf::BITS as u8 - self.buf_bits);
+            }
             val
         }
     }
@@ -161,14 +179,25 @@ fn read_buf_and_advance(input: &mut &[u8]) -> Buf {
 
 /// Minimum amount of bits required to store a value in the range
 /// `0..=max_value`.
-pub fn packed_bits(max_value: u32) -> u8 {
-    (u32::BITS - max_value.leading_zeros()) as u8
+pub fn packed_bits<T: ConstBits + PrimInt + Unsigned>(max_value: T) -> u8 {
+    (T::BITS - max_value.leading_zeros()) as u8
+}
+
+pub fn make_bitmask<T: ConstBits + ConstOne + PrimInt + Unsigned>(bits: u8) -> T {
+    if u32::from(bits) >= T::BITS {
+        T::max_value()
+    } else {
+        (T::ONE << usize::from(bits)) - T::ONE
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Debug;
     use std::iter::zip;
 
+    use num_traits::{ConstOne, ConstZero, PrimInt, Unsigned};
+    use rand::distributions::uniform::SampleUniform;
     use rand::rngs::StdRng;
     use rand::{Rng as _, SeedableRng as _};
 
@@ -179,45 +208,65 @@ mod tests {
         let mut packed = Vec::new();
         let mut w = BitWriter::new(&mut packed);
 
-        w.write(0b01010, 5);
-        w.write(0b10110, 5);
-        w.write(0b10100, 5);
-        w.write(0b010110010, 9);
-        w.write(0b101100001, 9);
-        w.write(0b001001101, 9);
-        w.write(0x12345678, 32);
+        w.write::<u32>(0b01010, 5);
+        w.write::<u32>(0b10110, 5);
+        w.write::<u32>(0b10100, 5);
+        w.write::<u32>(0b010110010, 9);
+        w.write::<u32>(0b101100001, 9);
+        w.write::<u32>(0b001001101, 9);
+        w.write::<u32>(0x12345678, 32);
         w.finish();
         assert_eq!(packed.len(), 10);
 
         let mut r = BitReader::new(&packed);
         r.set_bits(5);
-        assert_eq!(r.read(), 0b01010);
-        assert_eq!(r.read(), 0b10110);
-        assert_eq!(r.read(), 0b10100);
+        assert_eq!(r.read::<u32>(), 0b01010);
+        assert_eq!(r.read::<u32>(), 0b10110);
+        assert_eq!(r.read::<u32>(), 0b10100);
         r.set_bits(9);
-        assert_eq!(r.read(), 0b010110010);
-        assert_eq!(r.read(), 0b101100001);
-        assert_eq!(r.read(), 0b001001101);
+        assert_eq!(r.read::<u32>(), 0b010110010);
+        assert_eq!(r.read::<u32>(), 0b101100001);
+        assert_eq!(r.read::<u32>(), 0b001001101);
         r.set_bits(32);
-        assert_eq!(r.read(), 0x12345678);
+        assert_eq!(r.read::<u32>(), 0x12345678);
     }
 
     #[test]
     fn test_random() {
+        test_random_impl::<u8>();
+        test_random_impl::<u16>();
+        test_random_impl::<u32>();
+        test_random_impl::<u64>();
+    }
+
+    fn test_random_impl<T>()
+    where
+        Buf: AsPrimitive<T>,
+        T: ConstBits
+            + ConstOne
+            + ConstZero
+            + Copy
+            + Debug
+            + Into<Buf>
+            + PrimInt
+            + SampleUniform
+            + Unsigned
+            + 'static,
+    {
         let mut rng = StdRng::seed_from_u64(42);
 
         let mut bits_per_value = Vec::new();
-        let mut values = Vec::new();
+        let mut values = Vec::<T>::new();
         let mut packed = Vec::new();
-        let mut unpacked = Vec::new();
+        let mut unpacked = Vec::<T>::new();
         for len in 0..40 {
             for _ in 0..100 {
                 values.clear();
                 bits_per_value.clear();
                 let mut total_bits = 0;
                 for _ in 0..len {
-                    let bits = rng.gen_range(0u8..=32u8);
-                    values.push(rng.gen_range(0..(1u64 << bits)) as u32);
+                    let bits = rng.gen_range(0u8..=T::BITS as u8);
+                    values.push(rng.gen_range(T::ZERO..=make_bitmask(bits)));
                     bits_per_value.push(bits);
                     total_bits += u64::from(bits);
                 }
@@ -244,20 +293,53 @@ mod tests {
     }
 
     #[test]
-    fn test_packed_bits() {
-        assert_eq!(packed_bits(0), 0);
+    fn test_packed_bits_simple() {
+        assert_eq!(packed_bits(0_u32), 0);
 
-        assert_eq!(packed_bits(1), 1);
+        assert_eq!(packed_bits(1_u32), 1);
 
-        assert_eq!(packed_bits(2), 2);
-        assert_eq!(packed_bits(3), 2);
+        assert_eq!(packed_bits(2_u32), 2);
+        assert_eq!(packed_bits(3_u32), 2);
 
-        assert_eq!(packed_bits(4), 3);
-        assert_eq!(packed_bits(7), 3);
+        assert_eq!(packed_bits(4_u32), 3);
+        assert_eq!(packed_bits(7_u32), 3);
 
-        assert_eq!(packed_bits(0x_7FFF_FFFF), 31);
+        assert_eq!(packed_bits(0x_7FFF_FFFF_u32), 31);
 
-        assert_eq!(packed_bits(0x_8000_0000), 32);
-        assert_eq!(packed_bits(0x_FFFF_FFFF), 32);
+        assert_eq!(packed_bits(0x_8000_0000_u32), 32);
+        assert_eq!(packed_bits(0x_FFFF_FFFF_u32), 32);
+    }
+
+    #[test]
+    fn test_packed_bits_extensive() {
+        fn check<T: Unsigned + PrimInt + ConstBits + TryFrom<u128>>(v: u128, expected_bits: u8) {
+            if let Ok(x) = v.try_into() {
+                assert_eq!(packed_bits::<T>(x), expected_bits);
+            }
+        }
+
+        for expected_bits in 0..=128_u8 {
+            let (min, max);
+            if expected_bits == 0 {
+                (min, max) = (0, 0);
+            } else {
+                min = 1_u128 << (expected_bits - 1);
+                max = (min - 1) * 2 + 1;
+            }
+
+            check::<u8>(min, expected_bits);
+            check::<u16>(min, expected_bits);
+            check::<u32>(min, expected_bits);
+            check::<u64>(min, expected_bits);
+            check::<u128>(min, expected_bits);
+            check::<usize>(min, expected_bits);
+
+            check::<u8>(max, expected_bits);
+            check::<u16>(max, expected_bits);
+            check::<u32>(max, expected_bits);
+            check::<u64>(max, expected_bits);
+            check::<u128>(max, expected_bits);
+            check::<usize>(max, expected_bits);
+        }
     }
 }

--- a/lib/common/common/src/bitpacking_links.rs
+++ b/lib/common/common/src/bitpacking_links.rs
@@ -77,7 +77,7 @@ pub fn for_each_packed_link(
     if sorted_count != 0 {
         // 1. Header.
         r.set_bits(HEADER_BITS);
-        let bits_per_sorted = r.read() as u8 + MIN_BITS_PER_VALUE;
+        let bits_per_sorted = r.read::<u8>() + MIN_BITS_PER_VALUE;
         remaining_bits -= HEADER_BITS as usize;
 
         // 2. First `sorted_count` values, sorted and delta-encoded.
@@ -87,7 +87,7 @@ pub fn for_each_packed_link(
                 * bits_per_sorted as usize;
         let mut value = 0;
         while remaining_bits > remaining_bits_target {
-            value += r.read();
+            value += r.read::<u32>();
             f(value);
             remaining_bits -= bits_per_sorted as usize;
         }

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod fixed_length_priority_queue;
 pub mod iterator_ext;
 pub mod math;
 pub mod mmap_hashmap;
+pub mod num_traits;
 pub mod panic;
 pub mod rate_limiting;
 pub mod tar_ext;

--- a/lib/common/common/src/num_traits.rs
+++ b/lib/common/common/src/num_traits.rs
@@ -1,0 +1,29 @@
+//! Traits that should belong to the [`num-traits`] crate, but are missing.
+//!
+//! [`num-traits`]: https://crates.io/crates/num-traits
+
+use std::num::{NonZero, Saturating};
+
+pub trait ConstBits {
+    /// The size of this integer type in bits.
+    const BITS: u32;
+}
+
+macro_rules! impl_const_bits {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl ConstBits for $t {
+                const BITS: u32 = Self::BITS;
+            }
+            impl ConstBits for NonZero<$t> {
+                const BITS: u32 = Self::BITS;
+            }
+            impl ConstBits for Saturating<$t> {
+                const BITS: u32 = Self::BITS;
+            }
+        )*
+    };
+}
+
+impl_const_bits!(i8, i16, i32, i64, i128, isize);
+impl_const_bits!(u8, u16, u32, u64, u128, usize);


### PR DESCRIPTION
Depends on #5688 (for benchmarks).

This PR makes `bitpacking` generic to support not only `u32` but also `u64`.

This change makes benchmarks a bit faster. I can pinpoint particular changes in the code that caused it, but I'm not sure why.

```console
$ cargo bench -p common --bench bitpacking_tango -- compare tmp/prev -t 2
bitpacking/read                                    [  38.1 ns ...  36.8 ns ]      -3.29%*
bitpacking/write                                   [  43.4 ns ...  43.2 ns ]      -0.51%
bitpacking_links/read                              [ 349.3 ns ... 341.9 ns ]      -2.12%*
```