### PR TITLE
Resharding: add UUID to resharding operation

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10831,6 +10831,11 @@
           "shard_id"
         ],
         "properties": {
+          "uuid": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "direction": {
             "$ref": "#/components/schemas/ReshardingDirection"
           },

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -4,6 +4,7 @@ use common::validation::validate_shard_different_peers;
 use schemars::JsonSchema;
 use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use validator::{Validate, ValidationErrors};
 
 use crate::shards::shard::{PeerId, ShardId};
@@ -264,6 +265,7 @@ pub struct AbortShardTransfer {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct StartResharding {
+    pub uuid: Option<Uuid>,
     pub direction: ReshardingDirection,
     pub peer_id: Option<PeerId>,
     pub shard_key: Option<ShardKey>,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -42,6 +42,7 @@ use tokio::sync::mpsc::error::SendError;
 use tokio::sync::oneshot::error::RecvError as OneshotRecvError;
 use tokio::task::JoinError;
 use tonic::codegen::http::uri::InvalidUri;
+use uuid::Uuid;
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::config_diff::{self};
@@ -362,6 +363,9 @@ pub struct ShardTransferInfo {
 
 #[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct ReshardingInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<Uuid>,
+
     pub direction: ReshardingDirection,
 
     pub shard_id: ShardId,

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -471,6 +471,7 @@ impl ShardHolder {
 
         let status = tasks_pool.get_task_status(&resharding_state.key());
         resharding_operations.push(ReshardingInfo {
+            uuid: resharding_state.uuid,
             shard_id: resharding_state.shard_id,
             peer_id: resharding_state.peer_id,
             direction: resharding_state.direction,

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -21,6 +21,7 @@ impl ShardHolder {
 
     pub fn check_start_resharding(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
         let ReshardKey {
+            uuid: _,
             direction,
             peer_id: _,
             shard_id,
@@ -92,6 +93,7 @@ impl ShardHolder {
         new_shard: Option<ShardReplicaSet>,
     ) -> CollectionResult<()> {
         let ReshardKey {
+            uuid,
             direction,
             peer_id,
             shard_id,
@@ -115,7 +117,9 @@ impl ShardHolder {
                 "resharding is already in progress:\n{state:#?}",
             );
 
-            *state = Some(ReshardState::new(direction, peer_id, shard_id, shard_key));
+            *state = Some(ReshardState::new(
+                uuid, direction, peer_id, shard_id, shard_key,
+            ));
         })?;
 
         Ok(())
@@ -255,6 +259,7 @@ impl ShardHolder {
         force: bool,
     ) -> CollectionResult<()> {
         let ReshardKey {
+            uuid: _,
             direction,
             peer_id,
             shard_id,

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -530,6 +530,7 @@ pub async fn do_update_collection_cluster(
         }
         ClusterOperations::StartResharding(op) => {
             let StartResharding {
+                uuid,
                 direction,
                 peer_id,
                 shard_key,
@@ -627,6 +628,7 @@ pub async fn do_update_collection_cluster(
                     CollectionMetaOperations::Resharding(
                         collection_name.clone(),
                         ReshardingOperation::Start(ReshardKey {
+                            uuid,
                             direction,
                             peer_id,
                             shard_id,
@@ -652,6 +654,7 @@ pub async fn do_update_collection_cluster(
                     CollectionMetaOperations::Resharding(
                         collection_name.clone(),
                         ReshardingOperation::Abort(ReshardKey {
+                            uuid: state.uuid,
                             direction: state.direction,
                             peer_id: state.peer_id,
                             shard_id: state.shard_id,
@@ -751,6 +754,7 @@ pub async fn do_update_collection_cluster(
                     CollectionMetaOperations::Resharding(
                         collection_name.clone(),
                         ReshardingOperation::CommitRead(ReshardKey {
+                            uuid: state.uuid,
                             direction: state.direction,
                             peer_id: state.peer_id,
                             shard_id: state.shard_id,
@@ -779,6 +783,7 @@ pub async fn do_update_collection_cluster(
                     CollectionMetaOperations::Resharding(
                         collection_name.clone(),
                         ReshardingOperation::CommitWrite(ReshardKey {
+                            uuid: state.uuid,
                             direction: state.direction,
                             peer_id: state.peer_id,
                             shard_id: state.shard_id,

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -32,6 +32,7 @@ use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::{Access, AccessRequirements};
+use uuid::Uuid;
 
 pub async fn do_collection_exists(
     toc: &TableOfContent,
@@ -530,11 +531,14 @@ pub async fn do_update_collection_cluster(
         }
         ClusterOperations::StartResharding(op) => {
             let StartResharding {
-                uuid,
+                mut uuid,
                 direction,
                 peer_id,
                 shard_key,
             } = op.start_resharding;
+
+            // Assign random UUID if not specified by user before processing operation on all peers
+            uuid.get_or_insert_with(Uuid::new_v4);
 
             let collection_state = collection.state().await;
 


### PR DESCRIPTION
Add a UUID to resharding operations so we can uniquely identify them in cluster manager.

This is needed to prevent conflicts with reusing state when a collection is recreated.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?