### PR TITLE
Strict mode sparsevector

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -76,7 +76,7 @@
     - [StrictModeMultivectorConfig.MultivectorConfigEntry](#qdrant-StrictModeMultivectorConfig-MultivectorConfigEntry)
     - [StrictModeSparse](#qdrant-StrictModeSparse)
     - [StrictModeSparseConfig](#qdrant-StrictModeSparseConfig)
-    - [StrictModeSparseConfig.SparseConfigEntry](#qdrant-StrictModeSparseConfig-ConfigEntry)
+    - [StrictModeSparseConfig.SparseConfigEntry](#qdrant-StrictModeSparseConfig-SparseConfigEntry)
     - [TextIndexParams](#qdrant-TextIndexParams)
     - [UpdateCollection](#qdrant-UpdateCollection)
     - [UpdateCollectionClusterSetupRequest](#qdrant-UpdateCollectionClusterSetupRequest)
@@ -1471,6 +1471,7 @@ Note: 1kB = 1 vector of size 256. |
 | filter_max_conditions | [uint64](#uint64) | optional |  |
 | condition_max_size | [uint64](#uint64) | optional |  |
 | multivector_config | [StrictModeMultivectorConfig](#qdrant-StrictModeMultivectorConfig) | optional |  |
+| sparse_config | [StrictModeSparseConfig](#qdrant-StrictModeSparseConfig) | optional |  |
 
 
 
@@ -1520,9 +1521,14 @@ Note: 1kB = 1 vector of size 256. |
 
 
 
+
+
+
 <a name="qdrant-StrictModeSparse"></a>
 
-### StrictModeSparseVectors
+### StrictModeSparse
+
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -1530,27 +1536,37 @@ Note: 1kB = 1 vector of size 256. |
 
 
 
+
+
+
 <a name="qdrant-StrictModeSparseConfig"></a>
 
-### StrictModeSparseConfig.SparseConfig
-
-
-| Field        | Type                                                                             | Label | Description |
-|--------------|----------------------------------------------------------------------------------| ----- | ----------- |
-| sparse_config | [StrictModeSparseConfig.SparseConfigEntry](#qdrant-StrictModeSparseConfig-ConfigEntry) | repeated |  |
+### StrictModeSparseConfig
 
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sparse_config | [StrictModeSparseConfig.SparseConfigEntry](#qdrant-StrictModeSparseConfig-SparseConfigEntry) | repeated |  |
 
-<a name="qdrant-StrictModeSparseConfig-ConfigEntry"></a>
-
-### StrictModeSparseConfig-SparseConfigEntry
 
 
-| Field | Type                                              | Label | Description |
-| ----- |---------------------------------------------------| ----- | ----------- |
-| key | [string](#string)                                 |  |  |
+
+
+
+<a name="qdrant-StrictModeSparseConfig-SparseConfigEntry"></a>
+
+### StrictModeSparseConfig.SparseConfigEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
 | value | [StrictModeSparse](#qdrant-StrictModeSparse) |  |  |
+
+
+
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -74,6 +74,9 @@
     - [StrictModeMultivector](#qdrant-StrictModeMultivector)
     - [StrictModeMultivectorConfig](#qdrant-StrictModeMultivectorConfig)
     - [StrictModeMultivectorConfig.MultivectorConfigEntry](#qdrant-StrictModeMultivectorConfig-MultivectorConfigEntry)
+    - [StrictModeSparse](#qdrant-StrictModeSparse)
+    - [StrictModeSparseConfig](#qdrant-StrictModeSparseConfig)
+    - [StrictModeSparseConfig.SparseConfigEntry](#qdrant-StrictModeSparseConfig-ConfigEntry)
     - [TextIndexParams](#qdrant-TextIndexParams)
     - [UpdateCollection](#qdrant-UpdateCollection)
     - [UpdateCollectionClusterSetupRequest](#qdrant-UpdateCollectionClusterSetupRequest)
@@ -1517,6 +1520,37 @@ Note: 1kB = 1 vector of size 256. |
 
 
 
+<a name="qdrant-StrictModeSparse"></a>
+
+### StrictModeSparseVectors
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| max_length | [uint64](#uint64) | optional |  |
+
+
+
+<a name="qdrant-StrictModeSparseConfig"></a>
+
+### StrictModeSparseConfig.SparseConfig
+
+
+| Field        | Type                                                                             | Label | Description |
+|--------------|----------------------------------------------------------------------------------| ----- | ----------- |
+| sparse_config | [StrictModeSparseConfig.SparseConfigEntry](#qdrant-StrictModeSparseConfig-ConfigEntry) | repeated |  |
+
+
+
+
+<a name="qdrant-StrictModeSparseConfig-ConfigEntry"></a>
+
+### StrictModeSparseConfig-SparseConfigEntry
+
+
+| Field | Type                                              | Label | Description |
+| ----- |---------------------------------------------------| ----- | ----------- |
+| key | [string](#string)                                 |  |  |
+| value | [StrictModeSparse](#qdrant-StrictModeSparse) |  |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7369,7 +7369,10 @@
         }
       },
       "StrictModeMultivectorConfig": {
-        "type": "object"
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/StrictModeMultivector"
+        }
       },
       "StrictModeMultivector": {
         "type": "object",
@@ -7384,7 +7387,10 @@
         }
       },
       "StrictModeSparseConfig": {
-        "type": "object"
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/StrictModeSparse"
+        }
       },
       "StrictModeSparse": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7354,6 +7354,17 @@
                 "nullable": true
               }
             ]
+          },
+          "sparse_config": {
+            "description": "Sparse vector configuration",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeSparseConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -7365,6 +7376,21 @@
         "properties": {
           "max_vectors": {
             "description": "Max number of vectors in a multivector",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          }
+        }
+      },
+      "StrictModeSparseConfig": {
+        "type": "object"
+      },
+      "StrictModeSparse": {
+        "type": "object",
+        "properties": {
+          "max_length": {
+            "description": "Max length of sparse vector",
             "type": "integer",
             "format": "uint",
             "minimum": 1,

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1754,10 +1754,10 @@ impl From<StrictModeSparseConfig> for segment::types::StrictModeSparseConfig {
         Self {
             config: value
                 .sparse_config
-                .iter()
+                .into_iter()
                 .map(|(name, config)| {
                     (
-                        name.clone(),
+                        name,
                         segment::types::StrictModeSparse {
                             max_length: config.max_length.map(|i| i as usize),
                         },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1773,10 +1773,10 @@ impl From<segment::types::StrictModeSparseConfig> for StrictModeSparseConfig {
         Self {
             sparse_config: value
                 .config
-                .iter()
+                .into_iter()
                 .map(|(name, config)| {
                     (
-                        name.clone(),
+                        name,
                         StrictModeSparse {
                             max_length: config.max_length.map(|i| i as u64),
                         },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -26,7 +26,7 @@ use super::qdrant::{
     MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range, RawVector,
     RecommendStrategy, RetrievedPoint, SearchMatrixPair, SearchPointGroups, SearchPoints,
     ShardKeySelector, SparseIndices, StartFrom, StrictModeMultivector, StrictModeMultivectorConfig,
-    UuidIndexParams, VectorsOutput, WithLookup,
+    StrictModeSparse, StrictModeSparseConfig, UuidIndexParams, VectorsOutput, WithLookup,
 };
 use crate::conversions::json;
 use crate::grpc::qdrant::condition::ConditionOneOf;
@@ -1723,6 +1723,9 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
             multivector_config: value
                 .multivector_config
                 .map(segment::types::StrictModeMultivectorConfig::from),
+            sparse_config: value
+                .sparse_config
+                .map(segment::types::StrictModeSparseConfig::from),
         }
     }
 }
@@ -1738,6 +1741,44 @@ impl From<StrictModeMultivectorConfig> for segment::types::StrictModeMultivector
                         name.clone(),
                         segment::types::StrictModeMultivector {
                             max_vectors: config.max_vectors.map(|i| i as usize),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<StrictModeSparseConfig> for segment::types::StrictModeSparseConfig {
+    fn from(value: StrictModeSparseConfig) -> Self {
+        Self {
+            config: value
+                .sparse_config
+                .iter()
+                .map(|(name, config)| {
+                    (
+                        name.clone(),
+                        segment::types::StrictModeSparse {
+                            max_length: config.max_length.map(|i| i as usize),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<segment::types::StrictModeSparseConfig> for StrictModeSparseConfig {
+    fn from(value: segment::types::StrictModeSparseConfig) -> Self {
+        Self {
+            sparse_config: value
+                .config
+                .iter()
+                .map(|(name, config)| {
+                    (
+                        name.clone(),
+                        StrictModeSparse {
+                            max_length: config.max_length.map(|i| i as u64),
                         },
                     )
                 })
@@ -1771,6 +1812,7 @@ impl From<segment::types::StrictModeConfig> for StrictModeConfig {
             multivector_config: value
                 .multivector_config
                 .map(StrictModeMultivectorConfig::from),
+            sparse_config: value.sparse_config.map(StrictModeSparseConfig::from),
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -343,6 +343,15 @@ message StrictModeConfig {
   optional uint64 filter_max_conditions = 14;
   optional uint64 condition_max_size = 15;
   optional StrictModeMultivectorConfig multivector_config = 16;
+  optional StrictModeSparseConfig sparse_config = 17;
+}
+
+message StrictModeSparseConfig {
+  map<string, StrictModeSparse> sparse_config = 1;
+}
+
+message StrictModeSparse {
+  optional uint64 max_length = 10;
 }
 
 message StrictModeMultivectorConfig {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -525,6 +525,25 @@ pub struct StrictModeConfig {
     pub condition_max_size: ::core::option::Option<u64>,
     #[prost(message, optional, tag = "16")]
     pub multivector_config: ::core::option::Option<StrictModeMultivectorConfig>,
+    #[prost(message, optional, tag = "17")]
+    pub sparse_config: ::core::option::Option<StrictModeSparseConfig>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StrictModeSparseConfig {
+    #[prost(map = "string, message", tag = "1")]
+    pub sparse_config: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        StrictModeSparse,
+    >,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StrictModeSparse {
+    #[prost(uint64, optional, tag = "10")]
+    pub max_length: ::core::option::Option<u64>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -327,18 +327,18 @@ async fn check_multivectors_limits_update(
     Ok(())
 }
 
-async fn sparse_limits(sparse_config: &StrictModeSparseConfig) -> Option<TinyMap<String, usize>> {
+async fn sparse_limits(sparse_config: &StrictModeSparseConfig) -> Option<TinyMap<&str, usize>> {
     if sparse_config.config.is_empty() {
         return None;
     }
 
-    let sparse_max_size: TinyMap<String, usize> = sparse_config
+    let sparse_max_size: TinyMap<&str, usize> = sparse_config
         .config
         .iter()
         .filter_map(|(name, config)| {
             config
                 .max_length
-                .map(|max_length| (name.clone(), max_length))
+                .map(|max_length| (name.as_str(), max_length))
         })
         .collect();
 
@@ -407,7 +407,7 @@ async fn check_sparse_vector_limits_insert(
 
 fn check_sparse_vecstruct_limit(
     vector: &VectorStruct,
-    sparse_max_size_by_name: &TinyMap<String, usize>,
+    sparse_max_size_by_name: &TinyMap<&str, usize>,
 ) -> Result<(), CollectionError> {
     match vector {
         VectorStruct::Named(named) => {
@@ -427,7 +427,7 @@ fn check_sparse_vecstruct_limit(
 fn check_named_sparse_vec_limit(
     name: &str,
     vector: &Vector,
-    sparse_max_size_by_name: &TinyMap<String, usize>,
+    sparse_max_size_by_name: &TinyMap<&str, usize>,
 ) -> Result<(), CollectionError> {
     if let Vector::Sparse(sparse) = vector {
         if let Some(strict_sparse_limit) = sparse_max_size_by_name.get(name) {

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -3,7 +3,9 @@ use api::rest::{
 };
 use segment::data_types::tiny_map::TinyMap;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
-use segment::types::{Filter, StrictModeConfig, StrictModeMultivectorConfig};
+use segment::types::{
+    Filter, StrictModeConfig, StrictModeMultivectorConfig, StrictModeSparseConfig,
+};
 
 use super::{check_limit_opt, StrictModeVerification};
 use crate::collection::Collection;
@@ -137,6 +139,10 @@ impl StrictModeVerification for PointInsertOperations {
             check_multivectors_limits_insert(self, multivector_config).await?;
         }
 
+        if let Some(sparse_config) = &strict_mode_config.sparse_config {
+            check_sparse_vector_limits_insert(self, sparse_config).await?;
+        }
+
         Ok(())
     }
 
@@ -177,6 +183,10 @@ impl StrictModeVerification for UpdateVectors {
 
         if let Some(multivector_config) = &strict_mode_config.multivector_config {
             check_multivectors_limits_update(self, multivector_config).await?;
+        }
+
+        if let Some(sparse_config) = &strict_mode_config.sparse_config {
+            check_sparse_vector_limits_update(self, sparse_config).await?;
         }
 
         Ok(())
@@ -314,6 +324,131 @@ async fn check_multivectors_limits_update(
         )?;
     }
 
+    Ok(())
+}
+
+async fn sparse_limits(sparse_config: &StrictModeSparseConfig) -> Option<TinyMap<String, usize>> {
+    if sparse_config.config.is_empty() {
+        return None;
+    }
+
+    let sparse_max_size: TinyMap<String, usize> = sparse_config
+        .config
+        .iter()
+        .filter_map(|(name, config)| {
+            config
+                .max_length
+                .map(|max_length| (name.clone(), max_length))
+        })
+        .collect();
+
+    (!sparse_max_size.is_empty()).then_some(sparse_max_size)
+}
+
+async fn check_sparse_vector_limits_update(
+    point_insert: &UpdateVectors,
+    sparse_config: &StrictModeSparseConfig,
+) -> Result<(), CollectionError> {
+    let Some(sparse_max_size_by_name) = sparse_limits(sparse_config).await else {
+        return Ok(());
+    };
+
+    for point in &point_insert.points {
+        check_sparse_vecstruct_limit(&point.vector, &sparse_max_size_by_name)?;
+    }
+
+    Ok(())
+}
+
+async fn check_sparse_vector_limits_insert(
+    point_insert: &PointInsertOperations,
+    sparse_config: &StrictModeSparseConfig,
+) -> Result<(), CollectionError> {
+    let Some(sparse_max_size_by_name) = sparse_limits(sparse_config).await else {
+        return Ok(());
+    };
+
+    match point_insert {
+        PointInsertOperations::PointsBatch(batch) => match &batch.batch.vectors {
+            BatchVectorStruct::Named(named_batch_vectors) => {
+                for (name, vectors) in named_batch_vectors {
+                    for vector in vectors {
+                        check_named_sparse_vec_limit(name, vector, &sparse_max_size_by_name)?;
+                    }
+                }
+            }
+
+            BatchVectorStruct::Single(_)
+            | BatchVectorStruct::Document(_)
+            | BatchVectorStruct::MultiDense(_)
+            | BatchVectorStruct::Image(_)
+            | BatchVectorStruct::Object(_) => {}
+        },
+        PointInsertOperations::PointsList(list) => {
+            for point_struct in &list.points {
+                match &point_struct.vector {
+                    VectorStruct::Named(named_vectors) => {
+                        for (name, vector) in named_vectors {
+                            check_named_sparse_vec_limit(name, vector, &sparse_max_size_by_name)?;
+                        }
+                    }
+                    VectorStruct::Single(_) => {}
+                    VectorStruct::MultiDense(_) => {}
+                    VectorStruct::Document(_) => {}
+                    VectorStruct::Image(_) => {}
+                    VectorStruct::Object(_) => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_sparse_vecstruct_limit(
+    vector: &VectorStruct,
+    sparse_max_size_by_name: &TinyMap<String, usize>,
+) -> Result<(), CollectionError> {
+    match vector {
+        VectorStruct::Named(named) => {
+            for (name, vec) in named {
+                check_named_sparse_vec_limit(name, vec, sparse_max_size_by_name)?;
+            }
+            Ok(())
+        }
+        VectorStruct::Single(_) => Ok(()),
+        VectorStruct::MultiDense(_) => Ok(()),
+        VectorStruct::Document(_) => Ok(()),
+        VectorStruct::Image(_) => Ok(()),
+        VectorStruct::Object(_) => Ok(()),
+    }
+}
+
+fn check_named_sparse_vec_limit(
+    name: &str,
+    vector: &Vector,
+    sparse_max_size_by_name: &TinyMap<String, usize>,
+) -> Result<(), CollectionError> {
+    if let Vector::Sparse(sparse) = vector {
+        if let Some(strict_sparse_limit) = sparse_max_size_by_name.get(name) {
+            check_sparse_vector_limit(name, sparse, *strict_sparse_limit)?;
+        }
+    }
+    Ok(())
+}
+
+fn check_sparse_vector_limit(
+    name: &str,
+    sparse: &sparse::common::sparse_vector::SparseVector,
+    max_size: usize,
+) -> Result<(), CollectionError> {
+    let vector_len = sparse.indices.len();
+
+    if vector_len > max_size || sparse.values.len() > max_size {
+        return Err(CollectionError::bad_request(format!(
+            "Sparse vector '{name}' has a limit of {max_size} indices, but {vector_len} were provided!"
+        )));
+    }
     Ok(())
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -836,8 +836,7 @@ impl Hash for StrictModeConfig {
                 filter_max_conditions,
                 condition_max_size,
             ),
-            (multivector_config,
-            sparse_config,)
+            (multivector_config, sparse_config),
         )
             .hash(state);
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -836,8 +836,8 @@ impl Hash for StrictModeConfig {
                 filter_max_conditions,
                 condition_max_size,
             ),
-            multivector_config,
-            sparse_config,
+            (multivector_config,
+            sparse_config,)
         )
             .hash(state);
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -677,6 +677,7 @@ pub struct StrictModeSparse {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Hash)]
+#[schemars(deny_unknown_fields)]
 pub struct StrictModeSparseConfig {
     #[validate(nested)]
     #[serde(flatten)]
@@ -702,6 +703,7 @@ pub struct StrictModeMultivector {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Hash)]
+#[schemars(deny_unknown_fields)]
 pub struct StrictModeMultivectorConfig {
     #[validate(nested)]
     #[serde(flatten)]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -818,7 +818,7 @@ impl Hash for StrictModeConfig {
             filter_max_conditions,
             condition_max_size,
             multivector_config,
-            sparse_config: _,
+            sparse_config,
         } = self;
         (
             enabled,
@@ -837,7 +837,7 @@ impl Hash for StrictModeConfig {
                 condition_max_size,
             ),
             multivector_config,
-            // sparse_config,
+            sparse_config,
         )
             .hash(state);
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -3,7 +3,7 @@ use collection::operations::config_diff::{
 };
 use collection::operations::conversions::sharding_method_from_proto;
 use collection::operations::types::{SparseVectorsConfig, VectorsConfigDiff};
-use segment::types::{StrictModeConfig, StrictModeMultivectorConfig};
+use segment::types::{StrictModeConfig, StrictModeMultivectorConfig, StrictModeSparseConfig};
 use tonic::Status;
 
 use crate::content_manager::collection_meta_ops::{
@@ -100,6 +100,7 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
         multivector_config: value
             .multivector_config
             .map(StrictModeMultivectorConfig::from),
+        sparse_config: value.sparse_config.map(StrictModeSparseConfig::from),
     }
 }
 

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -569,7 +569,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         method="PUT",
         path_params={'collection_name': collection_name},
         body={
-            "vectors": {
+            "sparse_vectors": {
                 "sparse-vector": {}
             }
         }

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -570,11 +570,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         path_params={'collection_name': collection_name},
         body={
             "vectors": {
-                "sparse-vector": {
-                    "size": 100,
-                    "distance": "Dot",
-                },
-                "model": "text"
+                "sparse-vector": {}
             }
         }
     )
@@ -584,7 +580,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         "enabled": True,
         "sparse_config": {
             "sparse-vector": {
-                "max_length": 5
+                "max_length": 4
             }
         }
     })
@@ -601,7 +597,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                     "vector": {
                         "sparse-vector": {
                             "indices": [1, 2, 3, 4],
-                            "values": [1.0, 2.0, 3.0, 4.0]
+                            "values": [0.0, 0.1, 0.2, 0.3]
                         }
                     }
                 }
@@ -622,7 +618,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                     "vector": {
                         "sparse-vector": {
                             "indices": [1, 2, 3, 4, 5, 6],
-                            "values": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+                            "values": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
                         }
                     }
                 }
@@ -630,7 +626,8 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         }
     )
     assert not failed_upsert.ok
-    assert "Sparse vector 'sparse-vector' has a limit of 5 indices" in failed_upsert.json()['status']['error']
+    assert "Sparse vector 'sparse-vector' has a limit of 4 indices" in failed_upsert.json()['status']['error']
+
 
 def test_strict_mode_max_collection_size_upsert_batch(collection_name):
     basic_collection_setup(collection_name=collection_name)  # Clear collection to not depend on other tests

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -117,9 +117,9 @@ def test_strict_mode_query_limit_validation(collection_name):
         "enabled": True,
         "max_query_limit": 4,
     })
-    
+
     search_request().raise_for_status()
-    
+
     set_strict_mode(collection_name, {
         "max_query_limit": 3,
     })
@@ -149,7 +149,7 @@ def test_strict_mode_timeout_validation(collection_name):
         "enabled": True,
         "max_timeout": 2,
     })
-    
+
     search_request_with_timeout(2).raise_for_status()
 
     search_fail = search_request_with_timeout(3)
@@ -186,9 +186,9 @@ def test_strict_mode_unindexed_filter_read_validation(collection_name):
         "enabled": True,
         "unindexed_filtering_retrieve": True,
     })
-    
+
     search_request_with_filter().raise_for_status()
-    
+
     set_strict_mode(collection_name, {
         "unindexed_filtering_retrieve": False,
     })
@@ -242,9 +242,9 @@ def test_strict_mode_unindexed_filter_write_validation(collection_name):
         "enabled": True,
         "unindexed_filtering_update": True,
     })
-    
+
     update_request_with_filter().raise_for_status()
-    
+
     set_strict_mode(collection_name, {
         "unindexed_filtering_update": False,
     })
@@ -290,9 +290,9 @@ def test_strict_mode_max_ef_hnsw_validation(collection_name):
         "enabled": True,
         "search_max_hnsw_ef": 5,
     })
-    
+
     search_request().raise_for_status()
-    
+
     set_strict_mode(collection_name, {
         "search_max_hnsw_ef": 4,
     })
@@ -324,9 +324,9 @@ def test_strict_mode_allow_exact_validation(collection_name):
         "enabled": True,
         "search_allow_exact": True,
     })
-    
+
     search_request().raise_for_status()
-    
+
     set_strict_mode(collection_name, {
         "search_allow_exact": False,
     })
@@ -360,9 +360,9 @@ def test_strict_mode_search_max_oversampling_validation(collection_name):
         "enabled": True,
         "search_max_oversampling": 2.0,
     })
-    
+
     search_request().raise_for_status()
-    
+
     set_strict_mode(collection_name, {
         "enabled": True,
         "search_max_oversampling": 1.9,
@@ -556,7 +556,6 @@ def test_strict_mode_max_collection_size_upsert(collection_name):
     assert False, "Upserting should have failed but didn't"
 
 
-
 def test_strict_mode_max_sparse_length_upsert(collection_name):
     response = request_with_validation(
         api='/collections/{collection_name}',
@@ -574,7 +573,8 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                 "sparse-vector": {
                     "size": 100,
                     "distance": "Dot",
-                }
+                },
+                "model": "text"
             }
         }
     )
@@ -601,7 +601,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                     "vector": {
                         "sparse-vector": {
                             "indices": [1, 2, 3, 4],
-                            "values": [0.0, 0.1, 0.2, 0.3]
+                            "values": [1.0, 2.0, 3.0, 4.0]
                         }
                     }
                 }
@@ -622,7 +622,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                     "vector": {
                         "sparse-vector": {
                             "indices": [1, 2, 3, 4, 5, 6],
-                            "values": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
+                            "values": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
                         }
                     }
                 }
@@ -631,7 +631,6 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
     )
     assert not failed_upsert.ok
     assert "Sparse vector 'sparse-vector' has a limit of 5 indices" in failed_upsert.json()['status']['error']
-
 
 def test_strict_mode_max_collection_size_upsert_batch(collection_name):
     basic_collection_setup(collection_name=collection_name)  # Clear collection to not depend on other tests
@@ -1232,4 +1231,3 @@ def test_filter_nested_condition(collection_name):
     assert "condition" in search_fail.json()['status']['error']
     assert "limit" in search_fail.json()['status']['error']
     assert not search_fail.ok
-    

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -569,7 +569,6 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         api='/collections/{collection_name}',
         method="PUT",
         path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
         body={
             "vectors": {
                 "sparse-vector": {

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -584,7 +584,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         "enabled": True,
         "sparse_config": {
             "sparse-vector": {
-                "max_length": 3
+                "max_length": 5
             }
         }
     })
@@ -600,8 +600,8 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                     "id": 1,
                     "vector": {
                         "sparse-vector": {
-                            "indices": [1, 2, 3, 4, 5],
-                            "values": [0.1, 0.2, 0.3, 0.4, 0.5]
+                            "indices": [1, 2, 3, 4],
+                            "values": [0.0, 0.1, 0.2, 0.3]
                         }
                     }
                 }
@@ -618,11 +618,11 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         body={
             "points": [
                 {
-                    "id": 1,
+                    "id": 2,
                     "vector": {
                         "sparse-vector": {
                             "indices": [1, 2, 3, 4, 5, 6],
-                            "values": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+                            "values": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
                         }
                     }
                 }

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -574,8 +574,8 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                 "sparse-vector": {
                     "size": 100,
                     "distance": "Dot",
-                },
-            },
+                }
+            }
         }
     )
     assert response.ok
@@ -584,7 +584,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         "enabled": True,
         "sparse_config": {
             "sparse-vector": {
-                "max_length": 5,
+                "max_length": 3
             }
         }
     })
@@ -599,7 +599,10 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                 {
                     "id": 1,
                     "vector": {
-                        "sparse-vector": [1, 2, 3, 4, 5],
+                        "sparse-vector": {
+                            "indices": [1, 2, 3, 4, 5],
+                            "values": [0.1, 0.2, 0.3, 0.4, 0.5]
+                        }
                     }
                 }
             ]
@@ -617,14 +620,17 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
                 {
                     "id": 1,
                     "vector": {
-                        "sparse-vector": [1, 2, 3, 4, 5, 6],
+                        "sparse-vector": {
+                            "indices": [1, 2, 3, 4, 5, 6],
+                            "values": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+                        }
                     }
                 }
             ]
         }
     )
     assert not failed_upsert.ok
-    assert "Sparse vector 'sparse-vector' exceeds max length of 5" in failed_upsert.json()['status']['error']
+    assert "Sparse vector 'sparse-vector' has a limit of 5 indices" in failed_upsert.json()['status']['error']
 
 
 def test_strict_mode_max_collection_size_upsert_batch(collection_name):

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -561,6 +561,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
     response = request_with_validation(
         api='/collections/{collection_name}',
         method="DELETE",
+        query_params={'wait': 'true'},
         path_params={'collection_name': collection_name},
     )
     assert response.ok
@@ -569,6 +570,7 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
         api='/collections/{collection_name}',
         method="PUT",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "vectors": {
                 "sparse-vector": {

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -561,7 +561,6 @@ def test_strict_mode_max_sparse_length_upsert(collection_name):
     response = request_with_validation(
         api='/collections/{collection_name}',
         method="DELETE",
-        query_params={'wait': 'true'},
         path_params={'collection_name': collection_name},
     )
     assert response.ok


### PR DESCRIPTION
New sparse_config field in StrictModeConfig that allows setting maximum length constraints for sparse vectors
Each named sparse vector can have its own max_length limit.
The system will validate that both indices and values arrays in sparse vectors don't exceed the configured limit
Validation occurs during point insertion and update operations.
Attempts to insert or update sparse vectors exceeding the configured length limit will result in an error.