### PR TITLE
Bump version to v1.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "api"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "chrono",
  "common",
@@ -4735,7 +4735,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.13.0"
+version = "1.13.1"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.13.0"
+version = "1.13.1"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.13.0";
+pub const QDRANT_VERSION_STRING: &str = "1.13.1";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=9e359db7141a2446466e297807c1e99b408d70db
+IGNORE_UPTO=05e38230667f9b8d6222795c512ac9e6ca62d5a3
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Release PR for Qdrant 1.13.1.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/5759>.