### PR TITLE
Add `VectorName` type alias

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -8,8 +8,8 @@ use segment::common::utils::MaybeOneOrMany;
 use segment::data_types::order_by::OrderBy;
 use segment::json_path::JsonPath;
 use segment::types::{
-    Filter, IntPayloadType, Payload, PointIdType, SearchParams, ShardKey, WithPayloadInterface,
-    WithVector,
+    Filter, IntPayloadType, Payload, PointIdType, SearchParams, ShardKey, VectorNameBuf,
+    WithPayloadInterface, WithVector,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -70,10 +70,10 @@ fn multi_dense_vector_example() -> MultiDenseVector {
     ]
 }
 
-fn named_vector_example() -> HashMap<String, Vector> {
+fn named_vector_example() -> HashMap<VectorNameBuf, Vector> {
     let mut map = HashMap::new();
     map.insert(
-        "image-embeddings".to_string(),
+        "image-embeddings".into(),
         Vector::Dense(vec![0.873, 0.140625, 0.8976]),
     );
     map
@@ -88,7 +88,7 @@ pub enum VectorStruct {
     #[schemars(example = "multi_dense_vector_example")]
     MultiDense(MultiDenseVector),
     #[schemars(example = "named_vector_example")]
-    Named(HashMap<String, Vector>),
+    Named(HashMap<VectorNameBuf, Vector>),
     Document(Document),
     Image(Image),
     Object(InferenceObject),
@@ -103,7 +103,7 @@ pub enum VectorStructOutput {
     #[schemars(example = "multi_dense_vector_example")]
     MultiDense(MultiDenseVector),
     #[schemars(example = "named_vector_example")]
-    Named(HashMap<String, VectorOutput>),
+    Named(HashMap<VectorNameBuf, VectorOutput>),
 }
 
 impl VectorStruct {
@@ -222,7 +222,7 @@ pub struct InferenceObject {
 pub enum BatchVectorStruct {
     Single(Vec<DenseVector>),
     MultiDense(Vec<MultiDenseVector>),
-    Named(HashMap<String, Vec<Vector>>),
+    Named(HashMap<VectorNameBuf, Vec<Vector>>),
     Document(Vec<Document>),
     Image(Vec<Image>),
     Object(Vec<InferenceObject>),
@@ -384,7 +384,7 @@ pub struct QueryRequestInternal {
     pub query: Option<QueryInterface>,
 
     /// Define which vector name to use for querying. If missing, the default vector is used.
-    pub using: Option<String>,
+    pub using: Option<VectorNameBuf>,
 
     /// Filter conditions - return only those points that satisfy the specified conditions.
     #[validate(nested)]
@@ -524,7 +524,7 @@ pub struct Prefetch {
     pub query: Option<QueryInterface>,
 
     /// Define which vector name to use for querying. If missing, the default vector is used.
-    pub using: Option<String>,
+    pub using: Option<VectorNameBuf>,
 
     /// Filter conditions - return only those points that satisfy the specified conditions.
     #[validate(nested)]
@@ -667,7 +667,7 @@ pub struct LookupLocation {
     /// Optional name of the vector field within the collection.
     /// If not provided, the default vector field will be used.
     #[serde(default)]
-    pub vector: Option<String>,
+    pub vector: Option<VectorNameBuf>,
 
     /// Specify in which shards to look for the points, if not specified - look in all shards
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -794,7 +794,7 @@ pub struct QueryGroupsRequestInternal {
     pub query: Option<QueryInterface>,
 
     /// Define which vector name to use for querying. If missing, the default vector is used.
-    pub using: Option<String>,
+    pub using: Option<VectorNameBuf>,
 
     /// Filter conditions - return only those points that satisfy the specified conditions.
     #[validate(nested)]
@@ -845,7 +845,7 @@ pub struct SearchMatrixRequestInternal {
     #[validate(range(min = 1))]
     pub limit: Option<usize>,
     /// Define which vector name to use for querying. If missing, the default vector is used.
-    pub using: Option<String>,
+    pub using: Option<VectorNameBuf>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]

--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -8,7 +8,8 @@ use api::rest::{
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::vectors::{NamedVectorStruct, DEFAULT_VECTOR_NAME};
 use segment::types::{
-    Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, WithVector,
+    Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, VectorNameBuf,
+    WithVector,
 };
 
 use crate::collection::Collection;
@@ -31,7 +32,7 @@ pub struct CollectionSearchMatrixRequest {
     pub sample_size: usize,
     pub limit_per_sample: usize,
     pub filter: Option<Filter>,
-    pub using: String,
+    pub using: VectorNameBuf,
 }
 
 impl CollectionSearchMatrixRequest {
@@ -52,7 +53,7 @@ impl From<SearchMatrixRequestInternal> for CollectionSearchMatrixRequest {
             limit_per_sample: limit
                 .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_LIMIT_PER_SAMPLE),
             filter,
-            using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+            using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
         }
     }
 }

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -12,7 +12,7 @@ use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::{
     build_multivec_segment, build_simple_segment,
 };
-use segment::types::{Distance, Payload, PointIdType, SeqNumberType};
+use segment::types::{Distance, Payload, PointIdType, SeqNumberType, VectorName};
 use serde_json::json;
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
@@ -22,6 +22,9 @@ use crate::collection_manager::optimizers::segment_optimizer::OptimizerThreshold
 use crate::config::CollectionParams;
 use crate::operations::types::VectorsConfig;
 use crate::operations::vector_params_builder::VectorParamsBuilder;
+
+pub const VECTOR1_NAME: &VectorName = "vector1";
+pub const VECTOR2_NAME: &VectorName = "vector2";
 
 pub fn empty_segment(path: &Path) -> Segment {
     build_simple_segment(path, 4, Distance::Dot).unwrap()
@@ -71,8 +74,8 @@ pub fn random_multi_vec_segment(
         let random_vector1: Vec<_> = (0..dim1).map(|_| rnd.gen_range(0.0..1.0)).collect();
         let random_vector2: Vec<_> = (0..dim2).map(|_| rnd.gen_range(0.0..1.0)).collect();
         let mut vectors = NamedVectors::default();
-        vectors.insert("vector1".to_owned(), random_vector1.into());
-        vectors.insert("vector2".to_owned(), random_vector2.into());
+        vectors.insert(VECTOR1_NAME.to_owned(), random_vector1.into());
+        vectors.insert(VECTOR2_NAME.to_owned(), random_vector2.into());
 
         let point_id: PointIdType = id_gen.unique();
         let payload_value = rnd.gen_range(1..1_000);

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -23,7 +23,7 @@ use segment::telemetry::SegmentTelemetry;
 use segment::types::{
     Condition, Filter, HasIdCondition, Payload, PayloadFieldSchema, PayloadKeyType,
     PayloadKeyTypeRef, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo,
-    SegmentType, SeqNumberType, SnapshotFormat, WithPayload, WithVector,
+    SegmentType, SeqNumberType, SnapshotFormat, VectorName, VectorNameBuf, WithPayload, WithVector,
 };
 
 use crate::collection_manager::holders::segment_holder::LockedSegment;
@@ -324,7 +324,7 @@ impl ProxySegment {
     #[allow(clippy::too_many_arguments)]
     pub fn search(
         &self,
-        vector_name: &str,
+        vector_name: &VectorName,
         vector: &QueryVector,
         with_payload: &WithPayload,
         with_vector: &WithVector,
@@ -368,7 +368,7 @@ impl SegmentEntry for ProxySegment {
 
     fn search_batch(
         &self,
-        vector_name: &str,
+        vector_name: &VectorName,
         vectors: &[&QueryVector],
         with_payload: &WithPayload,
         with_vector: &WithVector,
@@ -535,7 +535,7 @@ impl SegmentEntry for ProxySegment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector_name: &str,
+        vector_name: &VectorName,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         self.move_if_exists(op_num, point_id, hw_counter)?;
@@ -605,7 +605,7 @@ impl SegmentEntry for ProxySegment {
 
     fn vector(
         &self,
-        vector_name: &str,
+        vector_name: &VectorName,
         point_id: PointIdType,
     ) -> OperationResult<Option<VectorInternal>> {
         return if self.deleted_points.read().contains_key(&point_id) {
@@ -892,7 +892,7 @@ impl SegmentEntry for ProxySegment {
         self.write_segment.get().read().deleted_point_count()
     }
 
-    fn available_vectors_size_in_bytes(&self, vector_name: &str) -> OperationResult<usize> {
+    fn available_vectors_size_in_bytes(&self, vector_name: &VectorName) -> OperationResult<usize> {
         let wrapped_segment = self.wrapped_segment.get();
         let wrapped_segment_guard = wrapped_segment.read();
         let wrapped_size = wrapped_segment_guard.available_vectors_size_in_bytes(vector_name)?;
@@ -1222,7 +1222,7 @@ impl SegmentEntry for ProxySegment {
         Ok(deleted_points)
     }
 
-    fn vector_names(&self) -> HashSet<String> {
+    fn vector_names(&self) -> HashSet<VectorNameBuf> {
         self.write_segment.get().read().vector_names()
     }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1397,7 +1397,7 @@ mod tests {
     use std::str::FromStr;
 
     use rand::Rng;
-    use segment::data_types::vectors::VectorInternal;
+    use segment::data_types::vectors::{VectorInternal, DEFAULT_VECTOR_NAME};
     use segment::json_path::JsonPath;
     use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
     use segment::types::{Distance, PayloadContainer};
@@ -1642,7 +1642,10 @@ mod tests {
             let locked_segment_2 = holder.get(sid2).unwrap().get();
             let read_segment_2 = locked_segment_2.read();
             assert!(read_segment_2.has_point(123.into()));
-            let vector = read_segment_2.vector("", 123.into()).unwrap().unwrap();
+            let vector = read_segment_2
+                .vector(DEFAULT_VECTOR_NAME, 123.into())
+                .unwrap()
+                .unwrap();
             assert_ne!(vector, VectorInternal::Dense(vec![9.0; 4]));
             assert_eq!(
                 read_segment_2
@@ -1659,7 +1662,10 @@ mod tests {
                 &[123.into()],
                 |_, _| unreachable!(),
                 |_point_id, vectors, payload| {
-                    vectors.insert("".to_string(), VectorInternal::Dense(vec![9.0; 4]));
+                    vectors.insert(
+                        DEFAULT_VECTOR_NAME.to_owned(),
+                        VectorInternal::Dense(vec![9.0; 4]),
+                    );
                     payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
                 },
                 |_| false,
@@ -1672,7 +1678,10 @@ mod tests {
 
         assert!(read_segment_1.has_point(123.into()));
 
-        let new_vector = read_segment_1.vector("", 123.into()).unwrap().unwrap();
+        let new_vector = read_segment_1
+            .vector(DEFAULT_VECTOR_NAME, 123.into())
+            .unwrap()
+            .unwrap();
         assert_eq!(new_vector, VectorInternal::Dense(vec![9.0; 4]));
         let new_payload_value = read_segment_1.payload(123.into(), &hw_counter).unwrap();
         assert_eq!(

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -218,7 +218,7 @@ mod tests {
     use parking_lot::RwLock;
     use segment::entry::entry_point::SegmentEntry;
     use segment::index::hnsw_index::num_rayon_threads;
-    use segment::types::{Distance, PayloadContainer, PayloadSchemaType};
+    use segment::types::{Distance, PayloadContainer, PayloadSchemaType, VectorName};
     use serde_json::{json, Value};
     use tempfile::Builder;
 
@@ -228,6 +228,9 @@ mod tests {
     use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
     use crate::operations::types::VectorsConfig;
     use crate::operations::vector_params_builder::VectorParamsBuilder;
+
+    const VECTOR1_NAME: &VectorName = "vector1";
+    const VECTOR2_NAME: &VectorName = "vector2";
 
     #[test]
     fn test_vacuum_conditions() {
@@ -409,11 +412,11 @@ mod tests {
         let collection_params = CollectionParams {
             vectors: VectorsConfig::Multi(BTreeMap::from([
                 (
-                    "vector1".into(),
+                    VECTOR1_NAME.to_owned(),
                     VectorParamsBuilder::new(vector1_dim, Distance::Dot).build(),
                 ),
                 (
-                    "vector2".into(),
+                    VECTOR2_NAME.to_owned(),
                     VectorParamsBuilder::new(vector2_dim, Distance::Dot).build(),
                 ),
             ])),
@@ -536,7 +539,7 @@ mod tests {
             // Delete 25% of vectors named vector1
             {
                 let id_tracker = segment.id_tracker.clone();
-                let vector1_data = segment.vector_data.get_mut("vector1").unwrap();
+                let vector1_data = segment.vector_data.get_mut(VECTOR1_NAME).unwrap();
                 let mut vector1_storage = vector1_data.vector_storage.borrow_mut();
 
                 let vector1_vecs_to_delete = id_tracker
@@ -554,7 +557,7 @@ mod tests {
             // Delete 10% of vectors named vector2
             {
                 let id_tracker = segment.id_tracker.clone();
-                let vector2_data = segment.vector_data.get_mut("vector2").unwrap();
+                let vector2_data = segment.vector_data.get_mut(VECTOR2_NAME).unwrap();
                 let mut vector2_storage = vector2_data.vector_storage.borrow_mut();
 
                 let vector2_vecs_to_delete = id_tracker

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -13,7 +13,7 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::json_path::JsonPath;
 use segment::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PointIdType,
-    SeqNumberType,
+    SeqNumberType, VectorNameBuf,
 };
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
@@ -89,7 +89,7 @@ pub(crate) fn update_vectors(
             },
             |id, owned_vectors, _| {
                 for (vector_name, vector_ref) in points_map[&id].iter() {
-                    owned_vectors.insert(vector_name.to_string(), vector_ref.to_owned());
+                    owned_vectors.insert(vector_name.to_owned(), vector_ref.to_owned());
                 }
             },
             |_| false,
@@ -109,7 +109,7 @@ pub(crate) fn delete_vectors(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: &[PointIdType],
-    vector_names: &[String],
+    vector_names: &[VectorNameBuf],
     hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_deleted_points = 0;
@@ -138,7 +138,7 @@ pub(crate) fn delete_vectors_by_filter(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     filter: &Filter,
-    vector_names: &[String],
+    vector_names: &[VectorNameBuf],
     hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let affected_points = points_by_filter(segments, filter)?;
@@ -516,7 +516,7 @@ where
         |id, vectors, old_payload| {
             let point = points_map[&id];
             for (name, vec) in point.get_vectors() {
-                vectors.insert(name.to_string(), vec.to_owned());
+                vectors.insert(name.into(), vec.to_owned());
             }
             if let Some(payload) = &point.payload {
                 *old_payload = payload.clone();

--- a/lib/collection/src/common/retrieve_request_trait.rs
+++ b/lib/collection/src/common/retrieve_request_trait.rs
@@ -1,6 +1,6 @@
 use api::rest::schema::ShardKeySelector;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
-use segment::types::PointIdType;
+use segment::types::{PointIdType, VectorNameBuf};
 
 use crate::operations::types::{DiscoverRequestInternal, RecommendRequestInternal, UsingVector};
 use crate::operations::universal_query::collection_query::{
@@ -14,7 +14,7 @@ pub trait RetrieveRequest {
 
     fn get_referenced_point_ids(&self) -> Vec<PointIdType>;
 
-    fn get_lookup_vector_name(&self) -> String;
+    fn get_lookup_vector_name(&self) -> VectorNameBuf;
 
     fn get_lookup_shard_key(&self) -> &Option<ShardKeySelector>;
 }
@@ -32,7 +32,7 @@ impl RetrieveRequest for RecommendRequestInternal {
             .collect()
     }
 
-    fn get_lookup_vector_name(&self) -> String {
+    fn get_lookup_vector_name(&self) -> VectorNameBuf {
         match &self.lookup_from {
             None => match &self.using {
                 None => DEFAULT_VECTOR_NAME.to_owned(),
@@ -84,7 +84,7 @@ impl RetrieveRequest for DiscoverRequestInternal {
         res
     }
 
-    fn get_lookup_vector_name(&self) -> String {
+    fn get_lookup_vector_name(&self) -> VectorNameBuf {
         match &self.lookup_from {
             None => match &self.using {
                 None => DEFAULT_VECTOR_NAME.to_owned(),
@@ -118,7 +118,7 @@ impl RetrieveRequest for CollectionQueryResolveRequest<'_> {
             .collect()
     }
 
-    fn get_lookup_vector_name(&self) -> String {
+    fn get_lookup_vector_name(&self) -> VectorNameBuf {
         match &self.lookup_from {
             None => self.using.clone(),
             Some(lookup_from) => match &lookup_from.vector {

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -31,7 +31,7 @@ fn discovery_into_core_search(
 
     let lookup_vector_name = request.get_lookup_vector_name();
 
-    let using = request.using.as_ref().map(|using| using.as_string());
+    let using = request.using.as_ref().map(|using| using.as_name());
 
     // Check we actually fetched all referenced vectors in this request
     let referenced_ids = request.get_referenced_point_ids();

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1797,7 +1797,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                                     .map
                                     .into_iter()
                                     .map(|(k, v)| Ok((k, v.try_into()?)))
-                                    .collect::<Result<BTreeMap<String, VectorParams>, Status>>()?,
+                                    .collect::<Result<BTreeMap<_, _>, Status>>()?,
                             ),
                         },
                     },

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -15,7 +15,7 @@ use segment::data_types::vectors::{
     BatchVectorStructInternal, MultiDenseVectorInternal, VectorInternal, VectorStructInternal,
     DEFAULT_VECTOR_NAME,
 };
-use segment::types::{Filter, Payload, PointIdType};
+use segment::types::{Filter, Payload, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumIter};
 use validator::{Validate, ValidationErrors};
@@ -192,7 +192,7 @@ impl From<VectorPersisted> for VectorInternal {
 pub enum VectorStructPersisted {
     Single(DenseVector),
     MultiDense(MultiDenseVector),
-    Named(HashMap<String, VectorPersisted>),
+    Named(HashMap<VectorNameBuf, VectorPersisted>),
 }
 
 impl Debug for VectorStructPersisted {
@@ -311,14 +311,14 @@ impl From<VectorStructPersisted> for NamedVectors<'_> {
     fn from(value: VectorStructPersisted) -> Self {
         match value {
             VectorStructPersisted::Single(vector) => {
-                NamedVectors::from_pairs([(DEFAULT_VECTOR_NAME.to_string(), vector)])
+                NamedVectors::from_pairs([(DEFAULT_VECTOR_NAME.to_owned(), vector)])
             }
             VectorStructPersisted::MultiDense(vector) => {
                 let mut named_vector = NamedVectors::default();
                 let multivec = MultiDenseVectorInternal::new_unchecked(vector);
 
                 named_vector.insert(
-                    DEFAULT_VECTOR_NAME.to_string(),
+                    DEFAULT_VECTOR_NAME.to_owned(),
                     segment::data_types::vectors::VectorInternal::from(multivec),
                 );
                 named_vector
@@ -353,11 +353,11 @@ impl PointStructPersisted {
         let mut named_vectors = NamedVectors::default();
         match &self.vector {
             VectorStructPersisted::Single(vector) => named_vectors.insert(
-                DEFAULT_VECTOR_NAME.to_string(),
+                DEFAULT_VECTOR_NAME.to_owned(),
                 VectorInternal::from(vector.clone()),
             ),
             VectorStructPersisted::MultiDense(vector) => named_vectors.insert(
-                DEFAULT_VECTOR_NAME.to_string(),
+                DEFAULT_VECTOR_NAME.to_owned(),
                 VectorInternal::from(MultiDenseVectorInternal::new_unchecked(vector.clone())),
             ),
             VectorStructPersisted::Named(vectors) => {
@@ -375,7 +375,7 @@ impl PointStructPersisted {
 pub enum BatchVectorStructPersisted {
     Single(Vec<DenseVector>),
     MultiDense(Vec<MultiDenseVector>),
-    Named(HashMap<String, Vec<VectorPersisted>>),
+    Named(HashMap<VectorNameBuf, Vec<VectorPersisted>>),
 }
 
 impl From<BatchVectorStructPersisted> for BatchVectorStructInternal {

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -3,11 +3,12 @@ use std::fmt::Debug;
 use segment::data_types::vectors::{
     DenseVector, Named, NamedQuery, NamedVectorStruct, VectorInternal,
 };
+use segment::types::VectorName;
 use segment::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::SparseVector;
 
 impl QueryEnum {
-    pub fn get_vector_name(&self) -> &str {
+    pub fn get_vector_name(&self) -> &VectorName {
         match self {
             QueryEnum::Nearest(vector) => vector.get_name(),
             QueryEnum::RecommendBestScore(reco_query) => reco_query.get_name(),
@@ -26,7 +27,7 @@ impl QueryEnum {
         }
     }
 
-    pub fn iterate_sparse(&self, mut f: impl FnMut(&str, &SparseVector)) {
+    pub fn iterate_sparse(&self, mut f: impl FnMut(&VectorName, &SparseVector)) {
         match self {
             QueryEnum::Nearest(vector) => match vector {
                 NamedVectorStruct::Sparse(named_sparse_vector) => {

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -9,8 +9,8 @@ use segment::data_types::vectors::{
 };
 use segment::json_path::JsonPath;
 use segment::types::{
-    Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, SearchParams,
-    WithPayloadInterface, WithVector,
+    Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, SearchParams, VectorName,
+    VectorNameBuf, WithPayloadInterface, WithVector,
 };
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 
@@ -28,7 +28,7 @@ use crate::recommendations::avg_vector_for_recommendation;
 pub struct CollectionQueryRequest {
     pub prefetch: Vec<CollectionPrefetch>,
     pub query: Option<Query>,
-    pub using: String,
+    pub using: VectorNameBuf,
     pub filter: Option<Filter>,
     pub score_threshold: Option<ScoreType>,
     pub limit: usize,
@@ -59,7 +59,7 @@ impl CollectionQueryRequest {
 pub struct CollectionQueryResolveRequest<'a> {
     pub vector_query: &'a VectorQuery<VectorInputInternal>,
     pub lookup_from: Option<LookupLocation>,
-    pub using: String,
+    pub using: VectorNameBuf,
 }
 
 /// Internal representation of a group query request, used to converge from REST and gRPC.
@@ -67,7 +67,7 @@ pub struct CollectionQueryResolveRequest<'a> {
 pub struct CollectionQueryGroupsRequest {
     pub prefetch: Vec<CollectionPrefetch>,
     pub query: Option<Query>,
-    pub using: String,
+    pub using: VectorNameBuf,
     pub filter: Option<Filter>,
     pub params: Option<SearchParams>,
     pub score_threshold: Option<ScoreType>,
@@ -99,9 +99,9 @@ impl Query {
     pub fn try_into_scoring_query(
         self,
         ids_to_vectors: &ReferencedVectors,
-        lookup_vector_name: &str,
+        lookup_vector_name: &VectorName,
         lookup_collection: Option<&String>,
-        using: String,
+        using: VectorNameBuf,
     ) -> CollectionResult<ScoringQuery> {
         let scoring_query = match self {
             Query::Vector(vector_query) => {
@@ -164,7 +164,7 @@ impl VectorQuery<VectorInputInternal> {
     fn ids_into_vectors(
         self,
         ids_to_vectors: &ReferencedVectors,
-        lookup_vector_name: &str,
+        lookup_vector_name: &VectorName,
         lookup_collection: Option<&String>,
     ) -> CollectionResult<VectorQuery<VectorInternal>> {
         match self {
@@ -259,7 +259,7 @@ impl VectorQuery<VectorInputInternal> {
     fn resolve_reco_reference(
         reco_query: RecoQuery<VectorInputInternal>,
         ids_to_vectors: &ReferencedVectors,
-        lookup_vector_name: &str,
+        lookup_vector_name: &VectorName,
         lookup_collection: Option<&String>,
     ) -> (Vec<VectorInternal>, Vec<VectorInternal>) {
         let positives = reco_query
@@ -288,12 +288,12 @@ impl VectorQuery<VectorInputInternal> {
     }
 }
 
-fn vector_not_found_error(vector_name: &str) -> CollectionError {
+fn vector_not_found_error(vector_name: &VectorName) -> CollectionError {
     CollectionError::not_found(format!("Vector with name {vector_name:?} for point"))
 }
 
 impl VectorQuery<VectorInternal> {
-    fn into_query_enum(self, using: String) -> CollectionResult<QueryEnum> {
+    fn into_query_enum(self, using: VectorNameBuf) -> CollectionResult<QueryEnum> {
         let query_enum = match self {
             VectorQuery::Nearest(vector) => {
                 QueryEnum::Nearest(NamedVectorStruct::new_from_vector(vector, using))
@@ -328,7 +328,7 @@ impl VectorQuery<VectorInternal> {
 pub struct CollectionPrefetch {
     pub prefetch: Vec<CollectionPrefetch>,
     pub query: Option<Query>,
-    pub using: String,
+    pub using: VectorNameBuf,
     pub filter: Option<Filter>,
     pub score_threshold: Option<ScoreType>,
     pub limit: usize,
@@ -354,7 +354,7 @@ impl CollectionPrefetch {
         self.lookup_from.as_ref().map(|x| &x.collection)
     }
 
-    fn get_lookup_vector_name(&self) -> String {
+    fn get_lookup_vector_name(&self) -> VectorNameBuf {
         self.lookup_from
             .as_ref()
             .and_then(|lookup_from| lookup_from.vector.as_ref())
@@ -456,7 +456,7 @@ impl CollectionQueryRequest {
         self.lookup_from.as_ref().map(|x| &x.collection)
     }
 
-    fn get_lookup_vector_name(&self) -> String {
+    fn get_lookup_vector_name(&self) -> VectorNameBuf {
         self.lookup_from
             .as_ref()
             .and_then(|lookup_from| lookup_from.vector.as_ref())
@@ -552,7 +552,7 @@ impl CollectionQueryRequest {
 
     pub fn validation(
         query: &Option<Query>,
-        using: &String,
+        using: &VectorNameBuf,
         prefetch: &[CollectionPrefetch],
         score_threshold: Option<ScoreType>,
     ) -> CollectionResult<()> {

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use api::rest::schema::ShardKeySelector;
 use api::rest::PointVectors;
 use schemars::JsonSchema;
-use segment::types::{Filter, PointIdType};
+use segment::types::{Filter, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
@@ -29,7 +29,7 @@ pub struct DeleteVectors {
     /// Vector names
     #[serde(alias = "vectors")]
     #[validate(length(min = 1, message = "must specify vector names to delete"))]
-    pub vector: HashSet<String>,
+    pub vector: HashSet<VectorNameBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
@@ -47,9 +47,9 @@ pub enum VectorOperations {
     /// Update vectors
     UpdateVectors(UpdateVectorsOp),
     /// Delete vectors if exists
-    DeleteVectors(PointIdsList, Vec<String>),
+    DeleteVectors(PointIdsList, Vec<VectorNameBuf>),
     /// Delete vectors by given filter criteria
-    DeleteVectorsByFilter(Filter, Vec<String>),
+    DeleteVectorsByFilter(Filter, Vec<VectorNameBuf>),
 }
 
 impl VectorOperations {

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -371,7 +371,7 @@ fn recommend_by_avg_vector(
     );
 
     let vector_name = match using {
-        None => DEFAULT_VECTOR_NAME.to_string(),
+        None => DEFAULT_VECTOR_NAME.to_owned(),
         Some(UsingVector::Name(name)) => name,
     };
 

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -12,7 +12,7 @@ use api::grpc::qdrant::{
 };
 use segment::data_types::vectors::VectorStructInternal;
 use segment::json_path::JsonPath;
-use segment::types::{Filter, PayloadFieldSchema, PointIdType, ScoredPoint};
+use segment::types::{Filter, PayloadFieldSchema, PointIdType, ScoredPoint, VectorNameBuf};
 use tonic::Status;
 
 use crate::operations::conversions::write_ordering_to_proto;
@@ -163,7 +163,7 @@ pub fn internal_delete_vectors(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     ids: Vec<PointIdType>,
-    vector_names: Vec<String>,
+    vector_names: Vec<VectorNameBuf>,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> DeleteVectorsInternal {
@@ -192,7 +192,7 @@ pub fn internal_delete_vectors_by_filter(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     filter: Filter,
-    vector_names: Vec<String>,
+    vector_names: Vec<VectorNameBuf>,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> DeleteVectorsInternal {

--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -5,7 +5,9 @@ use common::counter::hardware_accumulator::{HwMeasurementAcc, HwSharedDrain};
 use common::cpu::CpuBudget;
 use rand::rngs::ThreadRng;
 use rand::{thread_rng, RngCore};
-use segment::data_types::vectors::{NamedVector, NamedVectorStruct, VectorStructInternal};
+use segment::data_types::vectors::{
+    NamedVector, NamedVectorStruct, VectorStructInternal, DEFAULT_VECTOR_NAME,
+};
 use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
@@ -59,7 +61,7 @@ async fn test_hw_metrics_cancellation() {
     let req = CoreSearchRequestBatch {
         searches: vec![CoreSearchRequest {
             query: QueryEnum::Nearest(NamedVectorStruct::Dense(NamedVector {
-                name: "".to_string(),
+                name: DEFAULT_VECTOR_NAME.to_owned(),
                 vector: rand_vector(512, &mut rand),
             })),
             filter: None,

--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -4,6 +4,7 @@ use api::rest::{
     BaseGroupRequest, Batch, BatchVectorStruct, PointStruct, PointVectors, PointsList,
     SearchGroupsRequestInternal, SearchRequestInternal, Vector, VectorStruct,
 };
+use segment::types::VectorNameBuf;
 use sparse::common::sparse_vector::SparseVector;
 use validator::Validate;
 
@@ -20,14 +21,14 @@ fn wrong_sparse_vector() -> SparseVector {
 
 fn wrong_named_vector_struct() -> api::rest::NamedVectorStruct {
     api::rest::NamedVectorStruct::Sparse(segment::data_types::vectors::NamedSparseVector {
-        name: "sparse".to_owned(),
+        name: "sparse".into(),
         vector: wrong_sparse_vector(),
     })
 }
 
 fn wrong_point_struct() -> PointStruct {
-    let vector_data: HashMap<String, _> =
-        HashMap::from([("sparse".to_owned(), Vector::Sparse(wrong_sparse_vector()))]);
+    let vector_data: HashMap<VectorNameBuf, _> =
+        HashMap::from([("sparse".into(), Vector::Sparse(wrong_sparse_vector()))]);
     PointStruct {
         id: 0.into(),
         vector: VectorStruct::Named(vector_data),
@@ -54,10 +55,8 @@ fn validate_error_sparse_vector_point_struct() {
 
 #[test]
 fn validate_error_sparse_vector_points_batch() {
-    let vector_data: HashMap<String, Vec<_>> = HashMap::from([(
-        "sparse".to_owned(),
-        vec![Vector::Sparse(wrong_sparse_vector())],
-    )]);
+    let vector_data: HashMap<VectorNameBuf, Vec<_>> =
+        HashMap::from([("sparse".into(), vec![Vector::Sparse(wrong_sparse_vector())])]);
     check_validation_error(Batch {
         ids: vec![1.into()],
         vectors: BatchVectorStruct::Named(vector_data),
@@ -157,8 +156,8 @@ fn validate_error_sparse_vector_discover_request_internal() {
 
 #[test]
 fn validate_error_sparse_vector_point_vectors() {
-    let vector_data: HashMap<String, _> =
-        HashMap::from([("sparse".to_owned(), Vector::Sparse(wrong_sparse_vector()))]);
+    let vector_data: HashMap<VectorNameBuf, _> =
+        HashMap::from([("sparse".into(), Vector::Sparse(wrong_sparse_vector()))]);
 
     let vector_struct = VectorStruct::Named(vector_data);
 

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -7,6 +7,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
+use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 use tempfile::Builder;
 
 use crate::common::simple_collection_fixture;
@@ -27,7 +28,7 @@ async fn distance_matrix_empty() {
         sample_size,
         limit_per_sample,
         filter: None,
-        using: "".to_string(), // default vector name
+        using: DEFAULT_VECTOR_NAME.to_owned(),
     };
     let matrix = collection
         .search_points_matrix(request, ShardSelectorInternal::All, None, None, hw_acc)
@@ -77,7 +78,7 @@ async fn distance_matrix_anonymous_vector() {
         sample_size,
         limit_per_sample,
         filter: None,
-        using: "".to_string(), // default vector name
+        using: DEFAULT_VECTOR_NAME.to_owned(),
     };
     let matrix = collection
         .search_points_matrix(request, ShardSelectorInternal::All, None, None, hw_acc)

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -19,13 +19,16 @@ use std::sync::atomic::AtomicBool;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::vectors::{QueryVector, VectorRef};
-use crate::types::{SegmentConfig, SparseVectorDataConfig, VectorDataConfig};
+use crate::types::{SegmentConfig, SparseVectorDataConfig, VectorDataConfig, VectorName};
 
 pub type Flusher = Box<dyn FnOnce() -> OperationResult<()> + Send>;
 /// Check that the given vector name is part of the segment config.
 ///
 /// Returns an error if incompatible.
-pub fn check_vector_name(vector_name: &str, segment_config: &SegmentConfig) -> OperationResult<()> {
+pub fn check_vector_name(
+    vector_name: &VectorName,
+    segment_config: &SegmentConfig,
+) -> OperationResult<()> {
     // TODO(sparse) it's a wrong error check. We use the fact,
     // that get_vector_config_or_error can return only one type of error - VectorNameNotExists
     if get_vector_config_or_error(vector_name, segment_config).is_err() {
@@ -38,7 +41,7 @@ pub fn check_vector_name(vector_name: &str, segment_config: &SegmentConfig) -> O
 ///
 /// Returns an error if incompatible.
 pub fn check_vector(
-    vector_name: &str,
+    vector_name: &VectorName,
     query_vector: &QueryVector,
     segment_config: &SegmentConfig,
 ) -> OperationResult<()> {
@@ -107,7 +110,7 @@ fn check_query_sparse_vector(
 ///
 /// Returns an error if incompatible.
 pub fn check_query_vectors(
-    vector_name: &str,
+    vector_name: &VectorName,
     query_vectors: &[&QueryVector],
     segment_config: &SegmentConfig,
 ) -> OperationResult<()> {
@@ -142,14 +145,14 @@ pub fn check_named_vectors(
 ///
 /// Returns an error if incompatible.
 fn get_vector_config_or_error<'a>(
-    vector_name: &str,
+    vector_name: &VectorName,
     segment_config: &'a SegmentConfig,
 ) -> OperationResult<&'a VectorDataConfig> {
     segment_config
         .vector_data
         .get(vector_name)
         .ok_or_else(|| OperationError::VectorNameNotExists {
-            received_name: vector_name.into(),
+            received_name: vector_name.to_owned(),
         })
 }
 
@@ -157,14 +160,14 @@ fn get_vector_config_or_error<'a>(
 ///
 /// Returns an error if incompatible.
 fn get_sparse_vector_config_or_error<'a>(
-    vector_name: &str,
+    vector_name: &VectorName,
     segment_config: &'a SegmentConfig,
 ) -> OperationResult<&'a SparseVectorDataConfig> {
     segment_config
         .sparse_vector_data
         .get(vector_name)
         .ok_or_else(|| OperationError::VectorNameNotExists {
-            received_name: vector_name.into(),
+            received_name: vector_name.to_owned(),
         })
 }
 

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -9,7 +9,7 @@ use memory::mmap_type::Error as MmapError;
 use rayon::ThreadPoolBuildError;
 use thiserror::Error;
 
-use crate::types::{PayloadKeyType, PointIdType, SeqNumberType};
+use crate::types::{PayloadKeyType, PointIdType, SeqNumberType, VectorNameBuf};
 use crate::utils::mem::Mem;
 
 pub const PROCESS_CANCELLED_BY_SERVICE_MESSAGE: &str = "process cancelled by service";
@@ -23,7 +23,7 @@ pub enum OperationError {
         received_dim: usize,
     },
     #[error("Not existing vector name error: {received_name}")]
-    VectorNameNotExists { received_name: String },
+    VectorNameNotExists { received_name: VectorNameBuf },
     #[error("No point with id {missed_point_id}")]
     PointIdError { missed_point_id: PointIdType },
     #[error("Payload type does not match with previously given for field {field_name}. Expected: {expected_type}")]

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::vectors::VectorInternal;
 use crate::index::field_index::FieldIndex;
-use crate::types::PayloadKeyType;
+use crate::types::{PayloadKeyType, VectorNameBuf};
 
 pub type IndexesMap = HashMap<PayloadKeyType, Vec<FieldIndex>>;
 
@@ -48,7 +48,7 @@ pub fn merge_map(
 }
 
 pub fn transpose_map_into_named_vector<TVector: Into<VectorInternal>>(
-    map: HashMap<String, Vec<TVector>>,
+    map: HashMap<VectorNameBuf, Vec<TVector>>,
 ) -> Vec<NamedVectors<'static>> {
     let mut result = Vec::new();
     for (key, values) in map {

--- a/lib/segment/src/compat.rs
+++ b/lib/segment/src/compat.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     Distance, HnswConfig, Indexes, PayloadStorageType, QuantizationConfig, SegmentConfig,
-    SegmentState, SeqNumberType, VectorDataConfig, VectorStorageType,
+    SegmentState, SeqNumberType, VectorDataConfig, VectorNameBuf, VectorStorageType,
 };
 
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 #[deprecated = "use SegmentConfig instead"]
 pub struct SegmentConfigV5 {
-    pub vector_data: HashMap<String, VectorDataConfigV5>,
+    pub vector_data: HashMap<VectorNameBuf, VectorDataConfigV5>,
     /// Type of index used for search
     pub index: Indexes,
     /// Type of vector storage
@@ -141,7 +141,7 @@ mod tests {
         let old_segment = SegmentConfigV5 {
             vector_data: vec![
                 (
-                    "vec1".to_string(),
+                    "vec1".into(),
                     VectorDataConfigV5 {
                         size: 10,
                         distance: Distance::Dot,
@@ -158,7 +158,7 @@ mod tests {
                     },
                 ),
                 (
-                    "vec2".to_string(),
+                    "vec2".into(),
                     VectorDataConfigV5 {
                         size: 10,
                         distance: Distance::Dot,
@@ -223,7 +223,7 @@ mod tests {
         let old_segment = SegmentConfigV5 {
             vector_data: vec![
                 (
-                    "vec1".to_string(),
+                    "vec1".into(),
                     VectorDataConfigV5 {
                         size: 10,
                         distance: Distance::Dot,
@@ -233,7 +233,7 @@ mod tests {
                     },
                 ),
                 (
-                    "vec2".to_string(),
+                    "vec2".into(),
                     VectorDataConfigV5 {
                         size: 10,
                         distance: Distance::Dot,

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -18,7 +18,7 @@ use crate::telemetry::SegmentTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PointIdType,
     ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
-    SnapshotFormat, WithPayload, WithVector,
+    SnapshotFormat, VectorName, VectorNameBuf, WithPayload, WithVector,
 };
 
 /// Define all operations which can be performed with Segment or Segment-like entity.
@@ -35,7 +35,7 @@ pub trait SegmentEntry {
     #[allow(clippy::too_many_arguments)]
     fn search_batch(
         &self,
-        vector_name: &str,
+        vector_name: &VectorName,
         query_vectors: &[&QueryVector],
         with_payload: &WithPayload,
         with_vector: &WithVector,
@@ -72,7 +72,7 @@ pub trait SegmentEntry {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector_name: &str,
+        vector_name: &VectorName,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
@@ -110,7 +110,7 @@ pub trait SegmentEntry {
 
     fn vector(
         &self,
-        vector_name: &str,
+        vector_name: &VectorName,
         point_id: PointIdType,
     ) -> OperationResult<Option<VectorInternal>>;
 
@@ -185,7 +185,7 @@ pub trait SegmentEntry {
     /// Estimate available point count in this segment for given filter.
     fn estimate_point_count<'a>(&'a self, filter: Option<&'a Filter>) -> CardinalityEstimation;
 
-    fn vector_names(&self) -> HashSet<String>;
+    fn vector_names(&self) -> HashSet<VectorNameBuf>;
 
     /// Whether this segment is completely empty in terms of points
     ///
@@ -205,7 +205,7 @@ pub trait SegmentEntry {
     fn deleted_point_count(&self) -> usize;
 
     /// Size of all available vectors in storage
-    fn available_vectors_size_in_bytes(&self, vector_name: &str) -> OperationResult<usize>;
+    fn available_vectors_size_in_bytes(&self, vector_name: &VectorName) -> OperationResult<usize>;
 
     /// Max value from all `available_vectors_size_in_bytes`
     fn max_available_vectors_size_in_bytes(&self) -> OperationResult<usize> {

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use common::types::PointOffsetType;
 
-use crate::types::{FieldCondition, IsEmptyCondition, IsNullCondition};
+use crate::types::{FieldCondition, IsEmptyCondition, IsNullCondition, VectorNameBuf};
 
 pub mod bool_index;
 pub(super) mod facet_index;
@@ -30,7 +30,7 @@ pub enum PrimaryCondition {
     IsEmpty(IsEmptyCondition),
     IsNull(IsNullCondition),
     Ids(HashSet<PointOffsetType>),
-    HasVector(String),
+    HasVector(VectorNameBuf),
 }
 
 #[derive(Debug, Clone)]

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -38,7 +38,7 @@ use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     infer_collection_value_type, infer_value_type, Condition, FieldCondition, Filter,
     IsEmptyCondition, IsNullCondition, Payload, PayloadContainer, PayloadField, PayloadFieldSchema,
-    PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, VectorName,
+    PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, VectorNameBuf,
 };
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
@@ -50,7 +50,7 @@ pub struct StructPayloadIndex {
     /// Used for `has_id` condition and estimating cardinality
     pub(super) id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     /// Vector storages for each field, used for `has_vector` condition
-    pub(super) vector_storages: HashMap<VectorName, Arc<AtomicRefCell<VectorStorageEnum>>>,
+    pub(super) vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
     /// Indexes, associated with fields
     pub field_indexes: IndexesMap,
     config: PayloadConfig,
@@ -145,7 +145,7 @@ impl StructPayloadIndex {
     pub fn open(
         payload: Arc<AtomicRefCell<PayloadStorageEnum>>,
         id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-        vector_storages: HashMap<VectorName, Arc<AtomicRefCell<VectorStorageEnum>>>,
+        vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
         path: &Path,
         is_appendable: bool,
     ) -> OperationResult<Self> {

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -17,7 +17,7 @@ use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::payload_storage::{ConditionChecker, PayloadStorage};
 use crate::types::{
     Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition, MinShould,
-    OwnedPayloadRef, Payload, PayloadContainer, PayloadKeyType, VectorName,
+    OwnedPayloadRef, Payload, PayloadContainer, PayloadKeyType, VectorNameBuf,
 };
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
@@ -115,7 +115,7 @@ where
 pub fn check_payload<'a, R>(
     get_payload: Box<dyn Fn() -> OwnedPayloadRef<'a> + 'a>,
     id_tracker: Option<&IdTrackerSS>,
-    vector_storages: &HashMap<VectorName, Arc<AtomicRefCell<VectorStorageEnum>>>,
+    vector_storages: &HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
     query: &Filter,
     point_id: PointOffsetType,
     field_indexes: &HashMap<PayloadKeyType, R>,
@@ -226,7 +226,7 @@ where
 pub struct SimpleConditionChecker {
     payload_storage: Arc<AtomicRefCell<PayloadStorageEnum>>,
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-    vector_storages: HashMap<VectorName, Arc<AtomicRefCell<VectorStorageEnum>>>,
+    vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
     empty_payload: Payload,
 }
 
@@ -235,7 +235,7 @@ impl SimpleConditionChecker {
     pub fn new(
         payload_storage: Arc<AtomicRefCell<PayloadStorageEnum>>,
         id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-        vector_storages: HashMap<VectorName, Arc<AtomicRefCell<VectorStorageEnum>>>,
+        vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
     ) -> Self {
         SimpleConditionChecker {
             payload_storage,

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -26,7 +26,7 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndexEnum;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::types::{SegmentConfig, SegmentType, SeqNumberType, VectorName};
+use crate::types::{SegmentConfig, SegmentType, SeqNumberType, VectorNameBuf};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::VectorStorageEnum;
 
@@ -64,7 +64,7 @@ pub struct Segment {
     pub current_path: PathBuf,
     /// Component for mapping external ids to internal and also keeping track of point versions
     pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-    pub vector_data: HashMap<VectorName, VectorData>,
+    pub vector_data: HashMap<VectorNameBuf, VectorData>,
     pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     pub payload_storage: Arc<AtomicRefCell<PayloadStorageEnum>>,
     /// Shows if it is possible to insert more points into this segment

--- a/lib/segment/src/segment/search.rs
+++ b/lib/segment/src/segment/search.rs
@@ -12,6 +12,8 @@ use crate::data_types::vectors::VectorStructInternal;
 #[cfg(feature = "testing")]
 use crate::entry::entry_point::SegmentEntry;
 #[cfg(feature = "testing")]
+use crate::types::VectorName;
+#[cfg(feature = "testing")]
 use crate::types::{Filter, SearchParams};
 use crate::types::{ScoredPoint, WithPayload, WithVector};
 
@@ -94,7 +96,7 @@ impl Segment {
     #[cfg(feature = "testing")]
     pub fn search(
         &self,
-        vector_name: &str,
+        vector_name: &VectorName,
         vector: &QueryVector,
         with_payload: &WithPayload,
         with_vector: &WithVector,

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -26,7 +26,7 @@ use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::types::{
     Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointIdType,
-    SegmentState, SeqNumberType, SnapshotFormat,
+    SegmentState, SeqNumberType, SnapshotFormat, VectorName,
 };
 use crate::utils;
 use crate::vector_storage::VectorStorage;
@@ -351,7 +351,7 @@ impl Segment {
     #[inline]
     pub(super) fn vector_by_offset(
         &self,
-        vector_name: &str,
+        vector_name: &VectorName,
         point_offset: PointOffsetType,
     ) -> OperationResult<Option<VectorInternal>> {
         check_vector_name(vector_name, &self.segment_config)?;
@@ -630,7 +630,7 @@ impl Segment {
         }
     }
 
-    pub fn available_vector_count(&self, vector_name: &str) -> OperationResult<usize> {
+    pub fn available_vector_count(&self, vector_name: &VectorName) -> OperationResult<usize> {
         check_vector_name(vector_name, &self.segment_config)?;
         Ok(self.vector_data[vector_name]
             .vector_storage

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -41,7 +41,7 @@ use crate::segment_constructor::{
 };
 use crate::types::{
     CompactExtendedPointId, ExtendedPointId, PayloadFieldSchema, PayloadKeyType, SegmentConfig,
-    SegmentState, SeqNumberType,
+    SegmentState, SeqNumberType, VectorNameBuf,
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
@@ -51,7 +51,7 @@ pub struct SegmentBuilder {
     version: SeqNumberType,
     id_tracker: IdTrackerEnum,
     payload_storage: PayloadStorageEnum,
-    vector_storages: HashMap<String, VectorStorageEnum>,
+    vector_storages: HashMap<VectorNameBuf, VectorStorageEnum>,
     segment_config: SegmentConfig,
 
     // The path, where fully created segment will be moved
@@ -608,11 +608,11 @@ impl SegmentBuilder {
 
     fn update_quantization(
         segment_config: &SegmentConfig,
-        vector_storages: &HashMap<String, VectorStorageEnum>,
+        vector_storages: &HashMap<VectorNameBuf, VectorStorageEnum>,
         temp_path: &Path,
         permit: &CpuPermit,
         stopped: &AtomicBool,
-    ) -> OperationResult<HashMap<String, QuantizedVectors>> {
+    ) -> OperationResult<HashMap<VectorNameBuf, QuantizedVectors>> {
         let config = segment_config.clone();
 
         let mut quantized_vectors_map = HashMap::new();

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -36,7 +36,8 @@ use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::segment::{Segment, SegmentVersion, VectorData, SEGMENT_STATE_FILE};
 use crate::types::{
     Distance, Indexes, PayloadStorageType, SegmentConfig, SegmentState, SegmentType, SeqNumberType,
-    SparseVectorStorageType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
+    SparseVectorStorageType, VectorDataConfig, VectorName, VectorStorageDatatype,
+    VectorStorageType,
 };
 use crate::vector_storage::dense::appendable_dense_vector_storage::{
     open_appendable_in_ram_vector_storage, open_appendable_in_ram_vector_storage_byte,
@@ -73,7 +74,7 @@ fn sp<T>(t: T) -> Arc<AtomicRefCell<T>> {
     Arc::new(AtomicRefCell::new(t))
 }
 
-fn get_vector_name_with_prefix(prefix: &str, vector_name: &str) -> String {
+fn get_vector_name_with_prefix(prefix: &str, vector_name: &VectorName) -> String {
     if !vector_name.is_empty() {
         format!("{prefix}-{vector_name}")
     } else {
@@ -81,14 +82,14 @@ fn get_vector_name_with_prefix(prefix: &str, vector_name: &str) -> String {
     }
 }
 
-pub fn get_vector_storage_path(segment_path: &Path, vector_name: &str) -> PathBuf {
+pub fn get_vector_storage_path(segment_path: &Path, vector_name: &VectorName) -> PathBuf {
     segment_path.join(get_vector_name_with_prefix(
         VECTOR_STORAGE_PATH,
         vector_name,
     ))
 }
 
-pub fn get_vector_index_path(segment_path: &Path, vector_name: &str) -> PathBuf {
+pub fn get_vector_index_path(segment_path: &Path, vector_name: &VectorName) -> PathBuf {
     segment_path.join(get_vector_name_with_prefix(VECTOR_INDEX_PATH, vector_name))
 }
 
@@ -97,7 +98,7 @@ pub(crate) fn open_vector_storage(
     vector_config: &VectorDataConfig,
     stopped: &AtomicBool,
     vector_storage_path: &Path,
-    vector_name: &str,
+    vector_name: &VectorName,
 ) -> OperationResult<VectorStorageEnum> {
     let storage_element_type = vector_config.datatype.unwrap_or_default();
 
@@ -497,7 +498,7 @@ pub(crate) fn create_sparse_vector_index(
 pub(crate) fn create_sparse_vector_storage(
     database: Arc<RwLock<DB>>,
     path: &Path,
-    vector_name: &str,
+    vector_name: &VectorName,
     storage_type: &SparseVectorStorageType,
     stopped: &AtomicBool,
 ) -> OperationResult<VectorStorageEnum> {

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -78,7 +78,7 @@ pub fn build_multivec_segment(
 ) -> OperationResult<Segment> {
     let mut vectors_config = HashMap::new();
     vectors_config.insert(
-        "vector1".to_owned(),
+        "vector1".into(),
         VectorDataConfig {
             size: dim1,
             distance,
@@ -90,7 +90,7 @@ pub fn build_multivec_segment(
         },
     );
     vectors_config.insert(
-        "vector2".to_owned(),
+        "vector2".into(),
         VectorDataConfig {
             size: dim2,
             distance,

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -5,7 +5,7 @@ use crate::common::anonymize::Anonymize;
 use crate::common::operation_time_statistics::OperationDurationStatistics;
 use crate::types::{
     PayloadIndexInfo, SegmentConfig, SegmentInfo, SparseVectorDataConfig, VectorDataConfig,
-    VectorDataInfo,
+    VectorDataInfo, VectorNameBuf,
 };
 
 #[derive(Serialize, Clone, Debug, JsonSchema)]
@@ -40,7 +40,7 @@ impl PayloadIndexTelemetry {
 #[derive(Serialize, Clone, Debug, JsonSchema, Default)]
 pub struct VectorIndexSearchesTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub index_name: Option<String>,
+    pub index_name: Option<VectorNameBuf>,
 
     #[serde(skip_serializing_if = "OperationDurationStatistics::is_empty")]
     pub unfiltered_plain: OperationDurationStatistics,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -709,7 +709,7 @@ pub struct StrictModeSparse {
 pub struct StrictModeSparseConfig {
     #[validate(nested)]
     #[serde(flatten)]
-    pub config: BTreeMap<String, StrictModeSparse>,
+    pub config: BTreeMap<VectorNameBuf, StrictModeSparse>,
 }
 
 impl Merge for StrictModeSparseConfig {
@@ -735,7 +735,7 @@ pub struct StrictModeMultivector {
 pub struct StrictModeMultivectorConfig {
     #[validate(nested)]
     #[serde(flatten)]
-    pub config: BTreeMap<String, StrictModeMultivector>,
+    pub config: BTreeMap<VectorNameBuf, StrictModeMultivector>,
 }
 
 impl Merge for StrictModeMultivectorConfig {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -52,9 +52,10 @@ pub type DateTimePayloadType = DateTimeWrapper;
 pub type UuidPayloadType = Uuid;
 /// Type of Uuid point payload key
 pub type UuidIntType = u128;
-
-/// Name of the vector field
-pub type VectorName = String;
+/// Name of a vector
+pub type VectorName = str;
+/// Name of a vector (owned variant)
+pub type VectorNameBuf = String;
 
 /// Wraps `DateTime<Utc>` to allow more flexible deserialization
 #[derive(Clone, Copy, Serialize, JsonSchema, Debug, PartialEq, PartialOrd)]
@@ -915,10 +916,10 @@ impl PayloadStorageType {
 #[serde(rename_all = "snake_case")]
 pub struct SegmentConfig {
     #[serde(default)]
-    pub vector_data: HashMap<String, VectorDataConfig>,
+    pub vector_data: HashMap<VectorNameBuf, VectorDataConfig>,
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub sparse_vector_data: HashMap<String, SparseVectorDataConfig>,
+    pub sparse_vector_data: HashMap<VectorNameBuf, SparseVectorDataConfig>,
     /// Defines payload storage type
     pub payload_storage_type: PayloadStorageType,
 }
@@ -929,7 +930,7 @@ impl SegmentConfig {
     /// This grabs the quantization config for the given vector name if it exists.
     ///
     /// If no quantization is configured, `None` is returned.
-    pub fn quantization_config(&self, vector_name: &str) -> Option<&QuantizationConfig> {
+    pub fn quantization_config(&self, vector_name: &VectorName) -> Option<&QuantizationConfig> {
         self.vector_data
             .get(vector_name)
             .and_then(|v| v.quantization_config.as_ref())
@@ -2251,11 +2252,11 @@ pub struct HasIdCondition {
 /// Filter points which have specific vector assigned
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct HasVectorCondition {
-    pub has_vector: String,
+    pub has_vector: VectorNameBuf,
 }
 
-impl From<String> for HasVectorCondition {
-    fn from(vector: String) -> Self {
+impl From<VectorNameBuf> for HasVectorCondition {
+    fn from(vector: VectorNameBuf) -> Self {
         HasVectorCondition { has_vector: vector }
     }
 }
@@ -2445,7 +2446,7 @@ pub enum WithVector {
     /// If `false` - do not return vector
     Bool(bool),
     /// Specify which vector to return
-    Selector(Vec<String>),
+    Selector(Vec<VectorNameBuf>),
 }
 
 impl WithVector {

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -33,8 +33,8 @@ fn test_rebuild_with_removed_vectors() {
                 1,
                 i.into(),
                 NamedVectors::from_pairs([
-                    ("vector1".to_string(), vec![i as f32, 0., 0., 0.]),
-                    ("vector2".to_string(), vec![0., i as f32, 0., 0., 0., 0.]),
+                    ("vector1".into(), vec![i as f32, 0., 0., 0.]),
+                    ("vector2".into(), vec![0., i as f32, 0., 0., 0., 0.]),
                 ]),
                 &hw_counter,
             )
@@ -43,11 +43,11 @@ fn test_rebuild_with_removed_vectors() {
 
     for i in 0..NUM_VECTORS_2 {
         let vectors = if i % 5 == 0 {
-            NamedVectors::from_pairs([("vector1".to_string(), vec![0., 0., i as f32, 0.])])
+            NamedVectors::from_pairs([("vector1".into(), vec![0., 0., i as f32, 0.])])
         } else {
             NamedVectors::from_pairs([
-                ("vector1".to_string(), vec![0., 0., i as f32, 0.]),
-                ("vector2".to_string(), vec![0., 0., 0., i as f32, 0., 0.]),
+                ("vector1".into(), vec![0., 0., i as f32, 0.]),
+                ("vector2".into(), vec![0., 0., 0., i as f32, 0., 0.]),
             ])
         };
 

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -11,7 +11,7 @@ use segment::segment_constructor::build_segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
     Distance, Indexes, SegmentConfig, SparseVectorDataConfig, SparseVectorStorageType,
-    VectorDataConfig, VectorStorageType,
+    VectorDataConfig, VectorName, VectorStorageType,
 };
 use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
@@ -21,6 +21,7 @@ pub fn empty_segment(path: &Path) -> Segment {
 }
 
 pub const PAYLOAD_KEY: &str = "color";
+pub const SPARSE_VECTOR_NAME: &VectorName = "sparse";
 
 pub fn build_segment_1(path: &Path) -> Segment {
     let mut segment1 = empty_segment(path);
@@ -132,7 +133,7 @@ pub fn build_segment_3(path: &Path) -> Segment {
         &SegmentConfig {
             vector_data: HashMap::from([
                 (
-                    "vector1".to_owned(),
+                    "vector1".into(),
                     VectorDataConfig {
                         size: 4,
                         distance: Distance::Dot,
@@ -144,7 +145,7 @@ pub fn build_segment_3(path: &Path) -> Segment {
                     },
                 ),
                 (
-                    "vector2".to_owned(),
+                    "vector2".into(),
                     VectorDataConfig {
                         size: 1,
                         distance: Distance::Dot,
@@ -156,7 +157,7 @@ pub fn build_segment_3(path: &Path) -> Segment {
                     },
                 ),
                 (
-                    "vector3".to_owned(),
+                    "vector3".into(),
                     VectorDataConfig {
                         size: 4,
                         distance: Distance::Euclid,
@@ -177,9 +178,9 @@ pub fn build_segment_3(path: &Path) -> Segment {
 
     let collect_points_data = |vectors: &[DenseVector]| {
         NamedVectors::from_pairs([
-            ("vector1".to_owned(), vectors[0].clone()),
-            ("vector2".to_owned(), vectors[1].clone()),
-            ("vector3".to_owned(), vectors[2].clone()),
+            ("vector1".into(), vectors[0].clone()),
+            ("vector2".into(), vectors[1].clone()),
+            ("vector3".into(), vectors[2].clone()),
         ])
     };
 
@@ -258,7 +259,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
         &SegmentConfig {
             vector_data: Default::default(),
             sparse_vector_data: HashMap::from([(
-                "sparse".to_owned(),
+                SPARSE_VECTOR_NAME.to_owned(),
                 SparseVectorDataConfig {
                     index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
                     storage_type: SparseVectorStorageType::default(),
@@ -282,7 +283,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
         .upsert_point(
             1,
             1.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec1)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec1)),
             &hw_counter,
         )
         .unwrap();
@@ -290,7 +291,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
         .upsert_point(
             2,
             2.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec2)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec2)),
             &hw_counter,
         )
         .unwrap();
@@ -298,7 +299,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
         .upsert_point(
             3,
             3.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec3)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec3)),
             &hw_counter,
         )
         .unwrap();
@@ -306,7 +307,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
         .upsert_point(
             4,
             4.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec4)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec4)),
             &hw_counter,
         )
         .unwrap();
@@ -314,7 +315,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
         .upsert_point(
             5,
             5.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec5)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec5)),
             &hw_counter,
         )
         .unwrap();
@@ -350,7 +351,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
         &SegmentConfig {
             vector_data: Default::default(),
             sparse_vector_data: HashMap::from([(
-                "sparse".to_owned(),
+                SPARSE_VECTOR_NAME.to_owned(),
                 SparseVectorDataConfig {
                     index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
                     storage_type: SparseVectorStorageType::default(),
@@ -374,7 +375,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
         .upsert_point(
             11,
             11.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec1)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec1)),
             &hw_counter,
         )
         .unwrap();
@@ -382,7 +383,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
         .upsert_point(
             12,
             12.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec2)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec2)),
             &hw_counter,
         )
         .unwrap();
@@ -390,7 +391,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
         .upsert_point(
             13,
             13.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec3)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec3)),
             &hw_counter,
         )
         .unwrap();
@@ -398,7 +399,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
         .upsert_point(
             14,
             14.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec4)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec4)),
             &hw_counter,
         )
         .unwrap();
@@ -406,7 +407,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
         .upsert_point(
             15,
             15.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec5)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec5)),
             &hw_counter,
         )
         .unwrap();

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -26,7 +26,7 @@ use tempfile::Builder;
 
 use crate::fixtures::segment::{
     build_segment_1, build_segment_2, build_segment_sparse_1, build_segment_sparse_2,
-    empty_segment, PAYLOAD_KEY,
+    empty_segment, PAYLOAD_KEY, SPARSE_VECTOR_NAME,
 };
 
 #[test]
@@ -248,7 +248,7 @@ fn test_building_new_sparse_segment() {
         .upsert_point(
             100,
             3.into(),
-            NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec)),
+            NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vec)),
             &hw_counter,
         )
         .unwrap();

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -141,8 +141,8 @@ fn test_missed_vector_name() {
             7,
             1.into(),
             NamedVectors::from_pairs([
-                ("vector2".to_owned(), vec![10.]),
-                ("vector3".to_owned(), vec![5., 6., 7., 8.]),
+                ("vector2".into(), vec![10.]),
+                ("vector3".into(), vec![5., 6., 7., 8.]),
             ]),
             &hw_counter,
         )
@@ -154,8 +154,8 @@ fn test_missed_vector_name() {
             8,
             6.into(),
             NamedVectors::from_pairs([
-                ("vector2".to_owned(), vec![10.]),
-                ("vector3".to_owned(), vec![5., 6., 7., 8.]),
+                ("vector2".into(), vec![10.]),
+                ("vector3".into(), vec![5., 6., 7., 8.]),
             ]),
             &hw_counter,
         )
@@ -174,10 +174,10 @@ fn test_vector_name_not_exists() {
         6,
         6.into(),
         NamedVectors::from_pairs([
-            ("vector1".to_owned(), vec![5., 6., 7., 8.]),
-            ("vector2".to_owned(), vec![10.]),
-            ("vector3".to_owned(), vec![5., 6., 7., 8.]),
-            ("vector4".to_owned(), vec![5., 6., 7., 8.]),
+            ("vector1".into(), vec![5., 6., 7., 8.]),
+            ("vector2".into(), vec![10.]),
+            ("vector3".into(), vec![5., 6., 7., 8.]),
+            ("vector4".into(), vec![5., 6., 7., 8.]),
         ]),
         &hw_counter,
     );

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -24,8 +24,9 @@ use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use sparse::common::sparse_vector::SparseVector;
 use tempfile::Builder;
 
+use crate::fixtures::segment::SPARSE_VECTOR_NAME;
+
 const MAX_EXAMPLE_PAIRS: usize = 3;
-const SPARSE_VECTOR_NAME: &str = "sparse_test";
 
 fn convert_to_sparse_vector(vector: &[VectorElementType]) -> SparseVector {
     let mut sparse_vector = SparseVector::default();

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -28,7 +28,7 @@ use segment::types::PayloadFieldSchema::FieldType;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
     Condition, FieldCondition, Filter, Payload, ScoredPoint, SegmentConfig, SeqNumberType,
-    SparseVectorDataConfig, SparseVectorStorageType, VectorStorageDatatype,
+    SparseVectorDataConfig, SparseVectorStorageType, VectorName, VectorStorageDatatype,
     DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
 use segment::vector_storage::VectorStorage;
@@ -56,7 +56,7 @@ const LOW_FULL_SCAN_THRESHOLD: usize = 1;
 /// Full scan threshold to force plain search
 const LARGE_FULL_SCAN_THRESHOLD: usize = 10 * NUM_VECTORS;
 
-const SPARSE_VECTOR_NAME: &str = "sparse_vector";
+const SPARSE_VECTOR_NAME: &VectorName = "sparse_vector";
 
 /// Expects the filter to match ALL points in order to compare the results with/without filter
 fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize) {

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -16,6 +16,7 @@ use collection::shards::{replica_set, CollectionId};
 use schemars::JsonSchema;
 use segment::types::{
     PayloadFieldSchema, PayloadKeyType, QuantizationConfig, ShardKey, StrictModeConfig,
+    VectorNameBuf,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -171,7 +172,7 @@ pub struct CreateCollection {
     pub quantization_config: Option<QuantizationConfig>,
     /// Sparse vector data config.
     #[validate(nested)]
-    pub sparse_vectors: Option<BTreeMap<String, SparseVectorParams>>,
+    pub sparse_vectors: Option<BTreeMap<VectorNameBuf, SparseVectorParams>>,
     /// Strict-mode config.
     #[validate(nested)]
     pub strict_mode_config: Option<StrictModeConfig>,

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -11,6 +11,7 @@ use collection::shards::collection_shard_distribution::CollectionShardDistributi
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::CollectionId;
+use segment::types::VectorNameBuf;
 
 use super::TableOfContent;
 use crate::content_manager::collection_meta_ops::*;
@@ -265,7 +266,7 @@ impl TableOfContent {
     async fn check_collections_compatibility(
         &self,
         vectors: &VectorsConfig,
-        sparse_vectors: &Option<BTreeMap<String, SparseVectorParams>>,
+        sparse_vectors: &Option<BTreeMap<VectorNameBuf, SparseVectorParams>>,
         source_collection: &CollectionId,
     ) -> Result<(), StorageError> {
         let collection = self.get_collection_unchecked(source_collection).await?;

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -767,10 +767,10 @@ mod tests_ops {
             with_payload: Some(WithPayloadInterface::Bool(true)),
             with_vector: Some(WithVector::Bool(true)),
             score_threshold: Some(42.0),
-            using: Some(UsingVector::Name("vector".to_string())),
+            using: Some(UsingVector::Name("vector".into())),
             lookup_from: Some(LookupLocation {
                 collection: "col2".to_string(),
-                vector: Some("vector".to_string()),
+                vector: Some("vector".into()),
                 shard_key: None,
             }),
         };
@@ -1006,10 +1006,10 @@ mod tests_ops {
             offset: Some(100),
             with_payload: Some(WithPayloadInterface::Bool(true)),
             with_vector: Some(WithVector::Bool(true)),
-            using: Some(UsingVector::Name("vector".to_string())),
+            using: Some(UsingVector::Name("vector".into())),
             lookup_from: Some(LookupLocation {
                 collection: "col2".to_string(),
-                vector: Some("vector".to_string()),
+                vector: Some("vector".into()),
                 shard_key: None,
             }),
         };
@@ -1257,7 +1257,7 @@ mod tests_ops {
                             points: vec![ExtendedPointId::NumId(12345)],
                             shard_key: None,
                         },
-                        vec!["vector".to_string()],
+                        vec!["vector".into()],
                     ));
                 check_collection_update_operations_delete_vectors(&op);
             }
@@ -1265,7 +1265,7 @@ mod tests_ops {
                 let op = CollectionUpdateOperations::VectorOperation(
                     VectorOperations::DeleteVectorsByFilter(
                         make_filter_from_ids(vec![ExtendedPointId::NumId(12345)]),
-                        vec!["vector".to_string()],
+                        vec!["vector".into()],
                     ),
                 );
                 check_collection_update_operations_delete_vectors(&op);
@@ -1300,7 +1300,7 @@ mod tests_ops {
                     VectorOperations::DeleteVectorsByFilter(
                         make_filter_from_ids(vec![ExtendedPointId::NumId(12345)])
                             .merge_owned(PayloadConstraint::new_test("col").to_filter()),
-                        vec!["vector".to_string()],
+                        vec!["vector".into()],
                     ),
                 );
             },

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -77,7 +77,7 @@ pub async fn convert_query_point_groups_from_grpc(
     let request = CollectionQueryGroupsRequest {
         prefetch,
         query,
-        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
         filter: filter.map(TryFrom::try_from).transpose()?,
         score_threshold,
         with_vector: with_vectors
@@ -154,7 +154,7 @@ pub async fn convert_query_points_from_grpc(
     Ok(CollectionQueryRequest {
         prefetch,
         query,
-        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
         filter: filter.map(TryFrom::try_from).transpose()?,
         score_threshold,
         limit: limit
@@ -202,7 +202,7 @@ fn convert_prefetch_with_inferred(
     Ok(CollectionPrefetch {
         prefetch: nested_prefetches,
         query,
-        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
         filter: filter.map(TryFrom::try_from).transpose()?,
         score_threshold,
         limit: limit

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -55,7 +55,7 @@ pub async fn convert_query_groups_request_from_rest(
     Ok(CollectionQueryGroupsRequest {
         prefetch,
         query,
-        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
         filter,
         score_threshold,
         params,
@@ -111,7 +111,7 @@ pub async fn convert_query_request_from_rest(
     Ok(CollectionQueryRequest {
         prefetch,
         query,
-        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
         filter,
         score_threshold,
         limit: limit.unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
@@ -264,7 +264,7 @@ fn convert_prefetch_with_inferred(
     Ok(CollectionPrefetch {
         prefetch: nested_prefetches,
         query,
-        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
         filter,
         score_threshold,
         limit: limit.unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -2039,7 +2039,7 @@ pub async fn search_points_matrix(
             .transpose()
             .map_err(|_| Status::invalid_argument("could not parse 'limit' param into usize"))?
             .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_LIMIT_PER_SAMPLE),
-        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_string()),
+        using: using.unwrap_or(DEFAULT_VECTOR_NAME.to_owned()),
     };
 
     let toc = toc_provider


### PR DESCRIPTION
This PR replaces usages like `vector_name: &str` to use the following type aliases instead of raw `str` or `String`:

```rust
/// Name of a vector
pub type VectorName = str;
/// Name of a vector (owned variant)
pub type VectorNameBuf = String;
```

The naming is an analogy to `Path`/`PathBuf`.

Later these aliases could be replaced with newtypes. To aid with that, this PR updates the code that assumes strings to use more generic methods, e.g., `name.to_string()` → `name.to_owned()`.