### PR TITLE
Remove unecessary docker build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=xx / /
 # so, please, don't reorder them without prior consideration. 🥲
 
 RUN apt-get update \
-    && apt-get install -y clang libclang-dev llvm lld cmake protobuf-compiler jq \
+    && apt-get install -y clang lld cmake protobuf-compiler jq \
     && rustup component add rustfmt
 
 # `ARG`/`ENV` pair is a workaround for `docker build` backward-compatibility.


### PR DESCRIPTION
Those deps were introduced in https://github.com/qdrant/qdrant/pull/5765/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557.

But then partially reverted in https://github.com/qdrant/qdrant/pull/5768/files

The docker part was missing.