### PR TITLE
Optimize `merged_points` computation in `SegmentBuilder::update()`

### DIFF
--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod mmap_hashmap;
 pub mod num_traits;
 pub mod panic;
 pub mod rate_limiting;
+pub mod small_uint;
 pub mod tar_ext;
 pub mod tempfile_ext;
 pub mod top_k;

--- a/lib/common/common/src/small_uint.rs
+++ b/lib/common/common/src/small_uint.rs
@@ -5,14 +5,14 @@ impl U24 {
     pub const MAX: u32 = 0xFFFFFF;
 
     #[inline]
-    pub fn new_wrapped(value: u32) -> Self {
+    pub const fn new_wrapped(value: u32) -> Self {
         let arr = value.to_le_bytes();
         Self([arr[0], arr[1], arr[2]])
     }
 
     #[inline]
-    pub fn get(self) -> u32 {
-        u32::from_ne_bytes([self.0[0], self.0[1], self.0[2], 0])
+    pub const fn get(self) -> u32 {
+        u32::from_le_bytes([self.0[0], self.0[1], self.0[2], 0])
     }
 }
 
@@ -33,5 +33,17 @@ impl From<U24> for u32 {
     #[inline]
     fn from(value: U24) -> Self {
         value.get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    pub use super::*;
+
+    #[test]
+    fn test_u24() {
+        assert_eq!(U24::new_wrapped(0x13_57_9A_BC).get(), 0x57_9A_BC);
+        assert!(U24::try_from(0x13_57_9A_BC).is_err());
+        assert_eq!(U24::try_from(0x57_9A_BC).map(U24::get), Ok(0x57_9A_BC));
     }
 }

--- a/lib/common/common/src/small_uint.rs
+++ b/lib/common/common/src/small_uint.rs
@@ -1,0 +1,37 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct U24([u8; 3]);
+
+impl U24 {
+    pub const MAX: u32 = 0xFFFFFF;
+
+    #[inline]
+    pub fn new_wrapped(value: u32) -> Self {
+        let arr = value.to_le_bytes();
+        Self([arr[0], arr[1], arr[2]])
+    }
+
+    #[inline]
+    pub fn get(self) -> u32 {
+        u32::from_ne_bytes([self.0[0], self.0[1], self.0[2], 0])
+    }
+}
+
+impl TryFrom<u32> for U24 {
+    type Error = ();
+
+    #[inline]
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        let arr = value.to_le_bytes();
+        if arr[3] != 0 {
+            return Err(());
+        }
+        Ok(Self([arr[0], arr[1], arr[2]]))
+    }
+}
+
+impl From<U24> for u32 {
+    #[inline]
+    fn from(value: U24) -> Self {
+        value.get()
+    }
+}

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -2,6 +2,10 @@ use std::path::PathBuf;
 
 use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
+#[cfg(test)]
+use rand::rngs::StdRng;
+#[cfg(test)]
+use rand::Rng as _;
 
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
@@ -23,6 +27,15 @@ impl InMemoryIdTracker {
 
     pub fn into_internal(self) -> (Vec<SeqNumberType>, PointMappings) {
         (self.internal_to_version, self.mappings)
+    }
+
+    /// Generate a random [`InMemoryIdTracker`].
+    #[cfg(test)]
+    pub fn random(rand: &mut StdRng, size: u32, preserved_size: u32, bits_in_id: u8) -> Self {
+        Self {
+            internal_to_version: vec![rand.gen(); size as usize],
+            mappings: PointMappings::random_with_params(rand, size, preserved_size, bits_in_id),
+        }
     }
 }
 

--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -4,4 +4,129 @@ pub mod in_memory_id_tracker;
 pub mod point_mappings;
 pub mod simple_id_tracker;
 
+use common::types::PointOffsetType;
 pub use id_tracker_base::*;
+use itertools::Itertools as _;
+
+use crate::types::ExtendedPointId;
+
+/// Calling [`for_each_unique_point`] will yield this struct for each unique
+/// point.
+#[derive(Debug, Clone, Copy)]
+pub struct MergedPointId {
+    /// Unique external ID. If the same external ID is present in multiple
+    /// trackers, the item with the highest version takes precedence.
+    pub external_id: ExtendedPointId,
+    /// An index within `id_trackers` iterator that points to the [`IdTracker`]
+    /// that contains this point.
+    pub tracker_index: usize,
+    /// The internal ID of the point within the [`IdTracker`] that contains it.
+    pub internal_id: PointOffsetType,
+    /// The version of the point within the [`IdTracker`] that contains it.
+    pub version: u64,
+}
+
+/// Calls a closure for each unique point from multiple ID trackers.
+pub fn for_each_unique_point<'a>(
+    id_trackers: impl Iterator<Item = &'a (impl IdTracker + ?Sized + 'a)>,
+    mut f: impl FnMut(MergedPointId),
+) {
+    let mut iter = id_trackers
+        .enumerate()
+        .map(|(segment_index, id_tracker)| {
+            id_tracker
+                .iter_from(None)
+                .map(move |(external_id, internal_id)| MergedPointId {
+                    external_id,
+                    tracker_index: segment_index,
+                    internal_id,
+                    version: id_tracker.internal_version(internal_id).unwrap_or(0),
+                })
+        })
+        .kmerge_by(|a, b| a.external_id < b.external_id);
+
+    let Some(mut best_item) = iter.next() else {
+        return;
+    };
+
+    for item in iter {
+        if best_item.external_id == item.external_id {
+            if best_item.version < item.version {
+                best_item = item;
+            }
+        } else {
+            f(best_item);
+            best_item = item;
+        }
+    }
+    f(best_item);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{hash_map, HashMap};
+
+    use in_memory_id_tracker::InMemoryIdTracker;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng as _;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_for_each_unique_point(#[values(0, 1, 5)] tracker_count: usize) {
+        let mut rand = StdRng::seed_from_u64(42);
+
+        let id_trackers = (0..tracker_count)
+            .map(|_| InMemoryIdTracker::random(&mut rand, 1000, 500, 10))
+            .collect_vec();
+
+        let mut collisions = 0;
+
+        // Naive HashMap-based implementation of for_each_unique_point.
+        let mut expected = HashMap::<ExtendedPointId, MergedPointId>::new();
+        for (tracker_index, id_tracker) in id_trackers.iter().enumerate() {
+            for (external_id, internal_id) in id_tracker.iter_from(None) {
+                let version = id_tracker.internal_version(internal_id).unwrap();
+                let merged_point_id = MergedPointId {
+                    external_id,
+                    tracker_index,
+                    internal_id,
+                    version,
+                };
+                match expected.entry(external_id) {
+                    hash_map::Entry::Occupied(mut entry) => {
+                        collisions += 1;
+                        if entry.get().version < version {
+                            entry.insert(merged_point_id);
+                        }
+                    }
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(merged_point_id);
+                    }
+                }
+            }
+        }
+
+        if tracker_count > 1 {
+            // Ensure generated id_trackers have a lot of common points, so we
+            // are testing the merge logic.
+            assert!(collisions > 500);
+        } else {
+            // No collisions expected for a single or no id_trackers.
+            assert_eq!(collisions, 0);
+        }
+        if tracker_count == 0 {
+            assert!(expected.is_empty());
+        }
+
+        for_each_unique_point(id_trackers.iter(), |merged_point_id| {
+            let v = expected.remove(&merged_point_id.external_id).unwrap();
+            assert_eq!(merged_point_id.tracker_index, v.tracker_index);
+            assert_eq!(merged_point_id.internal_id, v.internal_id);
+            assert_eq!(merged_point_id.version, v.version);
+        });
+
+        assert!(expected.is_empty());
+    }
+}

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -10,8 +11,10 @@ use atomic_refcell::AtomicRefCell;
 use bitvec::macros::internal::funty::Integral;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::CpuPermit;
+use common::small_uint::U24;
 use common::types::PointOffsetType;
 use io::storage_version::StorageVersion;
+use itertools::Itertools;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -26,7 +29,7 @@ use crate::common::operation_error::{check_process_stopped, OperationError, Oper
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
-use crate::id_tracker::{IdTracker, IdTrackerEnum};
+use crate::id_tracker::{for_each_unique_point, IdTracker, IdTrackerEnum};
 use crate::index::field_index::FieldIndex;
 use crate::index::sparse_index::sparse_vector_index::SparseVectorIndexOpenArgs;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -36,7 +39,8 @@ use crate::payload_storage::PayloadStorage;
 use crate::segment::{Segment, SegmentVersion};
 use crate::segment_constructor::load_segment;
 use crate::types::{
-    ExtendedPointId, PayloadFieldSchema, PayloadKeyType, SegmentConfig, SegmentState, SeqNumberType,
+    CompactExtendedPointId, PayloadFieldSchema, PayloadKeyType, SegmentConfig, SegmentState,
+    SeqNumberType,
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
@@ -237,38 +241,38 @@ impl SegmentBuilder {
             return Ok(true);
         }
 
-        let mut merged_points: HashMap<ExtendedPointId, PositionedPointMetadata> = HashMap::new();
-
-        for (segment_index, segment) in segments.iter().enumerate() {
-            for external_id in segment.iter_points() {
-                let version = segment.point_version(external_id).unwrap_or(0);
-                let internal_id = segment.get_internal_id(external_id).unwrap();
-                merged_points
-                    .entry(external_id)
-                    .and_modify(|entry| {
-                        if entry.version < version {
-                            entry.segment_index = segment_index;
-                            entry.version = version;
-                            entry.internal_id = internal_id;
-                        }
-                    })
-                    .or_insert_with(|| PositionedPointMetadata {
-                        segment_index,
-                        internal_id,
-                        external_id,
-                        version,
-                        ordering: 0,
-                    });
-            }
+        struct PointData {
+            external_id: CompactExtendedPointId,
+            // ExtendedPointIdCompact is 17 bytes, we reduce `segment_index`
+            // to 3 bytes to avoid paddings and align nicely.
+            segment_index: U24,
+            internal_id: PointOffsetType,
+            version: u64,
+            ordering: u64,
         }
+
+        if segments.len() > U24::MAX as usize {
+            return Err(OperationError::service_error("Too many segments to update"));
+        }
+
+        let mut points_to_insert = Vec::new();
+        let locked_id_trackers = segments.iter().map(|s| s.id_tracker.borrow()).collect_vec();
+        for_each_unique_point(locked_id_trackers.iter().map(|i| i.deref()), |item| {
+            points_to_insert.push(PointData {
+                external_id: item.external_id.into(),
+                segment_index: U24::new_wrapped(item.tracker_index as u32),
+                internal_id: item.internal_id,
+                version: item.version,
+                ordering: 0,
+            });
+        });
+        drop(locked_id_trackers);
 
         let payloads: Vec<_> = segments.iter().map(|i| i.payload_index.borrow()).collect();
 
-        let mut points_to_insert: Vec<_> = merged_points.into_values().collect();
-
         for defragment_key in &self.defragment_keys {
             for point_data in &mut points_to_insert {
-                let Some(payload_indices) = payloads[point_data.segment_index]
+                let Some(payload_indices) = payloads[point_data.segment_index.get() as usize]
                     .field_indexes
                     .get(defragment_key)
                 else {
@@ -309,7 +313,8 @@ impl SegmentBuilder {
                 .collect::<Result<Vec<_>, OperationError>>()?;
 
             let mut iter = points_to_insert.iter().map(|point_data| {
-                let other_vector_storage = &other_vector_storages[point_data.segment_index];
+                let other_vector_storage =
+                    &other_vector_storages[point_data.segment_index.get() as usize];
                 let vec = other_vector_storage.get_vector(point_data.internal_id);
                 let vector_deleted = other_vector_storage.is_deleted_vector(point_data.internal_id);
                 (vec, vector_deleted)
@@ -337,10 +342,10 @@ impl SegmentBuilder {
 
                 let old_internal_id = point_data.internal_id;
 
-                let other_payload = payloads[point_data.segment_index]
+                let other_payload = payloads[point_data.segment_index.get() as usize]
                     .get_payload(old_internal_id, &HardwareCounterCell::disposable())?; // Internal operation, no measurement needed!
 
-                match self.id_tracker.internal_id(point_data.external_id) {
+                match self.id_tracker.internal_id(point_data.external_id.into()) {
                     Some(existing_internal_id) => {
                         debug_assert!(
                             false,
@@ -354,9 +359,9 @@ impl SegmentBuilder {
 
                         let remove_id = if existing_external_version < point_data.version {
                             // Other version is the newest, remove the existing one and replace
-                            self.id_tracker.drop(point_data.external_id)?;
+                            self.id_tracker.drop(point_data.external_id.into())?;
                             self.id_tracker
-                                .set_link(point_data.external_id, new_internal_id)?;
+                                .set_link(point_data.external_id.into(), new_internal_id)?;
                             self.id_tracker
                                 .set_internal_version(new_internal_id, point_data.version)?;
                             self.payload_storage.clear(existing_internal_id)?;
@@ -373,7 +378,7 @@ impl SegmentBuilder {
                     }
                     None => {
                         self.id_tracker
-                            .set_link(point_data.external_id, new_internal_id)?;
+                            .set_link(point_data.external_id.into(), new_internal_id)?;
                         self.id_tracker
                             .set_internal_version(new_internal_id, point_data.version)?;
                     }
@@ -665,13 +670,4 @@ fn create_temp_dir(parent_path: &Path) -> Result<TempDir, OperationError> {
                 err
             ))
         })
-}
-
-/// Internal point ID and metadata of a point.
-struct PositionedPointMetadata {
-    segment_index: usize,
-    internal_id: PointOffsetType,
-    external_id: ExtendedPointId,
-    version: SeqNumberType,
-    ordering: u64,
 }


### PR DESCRIPTION
This PR optimizes RAM usage of `SegmentBuilder::update()`. Two primary ideas: k-way merge and structure packing.

## K-way merge

We have a list of segments and we want to deduplicate point IDs within them. Previously we were using a huge `HashMap` for that. This required a lot of temporary memory.

But! Our `IdTracker`s let us iterate over IDs in a sorted order. By applying a k-way merge algorithm (which is kindly provided by `itertools`) we can iterate and deduplicate points across all segments in a single pass.

## Structure packing

The size of the `ExtendedPointId` enum is 24 which is excessive given that `Uuid` is 16 bytes long. The reason is the 8-byte alignment of `u64`.

By replacing `u64` with `[u8; 8]` (which doesn't require alignment), we can reduce the size of `ExtendedPointId` to 17 bytes. I've used [`zerocopy::…::U64`] as a wrapper around `[u8; 8]`.

The next tiny step is to switch `segment_index: usize` to `U24` which is 3 bytes long and combines well with 17-byte `ExtendedPointId`. I assume that this function won't be used to merge 16M segments. :sweat_smile:

Both of these tricks reduced the size of struct `PositionedPointMetadata` from 56 bytes to 40 bytes.

[`zerocopy::…::U64`]: https://docs.rs/zerocopy/latest/zerocopy/byteorder/native_endian/type.U64.html

# Benchmark

On my test of merging 4 segments with a total of 3744768 points, these changes reduced the additional RAM usage from 970MB to 590MB, making it use less memory than the HNSW graph building (a step at 1200M on the right side of the plot).

![memory_usage](https://github.com/user-attachments/assets/bd25c11c-6f3f-4a5d-bb4d-028db33a3c09)
