### PR TITLE
Cleanup JSON logger impl and add JSON support to on-disk logger

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -38,8 +38,16 @@ impl LoggerConfig {
     }
 }
 
+#[derive(Default, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogFormat {
+    #[default]
+    Text,
+    Json,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum SpanEvent {
     New,
     Enter,
@@ -73,7 +81,7 @@ impl From<SpanEvent> for fmt::format::FmtSpan {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize, Default)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum Color {
     #[default]
     Auto,

--- a/src/tracing/default.rs
+++ b/src/tracing/default.rs
@@ -2,26 +2,17 @@ use std::collections::HashSet;
 
 use common::ext::OptionExt;
 use serde::{Deserialize, Serialize};
-use tracing_subscriber::fmt::{self};
-use tracing_subscriber::{filter, registry, Layer};
+use tracing_subscriber::{fmt, registry, Layer};
 
 use super::*;
-
-#[derive(Default, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum LogFormat {
-    #[default]
-    Text,
-    Json,
-}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub log_level: Option<String>,
     pub span_events: Option<HashSet<config::SpanEvent>>,
+    pub format: Option<config::LogFormat>,
     pub color: Option<config::Color>,
-    pub log_format: Option<LogFormat>,
 }
 
 impl Config {
@@ -29,28 +20,22 @@ impl Config {
         let Self {
             log_level,
             span_events,
+            format,
             color,
-            log_format,
         } = other;
 
         self.log_level.replace_if_some(log_level);
         self.span_events.replace_if_some(span_events);
+        self.format.replace_if_some(format);
         self.color.replace_if_some(color);
-        self.log_format.replace_if_some(log_format);
     }
 }
-
-pub type Logger<S> =
-    filter::Filtered<Option<Box<dyn Layer<S> + Send + Sync>>, filter::EnvFilter, S>;
 
 pub fn new_logger<S>(config: &Config) -> Logger<S>
 where
     S: tracing::Subscriber + for<'span> registry::LookupSpan<'span>,
 {
-    let layer: Box<dyn Layer<S> + Send + Sync> = match config.log_format {
-        Some(LogFormat::Json) => Box::new(new_layer_with_json(config)),
-        Some(LogFormat::Text) | None => Box::new(new_layer(config)),
-    };
+    let layer = new_layer(config);
     let filter = new_filter(config);
     Some(layer).with_filter(filter)
 }
@@ -59,27 +44,16 @@ pub fn new_layer<S>(config: &Config) -> Box<dyn Layer<S> + Send + Sync>
 where
     S: tracing::Subscriber + for<'span> registry::LookupSpan<'span>,
 {
-    Box::new(
-        fmt::Layer::default()
-            .with_span_events(config::SpanEvent::unwrap_or_default_config(
-                &config.span_events,
-            ))
-            .with_ansi(config.color.unwrap_or_default().to_bool()),
-    )
-}
+    let layer = fmt::Layer::default()
+        .with_span_events(config::SpanEvent::unwrap_or_default_config(
+            &config.span_events,
+        ))
+        .with_ansi(config.color.unwrap_or_default().to_bool());
 
-pub fn new_layer_with_json<S>(config: &Config) -> Box<dyn Layer<S> + Send + Sync>
-where
-    S: tracing::Subscriber + for<'span> registry::LookupSpan<'span>,
-{
-    Box::new(
-        fmt::Layer::default()
-            .json()
-            .with_span_events(config::SpanEvent::unwrap_or_default_config(
-                &config.span_events,
-            ))
-            .with_ansi(config.color.unwrap_or_default().to_bool()),
-    )
+    match config.format {
+        None | Some(config::LogFormat::Text) => Box::new(layer),
+        Some(config::LogFormat::Json) => Box::new(layer.json()),
+    }
 }
 
 pub fn new_filter(config: &Config) -> filter::EnvFilter {

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -108,3 +108,10 @@ fn filter(user_filters: &str) -> filter::EnvFilter {
         .with_regex(false)
         .parse_lossy(filter)
 }
+
+#[rustfmt::skip] // `rustfmt` formats this into unreadable single line
+type Logger<S> = filter::Filtered<
+    Option<Box<dyn tracing_subscriber::Layer<S> + Send + Sync>>,
+    filter::EnvFilter,
+    S,
+>;

--- a/src/tracing/test.rs
+++ b/src/tracing/test.rs
@@ -28,8 +28,8 @@ fn deserialize_logger_config() {
                 config::SpanEvent::New,
                 config::SpanEvent::Close,
             ])),
+            format: None,
             color: Some(config::Color::Explicit(true)),
-            log_format: None,
         },
 
         on_disk: on_disk::Config {
@@ -40,6 +40,7 @@ fn deserialize_logger_config() {
                 config::SpanEvent::New,
                 config::SpanEvent::Close,
             ])),
+            format: None,
         },
     };
 
@@ -51,14 +52,15 @@ fn deserialize_json_logger_config() {
     let json = json!({
         "log_level": "debug",
         "span_events": ["new", "close"],
+        "format": "json",
         "color": true,
-        "log_format": "json",
 
         "on_disk": {
             "enabled": true,
             "log_file": "/logs/qdrant",
             "log_level": "tracing",
             "span_events": ["new", "close"],
+            "format": "text",
         }
     });
 
@@ -71,8 +73,8 @@ fn deserialize_json_logger_config() {
                 config::SpanEvent::New,
                 config::SpanEvent::Close,
             ])),
+            format: Some(config::LogFormat::Json),
             color: Some(config::Color::Explicit(true)),
-            log_format: Some(default::LogFormat::Json),
         },
 
         on_disk: on_disk::Config {
@@ -83,6 +85,7 @@ fn deserialize_json_logger_config() {
                 config::SpanEvent::New,
                 config::SpanEvent::Close,
             ])),
+            format: Some(config::LogFormat::Text),
         },
     };
 
@@ -106,14 +109,15 @@ fn deseriailze_config_with_explicit_nulls() {
     let json = json!({
         "log_level": null,
         "span_events": null,
+        "format": null,
         "color": null,
-        "log_format": null,
 
         "on_disk": {
             "enabled": null,
             "log_file": null,
             "log_level": null,
             "span_events": null,
+            "format": null,
         }
     });
 


### PR DESCRIPTION
Basically, subject: simplify JSON logger setup code and copy JSON support to on-disk logger.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
