### PR TITLE
Resharding: make UUID required, hide field in OpenAPI schema

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10831,11 +10831,6 @@
           "shard_id"
         ],
         "properties": {
-          "uuid": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
           "direction": {
             "$ref": "#/components/schemas/ReshardingDirection"
           },

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -265,6 +265,7 @@ pub struct AbortShardTransfer {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct StartResharding {
+    #[schemars(skip)]
     pub uuid: Option<Uuid>,
     pub direction: ReshardingDirection,
     pub peer_id: Option<PeerId>,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -363,8 +363,8 @@ pub struct ShardTransferInfo {
 
 #[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct ReshardingInfo {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uuid: Option<Uuid>,
+    #[schemars(skip)]
+    pub uuid: Uuid,
 
     pub direction: ReshardingDirection,
 

--- a/lib/collection/src/shards/resharding/mod.rs
+++ b/lib/collection/src/shards/resharding/mod.rs
@@ -40,8 +40,7 @@ pub(crate) const MAX_RETRY_COUNT: usize = 3;
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ReshardState {
-    #[serde(default)]
-    pub uuid: Option<Uuid>,
+    pub uuid: Uuid,
     pub peer_id: PeerId,
     pub shard_id: ShardId,
     pub shard_key: Option<ShardKey>,
@@ -51,7 +50,7 @@ pub struct ReshardState {
 
 impl ReshardState {
     pub fn new(
-        uuid: Option<Uuid>,
+        uuid: Uuid,
         direction: ReshardingDirection,
         peer_id: PeerId,
         shard_id: ShardId,
@@ -68,7 +67,7 @@ impl ReshardState {
     }
 
     pub fn matches(&self, key: &ReshardKey) -> bool {
-        self.uuid.zip(key.uuid).is_none_or(|(a, b)| a == b)
+        self.uuid == key.uuid
             && self.direction == key.direction
             && self.peer_id == key.peer_id
             && self.shard_id == key.shard_id
@@ -103,8 +102,8 @@ pub enum ReshardStage {
 /// Unique identifier of a resharding task
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema)]
 pub struct ReshardKey {
-    #[serde(default)]
-    pub uuid: Option<Uuid>,
+    #[schemars(skip)]
+    pub uuid: Uuid,
     #[serde(default)]
     pub direction: ReshardingDirection,
     pub peer_id: PeerId,

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -531,14 +531,14 @@ pub async fn do_update_collection_cluster(
         }
         ClusterOperations::StartResharding(op) => {
             let StartResharding {
-                mut uuid,
+                uuid,
                 direction,
                 peer_id,
                 shard_key,
             } = op.start_resharding;
 
             // Assign random UUID if not specified by user before processing operation on all peers
-            uuid.get_or_insert_with(Uuid::new_v4);
+            let uuid = uuid.unwrap_or_else(Uuid::new_v4);
 
             let collection_state = collection.state().await;
 


### PR DESCRIPTION
Two changes on top of <https://github.com/qdrant/qdrant/pull/5736>.

1. make the UUID required, all resharding operations will have some UUID
2. remove the UUID field from the OpenAPI schema, end users are not supposed to be using it

Note that the `start_resharding` operation still has an optional UUID. Users are not required to provide a UUID when starting resharding and Qdrant will fill it in for them.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?