### PR TITLE
Add GPU into github workflows

### DIFF
--- a/.github/workflows/dev-docker-image-build-gpu.yml
+++ b/.github/workflows/dev-docker-image-build-gpu.yml
@@ -1,0 +1,43 @@
+name: Build and push a branch gpu image to ghcr
+
+on:
+  workflow_dispatch:
+
+jobs:
+  branch-build-and-push:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            ref: ${{ github.ref.name }}
+        - name: Build the Docker image
+          run: |
+            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit" | tr '\n' ' ')
+            buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit" | tr '\n' ' ')
+
+            if [ -n "$buildx_containers" ]; then
+              echo "Buildx containers to delete: $buildx_containers"
+              docker container rm -f $buildx_containers
+            fi
+
+            if [ -n "$buildx_volumes" ]; then
+              echo "Buildx volumes to delete: $buildx_volumes"
+              docker volume rm -f $buildx_volumes
+            fi
+
+            branch=${GITHUB_REF_NAME//\//-} # replace all / with -
+            echo "Building branch $branch"
+
+            # Create build container
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker buildx create --use
+
+            # Authenticate on registries
+            docker login https://ghcr.io -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
+
+            # Build images for Github Registry
+            GITHUB_TAG_NVIDIA="-t ghcr.io/qdrant/qdrant:$branch-${{ github.sha }}-gpu-nvidia -t ghcr.io/qdrant/qdrant:$branch-gpu-nvidia"
+            docker buildx build --platform='linux/amd64' --build-arg GPU=nvidia --build-arg GIT_COMMIT_ID=${{ github.sha }} $GITHUB_TAG_NVIDIA --push --label "org.opencontainers.image.revision"=${{ github.sha }} .
+            
+            GITHUB_TAG_AMD="-t ghcr.io/qdrant/qdrant:$branch-${{ github.sha }}-gpu-amd -t ghcr.io/qdrant/qdrant:$branch-gpu-amd"
+            docker buildx build --platform='linux/amd64' --build-arg GPU=amd --build-arg GIT_COMMIT_ID=${{ github.sha }} $GITHUB_TAG_AMD --push --label "org.opencontainers.image.revision"=${{ github.sha }} .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,3 +52,47 @@ jobs:
         docker pull $DOCKERHUB_TAG_UNPRIVILEGED
         docker tag $DOCKERHUB_TAG_UNPRIVILEGED $GITHUB_TAG_UNPRIVILEGED
         docker push $GITHUB_TAG_UNPRIVILEGED
+
+  build-gpu:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
+    - name: Get current tag
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+    - name: Build the Docker image
+      env:
+        RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+      run: |
+        # Create build container
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --use
+
+        # Authenticate on registries
+        docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
+        docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
+
+        # Build GPU NVIDIA image for Docker Hub
+        DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}-gpu-nvidia"
+        DOCKERHUB_TAG_LATEST="qdrant/qdrant:gpu-nvidia-latest"
+        TAGS="-t ${DOCKERHUB_TAG} -t ${DOCKERHUB_TAG_LATEST}"
+        GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}-gpu-nvidia"
+
+        # Pull, retag and push to GitHub packages
+        docker buildx build --build-arg GPU=nvidia --platform='linux/amd64' --build-arg GIT_COMMIT_ID=${{ github.sha }} $TAGS --push --label "org.opencontainers.image.version"=$RELEASE_VERSION .
+        docker pull $DOCKERHUB_TAG
+        docker tag $DOCKERHUB_TAG $GITHUB_TAG
+        docker push $GITHUB_TAG
+
+        # Build GPU AMD image for Docker Hub
+        DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}-gpu-amd"
+        DOCKERHUB_TAG_LATEST="qdrant/qdrant:gpu-amd-latest"
+        TAGS="-t ${DOCKERHUB_TAG} -t ${DOCKERHUB_TAG_LATEST}"
+        GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}-gpu-amd"
+
+        # Pull, retag and push to GitHub packages
+        docker buildx build --build-arg GPU=amd --platform='linux/amd64' --build-arg GIT_COMMIT_ID=${{ github.sha }} $TAGS --push --label "org.opencontainers.image.version"=$RELEASE_VERSION .
+        docker pull $DOCKERHUB_TAG
+        docker tag $DOCKERHUB_TAG $GITHUB_TAG
+        docker push $GITHUB_TAG

--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -1,0 +1,109 @@
+name: Rust GPU tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+
+  # TODO: remove this block
+  pull_request:
+    branches: [ '**' ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+
+    steps:
+    - name: Install minimal stable
+      uses: dtolnay/rust-toolchain@stable
+    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+    - name: Install Vulkan packages
+      run: |
+        sudo apt-get install clang
+        sudo apt-get install mesa-vulkan-drivers libvulkan1 vulkan-tools vulkan-validationlayers
+        /usr/bin/vulkaninfo --summary
+    - name: Build
+      run: cargo build --tests --workspace --features gpu
+    - name: Run tests
+      # Profile "ci" is configured in .config/nextest.toml
+      run: cargo nextest run --workspace --features gpu --profile ci
+    - name: Upload test report
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-${{ matrix.os }}.xml
+        path: target/nextest/ci/junit.xml
+
+  # After tests are run, this hacky script will process the JUnit output of nextest
+  # and will create a GH Issue if there is a test marked as flaky,
+  # Failure of updating an issue is ignored because it fails for external contributors.
+  process-results:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Download test report
+        uses: actions/download-artifact@v4
+        with:
+          name: junit-${{ matrix.os }}.xml
+      - name: Process test report
+        id: process-test-report
+        run: |
+          pip install yq
+          xq '.. | select(type == "object") | select(has("flakyFailure"))' junit.xml > flaky_tests.json
+          echo has_flaky_tests=$(jq '. | has("flakyFailure")' flaky_tests.json) >> $GITHUB_OUTPUT
+      - name: Get flaky test details
+        id: get-flaky-tests
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        run: |
+          echo "Flaky tests found"
+          echo test=$(jq '.["@name"]' flaky_tests.json -r ) >> $GITHUB_OUTPUT
+          delimiter="###r###"
+          echo "content<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$(jq '[.flakyFailure] | flatten | .[0]["system-err"]' flaky_tests.json -r)" >> $GITHUB_OUTPUT
+          echo $delimiter >> $GITHUB_OUTPUT
+      - name: pull issue template
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/ISSUE_TEMPLATE/flaky_test.md
+          sparse-checkout-cone-mode: false
+      - name: Create issue for flaky tests
+        continue-on-error: true
+        id: create-issue
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_NAME: ${{ steps.get-flaky-tests.outputs.test }}
+          SYSTEM_ERROR: ${{ steps.get-flaky-tests.outputs.content }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          JOB_ID: ${{ github.job }}
+          SHA: ${{ github.sha }}
+          WORKFLOW: ${{ github.workflow }}
+          JOB: ${{ github.job }}
+          BRANCH: ${{ github.ref }}
+          OS: ${{ matrix.os }}
+          PR: "#${{ github.event.pull_request.number }}"
+        with:
+          filename: .github/ISSUE_TEMPLATE/flaky_test.md
+          update_existing: true

--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches: [ master ]
 
-  # TODO: remove this block
-  pull_request:
-    branches: [ '**' ]
-
 env:
   CARGO_TERM_COLOR: always
 
@@ -103,7 +99,6 @@ jobs:
           JOB: ${{ github.job }}
           BRANCH: ${{ github.ref }}
           OS: ${{ matrix.os }}
-          PR: "#${{ github.event.pull_request.number }}"
         with:
           filename: .github/ISSUE_TEMPLATE/flaky_test.md
           update_existing: true


### PR DESCRIPTION
This PR adds GPU into qdrant CI. It includes:
1. Run GPU unit tests. Trigger conditions: manual or merge into master
2. Build and push image into ghcr. Triggered manually only
3. Publish GPU images while release process

GPU images have tags with `-gpu-nvidia` or `-gpu-amd` postfix. Only x64, no arm because GPU image bases don't have arm builds. No unprivileged images for now.

Unit tests were processed using the LLVMPipe - Vulkan driver, which uses CPU to emulate compiled SPIR-V shaders. Tests pass
https://github.com/qdrant/qdrant/actions/runs/12668441957/job/35303874213?pr=5752