### PR TITLE
Rearrange graph_links.rs

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -14,7 +14,7 @@ use super::graph_links::{GraphLinks, GraphLinksFormat};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::rev_range;
 use crate::index::hnsw_index::entry_points::EntryPoints;
-use crate::index::hnsw_index::graph_links::GraphLinksConverter;
+use crate::index::hnsw_index::graph_links::GraphLinksSerializer;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::search_context::SearchContext;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
@@ -312,7 +312,7 @@ impl GraphLayers {
 
         let links = GraphLinks::load_from_file(&plain_path, true, GraphLinksFormat::Plain)?;
         let original_size = plain_path.metadata()?.len();
-        GraphLinksConverter::new(links.into_edges(), GraphLinksFormat::Compressed, m, m0)
+        GraphLinksSerializer::new(links.into_edges(), GraphLinksFormat::Compressed, m, m0)
             .save_as(&compressed_path)?;
         let new_size = compressed_path.metadata()?.len();
 
@@ -332,12 +332,12 @@ impl GraphLayers {
 
     #[cfg(feature = "testing")]
     pub fn compress_ram(&mut self) {
-        use crate::index::hnsw_index::graph_links::GraphLinksConverter;
+        use crate::index::hnsw_index::graph_links::GraphLinksSerializer;
         assert!(self.links.format() == GraphLinksFormat::Plain);
-        let dummy = GraphLinksConverter::new(Vec::new(), GraphLinksFormat::Plain, 0, 0)
+        let dummy = GraphLinksSerializer::new(Vec::new(), GraphLinksFormat::Plain, 0, 0)
             .to_graph_links_ram();
         let links = std::mem::replace(&mut self.links, dummy);
-        self.links = GraphLinksConverter::new(
+        self.links = GraphLinksSerializer::new(
             links.into_edges(),
             GraphLinksFormat::Compressed,
             self.m,
@@ -363,7 +363,7 @@ mod tests {
     use crate::fixtures::index_fixtures::{
         random_vector, FakeFilterContext, TestRawScorerProducer,
     };
-    use crate::index::hnsw_index::graph_links::GraphLinksConverter;
+    use crate::index::hnsw_index::graph_links::GraphLinksSerializer;
     use crate::index::hnsw_index::tests::{
         create_graph_layer_builder_fixture, create_graph_layer_fixture,
     };
@@ -407,7 +407,7 @@ mod tests {
         let graph_layers = GraphLayers {
             m,
             m0: 2 * m,
-            links: GraphLinksConverter::new(graph_links.clone(), format, m, 2 * m)
+            links: GraphLinksSerializer::new(graph_links.clone(), format, m, 2 * m)
                 .to_graph_links_ram(),
             entry_points: EntryPoints::new(entry_points_num),
             visited_pool: VisitedPool::new(),

--- a/lib/segment/src/index/hnsw_index/graph_links/header.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/header.rs
@@ -1,0 +1,33 @@
+use common::bitpacking_ordered;
+use zerocopy::little_endian::U64 as LittleU64;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+/// File header for the plain format.
+#[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C)]
+pub(super) struct HeaderPlain {
+    pub(super) point_count: u64,
+    pub(super) levels_count: u64,
+    pub(super) total_links_count: u64,
+    pub(super) total_offset_count: u64,
+    /// Either 0 or 4.
+    pub(super) offsets_padding_bytes: u64,
+    pub(super) zero_padding: [u8; 24],
+}
+
+/// File header for the compressed format.
+#[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, align(8))]
+pub(super) struct HeaderCompressed {
+    pub(super) point_count: LittleU64,
+    /// Should be [`HEADER_VERSION_COMPRESSED`].
+    pub(super) version: LittleU64,
+    pub(super) levels_count: LittleU64,
+    pub(super) total_links_bytes: LittleU64,
+    pub(super) offsets_parameters: bitpacking_ordered::Parameters,
+    pub(super) m: LittleU64,
+    pub(super) m0: LittleU64,
+    pub(super) zero_padding: [u8; 5],
+}
+
+pub(super) const HEADER_VERSION_COMPRESSED: u64 = 0xFFFF_FFFF_FFFF_FF01;

--- a/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
@@ -1,0 +1,225 @@
+use std::cmp::Reverse;
+use std::fs::File;
+use std::io::Write;
+use std::mem::{size_of, take};
+use std::path::Path;
+
+use common::bitpacking::packed_bits;
+use common::bitpacking_links::{pack_links, MIN_BITS_PER_VALUE};
+use common::bitpacking_ordered;
+use common::types::PointOffsetType;
+use common::zeros::WriteZerosExt;
+use itertools::Either;
+use zerocopy::little_endian::U64 as LittleU64;
+use zerocopy::IntoBytes as AsBytes;
+
+use super::header::{HeaderCompressed, HeaderPlain, HEADER_VERSION_COMPRESSED};
+use super::{GraphLinks, GraphLinksEnum, GraphLinksFormat};
+use crate::common::operation_error::OperationResult;
+
+pub struct GraphLinksSerializer {
+    m: usize,
+    m0: usize,
+    links: Vec<u8>,
+    kind: Kind,
+    reindex: Vec<PointOffsetType>,
+    level_offsets: Vec<u64>,
+}
+
+enum Kind {
+    Uncompressed {
+        offsets_padding: usize,
+        offsets: Vec<u64>,
+    },
+    Compressed {
+        compressed_offsets: Vec<u8>,
+        offsets_parameters: bitpacking_ordered::Parameters,
+    },
+}
+
+impl GraphLinksSerializer {
+    pub fn new(
+        mut edges: Vec<Vec<Vec<PointOffsetType>>>,
+        format: GraphLinksFormat,
+        m: usize,
+        m0: usize,
+    ) -> Self {
+        // create map from index in `offsets` to point_id
+        let mut back_index: Vec<usize> = (0..edges.len()).collect();
+        // sort by max layer and use this map to build `Self.reindex`
+        back_index.sort_unstable_by_key(|&i| Reverse(edges[i].len()));
+
+        // `reindex` is map from point id to index in `Self.offsets`
+        let mut reindex = vec![0; back_index.len()];
+        for i in 0..back_index.len() {
+            reindex[back_index[i]] = i as PointOffsetType;
+        }
+
+        let levels_count = back_index
+            .first()
+            .map_or(0, |&point_id| edges[point_id].len());
+        let mut point_count_by_level = vec![0; levels_count];
+        for point in &edges {
+            point_count_by_level[point.len() - 1] += 1;
+        }
+
+        let mut total_offsets_len = 0;
+        let mut level_offsets = Vec::with_capacity(levels_count);
+        let mut suffix_sum = point_count_by_level.iter().sum::<u64>();
+        for &value in point_count_by_level.iter() {
+            level_offsets.push(total_offsets_len);
+            total_offsets_len += suffix_sum;
+            suffix_sum -= value;
+        }
+        total_offsets_len += 1;
+
+        let mut links = Vec::new();
+        let mut offsets = Vec::with_capacity(total_offsets_len as usize);
+        offsets.push(0);
+        let bits_per_unsorted = packed_bits(u32::try_from(edges.len().saturating_sub(1)).unwrap())
+            .max(MIN_BITS_PER_VALUE);
+
+        for level in 0..levels_count {
+            let count = point_count_by_level.iter().skip(level).sum::<u64>() as usize;
+            let (sorted_count, iter) = match level {
+                0 => (m0, Either::Left(0..count)),
+                _ => (m, Either::Right(back_index[..count].iter().copied())),
+            };
+            iter.for_each(|id| {
+                let raw_links = take(&mut edges[id][level]);
+                match format {
+                    GraphLinksFormat::Compressed => {
+                        pack_links(&mut links, raw_links, bits_per_unsorted, sorted_count);
+                        offsets.push(links.len() as u64);
+                    }
+                    GraphLinksFormat::Plain => {
+                        links.extend_from_slice(raw_links.as_bytes());
+                        offsets.push((links.len() as u64) / size_of::<PointOffsetType>() as u64);
+                    }
+                }
+            });
+        }
+
+        let kind = match format {
+            GraphLinksFormat::Compressed => {
+                let (compressed_offsets, offsets_parameters) =
+                    bitpacking_ordered::compress(&offsets);
+                Kind::Compressed {
+                    compressed_offsets,
+                    offsets_parameters,
+                }
+            }
+            GraphLinksFormat::Plain => {
+                let len = links.len() + reindex.as_bytes().len();
+                Kind::Uncompressed {
+                    offsets_padding: len.next_multiple_of(size_of::<u64>()) - len,
+                    offsets,
+                }
+            }
+        };
+
+        Self {
+            m,
+            m0,
+            links,
+            kind,
+            reindex,
+            level_offsets,
+        }
+    }
+
+    pub fn to_graph_links_ram(&self) -> GraphLinks {
+        let format = match &self.kind {
+            Kind::Uncompressed { .. } => GraphLinksFormat::Plain,
+            Kind::Compressed { .. } => GraphLinksFormat::Compressed,
+        };
+
+        let size = self.level_offsets.as_bytes().len()
+            + self.reindex.as_bytes().len()
+            + self.links.len()
+            + (match &self.kind {
+                Kind::Uncompressed {
+                    offsets_padding: padding,
+                    offsets,
+                } => size_of::<HeaderPlain>() + padding + offsets.as_bytes().len(),
+                Kind::Compressed {
+                    compressed_offsets,
+                    offsets_parameters: _,
+                } => size_of::<HeaderCompressed>() + compressed_offsets.len(),
+            });
+
+        let mut data = Vec::with_capacity(size);
+        // Unwrap should be the safe as `impl Write` for `Vec` never fails.
+        self.serialize_to_writer(&mut data).unwrap();
+        debug_assert_eq!(data.len(), size);
+        // Unwrap should be safe as we just created the data.
+        GraphLinks::try_new(GraphLinksEnum::Ram(data), |x| x.load_view(format)).unwrap()
+    }
+
+    fn serialize_to_writer(&self, writer: &mut impl Write) -> std::io::Result<()> {
+        match &self.kind {
+            Kind::Uncompressed {
+                offsets_padding,
+                offsets,
+            } => {
+                let header = HeaderPlain {
+                    point_count: self.reindex.len() as u64,
+                    levels_count: self.level_offsets.len() as u64,
+                    total_links_count: self.links.len() as u64
+                        / size_of::<PointOffsetType>() as u64,
+                    total_offset_count: offsets.len() as u64,
+                    offsets_padding_bytes: *offsets_padding as u64,
+                    zero_padding: [0; 24],
+                };
+                writer.write_all(header.as_bytes())?;
+            }
+            Kind::Compressed {
+                compressed_offsets: _,
+                offsets_parameters,
+            } => {
+                let header = HeaderCompressed {
+                    version: HEADER_VERSION_COMPRESSED.into(),
+                    point_count: LittleU64::new(self.reindex.len() as u64),
+                    total_links_bytes: LittleU64::new(self.links.len() as u64),
+                    offsets_parameters: *offsets_parameters,
+                    levels_count: LittleU64::new(self.level_offsets.len() as u64),
+                    m: LittleU64::new(self.m as u64),
+                    m0: LittleU64::new(self.m0 as u64),
+                    zero_padding: [0; 5],
+                };
+                writer.write_all(header.as_bytes())?;
+            }
+        }
+
+        writer.write_all(self.level_offsets.as_bytes())?;
+        writer.write_all(self.reindex.as_bytes())?;
+        writer.write_all(&self.links)?;
+        match &self.kind {
+            Kind::Uncompressed {
+                offsets_padding: padding,
+                offsets,
+            } => {
+                writer.write_zeros(*padding)?;
+                writer.write_all(offsets.as_bytes())?;
+            }
+            Kind::Compressed {
+                compressed_offsets,
+                offsets_parameters: _,
+            } => {
+                writer.write_all(compressed_offsets)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn save_as(&self, path: &Path) -> OperationResult<()> {
+        let temp_path = path.with_extension("tmp");
+        let file = File::create(temp_path.as_path())?;
+        let mut buf = std::io::BufWriter::new(&file);
+        self.serialize_to_writer(&mut buf)?;
+        file.sync_all()?;
+        std::fs::rename(temp_path, path)?;
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -1,0 +1,171 @@
+use common::bitpacking::packed_bits;
+use common::bitpacking_links::{for_each_packed_link, MIN_BITS_PER_VALUE};
+use common::bitpacking_ordered;
+use common::types::PointOffsetType;
+use itertools::Itertools as _;
+use zerocopy::native_endian::U64 as NativeU64;
+use zerocopy::{FromBytes, Immutable};
+
+use super::header::{HeaderCompressed, HeaderPlain, HEADER_VERSION_COMPRESSED};
+use super::GraphLinksFormat;
+use crate::common::operation_error::{OperationError, OperationResult};
+
+/// An (almost) zero-copy, non-owning view into serialized graph links stored
+/// as a `&[u8]` slice.
+#[derive(Debug)]
+pub(super) struct GraphLinksView<'a> {
+    pub(super) reindex: &'a [PointOffsetType],
+    pub(super) compression: CompressionInfo<'a>,
+    /// Level offsets, copied into RAM for faster access.
+    /// Has at least two elements:
+    /// - [`super::GraphLinksSerializer`] always writes `0` as the first element.
+    /// - Additional element is added during deserialization.
+    pub(super) level_offsets: Vec<u64>,
+}
+
+#[derive(Debug)]
+pub(super) enum CompressionInfo<'a> {
+    Uncompressed {
+        links: &'a [u32],
+        offsets: &'a [NativeU64],
+    },
+    Compressed {
+        compressed_links: &'a [u8],
+        offsets: bitpacking_ordered::Reader<'a>,
+        m: usize,
+        m0: usize,
+        bits_per_unsorted: u8,
+    },
+}
+
+impl GraphLinksView<'_> {
+    pub(super) fn load(data: &[u8], format: GraphLinksFormat) -> OperationResult<GraphLinksView> {
+        match format {
+            GraphLinksFormat::Compressed => Self::load_compressed(data),
+            GraphLinksFormat::Plain => Self::load_plain(data),
+        }
+    }
+
+    fn load_plain(data: &[u8]) -> OperationResult<GraphLinksView> {
+        let (header, data) =
+            HeaderPlain::ref_from_prefix(data).map_err(|_| error_unsufficent_size())?;
+        let (level_offsets, data) =
+            read_level_offsets(data, header.levels_count, header.total_offset_count)?;
+        let (reindex, data) = get_slice::<PointOffsetType>(data, header.point_count)?;
+        let (links, data) = get_slice::<u32>(data, header.total_links_count)?;
+        let (_, data) = get_slice::<u8>(data, header.offsets_padding_bytes)?;
+        let (offsets, _bytes) = get_slice::<NativeU64>(data, header.total_offset_count)?;
+        Ok(GraphLinksView {
+            reindex,
+            compression: CompressionInfo::Uncompressed { links, offsets },
+            level_offsets,
+        })
+    }
+
+    fn load_compressed(data: &[u8]) -> OperationResult<GraphLinksView> {
+        let (header, data) =
+            HeaderCompressed::ref_from_prefix(data).map_err(|_| error_unsufficent_size())?;
+        debug_assert_eq!(header.version.get(), HEADER_VERSION_COMPRESSED);
+        let (level_offsets, data) = read_level_offsets(
+            data,
+            header.levels_count.get(),
+            header.offsets_parameters.length.get(),
+        )?;
+        let (reindex, data) = get_slice::<PointOffsetType>(data, header.point_count.get())?;
+        let (compressed_links, data) = get_slice::<u8>(data, header.total_links_bytes.get())?;
+        let (offsets, _bytes) = bitpacking_ordered::Reader::new(header.offsets_parameters, data)
+            .map_err(|e| {
+                OperationError::service_error(format!("Can't create decompressor: {e}"))
+            })?;
+        Ok(GraphLinksView {
+            reindex,
+            compression: CompressionInfo::Compressed {
+                compressed_links,
+                offsets,
+                m: header.m.get() as usize,
+                m0: header.m0.get() as usize,
+                bits_per_unsorted: MIN_BITS_PER_VALUE.max(packed_bits(
+                    u32::try_from(header.point_count.get().saturating_sub(1)).map_err(|_| {
+                        OperationError::service_error("Too many points in GraphLinks file")
+                    })?,
+                )),
+            },
+            level_offsets,
+        })
+    }
+
+    pub(super) fn for_each_link(
+        &self,
+        point_id: PointOffsetType,
+        level: usize,
+        f: impl FnMut(PointOffsetType),
+    ) {
+        let idx = if level == 0 {
+            point_id as usize
+        } else {
+            self.level_offsets[level] as usize + self.reindex[point_id as usize] as usize
+        };
+
+        match self.compression {
+            CompressionInfo::Uncompressed { links, offsets } => {
+                let links_range = offsets[idx].get() as usize..offsets[idx + 1].get() as usize;
+                links[links_range].iter().copied().for_each(f)
+            }
+            CompressionInfo::Compressed {
+                compressed_links,
+                ref offsets,
+                m,
+                m0,
+                bits_per_unsorted,
+            } => {
+                let links_range =
+                    offsets.get(idx).unwrap() as usize..offsets.get(idx + 1).unwrap() as usize;
+                for_each_packed_link(
+                    &compressed_links[links_range],
+                    bits_per_unsorted,
+                    if level == 0 { m0 } else { m },
+                    f,
+                );
+            }
+        }
+    }
+
+    pub(super) fn point_level(&self, point_id: PointOffsetType) -> usize {
+        let reindexed_point_id = u64::from(self.reindex[point_id as usize]);
+        for (level, (&a, &b)) in self
+            .level_offsets
+            .iter()
+            .skip(1)
+            .tuple_windows()
+            .enumerate()
+        {
+            if reindexed_point_id >= b - a {
+                return level;
+            }
+        }
+        // See the doc comment on `level_offsets`.
+        self.level_offsets.len() - 2
+    }
+}
+
+fn read_level_offsets(
+    bytes: &[u8],
+    levels_count: u64,
+    total_offset_count: u64,
+) -> OperationResult<(Vec<u64>, &[u8])> {
+    let (level_offsets, bytes) = get_slice::<u64>(bytes, levels_count)?;
+    let mut result = Vec::with_capacity(level_offsets.len() + 1);
+    result.extend_from_slice(level_offsets);
+    result.push(total_offset_count.checked_sub(1).ok_or_else(|| {
+        OperationError::service_error("Total offset count should be at least 1 in GraphLinks file")
+    })?);
+    Ok((result, bytes))
+}
+
+fn get_slice<T: FromBytes + Immutable>(data: &[u8], length: u64) -> OperationResult<(&[T], &[u8])> {
+    <[T]>::ref_from_prefix_with_elems(data, length as usize).map_err(|_| error_unsufficent_size())
+}
+
+fn error_unsufficent_size() -> OperationError {
+    OperationError::service_error("Unsufficent file size for GraphLinks file")
+}


### PR DESCRIPTION
This PR splits and cleans-up `graph_links.rs`. Full list of changes:

- Rename `GraphLinksConverter` to `GraphLinksSerializer`.
- Extract some structs from `graph_links.rs` into separate files:
  - (33 lines) `graph_links/header.rs`: `HeaderPlain` and `HeaderCompressed`.
  - (225 lines) `graph_links/serializer.rs`: for `GraphLinksSerializer`.
  - (171 lines) `graph_links/view.rs`: `GraphLinksView`.
  - (332 lines) `graph_links.rs`: `GraphLinks`, `GraphLinksEnum`, tests.
- In `header.rs`, remove `HeaderCompressed::version` doc comment about `HEADER_VERSION_COMPRESSED` as being outdated after merging #5749.
- Add doc comment to `GraphLinksView`.
- In `view.rs`/`GraphLinksView`, move some associated functions to the module level:
  - `read_level_offsets`
  - `get_slice`
  - `error_unsufficent_size`
