### PR TITLE
Resharding: wait on clean up deletes, exact counting in tests

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -940,7 +940,7 @@ impl ShardReplicaSet {
             });
 
         // TODO(resharding): Assign clock tag to the operation!? 🤔
-        let result = self.update_local(op.into(), false).await?.ok_or_else(|| {
+        let result = self.update_local(op.into(), true).await?.ok_or_else(|| {
             CollectionError::bad_request(format!(
                 "local shard {}:{} does not exist or is unavailable",
                 self.collection_id, self.shard_id,

--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -248,7 +248,7 @@ def test_resharding_down_abort_cleanup(tmp_path: pathlib.Path, peers: int):
         migrate_points(peer_uris[0], peer_id, shard_id, target_peer_id, target_shard_id, "down")
 
         # Assert that some points were forwarded and/or migrated to selected replica
-        resharding_points_count = count_local_points(peer_uri, shard_id, target_shard_id)
+        resharding_points_count = count_local_points(peer_uri, shard_id, target_shard_id, exact=True)
         assert resharding_points_count > 0
 
         # Append peer URI to the list of replica URIs
@@ -269,7 +269,7 @@ def test_resharding_down_abort_cleanup(tmp_path: pathlib.Path, peers: int):
 
     # Assert that forwarded and/or migrated points were deleted from non-target replicas
     for shard_id, peer_uri in enumerate(replica_uris):
-        resharding_points_count = count_local_points(peer_uri, shard_id, target_shard_id)
+        resharding_points_count = count_local_points(peer_uri, shard_id, target_shard_id, exact=True)
         assert resharding_points_count == 0
 
 
@@ -551,13 +551,13 @@ def assert_resharding_points_count(replica_uris: list[str]):
     target_shard_uri = replica_uris[-1]
 
     # Get points count in target replica
-    target_points_count = count_local_points(target_shard_uri, target_shard_id)
+    target_points_count = count_local_points(target_shard_uri, target_shard_id, exact=True)
 
     # Calculate total resharding points count in all other replicas
     total_resharding_points_count = 0
 
     for shard_id, shard_uri in enumerate(replica_uris[:-1]):
-        total_resharding_points_count += count_local_points(shard_uri, shard_id, target_shard_id)
+        total_resharding_points_count += count_local_points(shard_uri, shard_id, target_shard_id, exact=True)
 
     # Assert target replica points count matches total resharding points count
     assert target_points_count == total_resharding_points_count


### PR DESCRIPTION
This attempts to fix a count assertion in a resharding test ([ref](https://github.com/qdrant/qdrant/actions/runs/12744537238/job/35516646241?pr=5757#step:11:129)).

It does two things:
1. when deleting points to clean up, wait on the operation to complete
2. use exact point counts in tests

I was not able to reproduce this problem locally, so I'm depending on CI here to tell us if something is still off.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?