### PR TITLE
Safe bounds for `point_to_tokens_count`

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -160,8 +160,13 @@ impl InvertedIndex for MmapInvertedIndex {
         }
 
         self.deleted_points.set(idx as usize, true);
-        self.point_to_tokens_count[idx as usize] = 0;
-        self.active_points_count -= 1;
+        if let Some(count) = self.point_to_tokens_count.get_mut(idx as usize) {
+            *count = 0;
+
+            // `deleted_points`'s length can be larger than `point_to_tokens_count`'s length.
+            // Only if the index is within bounds of `point_to_tokens_count`, we decrement the active points count.
+            self.active_points_count -= 1;
+        }
         true
     }
 


### PR DESCRIPTION
Another crasher failure fix:

```log

2025-01-21T16:05:15.084473Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs at line 163: index out of bounds: the len is 1559 but the index is 1592

[...]

2025-01-21T16:05:15.887828Z ERROR qdrant::startup: Panic occurred in file /Users/luis/personal/Qdrant/qdrant/lib/collection/src/shards/replica_set/mod.rs at line 301: Failed to load local shard "./storage/collections/workload-crasher/0": Service internal error: Failed to join task that removes duplicate points from segment: task 33 panicked with message "index out of bounds: the len is 1559 but the index is 1592"
```

We missed to consider that the `deleted_points` bitslice can be bigger than `point_to_tokens_count`, so this panic was possible since we were accessing the index directly.

With these changes we now use `get_mut` instead, and decrease the `active_points_count` correctly.