### PR TITLE
Test: build binaries on CI to test recent RocksDB change

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,10 +1,10 @@
 name: Build and publish release packages
-permissions:
-  contents: write
+
 on:
-  release:
-    # 'published' is triggered when publishing draft release, 'created' is not
-    types: [published]
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   build-linux-binaries:
@@ -46,22 +46,13 @@ jobs:
         with:
           bin: qdrant
           target: ${{ matrix.target }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: true
       - name: Build Debian Package
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           bash -x tools/sync-web-ui.sh
           cargo install cargo-deb
           cargo deb --no-strip --target ${{ matrix.target }}
-      - name: Upload Debian package
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/${{ matrix.target }}/debian/*.deb
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
 
   build-mac-binaries:
     strategy:
@@ -87,7 +78,7 @@ jobs:
         with:
           bin: qdrant
           target: ${{ matrix.target }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: true
 
   build-windows-binaries:
     strategy:
@@ -112,7 +103,7 @@ jobs:
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: qdrant
-          token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: true
 
   build-app-image:
     strategy:
@@ -138,40 +129,3 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release
-
-      - name: Build AppImage
-        shell: bash
-        run: |
-          mkdir -p AppDir
-          cp docs/logo.svg qdrant.svg
-          cp target/release/qdrant .
-
-          curl -Lo linuxdeploy-x86_64.AppImage \
-              https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-          chmod +x linuxdeploy-x86_64.AppImage
-
-          ./linuxdeploy-x86_64.AppImage \
-              --appdir AppDir \
-              --executable qdrant \
-              -d pkg/appimage/qdrant.desktop \
-              -i qdrant.svg \
-              --custom-apprun pkg/appimage/AppRun.sh
-
-          wget -O dist-qdrant.zip "$(curl --silent "https://api.github.com/repos/qdrant/qdrant-web-ui/releases/latest" | jq -r '.assets[] | select(.name=="dist-qdrant.zip") | .browser_download_url')"          
-          unzip -o dist-qdrant.zip -d static
-          mv -n static/dist/* static/
-          rm -rf static/dist
-          mv static AppDir/usr/share
-
-          ./linuxdeploy-x86_64.AppImage \
-              --appdir AppDir \
-              --output appimage
-
-      - name: Upload AppImage
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: "qdrant-x86_64.AppImage"
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true


### PR DESCRIPTION
Build binaries on CI once to confirm <https://github.com/qdrant/qdrant/pull/5768> did not introduce problems.

Once CI is green we can close this PR - it'd mean the test has passed.