### PR TITLE
Resharding: fix abort on resharding up with replicas in active state

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -210,6 +210,10 @@ impl Collection {
             },
         }
 
+        shard_holder
+            .abort_resharding(resharding_key.clone(), force)
+            .await?;
+
         // Decrease the persisted shard count, ensures we don't load dropped shard on restart
         if resharding_key.direction == ReshardingDirection::Up {
             let mut config = self.collection_config.write().await;
@@ -235,8 +239,6 @@ impl Collection {
                 ShardingMethod::Custom => {}
             }
         }
-
-        shard_holder.abort_resharding(resharding_key, force).await?;
 
         Ok(())
     }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -344,10 +344,13 @@ impl ShardHolder {
         }
 
         // Remove new shard if resharding up
-        if direction == ReshardingDirection::Up {
+        if is_in_progress && direction == ReshardingDirection::Up {
             if let Some(shard) = self.get_shard(shard_id) {
                 match shard.peer_state(peer_id) {
-                    Some(ReplicaState::Resharding) => {
+                    // Valid replica states:
+                    // - in resharding state during migration transfer
+                    // - in active state after migration transfer
+                    Some(ReplicaState::Resharding | ReplicaState::Active) => {
                         log::debug!("removing peer {peer_id} from {shard_id} replica set");
                         shard.remove_peer(peer_id).await?;
                     }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -231,7 +231,7 @@ impl ShardHolder {
             )));
         };
 
-        // - do not abort if there is no active reshardinog operation with that key
+        // - do not abort if there is no active resharding operation with that key
         if !state.matches(resharding_key) {
             return Err(CollectionError::bad_request(format!(
                 "can't abort resharding {resharding_key}, \


### PR DESCRIPTION
When resharding up, migrated replicas will be in active state.

This fixes a problem where aborting resharding failed because it did not expect the active state.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
