### PR TITLE
Track slow pytest integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: poetry -C tests run ./tests/integration-tests.sh distributed
         shell: bash
       - name: Run integration tests - multiple peers - pytest
-        run: poetry -C tests run pytest tests/consensus_tests --durations=5
+        run: poetry -C tests run pytest tests/consensus_tests --durations=10
         timeout-minutes: 60
       - name: upload logs in case of failure
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: poetry -C tests run ./tests/integration-tests.sh distributed
         shell: bash
       - name: Run integration tests - multiple peers - pytest
-        run: poetry -C tests run pytest tests/consensus_tests
+        run: poetry -C tests run pytest tests/consensus_tests --durations=5
         timeout-minutes: 60
       - name: upload logs in case of failure
         uses: actions/upload-artifact@v4

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -46,7 +46,7 @@ if [ "$MODE" == "distributed" ]; then
   sleep 10
 fi
 
-pytest tests/openapi --durations=5
+pytest tests/openapi --durations=10
 
 ./tests/basic_api_test.sh
 

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -46,7 +46,7 @@ if [ "$MODE" == "distributed" ]; then
   sleep 10
 fi
 
-pytest tests/openapi
+pytest tests/openapi --durations=5
 
 ./tests/basic_api_test.sh
 


### PR DESCRIPTION
Configure `pytest` to report  the top 10 slowest tests for openapi and consensus tests.

The goal is to keep an eye on the run time to find possible improvements.

## openapi

```
============================= slowest 10 durations ==============================
46.81s call     tests/openapi/test_strictmode.py::test_strict_mode_max_collection_payload_size_upsert
46.53s call     tests/openapi/test_strictmode.py::test_strict_mode_max_collection_payload_size_upsert_batch
6.50s setup    tests/openapi/test_filtered_delete.py::test_delete_by_payload_filter[True]
5.16s setup    tests/openapi/test_filtered_delete.py::test_delete_by_payload_filter[False]
2.67s teardown tests/openapi/test_payload_indexing.py::test_payload_schemas
2.30s call     tests/openapi/test_payload_indexing.py::test_payload_schemas
2.24s call     tests/openapi/test_init_from_collection.py::test_init_from_collection_multivec[True]
1.89s call     tests/openapi/test_init_from_collection.py::test_init_from_collection_multivec[False]
1.85s setup    tests/openapi/test_order_by.py::test_order_by_int_ascending[False]
1.78s setup    tests/openapi/test_order_by.py::test_order_by_int_ascending[True]
=========== 686 passed, 1 skipped, 32 warnings in 194.03s (0:03:14) ============
```

## consensus

```
============================= slowest 10 durations ==============================
97.73s call     tests/consensus_tests/test_strict_mode.py::test_payload_strict_mode_upsert_no_local_shard
72.41s call     tests/consensus_tests/test_strict_mode.py::test_payload_strict_mode_upsert
33.57s call     tests/consensus_tests/test_snapshot_consistency.py::test_shard_wal_delta_transfer_manual_recovery
33.45s call     tests/consensus_tests/test_collection_creation_after_dropping.py::test_collection_creation_after_dropping
26.95s call     tests/consensus_tests/test_reinit_consensus.py::test_reinit_consensus
25.90s call     tests/consensus_tests/test_collection_recovery_limits.py::test_collection_recovery_user_requests_above_limit
25.51s call     tests/consensus_tests/test_shard_wal_delta_transfer.py::test_shard_fallback_on_big_diff
24.17s call     tests/consensus_tests/test_shard_wal_delta_transfer.py::test_shard_wal_delta_transfer_manual_recovery_chain
22.22s call     tests/consensus_tests/test_triple_replication.py::test_triple_replication
18.95s call     tests/consensus_tests/test_cluster_rejoin.py::test_rejoin_cluster
============ 179 passed, 19 skipped, 1 warning in 702.81s (0:11:42) ============
```

We could also report a higher top value or simply all duration alternatively.