### PR TITLE
Filter out empty filter conditions from gRPC

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -974,6 +974,7 @@ fn conditions_helper_from_grpc(
     conditions: Vec<Condition>,
 ) -> Result<Option<Vec<segment::types::Condition>>, tonic::Status> {
     // Convert gRPC into internal conditions, filter out empty conditions
+    // See: <https://github.com/qdrant/qdrant/pull/5690>
     let mut converted = Vec::with_capacity(conditions.len());
     for condition in conditions {
         if let Some(condition) = grpc_condition_into_condition(condition)? {


### PR DESCRIPTION
Fixes <https://github.com/qdrant/rust-client/issues/205>

Filter out empty gRPC filter conditions, rather than throwing an error. This was very easily triggered with `Condition::default()` in our Rust client.

Filtering out the condition so it is a 'match all' is probably better and is what users might expect from it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?