### PR TITLE
Remove setting OpenOptions flags to false

### DIFF
--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -15,7 +15,6 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<File> 
         let file = OpenOptions::new()
             .read(true)
             .write(true)
-            .create(false)
             // Don't truncate because we explicitly set the length later
             .truncate(false)
             .open(path)?;
@@ -39,22 +38,15 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<File> 
 
         std::fs::rename(&temp_path, path)?;
 
-        OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(false)
-            .truncate(false)
-            .open(path)
+        OpenOptions::new().read(true).write(true).open(path)
     }
 }
 
 pub fn open_read_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io::Result<Mmap> {
     let file = OpenOptions::new()
         .read(true)
-        .write(false)
         .append(true)
         .create(true)
-        .truncate(false)
         .open(path)?;
 
     let mmap = unsafe { Mmap::map(&file)? };
@@ -71,11 +63,7 @@ pub fn open_read_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io:
 }
 
 pub fn open_write_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io::Result<MmapMut> {
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(false)
-        .open(path)?;
+    let file = OpenOptions::new().read(true).write(true).open(path)?;
 
     let mmap = unsafe { MmapMut::map_mut(&file)? };
 

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -124,6 +124,7 @@ impl DynamicMmapFlags {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(directory.join(FLAGS_FILE))?;
         file.set_len(capacity_bytes as u64)?;
 

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -124,7 +124,6 @@ impl DynamicMmapFlags {
             .read(true)
             .write(true)
             .create(true)
-            .truncate(false)
             .open(directory.join(FLAGS_FILE))?;
         file.set_len(capacity_bytes as u64)?;
 

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -265,12 +265,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
 
 /// Open a file shortly for appending
 fn open_append<P: AsRef<Path>>(path: P) -> io::Result<File> {
-    OpenOptions::new()
-        .read(false)
-        .write(false)
-        .append(true)
-        .create(false)
-        .open(path)
+    OpenOptions::new().append(true).open(path)
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -23,11 +23,7 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
         quantized_vector_size: usize,
         vectors_count: usize,
     ) -> std::io::Result<QuantizedMmapStorage> {
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(false)
-            .create(false)
-            .open(path)?;
+        let file = std::fs::OpenOptions::new().read(true).open(path)?;
         let mmap = unsafe { Mmap::map(&file)? };
         madvise::madvise(&mmap, madvise::get_global())?;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -39,7 +39,6 @@ impl MultivectorOffsetsStorage for Vec<MultivectorOffset> {
         let offsets_file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
-            .create(false)
             .open(path)?;
         let offsets_mmap = unsafe { MmapMut::map_mut(&offsets_file) }?;
         let mut offsets_mmap_type =
@@ -71,7 +70,6 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
         let offsets_file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
-            .create(false)
             .open(path)?;
         let offsets_mmap = unsafe { MmapMut::map_mut(&offsets_file) }?;
         let offsets = unsafe { MmapSlice::<MultivectorOffset>::try_from(offsets_mmap)? };


### PR DESCRIPTION
As I was auditing the options combinations, I noticed that all `OpenOptions` flags are [false when creating the struct](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.new), so there is no need to specify them explicitly.