### PR TITLE
Cleanup some error types and conversions

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1192,9 +1192,6 @@ impl From<OperationError> for CollectionError {
             OperationError::VectorNameNotExists { .. } => Self::BadInput {
                 description: format!("{err}"),
             },
-            OperationError::MissedVectorName { .. } => Self::BadInput {
-                description: format!("{err}"),
-            },
             OperationError::PointIdError { missed_point_id } => {
                 Self::PointNotFound { missed_point_id }
             }

--- a/lib/common/io/src/file_operations.rs
+++ b/lib/common/io/src/file_operations.rs
@@ -106,6 +106,11 @@ impl From<bincode::Error> for Error {
 
 impl From<Error> for io::Error {
     fn from(err: Error) -> Self {
-        io::Error::new(io::ErrorKind::Other, err.to_string())
+        match err {
+            Error::Io(err) => err,
+            Error::Bincode(err) => Self::other(err),
+            Error::SerdeJson(err) => Self::other(err),
+            Error::Generic(msg) => Self::other(msg),
+        }
     }
 }

--- a/lib/common/io/src/file_operations.rs
+++ b/lib/common/io/src/file_operations.rs
@@ -51,7 +51,8 @@ pub fn advise_dontneed(path: &Path) -> Result<()> {
         let file = File::open(path)?;
         let fd = file.as_raw_fd();
 
-        fcntl::posix_fadvise(fd, 0, 0, fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED)?;
+        fcntl::posix_fadvise(fd, 0, 0, fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED)
+            .map_err(io::Error::from)?;
     }
 
     _ = path;
@@ -94,12 +95,6 @@ where
             atomicwrites::Error::Internal(err) => err.into(),
             atomicwrites::Error::User(err) => err.into(),
         }
-    }
-}
-
-impl From<nix::Error> for Error {
-    fn from(err: nix::Error) -> Self {
-        Self::Io(err.into())
     }
 }
 

--- a/lib/common/io/src/file_operations.rs
+++ b/lib/common/io/src/file_operations.rs
@@ -64,10 +64,6 @@ pub enum Error {
     #[error("{0}")]
     Io(#[from] io::Error),
 
-    #[cfg(unix)]
-    #[error("{0}")]
-    Errno(#[from] nix::errno::Errno),
-
     #[error("{0}")]
     Bincode(#[from] bincode::ErrorKind),
 
@@ -93,6 +89,12 @@ where
             atomicwrites::Error::Internal(err) => err.into(),
             atomicwrites::Error::User(err) => err.into(),
         }
+    }
+}
+
+impl From<nix::Error> for Error {
+    fn from(err: nix::Error) -> Self {
+        Self::Io(err.into())
     }
 }
 

--- a/lib/common/io/src/file_operations.rs
+++ b/lib/common/io/src/file_operations.rs
@@ -19,37 +19,42 @@ pub fn atomic_save_json<T: Serialize>(path: &Path, object: &T) -> Result<()> {
     Ok(())
 }
 
-pub fn read_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
-    Ok(serde_json::from_reader(BufReader::new(File::open(path)?))?)
+pub fn read_bin<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let file = File::open(path)?;
+    let value = bincode::deserialize_from(BufReader::new(file))?;
+    Ok(value)
 }
 
-pub fn read_bin<T: DeserializeOwned>(path: &Path) -> Result<T> {
-    Ok(bincode::deserialize_from(BufReader::new(File::open(
-        path,
-    )?))?)
+pub fn read_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let file = File::open(path)?;
+    let value = serde_json::from_reader(BufReader::new(file))?;
+    Ok(value)
 }
 
 /// Advise the operating system that the file is no longer needed to be in the page cache.
 pub fn advise_dontneed(path: &Path) -> Result<()> {
-    _ = path;
-
+    // https://github.com/nix-rust/nix/blob/v0.29.0/src/fcntl.rs#L35-L42
     #[cfg(any(
         target_os = "linux",
+        target_os = "freebsd",
         target_os = "android",
-        target_os = "emscripten",
         target_os = "fuchsia",
+        target_os = "emscripten",
         target_os = "wasi",
         target_env = "uclibc",
-        target_os = "freebsd",
-    ))] // https://github.com/nix-rust/nix/blob/v0.29.0/src/fcntl.rs#L35-L42
+    ))]
     {
-        nix::fcntl::posix_fadvise(
-            std::os::fd::AsRawFd::as_raw_fd(&File::open(path)?),
-            0,
-            0,
-            nix::fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED,
-        )?;
+        use std::os::fd::AsRawFd as _;
+
+        use nix::fcntl;
+
+        let file = File::open(path)?;
+        let fd = file.as_raw_fd();
+
+        fcntl::posix_fadvise(fd, 0, 0, fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED)?;
     }
+
+    _ = path;
 
     Ok(())
 }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -24,8 +24,6 @@ pub enum OperationError {
     },
     #[error("Not existing vector name error: {received_name}")]
     VectorNameNotExists { received_name: String },
-    #[error("Missed vector name error: {received_name}")]
-    MissedVectorName { received_name: String },
     #[error("No point with id {missed_point_id}")]
     PointIdError { missed_point_id: PointIdType },
     #[error("Payload type does not match with previously given for field {field_name}. Expected: {expected_type}")]


### PR DESCRIPTION
This PR
- removes unused error variant from `OperationError` in `segment` crate
- removes an error variant from `common::io::file_operations::Error` type and tweaks error conversions

It's just some small things I've noticed while reading `segment` crate code.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
