### PR TITLE
Strict mode multivector

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -71,6 +71,9 @@
     - [SparseVectorConfig.MapEntry](#qdrant-SparseVectorConfig-MapEntry)
     - [SparseVectorParams](#qdrant-SparseVectorParams)
     - [StrictModeConfig](#qdrant-StrictModeConfig)
+    - [StrictModeMultivector](#qdrant-StrictModeMultivector)
+    - [StrictModeMultivectorConfig](#qdrant-StrictModeMultivectorConfig)
+    - [StrictModeMultivectorConfig.MultivectorConfigEntry](#qdrant-StrictModeMultivectorConfig-MultivectorConfigEntry)
     - [TextIndexParams](#qdrant-TextIndexParams)
     - [UpdateCollection](#qdrant-UpdateCollection)
     - [UpdateCollectionClusterSetupRequest](#qdrant-UpdateCollectionClusterSetupRequest)
@@ -1464,6 +1467,53 @@ Note: 1kB = 1 vector of size 256. |
 | max_collection_payload_size_bytes | [uint64](#uint64) | optional |  |
 | filter_max_conditions | [uint64](#uint64) | optional |  |
 | condition_max_size | [uint64](#uint64) | optional |  |
+| multivector_config | [StrictModeMultivectorConfig](#qdrant-StrictModeMultivectorConfig) | optional |  |
+
+
+
+
+
+
+<a name="qdrant-StrictModeMultivector"></a>
+
+### StrictModeMultivector
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| max_vectors | [uint64](#uint64) | optional |  |
+
+
+
+
+
+
+<a name="qdrant-StrictModeMultivectorConfig"></a>
+
+### StrictModeMultivectorConfig
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| multivector_config | [StrictModeMultivectorConfig.MultivectorConfigEntry](#qdrant-StrictModeMultivectorConfig-MultivectorConfigEntry) | repeated |  |
+
+
+
+
+
+
+<a name="qdrant-StrictModeMultivectorConfig-MultivectorConfigEntry"></a>
+
+### StrictModeMultivectorConfig.MultivectorConfigEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [StrictModeMultivector](#qdrant-StrictModeMultivector) |  |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7343,6 +7343,32 @@
             "format": "uint",
             "minimum": 0,
             "nullable": true
+          },
+          "multivector_config": {
+            "description": "Multivector configuration",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeMultivectorConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "StrictModeMultivectorConfig": {
+        "type": "object"
+      },
+      "StrictModeMultivector": {
+        "type": "object",
+        "properties": {
+          "max_vectors": {
+            "description": "Max number of vectors in a multivector",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -25,7 +25,8 @@ use super::qdrant::{
     HardwareUsage, HasVectorCondition, KeywordIndexParams, LookupLocation, MaxOptimizationThreads,
     MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range, RawVector,
     RecommendStrategy, RetrievedPoint, SearchMatrixPair, SearchPointGroups, SearchPoints,
-    ShardKeySelector, SparseIndices, StartFrom, UuidIndexParams, VectorsOutput, WithLookup,
+    ShardKeySelector, SparseIndices, StartFrom, StrictModeMultivector, StrictModeMultivectorConfig,
+    UuidIndexParams, VectorsOutput, WithLookup,
 };
 use crate::conversions::json;
 use crate::grpc::qdrant::condition::ConditionOneOf;
@@ -1719,6 +1720,28 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
                 .map(|i| i as usize),
             filter_max_conditions: value.filter_max_conditions.map(|i| i as usize),
             condition_max_size: value.condition_max_size.map(|i| i as usize),
+            multivector_config: value
+                .multivector_config
+                .map(segment::types::StrictModeMultivectorConfig::from),
+        }
+    }
+}
+
+impl From<StrictModeMultivectorConfig> for segment::types::StrictModeMultivectorConfig {
+    fn from(value: StrictModeMultivectorConfig) -> Self {
+        Self {
+            config: value
+                .multivector_config
+                .iter()
+                .map(|(name, config)| {
+                    (
+                        name.clone(),
+                        segment::types::StrictModeMultivector {
+                            max_vectors: config.max_vectors.map(|i| i as usize),
+                        },
+                    )
+                })
+                .collect(),
         }
     }
 }
@@ -1745,6 +1768,28 @@ impl From<segment::types::StrictModeConfig> for StrictModeConfig {
                 .map(|i| i as u64),
             filter_max_conditions: value.filter_max_conditions.map(|i| i as u64),
             condition_max_size: value.condition_max_size.map(|i| i as u64),
+            multivector_config: value
+                .multivector_config
+                .map(StrictModeMultivectorConfig::from),
+        }
+    }
+}
+
+impl From<segment::types::StrictModeMultivectorConfig> for StrictModeMultivectorConfig {
+    fn from(value: segment::types::StrictModeMultivectorConfig) -> Self {
+        Self {
+            multivector_config: value
+                .config
+                .iter()
+                .map(|(name, config)| {
+                    (
+                        name.clone(),
+                        StrictModeMultivector {
+                            max_vectors: config.max_vectors.map(|i| i as u64),
+                        },
+                    )
+                })
+                .collect(),
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -342,6 +342,15 @@ message StrictModeConfig {
   optional uint64 max_collection_payload_size_bytes = 13;
   optional uint64 filter_max_conditions = 14;
   optional uint64 condition_max_size = 15;
+  optional StrictModeMultivectorConfig multivector_config = 16;
+}
+
+message StrictModeMultivectorConfig {
+  map<string, StrictModeMultivector> multivector_config = 1;
+}
+
+message StrictModeMultivector {
+  optional uint64 max_vectors  = 1;
 }
 
 message CreateCollection {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -523,6 +523,25 @@ pub struct StrictModeConfig {
     pub filter_max_conditions: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "15")]
     pub condition_max_size: ::core::option::Option<u64>,
+    #[prost(message, optional, tag = "16")]
+    pub multivector_config: ::core::option::Option<StrictModeMultivectorConfig>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StrictModeMultivectorConfig {
+    #[prost(map = "string, message", tag = "1")]
+    pub multivector_config: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        StrictModeMultivector,
+    >,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StrictModeMultivector {
+    #[prost(uint64, optional, tag = "1")]
+    pub max_vectors: ::core::option::Option<u64>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -29,7 +29,7 @@ pub type MultiDenseVector = Vec<DenseVector>;
 #[serde(untagged, rename_all = "snake_case")]
 pub enum Vector {
     Dense(DenseVector),
-    Sparse(sparse::common::sparse_vector::SparseVector),
+    Sparse(SparseVector),
     MultiDense(MultiDenseVector),
     Document(Document),
     Image(Image),
@@ -41,7 +41,7 @@ pub enum Vector {
 #[serde(untagged, rename_all = "snake_case")]
 pub enum VectorOutput {
     Dense(DenseVector),
-    Sparse(sparse::common::sparse_vector::SparseVector),
+    Sparse(SparseVector),
     MultiDense(MultiDenseVector),
 }
 
@@ -1022,7 +1022,7 @@ impl<'de> serde::Deserialize<'de> for PointInsertOperations {
 #[derive(Debug, Serialize, Clone, JsonSchema)]
 #[serde(untagged)]
 pub enum PointInsertOperations {
-    /// Inset points from a batch.
+    /// Insert points from a batch.
     PointsBatch(PointsBatch),
     /// Insert points from a list
     PointsList(PointsList),

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -460,11 +460,6 @@ mod test {
             search_max_hnsw_ef: Some(3),
             search_allow_exact: Some(false),
             search_max_oversampling: Some(0.2),
-            upsert_max_batchsize: None,
-            max_collection_vector_size_bytes: None,
-            read_rate_limit: None,
-            write_rate_limit: None,
-            max_collection_payload_size_bytes: None,
             ..Default::default()
         };
 

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -1,5 +1,9 @@
-use api::rest::{PointInsertOperations, UpdateVectors};
-use segment::types::{Filter, StrictModeConfig};
+use api::rest::{
+    BatchVectorStruct, MultiDenseVector, PointInsertOperations, UpdateVectors, Vector, VectorStruct,
+};
+use segment::data_types::tiny_map::TinyMap;
+use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
+use segment::types::{Filter, StrictModeConfig, StrictModeMultivectorConfig};
 
 use super::{check_limit_opt, StrictModeVerification};
 use crate::collection::Collection;
@@ -129,6 +133,10 @@ impl StrictModeVerification for PointInsertOperations {
 
         check_collection_size_limit(collection, strict_mode_config).await?;
 
+        if let Some(multivector_config) = &strict_mode_config.multivector_config {
+            check_multivectors_limits_insert(self, collection, multivector_config).await?;
+        }
+
         Ok(())
     }
 
@@ -166,6 +174,10 @@ impl StrictModeVerification for UpdateVectors {
         )?;
 
         check_collection_size_limit(collection, strict_mode_config).await?;
+
+        if let Some(multivector_config) = &strict_mode_config.multivector_config {
+            check_multivectors_limits_update(self, collection, multivector_config).await?;
+        }
 
         Ok(())
     }
@@ -247,6 +259,201 @@ fn check_collection_payload_size_limit(
         let size_in_mb = max_payload_storage_size_bytes as f32 / (1024.0 * 1024.0);
         return Err(CollectionError::bad_request(format!(
             "Max payload storage size limit of {size_in_mb}MB reached!",
+        )));
+    }
+
+    Ok(())
+}
+
+/// Compute a non-empty mapping of multivector limits by name.
+///
+/// Uses a tiny map as we expect a small number of multivectors to be configured per collection in strict mode.
+///
+/// Return None if no multivectors are configured with strict mode
+async fn multivector_limits_by_name(
+    collection: &Collection,
+    multivector_strict_config: &StrictModeMultivectorConfig,
+) -> Option<TinyMap<String, usize>> {
+    // If no multivectors strict mode no need to check anything.
+    if multivector_strict_config.config.is_empty() {
+        return None;
+    }
+    let collection_guard = collection.collection_config.read().await;
+
+    let multivector_max_size_by_name: TinyMap<String, usize> = collection_guard
+        .params
+        .vectors
+        .params_iter()
+        .filter_map(|(name, config)| config.multivector_config.map(|_strict_config| name)) // keep only configured multivectors
+        .filter_map(|multi_vector_name| {
+            multivector_strict_config
+                .config
+                .get(multi_vector_name)
+                .and_then(|config| config.max_vectors)
+                .map(|max_vectors| (multi_vector_name, max_vectors))
+        })
+        .map(|(name, max_vectors)| (name.to_string(), max_vectors))
+        .collect();
+    drop(collection_guard);
+
+    // If no multivectors are configured, no need to check anything.
+    if multivector_max_size_by_name.is_empty() {
+        None
+    } else {
+        Some(multivector_max_size_by_name)
+    }
+}
+
+async fn check_multivectors_limits_update(
+    point_insert: &UpdateVectors,
+    collection: &Collection,
+    multivector_strict_config: &StrictModeMultivectorConfig,
+) -> Result<(), CollectionError> {
+    let Some(multivector_max_size_by_name) =
+        multivector_limits_by_name(collection, multivector_strict_config).await
+    else {
+        return Ok(());
+    };
+
+    for point in &point_insert.points {
+        check_named_multivectors_vecstruct_limit(
+            DEFAULT_VECTOR_NAME,
+            &point.vector,
+            &multivector_max_size_by_name,
+        )?;
+    }
+
+    Ok(())
+}
+
+async fn check_multivectors_limits_insert(
+    point_insert: &PointInsertOperations,
+    collection: &Collection,
+    multivector_strict_config: &StrictModeMultivectorConfig,
+) -> Result<(), CollectionError> {
+    let Some(multivector_max_size_by_name) =
+        multivector_limits_by_name(collection, multivector_strict_config).await
+    else {
+        return Ok(());
+    };
+
+    match point_insert {
+        PointInsertOperations::PointsBatch(batch) => match &batch.batch.vectors {
+            BatchVectorStruct::MultiDense(multis) => {
+                for multi in multis {
+                    check_named_multivector_limit(
+                        DEFAULT_VECTOR_NAME,
+                        multi,
+                        &multivector_max_size_by_name,
+                    )?;
+                }
+            }
+            BatchVectorStruct::Named(named_batch_vectors) => {
+                for (name, vectors) in named_batch_vectors {
+                    for vector in vectors {
+                        check_named_multivectors_vec_limit(
+                            name,
+                            vector,
+                            &multivector_max_size_by_name,
+                        )?;
+                    }
+                }
+            }
+            BatchVectorStruct::Single(_)
+            | BatchVectorStruct::Document(_)
+            | BatchVectorStruct::Image(_)
+            | BatchVectorStruct::Object(_) => {}
+        },
+        PointInsertOperations::PointsList(list) => {
+            for point_struct in &list.points {
+                match &point_struct.vector {
+                    VectorStruct::MultiDense(multi) => {
+                        check_named_multivector_limit(
+                            DEFAULT_VECTOR_NAME,
+                            multi,
+                            &multivector_max_size_by_name,
+                        )?;
+                    }
+                    VectorStruct::Named(named_vectors) => {
+                        for (name, vector) in named_vectors {
+                            check_named_multivectors_vec_limit(
+                                name,
+                                vector,
+                                &multivector_max_size_by_name,
+                            )?;
+                        }
+                    }
+                    VectorStruct::Single(_)
+                    | VectorStruct::Document(_)
+                    | VectorStruct::Image(_)
+                    | VectorStruct::Object(_) => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_named_multivectors_vecstruct_limit(
+    name: &str,
+    vector: &VectorStruct,
+    multivector_max_size_by_name: &TinyMap<String, usize>,
+) -> Result<(), CollectionError> {
+    match vector {
+        VectorStruct::MultiDense(multi) => {
+            check_named_multivector_limit(name, multi, multivector_max_size_by_name)
+        }
+        VectorStruct::Named(named) => {
+            for (name, vec) in named {
+                check_named_multivectors_vec_limit(name, vec, multivector_max_size_by_name)?;
+            }
+            Ok(())
+        }
+        VectorStruct::Single(_)
+        | VectorStruct::Document(_)
+        | VectorStruct::Image(_)
+        | VectorStruct::Object(_) => Ok(()),
+    }
+}
+
+fn check_named_multivectors_vec_limit(
+    name: &str,
+    vector: &Vector,
+    multivector_max_size_by_name: &TinyMap<String, usize>,
+) -> Result<(), CollectionError> {
+    match vector {
+        Vector::MultiDense(multi) => {
+            check_named_multivector_limit(name, multi, multivector_max_size_by_name)
+        }
+        Vector::Dense(_)
+        | Vector::Sparse(_)
+        | Vector::Document(_)
+        | Vector::Image(_)
+        | Vector::Object(_) => Ok(()),
+    }
+}
+
+fn check_named_multivector_limit(
+    name: &str,
+    multi: &MultiDenseVector,
+    multivector_max_size_by_name: &TinyMap<String, usize>,
+) -> Result<(), CollectionError> {
+    if let Some(strict_multi_limit) = multivector_max_size_by_name.get(name) {
+        check_multivector_limit(name, multi, *strict_multi_limit)?
+    }
+    Ok(())
+}
+
+fn check_multivector_limit(
+    name: &str,
+    multi: &MultiDenseVector,
+    max_size: usize,
+) -> Result<(), CollectionError> {
+    let multi_len = multi.len();
+    if multi_len > max_size {
+        return Err(CollectionError::bad_request(format!(
+            "Multivector '{name}' has a limit of {max_size} vectors, but {multi_len} were provided!",
         )));
     }
 

--- a/lib/segment/src/data_types/tiny_map.rs
+++ b/lib/segment/src/data_types/tiny_map.rs
@@ -156,7 +156,7 @@ where
     }
 }
 
-impl<K, V> iter::FromIterator<(K, V)> for TinyMap<K, V>
+impl<K, V> FromIterator<(K, V)> for TinyMap<K, V>
 where
     K: Default,
     V: Default,

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -3,7 +3,7 @@ use collection::operations::config_diff::{
 };
 use collection::operations::conversions::sharding_method_from_proto;
 use collection::operations::types::{SparseVectorsConfig, VectorsConfigDiff};
-use segment::types::StrictModeConfig;
+use segment::types::{StrictModeConfig, StrictModeMultivectorConfig};
 use tonic::Status;
 
 use crate::content_manager::collection_meta_ops::{
@@ -97,6 +97,9 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
             .map(|i| i as usize),
         filter_max_conditions: value.filter_max_conditions.map(|i| i as usize),
         condition_max_size: value.condition_max_size.map(|i| i as usize),
+        multivector_config: value
+            .multivector_config
+            .map(StrictModeMultivectorConfig::from),
     }
 }
 

--- a/tests/openapi/helpers/collection_setup.py
+++ b/tests/openapi/helpers/collection_setup.py
@@ -310,10 +310,10 @@ def multipayload_collection_setup(
 
 
 def multivec_collection_setup(
-        collection_name='test_collection',
-        on_disk_payload=False,
-        on_disk_vectors=False,
-        distance=None,
+    collection_name='test_collection',
+    on_disk_payload=False,
+    on_disk_vectors=False,
+    distance=None,
 ):
     response = request_with_validation(
         api='/collections/{collection_name}',
@@ -443,10 +443,10 @@ def multivec_collection_setup(
 
 
 def full_collection_setup(
-        collection_name='test_collection',
-        on_disk_payload=False,
-        on_disk_vectors=False,
-        distance=None,
+    collection_name='test_collection',
+    on_disk_payload=False,
+    on_disk_vectors=False,
+    distance=None,
 ):
     response = request_with_validation(
         api='/collections/{collection_name}',


### PR DESCRIPTION
This PR adds a strict mode to multivector in order to bound the maximum number of vector a multivector can have.

The validation is triggered when inserting or updating points.

A new field is added to the strict mode to associate a multivector config to a named vector.

e.g.

```json
{
  "enabled": true,
  "multivector_config": {
    "dense-multi": {
      "max_vectors": 5
    }
  }
}
```

I used a configuration object to enable adding new constraints in the future.