### PR TITLE
Update config 0.15.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,13 +1270,13 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.14.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
+checksum = "3d84f8d224ac58107d53d3ec2b9ad39fd8c8c4e285d3c9cb35485ffd2ca88cb3"
 dependencies = [
- "nom",
  "pathdiff",
  "serde",
+ "winnow",
  "yaml-rust2",
 ]
 
@@ -7695,6 +7695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7749,9 +7758,9 @@ checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+checksum = "2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d"
 dependencies = [
  "arraydeque",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ uuid = { workspace = true }
 sys-info = "0.9.1"
 wal = { workspace = true }
 
-config = { version = "0.14.1", default-features = false, features = ["yaml"] }
+config = { version = "0.15.4", default-features = false, features = ["yaml"] }
 
 tokio = { workspace = true }
 

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -16,12 +16,13 @@ use crate::operations::snapshot_storage_ops::{self};
 use crate::operations::types::{CollectionError, CollectionResult};
 
 #[derive(Clone, Deserialize, Debug, Default)]
-pub struct SnapShotsConfig {
+pub struct SnapshotsConfig {
     pub snapshots_storage: SnapshotsStorageConfig,
     pub s3_config: Option<S3Config>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum SnapshotsStorageConfig {
     #[default]
     Local,
@@ -53,7 +54,7 @@ pub enum SnapshotStorageManager {
 }
 
 impl SnapshotStorageManager {
-    pub fn new(snapshots_config: &SnapShotsConfig) -> CollectionResult<Self> {
+    pub fn new(snapshots_config: &SnapshotsConfig) -> CollectionResult<Self> {
         match snapshots_config.snapshots_storage {
             SnapshotsStorageConfig::Local => {
                 Ok(SnapshotStorageManager::LocalFS(SnapshotStorageLocalFS))

--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -2,7 +2,7 @@ use std::default;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
-use crate::common::snapshots_manager::SnapShotsConfig;
+use crate::common::snapshots_manager::SnapshotsConfig;
 use crate::operations::types::NodeType;
 use crate::shards::transfer::ShardTransferMethod;
 
@@ -30,7 +30,7 @@ pub struct SharedStorageConfig {
     pub incoming_shard_transfers_limit: Option<usize>,
     pub outgoing_shard_transfers_limit: Option<usize>,
     pub snapshots_path: String,
-    pub snapshots_config: SnapShotsConfig,
+    pub snapshots_config: SnapshotsConfig,
 }
 
 impl Default for SharedStorageConfig {
@@ -66,7 +66,7 @@ impl SharedStorageConfig {
         incoming_shard_transfers_limit: Option<usize>,
         outgoing_shard_transfers_limit: Option<usize>,
         snapshots_path: String,
-        snapshots_config: SnapShotsConfig,
+        snapshots_config: SnapshotsConfig,
     ) -> Self {
         let update_queue_size = update_queue_size.unwrap_or(match node_type {
             NodeType::Normal => DEFAULT_UPDATE_QUEUE_SIZE,

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use collection::common::snapshots_manager::SnapShotsConfig;
+use collection::common::snapshots_manager::SnapshotsConfig;
 use collection::config::{default_on_disk_payload, WalConfig};
 use collection::operations::config_diff::OptimizersConfigDiff;
 use collection::operations::shared_storage_config::{
@@ -60,7 +60,7 @@ pub struct StorageConfig {
     #[validate(length(min = 1))]
     pub snapshots_path: String,
     #[serde(default)]
-    pub snapshots_config: SnapShotsConfig,
+    pub snapshots_config: SnapshotsConfig,
     #[validate(length(min = 1))]
     #[serde(default)]
     pub temp_path: Option<String>,


### PR DESCRIPTION
This PR updates to config [0.15.4](https://github.com/rust-cli/config-rs/blob/main/CHANGELOG.md#change-log)

The most important changes is that the configuration keys are now case sensitive.

We are only impacted for the `SnapshotsStorageConfig` where our default configuration uses lower case.

The solution is to apply `#[serde(rename_all = "lowercase")]` to the enum as usual.