### PR TITLE
Update codespell config

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,22 @@
 [codespell]
+
+exclude-file =
+  Cargo.lock,
+  tests/tls/cert/key.pem,
+
 # openapi.json is typically a released version and could carry old typos
-skip = .git,*.pdf,*.svg,openapi.json,key.pem,Cargo.lock
+skip =
+  openapi.json,
+  static,
+  target,
+
+# ABD - Geohash example
+# generall - The boss
 # hel - Query token
-# generall - the boss
-# mmapped - memory mapped
-ignore-words-list = crate,hel,generall,mmapped
+# mmapped - Memory mapped
+ignore-words-list =
+  ABD,
+  crate,
+  generall,
+  hel,
+  mmapped,

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,5 +20,3 @@ jobs:
         uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
-        with:
-          exclude_file: docs/CODE_OF_CONDUCT.md


### PR DESCRIPTION
This PR updates codespell config.

Primary change:
- added new word `ABD` to fix this recent error ([GitHub actions log](https://github.com/qdrant/qdrant/actions/runs/12901056521/job/35972529860?pr=5820)):
    ```
    Error: ./lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs:46: ABD ==> AND, BAD
    ```

Nice-to haves in this PR:
- Entries are split into multiple lines and reorganized for easier maintaining. Redundant entries removed.
- Added some entries from `.gitignore` (like `static`,`target`, etc), so it's now properly runnable locally using the [`codespell`](https://github.com/codespell-project/codespell) command.
- Removed options from `.github/workflows/codespell.yml`. Let `.codespellrc` be the single source of truth.

(not in this PR) Ideally, we'd move/convert `.codespellrc` to `tools/codespell.toml` and run it as `codespell --toml tools/codespell.toml`, but currently it's only supported in the CLI tool, but not in the GitHub action config.