### PR TITLE
Enable mmap storage using blob store for sparse vectors by default

### DIFF
--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -109,9 +109,6 @@ pub struct CollectionParams {
     // TODO: remove this setting after integration is finished
     #[serde(skip)]
     pub on_disk_payload_uses_mmap: bool,
-    // TODO: remove this setting after integration is finished
-    #[serde(skip)]
-    pub on_disk_sparse_vectors_uses_mmap: bool,
     /// Configuration of the sparse vector storage
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
@@ -140,7 +137,6 @@ impl CollectionParams {
             read_fan_out_factor: _, // May be changed
             on_disk_payload: _, // May be changed
             on_disk_payload_uses_mmap: _, // Temporary
-            on_disk_sparse_vectors_uses_mmap: _, // Temporary
             sparse_vectors,  // Parameters may be changes, but not the structure
         } = other;
 
@@ -192,7 +188,6 @@ impl Anonymize for CollectionParams {
             read_fan_out_factor: self.read_fan_out_factor,
             on_disk_payload: self.on_disk_payload,
             on_disk_payload_uses_mmap: self.on_disk_payload_uses_mmap,
-            on_disk_sparse_vectors_uses_mmap: self.on_disk_sparse_vectors_uses_mmap,
             sparse_vectors: self.sparse_vectors.anonymize(),
         }
     }
@@ -279,7 +274,6 @@ impl CollectionParams {
             read_fan_out_factor: None,
             on_disk_payload: default_on_disk_payload(),
             on_disk_payload_uses_mmap: false,
-            on_disk_sparse_vectors_uses_mmap: false,
             sparse_vectors: None,
         }
     }
@@ -506,9 +500,7 @@ impl CollectionParams {
                                     .and_then(|index| index.datatype)
                                     .map(VectorStorageDatatype::from),
                             },
-                            // Not configurable by user (at this point). When we switch the default, it will be switched here too.
-                            storage_type: params
-                                .storage_type(self.on_disk_sparse_vectors_uses_mmap),
+                            storage_type: params.storage_type(),
                         },
                     ))
                 })

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1810,7 +1810,6 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                         .map(sharding_method_from_proto)
                         .transpose()?,
                     on_disk_payload_uses_mmap: false,
-                    on_disk_sparse_vectors_uses_mmap: false,
                 },
             },
             hnsw_config: match config.hnsw_config {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1545,12 +1545,8 @@ pub struct SparseVectorParams {
 }
 
 impl SparseVectorParams {
-    pub fn storage_type(&self, use_new_storage: bool) -> SparseVectorStorageType {
-        if use_new_storage {
-            SparseVectorStorageType::Mmap
-        } else {
-            SparseVectorStorageType::default()
-        }
+    pub fn storage_type(&self) -> SparseVectorStorageType {
+        SparseVectorStorageType::default()
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -983,10 +983,10 @@ impl VectorDataConfig {
 pub enum SparseVectorStorageType {
     /// Storage on disk
     // (rocksdb storage)
-    #[default]
     OnDisk,
     /// Storage in memory maps
     // (blob_store storage)
+    #[default]
     Mmap,
 }
 

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -142,7 +142,6 @@ impl TableOfContent {
             sharding_method,
             on_disk_payload: on_disk_payload.unwrap_or(self.storage_config.on_disk_payload),
             on_disk_payload_uses_mmap: self.storage_config.on_disk_payload_uses_mmap,
-            on_disk_sparse_vectors_uses_mmap: self.storage_config.on_disk_sparse_vectors_uses_mmap,
             replication_factor: NonZeroU32::new(replication_factor).ok_or_else(|| {
                 StorageError::BadInput {
                     description: "`replication_factor` cannot be 0".to_string(),

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -69,9 +69,6 @@ pub struct StorageConfig {
     // TODO: remove this field after integration is finished
     #[serde(default)]
     pub on_disk_payload_uses_mmap: bool,
-    // TODO: remove this field after integration is finished
-    #[serde(default)]
-    pub on_disk_sparse_vectors_uses_mmap: bool,
     #[validate(nested)]
     pub optimizers: OptimizersConfig,
     #[validate(nested)]

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -38,7 +38,6 @@ fn test_alias_operation() {
         temp_path: None,
         on_disk_payload: false,
         on_disk_payload_uses_mmap: false,
-        on_disk_sparse_vectors_uses_mmap: false,
         optimizers: OptimizersConfig {
             deleted_threshold: 0.5,
             vacuum_min_vector_number: 100,


### PR DESCRIPTION
Prepare for the release of Qdrant 1.13 and enable the mmap storage for sparse vectors using blob store by default. This allows us to test it on chaos testing for some time.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
