### PR TITLE
Refactor rstest usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,12 +2162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,7 +2355,6 @@ dependencies = [
  "log",
  "memory",
  "parking_lot",
- "rand 0.8.5",
  "shaderc",
 ]
 
@@ -4424,15 +4417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,25 +5319,22 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
- "futures",
- "futures-timer",
  "rstest_macros",
  "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -6723,23 +6704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
-dependencies = [
- "indexmap 2.7.0",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7770,15 +7734,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,7 @@ prost-wkt-types = "0.5"
 prost-for-raft = { package = "prost", version = "=0.11.9" } # version of prost used by raft
 rand = "0.8.5"
 reqwest = { version = "0.12.11", default-features = false, features = ["http2", "stream", "rustls-tls", "blocking"] }
+rstest = {  version = "0.24.0", default-features = false }
 schemars = { version = "0.8.21", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive", "rc"] }

--- a/lib/blob_store/Cargo.toml
+++ b/lib/blob_store/Cargo.toml
@@ -32,7 +32,7 @@ rocksdb = { version = "0.22.0", optional = true }
 [dev-dependencies]
 criterion = { workspace = true }
 csv = "1.3.1"
-rstest = "0.23.0"
+rstest = { workspace = true }
 proptest = "1.6.0"
 bustle = "0.5.1"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -19,7 +19,7 @@ data-consistency-check = []
 [dev-dependencies]
 criterion = { workspace = true }
 proptest = "1.6.0"
-rstest = "0.23.0"
+rstest = { workspace = true }
 approx = "0.5.1"
 collection = { path = ".", features = ["testing"] }
 common = { path = "../common/common", features = ["testing"] }

--- a/lib/gpu/Cargo.toml
+++ b/lib/gpu/Cargo.toml
@@ -20,6 +20,5 @@ gpu-allocator = { version = "0.27.0", optional = true }
 shaderc = { version = "0.8.3", optional = true, features = ["build-from-source"]}
 
 log = "0.4"
-rand = "0.8.5"
 parking_lot = { workspace = true }
 memory = { path = "../common/memory" }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -33,7 +33,7 @@ indicatif = { workspace = true }
 rmp-serde = "~1.3"
 rand_distr = "0.4.3"
 walkdir = "2.5.0"
-rstest = "0.23.0"
+rstest = { workspace = true }
 segment = { path = ".", features = ["testing"] }
 proptest = "1.6.0"
 


### PR DESCRIPTION
This PR refactor our rstest integration

- promote dependency to workspace
- remove [default features](https://docs.rs/crate/rstest/latest/features#crate-name)
- bump version [0.24.0](https://github.com/la10736/rstest/releases/tag/v0.24.0)