### PR TITLE
Fix Clippy unused import on Windows

### DIFF
--- a/src/common/telemetry_ops/memory_telemetry.rs
+++ b/src/common/telemetry_ops/memory_telemetry.rs
@@ -1,7 +1,12 @@
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::Serialize;
-use storage::rbac::{Access, AccessRequirements};
+use storage::rbac::Access;
+#[cfg(all(
+    not(target_env = "msvc"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+use storage::rbac::AccessRequirements;
 #[cfg(all(
     not(target_env = "msvc"),
     any(target_arch = "x86_64", target_arch = "aarch64")


### PR DESCRIPTION
Spotted on CI.

```
warning: unused import: `AccessRequirements`
 --> src\common\telemetry_ops\memory_telemetry.rs:4:29
  |
4 | use storage::rbac::{Access, AccessRequirements};
  |                             ^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```