### PR TITLE
Fix cargo doc warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,9 @@ needless_pass_by_ref_mut = "warn"
 # https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
+[workspace.lints.rustdoc]
+private_intra_doc_links = "allow"
+
 [workspace.dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"

--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -532,7 +532,7 @@ impl From<MultiDenseVectorInternal> for grpc::MultiDenseVector {
 }
 
 impl From<grpc::MultiDenseVector> for MultiDenseVectorInternal {
-    /// Uses the equivalent of [new_unchecked()](segment_vectors::MultiDenseVectorInternal::new_unchecked), but rewritten to avoid collecting twice
+    /// Uses the equivalent of [`MultiDenseVectorInternal::new_unchecked`], but rewritten to avoid collecting twice
     fn from(value: grpc::MultiDenseVector) -> Self {
         let dim = value.vectors[0].data.len();
         let inner_vector = value

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1017,7 +1017,7 @@ impl<'s> SegmentHolder {
         Ok(LockedSegment::new(segment))
     }
 
-    /// Proxy all shard segments for [`proxy_all_segments_and_apply`]
+    /// Proxy all shard segments for [`Self::proxy_all_segments_and_apply`].
     #[allow(clippy::type_complexity)]
     fn proxy_all_segments<'a>(
         segments_lock: RwLockUpgradableReadGuard<'a, SegmentHolder>,
@@ -1093,7 +1093,7 @@ impl<'s> SegmentHolder {
         Ok((proxies, tmp_segment, segments_lock))
     }
 
-    /// Try to unproxy a single shard segment for [`proxy_all_segments_and_apply`]
+    /// Try to unproxy a single shard segment for [`Self::proxy_all_segments_and_apply`].
     ///
     /// # Warning
     ///
@@ -1148,7 +1148,7 @@ impl<'s> SegmentHolder {
         Ok(RwLockWriteGuard::downgrade_to_upgradable(write_segments))
     }
 
-    /// Unproxy all shard segments for [`proxy_all_segments_and_apply`]
+    /// Unproxy all shard segments for [`Self::proxy_all_segments_and_apply`].
     fn unproxy_all_segments(
         segments_lock: RwLockUpgradableReadGuard<SegmentHolder>,
         proxies: Vec<(SegmentId, SegmentId, LockedSegment)>,

--- a/lib/collection/src/collection_manager/probabilistic_segment_search_sampling.rs
+++ b/lib/collection/src/collection_manager/probabilistic_segment_search_sampling.rs
@@ -6,6 +6,8 @@
 ///
 /// TODO attach proper python code to generate the table
 /// Python code to generate the table:
+///
+/// ```python
 /// from scipy.stats import poisson
 /// q = 0.999 # probability to cover full top in all segments
 /// res = []
@@ -15,6 +17,7 @@
 ///     k = poisson.ppf(q**(1/s), lmbda)
 ///     res.append((lmbda, int(k)))
 /// res = sorted(res, key=lambda x: x[0])
+/// ```
 ///
 /// with additional code to remove duplicates and values within 5% of each other.
 const POISSON_DISTRIBUTION_SEARCH_SAMPLING: [(f64, usize); 121] = [

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -76,14 +76,14 @@ impl SegmentsSearcher {
         Ok((search_results_per_segment, further_searches_per_segment))
     }
 
-    /// Processes search result of [segment_size x batch_size]
+    /// Processes search result of `[segment_size x batch_size]`.
     ///
     /// # Arguments
-    /// * search_result - [segment_size x batch_size]
-    /// * limits - [batch_size] - how many results to return for each batched request
-    /// * further_searches - [segment_size x batch_size] - whether we can search further in the segment
+    /// * `search_result` - `[segment_size x batch_size]`
+    /// * `limits` - `[batch_size]` - how many results to return for each batched request
+    /// * `further_searches` - `[segment_size x batch_size]` - whether we can search further in the segment
     ///
-    /// Returns batch results aggregated by [batch_size] and list of queries, grouped by segment to re-run
+    /// Returns batch results aggregated by `[batch_size]` and list of queries, grouped by segment to re-run
     pub(crate) fn process_search_result_step1(
         search_result: BatchSearchResult,
         limits: Vec<usize>,

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -48,7 +48,7 @@ pub enum WriteOrdering {
 }
 
 /// Single vector data, as it is persisted in WAL
-/// Unlike [`Vector`], this struct only stores raw vectors, inferenced or resolved.
+/// Unlike [`api::rest::Vector`], this struct only stores raw vectors, inferenced or resolved.
 /// Unlike [`VectorInternal`], is not optimized for search
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[serde(untagged, rename_all = "snake_case")]

--- a/lib/collection/src/operations/snapshot_storage_ops.rs
+++ b/lib/collection/src/operations/snapshot_storage_ops.rs
@@ -65,12 +65,12 @@ pub async fn get_snapshot_description(
 /// This function adjusts the chunk size based on service limits and the total size of the data to be uploaded.
 /// Note:
 ///
-/// * Amazon S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+/// * Amazon S3: <https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html>
 ///     partsize: min 5 MB, max 5 GB, up to 10,000 parts.
-/// * Google Cloud Storage: https://cloud.google.com/storage/quotas?hl=ja#objects
+/// * Google Cloud Storage: <https://cloud.google.com/storage/quotas?hl=ja#objects>
 ///     partsize: min 5 MB, max 5 GB, up to 10,000 parts.
-/// * Azure Storage: https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob?tabs=microsoft-entra-id#remarks
-///     <TODO> It looks like Azure Storage has different limits for different service versions.
+/// * Azure Storage: <https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob?tabs=microsoft-entra-id#remarks>
+///     TODO: It looks like Azure Storage has different limits for different service versions.
 pub async fn get_appropriate_chunk_size(local_source_path: &Path) -> CollectionResult<usize> {
     const DEFAULT_CHUNK_SIZE: usize = 50 * 1024 * 1024;
     const MAX_PART_NUMBER: usize = 10000;

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -52,7 +52,9 @@ impl CollectionQueryRequest {
     pub const DEFAULT_WITH_PAYLOAD: WithPayloadInterface = WithPayloadInterface::Bool(false);
 }
 
-/// Lightweight representation of a query request to implement the [RetrieveRequest] trait.
+/// Lightweight representation of a query request to implement the [`RetrieveRequest`] trait.
+///
+/// [`RetrieveRequest`]: crate::common::retrieve_request_trait::RetrieveRequest
 #[derive(Debug)]
 pub struct CollectionQueryResolveRequest<'a> {
     pub vector_query: &'a VectorQuery<VectorInputInternal>,

--- a/lib/collection/src/operations/universal_query/mod.rs
+++ b/lib/collection/src/operations/universal_query/mod.rs
@@ -4,11 +4,21 @@
 //!
 //! Pipeline of type conversion:
 //!
-//! 1. `rest::QueryRequest`, `grpc::QueryPoints`: rest or grpc request. Used in API
-//! 2. `CollectionQueryRequest`: Direct representation of the API request, but to be used as a single type. Created at API to enter ToC.
-//! 3. `ShardQueryRequest`: same as the common request, but all point ids have been substituted with vectors. Created at Collection
-//! 4. `QueryShardPoints`: to be used in the internal service. Created for RemoteShard, converts to and from ShardQueryRequest
-//! 5. `PlannedQuery`: an easier-to-execute representation of a batch of [ShardQueryRequest]. Created in LocalShard
+//! 1. [`api::rest::QueryRequest`], [`api::grpc::qdrant::QueryPoints`]:
+//!    Rest or grpc request. Used in API.
+//! 2. [`collection_query::CollectionQueryRequest`]:
+//!    Direct representation of the API request, but to be used as a single type. Created at API to enter ToC.
+//! 3. [`ShardQueryRequest`]:
+//!    Same as the common request, but all point ids have been substituted with vectors. Created at Collection.
+//! 4. [`api::grpc::qdrant::QueryShardPoints`]:
+//!    to be used in the internal service. Created for [`RemoteShard`], converts to and from [`ShardQueryRequest`].
+//! 5. [`planned_query::PlannedQuery`]:
+//!    An easier-to-execute representation of a batch of [`ShardQueryRequest`]. Created in [`LocalShard`].
+//!
+//! [`LocalShard`]: crate::shards::local_shard::LocalShard
+//! [`RemoteShard`]: crate::shards::remote_shard::RemoteShard
+//! [`ShardQueryRequest`]: shard_query::ShardQueryRequest
+//! [`QueryShardPoints`]: api::grpc::qdrant::QueryShardPoints
 
 pub mod collection_query;
 pub mod planned_query;

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -91,7 +91,7 @@ impl Clock {
     ///
     /// # Thread safety
     ///
-    /// Clock *has to* be locked (using [`Clock::lock`]) before calling `tick_once`!
+    /// Clock *has to* be locked (using [`Clock::try_lock`]) before calling [`Clock::tick_once`]!
     #[must_use = "new clock tick value must be used"]
     fn tick_once(&self) -> u64 {
         // `Clock` tracks *next* tick, so we increment `next_tick` by 1 and return *previous* value

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -444,17 +444,21 @@ where
     ///
     /// Example:
     ///
-    ///  resolved_iters = [
+    /// ```text
+    /// resolved_iters = [
     ///     <- (10, A) <- (4, B) <- (3, C)
     ///     <- (10, A) <- (4, B) <- (3, C)
     ///     <- (4, B) <- (3, C)
     /// ]
+    /// ```
     ///
     /// output:
+    /// ```text
     /// {
     ///     10: [0, 1],
     ///     4:  [2],
     /// }
+    /// ```
     fn heads_map(&mut self) -> HashMap<Id, TinyVec<[RowId; EXPECTED_REPLICAS]>> {
         let capacity = self.resolved_iters.len();
         self.peek_heads()

--- a/lib/common/common/src/counter/counter_cell.rs
+++ b/lib/common/common/src/counter/counter_cell.rs
@@ -48,7 +48,7 @@ impl CounterCell {
     }
 
     /// Increases the counter by 1. This should be preferred over `incr` if you have mutable
-    /// access to the counter, since this method is likely faster: https://stackoverflow.com/a/55169016
+    /// access to the counter, since this method is likely faster: <https://stackoverflow.com/a/55169016>
     #[inline]
     pub fn incr_mut(&mut self) {
         self.incr_delta_mut(1);
@@ -56,7 +56,7 @@ impl CounterCell {
 
     /// Increases the counter by `delta`. This should be preferred over
     /// `incr_delta` if you have mutable access to the counter, since
-    /// this method is likely faster: https://stackoverflow.com/a/55169016
+    /// this method is likely faster: <https://stackoverflow.com/a/55169016>
     #[inline]
     pub fn incr_delta_mut(&mut self, delta: usize) {
         *self.counter.get_mut() += delta;

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -135,8 +135,7 @@ where
     /// # Warning
     ///
     /// This does not support slices, because those cannot be transmuted directly because it has
-    /// extra parts. See [`MmapSlice`], [`MmapType::slice_from`] and
-    /// [`std::slice::from_raw_parts`].
+    /// extra parts. See [`MmapSlice`] and [`std::slice::from_raw_parts`].
     ///
     /// # Safety
     ///

--- a/lib/common/memory/src/mmap_type_readonly.rs
+++ b/lib/common/memory/src/mmap_type_readonly.rs
@@ -129,8 +129,7 @@ where
     /// # Warning
     ///
     /// This does not support slices, because those cannot be transmuted directly because it has
-    /// extra parts. See [`MmapSliceReadOnly`], [`MmapTypeReadOnly::slice_from`] and
-    /// [`std::slice::from_raw_parts`].
+    /// extra parts. See [`MmapSliceReadOnly`] and [`std::slice::from_raw_parts`].
     ///
     /// # Safety
     ///

--- a/lib/segment/src/common/macros.rs
+++ b/lib/segment/src/common/macros.rs
@@ -4,7 +4,7 @@
 /// #[macro_rules_attribute::macro_rules_derive(schemars_rename_generics)]
 /// #[derive_args(<i32> => "NewName", ...)]
 /// ```
-/// Workaround for https://github.com/GREsau/schemars/issues/193
+/// Workaround for <https://github.com/GREsau/schemars/issues/193>
 macro_rules! schemars_rename_generics {
     {
         #[doc = $doc:literal]

--- a/lib/segment/src/common/reciprocal_rank_fusion.rs
+++ b/lib/segment/src/common/reciprocal_rank_fusion.rs
@@ -1,5 +1,5 @@
 //! Reciprocal Rank Fusion (RRF) is a method for combining rankings from multiple sources.
-//! See https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
+//! See <https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf>
 
 use std::collections::hash_map::Entry;
 

--- a/lib/segment/src/common/score_fusion.rs
+++ b/lib/segment/src/common/score_fusion.rs
@@ -118,7 +118,7 @@ pub fn min_max_norm(points: Vec<ScoredPoint>) -> Vec<ScoredPoint> {
 }
 
 /// Welford's method for stable one-pass mean and variance calculation.
-/// https://jonisalonen.com/2013/deriving-welfords-method-for-computing-variance/
+/// <https://jonisalonen.com/2013/deriving-welfords-method-for-computing-variance/>
 ///
 /// # Panics
 ///

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -84,11 +84,12 @@ impl MmapPostings {
     ///
     /// Assume the following layout:
     ///
-    /// * `last_doc_id: &'a PointOffsetType,`
-    /// * `chunks_index: &'a [CompressedPostingChunksIndex],`
-    /// * `data: &'a [u8],`
-    /// * `_alignment: &'a [u8], // 0-3 extra bytes to align the data`
-    /// * `remainder_postings: &'a [PointOffsetType],`
+    /// ```ignore
+    /// last_doc_id: &'a PointOffsetType,
+    /// chunks_index: &'a [CompressedPostingChunksIndex],
+    /// data: &'a [u8],
+    /// _alignment: &'a [u8], // 0-3 extra bytes to align the data
+    /// remainder_postings: &'a [PointOffsetType],
     /// ```
     fn get_reader(&self, header: &PostingListHeader) -> Option<ChunkReader<'_>> {
         let bytes = self.mmap.get(header.offset as usize..)?;

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -22,11 +22,11 @@ pub struct JsonPath {
 
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum JsonPathItem {
-    /// A key in a JSON object, e.g. ".foo"
+    /// A key in a JSON object, e.g. `.foo`
     Key(String),
-    /// An index in a JSON array, e.g. "[3]"
+    /// An index in a JSON array, e.g. `[3]`
     Index(usize),
-    /// All indices in a JSON array, i.e. "[]"
+    /// All indices in a JSON array, i.e. `[]`
     WildcardIndex,
 }
 

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -26,7 +26,7 @@ pub trait QueryScorer<TVector: ?Sized> {
 }
 
 /// Colbert MaxSim metric, metric for multi-dense vectors
-/// https://arxiv.org/pdf/2112.01488.pdf, figure 1
+/// <https://arxiv.org/pdf/2112.01488.pdf>, figure 1
 /// This metric is also implemented in `QuantizedMultivectorStorage` structure for quantized data.
 pub fn score_max_similarity<T: PrimitiveVectorElement, TMetric: Metric<T>>(
     multi_dense_a: TypedMultiDenseVectorRef<T>,

--- a/lib/sparse/src/index/compressed_posting_list.rs
+++ b/lib/sparse/src/index/compressed_posting_list.rs
@@ -31,7 +31,7 @@ pub struct CompressedPostingList<W: Weight> {
     quantization_params: W::QuantizationParams,
 }
 
-/// A non-owning view of [`GenericCompressedPostingList`].
+/// A non-owning view of [`CompressedPostingList`].
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CompressedPostingListView<'a, W: Weight> {
     id_data: &'a [u8],


### PR DESCRIPTION
Consider this review comment: https://github.com/qdrant/qdrant/pull/5820#discussion_r1924021890
These type of mistakes could be caught automatically by running `cargo doc`.
And, in fact, we have a few outdated references.

This PR fixes all issues found by running this command:
```bash
cargo doc --no-deps --document-private-items --workspace --all-features
```

Tho, this approach doesn't catch all possible errors:
- ```rust
  /// Only identifiers marked as links [`LikeThis`] or [LikeThis] are checked,
  /// but not `LikeThis` or LikeThis without brackets.
  ```
- `cargo doc` doesn't check comments in benchmark and tests.
- Only `/// doc comments` are checked, but not `// regular comments`.

Not adding it to CI yet as it could negatively affect CI times, it needs measurements.