### PR TITLE
API validation for unique dense and sparse vector names

### DIFF
--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -200,7 +200,7 @@ impl CreateCollectionOperation {
             if let Some(duplicate_name) = dense_names.find(|name| sparse_config.contains_key(*name))
             {
                 return Err(StorageError::bad_input(
-                    format!("Dense and sparse vector names must be unique - duplicate found with `{duplicate_name}`"),
+                    format!("Dense and sparse vector names must be unique - duplicate found with '{duplicate_name}'"),
                 ));
             }
         }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -196,14 +196,8 @@ impl CreateCollectionOperation {
     ) -> StorageResult<Self> {
         // validate vector names are unique between dense and sparse vectors
         if let Some(sparse_config) = &create_collection.sparse_vectors {
-            let dense_names: Vec<_> = create_collection
-                .vectors
-                .params_iter()
-                .map(|p| p.0)
-                .collect();
-            if let Some(duplicate_name) = dense_names
-                .into_iter()
-                .find(|name| sparse_config.contains_key(*name))
+            let mut dense_names = create_collection.vectors.params_iter().map(|p| p.0);
+            if let Some(duplicate_name) = dense_names.find(|name| sparse_config.contains_key(*name))
             {
                 return Err(StorageError::bad_input(
                     format!("Dense and sparse vector names must be unique - duplicate found with `{duplicate_name}`"),

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use validator::Validate;
 
+use crate::content_manager::errors::{StorageError, StorageResult};
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
 
 // *Operation wrapper structure is only required for better OpenAPI generation
@@ -189,12 +190,32 @@ pub struct CreateCollectionOperation {
 }
 
 impl CreateCollectionOperation {
-    pub fn new(collection_name: String, create_collection: CreateCollection) -> Self {
-        Self {
+    pub fn new(
+        collection_name: String,
+        create_collection: CreateCollection,
+    ) -> StorageResult<Self> {
+        // validate vector names are unique between dense and sparse vectors
+        if let Some(sparse_config) = &create_collection.sparse_vectors {
+            let dense_names: Vec<_> = create_collection
+                .vectors
+                .params_iter()
+                .map(|p| p.0)
+                .collect();
+            if let Some(duplicate_name) = dense_names
+                .into_iter()
+                .find(|name| sparse_config.contains_key(*name))
+            {
+                return Err(StorageError::bad_input(
+                    format!("Dense and sparse vector names must be unique - duplicate found with `{duplicate_name}`"),
+                ));
+            }
+        }
+
+        Ok(Self {
             collection_name,
             create_collection,
             distribution: None,
-        }
+        })
     }
 
     pub fn is_distribution_set(&self) -> bool {

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -38,7 +38,7 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
     type Error = Status;
 
     fn try_from(value: api::grpc::qdrant::CreateCollection) -> Result<Self, Self::Error> {
-        Ok(Self::CreateCollection(CreateCollectionOperation::new(
+        let op = CreateCollectionOperation::new(
             value.collection_name,
             CreateCollection {
                 vectors: match value.vectors_config.and_then(|config| config.config) {
@@ -71,7 +71,8 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
                 strict_mode_config: value.strict_mode_config.map(strict_mode_from_api),
                 uuid: None,
             },
-        )))
+        )?;
+        Ok(CollectionMetaOperations::CreateCollection(op))
     }
 }
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -148,7 +148,7 @@ async fn _do_recover_from_snapshot(
                 CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
                     collection_pass.to_string(),
                     snapshot_config.clone().into(),
-                ));
+                )?);
             dispatcher
                 .submit_collection_meta_op(operation, access, None)
                 .await?;

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -96,27 +96,30 @@ fn test_alias_operation() {
     handle
         .block_on(
             dispatcher.submit_collection_meta_op(
-                CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
-                    "test".to_string(),
-                    CreateCollection {
-                        vectors: VectorParamsBuilder::new(10, Distance::Cosine)
-                            .build()
-                            .into(),
-                        sparse_vectors: None,
-                        hnsw_config: None,
-                        wal_config: None,
-                        optimizers_config: None,
-                        shard_number: Some(1),
-                        on_disk_payload: None,
-                        replication_factor: None,
-                        write_consistency_factor: None,
-                        init_from: None,
-                        quantization_config: None,
-                        sharding_method: None,
-                        strict_mode_config: None,
-                        uuid: None,
-                    },
-                )),
+                CollectionMetaOperations::CreateCollection(
+                    CreateCollectionOperation::new(
+                        "test".to_string(),
+                        CreateCollection {
+                            vectors: VectorParamsBuilder::new(10, Distance::Cosine)
+                                .build()
+                                .into(),
+                            sparse_vectors: None,
+                            hnsw_config: None,
+                            wal_config: None,
+                            optimizers_config: None,
+                            shard_number: Some(1),
+                            on_disk_payload: None,
+                            replication_factor: None,
+                            write_consistency_factor: None,
+                            init_from: None,
+                            quantization_config: None,
+                            sharding_method: None,
+                            strict_mode_config: None,
+                            uuid: None,
+                        },
+                    )
+                    .unwrap(),
+                ),
                 FULL_ACCESS,
                 None,
             ),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1469,27 +1469,30 @@ mod tests {
         handle
             .block_on(
                 dispatcher.submit_collection_meta_op(
-                    CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
-                        "test".to_string(),
-                        CreateCollection {
-                            vectors: VectorParamsBuilder::new(10, Distance::Cosine)
-                                .build()
-                                .into(),
-                            sparse_vectors: None,
-                            hnsw_config: None,
-                            wal_config: None,
-                            optimizers_config: None,
-                            shard_number: Some(2),
-                            on_disk_payload: None,
-                            replication_factor: None,
-                            write_consistency_factor: None,
-                            init_from: None,
-                            quantization_config: None,
-                            sharding_method: None,
-                            strict_mode_config: None,
-                            uuid: None,
-                        },
-                    )),
+                    CollectionMetaOperations::CreateCollection(
+                        CreateCollectionOperation::new(
+                            "test".to_string(),
+                            CreateCollection {
+                                vectors: VectorParamsBuilder::new(10, Distance::Cosine)
+                                    .build()
+                                    .into(),
+                                sparse_vectors: None,
+                                hnsw_config: None,
+                                wal_config: None,
+                                optimizers_config: None,
+                                shard_number: Some(2),
+                                on_disk_payload: None,
+                                replication_factor: None,
+                                write_consistency_factor: None,
+                                init_from: None,
+                                quantization_config: None,
+                                sharding_method: None,
+                                strict_mode_config: None,
+                                uuid: None,
+                            },
+                        )
+                        .unwrap(),
+                    ),
                     Access::full("For test"),
                     None,
                 ),

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -65,7 +65,8 @@ pub async fn handle_existing_collections(
                 strict_mode_config: collection_state.config.strict_mode_config,
                 uuid: collection_state.config.uuid,
             },
-        );
+        )
+        .expect("Failed to create collection operation");
 
         let mut consensus_operations = Vec::new();
 

--- a/tests/openapi/test_sparse_vector_persistence.py
+++ b/tests/openapi/test_sparse_vector_persistence.py
@@ -111,7 +111,7 @@ def test_sparse_dense_vector_naming_validations(collection_name):
         }
     )
     assert not response.ok
-    assert 'Dense and sparse vector names must be unique - duplicate found with `image`' in response.json()["status"]["error"]
+    assert 'Dense and sparse vector names must be unique - duplicate found with \'image\'' in response.json()["status"]["error"]
 
     response = request_with_validation(
         api='/collections/{collection_name}',
@@ -128,4 +128,4 @@ def test_sparse_dense_vector_naming_validations(collection_name):
         }
     )
     assert not response.ok
-    assert 'Dense and sparse vector names must be unique - duplicate found with ``' in response.json()["status"]["error"]
+    assert 'Dense and sparse vector names must be unique - duplicate found with \'\'' in response.json()["status"]["error"]

--- a/tests/openapi/test_sparse_vector_persistence.py
+++ b/tests/openapi/test_sparse_vector_persistence.py
@@ -84,3 +84,31 @@ def test_sparse_vector_persisted_sorted(collection_name):
         assert results[i]['id'] == i + 1
         assert results[i]['vector']['text']['indices'] == [1, 2, 3]  # sorted by indices
         assert results[i]['vector']['text']['values'] == [0.1, 0.2, 0.3]  # aligned to respective indices
+
+
+def test_sparse_dense_vector_naming_validations(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "image": {
+                    "size": 2,
+                    "distance": "Euclid"
+                }
+            },
+            "sparse_vectors": {
+                "image": {}
+            }
+        }
+    )
+    assert not response.ok
+    assert 'Dense and sparse vector names must be unique - duplicate found with `image`' in response.json()["status"]["error"]

--- a/tests/openapi/test_sparse_vector_persistence.py
+++ b/tests/openapi/test_sparse_vector_persistence.py
@@ -112,3 +112,20 @@ def test_sparse_dense_vector_naming_validations(collection_name):
     )
     assert not response.ok
     assert 'Dense and sparse vector names must be unique - duplicate found with `image`' in response.json()["status"]["error"]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": 2,
+                "distance": "Euclid"
+            },
+            "sparse_vectors": {
+                "": {}
+            }
+        }
+    )
+    assert not response.ok
+    assert 'Dense and sparse vector names must be unique - duplicate found with ``' in response.json()["status"]["error"]


### PR DESCRIPTION
Tackling https://github.com/qdrant/qdrant/issues/3184

The new validation kicks in for both REST and gRPC.