### PR TITLE
search filters out points without version to honor flushing sequence

### DIFF
--- a/lib/collection/src/collection_manager/search_result_aggregator.rs
+++ b/lib/collection/src/collection_manager/search_result_aggregator.rs
@@ -85,13 +85,10 @@ impl BatchResultAggregator {
         let aggregator = &mut self.batch_aggregators[batch_id];
         for scored_point in search_results {
             debug_assert!(self.point_versions.contains_key(&scored_point.id));
-            let point_max_version = self
-                .point_versions
-                .get(&scored_point.id)
-                .copied()
-                .unwrap_or(0);
-            if scored_point.version >= point_max_version {
-                aggregator.push(scored_point);
+            if let Some(point_max_version) = self.point_versions.get(&scored_point.id) {
+                if scored_point.version >= *point_max_version {
+                    aggregator.push(scored_point);
+                }
             }
         }
     }


### PR DESCRIPTION
same motivation as https://github.com/qdrant/qdrant/pulls?q=is:pr%20is:closed

we have a `debug_assert` to catch this in test but we can go further by never creating the synthetic version 