### PR TITLE
Fix poetry version in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  POETRY_VERSION: 1.8.5
 
 jobs:
   test:
@@ -29,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install clang
-          curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
 
           poetry -C tests check --lock
           poetry -C tests install --no-root
@@ -59,7 +60,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
 
           poetry -C tests check --lock
           poetry -C tests install --no-root
@@ -90,7 +91,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
 
           poetry -C tests check --lock
           poetry -C tests install --no-root

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install clang
-          curl -sSL https://install.python-poetry.org | python3 -
+          curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
 
           poetry -C tests check --lock
           poetry -C tests install --no-root
@@ -59,7 +59,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+          curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
 
           poetry -C tests check --lock
           poetry -C tests install --no-root
@@ -90,7 +90,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+          curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
 
           poetry -C tests check --lock
           poetry -C tests install --no-root


### PR DESCRIPTION
It looks like the default poetry version installed changed over the weekend which breaks our CI.

```
You can uninstall at any time by executing this script with the --uninstall option,
and these changes will be reverted.

Installing Poetry (2.0.0)
Installing Poetry (2.0.0): Creating environment
Installing Poetry (2.0.0): Installing Poetry
Installing Poetry (2.0.0): Creating script
Installing Poetry (2.0.0): Done

Poetry (2.0.0) is installed now. Great!

You can test that everything is set up by executing:

`poetry --version`

Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.
Error: Process completed with exit code 1.
```

This PR proposes to fix the version of poetry to restore the previous behavior.