### PR TITLE
Fix broken shard key mapping storage, keep shard key numbers

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -23,9 +23,8 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{self, ShardConfig};
-use crate::shards::shard_holder::{
-    shard_not_found_error, ShardHolder, ShardKeyMapping, SHARD_KEY_MAPPING_FILE,
-};
+use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
+use crate::shards::shard_holder::{shard_not_found_error, ShardHolder, SHARD_KEY_MAPPING_FILE};
 use crate::shards::shard_versioning;
 
 impl Collection {

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -7,7 +7,8 @@ use crate::config::CollectionConfigInternal;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_holder::{ShardKeyMapping, ShardTransferChange};
+use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
+use crate::shards::shard_holder::ShardTransferChange;
 use crate::shards::transfer::ShardTransfer;
 
 impl Collection {

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -8,7 +8,7 @@ use crate::config::CollectionConfigInternal;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::resharding::ReshardState;
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_holder::ShardKeyMapping;
+use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
 use crate::shards::transfer::ShardTransfer;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1,4 +1,5 @@
 mod resharding;
+pub(crate) mod shard_mapping;
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -13,6 +14,7 @@ use futures::{stream, Future, StreamExt, TryStreamExt as _};
 use itertools::Itertools;
 use segment::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use segment::types::{ShardKey, SnapshotFormat};
+use shard_mapping::ShardKeyMapping;
 use tokio::runtime::Handle;
 use tokio::sync::{broadcast, OwnedRwLockReadGuard, RwLock};
 use tokio_util::codec::{BytesCodec, FramedRead};
@@ -48,8 +50,6 @@ use crate::shards::CollectionId;
 const SHARD_TRANSFERS_FILE: &str = "shard_transfers";
 const RESHARDING_STATE_FILE: &str = "resharding_state.json";
 pub const SHARD_KEY_MAPPING_FILE: &str = "shard_key_mapping.json";
-
-pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
 
 pub struct ShardHolder {
     shards: HashMap<ShardId, ShardReplicaSet>,

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -93,12 +93,14 @@ impl Deref for SaveOnDiskShardKeyMappingWrapper {
 /// This type supports two different persisted formats:
 ///
 /// - The `Old` format is the original format from when shard key mappings were implemented.
-/// - The `New` format is a more robust format, properly persisting shard key numbers.
+/// - The `New` format is a more robust, properly persisting shard key numbers.
 ///
 /// The old format is problematic because it does not persist shard key numbers properly. On load,
 /// shard key numbers would be converted into shard key strings breaking shard key mappings.
 ///
 /// This type functions as a compatibility layer between the two different persisted formats.
+///
+/// Bug: <https://github.com/qdrant/qdrant/pull/5838>
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 enum ShardKeyMappingWrapper {

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -1,0 +1,130 @@
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use common::tar_ext;
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use segment::types::ShardKey;
+use serde::{Deserialize, Serialize};
+
+use crate::save_on_disk::{Error, SaveOnDisk};
+use crate::shards::shard::ShardId;
+
+pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
+
+/// A `SaveOnDisk`-like structure for the shard key mapping
+///
+/// Hold the shard key mapping, and persists in a different format to disk.
+pub(super) struct SaveOnDiskShardKeyMappingWrapper {
+    /// Persist mapping in a robust format that doesn't loose shard key type information
+    persisted: SaveOnDisk<ShardKeyMappingWrapper>,
+    /// Shard key mapping view in original format
+    mapping: RwLock<ShardKeyMapping>,
+}
+
+impl SaveOnDiskShardKeyMappingWrapper {
+    /// Wraps `SaveOnDisk::load_or_init_default`, using a different persisted type.
+    pub fn load_or_init_default(path: impl Into<PathBuf>) -> Result<Self, Error> {
+        let persisted: SaveOnDisk<ShardKeyMappingWrapper> = SaveOnDisk::load_or_init_default(path)?;
+        let mapping = persisted.read().clone().into_mapping();
+        Ok(Self {
+            persisted,
+            mapping: RwLock::new(mapping),
+        })
+    }
+
+    /// Wraps `SaveOnDisk::write_optional`, using a different persisted type.
+    pub fn write_optional(
+        &self,
+        f: impl FnOnce(&ShardKeyMapping) -> Option<ShardKeyMapping>,
+    ) -> Result<bool, Error> {
+        let read_lock = self.mapping.upgradable_read();
+
+        let mut updated_mapping = None;
+
+        let is_changed = self.persisted.write_optional(|mapping| {
+            let persisted_mapping = f(&mapping.clone().into_mapping());
+
+            // If persisted mapping will be changed, clone it to update our mapping view
+            if let Some(ref mapping) = persisted_mapping {
+                updated_mapping.replace(mapping.clone());
+            }
+
+            persisted_mapping.map(ShardKeyMappingWrapper::from_mapping)
+        })?;
+
+        // Persisted mapping got changed, also update our mapping view
+        if let Some(new_mapping) = updated_mapping {
+            let mut write_lock = RwLockUpgradableReadGuard::upgrade(read_lock);
+            *write_lock = new_mapping;
+        }
+
+        Ok(is_changed)
+    }
+
+    /// Wraps `SaveOnDisk::save_to_tar`, using a different persisted type.
+    pub async fn save_to_tar(
+        &self,
+        tar: &tar_ext::BuilderExt,
+        path: impl AsRef<Path>,
+    ) -> Result<(), Error> {
+        self.persisted.save_to_tar(tar, path).await
+    }
+}
+
+impl Deref for SaveOnDiskShardKeyMappingWrapper {
+    type Target = RwLock<ShardKeyMapping>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.mapping
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+enum ShardKeyMappingWrapper {
+    Old(ShardKeyMapping),
+    New(Vec<NewShardKeyMapping>),
+}
+
+impl Default for ShardKeyMappingWrapper {
+    fn default() -> Self {
+        Self::Old(Default::default())
+    }
+}
+
+impl ShardKeyMappingWrapper {
+    fn from_mapping(mapping: ShardKeyMapping) -> Self {
+        if mapping.keys().any(|key| matches!(key, ShardKey::Number(_))) {
+            Self::New(
+                mapping
+                    .into_iter()
+                    .map(|(key, shard_ids)| NewShardKeyMapping { key, shard_ids })
+                    .collect(),
+            )
+        } else {
+            Self::Old(mapping)
+        }
+    }
+
+    fn into_mapping(self) -> ShardKeyMapping {
+        match self {
+            ShardKeyMappingWrapper::Old(mapping) => mapping,
+            ShardKeyMappingWrapper::New(mappings) => mappings
+                .into_iter()
+                .map(|mapping| (mapping.key, mapping.shard_ids))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct NewShardKeyMapping {
+    /// Shard key
+    ///
+    /// The key is persisted as untagged variant. The JSON value gives us enough information
+    /// however to distinguish between a shard key number and string.
+    key: ShardKey,
+    /// Associalted shard IDs.
+    shard_ids: HashSet<ShardId>,
+}

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -4,7 +4,7 @@ use super::{ShardTransfer, ShardTransferKey, ShardTransferMethod};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_holder::ShardKeyMapping;
+use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
 
 pub fn validate_transfer_exists(
     transfer_key: &ShardTransferKey,


### PR DESCRIPTION
Our shard key mapping storage for [user defined sharding](https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding) appears to be broken.

We support two types of custom shard keys, a string and a number. The shard key numbers are not persisted properly and are converted into shard key strings on load. This breaks user defined sharding because the strings and numbers are not interchangeable.

This changes the format in which we persist shard keys to fix this very problem. The new format uses better typing, so that numbers and strings can properly be distinguished.

More specifically, we now have two formats:
- The `Old` format is the original format from when shard key mappings were implemented
- The `New` format is a more robust, properly persisting shard key numbers

Both formats can be stored and loaded from disk. The same `shard_key_mapping.json` file is used. Currently this PR still prefers to store in the old format, but the new format is chosen if any shard key numbers are used. This ensures backwards compatibility.

In Qdrant 1.14 we change change to always prefer the new format. In a later version the old format can be entirely removed if we so desire.

We used a `SaveOnDisk<ShardKeyMapping>` structure to handle persisting. I've replaced that with a specialized `SaveOnDiskShardKeyMappingWrapper` structure that acts in the same way, but takes care of loading/persisting in both formats.

### Example

For example. If I now create a collection and add shard keys `"1"` and `"2"`, we still persist in the old format:

```json
{"1":[1],"2":[2]}
```

If I now add the shard key number `3`, it automagically changes into the new format:

```json
[{"key":"1","shard_ids":[1]},{"key":"2","shard_ids":[2]},{"key":3,"shard_ids":[3]}]
```

Again, this PR supports both formats interchangeably.

### Tasks

- [x] Add test

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?