### PR TITLE
Update storage compat 1.11 & 1.12

### DIFF
--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -124,5 +124,8 @@ test_version $PREV_PATCH_QDRANT_VERSION
 # Test previous minor version
 test_version $PREV_MINOR_QDRANT_VERSION
 
-# Test that it can read both rocksdb and blob_store (generated manually
-test_version 'v1.12.5-rocksdb+blob_store'
+# Test blob_store storage generated manually with
+# export QDRANT__STORAGE__ON_DISK_PAYLOAD_USES_MMAP=true
+# export QDRANT__STORAGE__ON_DISK_SPARSE_VECTORS_USES_MMAP=true
+# in the gen_storage_compat_data.sh script
+test_version 'v1.12.6-blob-store'

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -7,8 +7,8 @@ echo $PWD
 cd "$(dirname "$0")/../../"
 
 QDRANT_HOST='localhost:6333'
-PREV_PATCH_QDRANT_VERSION='v1.9.2'
-PREV_MINOR_QDRANT_VERSION='v1.8.4'
+PREV_PATCH_QDRANT_VERSION='v1.12.6'
+PREV_MINOR_QDRANT_VERSION='v1.11.5'
 
 RETRY_LIMIT=30
 
@@ -124,5 +124,5 @@ test_version $PREV_PATCH_QDRANT_VERSION
 # Test previous minor version
 test_version $PREV_MINOR_QDRANT_VERSION
 
-# Test that it can read both rocksdb and blob_store
-test_version 'v1.12.6-rocksdb+blob_store-pre_release'
+# Test that it can read both rocksdb and blob_store (generated manually
+test_version 'v1.12.5-rocksdb+blob_store'


### PR DESCRIPTION
We want to make sure that we are compatible with the latest minor version and previous patch.

`v1.12.6-rocksdb+blob_store-pre_release` did not contain proper blob store data as the script did not activate the feature properly.

I fixed this in a new archive and also documented how to do it.

I validated that the archive uses the new blob store for payload storage and sparse vector storage.

![blob-store-payload](https://github.com/user-attachments/assets/e6753e70-f3f1-4f55-90eb-870ff48aebe9)
![blob-store-sparse](https://github.com/user-attachments/assets/c1e6e554-09c3-4904-91d4-8271f0fe07af)
