### PR TITLE
No flush on Drop for Blobstore

### DIFF
--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -916,8 +916,8 @@ mod tests {
             assert!(stored_payload.is_some());
             assert_eq!(stored_payload.unwrap(), payload);
 
-            // drop storage
-            drop(storage);
+            // flush storage before dropping
+            storage.flush().unwrap();
         }
 
         // reopen storage

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -524,12 +524,6 @@ impl<V> BlobStore<V> {
     }
 }
 
-impl<V> Drop for BlobStore<V> {
-    fn drop(&mut self) {
-        self.flush().unwrap();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs::File;


### PR DESCRIPTION
We have a precise flushing sequence to ensure the consistency of the various data we managed.

Deciding to flush on drop could break this in unexpected ways.

This PR proposes to remove this implementation.