### PR TITLE
FixedLengthPriorityQueue: explicit sorted/unsorted methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -1243,6 +1243,7 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
+ "bytemuck",
  "common",
  "criterion",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 [workspace.dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"
+bytemuck = { version = "1.21.0", features = ["extern_crate_alloc", "transparentwrapper_extra"] }
 bytes = "1.9.0"
 chrono = { version = "0.4.39", features = ["serde"] }
 criterion = "0.5.1"

--- a/lib/collection/src/collection_manager/search_result_aggregator.rs
+++ b/lib/collection/src/collection_manager/search_result_aggregator.rs
@@ -30,7 +30,7 @@ impl SearchResultAggregator {
     }
 
     pub fn into_vec(self) -> Vec<ScoredPoint> {
-        self.queue.into_vec()
+        self.queue.into_sorted_vec()
     }
 
     pub fn lowest(&self) -> Option<&ScoredPoint> {

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 testing = []
 
 [dependencies]
+bytemuck = { workspace = true }
 num-traits = { workspace = true }
 num_cpus = "1.16"
 ordered-float = { workspace = true }

--- a/lib/segment/src/index/hnsw_index/entry_points.rs
+++ b/lib/segment/src/index/hnsw_index/entry_points.rs
@@ -103,7 +103,7 @@ impl EntryPoints {
             .or_else(|| {
                 // Searching for at least some entry point
                 self.extra_entry_points
-                    .iter()
+                    .iter_unsorted()
                     .filter(|entry| checker(entry.point_id))
                     .cloned()
                     .max_by_key(|ep| ep.level)

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_heap_tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_heap_tests.rs
@@ -210,7 +210,7 @@ fn test_gpu_nearest_heap(#[values(true, false)] linear: bool) {
             queue.push(scored_point);
             scores_output_cpu[group * inputs_count + i] = queue.top().unwrap().score;
         }
-        let sorted = queue.into_vec();
+        let sorted = queue.into_sorted_vec();
         for i in 0..ef {
             sorted_output_cpu[group * ef + i] = sorted[i].idx;
         }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -746,7 +746,7 @@ mod tests {
             let search_result = test
                 .graph_layers_builder
                 .search_on_level(entry, 0, ef, &mut scorer)
-                .into_vec();
+                .into_sorted_vec();
             for (cpu, (gpu_1, gpu_2)) in search_result
                 .iter()
                 .zip(gpu_responses_1[i].iter().zip(gpu_responses_2[i].iter()))

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -247,7 +247,7 @@ impl GraphLayers {
             &mut points_scorer,
         );
         let nearest = self.search_on_level(zero_level_entry, 0, max(top, ef), &mut points_scorer);
-        nearest.into_iter().take(top).collect_vec()
+        nearest.into_iter_sorted().take(top).collect_vec()
     }
 
     pub fn get_path(path: &Path) -> PathBuf {
@@ -435,7 +435,7 @@ mod tests {
 
         assert_eq!(nearest_on_level.len(), graph_links[0][0].len() + 1);
 
-        for nearest in &nearest_on_level {
+        for nearest in nearest_on_level.iter_unsorted() {
             // eprintln!("nearest = {:#?}", nearest);
             assert_eq!(
                 nearest.score,
@@ -530,6 +530,6 @@ mod tests {
 
         let graph_search = search_in_graph(&query, top, &vector_holder, &graph_layers);
 
-        assert_eq!(reference_top.into_vec(), graph_search);
+        assert_eq!(reference_top.into_sorted_vec(), graph_search);
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -359,7 +359,7 @@ impl GraphLayersBuilder {
     where
         F: FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
     {
-        let closest_iter = candidates.into_iter();
+        let closest_iter = candidates.into_iter_sorted();
         Self::select_candidate_with_heuristic_from_sorted(closest_iter, m, score_internal)
     }
 
@@ -416,7 +416,7 @@ impl GraphLayersBuilder {
                         &mut points_scorer,
                     );
 
-                    if let Some(the_nearest) = search_context.nearest.iter().max() {
+                    if let Some(the_nearest) = search_context.nearest.iter_unsorted().max() {
                         level_entry = *the_nearest;
                     }
 
@@ -482,7 +482,7 @@ impl GraphLayersBuilder {
                             }
                         }
                     } else {
-                        for nearest_point in &search_context.nearest {
+                        for nearest_point in search_context.nearest.iter_unsorted() {
                             {
                                 let mut links =
                                     self.links_layers[point_id as usize][curr_level].write();
@@ -722,7 +722,7 @@ mod tests {
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
 
-        assert_eq!(reference_top.into_vec(), graph_search);
+        assert_eq!(reference_top.into_sorted_vec(), graph_search);
     }
 
     #[rstest]
@@ -811,7 +811,7 @@ mod tests {
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
-        assert_eq!(reference_top.into_vec(), graph_search);
+        assert_eq!(reference_top.into_sorted_vec(), graph_search);
     }
 
     #[rstest]
@@ -887,7 +887,7 @@ mod tests {
             });
         }
 
-        let sorted_candidates = candidates.into_vec();
+        let sorted_candidates = candidates.into_sorted_vec();
 
         for x in sorted_candidates.iter().take(M) {
             eprintln!("sorted_candidates = ({}, {})", x.idx, x.score);

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -36,7 +36,7 @@ fn search_in_builder(
     );
 
     let nearest = builder.search_on_level(zero_level_entry, 0, max(top, ef), &mut points_scorer);
-    nearest.into_iter().take(top).collect_vec()
+    nearest.into_iter_sorted().take(top).collect_vec()
 }
 
 /// Check that HNSW index with raw and compacted links gives the same results

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -29,7 +29,10 @@ where
     for element in elements {
         pq.push(Reverse(element));
     }
-    pq.into_vec().into_iter().map(|Reverse(x)| x).collect()
+    pq.into_sorted_vec()
+        .into_iter()
+        .map(|Reverse(x)| x)
+        .collect()
 }
 
 pub fn peek_top_largest_iterable<I, E: Ord>(elements: I, top: usize) -> Vec<E>
@@ -46,7 +49,7 @@ where
     for element in elements {
         pq.push(element);
     }
-    pq.into_vec()
+    pq.into_sorted_vec()
 }
 
 pub fn peek_top_scores<E: Ord + Clone>(scores: &[E], top: usize) -> Vec<E> {

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -174,7 +174,7 @@ where
         // Instead of silently falling back to the sync implementation, we prefer to panic
         // and notify the user that they better use the default IO implementation.
 
-        pq.into_vec()
+        pq.into_sorted_vec()
     }
 
     fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
@@ -201,7 +201,7 @@ where
         // Instead of silently falling back to the sync implementation, we prefer to panic
         // and notify the user that they better use the default IO implementation.
 
-        pq.into_vec()
+        pq.into_sorted_vec()
     }
 }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -1046,7 +1046,7 @@ where
             }
         }
 
-        pq.into_vec()
+        pq.into_sorted_vec()
     }
 
     fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {


### PR DESCRIPTION
`FixedLengthPriorityQueue` API is confusing. Some iterators/conversions are ordered, some are not. Furthermore, these two implementations of `IntoIterator` contradict each other.

```rust
// unordered
impl<'a, T: Ord> IntoIterator for &'a FixedLengthPriorityQueue<T> { … }
// ordered
impl<T: Ord> IntoIterator for FixedLengthPriorityQueue<T> { … }
```

Giving that they are called implicitly, it makes things confusing:
```rust
let mut q = FixedLengthPriorityQueue::new(5);
for i in (0..5).rev() {
    q.push(i);
}

let mut a1 = Vec::new();
for &i in &q { // unordered
    a1.push(i);
}

let mut a2 = Vec::new();
for i in q { // ordered
    a2.push(i);
}

assert_eq!(a1, a2); // panic: [2, 4, 3, 1, 0] != [4, 3, 2, 1, 0]
```

This PR makes API more explicit:
- Implementations of `IntoIterator` are removed in favor of explicit `iter_unsorted` and `into_iter_sorted` methods.
- The method `into_vec` is renamed into `into_sorted_vec`.

Also, unlike old consuming `IntoIterator`, the new `into_iter_sorted` doesn't allocate intermediate vector, making it more efficient with partial iterators (i.e. `.take()`). Its based on a backported code from unstable Rust feature ([src](https://github.com/rust-lang/rust/blob/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/alloc/src/collections/binary_heap/mod.rs#L1616-L1657)).
