### PR TITLE
Filter broken gpu links

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/shaders/run_insert_vector.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/run_insert_vector.comp
@@ -103,8 +103,11 @@ void main() {
 
             subgroupMemoryBarrierShared();
             sort(NEAREST_HEAP_OFFSET, nearest_count);
+
+            subgroupMemoryBarrierShared();
             uint other_new_links_count = run_heuristic();
 
+            subgroupMemoryBarrierShared();
             for (uint j = gl_SubgroupInvocationID; j < other_new_links_count; j += SUBGROUP_SIZE) {
                 GET_LINK(other_id, j) = shared_buffer[NEAREST_HEAP_OFFSET + j].id;
             }
@@ -112,6 +115,8 @@ void main() {
                 LINKS_SET_SIZE(other_id, other_new_links_count);
             }
         }
+
+        subgroupMemoryBarrier();
 
         if (gl_SubgroupInvocationID == 0) {
             atomicExchange(atomics.data[other_id], 0);

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/search_context.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/search_context.comp
@@ -127,7 +127,10 @@ uint run_heuristic() {
         }
 
         if (is_good) {
-            shared_buffer[NEAREST_HEAP_OFFSET + result_count] = current_closest;
+            if (subgroupElect()) {
+                shared_buffer[NEAREST_HEAP_OFFSET + result_count] = current_closest;
+            }
+            subgroupMemoryBarrierShared();
             result_count += 1;
         }
     }


### PR DESCRIPTION
Fix https://github.com/qdrant/qdrant/issues/5834

It's a quick fix which includes additional sync in shaders and results filtering.
It's not a proper solution but it fixes panic.

