### PR TITLE
Standardize http crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
  "axum-core 0.4.3",
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "http-body-util",
  "itoa",
@@ -694,7 +694,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "http-body-util",
  "mime",
@@ -2377,7 +2377,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 1.0.0",
+ "http 1.2.0",
  "indexmap 2.7.0",
  "slab",
  "tokio",
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -2539,7 +2539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.0.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -2550,7 +2550,7 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.0.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "pin-project-lite",
 ]
@@ -2563,11 +2563,11 @@ checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "http-serde"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb7239a6d49eda628c2dfdd7e982c59b0c3f0fb99ce45c4237f02a520030688"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
 dependencies = [
- "http 1.0.0",
+ "http 1.2.0",
  "serde",
 ]
 
@@ -2623,7 +2623,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.4",
- "http 1.0.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "httparse",
  "httpdate",
@@ -2641,7 +2641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.0.0",
+ "http 1.2.0",
  "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.20",
@@ -2687,7 +2687,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.0.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "hyper 1.4.1",
  "pin-project-lite",
@@ -3068,7 +3068,7 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "dashmap",
- "http 1.0.0",
+ "http 1.2.0",
  "http-serde",
  "schemars",
  "serde",
@@ -5133,7 +5133,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.4",
- "http 1.0.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.4.1",
@@ -5675,7 +5675,7 @@ dependencies = [
  "geohash",
  "gpu",
  "half 2.4.1",
- "http 1.0.0",
+ "http 1.2.0",
  "indexmap 2.7.0",
  "indicatif",
  "io",
@@ -6705,7 +6705,7 @@ dependencies = [
  "base64 0.22.0",
  "bytes",
  "h2 0.4.4",
- "http 1.0.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 generic-tests = "0.1.3"
 half = { version = "2.4.1", features = ["alloc", "serde", "num-traits"] }
+http = "1.2.0"
 indexmap = { version = "2", features = ["serde"] }
 indicatif = { version = "0.17.9", features = ["rayon"] }
 itertools = "0.13.0"

--- a/lib/common/issues/Cargo.toml
+++ b/lib/common/issues/Cargo.toml
@@ -15,8 +15,8 @@ workspace = true
 [dependencies]
 chrono = { workspace = true }
 dashmap = { workspace = true }
-http = "1.0.0"
-http-serde = "2.0.0"
+http = { workspace = true }
+http-serde = "2.1.1"
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -85,7 +85,7 @@ smol_str = { version = "0.3.2", default-features = false, features = ["serde"] }
 fnv = { workspace = true }
 indexmap = { workspace = true }
 ahash = { workspace = true }
-http = "1.0.0"
+http = { workspace = true }
 self_cell = "1.1.0"
 sha2 = { workspace = true }
 smallvec = "1.13.2"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -29,7 +29,7 @@ schemars = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 tonic = { workspace = true }
-http = "0.2"
+http = "0.2.9" # version of http used by tonic 0.11.x
 parking_lot = { workspace = true }
 strum = { workspace = true }
 tap = { workspace = true }


### PR DESCRIPTION
Update and standardize the http crate [version](https://github.com/hyperium/http/blob/master/CHANGELOG.md).