### PR TITLE
IO metrics in hw counter types

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2811,6 +2811,8 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | cpu | [uint64](#uint64) |  |  |
+| io_read | [uint64](#uint64) |  |  |
+| io_write | [uint64](#uint64) |  |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12362,10 +12362,22 @@
         "description": "Usage of the hardware resources, spent to process the request",
         "type": "object",
         "required": [
-          "cpu"
+          "cpu",
+          "io_read",
+          "io_write"
         ],
         "properties": {
           "cpu": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "io_read": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "io_write": {
             "type": "integer",
             "format": "uint",
             "minimum": 0

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2233,6 +2233,8 @@ impl From<HwMeasurementAcc> for HardwareUsage {
     fn from(value: HwMeasurementAcc) -> Self {
         Self {
             cpu: value.get_cpu() as u64,
+            io_read: value.get_io_read() as u64,
+            io_write: value.get_io_write() as u64,
         }
     }
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -1098,4 +1098,6 @@ message GeoPoint {
 
 message HardwareUsage {
   uint64 cpu = 1;
+  uint64 io_read = 2;
+  uint64 io_write = 3;
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6288,6 +6288,10 @@ pub struct GeoPoint {
 pub struct HardwareUsage {
     #[prost(uint64, tag = "1")]
     pub cpu: u64,
+    #[prost(uint64, tag = "2")]
+    pub io_read: u64,
+    #[prost(uint64, tag = "3")]
+    pub io_write: u64,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/lib/api/src/rest/models.rs
+++ b/lib/api/src/rest/models.rs
@@ -52,6 +52,8 @@ pub struct ApiResponse<D> {
 #[serde(rename_all = "snake_case")]
 pub struct HardwareUsage {
     pub cpu: usize,
+    pub io_read: usize,
+    pub io_write: usize,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -787,7 +787,11 @@ impl ShardOperation for RemoteShard {
         } = search_batch_response;
 
         if let Some(usage) = usage {
-            hw_measurement_acc.accumulate_request(usage.cpu as usize);
+            hw_measurement_acc.accumulate_request(
+                usage.cpu as usize,
+                usage.io_read as usize,
+                usage.io_write as usize,
+            );
         }
 
         let result: Result<Vec<Vec<ScoredPoint>>, Status> = result
@@ -852,7 +856,11 @@ impl ShardOperation for RemoteShard {
         } = count_response;
 
         if let Some(usage) = usage {
-            hw_measurement_acc.accumulate_request(usage.cpu as usize);
+            hw_measurement_acc.accumulate_request(
+                usage.cpu as usize,
+                usage.io_read as usize,
+                usage.io_write as usize,
+            );
         }
 
         result.map_or_else(
@@ -953,7 +961,11 @@ impl ShardOperation for RemoteShard {
         } = batch_response;
 
         if let Some(usage) = usage {
-            hw_measurement_acc.accumulate_request(usage.cpu as usize);
+            hw_measurement_acc.accumulate_request(
+                usage.cpu as usize,
+                usage.io_read as usize,
+                usage.io_write as usize,
+            );
         }
 
         let result = results

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -41,12 +41,12 @@ impl HardwareCounterCell {
     }
 
     #[cfg(feature = "testing")]
-    pub fn new_with(cpu: usize) -> Self {
+    pub fn new_with(cpu: usize, io_read: usize, io_write: usize) -> Self {
         Self {
             cpu_multiplier: 1,
             cpu_counter: CounterCell::new_with(cpu),
-            io_read_counter: CounterCell::new(),
-            io_write_counter: CounterCell::new(),
+            io_read_counter: CounterCell::new_with(io_read),
+            io_write_counter: CounterCell::new_with(io_write),
             accumulator: HwMeasurementAcc::new(),
         }
     }

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -10,6 +10,8 @@ use super::hardware_accumulator::HwMeasurementAcc;
 pub struct HardwareCounterCell {
     cpu_multiplier: usize,
     pub(super) cpu_counter: CounterCell,
+    pub(super) io_read_counter: CounterCell,
+    pub(super) io_write_counter: CounterCell,
     pub(super) accumulator: HwMeasurementAcc,
 }
 
@@ -19,6 +21,8 @@ impl HardwareCounterCell {
         Self {
             cpu_multiplier: 1,
             cpu_counter: CounterCell::new(),
+            io_read_counter: CounterCell::new(),
+            io_write_counter: CounterCell::new(),
             accumulator: HwMeasurementAcc::new(),
         }
     }
@@ -30,6 +34,8 @@ impl HardwareCounterCell {
         Self {
             cpu_multiplier: 1,
             cpu_counter: CounterCell::new(),
+            io_read_counter: CounterCell::new(),
+            io_write_counter: CounterCell::new(),
             accumulator: HwMeasurementAcc::disposable(),
         }
     }
@@ -39,6 +45,8 @@ impl HardwareCounterCell {
         Self {
             cpu_multiplier: 1,
             cpu_counter: CounterCell::new_with(cpu),
+            io_read_counter: CounterCell::new(),
+            io_write_counter: CounterCell::new(),
             accumulator: HwMeasurementAcc::new(),
         }
     }
@@ -47,6 +55,8 @@ impl HardwareCounterCell {
         Self {
             cpu_multiplier: 1,
             cpu_counter: CounterCell::new(),
+            io_read_counter: CounterCell::new(),
+            io_write_counter: CounterCell::new(),
             accumulator,
         }
     }
@@ -58,6 +68,8 @@ impl HardwareCounterCell {
         Self {
             cpu_multiplier: self.cpu_multiplier,
             cpu_counter: CounterCell::new(),
+            io_read_counter: CounterCell::new(),
+            io_write_counter: CounterCell::new(),
             accumulator: self.accumulator.clone(),
         }
     }
@@ -76,9 +88,37 @@ impl HardwareCounterCell {
         &mut self.cpu_counter
     }
 
+    #[inline]
+    pub fn io_read_counter(&self) -> &CounterCell {
+        &self.io_read_counter
+    }
+
+    #[inline]
+    pub fn io_read_counter_mut(&mut self) -> &mut CounterCell {
+        &mut self.io_read_counter
+    }
+
+    #[inline]
+    pub fn io_write_counter(&self) -> &CounterCell {
+        &self.io_write_counter
+    }
+
+    #[inline]
+    pub fn io_write_mut(&mut self) -> &mut CounterCell {
+        &mut self.io_write_counter
+    }
+
     fn merge_to_accumulator(&self) {
-        let cpu_value = self.cpu_counter.get() * self.cpu_multiplier;
-        self.accumulator.accumulate(cpu_value);
+        let HardwareCounterCell {
+            cpu_multiplier,
+            cpu_counter,
+            io_read_counter,
+            io_write_counter,
+            accumulator,
+        } = self;
+
+        let cpu_value = cpu_counter.get() * cpu_multiplier;
+        accumulator.accumulate(cpu_value, io_read_counter.get(), io_write_counter.get());
     }
 }
 

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -667,7 +667,15 @@ impl TableOfContent {
     pub fn all_hw_metrics(&self) -> HashMap<String, HardwareUsage> {
         self.collection_hw_metrics
             .iter()
-            .map(|i| (i.key().to_string(), HardwareUsage { cpu: i.get_cpu() }))
+            .map(|i| {
+                let key = i.key().to_string();
+                let hw_usage = HardwareUsage {
+                    cpu: i.get_cpu(),
+                    io_read: i.get_io_read(),
+                    io_write: i.get_io_write(),
+                };
+                (key, hw_usage)
+            })
             .collect()
     }
 }

--- a/lib/storage/src/content_manager/toc/request_hw_counter.rs
+++ b/lib/storage/src/content_manager/toc/request_hw_counter.rs
@@ -34,6 +34,8 @@ impl RequestHwCounter {
         if self.report_to_api {
             Some(api::rest::models::HardwareUsage {
                 cpu: self.counter.get_cpu(),
+                io_read: self.counter.get_io_read(),
+                io_write: self.counter.get_io_write(),
             })
         } else {
             None
@@ -44,6 +46,8 @@ impl RequestHwCounter {
         if self.report_to_api {
             Some(api::grpc::qdrant::HardwareUsage {
                 cpu: self.counter.get_cpu() as u64,
+                io_read: self.counter.get_io_read() as u64,
+                io_write: self.counter.get_io_write() as u64,
             })
         } else {
             None

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -327,13 +327,31 @@ impl MetricsProvider for MemoryTelemetry {
 impl MetricsProvider for HardwareTelemetry {
     fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
         for (collection, hw_info) in self.collection_data.iter() {
-            let HardwareUsage { cpu } = hw_info;
+            let HardwareUsage {
+                cpu,
+                io_read,
+                io_write,
+            } = hw_info;
 
             metrics.push(metric_family(
                 "collection_hardware_metric_cpu",
                 "CPU measurements of a collection",
                 MetricType::GAUGE,
                 vec![gauge(*cpu as f64, &[("id", collection)])],
+            ));
+
+            metrics.push(metric_family(
+                "collection_hardware_metric_io_read",
+                "Total IO read metrics of a collection",
+                MetricType::GAUGE,
+                vec![gauge(*io_read as f64, &[("id", collection)])],
+            ));
+
+            metrics.push(metric_family(
+                "collection_hardware_metric_io_write",
+                "Total IO write metrics of a collection",
+                MetricType::GAUGE,
+                vec![gauge(*io_write as f64, &[("id", collection)])],
             ));
         }
     }


### PR DESCRIPTION
Adds two new metrics (`io_read` and `io_write`) to hardware counter types and Telemetry