### PR TITLE
Avoid flushing a zero-sized mmapped file

### DIFF
--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -165,7 +165,10 @@ where
         Box::new({
             let mmap = self.mmap.clone();
             move || {
-                mmap.flush()?;
+                // flushing a zero-sized mmap can cause panicking on some systems
+                if mmap.len() > 0 {
+                    mmap.flush()?;
+                }
                 Ok(())
             }
         })

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -10,7 +10,7 @@ use crate::index::field_index::full_text_index::mutable_inverted_index::MutableI
 use crate::index::field_index::full_text_index::postings_iterator::intersect_compressed_postings_iterator;
 
 #[cfg_attr(test, derive(Clone))]
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ImmutableInvertedIndex {
     pub(in crate::index::field_index::full_text_index) postings: Vec<CompressedPostingList>,
     pub(in crate::index::field_index::full_text_index) vocab: HashMap<String, TokenId>,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -285,6 +285,7 @@ mod tests {
     #[case(1111, 1110)]
     #[case(1111, 0)]
     #[case(10, 2)]
+    #[case(0, 0)]
     #[test]
     fn test_immutable_to_mmap(#[case] indexed_count: u32, #[case] deleted_count: u32) {
         let mutable = mutable_inverted_index(indexed_count, deleted_count);


### PR DESCRIPTION
Discovered when running crasher 🔥 

The problem arose when trying to convert an empty `ImmutableInvertedIndex` into a `MmapInvertedIndex`, which would create zero-sized files.

There seems to be no problem mmapping them, but, when we try to `msync` during flushing, it panics with an [`EINVAL` error](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/msync.2.html#//apple_ref/doc/man/2/msync).

I have done a simple fix where we just don't flush when the file length is zero.