### PR TITLE
Measure payload read IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "bustle",
+ "common",
  "criterion",
  "csv",
  "dataset",

--- a/lib/blob_store/Cargo.toml
+++ b/lib/blob_store/Cargo.toml
@@ -25,6 +25,7 @@ itertools = { workspace = true }
 io = { path = "../common/io" }
 memory = { path = "../common/memory" }
 dataset = { path = "../common/dataset" }
+common = { path = "../common/common" }
 
 # this is not on dev-dependencies because dev-dependencies cannot be optional :(
 rocksdb = { version = "0.23.0", optional = true }

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -1,6 +1,7 @@
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use io::file_operations::atomic_save_json;
 use lz4_flex::compress_prepend_size;
 use memory::mmap_type;
@@ -224,6 +225,28 @@ impl<V: Blob> BlobStore<V> {
         } = self.get_pointer(point_offset)?;
 
         let raw = self.read_from_pages(page_id, block_offset, length);
+        let decompressed = self.decompress(raw);
+        let value = V::from_bytes(&decompressed);
+
+        Some(value)
+    }
+
+    /// Get the value for a given point offset
+    pub fn get_value_measured(
+        &self,
+        point_offset: PointOffset,
+        hw_counter: &HardwareCounterCell,
+    ) -> Option<V> {
+        let ValuePointer {
+            page_id,
+            block_offset,
+            length,
+        } = self.get_pointer(point_offset)?;
+
+        let raw = self.read_from_pages(page_id, block_offset, length);
+
+        hw_counter.io_read_counter().incr_delta(raw.len());
+
         let decompressed = self.decompress(raw);
         let value = V::from_bytes(&decompressed);
 

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -216,19 +216,10 @@ impl<V: Blob> BlobStore<V> {
         raw_sections
     }
 
+    // TODO(io_measurement): Replace with `get_value_measured`
     /// Get the value for a given point offset
     pub fn get_value(&self, point_offset: PointOffset) -> Option<V> {
-        let ValuePointer {
-            page_id,
-            block_offset,
-            length,
-        } = self.get_pointer(point_offset)?;
-
-        let raw = self.read_from_pages(page_id, block_offset, length);
-        let decompressed = self.decompress(raw);
-        let value = V::from_bytes(&decompressed);
-
-        Some(value)
+        self.get_value_measured(point_offset, &HardwareCounterCell::disposable())
     }
 
     /// Get the value for a given point offset

--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use cancel::{CancellationToken, DropGuard};
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use parking_lot::RwLock;
 use segment::types::{Condition, Filter};
 use tokio::sync::watch::{Receiver, Sender};
@@ -293,6 +294,7 @@ async fn clean_task(
                 true,
                 None,
                 None,
+                HwMeasurementAcc::disposable(),
             )
             .await
         {

--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -294,7 +294,7 @@ async fn clean_task(
                 true,
                 None,
                 None,
-                HwMeasurementAcc::disposable(),
+                HwMeasurementAcc::disposable(), // Internal operation, no measurement needed!
             )
             .await
         {

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -239,6 +239,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<ScrollResult> {
         let default_request = ScrollRequestInternal::default();
 
@@ -290,6 +291,7 @@ impl Collection {
                         local_only,
                         order_by.as_ref(),
                         timeout,
+                        hw_measurement_acc.clone(),
                     )
                     .and_then(move |mut records| async move {
                         if shard_key.is_none() {
@@ -412,6 +414,7 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let with_payload_interface = request
             .with_payload
@@ -431,6 +434,8 @@ impl Collection {
                 let request = &request;
                 let with_payload = &with_payload;
 
+                let hw_acc = hw_measurement_acc.clone();
+
                 async move {
                     let mut records = shard
                         .retrieve(
@@ -440,6 +445,7 @@ impl Collection {
                             read_consistency,
                             timeout,
                             shard_selection.is_shard_id(),
+                            hw_acc,
                         )
                         .await?;
 

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -213,6 +213,7 @@ impl Collection {
             collection_by_name,
             read_consistency,
             timeout,
+            hw_measurement_acc.clone(),
         )
         .await?;
 

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -68,6 +68,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
     use itertools::Itertools;
     use parking_lot::RwLockUpgradableReadGuard;
     use segment::data_types::vectors::{
@@ -168,6 +169,7 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()
@@ -203,6 +205,7 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()
@@ -242,6 +245,7 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()
@@ -277,6 +281,7 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()
@@ -293,6 +298,7 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()
@@ -315,6 +321,7 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()
@@ -381,6 +388,7 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()
@@ -442,6 +450,7 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
             &is_stopped,
+            HwMeasurementAcc::new(),
         )
         .unwrap()
         .into_values()

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use parking_lot::RwLock;
 use rand::rngs::ThreadRng;
 use rand::Rng;
@@ -65,6 +66,7 @@ pub fn random_multi_vec_segment(
     let mut rnd = rand::thread_rng();
     let payload_key = "number";
     let keyword_key = "keyword";
+    let hw_counter = HardwareCounterCell::new();
     for _ in 0..num_vectors {
         let random_vector1: Vec<_> = (0..dim1).map(|_| rnd.gen_range(0.0..1.0)).collect();
         let random_vector2: Vec<_> = (0..dim2).map(|_| rnd.gen_range(0.0..1.0)).collect();
@@ -77,9 +79,11 @@ pub fn random_multi_vec_segment(
         let random_keyword = format!("keyword_{}", rnd.gen_range(1..10));
         let payload: Payload =
             json!({ payload_key: vec![payload_value], keyword_key: random_keyword}).into();
-        segment.upsert_point(opnum, point_id, vectors).unwrap();
         segment
-            .set_payload(opnum, point_id, &payload, &None)
+            .upsert_point(opnum, point_id, vectors, &hw_counter)
+            .unwrap();
+        segment
+            .set_payload(opnum, point_id, &payload, &None, &hw_counter)
             .unwrap();
     }
     segment
@@ -90,16 +94,22 @@ pub fn random_segment(path: &Path, opnum: SeqNumberType, num_vectors: u64, dim: 
     let mut segment = build_simple_segment(path, dim, Distance::Dot).unwrap();
     let mut rnd = rand::thread_rng();
     let payload_key = "number";
+    let hw_counter = HardwareCounterCell::new();
     for _ in 0..num_vectors {
         let random_vector: Vec<_> = (0..dim).map(|_| rnd.gen_range(0.0..1.0)).collect();
         let point_id: PointIdType = id_gen.unique();
         let payload_value = rnd.gen_range(1..1_000);
         let payload: Payload = json!({ payload_key: vec![payload_value] }).into();
         segment
-            .upsert_point(opnum, point_id, only_default_vector(&random_vector))
+            .upsert_point(
+                opnum,
+                point_id,
+                only_default_vector(&random_vector),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .set_payload(opnum, point_id, &payload, &None)
+            .set_payload(opnum, point_id, &payload, &None, &hw_counter)
             .unwrap();
     }
     segment
@@ -114,20 +124,22 @@ pub fn build_segment_1(path: &Path) -> Segment {
     let vec4 = vec![1.0, 1.0, 0.0, 1.0];
     let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment1
-        .upsert_point(1, 1.into(), only_default_vector(&vec1))
+        .upsert_point(1, 1.into(), only_default_vector(&vec1), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(2, 2.into(), only_default_vector(&vec2))
+        .upsert_point(2, 2.into(), only_default_vector(&vec2), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(3, 3.into(), only_default_vector(&vec3))
+        .upsert_point(3, 3.into(), only_default_vector(&vec3), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(4, 4.into(), only_default_vector(&vec4))
+        .upsert_point(4, 4.into(), only_default_vector(&vec4), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(5, 5.into(), only_default_vector(&vec5))
+        .upsert_point(5, 5.into(), only_default_vector(&vec5), &hw_counter)
         .unwrap();
 
     let payload_key = "color";
@@ -138,19 +150,19 @@ pub fn build_segment_1(path: &Path) -> Segment {
     let payload_option3: Payload = json!({ payload_key: vec!["blue".to_owned()] }).into();
 
     segment1
-        .set_payload(6, 1.into(), &payload_option1, &None)
+        .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 2.into(), &payload_option1, &None)
+        .set_payload(6, 2.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 3.into(), &payload_option3, &None)
+        .set_payload(6, 3.into(), &payload_option3, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 4.into(), &payload_option2, &None)
+        .set_payload(6, 4.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 5.into(), &payload_option2, &None)
+        .set_payload(6, 5.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
 
     segment1
@@ -168,27 +180,29 @@ pub fn build_segment_2(path: &Path) -> Segment {
     let vec14 = vec![1.0, 0.0, 0.0, 1.0];
     let vec15 = vec![1.0, 1.0, 0.0, 0.0];
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment2
-        .upsert_point(7, 4.into(), only_default_vector(&vec4))
+        .upsert_point(7, 4.into(), only_default_vector(&vec4), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(8, 5.into(), only_default_vector(&vec5))
+        .upsert_point(8, 5.into(), only_default_vector(&vec5), &hw_counter)
         .unwrap();
 
     segment2
-        .upsert_point(11, 11.into(), only_default_vector(&vec11))
+        .upsert_point(11, 11.into(), only_default_vector(&vec11), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(12, 12.into(), only_default_vector(&vec12))
+        .upsert_point(12, 12.into(), only_default_vector(&vec12), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(13, 13.into(), only_default_vector(&vec13))
+        .upsert_point(13, 13.into(), only_default_vector(&vec13), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(14, 14.into(), only_default_vector(&vec14))
+        .upsert_point(14, 14.into(), only_default_vector(&vec14), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(15, 15.into(), only_default_vector(&vec15))
+        .upsert_point(15, 15.into(), only_default_vector(&vec15), &hw_counter)
         .unwrap();
 
     segment2

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -134,6 +134,7 @@ impl ProxySegment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let deleted_points_guard = self.deleted_points.upgradable_read();
 
@@ -176,16 +177,16 @@ impl ProxySegment {
 
             let (all_vectors, payload) = (
                 wrapped_segment_guard.all_vectors(point_id)?,
-                wrapped_segment_guard.payload(point_id)?,
+                wrapped_segment_guard.payload_measured(point_id, hw_counter)?,
             );
 
             {
                 let segment_arc = self.write_segment.get();
                 let mut write_segment = segment_arc.write();
 
-                write_segment.upsert_point(op_num, point_id, all_vectors)?;
+                write_segment.upsert_point(op_num, point_id, all_vectors, hw_counter)?;
                 if !payload.is_empty() {
-                    write_segment.set_full_payload(op_num, point_id, &payload)?;
+                    write_segment.set_full_payload(op_num, point_id, &payload, hw_counter)?;
                 }
             }
 
@@ -299,7 +300,11 @@ impl ProxySegment {
                                 >= wrapped_segment.point_version(*point_id).unwrap_or(0),
                             "proxied point deletes should have newer version than point in segment",
                         );
-                        wrapped_segment.delete_point(versions.operation_version, *point_id)?;
+                        wrapped_segment.delete_point(
+                            versions.operation_version,
+                            *point_id,
+                            &HardwareCounterCell::disposable(), // Internal operation: no need to measure.
+                        )?;
                     }
                     OperationResult::Ok(())
                 })?;
@@ -448,18 +453,20 @@ impl SegmentEntry for ProxySegment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         vectors: NamedVectors,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id)?;
+        self.move_if_exists(op_num, point_id, hw_counter)?;
         self.write_segment
             .get()
             .write()
-            .upsert_point(op_num, point_id, vectors)
+            .upsert_point(op_num, point_id, vectors, hw_counter)
     }
 
     fn delete_point(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let mut was_deleted = false;
 
@@ -505,7 +512,7 @@ impl SegmentEntry for ProxySegment {
             .write_segment
             .get()
             .write()
-            .delete_point(op_num, point_id)?;
+            .delete_point(op_num, point_id, hw_counter)?;
 
         Ok(was_deleted || was_deleted_in_writable)
     }
@@ -515,12 +522,13 @@ impl SegmentEntry for ProxySegment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         vectors: NamedVectors,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id)?;
+        self.move_if_exists(op_num, point_id, hw_counter)?;
         self.write_segment
             .get()
             .write()
-            .update_vectors(op_num, point_id, vectors)
+            .update_vectors(op_num, point_id, vectors, hw_counter)
     }
 
     fn delete_vector(
@@ -528,12 +536,13 @@ impl SegmentEntry for ProxySegment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         vector_name: &str,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id)?;
+        self.move_if_exists(op_num, point_id, hw_counter)?;
         self.write_segment
             .get()
             .write()
-            .delete_vector(op_num, point_id, vector_name)
+            .delete_vector(op_num, point_id, vector_name, hw_counter)
     }
 
     fn set_full_payload(
@@ -541,12 +550,15 @@ impl SegmentEntry for ProxySegment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         full_payload: &Payload,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id)?;
-        self.write_segment
-            .get()
-            .write()
-            .set_full_payload(op_num, point_id, full_payload)
+        self.move_if_exists(op_num, point_id, hw_counter)?;
+        self.write_segment.get().write().set_full_payload(
+            op_num,
+            point_id,
+            full_payload,
+            hw_counter,
+        )
     }
 
     fn set_payload(
@@ -555,12 +567,13 @@ impl SegmentEntry for ProxySegment {
         point_id: PointIdType,
         payload: &Payload,
         key: &Option<JsonPath>,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id)?;
+        self.move_if_exists(op_num, point_id, hw_counter)?;
         self.write_segment
             .get()
             .write()
-            .set_payload(op_num, point_id, payload, key)
+            .set_payload(op_num, point_id, payload, key, hw_counter)
     }
 
     fn delete_payload(
@@ -568,24 +581,26 @@ impl SegmentEntry for ProxySegment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         key: PayloadKeyTypeRef,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id)?;
+        self.move_if_exists(op_num, point_id, hw_counter)?;
         self.write_segment
             .get()
             .write()
-            .delete_payload(op_num, point_id, key)
+            .delete_payload(op_num, point_id, key, hw_counter)
     }
 
     fn clear_payload(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id)?;
+        self.move_if_exists(op_num, point_id, hw_counter)?;
         self.write_segment
             .get()
             .write()
-            .clear_payload(op_num, point_id)
+            .clear_payload(op_num, point_id, hw_counter)
     }
 
     fn vector(
@@ -640,21 +655,6 @@ impl SegmentEntry for ProxySegment {
             }
         }
         Ok(result)
-    }
-
-    fn payload(&self, point_id: PointIdType) -> OperationResult<Payload> {
-        return if self.deleted_points.read().contains_key(&point_id) {
-            self.write_segment.get().read().payload(point_id)
-        } else {
-            {
-                let write_segment = self.write_segment.get();
-                let segment_guard = write_segment.read();
-                if segment_guard.has_point(point_id) {
-                    return segment_guard.payload(point_id);
-                }
-            }
-            self.wrapped_segment.get().read().payload(point_id)
-        };
     }
 
     fn payload_measured(
@@ -1174,6 +1174,7 @@ impl SegmentEntry for ProxySegment {
         &'a mut self,
         op_num: SeqNumberType,
         filter: &'a Filter,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<usize> {
         let mut deleted_points = 0;
         // we don’t want to cancel this filtered read
@@ -1216,7 +1217,7 @@ impl SegmentEntry for ProxySegment {
             .write_segment
             .get()
             .write()
-            .delete_filtered(op_num, filter)?;
+            .delete_filtered(op_num, filter, hw_counter)?;
 
         Ok(deleted_points)
     }
@@ -1364,15 +1365,19 @@ mod tests {
             LockedIndexChanges::default(),
         );
 
+        let hw_counter = HardwareCounterCell::new();
+
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         proxy_segment
-            .upsert_point(100, 4.into(), only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_counter)
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         proxy_segment
-            .upsert_point(101, 6.into(), only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
             .unwrap();
-        proxy_segment.delete_point(102, 1.into()).unwrap();
+        proxy_segment
+            .delete_point(102, 1.into(), &hw_counter)
+            .unwrap();
 
         let query_vector = [1.0, 1.0, 1.0, 1.0].into();
         let search_result = proxy_segment
@@ -1405,7 +1410,7 @@ mod tests {
 
         let payload_key = "color".parse().unwrap();
         proxy_segment
-            .delete_payload(103, 2.into(), &payload_key)
+            .delete_payload(103, 2.into(), &payload_key, &hw_counter)
             .unwrap();
 
         assert!(proxy_segment.write_segment.get().read().has_point(2.into()))
@@ -1424,15 +1429,19 @@ mod tests {
             LockedIndexChanges::default(),
         );
 
+        let hw_counter = HardwareCounterCell::new();
+
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         proxy_segment
-            .upsert_point(100, 4.into(), only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_counter)
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         proxy_segment
-            .upsert_point(101, 6.into(), only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
             .unwrap();
-        proxy_segment.delete_point(102, 1.into()).unwrap();
+        proxy_segment
+            .delete_point(102, 1.into(), &hw_counter)
+            .unwrap();
 
         let query_vector = [1.0, 1.0, 1.0, 1.0].into();
         let search_result = proxy_segment
@@ -1619,7 +1628,11 @@ mod tests {
 
         let mut proxy_segment = wrap_proxy(&dir, original_segment);
 
-        proxy_segment.delete_point(100, 2.into()).unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        proxy_segment
+            .delete_point(100, 2.into(), &hw_counter)
+            .unwrap();
 
         let proxy_res = proxy_segment.read_filtered(None, Some(100), None, &is_stopped);
         let proxy_res_filtered =
@@ -1641,7 +1654,9 @@ mod tests {
 
         let mut proxy_segment = wrap_proxy(&dir, original_segment);
 
-        proxy_segment.delete_point(100, 2.into()).unwrap();
+        let hw_cell = HardwareCounterCell::new();
+
+        proxy_segment.delete_point(100, 2.into(), &hw_cell).unwrap();
 
         proxy_segment
             .set_payload(
@@ -1649,6 +1664,7 @@ mod tests {
                 3.into(),
                 &json!({ "color": vec!["red".to_owned()] }).into(),
                 &None,
+                &hw_cell,
             )
             .unwrap();
         let proxy_res = proxy_segment.read_range(None, Some(10.into()));
@@ -1727,6 +1743,8 @@ mod tests {
         let deleted_points = LockedRmSet::default();
         let changed_indexes = LockedIndexChanges::default();
 
+        let hw_cell = HardwareCounterCell::new();
+
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment.clone(),
@@ -1743,16 +1761,16 @@ mod tests {
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         proxy_segment
-            .upsert_point(100, 4.into(), only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_cell)
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         proxy_segment
-            .upsert_point(101, 6.into(), only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_cell)
             .unwrap();
-        proxy_segment.delete_point(102, 1.into()).unwrap();
+        proxy_segment.delete_point(102, 1.into(), &hw_cell).unwrap();
 
         proxy_segment2
-            .upsert_point(201, 11.into(), only_default_vector(&vec6))
+            .upsert_point(201, 11.into(), only_default_vector(&vec6), &hw_cell)
             .unwrap();
 
         let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
@@ -1801,6 +1819,8 @@ mod tests {
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
+        let hw_cell = HardwareCounterCell::new();
+
         let mut proxy_segment = ProxySegment::new(
             original_segment,
             write_segment,
@@ -1814,20 +1834,22 @@ mod tests {
         assert_eq!(segment_info.num_vectors, 5);
 
         // Delete nonexistent point, counts should remain the same
-        proxy_segment.delete_point(101, 99999.into()).unwrap();
+        proxy_segment
+            .delete_point(101, 99999.into(), &hw_cell)
+            .unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 5);
         assert_eq!(segment_info.num_vectors, 5);
 
         // Delete point 1, counts should decrease by 1
-        proxy_segment.delete_point(102, 4.into()).unwrap();
+        proxy_segment.delete_point(102, 4.into(), &hw_cell).unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 4);
         assert_eq!(segment_info.num_vectors, 4);
 
         // Delete vector of point 2, vector count should now be zero
         proxy_segment
-            .delete_vector(103, 2.into(), DEFAULT_VECTOR_NAME)
+            .delete_vector(103, 2.into(), DEFAULT_VECTOR_NAME, &hw_cell)
             .unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 4);
@@ -1875,11 +1897,14 @@ mod tests {
         let mut original_segment = build_segment(dir.path(), &config, true).unwrap();
         let write_segment = build_segment(dir.path(), &config, true).unwrap();
 
+        let hw_cell = HardwareCounterCell::new();
+
         original_segment
             .upsert_point(
                 100,
                 4.into(),
                 NamedVectors::from_pairs([("a".into(), vec![0.4]), ("b".into(), vec![0.5])]),
+                &hw_cell,
             )
             .unwrap();
         original_segment
@@ -1887,6 +1912,7 @@ mod tests {
                 101,
                 6.into(),
                 NamedVectors::from_pairs([("a".into(), vec![0.6]), ("b".into(), vec![0.7])]),
+                &hw_cell,
             )
             .unwrap();
 
@@ -1911,6 +1937,7 @@ mod tests {
                 102,
                 8.into(),
                 NamedVectors::from_pairs([("a".into(), vec![0.0])]),
+                &hw_cell,
             )
             .unwrap();
         proxy_segment
@@ -1918,6 +1945,7 @@ mod tests {
                 103,
                 10.into(),
                 NamedVectors::from_pairs([("b".into(), vec![1.0])]),
+                &hw_cell,
             )
             .unwrap();
         let segment_info = proxy_segment.info();
@@ -1925,25 +1953,29 @@ mod tests {
         assert_eq!(segment_info.num_vectors, 6);
 
         // Delete nonexistent point, counts should remain the same
-        proxy_segment.delete_point(104, 1.into()).unwrap();
+        proxy_segment.delete_point(104, 1.into(), &hw_cell).unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 4);
         assert_eq!(segment_info.num_vectors, 6);
 
         // Delete point 4, counts should decrease by 1
-        proxy_segment.delete_point(105, 4.into()).unwrap();
+        proxy_segment.delete_point(105, 4.into(), &hw_cell).unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 3);
         assert_eq!(segment_info.num_vectors, 4);
 
         // Delete vector 'a' of point 6, vector count should decrease by 1
-        proxy_segment.delete_vector(106, 6.into(), "a").unwrap();
+        proxy_segment
+            .delete_vector(106, 6.into(), "a", &hw_cell)
+            .unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 3);
         assert_eq!(segment_info.num_vectors, 3);
 
         // Deleting it again shouldn't chain anything
-        proxy_segment.delete_vector(107, 6.into(), "a").unwrap();
+        proxy_segment
+            .delete_vector(107, 6.into(), "a", &hw_cell)
+            .unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 3);
         assert_eq!(segment_info.num_vectors, 3);
@@ -1954,6 +1986,7 @@ mod tests {
                 108,
                 8.into(),
                 NamedVectors::from_pairs([("a".into(), vec![0.0])]),
+                &hw_cell,
             )
             .unwrap();
         let segment_info = proxy_segment.info();
@@ -1966,6 +1999,7 @@ mod tests {
                 109,
                 8.into(),
                 NamedVectors::from_pairs([("a".into(), vec![0.0]), ("b".into(), vec![0.0])]),
+                &hw_cell,
             )
             .unwrap();
         let segment_info = proxy_segment.info();
@@ -2020,12 +2054,15 @@ mod tests {
 
         let current_version = proxy_segment.version();
 
+        let hw_cell = HardwareCounterCell::new();
+
         wrapped_segment
             .write()
             .upsert_point(
                 current_version + 1,
                 42.into(),
                 only_default_vector(&[4.0, 2.0, 0.0, 0.0]),
+                &hw_cell,
             )
             .unwrap();
 
@@ -2034,6 +2071,7 @@ mod tests {
                 current_version + 2,
                 69.into(),
                 only_default_vector(&[6.0, 9.0, 0.0, 0.0]),
+                &hw_cell,
             )
             .unwrap();
 
@@ -2061,6 +2099,7 @@ mod tests {
                 current_version + 1,
                 666.into(),
                 only_default_vector(&[6.0, 6.0, 6.0, 0.0]),
+                &hw_cell,
             )
             .unwrap();
 
@@ -2069,6 +2108,7 @@ mod tests {
                 current_version + 2,
                 42.into(),
                 only_default_vector(&[0.0, 0.0, 4.0, 2.0]),
+                &hw_cell,
             )
             .unwrap();
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -177,7 +177,7 @@ impl ProxySegment {
 
             let (all_vectors, payload) = (
                 wrapped_segment_guard.all_vectors(point_id)?,
-                wrapped_segment_guard.payload_measured(point_id, hw_counter)?,
+                wrapped_segment_guard.payload(point_id, hw_counter)?,
             );
 
             {
@@ -657,7 +657,7 @@ impl SegmentEntry for ProxySegment {
         Ok(result)
     }
 
-    fn payload_measured(
+    fn payload(
         &self,
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,
@@ -666,19 +666,19 @@ impl SegmentEntry for ProxySegment {
             self.write_segment
                 .get()
                 .read()
-                .payload_measured(point_id, hw_counter)
+                .payload(point_id, hw_counter)
         } else {
             {
                 let write_segment = self.write_segment.get();
                 let segment_guard = write_segment.read();
                 if segment_guard.has_point(point_id) {
-                    return segment_guard.payload_measured(point_id, hw_counter);
+                    return segment_guard.payload(point_id, hw_counter);
                 }
             }
             self.wrapped_segment
                 .get()
                 .read()
-                .payload_measured(point_id, hw_counter)
+                .payload(point_id, hw_counter)
         };
     }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -9,6 +9,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use ahash::AHashMap;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
 use common::tar_ext;
 use futures::future::try_join_all;
@@ -621,6 +622,7 @@ impl<'s> SegmentHolder {
         mut point_operation: F,
         mut point_cow_operation: H,
         update_nonappendable: G,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<HashSet<PointIdType>>
     where
         F: FnMut(PointIdType, &mut RwLockWriteGuard<dyn SegmentEntry>) -> OperationResult<bool>,
@@ -652,15 +654,21 @@ impl<'s> SegmentHolder {
                         &appendable_segments,
                         |_appendable_idx, appendable_write_segment| {
                             let mut all_vectors = write_segment.all_vectors(point_id)?;
-                            let mut payload = write_segment.payload(point_id)?;
+                            let mut payload =
+                                write_segment.payload_measured(point_id, hw_counter)?;
 
                             point_cow_operation(point_id, &mut all_vectors, &mut payload);
 
-                            appendable_write_segment.upsert_point(op_num, point_id, all_vectors)?;
+                            appendable_write_segment.upsert_point(
+                                op_num,
+                                point_id,
+                                all_vectors,
+                                hw_counter,
+                            )?;
                             appendable_write_segment
-                                .set_full_payload(op_num, point_id, &payload)?;
+                                .set_full_payload(op_num, point_id, &payload, hw_counter)?;
 
-                            write_segment.delete_point(op_num, point_id)?;
+                            write_segment.delete_point(op_num, point_id, hw_counter)?;
 
                             Ok(true)
                         },
@@ -1270,10 +1278,13 @@ impl<'s> SegmentHolder {
                     let mut removed_points = 0;
                     let segment_arc = locked_segment.get();
                     let mut write_segment = segment_arc.write();
+
+                    let disposable_hw_counter = HardwareCounterCell::disposable();
+
                     for &point_id in &points {
                         if let Some(point_version) = write_segment.point_version(point_id) {
                             removed_points += 1;
-                            write_segment.delete_point(point_version, point_id)?;
+                            write_segment.delete_point(point_version, point_id, &disposable_hw_counter)?; // Internal operation
                         }
                     }
 
@@ -1448,6 +1459,7 @@ mod tests {
                 },
                 |point_id, _, _| processed_points2.push(point_id),
                 |_| update_nonappendable,
+                &HardwareCounterCell::new(),
             )
             .unwrap();
 
@@ -1496,12 +1508,15 @@ mod tests {
         let mut segment1 = build_segment_1(dir.path());
         let mut segment2 = build_segment_2(dir.path());
 
+        let hw_counter = HardwareCounterCell::new();
+
         // Insert operation 100 with point 123 and 456 into segment 1, and 789 into segment 2
         segment1
             .upsert_point(
                 100,
                 123.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0, 1.0, 2.0, 3.0]),
+                &hw_counter,
             )
             .unwrap();
         segment1
@@ -1509,6 +1524,7 @@ mod tests {
                 100,
                 456.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0, 1.0, 2.0, 3.0]),
+                &hw_counter,
             )
             .unwrap();
         segment2
@@ -1516,6 +1532,7 @@ mod tests {
                 100,
                 789.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0, 1.0, 2.0, 3.0]),
+                &hw_counter,
             )
             .unwrap();
 
@@ -1528,6 +1545,7 @@ mod tests {
                     99999,
                     99999.into(),
                     segment::data_types::vectors::only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+                    &hw_counter,
                 )
                 .unwrap();
         }
@@ -1537,6 +1555,7 @@ mod tests {
                     99999,
                     99999.into(),
                     segment::data_types::vectors::only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+                    &hw_counter,
                 )
                 .unwrap();
         }
@@ -1563,6 +1582,7 @@ mod tests {
                 },
                 |point_id, _, _| processed_points2.push(point_id),
                 |_| false,
+                &hw_counter,
             )
             .unwrap();
         assert_eq!(3, processed_points.len() + processed_points2.len());
@@ -1594,17 +1614,20 @@ mod tests {
         let segment1 = build_segment_1(dir.path());
         let mut segment2 = build_segment_1(dir.path());
 
+        let hw_counter = HardwareCounterCell::new();
+
         segment2
             .upsert_point(
                 100,
                 123.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0, 1.0, 2.0, 3.0]),
+                &hw_counter,
             )
             .unwrap();
         let mut payload = Payload::default();
         payload.0.insert(PAYLOAD_KEY.to_string(), 42.into());
         segment2
-            .set_full_payload(100, 123.into(), &payload)
+            .set_full_payload(100, 123.into(), &payload, &hw_counter)
             .unwrap();
         segment2.appendable_flag = false;
 
@@ -1624,7 +1647,7 @@ mod tests {
             assert_ne!(vector, VectorInternal::Dense(vec![9.0; 4]));
             assert_eq!(
                 read_segment_2
-                    .payload(123.into())
+                    .payload_measured(123.into(), &hw_counter)
                     .unwrap()
                     .get_value(&JsonPath::from_str(PAYLOAD_KEY).unwrap())[0],
                 &Value::from(42)
@@ -1641,6 +1664,7 @@ mod tests {
                     payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
                 },
                 |_| false,
+                &hw_counter,
             )
             .unwrap();
 
@@ -1651,7 +1675,9 @@ mod tests {
 
         let new_vector = read_segment_1.vector("", 123.into()).unwrap().unwrap();
         assert_eq!(new_vector, VectorInternal::Dense(vec![9.0; 4]));
-        let new_payload_value = read_segment_1.payload(123.into()).unwrap();
+        let new_payload_value = read_segment_1
+            .payload_measured(123.into(), &hw_counter)
+            .unwrap();
         assert_eq!(
             new_payload_value.get_value(&JsonPath::from_str(PAYLOAD_KEY).unwrap())[0],
             &Value::from(2)
@@ -1665,18 +1691,20 @@ mod tests {
         let mut segment1 = build_segment_1(dir.path());
         let mut segment2 = build_segment_1(dir.path());
 
+        let hw_counter = HardwareCounterCell::new();
+
         segment1
-            .set_payload(100, 1.into(), &json!({}).into(), &None)
+            .set_payload(100, 1.into(), &json!({}).into(), &None, &hw_counter)
             .unwrap();
         segment1
-            .set_payload(100, 2.into(), &json!({}).into(), &None)
+            .set_payload(100, 2.into(), &json!({}).into(), &None, &hw_counter)
             .unwrap();
 
         segment2
-            .set_payload(200, 4.into(), &json!({}).into(), &None)
+            .set_payload(200, 4.into(), &json!({}).into(), &None, &hw_counter)
             .unwrap();
         segment2
-            .set_payload(200, 5.into(), &json!({}).into(), &None)
+            .set_payload(200, 5.into(), &json!({}).into(), &None, &hw_counter)
             .unwrap();
 
         let mut holder = SegmentHolder::default();
@@ -1709,11 +1737,14 @@ mod tests {
         let mut segment1 = empty_segment(dir.path());
         let mut segment2 = empty_segment(dir.path());
 
+        let hw_counter = HardwareCounterCell::new();
+
         segment1
             .upsert_point(
                 2,
                 10.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0; 4]),
+                &hw_counter,
             )
             .unwrap();
         segment2
@@ -1721,6 +1752,7 @@ mod tests {
                 3,
                 10.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0; 4]),
+                &hw_counter,
             )
             .unwrap();
 
@@ -1729,6 +1761,7 @@ mod tests {
                 1,
                 11.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0; 4]),
+                &hw_counter,
             )
             .unwrap();
         segment2
@@ -1736,6 +1769,7 @@ mod tests {
                 2,
                 11.into(),
                 segment::data_types::vectors::only_default_vector(&[0.0; 4]),
+                &hw_counter,
             )
             .unwrap();
 
@@ -1788,6 +1822,8 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let vector = segment::data_types::vectors::only_default_vector(&[0.0; 4]);
 
+        let hw_counter = HardwareCounterCell::new();
+
         let mut segments = [
             empty_segment(dir.path()),
             empty_segment(dir.path()),
@@ -1805,7 +1841,7 @@ mod tests {
             for segment in &mut segments {
                 let version = rand.gen_range(1..10);
                 segment
-                    .upsert_point(version, point_id, vector.clone())
+                    .upsert_point(version, point_id, vector.clone(), &hw_counter)
                     .unwrap();
                 max_version = version.max(max_version);
             }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -654,8 +654,7 @@ impl<'s> SegmentHolder {
                         &appendable_segments,
                         |_appendable_idx, appendable_write_segment| {
                             let mut all_vectors = write_segment.all_vectors(point_id)?;
-                            let mut payload =
-                                write_segment.payload_measured(point_id, hw_counter)?;
+                            let mut payload = write_segment.payload(point_id, hw_counter)?;
 
                             point_cow_operation(point_id, &mut all_vectors, &mut payload);
 
@@ -1647,7 +1646,7 @@ mod tests {
             assert_ne!(vector, VectorInternal::Dense(vec![9.0; 4]));
             assert_eq!(
                 read_segment_2
-                    .payload_measured(123.into(), &hw_counter)
+                    .payload(123.into(), &hw_counter)
                     .unwrap()
                     .get_value(&JsonPath::from_str(PAYLOAD_KEY).unwrap())[0],
                 &Value::from(42)
@@ -1675,9 +1674,7 @@ mod tests {
 
         let new_vector = read_segment_1.vector("", 123.into()).unwrap().unwrap();
         assert_eq!(new_vector, VectorInternal::Dense(vec![9.0; 4]));
-        let new_payload_value = read_segment_1
-            .payload_measured(123.into(), &hw_counter)
-            .unwrap();
+        let new_payload_value = read_segment_1.payload(123.into(), &hw_counter).unwrap();
         assert_eq!(
             new_payload_value.get_value(&JsonPath::from_str(PAYLOAD_KEY).unwrap())[0],
             &Value::from(2)

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -284,6 +284,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
+    use common::counter::hardware_counter::HardwareCounterCell;
     use common::cpu::CpuPermit;
     use itertools::Itertools;
     use parking_lot::lock_api::RwLock;
@@ -634,10 +635,13 @@ mod tests {
             .unwrap()
             .num_vectors;
 
+        let hw_counter = HardwareCounterCell::new();
+
         process_point_operation(
             locked_holder.deref(),
             opnum.next().unwrap(),
             insert_point_ops,
+            &hw_counter,
         )
         .unwrap();
 
@@ -708,6 +712,7 @@ mod tests {
             locked_holder.deref(),
             opnum.next().unwrap(),
             insert_point_ops,
+            &hw_counter,
         )
         .unwrap();
     }

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::disk::dir_size;
 use io::storage_version::StorageVersion;
@@ -482,7 +483,11 @@ pub trait SegmentOptimizer {
             .collect::<Vec<_>>();
         for (point_id, versions) in deleted_points_snapshot {
             optimized_segment
-                .delete_point(versions.operation_version, point_id)
+                .delete_point(
+                    versions.operation_version,
+                    point_id,
+                    &HardwareCounterCell::disposable(), // Internal operation, no need for measurement.
+                )
                 .unwrap();
         }
 
@@ -668,7 +673,11 @@ pub trait SegmentOptimizer {
                     "proxied point deletes should have newer version than point in segment",
                 );
                 optimized_segment
-                    .delete_point(versions.operation_version, point_id)
+                    .delete_point(
+                        versions.operation_version,
+                        point_id,
+                        &HardwareCounterCell::disposable(), // Internal operation, no measurement needed!
+                    )
                     .unwrap();
             }
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -365,9 +365,7 @@ mod tests {
         // Check payload is preserved in optimized segment
         for &point_id in &segment_points_to_assign1 {
             assert!(segment_guard.has_point(point_id));
-            let payload = segment_guard
-                .payload_measured(point_id, &hw_counter)
-                .unwrap();
+            let payload = segment_guard.payload(point_id, &hw_counter).unwrap();
             let payload_color = payload
                 .get_value(&"color".parse().unwrap())
                 .into_iter()

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -212,6 +212,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
+    use common::counter::hardware_counter::HardwareCounterCell;
     use common::cpu::CpuPermit;
     use itertools::Itertools;
     use parking_lot::RwLock;
@@ -237,6 +238,8 @@ mod tests {
 
         let segment = holder.get(segment_id).unwrap();
 
+        let hw_counter = HardwareCounterCell::new();
+
         let original_segment_path = match segment {
             LockedSegment::Original(s) => s.read().current_path.clone(),
             LockedSegment::Proxy(_) => panic!("Not expected"),
@@ -251,7 +254,11 @@ mod tests {
             .collect_vec();
 
         for &point_id in &segment_points_to_delete {
-            segment.get().write().delete_point(101, point_id).unwrap();
+            segment
+                .get()
+                .write()
+                .delete_point(101, point_id, &hw_counter)
+                .unwrap();
         }
 
         let segment_points_to_assign1 = segment
@@ -274,7 +281,13 @@ mod tests {
             segment
                 .get()
                 .write()
-                .set_payload(102, point_id, &json!({ "color": "red" }).into(), &None)
+                .set_payload(
+                    102,
+                    point_id,
+                    &json!({ "color": "red" }).into(),
+                    &None,
+                    &hw_counter,
+                )
                 .unwrap();
         }
 
@@ -282,7 +295,13 @@ mod tests {
             segment
                 .get()
                 .write()
-                .set_payload(102, point_id, &json!({"size": 0.42}).into(), &None)
+                .set_payload(
+                    102,
+                    point_id,
+                    &json!({"size": 0.42}).into(),
+                    &None,
+                    &hw_counter,
+                )
                 .unwrap();
         }
 
@@ -346,7 +365,9 @@ mod tests {
         // Check payload is preserved in optimized segment
         for &point_id in &segment_points_to_assign1 {
             assert!(segment_guard.has_point(point_id));
-            let payload = segment_guard.payload(point_id).unwrap();
+            let payload = segment_guard
+                .payload_measured(point_id, &hw_counter)
+                .unwrap();
             let payload_color = payload
                 .get_value(&"color".parse().unwrap())
                 .into_iter()
@@ -493,6 +514,8 @@ mod tests {
             vacuum_optimizer.check_condition(locked_holder.clone(), &Default::default());
         assert_eq!(suggested_to_optimize.len(), 0);
 
+        let hw_counter = HardwareCounterCell::new();
+
         // Delete some points and vectors
         {
             let holder = locked_holder.write();
@@ -509,7 +532,7 @@ mod tests {
                 .filter_map(|(i, point_id)| (i % 10 == 3).then_some(point_id))
                 .collect_vec();
             for &point_id in &segment_points_to_delete {
-                segment.delete_point(201, point_id).unwrap();
+                segment.delete_point(201, point_id, &hw_counter).unwrap();
             }
 
             // Delete 25% of vectors named vector1

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::ScoreType;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, TryStreamExt};
@@ -372,6 +373,7 @@ impl SegmentsSearcher {
         with_payload: &WithPayload,
         with_vector: &WithVector,
         runtime_handle: &Handle,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<HashMap<PointIdType, RecordInternal>> {
         let stopping_guard = StoppingGuard::new();
         runtime_handle
@@ -389,6 +391,7 @@ impl SegmentsSearcher {
                         &with_payload,
                         &with_vector,
                         &is_stopped,
+                        hw_measurement_acc,
                     )
                 }
             })
@@ -401,9 +404,12 @@ impl SegmentsSearcher {
         with_payload: &WithPayload,
         with_vector: &WithVector,
         is_stopped: &AtomicBool,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<HashMap<PointIdType, RecordInternal>> {
         let mut point_version: HashMap<PointIdType, SeqNumberType> = Default::default();
         let mut point_records: HashMap<PointIdType, RecordInternal> = Default::default();
+
+        let hw_counter = HardwareCounterCell::new_with_accumulator(hw_measurement_acc);
 
         segments
             .read()
@@ -424,9 +430,9 @@ impl SegmentsSearcher {
                         id,
                         payload: if with_payload.enable {
                             if let Some(selector) = &with_payload.payload_selector {
-                                Some(selector.process(segment.payload(id)?))
+                                Some(selector.process(segment.payload_measured(id, &hw_counter)?))
                             } else {
-                                Some(segment.payload(id)?)
+                                Some(segment.payload_measured(id, &hw_counter)?)
                             }
                         } else {
                             None
@@ -885,6 +891,7 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
             &AtomicBool::new(false),
+            HwMeasurementAcc::new(),
         )
         .unwrap();
         assert_eq!(records.len(), 3);

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -430,9 +430,9 @@ impl SegmentsSearcher {
                         id,
                         payload: if with_payload.enable {
                             if let Some(selector) = &with_payload.payload_selector {
-                                Some(selector.process(segment.payload_measured(id, &hw_counter)?))
+                                Some(selector.process(segment.payload(id, &hw_counter)?))
                             } else {
-                                Some(segment.payload_measured(id, &hw_counter)?)
+                                Some(segment.payload(id, &hw_counter)?)
                             }
                         } else {
                             None

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -449,7 +449,7 @@ pub(crate) fn sync_points(
                 Err(OperationError::InconsistentStorage { .. }) => NamedVectors::default(),
                 Err(e) => return Err(e),
             };
-            let payload = segment.payload_measured(id, hw_counter)?;
+            let payload = segment.payload(id, hw_counter)?;
             let point = id_to_point.get(&id).unwrap();
             if point.get_vectors() != all_vectors {
                 points_to_update.push(*point);

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicBool;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use itertools::iproduct;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use segment::common::operation_error::{OperationError, OperationResult};
@@ -41,6 +42,7 @@ pub(crate) fn delete_points(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     ids: &[PointIdType],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_deleted_points = 0;
 
@@ -48,7 +50,7 @@ pub(crate) fn delete_points(
         let deleted_points = segments.apply_points(
             batch,
             |_| (),
-            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id),
+            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
         )?;
 
         total_deleted_points += deleted_points;
@@ -62,6 +64,7 @@ pub(crate) fn update_vectors(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: Vec<PointVectorsPersisted>,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     // Build a map of vectors to update per point, merge updates on same point ID
     let mut points_map: HashMap<PointIdType, NamedVectors> = HashMap::new();
@@ -82,7 +85,7 @@ pub(crate) fn update_vectors(
             batch,
             |id, write_segment| {
                 let vectors = points_map[&id].clone();
-                write_segment.update_vectors(op_num, id, vectors)
+                write_segment.update_vectors(op_num, id, vectors, hw_counter)
             },
             |id, owned_vectors, _| {
                 for (vector_name, vector_ref) in points_map[&id].iter() {
@@ -90,6 +93,7 @@ pub(crate) fn update_vectors(
                 }
             },
             |_| false,
+            hw_counter,
         )?;
         check_unprocessed_points(batch, &updated_points)?;
         total_updated_points += updated_points.len();
@@ -106,6 +110,7 @@ pub(crate) fn delete_vectors(
     op_num: SeqNumberType,
     points: &[PointIdType],
     vector_names: &[String],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_deleted_points = 0;
 
@@ -116,7 +121,7 @@ pub(crate) fn delete_vectors(
             |id, _idx, write_segment, ()| {
                 let mut res = true;
                 for name in vector_names {
-                    res &= write_segment.delete_vector(op_num, id, name)?;
+                    res &= write_segment.delete_vector(op_num, id, name, hw_counter)?;
                 }
                 Ok(res)
             },
@@ -134,9 +139,10 @@ pub(crate) fn delete_vectors_by_filter(
     op_num: SeqNumberType,
     filter: &Filter,
     vector_names: &[String],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let affected_points = points_by_filter(segments, filter)?;
-    delete_vectors(segments, op_num, &affected_points, vector_names)
+    delete_vectors(segments, op_num, &affected_points, vector_names, hw_counter)
 }
 
 /// Batch size when modifying payload.
@@ -147,6 +153,7 @@ pub(crate) fn overwrite_payload(
     op_num: SeqNumberType,
     payload: &Payload,
     points: &[PointIdType],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_updated_points = 0;
 
@@ -154,11 +161,12 @@ pub(crate) fn overwrite_payload(
         let updated_points = segments.apply_points_with_conditional_move(
             op_num,
             batch,
-            |id, write_segment| write_segment.set_full_payload(op_num, id, payload),
+            |id, write_segment| write_segment.set_full_payload(op_num, id, payload, hw_counter),
             |_, _, old_payload| {
                 *old_payload = payload.clone();
             },
             |segment| segment.get_indexed_fields().is_empty(),
+            hw_counter,
         )?;
 
         total_updated_points += updated_points.len();
@@ -173,9 +181,10 @@ pub(crate) fn overwrite_payload_by_filter(
     op_num: SeqNumberType,
     payload: &Payload,
     filter: &Filter,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let affected_points = points_by_filter(segments, filter)?;
-    overwrite_payload(segments, op_num, payload, &affected_points)
+    overwrite_payload(segments, op_num, payload, &affected_points, hw_counter)
 }
 
 pub(crate) fn set_payload(
@@ -184,6 +193,7 @@ pub(crate) fn set_payload(
     payload: &Payload,
     points: &[PointIdType],
     key: &Option<JsonPath>,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_updated_points = 0;
 
@@ -191,7 +201,7 @@ pub(crate) fn set_payload(
         let updated_points = segments.apply_points_with_conditional_move(
             op_num,
             chunk,
-            |id, write_segment| write_segment.set_payload(op_num, id, payload, key),
+            |id, write_segment| write_segment.set_payload(op_num, id, payload, key, hw_counter),
             |_, _, old_payload| match key {
                 Some(key) => old_payload.merge_by_key(payload, key),
                 None => old_payload.merge(payload),
@@ -201,6 +211,7 @@ pub(crate) fn set_payload(
                     !indexed_path.is_affected_by_value_set(&payload.0, key.as_ref())
                 })
             },
+            hw_counter,
         )?;
 
         check_unprocessed_points(chunk, &updated_points)?;
@@ -231,9 +242,10 @@ pub(crate) fn set_payload_by_filter(
     payload: &Payload,
     filter: &Filter,
     key: &Option<JsonPath>,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let affected_points = points_by_filter(segments, filter)?;
-    set_payload(segments, op_num, payload, &affected_points, key)
+    set_payload(segments, op_num, payload, &affected_points, key, hw_counter)
 }
 
 pub(crate) fn delete_payload(
@@ -241,6 +253,7 @@ pub(crate) fn delete_payload(
     op_num: SeqNumberType,
     points: &[PointIdType],
     keys: &[PayloadKeyType],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_deleted_points = 0;
 
@@ -251,7 +264,7 @@ pub(crate) fn delete_payload(
             |id, write_segment| {
                 let mut res = true;
                 for key in keys {
-                    res &= write_segment.delete_payload(op_num, id, key)?;
+                    res &= write_segment.delete_payload(op_num, id, key, hw_counter)?;
                 }
                 Ok(res)
             },
@@ -267,6 +280,7 @@ pub(crate) fn delete_payload(
                     },
                 )
             },
+            hw_counter,
         )?;
 
         check_unprocessed_points(batch, &updated_points)?;
@@ -281,15 +295,17 @@ pub(crate) fn delete_payload_by_filter(
     op_num: SeqNumberType,
     filter: &Filter,
     keys: &[PayloadKeyType],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let affected_points = points_by_filter(segments, filter)?;
-    delete_payload(segments, op_num, &affected_points, keys)
+    delete_payload(segments, op_num, &affected_points, keys, hw_counter)
 }
 
 pub(crate) fn clear_payload(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: &[PointIdType],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_updated_points = 0;
 
@@ -297,9 +313,10 @@ pub(crate) fn clear_payload(
         let updated_points = segments.apply_points_with_conditional_move(
             op_num,
             batch,
-            |id, write_segment| write_segment.clear_payload(op_num, id),
+            |id, write_segment| write_segment.clear_payload(op_num, id, hw_counter),
             |_, _, payload| payload.0.clear(),
             |segment| segment.get_indexed_fields().is_empty(),
+            hw_counter,
         )?;
         check_unprocessed_points(batch, &updated_points)?;
         total_updated_points += updated_points.len();
@@ -313,6 +330,7 @@ pub(crate) fn clear_payload_by_filter(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     filter: &Filter,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let points_to_clear = points_by_filter(segments, filter)?;
 
@@ -322,9 +340,10 @@ pub(crate) fn clear_payload_by_filter(
         let updated_points = segments.apply_points_with_conditional_move(
             op_num,
             batch,
-            |id, write_segment| write_segment.clear_payload(op_num, id),
+            |id, write_segment| write_segment.clear_payload(op_num, id, hw_counter),
             |_, _, payload| payload.0.clear(),
             |segment| segment.get_indexed_fields().is_empty(),
+            hw_counter,
         )?;
         total_updated_points += updated_points.len();
     }
@@ -377,10 +396,11 @@ fn upsert_with_payload(
     point_id: PointIdType,
     vectors: NamedVectors,
     payload: Option<&Payload>,
+    hw_counter: &HardwareCounterCell,
 ) -> OperationResult<bool> {
-    let mut res = segment.upsert_point(op_num, point_id, vectors)?;
+    let mut res = segment.upsert_point(op_num, point_id, vectors, hw_counter)?;
     if let Some(full_payload) = payload {
-        res &= segment.set_full_payload(op_num, point_id, full_payload)?;
+        res &= segment.set_full_payload(op_num, point_id, full_payload, hw_counter)?;
     }
     Ok(res)
 }
@@ -401,6 +421,7 @@ pub(crate) fn sync_points(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[PointStructPersisted],
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<(usize, usize, usize)> {
     let id_to_point: HashMap<PointIdType, _> = points.iter().map(|p| (p.id, p)).collect();
     let sync_points: HashSet<_> = points.iter().map(|p| p.id).collect();
@@ -411,7 +432,7 @@ pub(crate) fn sync_points(
         .collect();
     // 2. Remove points, which are not present in the sync operation
     let points_to_remove: Vec<_> = stored_point_ids.difference(&sync_points).copied().collect();
-    let deleted = delete_points(segments, op_num, points_to_remove.as_slice())?;
+    let deleted = delete_points(segments, op_num, points_to_remove.as_slice(), hw_counter)?;
     // 3. Retrieve overlapping points, detect which one of them are changed
     let existing_point_ids: Vec<_> = stored_point_ids
         .intersection(&sync_points)
@@ -428,7 +449,7 @@ pub(crate) fn sync_points(
                 Err(OperationError::InconsistentStorage { .. }) => NamedVectors::default(),
                 Err(e) => return Err(e),
             };
-            let payload = segment.payload(id)?;
+            let payload = segment.payload_measured(id, hw_counter)?;
             let point = id_to_point.get(&id).unwrap();
             if point.get_vectors() != all_vectors {
                 points_to_update.push(*point);
@@ -456,7 +477,7 @@ pub(crate) fn sync_points(
     });
 
     // 5. Upsert points which differ from the stored ones
-    let num_replaced = upsert_points(segments, op_num, points_to_update)?;
+    let num_replaced = upsert_points(segments, op_num, points_to_update, hw_counter)?;
     debug_assert!(num_replaced <= num_updated, "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})");
 
     Ok((deleted, num_new, num_updated))
@@ -469,6 +490,7 @@ pub(crate) fn upsert_points<'a, T>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: T,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize>
 where
     T: IntoIterator<Item = &'a PointStructPersisted>,
@@ -488,6 +510,7 @@ where
                 id,
                 point.get_vectors(),
                 point.payload.as_ref(),
+                hw_counter,
             )
         },
         |id, vectors, old_payload| {
@@ -500,6 +523,7 @@ where
             }
         },
         |_| false,
+        hw_counter,
     )?;
 
     let mut res = updated_points.len();
@@ -521,6 +545,7 @@ where
                 point_id,
                 point.get_vectors(),
                 point.payload.as_ref(),
+                hw_counter,
             )?);
         }
         RwLockWriteGuard::unlock_fair(write_segment);
@@ -533,9 +558,12 @@ pub(crate) fn process_point_operation(
     segments: &RwLock<SegmentHolder>,
     op_num: SeqNumberType,
     point_operation: PointOperations,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     match point_operation {
-        PointOperations::DeletePoints { ids, .. } => delete_points(&segments.read(), op_num, &ids),
+        PointOperations::DeletePoints { ids, .. } => {
+            delete_points(&segments.read(), op_num, &ids, hw_counter)
+        }
         PointOperations::UpsertPoints(operation) => {
             let points: Vec<_> = match operation {
                 PointInsertOperationsInternal::PointsBatch(batch) => {
@@ -562,11 +590,11 @@ pub(crate) fn process_point_operation(
                 }
                 PointInsertOperationsInternal::PointsList(points) => points,
             };
-            let res = upsert_points(&segments.read(), op_num, points.iter())?;
+            let res = upsert_points(&segments.read(), op_num, points.iter(), hw_counter)?;
             Ok(res)
         }
         PointOperations::DeletePointsByFilter(filter) => {
-            delete_points_by_filter(&segments.read(), op_num, &filter)
+            delete_points_by_filter(&segments.read(), op_num, &filter, hw_counter)
         }
         PointOperations::SyncPoints(operation) => {
             let (deleted, new, updated) = sync_points(
@@ -575,6 +603,7 @@ pub(crate) fn process_point_operation(
                 operation.from_id,
                 operation.to_id,
                 &operation.points,
+                hw_counter,
             )?;
             Ok(deleted + new + updated)
         }
@@ -585,16 +614,21 @@ pub(crate) fn process_vector_operation(
     segments: &RwLock<SegmentHolder>,
     op_num: SeqNumberType,
     vector_operation: VectorOperations,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     match vector_operation {
         VectorOperations::UpdateVectors(operation) => {
-            update_vectors(&segments.read(), op_num, operation.points)
+            update_vectors(&segments.read(), op_num, operation.points, hw_counter)
         }
-        VectorOperations::DeleteVectors(ids, vector_names) => {
-            delete_vectors(&segments.read(), op_num, &ids.points, &vector_names)
-        }
+        VectorOperations::DeleteVectors(ids, vector_names) => delete_vectors(
+            &segments.read(),
+            op_num,
+            &ids.points,
+            &vector_names,
+            hw_counter,
+        ),
         VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
-            delete_vectors_by_filter(&segments.read(), op_num, &filter, &vector_names)
+            delete_vectors_by_filter(&segments.read(), op_num, &filter, &vector_names, hw_counter)
         }
     }
 }
@@ -603,14 +637,29 @@ pub(crate) fn process_payload_operation(
     segments: &RwLock<SegmentHolder>,
     op_num: SeqNumberType,
     payload_operation: PayloadOps,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     match payload_operation {
         PayloadOps::SetPayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                set_payload(&segments.read(), op_num, &payload, &points, &sp.key)
+                set_payload(
+                    &segments.read(),
+                    op_num,
+                    &payload,
+                    &points,
+                    &sp.key,
+                    hw_counter,
+                )
             } else if let Some(filter) = sp.filter {
-                set_payload_by_filter(&segments.read(), op_num, &payload, &filter, &sp.key)
+                set_payload_by_filter(
+                    &segments.read(),
+                    op_num,
+                    &payload,
+                    &filter,
+                    &sp.key,
+                    hw_counter,
+                )
             } else {
                 Err(CollectionError::BadRequest {
                     description: "No points or filter specified".to_string(),
@@ -619,9 +668,9 @@ pub(crate) fn process_payload_operation(
         }
         PayloadOps::DeletePayload(dp) => {
             if let Some(points) = dp.points {
-                delete_payload(&segments.read(), op_num, &points, &dp.keys)
+                delete_payload(&segments.read(), op_num, &points, &dp.keys, hw_counter)
             } else if let Some(filter) = dp.filter {
-                delete_payload_by_filter(&segments.read(), op_num, &filter, &dp.keys)
+                delete_payload_by_filter(&segments.read(), op_num, &filter, &dp.keys, hw_counter)
             } else {
                 Err(CollectionError::BadRequest {
                     description: "No points or filter specified".to_string(),
@@ -629,17 +678,17 @@ pub(crate) fn process_payload_operation(
             }
         }
         PayloadOps::ClearPayload { ref points, .. } => {
-            clear_payload(&segments.read(), op_num, points)
+            clear_payload(&segments.read(), op_num, points, hw_counter)
         }
         PayloadOps::ClearPayloadByFilter(ref filter) => {
-            clear_payload_by_filter(&segments.read(), op_num, filter)
+            clear_payload_by_filter(&segments.read(), op_num, filter, hw_counter)
         }
         PayloadOps::OverwritePayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                overwrite_payload(&segments.read(), op_num, &payload, &points)
+                overwrite_payload(&segments.read(), op_num, &payload, &points, hw_counter)
             } else if let Some(filter) = sp.filter {
-                overwrite_payload_by_filter(&segments.read(), op_num, &payload, &filter)
+                overwrite_payload_by_filter(&segments.read(), op_num, &payload, &filter, hw_counter)
             } else {
                 Err(CollectionError::BadRequest {
                     description: "No points or filter specified".to_string(),
@@ -675,6 +724,7 @@ pub(crate) fn delete_points_by_filter(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     filter: &Filter,
+    hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<usize> {
     let mut total_deleted = 0;
     // we don’t want to cancel this filtered read
@@ -702,7 +752,7 @@ pub(crate) fn delete_points_by_filter(
 
         let mut deleted_in_batch = 0;
         while let Some(point_id) = curr_points.pop() {
-            if s.delete_point(op_num, point_id)? {
+            if s.delete_point(op_num, point_id, hw_counter)? {
                 total_deleted += 1;
                 deleted_in_batch += 1;
             }

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::data_types::vectors::{only_default_vector, VectorStructInternal};
@@ -322,6 +323,7 @@ fn test_proxy_shared_updates() {
         &with_payload,
         &with_vector,
         &is_stopped,
+        HwMeasurementAcc::new(),
     )
     .unwrap();
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::data_types::vectors::{only_default_vector, VectorStructInternal};
@@ -63,6 +64,8 @@ fn test_update_proxy_segments() {
         only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
     ];
 
+    let hw_counter = HardwareCounterCell::new();
+
     for i in 1..10 {
         let points = vec![
             PointStructPersisted {
@@ -76,7 +79,7 @@ fn test_update_proxy_segments() {
                 payload: None,
             },
         ];
-        upsert_points(&segments.read(), 1000 + i, &points).unwrap();
+        upsert_points(&segments.read(), 1000 + i, &points, &hw_counter).unwrap();
     }
 
     let all_ids = segments
@@ -113,6 +116,8 @@ fn test_move_points_to_copy_on_write() {
 
     let proxy_id = wrap_proxy(segments.clone(), sid1, dir.path());
 
+    let hw_counter = HardwareCounterCell::new();
+
     let points = vec![
         PointStructPersisted {
             id: 1.into(),
@@ -126,7 +131,7 @@ fn test_move_points_to_copy_on_write() {
         },
     ];
 
-    upsert_points(&segments.read(), 1001, &points).unwrap();
+    upsert_points(&segments.read(), 1001, &points, &hw_counter).unwrap();
 
     let points = vec![
         PointStructPersisted {
@@ -141,7 +146,7 @@ fn test_move_points_to_copy_on_write() {
         },
     ];
 
-    upsert_points(&segments.read(), 1002, &points).unwrap();
+    upsert_points(&segments.read(), 1002, &points, &hw_counter).unwrap();
 
     let segments_write = segments.write();
 
@@ -189,6 +194,8 @@ fn test_upsert_points_in_smallest_segment() {
     let mut segment2 = build_segment_2(dir.path());
     let segment3 = empty_segment(dir.path());
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Fill segment 1 and 2 to the capacity
     for point_id in 0..100 {
         segment1
@@ -196,6 +203,7 @@ fn test_upsert_points_in_smallest_segment() {
                 20,
                 point_id.into(),
                 only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+                &hw_counter,
             )
             .unwrap();
         segment2
@@ -203,6 +211,7 @@ fn test_upsert_points_in_smallest_segment() {
                 20,
                 (100 + point_id).into(),
                 only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+                &hw_counter,
             )
             .unwrap();
     }
@@ -224,7 +233,7 @@ fn test_upsert_points_in_smallest_segment() {
             payload: None,
         })
         .collect();
-    upsert_points(&segments.read(), 1000, &points).unwrap();
+    upsert_points(&segments.read(), 1000, &points, &hw_counter).unwrap();
 
     // Segment 1 and 2 are over capacity, we expect to have the new points in segment 3
     {
@@ -261,23 +270,33 @@ fn test_proxy_shared_updates() {
     let idx1 = PointIdType::from(1);
     let idx2 = PointIdType::from(2);
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment1
-        .upsert_point(10, idx1, only_default_vector(&old_vec))
+        .upsert_point(10, idx1, only_default_vector(&old_vec), &hw_counter)
         .unwrap();
-    segment1.set_payload(10, idx1, &old_payload, &None).unwrap();
     segment1
-        .upsert_point(20, idx2, only_default_vector(&new_vec))
+        .set_payload(10, idx1, &old_payload, &None, &hw_counter)
         .unwrap();
-    segment1.set_payload(20, idx2, &new_payload, &None).unwrap();
+    segment1
+        .upsert_point(20, idx2, only_default_vector(&new_vec), &hw_counter)
+        .unwrap();
+    segment1
+        .set_payload(20, idx2, &new_payload, &None, &hw_counter)
+        .unwrap();
 
     segment2
-        .upsert_point(20, idx1, only_default_vector(&new_vec))
+        .upsert_point(20, idx1, only_default_vector(&new_vec), &hw_counter)
         .unwrap();
-    segment2.set_payload(20, idx1, &new_payload, &None).unwrap();
     segment2
-        .upsert_point(10, idx2, only_default_vector(&old_vec))
+        .set_payload(20, idx1, &new_payload, &None, &hw_counter)
         .unwrap();
-    segment2.set_payload(10, idx2, &old_payload, &None).unwrap();
+    segment2
+        .upsert_point(10, idx2, only_default_vector(&old_vec), &hw_counter)
+        .unwrap();
+    segment2
+        .set_payload(10, idx2, &old_payload, &None, &hw_counter)
+        .unwrap();
 
     let deleted_points = proxy_segment::LockedRmSet::default();
     let changed_indexes = proxy_segment::LockedIndexChanges::default();
@@ -308,7 +327,7 @@ fn test_proxy_shared_updates() {
 
     let ids = vec![idx1, idx2];
 
-    set_payload(&holder, 30, &payload, &ids, &None).unwrap();
+    set_payload(&holder, 30, &payload, &ids, &None, &hw_counter).unwrap();
 
     let locked_holder = Arc::new(RwLock::new(holder));
 

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -198,6 +198,7 @@ where
         collection_by_name,
         read_consistency,
         timeout,
+        hw_measurement_acc.clone(),
     )
     .await?;
 

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -94,6 +94,7 @@ where
                 self.read_consistency,
                 self.shard_selection.clone(),
                 self.timeout,
+                self.hw_measurement_acc.clone(),
             )
             .await?;
 
@@ -103,7 +104,7 @@ where
             self.read_consistency,
             self.shard_selection.clone(),
             self.timeout,
-            self.hw_measurement_acc,
+            self.hw_measurement_acc.clone(),
         )
         .await?;
 
@@ -126,6 +127,7 @@ where
                     self.read_consistency,
                     &self.shard_selection,
                     timeout,
+                    self.hw_measurement_acc.clone(),
                 )
                 .await?
             };

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -88,6 +88,7 @@ impl GroupRequest {
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<QueryGroupRequest>
     where
         F: Fn(String) -> Fut,
@@ -102,6 +103,7 @@ impl GroupRequest {
                     collection_by_name,
                     read_consistency,
                     timeout,
+                    hw_measurement_acc.clone(),
                 )
                 .await?;
 
@@ -119,6 +121,7 @@ impl GroupRequest {
                     collection_by_name,
                     read_consistency,
                     timeout,
+                    hw_measurement_acc.clone(),
                 )
                 .await?;
                 query_req.try_into_shard_request(&collection.id, &referenced_vectors)?
@@ -475,6 +478,7 @@ pub async fn group_by(
             read_consistency,
             &shard_selection,
             timeout,
+            hw_measurement_acc.clone(),
         )
         .await?
         .into_iter()

--- a/lib/collection/src/lookup/mod.rs
+++ b/lib/collection/src/lookup/mod.rs
@@ -3,6 +3,7 @@ pub mod types;
 use std::collections::HashMap;
 use std::time::Duration;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::Future;
 use itertools::Itertools;
 use segment::types::{PointIdType, WithPayloadInterface, WithVector};
@@ -35,6 +36,7 @@ pub async fn lookup_ids<'a, F, Fut>(
     read_consistency: Option<ReadConsistency>,
     shard_selection: &ShardSelectorInternal,
     timeout: Option<Duration>,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<HashMap<PseudoId, RecordInternal>>
 where
     F: FnOnce(String) -> Fut,
@@ -62,7 +64,13 @@ where
     };
 
     let result = collection
-        .retrieve(point_request, read_consistency, shard_selection, timeout)
+        .retrieve(
+            point_request,
+            read_consistency,
+            shard_selection,
+            timeout,
+            hw_measurement_acc,
+        )
         .await?
         .into_iter()
         .map(|point| (PseudoId::from(point.id), point))

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -284,6 +284,7 @@ where
         collection_by_name,
         read_consistency,
         timeout,
+        hw_measurement_acc.clone(),
     )
     .await?;
 

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -92,6 +92,7 @@ impl ShardOperation for DummyShard {
         _: &Handle,
         _: Option<&OrderBy>,
         _: Option<Duration>,
+        _: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         self.dummy()
     }
@@ -127,6 +128,7 @@ impl ShardOperation for DummyShard {
         _: &WithVector,
         _: &Handle,
         _: Option<Duration>,
+        _: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         self.dummy()
     }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -138,7 +138,8 @@ impl ForwardProxyShard {
                 None,
                 runtime_handle,
                 None,
-                None, // no timeout
+                None,                           // no timeout
+                HwMeasurementAcc::disposable(), // Internal operation, no need to measure hardware here.
             )
             .await?;
         let next_page_offset = if batch.len() < limit {
@@ -343,6 +344,7 @@ impl ShardOperation for ForwardProxyShard {
         search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let local_shard = &self.wrapped_shard;
         local_shard
@@ -355,6 +357,7 @@ impl ShardOperation for ForwardProxyShard {
                 search_runtime_handle,
                 order_by,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }
@@ -396,6 +399,7 @@ impl ShardOperation for ForwardProxyShard {
         with_vector: &WithVector,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let local_shard = &self.wrapped_shard;
         local_shard
@@ -405,6 +409,7 @@ impl ShardOperation for ForwardProxyShard {
                 with_vector,
                 search_runtime_handle,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -16,6 +16,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuBudget;
 use common::rate_limiting::RateLimiter;
 use common::types::TelemetryDetail;
@@ -615,7 +616,12 @@ impl LocalShard {
             }
 
             // Propagate `CollectionError::ServiceError`, but skip other error types.
-            match &CollectionUpdater::update(segments, op_num, update.operation) {
+            match &CollectionUpdater::update(
+                segments,
+                op_num,
+                update.operation,
+                &HardwareCounterCell::disposable(), // Internal operation, no measurement needed.
+            ) {
                 Err(err @ CollectionError::ServiceError { error, backtrace }) => {
                     let path = self.path.display();
 

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -118,6 +118,7 @@ impl ShardOperation for LocalShard {
         search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         // Check read rate limiter before proceeding
         self.check_read_rate_limiter(1)?;
@@ -131,6 +132,7 @@ impl ShardOperation for LocalShard {
                     filter,
                     search_runtime_handle,
                     timeout,
+                    hw_measurement_acc,
                 )
                 .await
             }
@@ -144,6 +146,7 @@ impl ShardOperation for LocalShard {
                         search_runtime_handle,
                         order_by,
                         timeout,
+                        hw_measurement_acc,
                     )
                     .await?;
 
@@ -213,6 +216,7 @@ impl ShardOperation for LocalShard {
         with_vector: &WithVector,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         // Check read rate limiter before proceeding
         self.check_read_rate_limiter(1)?;
@@ -225,6 +229,7 @@ impl ShardOperation for LocalShard {
                 with_payload,
                 with_vector,
                 search_runtime_handle,
+                hw_measurement_acc,
             ),
         )
         .await

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -219,6 +219,7 @@ impl ShardOperation for ProxyShard {
         search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let local_shard = &self.wrapped_shard;
         local_shard
@@ -231,6 +232,7 @@ impl ShardOperation for ProxyShard {
                 search_runtime_handle,
                 order_by,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }
@@ -277,6 +279,7 @@ impl ShardOperation for ProxyShard {
         with_vector: &WithVector,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let local_shard = &self.wrapped_shard;
         local_shard
@@ -286,6 +289,7 @@ impl ShardOperation for ProxyShard {
                 with_vector,
                 search_runtime_handle,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -251,6 +251,7 @@ impl ShardOperation for QueueProxyShard {
         search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         self.inner_unchecked()
             .scroll_by(
@@ -262,6 +263,7 @@ impl ShardOperation for QueueProxyShard {
                 search_runtime_handle,
                 order_by,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }
@@ -303,6 +305,7 @@ impl ShardOperation for QueueProxyShard {
         with_vector: &WithVector,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         self.inner_unchecked()
             .retrieve(
@@ -311,6 +314,7 @@ impl ShardOperation for QueueProxyShard {
                 with_vector,
                 search_runtime_handle,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }
@@ -565,6 +569,7 @@ impl ShardOperation for Inner {
         search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let local_shard = &self.wrapped_shard;
         local_shard
@@ -577,6 +582,7 @@ impl ShardOperation for Inner {
                 search_runtime_handle,
                 order_by,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }
@@ -623,6 +629,7 @@ impl ShardOperation for Inner {
         with_vector: &WithVector,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let local_shard = &self.wrapped_shard;
         local_shard
@@ -632,6 +639,7 @@ impl ShardOperation for Inner {
                 with_vector,
                 search_runtime_handle,
                 timeout,
+                hw_measurement_acc,
             )
             .await
     }

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -684,6 +684,7 @@ impl ShardOperation for RemoteShard {
         _search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        _hw_measurement_acc: HwMeasurementAcc, // TODO(io_measurement) fill this with response data
     ) -> CollectionResult<Vec<RecordInternal>> {
         let processed_timeout = Self::process_read_timeout(timeout, "scroll")?;
         let scroll_points = ScrollPoints {
@@ -880,6 +881,7 @@ impl ShardOperation for RemoteShard {
         with_vector: &WithVector,
         _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        _hw_measurement_acc: HwMeasurementAcc, // TODO(io_measurement): uncomment below and use this parameter
     ) -> CollectionResult<Vec<RecordInternal>> {
         let processed_timeout = Self::process_read_timeout(timeout, "retrieve")?;
         let get_points = GetPoints {
@@ -906,6 +908,15 @@ impl ShardOperation for RemoteShard {
             })
             .await?
             .into_inner();
+
+        // TODO(io_measurement) implement
+        // if let Some(usage) = usage {
+        //     hw_measurement_acc.accumulate_request(
+        //         usage.cpu as usize,
+        //         usage.io_read as usize,
+        //         usage.io_write as usize,
+        //     );
+        // }
 
         let result: Result<Vec<RecordInternal>, Status> = get_response
             .result

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::cpu::CpuBudget;
 use common::rate_limiting::RateLimiter;
 use common::types::TelemetryDetail;
@@ -886,7 +887,11 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub async fn delete_local_points(&self, filter: Filter) -> CollectionResult<UpdateResult> {
+    pub async fn delete_local_points(
+        &self,
+        filter: Filter,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<UpdateResult> {
         let local_shard_guard = self.local.read().await;
 
         let Some(local_shard) = local_shard_guard.deref() else {
@@ -912,6 +917,7 @@ impl ShardReplicaSet {
                     &self.search_runtime,
                     None,
                     None,
+                    hw_measurement_acc.clone(),
                 )
                 .await?;
 

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -25,6 +25,7 @@ impl ShardReplicaSet {
         local_only: bool,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let with_payload_interface = Arc::new(with_payload_interface.clone());
         let with_vector = Arc::new(with_vector.clone());
@@ -39,6 +40,8 @@ impl ShardReplicaSet {
                 let search_runtime = self.search_runtime.clone();
                 let order_by = order_by.clone();
 
+                let hw_acc = hw_measurement_acc.clone();
+
                 async move {
                     shard
                         .scroll_by(
@@ -50,6 +53,7 @@ impl ShardReplicaSet {
                             &search_runtime,
                             order_by.as_deref(),
                             timeout,
+                            hw_acc,
                         )
                         .await
                 }
@@ -113,6 +117,7 @@ impl ShardReplicaSet {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn retrieve(
         &self,
         request: Arc<PointRequestInternal>,
@@ -121,6 +126,7 @@ impl ShardReplicaSet {
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
         local_only: bool,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let with_payload = Arc::new(with_payload.clone());
         let with_vector = Arc::new(with_vector.clone());
@@ -132,6 +138,8 @@ impl ShardReplicaSet {
                 let with_vector = with_vector.clone();
                 let search_runtime = self.search_runtime.clone();
 
+                let hw_acc = hw_measurement_acc.clone();
+
                 async move {
                     shard
                         .retrieve(
@@ -140,6 +148,7 @@ impl ShardReplicaSet {
                             &with_vector,
                             &search_runtime,
                             timeout,
+                            hw_acc,
                         )
                         .await
                 }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::ops::Deref as _;
 use std::sync::Arc;
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::{Condition, CustomIdCheckerCondition as _, Filter, ShardKey};
 
 use super::ShardHolder;
@@ -329,7 +330,9 @@ impl ShardHolder {
                 // Remove any points that might have been transferred from target shard
                 let filter = self.hash_ring_filter(id).expect("hash ring filter");
                 let filter = Filter::new_must_not(Condition::CustomIdChecker(Arc::new(filter)));
-                shard.delete_local_points(filter).await?;
+                shard
+                    .delete_local_points(filter, HwMeasurementAcc::disposable()) // Internal operation, no performance tracking needed
+                    .await?;
             }
         }
 

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -31,6 +31,7 @@ pub trait ShardOperation {
         search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
         timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>>;
 
     async fn info(&self) -> CollectionResult<CollectionInfo>;
@@ -58,6 +59,7 @@ pub trait ShardOperation {
         with_vector: &WithVector,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
+        hardware_accumulator: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>>;
 
     async fn query_batch(

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuBudget;
 use futures::future::join_all;
 use itertools::Itertools;
@@ -273,6 +274,8 @@ async fn test_new_segment_when_all_over_capacity() {
 
     assert_eq!(segments.read().len(), 6);
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Insert some points in the smallest segment to fill capacity
     {
         let segments_read = segments.read();
@@ -294,7 +297,12 @@ async fn test_new_segment_when_all_over_capacity() {
             segment
                 .get()
                 .write()
-                .upsert_point(101, point_id, only_default_vector(&random_vector))
+                .upsert_point(
+                    101,
+                    point_id,
+                    only_default_vector(&random_vector),
+                    &hw_counter,
+                )
                 .unwrap();
         }
     }

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -166,6 +166,7 @@ async fn test_scroll_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .expect("failed to search");
@@ -193,6 +194,7 @@ async fn test_scroll_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .expect("failed to search");
@@ -224,6 +226,7 @@ async fn test_retrieve_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .expect("failed to search");

--- a/lib/collection/tests/integration/collection_restore_test.rs
+++ b/lib/collection/tests/integration/collection_restore_test.rs
@@ -5,6 +5,7 @@ use collection::operations::point_ops::{
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::ScrollRequestInternal;
 use collection::operations::CollectionUpdateOperations;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::json_path::JsonPath;
 use segment::types::{PayloadContainer, PayloadSelectorExclude, WithPayloadInterface};
@@ -113,6 +114,7 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -194,6 +196,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -230,6 +233,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -265,7 +265,13 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
         with_vector: true.into(),
     };
     let retrieved = loaded_collection
-        .retrieve(request, None, &ShardSelectorInternal::All, None)
+        .retrieve(
+            request,
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
         .await
         .unwrap();
 
@@ -444,6 +450,7 @@ async fn test_read_api_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -573,6 +580,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 None,
                 &ShardSelectorInternal::All,
                 None,
+                HwMeasurementAcc::new(),
             )
             .await
             .unwrap();
@@ -604,6 +612,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 None,
                 &ShardSelectorInternal::All,
                 None,
+                HwMeasurementAcc::new(),
             )
             .await
             .unwrap();
@@ -644,6 +653,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 None,
                 &ShardSelectorInternal::All,
                 None,
+                HwMeasurementAcc::new(),
             )
             .await
             .unwrap();
@@ -683,6 +693,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 None,
                 &ShardSelectorInternal::All,
                 None,
+                HwMeasurementAcc::new(),
             )
             .await
             .unwrap();
@@ -719,6 +730,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();
@@ -812,6 +824,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -8,6 +8,7 @@ use collection::operations::point_ops::{
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::shards::shard::ShardId;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use rand::rngs::SmallRng;
 use rand::{self, Rng, SeedableRng};
@@ -122,6 +123,7 @@ async fn happy_lookup_ids() {
         read_consistency,
         &shard_selection,
         None,
+        HwMeasurementAcc::new(),
     )
     .await;
 
@@ -211,6 +213,7 @@ async fn nonexistent_lookup_ids_are_ignored(#[case] value: impl Into<PseudoId>) 
         read_consistency,
         &shard_selection,
         None,
+        HwMeasurementAcc::new(),
     )
     .await;
 
@@ -244,6 +247,7 @@ async fn err_when_collection_by_name_returns_none() {
         read_consistency,
         &shard_selection,
         None,
+        HwMeasurementAcc::new(),
     )
     .await;
 

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -223,6 +223,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             None,
             &ShardSelectorInternal::All,
             None,
+            HwMeasurementAcc::new(),
         )
         .await
         .unwrap();

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::prelude::StdRng;
@@ -53,13 +54,15 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
         payload_storage_type: Default::default(),
     };
 
+    let hw_counter = HardwareCounterCell::new();
+
     let mut segment = build_segment(segment_dir.path(), &segment_config, true).unwrap();
     for n in 0..NUM_POINTS {
         let idx = (n as u64).into();
         let multi_vec = random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT);
         let named_vectors = only_default_multi_vector(&multi_vec);
         segment
-            .upsert_point(n as SeqNumberType, idx, named_vectors)
+            .upsert_point(n as SeqNumberType, idx, named_vectors, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/benches/segment_info.rs
+++ b/lib/segment/benches/segment_info.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{criterion_group, criterion_main, Criterion};
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
@@ -50,12 +51,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     }
     let payload = Payload::from(payload);
 
+    let hw_counter = HardwareCounterCell::new();
+
     for id in 0..100000u64 {
         segment
-            .upsert_point(100, id.into(), only_default_vector(&vector))
+            .upsert_point(100, id.into(), only_default_vector(&vector), &hw_counter)
             .unwrap();
         segment
-            .set_payload(100, id.into(), &payload, &None)
+            .set_payload(100, id.into(), &payload, &None, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
 
@@ -106,6 +107,14 @@ pub trait SegmentEntry {
     ) -> OperationResult<Option<VectorInternal>>;
 
     fn all_vectors(&self, point_id: PointIdType) -> OperationResult<NamedVectors>;
+
+    /// Retrieve payload for the point
+    /// If not found, return empty payload
+    fn payload_measured(
+        &self,
+        point_id: PointIdType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload>;
 
     /// Retrieve payload for the point
     /// If not found, return empty payload

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -118,7 +118,7 @@ pub trait SegmentEntry {
 
     /// Retrieve payload for the point
     /// If not found, return empty payload
-    fn payload_measured(
+    fn payload(
         &self,
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -50,12 +50,14 @@ pub trait SegmentEntry {
         op_num: SeqNumberType,
         point_id: PointIdType,
         vectors: NamedVectors,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn delete_point(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn update_vectors(
@@ -63,6 +65,7 @@ pub trait SegmentEntry {
         op_num: SeqNumberType,
         point_id: PointIdType,
         vectors: NamedVectors,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn delete_vector(
@@ -70,6 +73,7 @@ pub trait SegmentEntry {
         op_num: SeqNumberType,
         point_id: PointIdType,
         vector_name: &str,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn set_payload(
@@ -78,6 +82,7 @@ pub trait SegmentEntry {
         point_id: PointIdType,
         payload: &Payload,
         key: &Option<JsonPath>,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn set_full_payload(
@@ -85,6 +90,7 @@ pub trait SegmentEntry {
         op_num: SeqNumberType,
         point_id: PointIdType,
         full_payload: &Payload,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn delete_payload(
@@ -92,12 +98,14 @@ pub trait SegmentEntry {
         op_num: SeqNumberType,
         point_id: PointIdType,
         key: PayloadKeyTypeRef,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn clear_payload(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
     fn vector(
@@ -115,10 +123,6 @@ pub trait SegmentEntry {
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload>;
-
-    /// Retrieve payload for the point
-    /// If not found, return empty payload
-    fn payload(&self, point_id: PointIdType) -> OperationResult<Payload>;
 
     /// Iterator over all points in segment in ascending order.
     fn iter_points(&self) -> Box<dyn Iterator<Item = PointIdType> + '_>;
@@ -289,6 +293,7 @@ pub trait SegmentEntry {
         &'a mut self,
         op_num: SeqNumberType,
         filter: &'a Filter,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<usize>;
 
     /// Take a snapshot of the segment.

--- a/lib/segment/src/fixtures/segment_fixtures.rs
+++ b/lib/segment/src/fixtures/segment_fixtures.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use common::counter::hardware_counter::HardwareCounterCell;
+
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::entry::entry_point::SegmentEntry;
@@ -17,6 +19,8 @@ pub fn random_segment(path: &Path, num_points: usize) -> Segment {
 
     let mut segment = build_simple_segment(path, dim, distance).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     for point_id in 0..num_points {
         let vector = random_vector(&mut rnd_gen, dim);
         let payload = generate_diverse_payload(&mut rnd_gen);
@@ -26,10 +30,11 @@ pub fn random_segment(path: &Path, num_points: usize) -> Segment {
                 100,
                 (point_id as u64).into(),
                 NamedVectors::from_ref(DEFAULT_VECTOR_NAME, vector.as_slice().into()),
+                &hw_counter,
             )
             .unwrap();
         segment
-            .set_payload(100, (point_id as u64).into(), &payload, &None)
+            .set_payload(100, (point_id as u64).into(), &payload, &None, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use rand::thread_rng;
@@ -34,6 +35,8 @@ fn test_graph_connectivity() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     let config = SegmentConfig {
         vector_data: HashMap::from([(
             DEFAULT_VECTOR_NAME.to_owned(),
@@ -57,7 +60,12 @@ fn test_graph_connectivity() {
         let vector = random_vector(&mut rnd, dim);
 
         segment
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
     }
 

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -100,6 +101,12 @@ pub trait PayloadIndex {
 
     /// Get payload for point
     fn get_payload(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
+
+    fn get_payload_measured(
+        &self,
+        point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload>;
 
     /// Delete payload by key
     fn delete_payload(

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -100,9 +100,7 @@ pub trait PayloadIndex {
     ) -> OperationResult<()>;
 
     /// Get payload for point
-    fn get_payload(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
-
-    fn get_payload_measured(
+    fn get_payload(
         &self,
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use schemars::_serde_json::Value;
 
@@ -174,6 +175,14 @@ impl PayloadIndex for PlainPayloadIndex {
     }
 
     fn get_payload(&self, _point_id: PointOffsetType) -> OperationResult<Payload> {
+        unreachable!()
+    }
+
+    fn get_payload_measured(
+        &self,
+        _point_id: PointOffsetType,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
         unreachable!()
     }
 

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -174,11 +174,7 @@ impl PayloadIndex for PlainPayloadIndex {
         unreachable!()
     }
 
-    fn get_payload(&self, _point_id: PointOffsetType) -> OperationResult<Payload> {
-        unreachable!()
-    }
-
-    fn get_payload_measured(
+    fn get_payload(
         &self,
         _point_id: PointOffsetType,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use itertools::Either;
 use log::debug;
@@ -592,6 +593,14 @@ impl PayloadIndex for StructPayloadIndex {
 
     fn get_payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
         self.payload.borrow().get(point_id)
+    }
+
+    fn get_payload_measured(
+        &self,
+        point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        self.payload.borrow().get_measured(point_id, hw_counter)
     }
 
     fn delete_payload(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -572,7 +572,9 @@ impl PayloadIndex for StructPayloadIndex {
             self.payload.borrow_mut().set(point_id, payload)?;
         };
 
-        let updated_payload = self.get_payload(point_id)?;
+        let hw_counter = HardwareCounterCell::disposable(); // TODO(io_measurement): Implement!!
+
+        let updated_payload = self.get_payload(point_id, &hw_counter)?;
         for (field, field_index) in &mut self.field_indexes {
             if !field.is_affected_by_value_set(&payload.0, key.as_ref()) {
                 continue;
@@ -591,11 +593,7 @@ impl PayloadIndex for StructPayloadIndex {
         Ok(())
     }
 
-    fn get_payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
-        self.payload.borrow().get(point_id)
-    }
-
-    fn get_payload_measured(
+    fn get_payload(
         &self,
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -51,6 +51,14 @@ impl PayloadStorage for InMemoryPayloadStorage {
         }
     }
 
+    fn get_measured(
+        &self,
+        point_id: PointOffsetType,
+        _: &common::counter::hardware_counter::HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        self.get(point_id)
+    }
+
     fn delete(&mut self, point_id: PointOffsetType, key: &JsonPath) -> OperationResult<Vec<Value>> {
         match self.payload.get_mut(&point_id) {
             Some(payload) => {

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use blob_store::config::StorageOptions;
 use blob_store::{Blob, BlobStore};
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use serde_json::Value;
@@ -114,6 +115,17 @@ impl PayloadStorage for MmapPayloadStorage {
 
     fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
         match self.storage.read().get_value(point_id) {
+            Some(payload) => Ok(payload),
+            None => Ok(Default::default()),
+        }
+    }
+
+    fn get_measured(
+        &self,
+        point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        match self.storage.read().get_value_measured(point_id, hw_counter) {
             Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -26,6 +27,12 @@ pub trait PayloadStorage {
 
     /// Get payload for point. If no payload found, return empty payload
     fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
+
+    fn get_measured(
+        &self,
+        point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload>;
 
     /// Delete payload by point_id and key
     fn delete(&mut self, point_id: PointOffsetType, key: &JsonPath) -> OperationResult<Vec<Value>>;

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -25,6 +25,7 @@ pub trait PayloadStorage {
         key: &JsonPath,
     ) -> OperationResult<()>;
 
+    // TODO(io_measurement): Replace with `get_measured`
     /// Get payload for point. If no payload found, return empty payload
     fn get(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
 

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -91,6 +92,20 @@ impl PayloadStorage for PayloadStorageEnum {
             PayloadStorageEnum::SimplePayloadStorage(s) => s.get(point_id),
             PayloadStorageEnum::OnDiskPayloadStorage(s) => s.get(point_id),
             PayloadStorageEnum::MmapPayloadStorage(s) => s.get(point_id),
+        }
+    }
+
+    fn get_measured(
+        &self,
+        point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.get_measured(point_id, hw_counter),
+            PayloadStorageEnum::SimplePayloadStorage(s) => s.get_measured(point_id, hw_counter),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.get_measured(point_id, hw_counter),
+            PayloadStorageEnum::MmapPayloadStorage(s) => s.get_measured(point_id, hw_counter),
         }
     }
 

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -55,6 +55,14 @@ impl PayloadStorage for SimplePayloadStorage {
         }
     }
 
+    fn get_measured(
+        &self,
+        point_id: PointOffsetType,
+        _: &common::counter::hardware_counter::HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        self.get(point_id)
+    }
+
     fn delete(
         &mut self,
         point_id: PointOffsetType,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::thread::{self};
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
 use io::storage_version::VERSION_FILE;
@@ -296,6 +297,15 @@ impl SegmentEntry for Segment {
     fn payload(&self, point_id: PointIdType) -> OperationResult<Payload> {
         let internal_id = self.lookup_internal_id(point_id)?;
         self.payload_by_offset(internal_id)
+    }
+
+    fn payload_measured(
+        &self,
+        point_id: PointIdType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        let internal_id = self.lookup_internal_id(point_id)?;
+        self.payload_by_offset_measured(internal_id, hw_counter)
     }
 
     fn iter_points(&self) -> Box<dyn Iterator<Item = PointIdType> + '_> {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -75,10 +75,12 @@ impl SegmentEntry for Segment {
 
         check_stopped(&vector_query_context.is_stopped())?;
 
+        let hw_counter = vector_query_context.hardware_counter();
+
         internal_results
             .into_iter()
             .map(|internal_result| {
-                self.process_search_result(internal_result, with_payload, with_vector)
+                self.process_search_result(internal_result, with_payload, with_vector, &hw_counter)
             })
             .collect()
     }
@@ -88,6 +90,7 @@ impl SegmentEntry for Segment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         mut vectors: NamedVectors,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set Values!
     ) -> OperationResult<bool> {
         debug_assert!(self.is_appendable());
         check_named_vectors(&vectors, &self.segment_config)?;
@@ -108,6 +111,7 @@ impl SegmentEntry for Segment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set Values!
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
@@ -145,6 +149,7 @@ impl SegmentEntry for Segment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         mut vectors: NamedVectors,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set Values!
     ) -> OperationResult<bool> {
         check_named_vectors(&vectors, &self.segment_config)?;
         vectors.preprocess(|name| self.config().vector_data.get(name).unwrap());
@@ -167,6 +172,7 @@ impl SegmentEntry for Segment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         vector_name: &str,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set values!
     ) -> OperationResult<bool> {
         check_vector_name(vector_name, &self.segment_config)?;
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
@@ -194,6 +200,7 @@ impl SegmentEntry for Segment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         full_payload: &Payload,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set values!
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
@@ -216,6 +223,7 @@ impl SegmentEntry for Segment {
         point_id: PointIdType,
         payload: &Payload,
         key: &Option<JsonPath>,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set values!
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
@@ -237,6 +245,7 @@ impl SegmentEntry for Segment {
         op_num: SeqNumberType,
         point_id: PointIdType,
         key: PayloadKeyTypeRef,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set values!
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
@@ -257,6 +266,7 @@ impl SegmentEntry for Segment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
+        _hw_counter: &HardwareCounterCell, // TODO(io_measurement): Set values!
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
@@ -294,10 +304,10 @@ impl SegmentEntry for Segment {
         Ok(result)
     }
 
-    fn payload(&self, point_id: PointIdType) -> OperationResult<Payload> {
-        let internal_id = self.lookup_internal_id(point_id)?;
-        self.payload_by_offset(internal_id)
-    }
+    // fn payload(&self, point_id: PointIdType) -> OperationResult<Payload> {
+    //     let internal_id = self.lookup_internal_id(point_id)?;
+    //     self.payload_by_offset(internal_id)
+    // }
 
     fn payload_measured(
         &self,
@@ -763,11 +773,12 @@ impl SegmentEntry for Segment {
         &'a mut self,
         op_num: SeqNumberType,
         filter: &'a Filter,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<usize> {
         let mut deleted_points = 0;
         let is_stopped = AtomicBool::new(false);
         for point_id in self.read_filtered(None, None, Some(filter), &is_stopped) {
-            deleted_points += usize::from(self.delete_point(op_num, point_id)?);
+            deleted_points += usize::from(self.delete_point(op_num, point_id, hw_counter)?);
         }
 
         Ok(deleted_points)

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -304,18 +304,13 @@ impl SegmentEntry for Segment {
         Ok(result)
     }
 
-    // fn payload(&self, point_id: PointIdType) -> OperationResult<Payload> {
-    //     let internal_id = self.lookup_internal_id(point_id)?;
-    //     self.payload_by_offset(internal_id)
-    // }
-
-    fn payload_measured(
+    fn payload(
         &self,
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         let internal_id = self.lookup_internal_id(point_id)?;
-        self.payload_by_offset_measured(internal_id, hw_counter)
+        self.payload_by_offset(internal_id, hw_counter)
     }
 
     fn iter_points(&self) -> Box<dyn Iterator<Item = PointIdType> + '_> {

--- a/lib/segment/src/segment/search.rs
+++ b/lib/segment/src/segment/search.rs
@@ -1,3 +1,4 @@
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::ScoredPointOffset;
 
 use super::Segment;
@@ -21,6 +22,7 @@ impl Segment {
         internal_result: Vec<ScoredPointOffset>,
         with_payload: &WithPayload,
         with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<ScoredPoint>> {
         let id_tracker = self.id_tracker.borrow();
         internal_result
@@ -47,7 +49,9 @@ impl Segment {
                     ))
                 })?;
                 let payload = if with_payload.enable {
-                    let initial_payload = self.payload_by_offset(point_offset)?;
+                    let initial_payload =
+                        self.payload_by_offset_measured(point_offset, hw_counter)?;
+
                     let processed_payload = if let Some(i) = &with_payload.payload_selector {
                         i.process(initial_payload)
                     } else {

--- a/lib/segment/src/segment/search.rs
+++ b/lib/segment/src/segment/search.rs
@@ -49,8 +49,7 @@ impl Segment {
                     ))
                 })?;
                 let payload = if with_payload.enable {
-                    let initial_payload =
-                        self.payload_by_offset_measured(point_offset, hw_counter)?;
+                    let initial_payload = self.payload_by_offset(point_offset, hw_counter)?;
 
                     let processed_payload = if let Some(i) = &with_payload.payload_selector {
                         i.process(initial_payload)

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::thread::{self, JoinHandle};
 
 use bitvec::prelude::BitVec;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use memory::mmap_ops;
@@ -410,6 +411,18 @@ impl Segment {
         point_offset: PointOffsetType,
     ) -> OperationResult<Payload> {
         self.payload_index.borrow().get_payload(point_offset)
+    }
+
+    /// Retrieve payload by internal ID
+    #[inline]
+    pub(super) fn payload_by_offset_measured(
+        &self,
+        point_offset: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        self.payload_index
+            .borrow()
+            .get_payload_measured(point_offset, hw_counter)
     }
 
     pub fn save_current_state(&self) -> OperationResult<()> {

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -406,15 +406,6 @@ impl Segment {
 
     /// Retrieve payload by internal ID
     #[inline]
-    pub(super) fn payload_by_offset(
-        &self,
-        point_offset: PointOffsetType,
-    ) -> OperationResult<Payload> {
-        self.payload_index.borrow().get_payload(point_offset)
-    }
-
-    /// Retrieve payload by internal ID
-    #[inline]
     pub(super) fn payload_by_offset_measured(
         &self,
         point_offset: PointOffsetType,

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -406,14 +406,14 @@ impl Segment {
 
     /// Retrieve payload by internal ID
     #[inline]
-    pub(super) fn payload_by_offset_measured(
+    pub(super) fn payload_by_offset(
         &self,
         point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         self.payload_index
             .borrow()
-            .get_payload_measured(point_offset, hw_counter)
+            .get_payload(point_offset, hw_counter)
     }
 
     pub fn save_current_state(&self) -> OperationResult<()> {

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -314,8 +314,8 @@ fn test_snapshot(#[case] format: SnapshotFormat) {
         let restored_vectors = restored_segment.all_vectors(id).unwrap();
         assert_eq!(vectors, restored_vectors);
 
-        let payload = segment.payload_measured(id, &hw_counter).unwrap();
-        let restored_payload = restored_segment.payload_measured(id, &hw_counter).unwrap();
+        let payload = segment.payload(id, &hw_counter).unwrap();
+        let restored_payload = restored_segment.payload(id, &hw_counter).unwrap();
         assert_eq!(payload, restored_payload);
     }
 }

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::sync::atomic::AtomicBool;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use rstest::rstest;
 use tempfile::Builder;
@@ -41,15 +42,17 @@ fn test_search_batch_equivalence_single() {
     };
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     let vec4 = vec![1.1, 1.0, 0.0, 1.0];
     segment
-        .upsert_point(100, 4.into(), only_default_vector(&vec4))
+        .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_counter)
         .unwrap();
     let vec6 = vec![1.0, 1.0, 0.5, 1.0];
     segment
-        .upsert_point(101, 6.into(), only_default_vector(&vec6))
+        .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
         .unwrap();
-    segment.delete_point(102, 1.into()).unwrap();
+    segment.delete_point(102, 1.into(), &hw_counter).unwrap();
 
     let query_vector = [1.0, 1.0, 1.0, 1.0].into();
     let search_result = segment
@@ -117,14 +120,18 @@ fn test_from_filter_attributes() {
         payload_storage_type: Default::default(),
     };
 
+    let hw_counter = HardwareCounterCell::new();
+
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
     segment
-        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]))
+        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]), &hw_counter)
         .unwrap();
 
     let payload: Payload = serde_json::from_str(data).unwrap();
 
-    segment.set_full_payload(0, 0.into(), &payload).unwrap();
+    segment
+        .set_full_payload(0, 0.into(), &payload, &hw_counter)
+        .unwrap();
 
     let filter_valid_str = r#"
         {
@@ -213,14 +220,21 @@ fn test_snapshot(#[case] format: SnapshotFormat) {
         payload_storage_type: Default::default(),
     };
 
+    let hw_counter = HardwareCounterCell::new();
+
     let mut segment = build_segment(segment_base_dir.path(), &config, true).unwrap();
 
     segment
-        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]))
+        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]), &hw_counter)
         .unwrap();
 
     segment
-        .set_full_payload(1, 0.into(), &serde_json::from_str(data).unwrap())
+        .set_full_payload(
+            1,
+            0.into(),
+            &serde_json::from_str(data).unwrap(),
+            &hw_counter,
+        )
         .unwrap();
 
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
@@ -300,8 +314,8 @@ fn test_snapshot(#[case] format: SnapshotFormat) {
         let restored_vectors = restored_segment.all_vectors(id).unwrap();
         assert_eq!(vectors, restored_vectors);
 
-        let payload = segment.payload(id).unwrap();
-        let restored_payload = restored_segment.payload(id).unwrap();
+        let payload = segment.payload_measured(id, &hw_counter).unwrap();
+        let restored_payload = restored_segment.payload_measured(id, &hw_counter).unwrap();
         assert_eq!(payload, restored_payload);
     }
 }
@@ -336,13 +350,17 @@ fn test_background_flush() {
         payload_storage_type: Default::default(),
     };
 
+    let hw_counter = HardwareCounterCell::new();
+
     let mut segment = build_segment(segment_base_dir.path(), &config, true).unwrap();
     segment
-        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]))
+        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]), &hw_counter)
         .unwrap();
 
     let payload: Payload = serde_json::from_str(data).unwrap();
-    segment.set_full_payload(0, 0.into(), &payload).unwrap();
+    segment
+        .set_full_payload(0, 0.into(), &payload, &hw_counter)
+        .unwrap();
     segment.flush(false, false).unwrap();
 
     // call flush second time to check that background flush finished successful
@@ -371,13 +389,15 @@ fn test_check_consistency() {
     };
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     let vec4 = vec![1.1, 1.0, 0.0, 1.0];
     segment
-        .upsert_point(100, 4.into(), only_default_vector(&vec4))
+        .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_counter)
         .unwrap();
     let vec6 = vec![1.0, 1.0, 0.5, 1.0];
     segment
-        .upsert_point(101, 6.into(), only_default_vector(&vec6))
+        .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
         .unwrap();
 
     // first pass on consistent data
@@ -466,25 +486,27 @@ fn test_point_vector_count() {
     };
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Insert point ID 4 and 6, assert counts
     segment
-        .upsert_point(100, 4.into(), only_default_vector(&[0.4]))
+        .upsert_point(100, 4.into(), only_default_vector(&[0.4]), &hw_counter)
         .unwrap();
     segment
-        .upsert_point(101, 6.into(), only_default_vector(&[0.6]))
+        .upsert_point(101, 6.into(), only_default_vector(&[0.6]), &hw_counter)
         .unwrap();
     let segment_info = segment.info();
     assert_eq!(segment_info.num_points, 2);
     assert_eq!(segment_info.num_vectors, 2);
 
     // Delete nonexistent point, counts should remain the same
-    segment.delete_point(102, 1.into()).unwrap();
+    segment.delete_point(102, 1.into(), &hw_counter).unwrap();
     let segment_info = segment.info();
     assert_eq!(segment_info.num_points, 2);
     assert_eq!(segment_info.num_vectors, 2);
 
     // Delete point 4, counts should decrease by 1
-    segment.delete_point(103, 4.into()).unwrap();
+    segment.delete_point(103, 4.into(), &hw_counter).unwrap();
     let segment_info = segment.info();
     assert_eq!(segment_info.num_points, 1);
     assert_eq!(segment_info.num_vectors, 2); // We don't propagate deletes to vectors at this time
@@ -534,12 +556,15 @@ fn test_point_vector_count_multivec() {
     };
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Insert point ID 4 and 6 fully, 8 and 10 partially, assert counts
     segment
         .upsert_point(
             100,
             4.into(),
             NamedVectors::from_pairs([("a".into(), vec![0.4]), ("b".into(), vec![0.5])]),
+            &hw_counter,
         )
         .unwrap();
     segment
@@ -547,6 +572,7 @@ fn test_point_vector_count_multivec() {
             101,
             6.into(),
             NamedVectors::from_pairs([("a".into(), vec![0.6]), ("b".into(), vec![0.7])]),
+            &hw_counter,
         )
         .unwrap();
     segment
@@ -554,6 +580,7 @@ fn test_point_vector_count_multivec() {
             102,
             8.into(),
             NamedVectors::from_pairs([("a".into(), vec![0.0])]),
+            &hw_counter,
         )
         .unwrap();
     segment
@@ -561,6 +588,7 @@ fn test_point_vector_count_multivec() {
             103,
             10.into(),
             NamedVectors::from_pairs([("b".into(), vec![1.0])]),
+            &hw_counter,
         )
         .unwrap();
     let segment_info = segment.info();
@@ -568,25 +596,29 @@ fn test_point_vector_count_multivec() {
     assert_eq!(segment_info.num_vectors, 6);
 
     // Delete nonexistent point, counts should remain the same
-    segment.delete_point(104, 1.into()).unwrap();
+    segment.delete_point(104, 1.into(), &hw_counter).unwrap();
     let segment_info = segment.info();
     assert_eq!(segment_info.num_points, 4);
     assert_eq!(segment_info.num_vectors, 6);
 
     // Delete point 4, counts should decrease by 1
-    segment.delete_point(105, 4.into()).unwrap();
+    segment.delete_point(105, 4.into(), &hw_counter).unwrap();
     let segment_info = segment.info();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 6); // We don't propagate deletes to vectors at this time
 
     // Delete vector 'a' of point 6, vector count should decrease by 1
-    segment.delete_vector(106, 6.into(), "a").unwrap();
+    segment
+        .delete_vector(106, 6.into(), "a", &hw_counter)
+        .unwrap();
     let segment_info = segment.info();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 5);
 
     // Deleting it again shouldn't chain anything
-    segment.delete_vector(107, 6.into(), "a").unwrap();
+    segment
+        .delete_vector(107, 6.into(), "a", &hw_counter)
+        .unwrap();
     let segment_info = segment.info();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 5);
@@ -651,6 +683,8 @@ fn test_vector_compatibility_checks() {
     };
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Insert one point for a reference internal ID
     let point_id = 4.into();
     segment
@@ -661,6 +695,7 @@ fn test_vector_compatibility_checks() {
                 ("a".into(), vec![0.1, 0.2, 0.3, 0.4]),
                 ("b".into(), vec![1.0, 0.9]),
             ]),
+            &hw_counter,
         )
         .unwrap();
     let internal_id = segment.lookup_internal_id(point_id).unwrap();
@@ -751,7 +786,7 @@ fn test_vector_compatibility_checks() {
     for vectors in wrong_vectors_multi {
         check_named_vectors(&vectors, &config).err().unwrap();
         segment
-            .upsert_point(101, point_id, vectors.clone())
+            .upsert_point(101, point_id, vectors.clone(), &hw_counter)
             .err()
             .unwrap();
         segment
@@ -772,7 +807,7 @@ fn test_vector_compatibility_checks() {
         check_vector_name(wrong_name, &config).err().unwrap();
         segment.vector(wrong_name, point_id).err().unwrap();
         segment
-            .delete_vector(101, point_id, wrong_name)
+            .delete_vector(101, point_id, wrong_name, &hw_counter)
             .err()
             .unwrap();
         segment.available_vector_count(wrong_name).err().unwrap();
@@ -812,9 +847,17 @@ fn test_handle_point_version() {
         sparse_vector_data: Default::default(),
         payload_storage_type: Default::default(),
     };
+
+    let hw_counter = HardwareCounterCell::new();
+
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
     segment
-        .upsert_point(100, 1.into(), only_default_vector(&[1.1, 1.0, 0.0, 1.0]))
+        .upsert_point(
+            100,
+            1.into(),
+            only_default_vector(&[1.1, 1.0, 0.0, 1.0]),
+            &hw_counter,
+        )
         .unwrap();
 
     // Do not handle operation on existing point when providing an old version

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use ahash::AHasher;
 use atomic_refcell::AtomicRefCell;
 use bitvec::macros::internal::funty::Integral;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use io::storage_version::StorageVersion;
@@ -336,8 +337,8 @@ impl SegmentBuilder {
 
                 let old_internal_id = point_data.internal_id;
 
-                let other_payload =
-                    payloads[point_data.segment_index].get_payload(old_internal_id)?;
+                let other_payload = payloads[point_data.segment_index]
+                    .get_payload(old_internal_id, &HardwareCounterCell::disposable())?; // Internal operation, no measurement needed!
 
                 match self.id_tracker.internal_id(point_data.external_id) {
                     Some(existing_internal_id) => {

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -115,6 +115,7 @@ pub fn build_multivec_segment(
 
 #[cfg(test)]
 mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
     use serde_json::json;
     use tempfile::Builder;
 
@@ -143,26 +144,28 @@ mod tests {
         let vec4 = vec![1.0, 1.0, 0.0, 1.0];
         let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
-        match segment.upsert_point(1, 120.into(), only_default_vector(&wrong_vec)) {
+        let hw_counter = HardwareCounterCell::new();
+
+        match segment.upsert_point(1, 120.into(), only_default_vector(&wrong_vec), &hw_counter) {
             Err(OperationError::WrongVectorDimension { .. }) => (),
             Err(_) => panic!("Wrong error"),
             Ok(_) => panic!("Operation with wrong vector should fail"),
         };
 
         segment
-            .upsert_point(2, 1.into(), only_default_vector(&vec1))
+            .upsert_point(2, 1.into(), only_default_vector(&vec1), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(2, 2.into(), only_default_vector(&vec2))
+            .upsert_point(2, 2.into(), only_default_vector(&vec2), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(2, 3.into(), only_default_vector(&vec3))
+            .upsert_point(2, 3.into(), only_default_vector(&vec3), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(2, 4.into(), only_default_vector(&vec4))
+            .upsert_point(2, 4.into(), only_default_vector(&vec4), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(2, 5.into(), only_default_vector(&vec5))
+            .upsert_point(2, 5.into(), only_default_vector(&vec5), &hw_counter)
             .unwrap();
 
         segment
@@ -171,6 +174,7 @@ mod tests {
                 1.into(),
                 &json!({ "color": vec!["red".to_owned(), "green".to_owned()] }).into(),
                 &None,
+                &hw_counter,
             )
             .unwrap();
 
@@ -180,6 +184,7 @@ mod tests {
                 2.into(),
                 &json!({ "color": vec!["red".to_owned(), "blue".to_owned()] }).into(),
                 &None,
+                &hw_counter,
             )
             .unwrap();
 
@@ -189,6 +194,7 @@ mod tests {
                 3.into(),
                 &json!({ "color": vec!["red".to_owned(), "yellow".to_owned()] }).into(),
                 &None,
+                &hw_counter,
             )
             .unwrap();
 
@@ -198,30 +204,31 @@ mod tests {
                 4.into(),
                 &json!({ "color": vec!["red".to_owned(), "green".to_owned()] }).into(),
                 &None,
+                &hw_counter,
             )
             .unwrap();
 
         // Replace vectors
         segment
-            .upsert_point(4, 1.into(), only_default_vector(&vec1))
+            .upsert_point(4, 1.into(), only_default_vector(&vec1), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(5, 2.into(), only_default_vector(&vec2))
+            .upsert_point(5, 2.into(), only_default_vector(&vec2), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(6, 3.into(), only_default_vector(&vec3))
+            .upsert_point(6, 3.into(), only_default_vector(&vec3), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(7, 4.into(), only_default_vector(&vec4))
+            .upsert_point(7, 4.into(), only_default_vector(&vec4), &hw_counter)
             .unwrap();
         segment
-            .upsert_point(8, 5.into(), only_default_vector(&vec5))
+            .upsert_point(8, 5.into(), only_default_vector(&vec5), &hw_counter)
             .unwrap();
 
         assert_eq!(segment.version(), 8);
 
         let declined = segment
-            .upsert_point(3, 5.into(), only_default_vector(&vec5))
+            .upsert_point(3, 5.into(), only_default_vector(&vec5), &hw_counter)
             .unwrap();
 
         // Should not be processed due to operation number

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
@@ -69,11 +70,18 @@ fn test_batch_and_single_request_equivalency() {
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
         let payload: Payload = json!({int_key:int_payload,}).into();
 
+        let hw_counter = HardwareCounterCell::new();
+
         segment
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -95,6 +95,7 @@ fn test_byte_storage_hnsw(
     #[case] ef: usize,
     #[case] max_failures: usize, // out of 100
 ) {
+    use common::counter::hardware_counter::HardwareCounterCell;
     use segment::index::hnsw_index::num_rayon_threads;
     use segment::json_path::JsonPath;
     use segment::types::PayloadSchemaType;
@@ -174,17 +175,29 @@ fn test_byte_storage_hnsw(
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
         let payload: Payload = json!({int_key:int_payload,}).into();
 
+        let hw_counter = HardwareCounterCell::new();
+
         segment_float
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment_float
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
         segment_byte
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment_byte
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -226,6 +226,7 @@ fn test_byte_storage_binary_quantization_hnsw(
     #[case] ef: usize,
     #[case] min_acc: f64, // out of 100
 ) {
+    use common::counter::hardware_counter::HardwareCounterCell;
     use segment::json_path::JsonPath;
 
     let stopped = AtomicBool::new(false);
@@ -274,6 +275,8 @@ fn test_byte_storage_binary_quantization_hnsw(
         );
     }
 
+    let hw_counter = HardwareCounterCell::new();
+
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim, storage_data_type);
@@ -282,10 +285,15 @@ fn test_byte_storage_binary_quantization_hnsw(
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment_byte
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment_byte
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -3,6 +3,7 @@ const NUM_VECTORS_2: u64 = 500;
 
 use std::sync::atomic::AtomicBool;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
@@ -24,6 +25,8 @@ fn test_rebuild_with_removed_vectors() {
     let mut segment1 = build_multivec_segment(dir.path(), 4, 6, Distance::Dot).unwrap();
     let mut segment2 = build_multivec_segment(dir.path(), 4, 6, Distance::Dot).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     for i in 0..NUM_VECTORS_1 {
         segment1
             .upsert_point(
@@ -33,6 +36,7 @@ fn test_rebuild_with_removed_vectors() {
                     ("vector1".to_string(), vec![i as f32, 0., 0., 0.]),
                     ("vector2".to_string(), vec![0., i as f32, 0., 0., 0., 0.]),
                 ]),
+                &hw_counter,
             )
             .unwrap();
     }
@@ -48,27 +52,27 @@ fn test_rebuild_with_removed_vectors() {
         };
 
         segment2
-            .upsert_point(1, (NUM_VECTORS_1 + i).into(), vectors)
+            .upsert_point(1, (NUM_VECTORS_1 + i).into(), vectors, &hw_counter)
             .unwrap();
     }
 
     for i in 0..NUM_VECTORS_2 {
         if i % 3 == 0 {
             segment2
-                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector1")
+                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector1", &hw_counter)
                 .unwrap();
             segment2
-                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2")
+                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2", &hw_counter)
                 .unwrap();
         }
         if i % 3 == 1 {
             segment2
-                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2")
+                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2", &hw_counter)
                 .unwrap();
         }
         if i % 2 == 0 {
             segment2
-                .delete_point(2, (NUM_VECTORS_1 + i).into())
+                .delete_point(2, (NUM_VECTORS_1 + i).into(), &hw_counter)
                 .unwrap();
         }
     }

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use itertools::Itertools;
@@ -59,6 +60,8 @@ fn exact_search_test() {
 
     let int_key = "int";
 
+    let hw_counter = HardwareCounterCell::new();
+
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
@@ -68,10 +71,15 @@ fn exact_search_test() {
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
     // let opnum = num_vectors + 1;

--- a/lib/segment/tests/integration/fail_recovery_test.rs
+++ b/lib/segment/tests/integration/fail_recovery_test.rs
@@ -1,3 +1,4 @@
+use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::{OperationError, SegmentFailedState};
 use segment::data_types::vectors::only_default_vector;
 use segment::entry::entry_point::SegmentEntry;
@@ -14,11 +15,13 @@ fn test_insert_fail_recovery() {
 
     let mut segment = empty_segment(dir.path());
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment
-        .upsert_point(1, 1.into(), only_default_vector(&vec1))
+        .upsert_point(1, 1.into(), only_default_vector(&vec1), &hw_counter)
         .unwrap();
     segment
-        .upsert_point(1, 2.into(), only_default_vector(&vec1))
+        .upsert_point(1, 2.into(), only_default_vector(&vec1), &hw_counter)
         .unwrap();
 
     segment.error_status = Some(SegmentFailedState {
@@ -33,6 +36,7 @@ fn test_insert_fail_recovery() {
         1.into(),
         &json!({ "color": vec!["red".to_string()] }).into(),
         &None,
+        &hw_counter,
     );
     assert!(fail_res.is_err());
 
@@ -42,6 +46,7 @@ fn test_insert_fail_recovery() {
         2.into(),
         &json!({ "color": vec!["red".to_string()] }).into(),
         &None,
+        &hw_counter,
     );
     assert!(fail_res.is_err());
 
@@ -51,6 +56,7 @@ fn test_insert_fail_recovery() {
         2.into(),
         &json!({ "color": vec!["red".to_string()] }).into(),
         &None,
+        &hw_counter,
     );
     assert!(ok_res.is_ok());
     assert!(segment.error_status.is_some());
@@ -61,6 +67,7 @@ fn test_insert_fail_recovery() {
         1.into(),
         &json!({ "color": vec!["red".to_string()] }).into(),
         &None,
+        &hw_counter,
     );
 
     assert!(recover_res.is_ok());

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, TelemetryDetail};
 use itertools::Itertools;
@@ -121,6 +122,7 @@ fn _test_filterable_hnsw(
 
     let int_key = "int";
 
+    let hw_counter = HardwareCounterCell::new();
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
@@ -130,10 +132,15 @@ fn _test_filterable_hnsw(
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{only_default_vector, DenseVector, VectorRef};
 use segment::entry::entry_point::SegmentEntry;
@@ -30,20 +31,22 @@ pub fn build_segment_1(path: &Path) -> Segment {
     let vec4 = vec![1.0, 1.0, 0.0, 1.0];
     let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment1
-        .upsert_point(1, 1.into(), only_default_vector(&vec1))
+        .upsert_point(1, 1.into(), only_default_vector(&vec1), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(2, 2.into(), only_default_vector(&vec2))
+        .upsert_point(2, 2.into(), only_default_vector(&vec2), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(3, 3.into(), only_default_vector(&vec3))
+        .upsert_point(3, 3.into(), only_default_vector(&vec3), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(4, 4.into(), only_default_vector(&vec4))
+        .upsert_point(4, 4.into(), only_default_vector(&vec4), &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(5, 5.into(), only_default_vector(&vec5))
+        .upsert_point(5, 5.into(), only_default_vector(&vec5), &hw_counter)
         .unwrap();
 
     let payload_key = PAYLOAD_KEY;
@@ -53,19 +56,19 @@ pub fn build_segment_1(path: &Path) -> Segment {
     let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
 
     segment1
-        .set_payload(6, 1.into(), &payload_option1, &None)
+        .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 2.into(), &payload_option1, &None)
+        .set_payload(6, 2.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 3.into(), &payload_option3, &None)
+        .set_payload(6, 3.into(), &payload_option3, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 4.into(), &payload_option2, &None)
+        .set_payload(6, 4.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 5.into(), &payload_option2, &None)
+        .set_payload(6, 5.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
 
     segment1
@@ -80,20 +83,22 @@ pub fn build_segment_2(path: &Path) -> Segment {
     let vec4 = vec![-1.0, 1.0, 0.0, 1.0];
     let vec5 = vec![-1.0, 0.0, 0.0, 0.0];
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment2
-        .upsert_point(11, 11.into(), only_default_vector(&vec1))
+        .upsert_point(11, 11.into(), only_default_vector(&vec1), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(12, 12.into(), only_default_vector(&vec2))
+        .upsert_point(12, 12.into(), only_default_vector(&vec2), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(13, 13.into(), only_default_vector(&vec3))
+        .upsert_point(13, 13.into(), only_default_vector(&vec3), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(14, 14.into(), only_default_vector(&vec4))
+        .upsert_point(14, 14.into(), only_default_vector(&vec4), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(15, 15.into(), only_default_vector(&vec5))
+        .upsert_point(15, 15.into(), only_default_vector(&vec5), &hw_counter)
         .unwrap();
 
     let payload_key = PAYLOAD_KEY;
@@ -103,19 +108,19 @@ pub fn build_segment_2(path: &Path) -> Segment {
     let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
 
     segment2
-        .set_payload(16, 11.into(), &payload_option1, &None)
+        .set_payload(16, 11.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 12.into(), &payload_option1, &None)
+        .set_payload(16, 12.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 13.into(), &payload_option3, &None)
+        .set_payload(16, 13.into(), &payload_option3, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 14.into(), &payload_option2, &None)
+        .set_payload(16, 14.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 15.into(), &payload_option2, &None)
+        .set_payload(16, 15.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
 
     segment2
@@ -204,20 +209,22 @@ pub fn build_segment_3(path: &Path) -> Segment {
         vec![-1.0, 0.0, 1.0, 1.0],
     ];
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment3
-        .upsert_point(1, 1.into(), collect_points_data(&vec1))
+        .upsert_point(1, 1.into(), collect_points_data(&vec1), &hw_counter)
         .unwrap();
     segment3
-        .upsert_point(2, 2.into(), collect_points_data(&vec2))
+        .upsert_point(2, 2.into(), collect_points_data(&vec2), &hw_counter)
         .unwrap();
     segment3
-        .upsert_point(3, 3.into(), collect_points_data(&vec3))
+        .upsert_point(3, 3.into(), collect_points_data(&vec3), &hw_counter)
         .unwrap();
     segment3
-        .upsert_point(4, 4.into(), collect_points_data(&vec4))
+        .upsert_point(4, 4.into(), collect_points_data(&vec4), &hw_counter)
         .unwrap();
     segment3
-        .upsert_point(5, 5.into(), collect_points_data(&vec5))
+        .upsert_point(5, 5.into(), collect_points_data(&vec5), &hw_counter)
         .unwrap();
 
     let payload_key = PAYLOAD_KEY;
@@ -227,19 +234,19 @@ pub fn build_segment_3(path: &Path) -> Segment {
     let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
 
     segment3
-        .set_payload(6, 1.into(), &payload_option1, &None)
+        .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment3
-        .set_payload(6, 2.into(), &payload_option1, &None)
+        .set_payload(6, 2.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment3
-        .set_payload(6, 3.into(), &payload_option3, &None)
+        .set_payload(6, 3.into(), &payload_option3, &None, &hw_counter)
         .unwrap();
     segment3
-        .set_payload(6, 4.into(), &payload_option2, &None)
+        .set_payload(6, 4.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
     segment3
-        .set_payload(6, 5.into(), &payload_option2, &None)
+        .set_payload(6, 5.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
 
     segment3
@@ -269,11 +276,14 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
     let vec4 = SparseVector::new(vec![0, 1, 2, 3], vec![1.0, 1.0, 0.0, 1.0]).unwrap();
     let vec5 = SparseVector::new(vec![0, 1, 2, 3], vec![1.0, 0.0, 0.0, 0.0]).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment1
         .upsert_point(
             1,
             1.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec1)),
+            &hw_counter,
         )
         .unwrap();
     segment1
@@ -281,6 +291,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
             2,
             2.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec2)),
+            &hw_counter,
         )
         .unwrap();
     segment1
@@ -288,6 +299,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
             3,
             3.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec3)),
+            &hw_counter,
         )
         .unwrap();
     segment1
@@ -295,6 +307,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
             4,
             4.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec4)),
+            &hw_counter,
         )
         .unwrap();
     segment1
@@ -302,6 +315,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
             5,
             5.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec5)),
+            &hw_counter,
         )
         .unwrap();
 
@@ -312,19 +326,19 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
     let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
 
     segment1
-        .set_payload(6, 1.into(), &payload_option1, &None)
+        .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 2.into(), &payload_option1, &None)
+        .set_payload(6, 2.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 3.into(), &payload_option3, &None)
+        .set_payload(6, 3.into(), &payload_option3, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 4.into(), &payload_option2, &None)
+        .set_payload(6, 4.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
     segment1
-        .set_payload(6, 5.into(), &payload_option2, &None)
+        .set_payload(6, 5.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
 
     segment1
@@ -348,6 +362,8 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
     )
     .unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     let vec1 = SparseVector::new(vec![0, 1, 2, 3], vec![-1.0, 0.0, 1.0, 1.0]).unwrap();
     let vec2 = SparseVector::new(vec![0, 1, 2, 3], vec![-1.0, 0.0, 1.0, 0.0]).unwrap();
     let vec3 = SparseVector::new(vec![0, 1, 2, 3], vec![-1.0, 1.0, 1.0, 1.0]).unwrap();
@@ -359,6 +375,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             11,
             11.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec1)),
+            &hw_counter,
         )
         .unwrap();
     segment2
@@ -366,6 +383,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             12,
             12.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec2)),
+            &hw_counter,
         )
         .unwrap();
     segment2
@@ -373,6 +391,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             13,
             13.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec3)),
+            &hw_counter,
         )
         .unwrap();
     segment2
@@ -380,6 +399,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             14,
             14.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec4)),
+            &hw_counter,
         )
         .unwrap();
     segment2
@@ -387,6 +407,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             15,
             15.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec5)),
+            &hw_counter,
         )
         .unwrap();
 
@@ -397,19 +418,19 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
     let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
 
     segment2
-        .set_payload(16, 11.into(), &payload_option1, &None)
+        .set_payload(16, 11.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 12.into(), &payload_option1, &None)
+        .set_payload(16, 12.into(), &payload_option1, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 13.into(), &payload_option3, &None)
+        .set_payload(16, 13.into(), &payload_option3, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 14.into(), &payload_option2, &None)
+        .set_payload(16, 14.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
     segment2
-        .set_payload(16, 15.into(), &payload_option2, &None)
+        .set_payload(16, 15.into(), &payload_option2, &None, &hw_counter)
         .unwrap();
 
     segment2

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex;
@@ -97,11 +98,18 @@ fn test_gpu_filterable_hnsw() {
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
         let payload: Payload = json!({int_key:int_payload,}).into();
 
+        let hw_counter = HardwareCounterCell::new();
+
         segment
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -101,6 +101,7 @@ fn test_multi_filterable_hnsw(
     #[case] ef: usize,
     #[case] max_failures: usize, // out of 100
 ) {
+    use common::counter::hardware_counter::HardwareCounterCell;
     use segment::json_path::JsonPath;
 
     let stopped = AtomicBool::new(false);
@@ -137,6 +138,8 @@ fn test_multi_filterable_hnsw(
 
     let int_key = "int";
 
+    let hw_counter = HardwareCounterCell::new();
+
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
     for n in 0..num_points {
         let idx = n.into();
@@ -149,10 +152,10 @@ fn test_multi_filterable_hnsw(
 
         let named_vectors = only_default_multi_vector(&multi_vec);
         segment
-            .upsert_point(n as SeqNumberType, idx, named_vectors)
+            .upsert_point(n as SeqNumberType, idx, named_vectors, &hw_counter)
             .unwrap();
         segment
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
     assert_eq!(

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
@@ -81,6 +82,8 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
     )
     .unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);
@@ -104,10 +107,15 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment
-            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
 
         let internal_id = segment.id_tracker.borrow().internal_id(idx).unwrap();

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::types::ScoredPointOffset;
 use itertools::Itertools;
@@ -238,6 +239,8 @@ fn test_multivector_quantization_hnsw(
 
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);
@@ -246,10 +249,15 @@ fn test_multivector_quantization_hnsw(
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment
-            .upsert_point(n as SeqNumberType, idx, only_default_multi_vector(&vector))
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_multi_vector(&vector),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use fnv::FnvBuildHasher;
@@ -60,6 +61,8 @@ impl TestSegments {
     fn new() -> Self {
         let base_dir = Builder::new().prefix("test_segments").tempdir().unwrap();
 
+        let hw_counter = HardwareCounterCell::new();
+
         let mut rnd = StdRng::seed_from_u64(42);
 
         let config = Self::make_simple_config(true);
@@ -85,16 +88,16 @@ impl TestSegments {
             let payload: Payload = generate_diverse_payload(&mut rnd);
 
             plain_segment
-                .upsert_point(opnum, idx, only_default_vector(&vector))
+                .upsert_point(opnum, idx, only_default_vector(&vector), &hw_counter)
                 .unwrap();
             struct_segment
-                .upsert_point(opnum, idx, only_default_vector(&vector))
+                .upsert_point(opnum, idx, only_default_vector(&vector), &hw_counter)
                 .unwrap();
             plain_segment
-                .set_full_payload(opnum, idx, &payload)
+                .set_full_payload(opnum, idx, &payload, &hw_counter)
                 .unwrap();
             struct_segment
-                .set_full_payload(opnum, idx, &payload)
+                .set_full_payload(opnum, idx, &payload, &hw_counter)
                 .unwrap();
 
             opnum += 1;
@@ -162,13 +165,13 @@ impl TestSegments {
             opnum += 1;
             let idx_to_remove = rnd.gen_range(0..num_points);
             plain_segment
-                .clear_payload(opnum, idx_to_remove.into())
+                .clear_payload(opnum, idx_to_remove.into(), &hw_counter)
                 .unwrap();
             struct_segment
-                .clear_payload(opnum, idx_to_remove.into())
+                .clear_payload(opnum, idx_to_remove.into(), &hw_counter)
                 .unwrap();
             mmap_segment
-                .clear_payload(opnum, idx_to_remove.into())
+                .clear_payload(opnum, idx_to_remove.into(), &hw_counter)
                 .unwrap();
         }
 
@@ -176,13 +179,13 @@ impl TestSegments {
             opnum += 1;
             let idx_to_remove = rnd.gen_range(0..num_points);
             plain_segment
-                .delete_point(opnum, idx_to_remove.into())
+                .delete_point(opnum, idx_to_remove.into(), &hw_counter)
                 .unwrap();
             struct_segment
-                .delete_point(opnum, idx_to_remove.into())
+                .delete_point(opnum, idx_to_remove.into(), &hw_counter)
                 .unwrap();
             mmap_segment
-                .delete_point(opnum, idx_to_remove.into())
+                .delete_point(opnum, idx_to_remove.into(), &hw_counter)
                 .unwrap();
         }
 
@@ -384,6 +387,8 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
 
     eprintln!("{deep_nested_str_proj_key}");
 
+    let hw_counter = HardwareCounterCell::new();
+
     opnum += 1;
     for n in 0..num_points {
         let idx = n.into();
@@ -391,16 +396,16 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
         let payload: Payload = generate_diverse_nested_payload(&mut rnd);
 
         plain_segment
-            .upsert_point(opnum, idx, only_default_vector(&vector))
+            .upsert_point(opnum, idx, only_default_vector(&vector), &hw_counter)
             .unwrap();
         struct_segment
-            .upsert_point(opnum, idx, only_default_vector(&vector))
+            .upsert_point(opnum, idx, only_default_vector(&vector), &hw_counter)
             .unwrap();
         plain_segment
-            .set_full_payload(opnum, idx, &payload)
+            .set_full_payload(opnum, idx, &payload, &hw_counter)
             .unwrap();
         struct_segment
-            .set_full_payload(opnum, idx, &payload)
+            .set_full_payload(opnum, idx, &payload, &hw_counter)
             .unwrap();
 
         opnum += 1;
@@ -410,10 +415,10 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
         opnum += 1;
         let idx_to_remove = rnd.gen_range(0..num_points);
         plain_segment
-            .clear_payload(opnum, idx_to_remove.into())
+            .clear_payload(opnum, idx_to_remove.into(), &hw_counter)
             .unwrap();
         struct_segment
-            .clear_payload(opnum, idx_to_remove.into())
+            .clear_payload(opnum, idx_to_remove.into(), &hw_counter)
             .unwrap();
     }
 
@@ -421,10 +426,10 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
         opnum += 1;
         let idx_to_remove = rnd.gen_range(0..num_points);
         plain_segment
-            .delete_point(opnum, idx_to_remove.into())
+            .delete_point(opnum, idx_to_remove.into(), &hw_counter)
             .unwrap();
         struct_segment
-            .delete_point(opnum, idx_to_remove.into())
+            .delete_point(opnum, idx_to_remove.into(), &hw_counter)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -192,7 +192,7 @@ fn check_points_defragmented(
 
     for internal_id in id_tracker.iter_internal() {
         let external_id = id_tracker.external_id(internal_id).unwrap();
-        let payload = segment.payload_measured(external_id, &hw_counter).unwrap();
+        let payload = segment.payload(external_id, &hw_counter).unwrap();
         let values = payload.get_value(defragment_key);
 
         if values.is_empty() {

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
 use itertools::Itertools;
 use segment::common::operation_error::OperationError;
@@ -41,9 +42,16 @@ fn test_building_new_segment() {
     let mut builder =
         SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Include overlapping with segment1 to check the
     segment2
-        .upsert_point(100, 3.into(), only_default_vector(&[0., 0., 0., 0.]))
+        .upsert_point(
+            100,
+            3.into(),
+            only_default_vector(&[0., 0., 0., 0.]),
+            &hw_counter,
+        )
         .unwrap();
 
     builder
@@ -109,9 +117,16 @@ fn test_building_new_defragmented_segment() {
     let mut builder =
         SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Include overlapping with segment1 to check the
     segment2
-        .upsert_point(100, 3.into(), only_default_vector(&[0., 0., 0., 0.]))
+        .upsert_point(
+            100,
+            3.into(),
+            only_default_vector(&[0., 0., 0., 0.]),
+            &hw_counter,
+        )
         .unwrap();
 
     builder.set_defragment_keys(vec![defragment_key.clone()]);
@@ -173,9 +188,11 @@ fn check_points_defragmented(
     // keeps track of groups/values that have already been seen while iterating
     let mut seen_values: Vec<Value> = vec![];
 
+    let hw_counter = HardwareCounterCell::new();
+
     for internal_id in id_tracker.iter_internal() {
         let external_id = id_tracker.external_id(internal_id).unwrap();
-        let payload = segment.payload(external_id).unwrap();
+        let payload = segment.payload_measured(external_id, &hw_counter).unwrap();
         let values = payload.get_value(defragment_key);
 
         if values.is_empty() {
@@ -217,6 +234,8 @@ fn test_building_new_sparse_segment() {
 
     let stopped = AtomicBool::new(false);
 
+    let hw_counter = HardwareCounterCell::new();
+
     let segment1 = build_segment_sparse_1(dir.path());
     let mut segment2 = build_segment_sparse_2(dir.path());
 
@@ -230,6 +249,7 @@ fn test_building_new_sparse_segment() {
             100,
             3.into(),
             NamedVectors::from_ref("sparse", VectorRef::Sparse(&vec)),
+            &hw_counter,
         )
         .unwrap();
 
@@ -353,22 +373,24 @@ fn test_building_new_segment_bug_5614() {
     let vector_100_high = only_default_vector(&[3., 3., 0., 0.]);
     let vector_101_high = only_default_vector(&[4., 4., 0., 0.]);
 
+    let hw_counter = HardwareCounterCell::new();
+
     // Insert point 100 and 101 in both segments
     // Do this in a specific order so that:
     // - the latter segment has a higher point version
     // - the internal point IDs don't match across segments
     segment1
-        .upsert_point(123, 100.into(), vector_100_low)
+        .upsert_point(123, 100.into(), vector_100_low, &hw_counter)
         .unwrap();
     segment1
-        .upsert_point(123, 101.into(), vector_101_low)
+        .upsert_point(123, 101.into(), vector_101_low, &hw_counter)
         .unwrap();
 
     segment2
-        .upsert_point(124, 101.into(), vector_101_high.clone())
+        .upsert_point(124, 101.into(), vector_101_high.clone(), &hw_counter)
         .unwrap();
     segment2
-        .upsert_point(124, 100.into(), vector_100_high.clone())
+        .upsert_point(124, 100.into(), vector_100_high.clone(), &hw_counter)
         .unwrap();
 
     builder.update(&[&segment1, &segment2], &stopped).unwrap();
@@ -407,15 +429,32 @@ fn test_building_cancellation() {
     let mut segment = empty_segment(dir.path());
     let mut segment_2 = empty_segment(dir_2.path());
 
+    let hw_counter = HardwareCounterCell::new();
+
     for idx in 0..2000 {
         baseline_segment
-            .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
+            .upsert_point(
+                1,
+                idx.into(),
+                only_default_vector(&[0., 0., 0., 0.]),
+                &hw_counter,
+            )
             .unwrap();
         segment
-            .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
+            .upsert_point(
+                1,
+                idx.into(),
+                only_default_vector(&[0., 0., 0., 0.]),
+                &hw_counter,
+            )
             .unwrap();
         segment_2
-            .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
+            .upsert_point(
+                1,
+                idx.into(),
+                only_default_vector(&[0., 0., 0., 0.]),
+                &hw_counter,
+            )
             .unwrap();
     }
 
@@ -470,9 +509,16 @@ fn test_building_new_segment_with_mmap_payload() {
         PayloadStorageType::Mmap
     );
 
+    let hw_counter = HardwareCounterCell::new();
+
     // add one point
     segment1
-        .upsert_point(1, 1.into(), only_default_vector(&[1.0, 0.0, 1.0, 1.0]))
+        .upsert_point(
+            1,
+            1.into(),
+            only_default_vector(&[1.0, 0.0, 1.0, 1.0]),
+            &hw_counter,
+        )
         .unwrap();
 
     let builder = SegmentBuilder::new(

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -229,8 +229,8 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
         let restored_vectors = restored_segment.all_vectors(id).unwrap();
         assert_eq!(vectors, restored_vectors);
 
-        let payload = segment.payload_measured(id, &hw_counter).unwrap();
-        let restored_payload = restored_segment.payload_measured(id, &hw_counter).unwrap();
+        let payload = segment.payload(id, &hw_counter).unwrap();
+        let restored_payload = restored_segment.payload(id, &hw_counter).unwrap();
         assert_eq!(payload, restored_payload);
     }
 }

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -24,6 +24,8 @@ use tempfile::Builder;
 #[case::regular(SnapshotFormat::Regular)]
 #[case::streamable(SnapshotFormat::Streamable)]
 fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
+    use common::counter::hardware_counter::HardwareCounterCell;
+
     let _ = env_logger::builder().is_test(true).try_init();
 
     let data = r#"
@@ -56,18 +58,30 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
 
     let mut segment = build_segment(segment_builder_dir.path(), &building_config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     segment
-        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]))
+        .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]), &hw_counter)
         .unwrap();
     segment
-        .upsert_point(1, 1.into(), only_default_vector(&[2.0, 2.0]))
+        .upsert_point(1, 1.into(), only_default_vector(&[2.0, 2.0]), &hw_counter)
         .unwrap();
 
     segment
-        .set_full_payload(2, 0.into(), &serde_json::from_str(data).unwrap())
+        .set_full_payload(
+            2,
+            0.into(),
+            &serde_json::from_str(data).unwrap(),
+            &hw_counter,
+        )
         .unwrap();
     segment
-        .set_full_payload(3, 0.into(), &serde_json::from_str(data).unwrap())
+        .set_full_payload(
+            3,
+            0.into(),
+            &serde_json::from_str(data).unwrap(),
+            &hw_counter,
+        )
         .unwrap();
 
     segment
@@ -208,13 +222,15 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
         restored_segment.deleted_point_count(),
     );
 
+    let hw_counter = HardwareCounterCell::new();
+
     for id in segment.iter_points() {
         let vectors = segment.all_vectors(id).unwrap();
         let restored_vectors = restored_segment.all_vectors(id).unwrap();
         assert_eq!(vectors, restored_vectors);
 
-        let payload = segment.payload(id).unwrap();
-        let restored_payload = restored_segment.payload(id).unwrap();
+        let payload = segment.payload_measured(id, &hw_counter).unwrap();
+        let restored_payload = restored_segment.payload_measured(id, &hw_counter).unwrap();
         assert_eq!(payload, restored_payload);
     }
 }

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicBool;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::TelemetryDetail;
 use itertools::Itertools;
 use rand::prelude::StdRng;
@@ -148,15 +149,17 @@ fn sparse_index_discover_test() {
     let mut sparse_segment = build_segment(dir.path(), &sparse_config, true).unwrap();
     let mut dense_segment = build_segment(dir.path(), &dense_config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     for n in 0..num_vectors {
         let (sparse_vector, dense_vector) = random_named_vector(&mut rnd, dim);
 
         let idx = n.into();
         sparse_segment
-            .upsert_point(n as SeqNumberType, idx, sparse_vector)
+            .upsert_point(n as SeqNumberType, idx, sparse_vector, &hw_counter)
             .unwrap();
         dense_segment
-            .upsert_point(n as SeqNumberType, idx, dense_vector)
+            .upsert_point(n as SeqNumberType, idx, dense_vector, &hw_counter)
             .unwrap();
     }
 
@@ -269,12 +272,14 @@ fn sparse_index_hardware_measurement_test() {
 
     let mut sparse_segment = build_segment(dir.path(), &sparse_config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     for n in 0..num_vectors {
         let (sparse_vector, _) = random_named_vector(&mut rnd, dim);
 
         let idx = n.into();
         sparse_segment
-            .upsert_point(n as SeqNumberType, idx, sparse_vector)
+            .upsert_point(n as SeqNumberType, idx, sparse_vector, &hw_counter)
             .unwrap();
     }
     let payload_index_ptr = sparse_segment.payload_index.clone();

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::fs::remove_file;
 use std::sync::atomic::AtomicBool;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, TelemetryDetail};
 use io::storage_version::VERSION_FILE;
 use itertools::Itertools;
@@ -587,13 +588,15 @@ fn sparse_vector_index_persistence_test() {
     };
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     for n in 0..num_vectors {
         let vector: VectorInternal = random_sparse_vector(&mut rnd, dim).into();
         let mut named_vector = NamedVectors::default();
         named_vector.insert(SPARSE_VECTOR_NAME.to_owned(), vector);
         let idx = n.into();
         segment
-            .upsert_point(n as SeqNumberType, idx, named_vector)
+            .upsert_point(n as SeqNumberType, idx, named_vector, &hw_counter)
             .unwrap();
     }
     segment.flush(true, false).unwrap();
@@ -756,6 +759,8 @@ fn sparse_vector_test_large_index() {
     };
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
+    let hw_counter = HardwareCounterCell::new();
+
     let vector: VectorInternal = SparseVector {
         indices: vec![DimId::MAX],
         values: vec![0.0],
@@ -765,7 +770,7 @@ fn sparse_vector_test_large_index() {
     named_vector.insert(SPARSE_VECTOR_NAME.to_owned(), vector);
     let idx = 0.into();
     segment
-        .upsert_point(0 as SeqNumberType, idx, named_vector)
+        .upsert_point(0 as SeqNumberType, idx, named_vector, &hw_counter)
         .unwrap();
 
     let borrowed_vector_index = segment.vector_data[SPARSE_VECTOR_NAME]

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -13,6 +13,7 @@ use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndex
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::CollectionId;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::{WithPayloadInterface, WithVector};
 use tokio::sync::RwLock;
 
@@ -107,6 +108,7 @@ async fn replicate_shard_data(
                 None,
                 &ShardSelectorInternal::ShardId(shard_id),
                 None,
+                HwMeasurementAcc::disposable(), // Internal operation, don't measure hardware here
             )
             .await?;
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -196,6 +196,7 @@ impl TableOfContent {
     /// # Result
     ///
     /// List of points with specified information included
+    #[allow(clippy::too_many_arguments)]
     pub async fn retrieve(
         &self,
         collection_name: &str,
@@ -204,12 +205,19 @@ impl TableOfContent {
         timeout: Option<Duration>,
         shard_selection: ShardSelectorInternal,
         access: Access,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> StorageResult<Vec<RecordInternal>> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
         let collection = self.get_collection(&collection_pass).await?;
         collection
-            .retrieve(request, read_consistency, &shard_selection, timeout)
+            .retrieve(
+                request,
+                read_consistency,
+                &shard_selection,
+                timeout,
+                hw_measurement_acc,
+            )
             .await
             .map_err(|err| err.into())
     }
@@ -312,6 +320,7 @@ impl TableOfContent {
     /// # Result
     ///
     /// List of points with specified information included
+    #[allow(clippy::too_many_arguments)]
     pub async fn scroll(
         &self,
         collection_name: &str,
@@ -320,12 +329,19 @@ impl TableOfContent {
         timeout: Option<Duration>,
         shard_selection: ShardSelectorInternal,
         access: Access,
+        hw_measurement_acc: HwMeasurementAcc,
     ) -> StorageResult<ScrollResult> {
         let collection_pass = access.check_point_op(collection_name, &mut request)?;
 
         let collection = self.get_collection(&collection_pass).await?;
         collection
-            .scroll_by(request, read_consistency, &shard_selection, timeout)
+            .scroll_by(
+                request,
+                read_consistency,
+                &shard_selection,
+                timeout,
+                hw_measurement_acc,
+            )
             .await
             .map_err(|err| err.into())
     }

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -9,6 +9,7 @@ use collection::operations::types::{
 };
 use collection::operations::verification::{new_unchecked_verification_pass, VerificationPass};
 use collection::shards::shard::ShardId;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::{Condition, Filter};
 use serde::Deserialize;
 use storage::content_manager::collection_verification::check_strict_mode;
@@ -51,6 +52,7 @@ async fn get_points(
             params.timeout(),
             ShardSelectorInternal::ShardId(path.shard),
             access,
+            HwMeasurementAcc::disposable(), // TODO(io_measurement): implement!!
         )
         .await?;
 
@@ -113,6 +115,7 @@ async fn scroll_points(
                 params.timeout(),
                 ShardSelectorInternal::ShardId(path.shard),
                 access,
+                HwMeasurementAcc::disposable(), // TODO(io_measurement): implement!!
             )
             .await
     })

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -7,6 +7,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     PointRequest, PointRequestInternal, RecordInternal, ScrollRequest,
 };
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::TryFutureExt;
 use itertools::Itertools;
 use segment::types::{PointIdType, WithPayloadInterface};
@@ -57,6 +58,7 @@ async fn do_get_point(
         timeout,
         shard_selection,
         access,
+        HwMeasurementAcc::disposable(), // TODO(io_measurement): implement!!
     )
     .await
     .map(|points| points.into_iter().next())
@@ -146,6 +148,7 @@ async fn get_points(
             params.timeout(),
             shard_selection,
             access,
+            HwMeasurementAcc::disposable(), // TODO(io_measurement): implement!!
         )
         .map_ok(|response| {
             response
@@ -195,6 +198,7 @@ async fn scroll_points(
         params.timeout(),
         shard_selection,
         access,
+        HwMeasurementAcc::disposable(), // TODO(io_measurement): implement!!
     ))
     .await
 }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -1079,6 +1079,7 @@ pub async fn do_count_points(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_get_points(
     toc: &TableOfContent,
     collection_name: &str,
@@ -1087,6 +1088,7 @@ pub async fn do_get_points(
     timeout: Option<Duration>,
     shard_selection: ShardSelectorInternal,
     access: Access,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<Vec<RecordInternal>, StorageError> {
     toc.retrieve(
         collection_name,
@@ -1095,10 +1097,12 @@ pub async fn do_get_points(
         timeout,
         shard_selection,
         access,
+        hw_measurement_acc,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_scroll_points(
     toc: &TableOfContent,
     collection_name: &str,
@@ -1107,6 +1111,7 @@ pub async fn do_scroll_points(
     timeout: Option<Duration>,
     shard_selection: ShardSelectorInternal,
     access: Access,
+    hw_measurement_acc: HwMeasurementAcc,
 ) -> Result<ScrollResult, StorageError> {
     toc.scroll(
         collection_name,
@@ -1115,6 +1120,7 @@ pub async fn do_scroll_points(
         timeout,
         shard_selection,
         access,
+        hw_measurement_acc,
     )
     .await
 }

--- a/src/segment_inspector.rs
+++ b/src/segment_inspector.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
 use clap::Parser;
+use common::counter::hardware_counter::HardwareCounterCell;
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment_constructor::load_segment;
 use segment::types::PointIdType;
@@ -62,7 +63,9 @@ fn main() {
             let internal_id = segment.get_internal_id(point_id);
             if internal_id.is_some() {
                 let version = segment.point_version(point_id);
-                let payload = segment.payload(point_id).unwrap();
+                let payload = segment
+                    .payload_measured(point_id, &HardwareCounterCell::disposable())
+                    .unwrap();
                 // let vectors = segment.all_vectors(point_id).unwrap();
 
                 println!("Internal ID: {internal_id:?}");

--- a/src/segment_inspector.rs
+++ b/src/segment_inspector.rs
@@ -64,7 +64,7 @@ fn main() {
             if internal_id.is_some() {
                 let version = segment.point_version(point_id);
                 let payload = segment
-                    .payload_measured(point_id, &HardwareCounterCell::disposable())
+                    .payload(point_id, &HardwareCounterCell::disposable())
                     .unwrap();
                 // let vectors = segment.all_vectors(point_id).unwrap();
 

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -107,11 +107,17 @@ impl Points for PointsService {
 
         let access = extract_access(&mut request);
 
+        let inner_request = request.into_inner();
+
+        let hw_metrics =
+            self.get_request_collection_hw_usage_counter(inner_request.collection_name.clone());
+
         get(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
-            request.into_inner(),
+            inner_request,
             None,
             access,
+            hw_metrics,
         )
         .await
     }
@@ -384,11 +390,18 @@ impl Points for PointsService {
         validate(request.get_ref())?;
 
         let access = extract_access(&mut request);
+
+        let inner_request = request.into_inner();
+
+        let hw_metrics =
+            self.get_request_collection_hw_usage_counter(inner_request.collection_name.clone());
+
         scroll(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
-            request.into_inner(),
+            inner_request,
             None,
             access,
+            hw_metrics,
         )
         .await
     }

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1584,6 +1584,7 @@ pub async fn scroll(
     scroll_points: ScrollPoints,
     shard_selection: Option<ShardId>,
     access: Access,
+    request_hw_counter: RequestHwCounter,
 ) -> Result<Response<ScrollResponse>, Status> {
     let ScrollPoints {
         collection_name,
@@ -1635,6 +1636,7 @@ pub async fn scroll(
         timeout,
         shard_selector,
         access,
+        request_hw_counter.get_counter(),
     )
     .await?;
 
@@ -1650,6 +1652,7 @@ pub async fn scroll(
         next_page_offset: scrolled_points.next_page_offset.map(|n| n.into()),
         result: points,
         time: timing.elapsed().as_secs_f64(),
+        // usage: request_hw_counter.to_grpc_api(), // TODO(io_measurement): add to API!
     };
 
     Ok(Response::new(response))
@@ -1718,6 +1721,7 @@ pub async fn get(
     get_points: GetPoints,
     shard_selection: Option<ShardId>,
     access: Access,
+    request_hw_counter: RequestHwCounter,
 ) -> Result<Response<GetResponse>, Status> {
     let GetPoints {
         collection_name,
@@ -1764,12 +1768,14 @@ pub async fn get(
         timeout,
         shard_selector,
         access,
+        request_hw_counter.get_counter(),
     )
     .await?;
 
     let response = GetResponse {
         result: records.into_iter().map(|point| point.into()).collect(),
         time: timing.elapsed().as_secs_f64(),
+        // usage: request_hw_counter.to_grpc_api(), // TODO(io_measurement): add to API!
     };
 
     Ok(Response::new(response))

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -526,11 +526,16 @@ impl PointsInternal for PointsInternalService {
 
         scroll_points.read_consistency = None; // *Have* to be `None`!
 
+        let hw_data = self.get_request_collection_hw_usage_counter_for_internal(
+            scroll_points.collection_name.clone(),
+        );
+
         scroll(
             UncheckedTocProvider::new_unchecked(&self.toc),
             scroll_points,
             shard_id,
             FULL_ACCESS.clone(),
+            hw_data,
         )
         .await
     }
@@ -551,11 +556,16 @@ impl PointsInternal for PointsInternalService {
 
         get_points.read_consistency = None; // *Have* to be `None`!
 
+        let hw_data = self.get_request_collection_hw_usage_counter_for_internal(
+            get_points.collection_name.clone(),
+        );
+
         get(
             UncheckedTocProvider::new_unchecked(&self.toc),
             get_points,
             shard_id,
             FULL_ACCESS.clone(),
+            hw_data,
         )
         .await
     }

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::future::BoxFuture;
 use storage::rbac::Access;
 use tonic::body::BoxBody;
@@ -19,9 +20,16 @@ pub struct AuthMiddleware<S> {
     service: S,
 }
 
-async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, Status> {
+async fn check(
+    auth_keys: Arc<AuthKeys>,
+    mut req: Request,
+    hw_measurement_acc: HwMeasurementAcc,
+) -> Result<Request, Status> {
     let (access, api_key) = auth_keys
-        .validate_request(|key| req.headers().get(key).and_then(|val| val.to_str().ok()))
+        .validate_request(
+            |key| req.headers().get(key).and_then(|val| val.to_str().ok()),
+            hw_measurement_acc,
+        )
         .await
         .map_err(|e| match e {
             AuthError::Unauthorized(e) => Status::unauthenticated(e),
@@ -64,8 +72,10 @@ where
     fn call(&mut self, request: Request) -> Self::Future {
         let auth_keys = self.auth_keys.clone();
         let mut service = self.service.clone();
+        let hw_measurement_acc = HwMeasurementAcc::disposable(); // TODO(io_measurement): propagate this value!
+
         Box::pin(async move {
-            match check(auth_keys, request).await {
+            match check(auth_keys, request, hw_measurement_acc).await {
                 Ok(req) => service.call(req).await,
                 Err(e) => Ok(e.to_http()),
             }


### PR DESCRIPTION
This PR introduces measuring read IO for payload index for several endpoints. Collected values are currently only reported in metrics/telemetry API. Per endpoint reporting, tests, distributed support and TODOs will be done in separate PRs to not make this even larger.

Since it's mostly function signature changes, splitting into multiple PRs without merging half baked things is hard. This is why I decided to create a larger PR that can be reviewed on per commit level.