### PR TITLE
Split HNSWIndex::open and HNSWIndex::build

### DIFF
--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -13,7 +13,7 @@ use segment::fixtures::payload_fixtures::random_multi_vector;
 use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::VectorIndex;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::Distance::Dot;
 use segment::types::{
     HnswConfig, Indexes, MultiVectorConfig, SegmentConfig, SeqNumberType, VectorDataConfig,
@@ -79,17 +79,21 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: segment.payload_index.clone(),
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: segment.payload_index.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     // intent: bench `search` without filter

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -11,7 +11,6 @@ use bitvec::vec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 #[cfg(target_os = "linux")]
 use common::cpu::linux_low_thread_priority;
-use common::cpu::{get_num_cpus, CpuPermit};
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use log::debug;
 use memory::mmap_ops;
@@ -20,6 +19,7 @@ use rand::thread_rng;
 use rayon::prelude::*;
 use rayon::ThreadPool;
 
+#[cfg(feature = "gpu")]
 use super::gpu::gpu_devices_manager::LockedGpuDevice;
 use super::gpu::gpu_vector_storage::GpuVectorStorage;
 use super::graph_links::GraphLinksFormat;
@@ -45,6 +45,7 @@ use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 use crate::index::{PayloadIndex, VectorIndex};
 #[cfg(feature = "gpu")]
 use crate::payload_storage::FilterContext;
+use crate::segment_constructor::VectorIndexBuildArgs;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::Condition::Field;
 use crate::types::{
@@ -114,9 +115,6 @@ pub struct HnswIndexOpenArgs<'a> {
     pub quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
     pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     pub hnsw_config: HnswConfig,
-    pub permit: Option<Arc<CpuPermit>>,
-    pub gpu_device: Option<&'a LockedGpuDevice<'a>>,
-    pub stopped: &'a AtomicBool,
 }
 
 impl HNSWIndex {
@@ -128,78 +126,38 @@ impl HNSWIndex {
             quantized_vectors,
             payload_index,
             hnsw_config,
-            permit,
-            gpu_device,
-            stopped,
         } = args;
 
-        create_dir_all(path)?;
-
         let config_path = HnswGraphConfig::get_config_path(path);
-        let graph_path = GraphLayers::get_path(path);
-        let (config, graph) = if graph_path.exists() {
-            let config = if config_path.exists() {
-                HnswGraphConfig::load(&config_path)?
-            } else {
-                let vector_storage = vector_storage.borrow();
-                let available_vectors = vector_storage.available_vector_count();
-                let full_scan_threshold = vector_storage
-                    .size_of_available_vectors_in_bytes()
-                    .checked_div(available_vectors)
-                    .and_then(|avg_vector_size| {
-                        hnsw_config
-                            .full_scan_threshold
-                            .saturating_mul(BYTES_IN_KB)
-                            .checked_div(avg_vector_size)
-                    })
-                    .unwrap_or(1);
-
-                HnswGraphConfig::new(
-                    hnsw_config.m,
-                    hnsw_config.ef_construct,
-                    full_scan_threshold,
-                    hnsw_config.max_indexing_threads,
-                    hnsw_config.payload_m,
-                    available_vectors,
-                )
-            };
-
-            let do_convert = LINK_COMPRESSION_CONVERT_EXISTING;
-
-            (
-                config,
-                GraphLayers::load(path, !hnsw_config.on_disk.unwrap_or(false), do_convert)?,
-            )
+        let config = if config_path.exists() {
+            HnswGraphConfig::load(&config_path)?
         } else {
-            let num_cpus = match permit {
-                Some(p) => p.num_cpus as usize,
-                None => {
-                    log::warn!("Rebuilding HNSW index");
+            let vector_storage = vector_storage.borrow();
+            let available_vectors = vector_storage.available_vector_count();
+            let full_scan_threshold = vector_storage
+                .size_of_available_vectors_in_bytes()
+                .checked_div(available_vectors)
+                .and_then(|avg_vector_size| {
+                    hnsw_config
+                        .full_scan_threshold
+                        .saturating_mul(BYTES_IN_KB)
+                        .checked_div(avg_vector_size)
+                })
+                .unwrap_or(1);
 
-                    // We have no CPU permit, meaning this call is not triggered by the segment
-                    // optimizer which is supposed to be the only entity that builds an HNSW index.
-                    // This should never be executed unless files are removed manually.
-                    debug_assert!(false);
-
-                    get_num_cpus()
-                }
-            };
-            let (config, graph) = Self::build_index(
-                path,
-                id_tracker.as_ref().borrow().deref(),
-                &vector_storage.borrow(),
-                &quantized_vectors.borrow(),
-                &payload_index.borrow(),
-                &hnsw_config,
-                num_cpus,
-                gpu_device,
-                stopped,
-            )?;
-
-            config.save(&config_path)?;
-
-            (config, graph)
+            HnswGraphConfig::new(
+                hnsw_config.m,
+                hnsw_config.ef_construct,
+                full_scan_threshold,
+                hnsw_config.max_indexing_threads,
+                hnsw_config.payload_m,
+                available_vectors,
+            )
         };
+
+        let do_convert = LINK_COMPRESSION_CONVERT_EXISTING;
+
+        let graph = GraphLayers::load(path, !hnsw_config.on_disk.unwrap_or(false), do_convert)?;
 
         Ok(HNSWIndex {
             id_tracker,
@@ -222,21 +180,45 @@ impl HNSWIndex {
         self.quantized_vectors.clone()
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn build_index(
-        path: &Path,
-        id_tracker: &IdTrackerSS,
-        vector_storage: &VectorStorageEnum,
-        quantized_vectors: &Option<QuantizedVectors>,
-        payload_index: &StructPayloadIndex,
-        hnsw_config: &HnswConfig,
-        num_cpus: usize,
-        #[allow(unused_variables)] gpu_device: Option<&LockedGpuDevice>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<(HnswGraphConfig, GraphLayers)> {
-        let total_vector_count = vector_storage.total_vector_count();
+    pub fn build(
+        open_args: HnswIndexOpenArgs<'_>,
+        build_args: VectorIndexBuildArgs<'_>,
+    ) -> OperationResult<Self> {
+        if HnswGraphConfig::get_config_path(open_args.path).exists()
+            || GraphLayers::get_path(open_args.path).exists()
+        {
+            log::warn!(
+                "HNSW index already exists at {:?}, skipping building",
+                open_args.path
+            );
+            debug_assert!(false);
+            return Self::open(open_args);
+        }
 
-        let full_scan_threshold = vector_storage
+        let HnswIndexOpenArgs {
+            path,
+            id_tracker,
+            vector_storage,
+            quantized_vectors,
+            payload_index,
+            hnsw_config,
+        } = open_args;
+        let VectorIndexBuildArgs {
+            permit,
+            gpu_device,
+            stopped,
+        } = build_args;
+
+        create_dir_all(path)?;
+
+        let id_tracker_ref = id_tracker.borrow();
+        let vector_storage_ref = vector_storage.borrow();
+        let quantized_vectors_ref = quantized_vectors.borrow();
+        let payload_index_ref = payload_index.borrow();
+
+        let total_vector_count = vector_storage_ref.total_vector_count();
+
+        let full_scan_threshold = vector_storage_ref
             .size_of_available_vectors_in_bytes()
             .checked_div(total_vector_count)
             .and_then(|avg_vector_size| {
@@ -258,7 +240,7 @@ impl HNSWIndex {
 
         // Build main index graph
         let mut rng = thread_rng();
-        let deleted_bitslice = vector_storage.deleted_vector_bitslice();
+        let deleted_bitslice = vector_storage_ref.deleted_vector_bitslice();
 
         #[cfg(feature = "gpu")]
         let gpu_name_postfix = if let Some(gpu_device) = gpu_device {
@@ -268,8 +250,11 @@ impl HNSWIndex {
         };
         #[cfg(not(feature = "gpu"))]
         let gpu_name_postfix = "";
+        #[cfg(not(feature = "gpu"))]
+        let _ = gpu_device;
         debug!(
-            "building HNSW for {total_vector_count} vectors with {num_cpus} CPUs{gpu_name_postfix}"
+            "building HNSW for {total_vector_count} vectors with {} CPUs{gpu_name_postfix}",
+            permit.num_cpus,
         );
 
         let num_entries = std::cmp::max(
@@ -290,7 +275,7 @@ impl HNSWIndex {
 
         let pool = rayon::ThreadPoolBuilder::new()
             .thread_name(|idx| format!("hnsw-build-{idx}"))
-            .num_threads(num_cpus)
+            .num_threads(permit.num_cpus as usize)
             .spawn_handler(|thread| {
                 let mut b = thread::Builder::new();
                 if let Some(name) = thread.name() {
@@ -315,7 +300,7 @@ impl HNSWIndex {
             .build()?;
 
         let mut indexed_vectors = 0;
-        for vector_id in id_tracker.iter_ids_excluding(deleted_bitslice) {
+        for vector_id in id_tracker_ref.iter_ids_excluding(deleted_bitslice) {
             check_process_stopped(stopped)?;
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(vector_id, level);
@@ -333,12 +318,16 @@ impl HNSWIndex {
         #[cfg(feature = "gpu")]
         let gpu_vectors = if build_main_graph {
             let timer = std::time::Instant::now();
-            let gpu_vectors =
-                Self::create_gpu_vectors(gpu_device, vector_storage, quantized_vectors, stopped)?;
+            let gpu_vectors = Self::create_gpu_vectors(
+                gpu_device,
+                &vector_storage_ref,
+                &quantized_vectors_ref,
+                stopped,
+            )?;
             if let Some(gpu_constructed_graph) = Self::build_main_graph_on_gpu(
-                id_tracker,
-                vector_storage,
-                quantized_vectors,
+                id_tracker_ref.deref(),
+                &vector_storage_ref,
+                &quantized_vectors_ref,
                 gpu_vectors.as_ref(),
                 &graph_layers_builder,
                 deleted_bitslice,
@@ -359,7 +348,7 @@ impl HNSWIndex {
         if build_main_graph {
             let timer = std::time::Instant::now();
 
-            let mut ids_iterator = id_tracker.iter_ids_excluding(deleted_bitslice);
+            let mut ids_iterator = id_tracker_ref.iter_ids_excluding(deleted_bitslice);
 
             let first_few_ids: Vec<_> = ids_iterator
                 .by_ref()
@@ -369,24 +358,24 @@ impl HNSWIndex {
 
             let insert_point = |vector_id| {
                 check_process_stopped(stopped)?;
-                let vector = vector_storage.get_vector(vector_id);
+                let vector = vector_storage_ref.get_vector(vector_id);
                 let vector = vector.as_vec_ref().into();
                 // No need to accumulate hardware, since this is an internal operation
                 let internal_hardware_counter = HardwareCounterCell::disposable();
 
-                let raw_scorer = if let Some(quantized_storage) = quantized_vectors.as_ref() {
+                let raw_scorer = if let Some(quantized_storage) = quantized_vectors_ref.as_ref() {
                     quantized_storage.raw_scorer(
                         vector,
-                        id_tracker.deleted_point_bitslice(),
-                        vector_storage.deleted_vector_bitslice(),
+                        id_tracker_ref.deleted_point_bitslice(),
+                        vector_storage_ref.deleted_vector_bitslice(),
                         stopped,
                         internal_hardware_counter,
                     )
                 } else {
                     new_raw_scorer(
                         vector,
-                        vector_storage,
-                        id_tracker.deleted_point_bitslice(),
+                        &vector_storage_ref,
+                        id_tracker_ref.deleted_point_bitslice(),
                         stopped,
                         internal_hardware_counter,
                     )
@@ -428,7 +417,7 @@ impl HNSWIndex {
                 BitVec::repeat(false, total_vector_count)
             };
 
-            for (field, _) in payload_index.indexed_fields() {
+            for (field, _) in payload_index_ref.indexed_fields() {
                 debug!("building additional index for field {}", &field);
 
                 // It is expected, that graph will become disconnected less than
@@ -442,7 +431,7 @@ impl HNSWIndex {
                     usize::MAX
                 };
 
-                for payload_block in payload_index.payload_blocks(&field, full_scan_threshold) {
+                for payload_block in payload_index_ref.payload_blocks(&field, full_scan_threshold) {
                     check_process_stopped(stopped)?;
                     if payload_block.cardinality > max_block_size {
                         continue;
@@ -458,11 +447,11 @@ impl HNSWIndex {
                         false,
                     );
                     Self::build_filtered_graph(
-                        id_tracker,
-                        vector_storage,
-                        quantized_vectors,
+                        id_tracker_ref.deref(),
+                        &vector_storage_ref,
+                        &quantized_vectors_ref,
                         gpu_vectors.as_ref(),
-                        payload_index,
+                        &payload_index_ref,
                         &pool,
                         stopped,
                         &mut additional_graph,
@@ -503,7 +492,24 @@ impl HNSWIndex {
         }
 
         debug!("finish additional payload field indexing");
-        Ok((config, graph))
+
+        config.save(&HnswGraphConfig::get_config_path(path))?;
+
+        drop(id_tracker_ref);
+        drop(vector_storage_ref);
+        drop(quantized_vectors_ref);
+        drop(payload_index_ref);
+
+        Ok(HNSWIndex {
+            id_tracker,
+            vector_storage,
+            quantized_vectors,
+            payload_index,
+            config,
+            path: path.to_owned(),
+            graph,
+            searches_telemetry: HNSWSearchesTelemetry::new(),
+        })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -93,6 +93,20 @@ struct HNSWSearchesTelemetry {
     exact_unfiltered: Arc<Mutex<OperationDurationsAggregator>>,
 }
 
+impl HNSWSearchesTelemetry {
+    fn new() -> Self {
+        Self {
+            unfiltered_plain: OperationDurationsAggregator::new(),
+            filtered_plain: OperationDurationsAggregator::new(),
+            unfiltered_hnsw: OperationDurationsAggregator::new(),
+            small_cardinality: OperationDurationsAggregator::new(),
+            large_cardinality: OperationDurationsAggregator::new(),
+            exact_filtered: OperationDurationsAggregator::new(),
+            exact_unfiltered: OperationDurationsAggregator::new(),
+        }
+    }
+}
+
 pub struct HnswIndexOpenArgs<'a> {
     pub path: &'a Path,
     pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
@@ -195,15 +209,7 @@ impl HNSWIndex {
             config,
             path: path.to_owned(),
             graph,
-            searches_telemetry: HNSWSearchesTelemetry {
-                unfiltered_hnsw: OperationDurationsAggregator::new(),
-                unfiltered_plain: OperationDurationsAggregator::new(),
-                filtered_plain: OperationDurationsAggregator::new(),
-                small_cardinality: OperationDurationsAggregator::new(),
-                large_cardinality: OperationDurationsAggregator::new(),
-                exact_filtered: OperationDurationsAggregator::new(),
-                exact_unfiltered: OperationDurationsAggregator::new(),
-            },
+            searches_telemetry: HNSWSearchesTelemetry::new(),
         })
     }
 

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -13,7 +13,7 @@ use crate::entry::entry_point::SegmentEntry;
 use crate::fixtures::index_fixtures::random_vector;
 use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use crate::index::hnsw_index::num_rayon_threads;
-use crate::segment_constructor::build_segment;
+use crate::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use crate::types::{
     Distance, HnswConfig, Indexes, SegmentConfig, SeqNumberType, VectorDataConfig,
     VectorStorageType,
@@ -83,19 +83,23 @@ fn test_graph_connectivity() {
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
 
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
-            .vector_storage
-            .clone(),
-        quantized_vectors: Default::default(),
-        payload_index: payload_index_ptr,
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            quantized_vectors: Default::default(),
+            payload_index: payload_index_ptr,
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let mut reverse_links = vec![vec![]; num_vectors as usize];

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -20,9 +20,8 @@ use uuid::Uuid;
 
 use super::{
     create_mutable_id_tracker, create_payload_storage, create_sparse_vector_index,
-    create_sparse_vector_storage, create_vector_index, get_payload_index_path,
-    get_vector_index_path, get_vector_storage_path, new_segment_path, open_segment_db,
-    open_vector_storage,
+    create_sparse_vector_storage, get_payload_index_path, get_vector_index_path,
+    get_vector_storage_path, new_segment_path, open_segment_db, open_vector_storage,
 };
 use crate::common::error_logging::LogError;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
@@ -37,7 +36,9 @@ use crate::index::PayloadIndex;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::payload_storage::PayloadStorage;
 use crate::segment::{Segment, SegmentVersion};
-use crate::segment_constructor::load_segment;
+use crate::segment_constructor::{
+    build_vector_index, load_segment, VectorIndexBuildArgs, VectorIndexOpenArgs,
+};
 use crate::types::{
     CompactExtendedPointId, ExtendedPointId, PayloadFieldSchema, PayloadKeyType, SegmentConfig,
     SegmentState, SeqNumberType,
@@ -527,21 +528,22 @@ impl SegmentBuilder {
             let permit = Arc::new(permit);
 
             for (vector_name, vector_config) in &segment_config.vector_data {
-                let vector_storage_arc = vector_storages_arc.remove(vector_name).unwrap();
-                let vector_index_path = get_vector_index_path(temp_dir.path(), vector_name);
-                let quantized_vectors = quantized_vectors.remove(vector_name);
-                let quantized_vectors_arc = Arc::new(AtomicRefCell::new(quantized_vectors));
-
-                create_vector_index(
+                build_vector_index(
                     vector_config,
-                    &vector_index_path,
-                    id_tracker_arc.clone(),
-                    vector_storage_arc,
-                    payload_index_arc.clone(),
-                    quantized_vectors_arc,
-                    Some(permit.clone()),
-                    gpu_device.as_ref(),
-                    stopped,
+                    VectorIndexOpenArgs {
+                        path: &get_vector_index_path(temp_dir.path(), vector_name),
+                        id_tracker: id_tracker_arc.clone(),
+                        vector_storage: vector_storages_arc.remove(vector_name).unwrap(),
+                        payload_index: payload_index_arc.clone(),
+                        quantized_vectors: Arc::new(AtomicRefCell::new(
+                            quantized_vectors.remove(vector_name),
+                        )),
+                    },
+                    VectorIndexBuildArgs {
+                        permit: permit.clone(),
+                        gpu_device: gpu_device.as_ref(),
+                        stopped,
+                    },
                 )?;
             }
 

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -15,7 +15,7 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::VectorIndex;
 use segment::json_path::JsonPath;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
     SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType, WithPayload,
@@ -164,17 +164,21 @@ fn test_batch_and_single_request_equivalency() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: payload_index_ptr,
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: payload_index_ptr,
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     for _ in 0..10 {

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -98,6 +98,7 @@ fn test_byte_storage_hnsw(
     use common::counter::hardware_counter::HardwareCounterCell;
     use segment::index::hnsw_index::num_rayon_threads;
     use segment::json_path::JsonPath;
+    use segment::segment_constructor::VectorIndexBuildArgs;
     use segment::types::PayloadSchemaType;
 
     let stopped = AtomicBool::new(false);
@@ -223,21 +224,25 @@ fn test_byte_storage_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index_byte = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir_byte.path(),
-        id_tracker: segment_byte.id_tracker.clone(),
-        vector_storage: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
-            .vector_storage
-            .clone(),
-        quantized_vectors: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
-            .quantized_vectors
-            .clone(),
-        payload_index: segment_byte.payload_index.clone(),
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index_byte = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir_byte.path(),
+            id_tracker: segment_byte.id_tracker.clone(),
+            vector_storage: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            quantized_vectors: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+                .quantized_vectors
+                .clone(),
+            payload_index: segment_byte.payload_index.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -228,6 +228,7 @@ fn test_byte_storage_binary_quantization_hnsw(
 ) {
     use common::counter::hardware_counter::HardwareCounterCell;
     use segment::json_path::JsonPath;
+    use segment::segment_constructor::VectorIndexBuildArgs;
 
     let stopped = AtomicBool::new(false);
 
@@ -345,21 +346,25 @@ fn test_byte_storage_binary_quantization_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index_byte = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir_byte.path(),
-        id_tracker: segment_byte.id_tracker.clone(),
-        vector_storage: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
-            .vector_storage
-            .clone(),
-        quantized_vectors: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
-            .quantized_vectors
-            .clone(),
-        payload_index: segment_byte.payload_index.clone(),
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index_byte = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir_byte.path(),
+            id_tracker: segment_byte.id_tracker.clone(),
+            vector_storage: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            quantized_vectors: segment_byte.vector_data[DEFAULT_VECTOR_NAME]
+                .quantized_vectors
+                .clone(),
+            payload_index: segment_byte.payload_index.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 5;

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -14,7 +14,7 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
     Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
@@ -135,21 +135,25 @@ fn exact_search_test() {
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
-            .vector_storage
-            .clone(),
-        quantized_vectors: segment.vector_data[DEFAULT_VECTOR_NAME]
-            .quantized_vectors
-            .clone(),
-        payload_index: payload_index_ptr.clone(),
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            quantized_vectors: segment.vector_data[DEFAULT_VECTOR_NAME]
+                .quantized_vectors
+                .clone(),
+            payload_index: payload_index_ptr.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -16,7 +16,7 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
     Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
@@ -198,17 +198,21 @@ fn _test_filterable_hnsw(
 
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: payload_index_ptr.clone(),
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: payload_index_ptr.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -16,7 +16,7 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
     Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
@@ -141,17 +141,21 @@ fn test_gpu_filterable_hnsw() {
         Mutex::new(gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap());
     let locked_device = LockedGpuDevice::new(device.lock());
 
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: payload_index_ptr.clone(),
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: Some(&locked_device), // enable GPU
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: payload_index_ptr.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: Some(&locked_device), // enable GPU
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -14,7 +14,7 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
     SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
@@ -117,17 +117,21 @@ fn hnsw_discover_precision() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: payload_index_ptr,
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: payload_index_ptr,
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 3;
@@ -248,17 +252,21 @@ fn filtered_hnsw_discover_precision() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: payload_index_ptr,
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: payload_index_ptr,
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -103,6 +103,7 @@ fn test_multi_filterable_hnsw(
 ) {
     use common::counter::hardware_counter::HardwareCounterCell;
     use segment::json_path::JsonPath;
+    use segment::segment_constructor::VectorIndexBuildArgs;
 
     let stopped = AtomicBool::new(false);
 
@@ -186,17 +187,21 @@ fn test_multi_filterable_hnsw(
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: payload_index_ptr,
-        hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: payload_index_ptr,
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let top = 3;

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -18,7 +18,7 @@ use segment::fixtures::payload_fixtures::random_int_payload;
 use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::VectorIndex;
 use segment::json_path::JsonPath;
-use segment::segment_constructor::build_segment;
+use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use segment::types::{
@@ -149,17 +149,21 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
     let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
-    let hnsw_index_dense = HNSWIndex::open(HnswIndexOpenArgs {
-        path: hnsw_dir.path(),
-        id_tracker: segment.id_tracker.clone(),
-        vector_storage: vector_storage.clone(),
-        quantized_vectors: quantized_vectors.clone(),
-        payload_index: segment.payload_index.clone(),
-        hnsw_config: hnsw_config.clone(),
-        permit: Some(permit.clone()),
-        gpu_device: None,
-        stopped: &stopped,
-    })
+    let hnsw_index_dense = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: vector_storage.clone(),
+            quantized_vectors: quantized_vectors.clone(),
+            payload_index: segment.payload_index.clone(),
+            hnsw_config: hnsw_config.clone(),
+        },
+        VectorIndexBuildArgs {
+            permit: permit.clone(),
+            gpu_device: None,
+            stopped: &stopped,
+        },
+    )
     .unwrap();
 
     let multi_storage = Arc::new(AtomicRefCell::new(multi_storage));
@@ -171,9 +175,6 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         quantized_vectors: quantized_vectors.clone(),
         payload_index: segment.payload_index.clone(),
         hnsw_config,
-        permit: Some(permit),
-        gpu_device: None,
-        stopped: &stopped,
     })
     .unwrap();
 


### PR DESCRIPTION
Currently, `HNSWIndex::open()` is responsible for both opening and building the index.
Some of the `open()` parameters are relevant only for the building process, but callers still have to provide them.
Pending PR #5835 adds yet additional build-only parameter to the pile, so we decided to split it into two methods: `open()` and `build()`.
https://github.com/qdrant/qdrant/pull/5835#discussion_r1924136245

In this PR:
1. `HNSWIndex::open()` is split into `HNSWIndex::open()` and `HNSWIndex::build()`.
2. The former is read-only and the latter writes the index.
3. The changes in the API are illustrated by the following command that was used to automatically rewrite call sites:
   ```shell
   ast-grep run -i --pattern '
       HNSWIndex::open(HnswIndexOpenArgs {
           path: $A,
           id_tracker: $B,
           vector_storage: $C,
           quantized_vectors: $D,
           payload_index: $E,
           hnsw_config,
           permit: Some(permit),
           gpu_device: $G,
           stopped: $H,
       })
   ' --rewrite '
       HNSWIndex::build(
           HnswIndexOpenArgs {
               path: $A,
               id_tracker: $B,
               vector_storage: $C,
               quantized_vectors: $D,
               payload_index: $E,
               hnsw_config,
           },
           VectorIndexBuildArgs {
               permit,
               gpu_device: $G,
               stopped: $H,
           },
       )
   '
   ```
4. To let `open()` to be fully read-only, the following fallback logic is dropped completely.
   It was considered to be rare and never seen in the production.
   https://github.com/qdrant/qdrant/blob/551006ba330a4d43c428af270710a36618db955a/lib/segment/src/index/hnsw_index/hnsw.rs#L160-L172
