### PR TITLE
Pass `old_indices` to `HNSWIndex::new`

### DIFF
--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -90,6 +90,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -205,6 +205,7 @@ impl HNSWIndex {
         } = open_args;
         let VectorIndexBuildArgs {
             permit,
+            old_indices: _,
             gpu_device,
             stopped,
         } = build_args;

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -96,6 +96,7 @@ fn test_graph_connectivity() {
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -374,6 +374,9 @@ pub(crate) struct VectorIndexOpenArgs<'a> {
 
 pub struct VectorIndexBuildArgs<'a> {
     pub permit: Arc<CpuPermit>,
+    /// Vector indices from other segments, used to speed up index building.
+    /// May or may not contain the same vectors.
+    pub old_indices: &'a [Arc<AtomicRefCell<VectorIndexEnum>>],
     pub gpu_device: Option<&'a LockedGpuDevice<'a>>,
     pub stopped: &'a AtomicBool,
 }

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -175,6 +175,7 @@ fn test_batch_and_single_request_equivalency() {
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -239,6 +239,7 @@ fn test_byte_storage_hnsw(
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -361,6 +361,7 @@ fn test_byte_storage_binary_quantization_hnsw(
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -150,6 +150,7 @@ fn exact_search_test() {
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -209,6 +209,7 @@ fn _test_filterable_hnsw(
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -152,6 +152,7 @@ fn test_gpu_filterable_hnsw() {
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: Some(&locked_device), // enable GPU
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -128,6 +128,7 @@ fn hnsw_discover_precision() {
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },
@@ -263,6 +264,7 @@ fn filtered_hnsw_discover_precision() {
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -148,6 +148,7 @@ fn hnsw_quantized_search_test(
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -198,6 +198,7 @@ fn test_multi_filterable_hnsw(
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -160,6 +160,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         },
         VectorIndexBuildArgs {
             permit: permit.clone(),
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -332,6 +332,7 @@ fn test_multivector_quantization_hnsw(
         },
         VectorIndexBuildArgs {
             permit,
+            old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
         },


### PR DESCRIPTION
This PR lets segment builder to pass `old_indices` to `HNSWIndex::new`.
In subsequent PRs these indices would be used for incremental index building.