### PR TITLE
Resharding: expose direction in gRPC API

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -96,6 +96,7 @@
     - [PayloadSchemaType](#qdrant-PayloadSchemaType)
     - [QuantizationType](#qdrant-QuantizationType)
     - [ReplicaState](#qdrant-ReplicaState)
+    - [ReshardingDirection](#qdrant-ReshardingDirection)
     - [ShardTransferMethod](#qdrant-ShardTransferMethod)
     - [ShardingMethod](#qdrant-ShardingMethod)
     - [TokenizerType](#qdrant-TokenizerType)
@@ -1298,6 +1299,7 @@ Note: 1kB = 1 vector of size 256. |
 | shard_id | [uint32](#uint32) |  |  |
 | peer_id | [uint64](#uint64) |  |  |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional |  |
+| direction | [ReshardingDirection](#qdrant-ReshardingDirection) |  |  |
 
 
 
@@ -1852,6 +1854,18 @@ Note: 1kB = 1 vector of size 256. |
 | Recovery | 6 | Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true |
 | Resharding | 7 | Points are being migrated to this shard as part of scale-up resharding |
 | ReshardingScaleDown | 8 | Points are being migrated to this shard as part of scale-down resharding |
+
+
+
+<a name="qdrant-ReshardingDirection"></a>
+
+### ReshardingDirection
+Resharding direction, scale up or down in number of shards
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| Up | 0 | Scale up, add a new shard |
+| Down | 1 | Scale down, remove a shard |
 
 
 

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -589,6 +589,15 @@ message ReshardingInfo {
   uint32 shard_id = 1;
   uint64 peer_id = 2;
   optional ShardKey shard_key = 3;
+  ReshardingDirection direction = 4;
+}
+
+/*
+  Resharding direction, scale up or down in number of shards
+*/
+enum ReshardingDirection {
+  Up = 0; // Scale up, add a new shard
+  Down = 1; // Scale down, remove a shard
 }
 
 message CollectionClusterInfoResponse {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -149,7 +149,7 @@ message MaxOptimizationThreads {
     enum Setting {
         Auto = 0;
     }
-    
+
     oneof variant {
         uint64 value = 1;
         Setting setting = 2;
@@ -271,10 +271,10 @@ message OptimizersConfigDiff {
   Interval between forced flushes.
   */
   optional uint64 flush_interval_sec = 7;
-  
+
   // Deprecated in favor of `max_optimization_threads`
   optional uint64 deprecated_max_optimization_threads = 8;
-  
+
   /*
   Max number of threads (jobs) for running optimizations per shard.
   Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1105,6 +1105,8 @@ pub struct ReshardingInfo {
     pub peer_id: u64,
     #[prost(message, optional, tag = "3")]
     pub shard_key: ::core::option::Option<ShardKey>,
+    #[prost(enumeration = "ReshardingDirection", tag = "4")]
+    pub direction: i32,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1708,6 +1710,36 @@ impl ReplicaState {
             "Recovery" => Some(Self::Recovery),
             "Resharding" => Some(Self::Resharding),
             "ReshardingScaleDown" => Some(Self::ReshardingScaleDown),
+            _ => None,
+        }
+    }
+}
+/// Resharding direction, scale up or down in number of shards
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ReshardingDirection {
+    /// Scale up, add a new shard
+    Up = 0,
+    /// Scale down, remove a shard
+    Down = 1,
+}
+impl ReshardingDirection {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ReshardingDirection::Up => "Up",
+            ReshardingDirection::Down => "Down",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Up" => Some(Self::Up),
+            "Down" => Some(Self::Down),
             _ => None,
         }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -27,6 +27,7 @@ use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, 
 use sparse::common::sparse_vector::{validate_sparse_vector_impl, SparseVector};
 use tonic::Status;
 
+use super::cluster_ops::ReshardingDirection;
 use super::consistency_params::ReadConsistency;
 use super::types::{
     CollectionConfig, ContextExamplePair, CoreSearchRequest, Datatype, DiscoverRequestInternal,
@@ -1507,6 +1508,16 @@ impl From<ReshardingInfo> for api::grpc::qdrant::ReshardingInfo {
             shard_id: value.shard_id,
             peer_id: value.peer_id,
             shard_key: value.shard_key.map(convert_shard_key_to_grpc),
+            direction: api::grpc::qdrant::ReshardingDirection::from(value.direction) as i32,
+        }
+    }
+}
+
+impl From<ReshardingDirection> for api::grpc::qdrant::ReshardingDirection {
+    fn from(value: ReshardingDirection) -> Self {
+        match value {
+            ReshardingDirection::Up => api::grpc::qdrant::ReshardingDirection::Up,
+            ReshardingDirection::Down => api::grpc::qdrant::ReshardingDirection::Down,
         }
     }
 }


### PR DESCRIPTION
The gRPC API did not expose what direction we were resharding into.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?