### PR TITLE
Cleanup `#[allow(dead_code)]` annotations

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -186,7 +186,6 @@ impl ShardCleanTasks {
 /// used in context of resharding, where points are transferred to different shards.
 pub(super) struct ShardCleanTask {
     /// Handle of the clean task
-    #[allow(dead_code)]
     handle: JoinHandle<()>,
     /// Watch channel with current status of the task
     status: Receiver<ShardCleanStatus>,

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -21,14 +21,13 @@ use crate::collection::Collection;
 // If you're not implementing a new point-api endpoint for which a strict mode check
 // is required, this is safe to use.
 pub fn new_unchecked_verification_pass() -> VerificationPass {
-    VerificationPass { inner: () }
+    VerificationPass { _inner: () }
 }
 
 /// A pass, created on successful verification.
 pub struct VerificationPass {
     // Private field, so we can't instantiate it from somewhere else.
-    #[allow(dead_code)]
-    inner: (),
+    _inner: (),
 }
 
 /// Trait to verify strict mode for requests.

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -61,7 +61,7 @@ impl PostingListHeader {
 /// [ PostingListHeader, PostingListHeader, ... ] |
 /// [ CompressedMmapPostingList, CompressedMmapPostingList, ... ] |`
 pub struct MmapPostings {
-    path: PathBuf,
+    _path: PathBuf,
     mmap: Mmap,
     header: PostingsHeader,
 }
@@ -200,6 +200,10 @@ impl MmapPostings {
             )
         })?;
 
-        Ok(Self { path, mmap, header })
+        Ok(Self {
+            _path: path,
+            mmap,
+            header,
+        })
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::path::PathBuf;
 

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -119,9 +119,8 @@ mod tests {
     use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
     use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
-    #[allow(dead_code)]
     pub struct GpuGraphTestData {
-        pub dir: TempDir,
+        pub _temp_dir: TempDir,
         pub vector_storage: VectorStorageEnum,
         pub vector_holder: TestRawScorerProducer<CosineMetric>,
         pub graph_layers_builder: GraphLayersBuilder,
@@ -141,8 +140,8 @@ mod tests {
         let vector_holder = TestRawScorerProducer::<CosineMetric>::new(dim, num_vectors, &mut rng);
 
         // upload vectors to storage
-        let dir = tempfile::Builder::new().prefix("db_dir").tempdir().unwrap();
-        let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+        let temp_dir = tempfile::Builder::new().prefix("db_dir").tempdir().unwrap();
+        let db = open_db(temp_dir.path(), &[DB_VECTOR_CF]).unwrap();
         let mut storage = open_simple_dense_vector_storage(
             db,
             DB_VECTOR_CF,
@@ -184,7 +183,7 @@ mod tests {
             .collect();
 
         GpuGraphTestData {
-            dir,
+            _temp_dir: temp_dir,
             vector_storage: storage,
             vector_holder,
             graph_layers_builder,

--- a/lib/segment/src/index/sparse_index/mod.rs
+++ b/lib/segment/src/index/sparse_index/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 pub mod indices_tracker;
 pub mod sparse_index_config;
 pub mod sparse_search_telemetry;

--- a/lib/segment/src/vector_storage/async_io_mock.rs
+++ b/lib/segment/src/vector_storage/async_io_mock.rs
@@ -1,17 +1,17 @@
+#![allow(dead_code)] // The mock is unused on Linux, and so produces dead code warnings
+
 use std::fs::File;
 
 use crate::common::operation_error::OperationResult;
 use crate::data_types::primitive::PrimitiveVectorElement;
 
 // This is a mock implementation of the async_io module for those platforms that don't support io_uring.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct UringReader<T: PrimitiveVectorElement> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-#[allow(dead_code)]
-#[allow(clippy::unnecessary_wraps)] // Using the same type as the real implementation
+#[allow(clippy::unnecessary_wraps)] // Mock `new` have to follow the same signature as real `UringReader`
 impl<T: PrimitiveVectorElement> UringReader<T> {
     pub fn new(_file: File, _raw_size: usize, _header_size: usize) -> OperationResult<Self> {
         Ok(Self {

--- a/lib/sparse/benches/prof.rs
+++ b/lib/sparse/benches/prof.rs
@@ -46,7 +46,6 @@ pub struct FlamegraphProfiler<'a> {
 }
 
 impl FlamegraphProfiler<'_> {
-    #[allow(dead_code)]
     pub fn new(frequency: c_int) -> Self {
         FlamegraphProfiler {
             frequency,

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -21,6 +21,7 @@ pub struct InvertedIndexCompressedImmutableRam<W: Weight> {
 }
 
 impl<W: Weight> InvertedIndexCompressedImmutableRam<W> {
+    #[allow(dead_code)]
     pub(super) fn into_postings(self) -> Vec<CompressedPostingList<W>> {
         self.postings
     }

--- a/lib/sparse/src/index/mod.rs
+++ b/lib/sparse/src/index/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 pub mod compressed_posting_list;
 pub mod inverted_index;
 pub mod loaders;

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -474,7 +474,7 @@ mod tests {
     /// Helper struct to store both an index and a temporary directory
     struct TestIndex<I: InvertedIndex> {
         index: I,
-        temp_dir: TempDir,
+        _temp_dir: TempDir,
     }
 
     impl<I: InvertedIndex> TestIndex<I> {
@@ -485,7 +485,7 @@ mod tests {
                 .unwrap();
             TestIndex {
                 index: I::from_ram_index(Cow::Owned(ram_index), &temp_dir).unwrap(),
-                temp_dir,
+                _temp_dir: temp_dir,
             }
         }
     }
@@ -885,6 +885,7 @@ mod tests {
     }
 
     /// Generates a random inverted index with `num_vectors` vectors
+    #[allow(dead_code)]
     fn random_inverted_index<R: Rng + ?Sized>(
         rnd_gen: &mut R,
         num_vectors: u32,

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -292,7 +292,7 @@ impl TableOfContent {
         Ok(())
     }
 
-    #[allow(dead_code)] // Currently unused ¯\_(ツ)_/¯
+    #[allow(dead_code)]
     fn remove_shards_at_peer_sync(&self, peer_id: PeerId) -> Result<(), StorageError> {
         self.general_runtime
             .block_on(self.remove_shards_at_peer(peer_id))

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -137,8 +137,6 @@ fn log_service_error(err: &StorageError) {
     }
 }
 
-pub type HttpResult<T, E = HttpError> = Result<T, E>;
-
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct HttpError(StorageError);

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -1,9 +1,7 @@
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod actix_telemetry;
 pub mod api;
 mod auth;
 mod certificate_helpers;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod helpers;
 pub mod web_ui;
 
@@ -53,7 +51,6 @@ pub async fn index() -> impl Responder {
     HttpResponse::Ok().json(VersionInfo::default())
 }
 
-#[allow(dead_code)]
 pub fn init(
     dispatcher: Arc<Dispatcher>,
     telemetry_collector: Arc<tokio::sync::Mutex<TelemetryCollector>>,

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -34,7 +34,7 @@ pub struct HealthChecker {
     // Signal to the health checker task, that the API was called.
     // Used to drive the health checker task and avoid constant polling.
     check_ready_signal: Arc<sync::Notify>,
-    cancel: cancel::DropGuard,
+    _cancel: cancel::DropGuard,
 }
 
 impl HealthChecker {
@@ -58,7 +58,7 @@ impl HealthChecker {
             is_ready: task.is_ready.clone(),
             is_ready_signal: task.is_ready_signal.clone(),
             check_ready_signal: task.check_ready_signal.clone(),
-            cancel: task.cancel.clone().drop_guard(),
+            _cancel: task.cancel.clone().drop_guard(),
         };
 
         let task = runtime.spawn(task.exec());

--- a/src/common/inference/mod.rs
+++ b/src/common/inference/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::convert::Infallible;
 use std::fmt;
 use std::future::{ready, Ready};

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,22 +1,14 @@
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod collections;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod error_reporting;
-#[allow(dead_code)]
 pub mod health;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod helpers;
 pub mod http_client;
 pub mod metrics;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod points;
 pub mod snapshots;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod stacktrace;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod telemetry;
 pub mod telemetry_ops;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod telemetry_reporting;
 
 pub mod auth;
@@ -25,7 +17,6 @@ pub mod strings;
 
 pub mod debugger;
 
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod inference;
 
 pub mod pyroscope_state;

--- a/src/common/stacktrace.rs
+++ b/src/common/stacktrace.rs
@@ -14,6 +14,7 @@ struct StackTraceFrame {
 }
 
 impl StackTraceFrame {
+    #[allow(dead_code)]
     pub fn render(&self) -> String {
         let mut result = String::new();
         for symbol in &self.symbols {

--- a/src/common/telemetry_ops/requests_telemetry.rs
+++ b/src/common/telemetry_ops/requests_telemetry.rs
@@ -59,7 +59,6 @@ impl ActixTelemetryCollector {
 }
 
 impl TonicTelemetryCollector {
-    #[allow(dead_code)]
     pub fn create_grpc_telemetry_collector(&mut self) -> Arc<Mutex<TonicWorkerTelemetryCollector>> {
         let worker: Arc<Mutex<_>> = Default::default();
         self.workers.push(worker.clone());
@@ -77,7 +76,6 @@ impl TonicTelemetryCollector {
 }
 
 impl TonicWorkerTelemetryCollector {
-    #[allow(dead_code)]
     pub fn add_response(&mut self, method: String, instant: std::time::Instant) {
         let aggregator = self
             .methods

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use api::rest::models::{CollectionsResponse, HardwareUsage, VersionInfo};
 use api::rest::schema::PointInsertOperations;
 use api::rest::{

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,7 +16,6 @@ use crate::tracing;
 const DEFAULT_CONFIG: &str = include_str!("../config/config.yaml");
 
 #[derive(Debug, Deserialize, Validate, Clone)]
-#[allow(dead_code)] // necessary because some field are only used in main.rs
 pub struct ServiceConfig {
     #[validate(length(min = 1))]
     pub host: String,
@@ -77,13 +76,11 @@ pub struct ClusterConfig {
     #[serde(default)]
     #[validate(nested)]
     pub consensus: ConsensusConfig,
-    #[allow(dead_code)] // `schema_generator` complains 🙄
     #[serde(default)]
     pub resharding_enabled: bool, // disabled by default
 }
 
 #[derive(Debug, Deserialize, Clone, Validate)]
-#[allow(dead_code)] // necessary because some field are only used in main.rs
 pub struct P2pConfig {
     #[serde(default)]
     pub port: Option<u16>,
@@ -117,7 +114,6 @@ pub struct ConsensusConfig {
     #[validate(range(min = 1))]
     #[serde(default = "default_message_timeout_tics")]
     pub message_timeout_ticks: u64,
-    #[allow(dead_code)] // `schema_generator` complains about this 🙄
     #[serde(default)]
     pub compact_wal_entries: u64, // compact WAL when it grows to enough applied entries
 }
@@ -190,7 +186,6 @@ pub struct GpuConfig {
 }
 
 #[derive(Debug, Deserialize, Clone, Validate)]
-#[allow(dead_code)] // necessary because some field are only used in main.rs
 pub struct Settings {
     #[serde(default)]
     pub log_level: Option<String>,
@@ -222,7 +217,6 @@ pub struct Settings {
 }
 
 impl Settings {
-    #[allow(dead_code)]
     pub fn new(custom_config_path: Option<String>) -> Result<Self, ConfigError> {
         let mut load_errors = vec![];
         let config_exists = |path| File::with_name(path).collect().is_ok();
@@ -294,7 +288,6 @@ impl Settings {
         )
     }
 
-    #[allow(dead_code)]
     pub fn validate_and_warn(&self) {
         //
         // JWT RBAC

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // `schema_generator` binary target produce warnings
-
 pub mod config;
 pub mod default;
 pub mod handle;


### PR DESCRIPTION
This PR
- replaces multiple `#[allow(dead_code)]` in the main `qdrant` crate with a single module-level annotation in `schema_generator.rs`
- removes `#[allow(dead_code)]` annotations, that are not required anymore
- and in a few places it replaces `#[allow(dead_code)]` annotations on unused structure fields with `_` prefix

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
