### PR TITLE
Remove peer metadata from Raft state, when removing peer

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -68,15 +68,19 @@ impl Persistent {
         &mut self,
         meta: &SnapshotMetadata,
         address_by_id: PeerAddressById,
-        metadata_by_id: PeerMetadataById,
+        mut metadata_by_id: PeerMetadataById,
     ) -> Result<(), StorageError> {
+        metadata_by_id.retain(|peer_id, _| address_by_id.contains_key(peer_id));
+
         *self.peer_address_by_id.write() = address_by_id;
         *self.peer_metadata_by_id.write() = metadata_by_id;
+
         self.state.conf_state = meta.get_conf_state().clone();
         self.state.hard_state.term = cmp::max(self.state.hard_state.term, meta.term);
         self.state.hard_state.commit = meta.index;
         self.apply_progress_queue.set_from_snapshot(meta.index);
         self.latest_snapshot_meta = meta.into();
+
         self.save()
     }
 

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -108,7 +108,7 @@ impl Persistent {
             Self::init(path_json.clone(), first_peer, None)?
         };
 
-        let mut state = if reinit {
+        let state = if reinit {
             if first_peer {
                 // Re-initialize consensus of the first peer is different from the rest
                 // Effectively, we should remove all other peers from voters and learners
@@ -138,15 +138,15 @@ impl Persistent {
         Ok(state)
     }
 
-    fn remove_unknown_peer_metadata(&mut self) -> bool {
+    fn remove_unknown_peer_metadata(&self) -> bool {
         let mut peer_metadata = self.peer_metadata_by_id.write();
         let peer_metadata_len = peer_metadata.len();
 
         let peer_address = self.peer_address_by_id.read();
         peer_metadata.retain(|peer_id, _| peer_address.contains_key(peer_id));
 
-        let is_updated = peer_metadata_len != peer_metadata.len();
-        is_updated
+        // Return `true`, if `peer_metadata` was updated
+        peer_metadata_len != peer_metadata.len()
     }
 
     pub fn unapplied_entities_count(&self) -> usize {

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -586,7 +586,10 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         // plus we need to make additional removing in the `channel_pool`.
         // So we handle `remove_peer` inside the `toc` and persist changes in the `persistent` after that.
         self.toc.remove_peer(peer_id)?;
-        self.persistent.read().save()
+
+        let persistent = self.persistent.read();
+        persistent.peer_metadata_by_id.write().remove(&peer_id);
+        persistent.save()
     }
 
     async fn await_receiver(


### PR DESCRIPTION
Currently, if we continuously add and remove peers to the cluster, `raft_metadata.json` will keep growing. This PR fixes it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
