### PR TITLE
Fix gRPC deleted threshold validation 

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -151,7 +151,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("ListCollectionAliasesRequest.collection_name", "length(min = 1, max = 255)"),
             ("HnswConfigDiff.ef_construct", "range(min = 4)"),
             ("WalConfigDiff.wal_capacity_mb", "range(min = 1)"),
-            ("OptimizersConfigDiff.deleted_threshold", "range(min = 1.0)"),
+            ("OptimizersConfigDiff.deleted_threshold", "range(min = 0.0, max = 1.0)"),
             ("OptimizersConfigDiff.vacuum_min_vector_number", "range(min = 100)"),
             ("OptimizersConfigDiff.max_segment_size", "range(min = 1)"),
             ("VectorsConfig.config", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -335,7 +335,7 @@ pub struct WalConfigDiff {
 pub struct OptimizersConfigDiff {
     /// The minimal fraction of deleted vectors in a segment, required to perform segment optimization
     #[prost(double, optional, tag = "1")]
-    #[validate(range(min = 1.0))]
+    #[validate(range(min = 0.0, max = 1.0))]
     pub deleted_threshold: ::core::option::Option<f64>,
     /// The minimal number of vectors in a segment, required to perform segment optimization
     #[prost(uint64, optional, tag = "2")]


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/5807>.

The deleted threshold validation in our gRPC interface was incorrect. It should allow a range of [0.0, 1.0].

The REST interface was already set up correctly.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?