### PR TITLE
Newsletter redirect link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Examples and/or documentation of Qdrant integrations:
 ## Contacts
 
 - Have questions? Join our [Discord channel](https://qdrant.to/discord) or mention [@qdrant_engine on Twitter](https://qdrant.to/twitter)
-- Want to stay in touch with latest releases? Subscribe to our [Newsletters](https://qdrant.to/newsletter)
+- Want to stay in touch with latest releases? Subscribe to our [Newsletters](https://qdrant.tech/subscribe/)
 - Looking for a managed cloud? Check [pricing](https://qdrant.tech/pricing/), need something personalised? We're at [info@qdrant.tech](mailto:info@qdrant.tech)
 
 ## License


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/5731>

fix : correct broken newsletter link
Wrong hyperlink to newsletter in README

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
