### PR TITLE
Fix clippy 1.84

### DIFF
--- a/lib/common/issues/src/dashboard.rs
+++ b/lib/common/issues/src/dashboard.rs
@@ -71,7 +71,7 @@ impl Dashboard {
                 kv.value()
                     .related_collection
                     .as_ref()
-                    .map_or(false, |c| c == collection_name)
+                    .is_some_and(|c| c == collection_name)
             })
             .map(|kv| kv.value().clone())
             .collect()


### PR DESCRIPTION
Rust 1.84 lands on [January 9th](https://releases.rs/docs/1.84.0/)

Lucky for us there is only a tiny Clippy violation this time around.