### PR TITLE
Separate file for compressed links; variant 2

### DIFF
--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -9,6 +9,7 @@ use segment::data_types::vectors::VectorElementType;
 use segment::fixtures::index_fixtures::{random_vector, FakeFilterContext, TestRawScorerProducer};
 use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
+use segment::index::hnsw_index::graph_links::GraphLinksFormat;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::{CosineMetric, DotProductMetric};
@@ -41,7 +42,7 @@ fn build_index<TMetric: Metric<VectorElementType>>(
     }
     (
         vector_holder,
-        graph_layers_builder.into_graph_layers_ram(false),
+        graph_layers_builder.into_graph_layers_ram(GraphLinksFormat::Plain),
     )
 }
 

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -51,7 +51,8 @@ fn hnsw_benchmark(c: &mut Criterion) {
 
         if graph_fname.exists() && links_fname.exists() {
             eprintln!("Loading cached links from {links_fname:?}");
-            graph_layers = GraphLayers::load(&graph_fname, &links_fname, false, false).unwrap();
+            graph_layers =
+                GraphLayers::load(&graph_fname, &links_fname, false, false, false).unwrap();
         } else {
             let mut graph_layers_builder =
                 GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -51,8 +51,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
 
         if graph_fname.exists() && links_fname.exists() {
             eprintln!("Loading cached links from {links_fname:?}");
-            graph_layers =
-                GraphLayers::load(&graph_fname, &links_fname, false, false, false).unwrap();
+            graph_layers = GraphLayers::load(&graph_fname, &links_fname, false, false).unwrap();
         } else {
             let mut graph_layers_builder =
                 GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -111,6 +111,7 @@ mod tests {
     use crate::fixtures::payload_fixtures::random_vector;
     use crate::index::hnsw_index::graph_layers::GraphLayers;
     use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
+    use crate::index::hnsw_index::graph_links::GraphLinksFormat;
     use crate::index::hnsw_index::point_scorer::FilteredScorer;
     use crate::spaces::simple::CosineMetric;
     use crate::types::Distance;
@@ -224,8 +225,10 @@ mod tests {
         ef: usize,
         accuracy: f32,
     ) {
-        let graph: GraphLayers = graph.into_graph_layers_ram(false);
-        let ref_graph: GraphLayers = test.graph_layers_builder.into_graph_layers_ram(false);
+        let graph: GraphLayers = graph.into_graph_layers_ram(GraphLinksFormat::Plain);
+        let ref_graph: GraphLayers = test
+            .graph_layers_builder
+            .into_graph_layers_ram(GraphLinksFormat::Plain);
 
         let mut total_sames = 0;
         let total_top = top * test.search_vectors.len();

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -317,7 +317,7 @@ impl GraphLayers {
     #[cfg(feature = "testing")]
     pub fn compress_ram(&mut self) {
         use crate::index::hnsw_index::graph_links::GraphLinksConverter;
-        assert!(!self.links.compressed() && !self.links.on_disk());
+        assert!(!self.links.compressed());
         let dummy = GraphLinksConverter::new(Vec::new(), false, 0, 0).to_graph_links_ram();
         let links = std::mem::replace(&mut self.links, dummy);
         self.links = GraphLinksConverter::new(links.into_edges(), true, self.m, self.m0)
@@ -429,6 +429,7 @@ mod tests {
     }
 
     #[rstest]
+    #[case::uncompressed((false, false))]
     #[case::converted((false, true))]
     #[case::compressed((true, false))]
     fn test_save_and_load(#[case] (compressed, converted): (bool, bool)) {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -432,8 +432,6 @@ mod tests {
     #[case::converted((false, true))]
     #[case::compressed((true, false))]
     fn test_save_and_load(#[case] (compressed, converted): (bool, bool)) {
-        eprintln!("(compressed, converted) = {:#?}", (compressed, converted));
-
         let num_vectors = 100;
         let dim = 8;
         let top = 5;
@@ -461,6 +459,8 @@ mod tests {
 
         let path = GraphLayers::get_path(dir.path());
         graph_layers.save(&path).unwrap();
+
+        drop(graph_layers);
 
         let load_links_path = if !compressed && converted {
             GraphLayers::convert_to_compressed(&path, &regular_links_path, &compressed_links_path)

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -429,10 +429,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::uncompressed((false, false))]
     #[case::converted((false, true))]
     #[case::compressed((true, false))]
     fn test_save_and_load(#[case] (compressed, converted): (bool, bool)) {
+        eprintln!("(compressed, converted) = {:#?}", (compressed, converted));
+
         let num_vectors = 100;
         let dim = 8;
         let top = 5;
@@ -469,7 +470,9 @@ mod tests {
             links_path
         };
 
-        let graph2 = GraphLayers::load(&path, load_links_path, false, compressed).unwrap();
+        let load_compressed = compressed || converted;
+
+        let graph2 = GraphLayers::load(&path, load_links_path, false, load_compressed).unwrap();
 
         let res2 = search_in_graph(&query, top, &vector_holder, &graph2);
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -277,9 +277,12 @@ impl GraphLayers {
     ) -> OperationResult<Self> {
         let graph_data: GraphLayerData = read_bin(graph_path)?;
 
-        if do_compress && !compressed {
+        let compressed = if do_compress && !compressed {
             convert_to_compressed(links_path, graph_data.m, graph_data.m0)?;
-        }
+            true
+        } else {
+            compressed
+        };
 
         Ok(Self {
             m: graph_data.m,

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -4,16 +4,17 @@ use std::path::{Path, PathBuf};
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoredPointOffset};
-use io::file_operations::{atomic_save_bin, read_bin};
+use io::file_operations::read_bin;
 use itertools::Itertools;
 use memory::mmap_ops;
 use serde::{Deserialize, Serialize};
 
 use super::entry_points::EntryPoint;
-use super::graph_links::{convert_to_compressed, GraphLinks};
-use crate::common::operation_error::OperationResult;
+use super::graph_links::{GraphLinks, GraphLinksFormat};
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::rev_range;
 use crate::index::hnsw_index::entry_points::EntryPoints;
+use crate::index::hnsw_index::graph_links::GraphLinksConverter;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::search_context::SearchContext;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
@@ -27,18 +28,17 @@ pub const COMPRESSED_HNSW_LINKS_FILE: &str = "links_compressed.bin";
 
 /// Contents of the `graph.bin` file.
 #[derive(Deserialize, Serialize, Debug)]
-struct GraphLayerData<'a> {
-    m: usize,
-    m0: usize,
-    ef_construct: usize,
-    entry_points: Cow<'a, EntryPoints>,
+pub(super) struct GraphLayerData<'a> {
+    pub(super) m: usize,
+    pub(super) m0: usize,
+    pub(super) ef_construct: usize,
+    pub(super) entry_points: Cow<'a, EntryPoints>,
 }
 
 #[derive(Debug)]
 pub struct GraphLayers {
     pub(super) m: usize,
     pub(super) m0: usize,
-    pub(super) ef_construct: usize,
     pub(super) links: GraphLinks,
     pub(super) entry_points: EntryPoints,
     pub(super) visited_pool: VisitedPool,
@@ -254,12 +254,18 @@ impl GraphLayers {
         path.join(HNSW_GRAPH_FILE)
     }
 
-    pub fn get_links_path(path: &Path) -> PathBuf {
-        path.join(HNSW_LINKS_FILE)
+    pub fn get_links_path(path: &Path, format: GraphLinksFormat) -> PathBuf {
+        match format {
+            GraphLinksFormat::Plain => path.join(HNSW_LINKS_FILE),
+            GraphLinksFormat::Compressed => path.join(COMPRESSED_HNSW_LINKS_FILE),
+        }
     }
 
-    pub fn get_compressed_links_path(path: &Path) -> PathBuf {
-        path.join(COMPRESSED_HNSW_LINKS_FILE)
+    pub fn files(&self, path: &Path) -> Vec<PathBuf> {
+        vec![
+            GraphLayers::get_path(path),
+            GraphLayers::get_links_path(path, self.links.format()),
+        ]
     }
 
     pub fn num_points(&self) -> usize {
@@ -268,60 +274,76 @@ impl GraphLayers {
 }
 
 impl GraphLayers {
-    pub fn load(
-        graph_path: &Path,
-        links_path: &Path,
-        on_disk: bool,
-        compressed: bool,
-    ) -> OperationResult<Self> {
-        let graph_data: GraphLayerData = read_bin(graph_path)?;
+    pub fn load(dir: &Path, on_disk: bool, compress: bool) -> OperationResult<Self> {
+        let graph_data: GraphLayerData = read_bin(&GraphLayers::get_path(dir))?;
+
+        if compress {
+            Self::convert_to_compressed(dir, graph_data.m, graph_data.m0)?;
+        }
 
         Ok(Self {
             m: graph_data.m,
             m0: graph_data.m0,
-            ef_construct: graph_data.ef_construct,
-            links: GraphLinks::load_from_file(links_path, on_disk, compressed)?,
+            links: Self::load_links(dir, on_disk)?,
             entry_points: graph_data.entry_points.into_owned(),
             visited_pool: VisitedPool::new(),
         })
     }
 
-    pub fn convert_to_compressed(
-        graph_path: &Path,
-        links_path: &Path,
-        compressed_links_path: &Path,
-    ) -> OperationResult<()> {
-        let graph_data: GraphLayerData = read_bin(graph_path)?;
-        convert_to_compressed(
-            links_path,
-            compressed_links_path,
-            graph_data.m,
-            graph_data.m0,
-        )?;
-        Ok(())
-    }
-
-    pub fn save(&self, path: &Path) -> OperationResult<()> {
-        Ok(atomic_save_bin(path, &self.data())?)
-    }
-
-    fn data(&self) -> GraphLayerData {
-        GraphLayerData {
-            m: self.m,
-            m0: self.m0,
-            ef_construct: self.ef_construct,
-            entry_points: Cow::Borrowed(&self.entry_points),
+    fn load_links(dir: &Path, on_disk: bool) -> OperationResult<GraphLinks> {
+        for format in [GraphLinksFormat::Compressed, GraphLinksFormat::Plain] {
+            let path = GraphLayers::get_links_path(dir, format);
+            if path.exists() {
+                return GraphLinks::load_from_file(&path, on_disk, format);
+            }
         }
+        Err(OperationError::service_error("No links file found"))
+    }
+
+    fn convert_to_compressed(dir: &Path, m: usize, m0: usize) -> OperationResult<()> {
+        let plain_path = Self::get_links_path(dir, GraphLinksFormat::Plain);
+        let compressed_path = Self::get_links_path(dir, GraphLinksFormat::Compressed);
+
+        if compressed_path.exists() {
+            return Ok(());
+        }
+
+        let start = std::time::Instant::now();
+
+        let links = GraphLinks::load_from_file(&plain_path, true, GraphLinksFormat::Plain)?;
+        let original_size = plain_path.metadata()?.len();
+        GraphLinksConverter::new(links.into_edges(), GraphLinksFormat::Compressed, m, m0)
+            .save_as(&compressed_path)?;
+        let new_size = compressed_path.metadata()?.len();
+
+        // Remove the original file
+        std::fs::remove_file(plain_path)?;
+
+        log::debug!(
+            "Compressed HNSW graph links in {:.1?}: {:.1}MB -> {:.1}MB ({:.1}%)",
+            start.elapsed(),
+            original_size as f64 / 1024.0 / 1024.0,
+            new_size as f64 / 1024.0 / 1024.0,
+            new_size as f64 / original_size as f64 * 100.0,
+        );
+
+        Ok(())
     }
 
     #[cfg(feature = "testing")]
     pub fn compress_ram(&mut self) {
         use crate::index::hnsw_index::graph_links::GraphLinksConverter;
-        assert!(!self.links.compressed());
-        let dummy = GraphLinksConverter::new(Vec::new(), false, 0, 0).to_graph_links_ram();
-        let links = std::mem::replace(&mut self.links, dummy);
-        self.links = GraphLinksConverter::new(links.into_edges(), true, self.m, self.m0)
+        assert!(self.links.format() == GraphLinksFormat::Plain);
+        let dummy = GraphLinksConverter::new(Vec::new(), GraphLinksFormat::Plain, 0, 0)
             .to_graph_links_ram();
+        let links = std::mem::replace(&mut self.links, dummy);
+        self.links = GraphLinksConverter::new(
+            links.into_edges(),
+            GraphLinksFormat::Compressed,
+            self.m,
+            self.m0,
+        )
+        .to_graph_links_ram();
     }
 
     pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
@@ -331,10 +353,6 @@ impl GraphLayers {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-    use std::io::Write;
-
-    use itertools::Itertools;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
     use rstest::rstest;
@@ -370,12 +388,11 @@ mod tests {
     const M: usize = 8;
 
     #[rstest]
-    #[case::uncompressed(false)]
-    #[case::compressed(true)]
-    fn test_search_on_level(#[case] compressed: bool) {
+    #[case::uncompressed(GraphLinksFormat::Plain)]
+    #[case::compressed(GraphLinksFormat::Compressed)]
+    fn test_search_on_level(#[case] format: GraphLinksFormat) {
         let dim = 8;
         let m = 8;
-        let ef_construct = 32;
         let entry_points_num = 10;
         let num_vectors = 10;
 
@@ -390,8 +407,7 @@ mod tests {
         let graph_layers = GraphLayers {
             m,
             m0: 2 * m,
-            ef_construct,
-            links: GraphLinksConverter::new(graph_links.clone(), compressed, m, 2 * m)
+            links: GraphLinksConverter::new(graph_links.clone(), format, m, 2 * m)
                 .to_graph_links_ram(),
             entry_points: EntryPoints::new(entry_points_num),
             visited_pool: VisitedPool::new(),
@@ -429,10 +445,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::uncompressed((false, false))]
-    #[case::converted((false, true))]
-    #[case::compressed((true, false))]
-    fn test_save_and_load(#[case] (compressed, converted): (bool, bool)) {
+    #[case::uncompressed((GraphLinksFormat::Plain, false))]
+    #[case::converted((GraphLinksFormat::Plain, true))]
+    #[case::compressed((GraphLinksFormat::Compressed, false))]
+    #[case::recompressed((GraphLinksFormat::Compressed, true))]
+    fn test_save_and_load(#[case] (initial_format, compress): (GraphLinksFormat, bool)) {
         let num_vectors = 100;
         let dim = 8;
         let top = 5;
@@ -441,49 +458,32 @@ mod tests {
 
         let dir = Builder::new().prefix("graph_dir").tempdir().unwrap();
 
-        let regular_links_path = GraphLayers::get_links_path(dir.path());
-        let compressed_links_path = GraphLayers::get_compressed_links_path(dir.path());
-        let links_path = if compressed {
-            compressed_links_path.as_path()
-        } else {
-            regular_links_path.as_path()
-        };
-        let (vector_holder, graph_layers_builder) =
-            create_graph_layer_builder_fixture(num_vectors, M, dim, false, &mut rng);
-        let graph_layers = graph_layers_builder
-            .into_graph_layers(links_path, compressed, true)
-            .unwrap();
-
         let query = random_vector(&mut rng, dim);
 
-        let res1 = search_in_graph(&query, top, &vector_holder, &graph_layers);
+        let (vector_holder, graph_layers_builder) =
+            create_graph_layer_builder_fixture(num_vectors, M, dim, false, &mut rng);
+        let graph1 = graph_layers_builder
+            .into_graph_layers(dir.path(), initial_format, true)
+            .unwrap();
+        assert_eq!(graph1.links.format(), initial_format);
+        let res1 = search_in_graph(&query, top, &vector_holder, &graph1);
+        drop(graph1);
 
-        let path = GraphLayers::get_path(dir.path());
-        graph_layers.save(&path).unwrap();
-
-        drop(graph_layers);
-
-        let load_links_path = if !compressed && converted {
-            GraphLayers::convert_to_compressed(&path, &regular_links_path, &compressed_links_path)
-                .unwrap();
-            compressed_links_path.as_path()
+        let graph2 = GraphLayers::load(dir.path(), false, compress).unwrap();
+        if compress {
+            assert_eq!(graph2.links.format(), GraphLinksFormat::Compressed);
         } else {
-            links_path
-        };
-
-        let load_compressed = compressed || converted;
-
-        let graph2 = GraphLayers::load(&path, load_links_path, false, load_compressed).unwrap();
-
+            assert_eq!(graph2.links.format(), initial_format);
+        }
         let res2 = search_in_graph(&query, top, &vector_holder, &graph2);
 
         assert_eq!(res1, res2)
     }
 
     #[rstest]
-    #[case::uncompressed(false)]
-    #[case::compressed(true)]
-    fn test_add_points(#[case] compressed: bool) {
+    #[case::uncompressed(GraphLinksFormat::Plain)]
+    #[case::compressed(GraphLinksFormat::Compressed)]
+    fn test_add_points(#[case] format: GraphLinksFormat) {
         let num_vectors = 1000;
         let dim = 8;
 
@@ -492,7 +492,7 @@ mod tests {
         type M = CosineMetric;
 
         let (vector_holder, graph_layers) =
-            create_graph_layer_fixture::<M, _>(num_vectors, M, dim, compressed, false, &mut rng);
+            create_graph_layer_fixture::<M, _>(num_vectors, M, dim, format, false, &mut rng);
 
         let main_entry = graph_layers
             .entry_points
@@ -531,43 +531,5 @@ mod tests {
         let graph_search = search_in_graph(&query, top, &vector_holder, &graph_layers);
 
         assert_eq!(reference_top.into_vec(), graph_search);
-    }
-
-    #[test]
-    #[ignore]
-    fn test_draw_hnsw_graph() {
-        let dim = 2;
-        let num_vectors = 500;
-
-        let mut rng = StdRng::seed_from_u64(42);
-
-        let (vector_holder, graph_layers) = create_graph_layer_fixture::<CosineMetric, _>(
-            num_vectors,
-            M,
-            dim,
-            true,
-            true,
-            &mut rng,
-        );
-
-        let graph_json = serde_json::to_string_pretty(&graph_layers.data()).unwrap();
-
-        let vectors_json = serde_json::to_string_pretty(
-            &(0..vector_holder.vectors.len() as PointOffsetType)
-                .map(|point_id| {
-                    vector_holder
-                        .vectors
-                        .get(point_id as VectorOffsetType)
-                        .to_vec()
-                })
-                .collect_vec(),
-        )
-        .unwrap();
-
-        let mut file = File::create("graph.json").unwrap();
-        file.write_all(
-            format!("{{ \"graph\": {graph_json}, \n \"vectors\": {vectors_json} }}").as_bytes(),
-        )
-        .unwrap();
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -86,7 +86,7 @@ impl GraphLayersBuilder {
         links_converter.save_as(path)?;
 
         let links = if on_disk {
-            GraphLinks::load_from_file(path, true)?
+            GraphLinks::load_from_file(path, true, compressed)?
         } else {
             links_converter.to_graph_links_ram()
         };

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::{max, min};
 use std::collections::BinaryHeap;
 use std::path::Path;
@@ -6,11 +7,13 @@ use std::sync::atomic::AtomicUsize;
 use bitvec::prelude::BitVec;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use io::file_operations::atomic_save_bin;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use rand::distributions::Uniform;
 use rand::Rng;
 
-use super::graph_links::GraphLinks;
+use super::graph_layers::GraphLayerData;
+use super::graph_links::{GraphLinks, GraphLinksFormat};
 use crate::common::operation_error::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
 use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase, LinkContainer};
@@ -78,36 +81,46 @@ impl GraphLayersBuilder {
     pub fn into_graph_layers(
         self,
         path: &Path,
-        compressed: bool,
+        format: GraphLinksFormat,
         on_disk: bool,
     ) -> OperationResult<GraphLayers> {
+        let links_path = GraphLayers::get_links_path(path, format);
+
         let links_converter =
-            Self::links_layers_to_converter(self.links_layers, compressed, self.m, self.m0);
-        links_converter.save_as(path)?;
+            Self::links_layers_to_converter(self.links_layers, format, self.m, self.m0);
+        links_converter.save_as(&links_path)?;
 
         let links = if on_disk {
-            GraphLinks::load_from_file(path, true, compressed)?
+            GraphLinks::load_from_file(&links_path, true, format)?
         } else {
             links_converter.to_graph_links_ram()
         };
 
-        Ok(GraphLayers {
+        let entry_points = self.entry_points.into_inner();
+
+        let data = GraphLayerData {
             m: self.m,
             m0: self.m0,
             ef_construct: self.ef_construct,
+            entry_points: Cow::Borrowed(&entry_points),
+        };
+        atomic_save_bin(&GraphLayers::get_path(path), &data)?;
+
+        Ok(GraphLayers {
+            m: self.m,
+            m0: self.m0,
             links,
-            entry_points: self.entry_points.into_inner(),
+            entry_points,
             visited_pool: self.visited_pool,
         })
     }
 
     #[cfg(feature = "testing")]
-    pub fn into_graph_layers_ram(self, compressed: bool) -> GraphLayers {
+    pub fn into_graph_layers_ram(self, format: GraphLinksFormat) -> GraphLayers {
         GraphLayers {
             m: self.m,
             m0: self.m0,
-            ef_construct: self.ef_construct,
-            links: Self::links_layers_to_converter(self.links_layers, compressed, self.m, self.m0)
+            links: Self::links_layers_to_converter(self.links_layers, format, self.m, self.m0)
                 .to_graph_links_ram(),
             entry_points: self.entry_points.into_inner(),
             visited_pool: self.visited_pool,
@@ -116,7 +129,7 @@ impl GraphLayersBuilder {
 
     fn links_layers_to_converter(
         link_layers: Vec<LockedLayersContainer>,
-        compressed: bool,
+        format: GraphLinksFormat,
         m: usize,
         m0: usize,
     ) -> GraphLinksConverter {
@@ -124,7 +137,7 @@ impl GraphLayersBuilder {
             .into_iter()
             .map(|l| l.into_iter().map(|l| l.into_inner()).collect())
             .collect();
-        GraphLinksConverter::new(edges, compressed, m, m0)
+        GraphLinksConverter::new(edges, format, m, m0)
     }
 
     #[cfg(feature = "gpu")]
@@ -645,9 +658,9 @@ mod tests {
 
     #[cfg(not(windows))] // https://github.com/qdrant/qdrant/issues/1452
     #[rstest]
-    #[case::uncompressed(false)]
-    #[case::compressed(true)]
-    fn test_parallel_graph_build(#[case] compressed: bool) {
+    #[case::uncompressed(GraphLinksFormat::Plain)]
+    #[case::compressed(GraphLinksFormat::Compressed)]
+    fn test_parallel_graph_build(#[case] format: GraphLinksFormat) {
         let num_vectors = 1000;
         let dim = 8;
 
@@ -701,7 +714,7 @@ mod tests {
             });
         }
 
-        let graph = graph_layers_builder.into_graph_layers_ram(compressed);
+        let graph = graph_layers_builder.into_graph_layers_ram(format);
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
@@ -713,9 +726,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case::uncompressed(false)]
-    #[case::compressed(true)]
-    fn test_add_points(#[case] compressed: bool) {
+    #[case::uncompressed(GraphLinksFormat::Plain)]
+    #[case::compressed(GraphLinksFormat::Compressed)]
+    fn test_add_points(#[case] format: GraphLinksFormat) {
         let num_vectors = 1000;
         let dim = 8;
 
@@ -728,7 +741,7 @@ mod tests {
             create_graph_layer::<M, _>(num_vectors, dim, false, &mut rng);
 
         let (_vector_holder_orig, graph_layers_orig) =
-            create_graph_layer_fixture::<M, _>(num_vectors, M, dim, compressed, false, &mut rng2);
+            create_graph_layer_fixture::<M, _>(num_vectors, M, dim, format, false, &mut rng2);
 
         // check is graph_layers_builder links are equal to graph_layers_orig
         let orig_len = graph_layers_orig.links.num_points();
@@ -740,7 +753,10 @@ mod tests {
             let links_orig = &graph_layers_orig.links.links_vec(idx as PointOffsetType, 0);
             let links_builder = graph_layers_builder.links_layers[idx][0].read();
             let link_container_from_builder = links_builder.iter().copied().collect::<Vec<_>>();
-            let m = if compressed { M * 2 } else { 0 };
+            let m = match format {
+                GraphLinksFormat::Plain => 0,
+                GraphLinksFormat::Compressed => M * 2,
+            };
             assert_eq!(
                 normalize_links(m, links_orig.clone()),
                 normalize_links(m, link_container_from_builder),
@@ -788,7 +804,7 @@ mod tests {
             });
         }
 
-        let graph = graph_layers_builder.into_graph_layers_ram(compressed);
+        let graph = graph_layers_builder.into_graph_layers_ram(format);
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
@@ -799,9 +815,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case::uncompressed(false)]
-    #[case::compressed(true)]
-    fn test_hnsw_graph_properties(#[case] compressed: bool) {
+    #[case::uncompressed(GraphLinksFormat::Plain)]
+    #[case::compressed(GraphLinksFormat::Compressed)]
+    fn test_hnsw_graph_properties(#[case] format: GraphLinksFormat) {
         const NUM_VECTORS: usize = 5_000;
         const DIM: usize = 16;
         const M: usize = 16;
@@ -822,7 +838,7 @@ mod tests {
             graph_layers_builder.set_levels(idx, level);
             graph_layers_builder.link_new_point(idx, scorer);
         }
-        let graph_layers = graph_layers_builder.into_graph_layers_ram(compressed);
+        let graph_layers = graph_layers_builder.into_graph_layers_ram(format);
 
         let num_points = graph_layers.links.num_points();
         eprintln!("number_points = {num_points:#?}");

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -451,16 +451,26 @@ impl GraphLinksConverter {
     }
 }
 
-pub fn convert_to_compressed(path: &Path, m: usize, m0: usize) -> OperationResult<()> {
+pub fn convert_to_compressed(
+    from_path: &Path,
+    to_path: &Path,
+    m: usize,
+    m0: usize,
+) -> OperationResult<()> {
     let start = std::time::Instant::now();
 
-    let links = GraphLinks::load_from_file(path, true, false)?;
+    let links = GraphLinks::load_from_file(from_path, true, false)?;
 
     debug_assert!(!links.compressed());
 
-    let original_size = path.metadata()?.len();
-    GraphLinksConverter::new(links.into_edges(), true, m, m0).save_as(path)?;
-    let new_size = path.metadata()?.len();
+    debug_assert!(!to_path.exists());
+
+    let original_size = from_path.metadata()?.len();
+    GraphLinksConverter::new(links.into_edges(), true, m, m0).save_as(to_path)?;
+    let new_size = to_path.metadata()?.len();
+
+    // Remove the original file
+    std::fs::remove_file(from_path)?;
 
     log::debug!(
         "Compressed HNSW graph links in {:.1?}: {:.1}MB -> {:.1}MB ({:.1}%)",

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -81,6 +81,12 @@ enum CompressionInfo<'a> {
     },
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GraphLinksFormat {
+    Plain,
+    Compressed,
+}
+
 /// File header for the plain format.
 #[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
@@ -116,11 +122,10 @@ struct HeaderCompressed {
 const HEADER_VERSION_COMPRESSED: u64 = 0xFFFF_FFFF_FFFF_FF01;
 
 impl GraphLinksView<'_> {
-    fn load(data: &[u8], compressed: bool) -> OperationResult<GraphLinksView> {
-        if compressed {
-            Self::load_compressed(data)
-        } else {
-            Self::load_plain(data)
+    fn load(data: &[u8], format: GraphLinksFormat) -> OperationResult<GraphLinksView> {
+        match format {
+            GraphLinksFormat::Compressed => Self::load_compressed(data),
+            GraphLinksFormat::Plain => Self::load_plain(data),
         }
     }
 
@@ -277,7 +282,7 @@ enum GraphLinksConverterKind {
 impl GraphLinksConverter {
     pub fn new(
         mut edges: Vec<Vec<Vec<PointOffsetType>>>,
-        compressed: bool,
+        format: GraphLinksFormat,
         m: usize,
         m0: usize,
     ) -> Self {
@@ -324,27 +329,34 @@ impl GraphLinksConverter {
             };
             iter.for_each(|id| {
                 let raw_links = take(&mut edges[id][level]);
-                if compressed {
-                    pack_links(&mut links, raw_links, bits_per_unsorted, sorted_count);
-                    offsets.push(links.len() as u64);
-                } else {
-                    links.extend_from_slice(raw_links.as_bytes());
-                    offsets.push((links.len() as u64) / size_of::<PointOffsetType>() as u64);
+                match format {
+                    GraphLinksFormat::Compressed => {
+                        pack_links(&mut links, raw_links, bits_per_unsorted, sorted_count);
+                        offsets.push(links.len() as u64);
+                    }
+                    GraphLinksFormat::Plain => {
+                        links.extend_from_slice(raw_links.as_bytes());
+                        offsets.push((links.len() as u64) / size_of::<PointOffsetType>() as u64);
+                    }
                 }
             });
         }
 
-        let kind = if compressed {
-            let (compressed_offsets, offsets_parameters) = bitpacking_ordered::compress(&offsets);
-            GraphLinksConverterKind::Compressed {
-                compressed_offsets,
-                offsets_parameters,
+        let kind = match format {
+            GraphLinksFormat::Compressed => {
+                let (compressed_offsets, offsets_parameters) =
+                    bitpacking_ordered::compress(&offsets);
+                GraphLinksConverterKind::Compressed {
+                    compressed_offsets,
+                    offsets_parameters,
+                }
             }
-        } else {
-            let len = links.len() + reindex.as_bytes().len();
-            GraphLinksConverterKind::Uncompressed {
-                offsets_padding: len.next_multiple_of(size_of::<u64>()) - len,
-                offsets,
+            GraphLinksFormat::Plain => {
+                let len = links.len() + reindex.as_bytes().len();
+                GraphLinksConverterKind::Uncompressed {
+                    offsets_padding: len.next_multiple_of(size_of::<u64>()) - len,
+                    offsets,
+                }
             }
         };
 
@@ -359,7 +371,10 @@ impl GraphLinksConverter {
     }
 
     pub fn to_graph_links_ram(&self) -> GraphLinks {
-        let is_compressed = matches!(self.kind, GraphLinksConverterKind::Compressed { .. });
+        let format = match &self.kind {
+            GraphLinksConverterKind::Uncompressed { .. } => GraphLinksFormat::Plain,
+            GraphLinksConverterKind::Compressed { .. } => GraphLinksFormat::Compressed,
+        };
 
         let size = self.level_offsets.as_bytes().len()
             + self.reindex.as_bytes().len()
@@ -380,7 +395,7 @@ impl GraphLinksConverter {
         self.serialize_to_writer(&mut data).unwrap();
         debug_assert_eq!(data.len(), size);
         // Unwrap should be safe as we just created the data.
-        GraphLinks::try_new(GraphLinksEnum::Ram(data), |x| x.load_view(is_compressed)).unwrap()
+        GraphLinks::try_new(GraphLinksEnum::Ram(data), |x| x.load_view(format)).unwrap()
     }
 
     fn serialize_to_writer(&self, writer: &mut impl Write) -> std::io::Result<()> {
@@ -451,38 +466,6 @@ impl GraphLinksConverter {
     }
 }
 
-pub fn convert_to_compressed(
-    from_path: &Path,
-    to_path: &Path,
-    m: usize,
-    m0: usize,
-) -> OperationResult<()> {
-    let start = std::time::Instant::now();
-
-    let links = GraphLinks::load_from_file(from_path, true, false)?;
-
-    debug_assert!(!links.compressed());
-
-    debug_assert!(!to_path.exists());
-
-    let original_size = from_path.metadata()?.len();
-    GraphLinksConverter::new(links.into_edges(), true, m, m0).save_as(to_path)?;
-    let new_size = to_path.metadata()?.len();
-
-    // Remove the original file
-    std::fs::remove_file(from_path)?;
-
-    log::debug!(
-        "Compressed HNSW graph links in {:.1?}: {:.1}MB -> {:.1}MB ({:.1}%)",
-        start.elapsed(),
-        original_size as f64 / 1024.0 / 1024.0,
-        new_size as f64 / 1024.0 / 1024.0,
-        new_size as f64 / original_size as f64 * 100.0,
-    );
-
-    Ok(())
-}
-
 self_cell::self_cell! {
     pub struct GraphLinks {
         owner: GraphLinksEnum,
@@ -500,21 +483,25 @@ enum GraphLinksEnum {
 }
 
 impl GraphLinksEnum {
-    fn load_view(&self, compressed: bool) -> OperationResult<GraphLinksView> {
+    fn load_view(&self, format: GraphLinksFormat) -> OperationResult<GraphLinksView> {
         let data = match self {
             GraphLinksEnum::Ram(data) => data.as_slice(),
             GraphLinksEnum::Mmap(mmap) => &mmap[..],
         };
-        GraphLinksView::load(data, compressed)
+        GraphLinksView::load(data, format)
     }
 }
 
 impl GraphLinks {
-    pub fn load_from_file(path: &Path, on_disk: bool, compressed: bool) -> OperationResult<Self> {
+    pub fn load_from_file(
+        path: &Path,
+        on_disk: bool,
+        format: GraphLinksFormat,
+    ) -> OperationResult<Self> {
         let populate = !on_disk;
         let mmap = open_read_mmap(path, AdviceSetting::Advice(Advice::Random), populate)?;
         Self::try_new(GraphLinksEnum::Mmap(Arc::new(mmap)), |x| {
-            x.load_view(compressed)
+            x.load_view(format)
         })
     }
 
@@ -522,8 +509,11 @@ impl GraphLinks {
         self.borrow_dependent()
     }
 
-    pub fn compressed(&self) -> bool {
-        matches!(self.view().compression, CompressionInfo::Compressed { .. })
+    pub fn format(&self) -> GraphLinksFormat {
+        match self.view().compression {
+            CompressionInfo::Uncompressed { .. } => GraphLinksFormat::Plain,
+            CompressionInfo::Compressed { .. } => GraphLinksFormat::Compressed,
+        }
     }
 
     pub fn on_disk(&self) -> bool {
@@ -623,7 +613,7 @@ mod tests {
     fn compare_links(
         mut left: Vec<Vec<Vec<PointOffsetType>>>,
         mut right: Vec<Vec<Vec<PointOffsetType>>>,
-        compressed: bool,
+        format: GraphLinksFormat,
         m: usize,
         m0: usize,
     ) {
@@ -634,14 +624,15 @@ mod tests {
                     .enumerate()
                     .for_each(|(level_idx, links)| {
                         *links = normalize_links(
-                            if compressed {
-                                if level_idx == 0 {
-                                    m0
-                                } else {
-                                    m
+                            match format {
+                                GraphLinksFormat::Compressed => {
+                                    if level_idx == 0 {
+                                        m0
+                                    } else {
+                                        m
+                                    }
                                 }
-                            } else {
-                                0
+                                GraphLinksFormat::Plain => 0,
                             },
                             std::mem::take(links),
                         );
@@ -656,26 +647,26 @@ mod tests {
         points_count: usize,
         max_levels_count: usize,
         on_disk: bool,
-        compressed: bool,
+        format: GraphLinksFormat,
         m: usize,
         m0: usize,
     ) {
         let path = Builder::new().prefix("graph_dir").tempdir().unwrap();
         let links_file = path.path().join("links.bin");
         let links = random_links(points_count, max_levels_count, m, m0);
-        GraphLinksConverter::new(links.clone(), compressed, m, m0)
+        GraphLinksConverter::new(links.clone(), format, m, m0)
             .save_as(&links_file)
             .unwrap();
-        let cmp_links = GraphLinks::load_from_file(&links_file, on_disk, compressed)
+        let cmp_links = GraphLinks::load_from_file(&links_file, on_disk, format)
             .unwrap()
             .into_edges();
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
     }
 
     #[rstest]
-    #[case::uncompressed(false)]
-    #[case::compressed(true)]
-    fn test_graph_links_construction(#[case] compressed: bool) {
+    #[case::uncompressed(GraphLinksFormat::Plain)]
+    #[case::compressed(GraphLinksFormat::Compressed)]
+    fn test_graph_links_construction(#[case] format: GraphLinksFormat) {
         let m = 2;
         let m0 = m * 2;
 
@@ -683,7 +674,7 @@ mod tests {
                               m: usize,
                               m0: usize|
          -> Vec<Vec<Vec<PointOffsetType>>> {
-            GraphLinksConverter::new(links, compressed, m, m0)
+            GraphLinksConverter::new(links, format, m, m0)
                 .to_graph_links_ram()
                 .into_edges()
         };
@@ -691,17 +682,17 @@ mod tests {
         // no points
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![];
         let cmp_links = make_cmp_links(links.clone(), m, m0);
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
 
         // 2 points without any links
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![]], vec![vec![]]];
         let cmp_links = make_cmp_links(links.clone(), m, m0);
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
 
         // one link at level 0
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![1]], vec![vec![0]]];
         let cmp_links = make_cmp_links(links.clone(), m, m0);
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
 
         // 3 levels with no links at second level
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
@@ -710,7 +701,7 @@ mod tests {
             vec![vec![0, 1], vec![], vec![1]],
         ];
         let cmp_links = make_cmp_links(links.clone(), m, m0);
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
 
         // 3 levels with no links at last level
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
@@ -719,7 +710,7 @@ mod tests {
             vec![vec![0, 1]],
         ];
         let cmp_links = make_cmp_links(links.clone(), m, m0);
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
 
         // 4 levels with random nonexistent links
         let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
@@ -730,23 +721,23 @@ mod tests {
             vec![vec![0, 1, 9, 18], vec![1, 5, 6], vec![5], vec![9]],
         ];
         let cmp_links = make_cmp_links(links.clone(), m, m0);
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
 
         // fully random links
         let m = 8;
         let m0 = m * 2;
         let links = random_links(100, 10, m, m0);
         let cmp_links = make_cmp_links(links.clone(), m, m0);
-        compare_links(links, cmp_links, compressed, m, m0);
+        compare_links(links, cmp_links, format, m, m0);
     }
 
     #[test]
     fn test_graph_links_mmap_ram_compatibility() {
         let m = 8;
         let m0 = m * 2;
-        test_save_load(1000, 10, true, true, m, m0);
-        test_save_load(1000, 10, false, true, m, m0);
-        test_save_load(1000, 10, true, false, m, m0);
-        test_save_load(1000, 10, false, false, m, m0);
+        test_save_load(1000, 10, true, GraphLinksFormat::Compressed, m, m0);
+        test_save_load(1000, 10, false, GraphLinksFormat::Compressed, m, m0);
+        test_save_load(1000, 10, true, GraphLinksFormat::Plain, m, m0);
+        test_save_load(1000, 10, false, GraphLinksFormat::Plain, m, m0);
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -189,9 +189,9 @@ impl HNSWIndex {
                 )
             };
 
-            let graph_links_path = if !is_links_compressed
-                && LinkCompressionExperimentalSetting::from_env().convert_existing
-            {
+            let do_convert = LinkCompressionExperimentalSetting::from_env().convert_existing;
+
+            let graph_links_path = if !is_links_compressed && do_convert {
                 GraphLayers::convert_to_compressed(
                     graph_links_path,
                     &regular_links,
@@ -208,7 +208,7 @@ impl HNSWIndex {
                     &graph_path,
                     graph_links_path,
                     !hnsw_config.on_disk.unwrap_or(false),
-                    is_links_compressed,
+                    is_links_compressed || do_convert,
                 )?,
             )
         } else {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -192,11 +192,7 @@ impl HNSWIndex {
             let do_convert = LinkCompressionExperimentalSetting::from_env().convert_existing;
 
             let graph_links_path = if !is_links_compressed && do_convert {
-                GraphLayers::convert_to_compressed(
-                    graph_links_path,
-                    &regular_links,
-                    &compressed_links,
-                )?;
+                GraphLayers::convert_to_compressed(&graph_path, &regular_links, &compressed_links)?;
                 compressed_links.as_path()
             } else {
                 graph_links_path

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -22,6 +22,7 @@ use rayon::ThreadPool;
 
 use super::gpu::gpu_devices_manager::LockedGpuDevice;
 use super::gpu::gpu_vector_storage::GpuVectorStorage;
+use super::graph_links::GraphLinksFormat;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
@@ -102,8 +103,8 @@ pub struct HnswIndexOpenArgs<'a> {
 }
 
 struct LinkCompressionExperimentalSetting {
-    /// Whether newly created graphs should be written in the compressed format.
-    write_new: bool,
+    /// Preferable format for newly created graphs.
+    format: GraphLinksFormat,
     /// Whether to convert existing uncompressed graphs to the compressed format.
     convert_existing: bool,
 }
@@ -116,20 +117,20 @@ impl LinkCompressionExperimentalSetting {
     /// or moved to an appropriate place in the configuration.
     fn from_env() -> Self {
         let name = "__QDRANT_COMPRESSED_LINKS";
-        let (write_new, convert_existing) = match std::env::var(name).as_deref() {
-            Ok("0") | Err(std::env::VarError::NotPresent) => (false, false),
-            Ok("1") => (true, false),
-            Ok("2") => (true, true),
+        let (format, convert_existing) = match std::env::var(name).as_deref() {
+            Ok("0") | Err(std::env::VarError::NotPresent) => (GraphLinksFormat::Plain, false),
+            Ok("1") => (GraphLinksFormat::Compressed, false),
+            Ok("2") => (GraphLinksFormat::Compressed, true),
             _ => {
                 log::warn!(
                     "Unknown value for {name}={:?}, defaulting to 0",
                     std::env::var_os(name),
                 );
-                (false, false)
+                (GraphLinksFormat::Plain, false)
             }
         };
         Self {
-            write_new,
+            format,
             convert_existing,
         }
     }
@@ -153,15 +154,6 @@ impl HNSWIndex {
 
         let config_path = HnswGraphConfig::get_config_path(path);
         let graph_path = GraphLayers::get_path(path);
-        let regular_links = GraphLayers::get_links_path(path);
-        let compressed_links = GraphLayers::get_compressed_links_path(path);
-        let (graph_links_path, is_links_compressed) = {
-            if compressed_links.exists() {
-                (compressed_links.as_path(), true)
-            } else {
-                (regular_links.as_path(), false)
-            }
-        };
         let (config, graph) = if graph_path.exists() {
             let config = if config_path.exists() {
                 HnswGraphConfig::load(&config_path)?
@@ -191,21 +183,9 @@ impl HNSWIndex {
 
             let do_convert = LinkCompressionExperimentalSetting::from_env().convert_existing;
 
-            let graph_links_path = if !is_links_compressed && do_convert {
-                GraphLayers::convert_to_compressed(&graph_path, &regular_links, &compressed_links)?;
-                compressed_links.as_path()
-            } else {
-                graph_links_path
-            };
-
             (
                 config,
-                GraphLayers::load(
-                    &graph_path,
-                    graph_links_path,
-                    !hnsw_config.on_disk.unwrap_or(false),
-                    is_links_compressed || do_convert,
-                )?,
+                GraphLayers::load(path, !hnsw_config.on_disk.unwrap_or(false), do_convert)?,
             )
         } else {
             let num_cpus = match permit {
@@ -234,7 +214,6 @@ impl HNSWIndex {
             )?;
 
             config.save(&config_path)?;
-            graph.save(&graph_path)?;
 
             (config, graph)
         };
@@ -531,16 +510,9 @@ impl HNSWIndex {
 
         config.indexed_vector_count.replace(indexed_vectors);
 
-        let do_compression = LinkCompressionExperimentalSetting::from_env().write_new;
-        let links_path = if do_compression {
-            GraphLayers::get_compressed_links_path(path)
-        } else {
-            GraphLayers::get_links_path(path)
-        };
-
         let graph: GraphLayers = graph_layers_builder.into_graph_layers(
-            &links_path,
-            do_compression,
+            path,
+            LinkCompressionExperimentalSetting::from_env().format,
             hnsw_config.on_disk.unwrap_or(false),
         )?;
 
@@ -1331,15 +1303,12 @@ impl VectorIndex for HNSWIndex {
     }
 
     fn files(&self) -> Vec<PathBuf> {
-        [
-            GraphLayers::get_path(&self.path),
-            GraphLayers::get_links_path(&self.path),
-            GraphLayers::get_compressed_links_path(&self.path),
-            HnswGraphConfig::get_config_path(&self.path),
-        ]
-        .into_iter()
-        .filter(|p| p.exists())
-        .collect()
+        let mut files = self.graph.files(&self.path);
+        let config_path = HnswGraphConfig::get_config_path(&self.path);
+        if config_path.exists() {
+            files.push(config_path);
+        }
+        files
     }
 
     fn indexed_vector_count(&self) -> usize {

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -4,6 +4,7 @@ mod test_graph_connectivity;
 use common::types::PointOffsetType;
 use rand::Rng;
 
+use super::graph_links::GraphLinksFormat;
 use crate::data_types::vectors::VectorElementType;
 use crate::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer};
 use crate::index::hnsw_index::graph_layers::GraphLayers;
@@ -53,7 +54,7 @@ pub(crate) fn create_graph_layer_fixture<TMetric: Metric<VectorElementType>, R>(
     num_vectors: usize,
     m: usize,
     dim: usize,
-    compressed: bool,
+    format: GraphLinksFormat,
     use_heuristic: bool,
     rng: &mut R,
 ) -> (TestRawScorerProducer<TMetric>, GraphLayers)
@@ -65,6 +66,6 @@ where
 
     (
         vector_holder,
-        graph_layers_builder.into_graph_layers_ram(compressed),
+        graph_layers_builder.into_graph_layers_ram(format),
     )
 }

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -9,6 +9,7 @@ use rstest::rstest;
 use crate::fixtures::index_fixtures::random_vector;
 use crate::index::hnsw_index::graph_layers::GraphLayersBase;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
+use crate::index::hnsw_index::graph_links::GraphLinksFormat;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::tests::create_graph_layer_builder_fixture;
 use crate::spaces::simple::CosineMetric;
@@ -40,9 +41,9 @@ fn search_in_builder(
 
 /// Check that HNSW index with raw and compacted links gives the same results
 #[rstest]
-#[case::uncompressed(false)]
-#[case::compressed(true)]
-fn test_compact_graph_layers(#[case] compressed: bool) {
+#[case::uncompressed(GraphLinksFormat::Plain)]
+#[case::compressed(GraphLinksFormat::Compressed)]
+fn test_compact_graph_layers(#[case] format: GraphLinksFormat) {
     let num_vectors = 1000;
     let num_queries = 100;
     let m = 16;
@@ -68,7 +69,7 @@ fn test_compact_graph_layers(#[case] compressed: bool) {
         })
         .collect_vec();
 
-    let graph_layers = graph_layers_builder.into_graph_layers_ram(compressed);
+    let graph_layers = graph_layers_builder.into_graph_layers_ram(format);
 
     let results = queries
         .iter()


### PR DESCRIPTION
This is an alternative implementation of #5704.

Changes compared to #5704:
- Instead of dealing with link filenames inside of `HNSWIndex`, encapsulate this logic into `GraphLayers`.
- Replace boolean logic with a new enum `GraphLinksFormat`.