### PR TITLE
Separate file for compressed links

### DIFF
--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -51,7 +51,8 @@ fn hnsw_benchmark(c: &mut Criterion) {
 
         if graph_fname.exists() && links_fname.exists() {
             eprintln!("Loading cached links from {links_fname:?}");
-            graph_layers = GraphLayers::load(&graph_fname, &links_fname, false, false).unwrap();
+            graph_layers =
+                GraphLayers::load(&graph_fname, &links_fname, false, false, false).unwrap();
         } else {
             let mut graph_layers_builder =
                 GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -51,8 +51,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
 
         if graph_fname.exists() && links_fname.exists() {
             eprintln!("Loading cached links from {links_fname:?}");
-            graph_layers =
-                GraphLayers::load(&graph_fname, &links_fname, false, false, false).unwrap();
+            graph_layers = GraphLayers::load(&graph_fname, &links_fname, false, false).unwrap();
         } else {
             let mut graph_layers_builder =
                 GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -317,7 +317,7 @@ impl GraphLayers {
     #[cfg(feature = "testing")]
     pub fn compress_ram(&mut self) {
         use crate::index::hnsw_index::graph_links::GraphLinksConverter;
-        assert!(!self.links.compressed() && !self.links.on_disk());
+        assert!(!self.links.compressed());
         let dummy = GraphLinksConverter::new(Vec::new(), false, 0, 0).to_graph_links_ram();
         let links = std::mem::replace(&mut self.links, dummy);
         self.links = GraphLinksConverter::new(links.into_edges(), true, self.m, self.m0)
@@ -429,6 +429,7 @@ mod tests {
     }
 
     #[rstest]
+    #[case::uncompressed((false, false))]
     #[case::converted((false, true))]
     #[case::compressed((true, false))]
     fn test_save_and_load(#[case] (compressed, converted): (bool, bool)) {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -432,8 +432,6 @@ mod tests {
     #[case::converted((false, true))]
     #[case::compressed((true, false))]
     fn test_save_and_load(#[case] (compressed, converted): (bool, bool)) {
-        eprintln!("(compressed, converted) = {:#?}", (compressed, converted));
-
         let num_vectors = 100;
         let dim = 8;
         let top = 5;
@@ -461,6 +459,8 @@ mod tests {
 
         let path = GraphLayers::get_path(dir.path());
         graph_layers.save(&path).unwrap();
+
+        drop(graph_layers);
 
         let load_links_path = if !compressed && converted {
             GraphLayers::convert_to_compressed(&path, &regular_links_path, &compressed_links_path)

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -429,10 +429,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::uncompressed((false, false))]
     #[case::converted((false, true))]
     #[case::compressed((true, false))]
     fn test_save_and_load(#[case] (compressed, converted): (bool, bool)) {
+        eprintln!("(compressed, converted) = {:#?}", (compressed, converted));
+
         let num_vectors = 100;
         let dim = 8;
         let top = 5;
@@ -469,7 +470,9 @@ mod tests {
             links_path
         };
 
-        let graph2 = GraphLayers::load(&path, load_links_path, false, compressed).unwrap();
+        let load_compressed = compressed || converted;
+
+        let graph2 = GraphLayers::load(&path, load_links_path, false, load_compressed).unwrap();
 
         let res2 = search_in_graph(&query, top, &vector_holder, &graph2);
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -277,9 +277,12 @@ impl GraphLayers {
     ) -> OperationResult<Self> {
         let graph_data: GraphLayerData = read_bin(graph_path)?;
 
-        if do_compress && !compressed {
+        let compressed = if do_compress && !compressed {
             convert_to_compressed(links_path, graph_data.m, graph_data.m0)?;
-        }
+            true
+        } else {
+            compressed
+        };
 
         Ok(Self {
             m: graph_data.m,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -86,7 +86,7 @@ impl GraphLayersBuilder {
         links_converter.save_as(path)?;
 
         let links = if on_disk {
-            GraphLinks::load_from_file(path, true)?
+            GraphLinks::load_from_file(path, true, compressed)?
         } else {
             links_converter.to_graph_links_ram()
         };

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -451,16 +451,26 @@ impl GraphLinksConverter {
     }
 }
 
-pub fn convert_to_compressed(path: &Path, m: usize, m0: usize) -> OperationResult<()> {
+pub fn convert_to_compressed(
+    from_path: &Path,
+    to_path: &Path,
+    m: usize,
+    m0: usize,
+) -> OperationResult<()> {
     let start = std::time::Instant::now();
 
-    let links = GraphLinks::load_from_file(path, true, false)?;
+    let links = GraphLinks::load_from_file(from_path, true, false)?;
 
     debug_assert!(!links.compressed());
 
-    let original_size = path.metadata()?.len();
-    GraphLinksConverter::new(links.into_edges(), true, m, m0).save_as(path)?;
-    let new_size = path.metadata()?.len();
+    debug_assert!(!to_path.exists());
+
+    let original_size = from_path.metadata()?.len();
+    GraphLinksConverter::new(links.into_edges(), true, m, m0).save_as(to_path)?;
+    let new_size = to_path.metadata()?.len();
+
+    // Remove the original file
+    std::fs::remove_file(from_path)?;
 
     log::debug!(
         "Compressed HNSW graph links in {:.1?}: {:.1}MB -> {:.1}MB ({:.1}%)",

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -189,9 +189,9 @@ impl HNSWIndex {
                 )
             };
 
-            let graph_links_path = if !is_links_compressed
-                && LinkCompressionExperimentalSetting::from_env().convert_existing
-            {
+            let do_convert = LinkCompressionExperimentalSetting::from_env().convert_existing;
+
+            let graph_links_path = if !is_links_compressed && do_convert {
                 GraphLayers::convert_to_compressed(
                     graph_links_path,
                     &regular_links,
@@ -208,7 +208,7 @@ impl HNSWIndex {
                     &graph_path,
                     graph_links_path,
                     !hnsw_config.on_disk.unwrap_or(false),
-                    is_links_compressed,
+                    is_links_compressed || do_convert,
                 )?,
             )
         } else {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -192,11 +192,7 @@ impl HNSWIndex {
             let do_convert = LinkCompressionExperimentalSetting::from_env().convert_existing;
 
             let graph_links_path = if !is_links_compressed && do_convert {
-                GraphLayers::convert_to_compressed(
-                    graph_links_path,
-                    &regular_links,
-                    &compressed_links,
-                )?;
+                GraphLayers::convert_to_compressed(&graph_path, &regular_links, &compressed_links)?;
                 compressed_links.as_path()
             } else {
                 graph_links_path


### PR DESCRIPTION
Depends on https://github.com/qdrant/qdrant/pull/5700 

1. Fixes `on_disk` parameter for loading of the HNSW links
2. Always loads mmaps and change `populate` if the user wants `on_disk` experience
3. Decide compression based on file name, rather than guessing from version.

Notes for the future: 

- I would prefer to have completely separate structures for compressed and non-compressed implementations, probably even allow those structures to own data to be completely independent. Current version works, but with internal enums the implementation looks very complicated and hard to understand. Any further extension (e.g. compression v2) will make the code unreadable.

- `graph_links.rs` contains a number of structures and enums and is hard to navigate, in future it should be split into multiple files.
