### PR TITLE
Enable workspace lints for `gpu`

### DIFF
--- a/lib/gpu/Cargo.toml
+++ b/lib/gpu/Cargo.toml
@@ -7,6 +7,9 @@ authors = [
 license = "Apache-2.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [features]
 gpu = [
     "dep:ash",

--- a/lib/gpu/src/context.rs
+++ b/lib/gpu/src/context.rs
@@ -390,7 +390,7 @@ impl Drop for Context {
                 // Error was logged, do memory leak to keep the gpu running.
                 let resources = self.resources.clone();
                 self.resources.clear();
-                for resource in resources.into_iter() {
+                for resource in resources {
                     // !!!!!!!!!
                     std::mem::forget(resource);
                 }

--- a/lib/gpu/src/debug_messenger.rs
+++ b/lib/gpu/src/debug_messenger.rs
@@ -110,7 +110,8 @@ unsafe extern "system" fn vulkan_debug_callback_panic(
     };
     let backtrace = std::backtrace::Backtrace::force_capture().to_string();
     panic!(
-        "Vulkan panic ({} {}) \nWith message: {}, \nBackrace: {}",
-        message_type, severity, message, backtrace,
+        "Vulkan panic ({message_type} {severity}) \n\
+         With message: {message}, \n\
+         Backrace: {backtrace}",
     )
 }

--- a/lib/gpu/src/device.rs
+++ b/lib/gpu/src/device.rs
@@ -260,8 +260,8 @@ impl Device {
                 };
                 let queue = Queue {
                     vk_queue,
-                    vk_queue_index,
                     vk_queue_family_index,
+                    vk_queue_index,
                 };
 
                 let queue_flags = vk_queue_family.queue_flags;
@@ -395,8 +395,7 @@ impl Device {
 
             if !is_extension_available {
                 return Err(GpuError::NotSupported(format!(
-                    "Extension {:?} is not supported",
-                    required_extension
+                    "Extension {required_extension:?} is not supported"
                 )));
             }
         }

--- a/lib/gpu/src/instance.rs
+++ b/lib/gpu/src/instance.rs
@@ -69,7 +69,7 @@ impl Instance {
         // Create Vulkan API entry point.
         let entry = unsafe {
             ash::Entry::load().map_err(|e| {
-                GpuError::Other(format!("Failed to create Vulkan API entry point {:?}", e))
+                GpuError::Other(format!("Failed to create Vulkan API entry point {e:?}"))
             })?
         };
 
@@ -284,7 +284,7 @@ impl Instance {
                         content: code.to_owned(),
                     })
                 } else {
-                    Err(format!("Include file not found: {}", filename))
+                    Err(format!("Include file not found: {filename}"))
                 }
             });
         }
@@ -298,7 +298,7 @@ impl Instance {
                 "main",
                 Some(&options),
             )
-            .map_err(|e| GpuError::Other(format!("Failed to compile shader: {:?}", e)))?;
+            .map_err(|e| GpuError::Other(format!("Failed to compile shader: {e:?}")))?;
         Ok(result.as_binary_u8().to_owned())
     }
 
@@ -341,10 +341,7 @@ impl Instance {
                 name.to_str().unwrap_or("") == extension
             });
             if !extension_found {
-                return Err(GpuError::Other(format!(
-                    "Extension {} not found",
-                    extension
-                )));
+                return Err(GpuError::Other(format!("Extension {extension} not found")));
             }
         }
         Ok(())
@@ -358,7 +355,7 @@ impl Instance {
                 name.to_str().unwrap_or("") == layer
             });
             if !layer_found {
-                return Err(GpuError::Other(format!("Layer {} not found", layer)));
+                return Err(GpuError::Other(format!("Layer {layer} not found")));
             }
         }
         Ok(())

--- a/lib/gpu/src/lib.rs
+++ b/lib/gpu/src/lib.rs
@@ -67,7 +67,7 @@ impl From<gpu_allocator::AllocationError> for GpuError {
     fn from(error: gpu_allocator::AllocationError) -> GpuError {
         match error {
             gpu_allocator::AllocationError::OutOfMemory => GpuError::OutOfMemory,
-            _ => GpuError::Other(format!("GPU allocator error: {:?}", error)),
+            _ => GpuError::Other(format!("GPU allocator error: {error:?}")),
         }
     }
 }
@@ -94,7 +94,7 @@ impl From<vk::Result> for GpuError {
             vk::Result::ERROR_FORMAT_NOT_SUPPORTED => {
                 GpuError::NotSupported("Format is not supported".to_string())
             }
-            _ => GpuError::Other(format!("Vulkan API error: {:?}", result)),
+            _ => GpuError::Other(format!("Vulkan API error: {result:?}")),
         }
     }
 }

--- a/lib/gpu/src/pipeline.rs
+++ b/lib/gpu/src/pipeline.rs
@@ -73,8 +73,7 @@ impl Pipeline {
                     Ok(descriptor_set_layouts.vk_descriptor_set_layout())
                 } else {
                     Err(GpuError::Other(format!(
-                        "Descriptor set layout {} is missing",
-                        descriptor_set_index
+                        "Descriptor set layout {descriptor_set_index} is missing"
                     )))
                 }
             })


### PR DESCRIPTION
This PR enables our default set of lints for the `gpu` crate and fixes them.
Fixes are performed automatically using the following command:
```console
cargo clippy -p gpu --all-features --all-targets
```

---
For the reference, a command to find crates without lints enabled:
```console
find -name Cargo.toml | xargs grep -L '^workspace = true$'
```
(currently only `gpu` is missing)