### PR TITLE
Add payload_json! macro

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -78,6 +78,7 @@ mod tests {
     };
     use segment::entry::entry_point::SegmentEntry;
     use segment::json_path::JsonPath;
+    use segment::payload_json;
     use segment::types::PayloadSchemaType::Keyword;
     use segment::types::{Payload, PayloadContainer, PayloadFieldSchema, WithPayload};
     use serde_json::json;
@@ -119,7 +120,7 @@ mod tests {
             PointStructPersisted {
                 id: 13.into(),
                 vector: VectorStructPersisted::from(VectorStructInternal::from(vec13)),
-                payload: Some(json!({ "color": "red" }).into()),
+                payload: Some(payload_json! { "color": "red" }),
             },
             PointStructPersisted {
                 id: 14.into(),

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -8,12 +8,12 @@ use rand::Rng;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::only_default_vector;
 use segment::entry::entry_point::SegmentEntry;
+use segment::payload_json;
 use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::{
     build_multivec_segment, build_simple_segment,
 };
-use segment::types::{Distance, Payload, PointIdType, SeqNumberType, VectorName};
-use serde_json::json;
+use segment::types::{Distance, PointIdType, SeqNumberType, VectorName};
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
@@ -80,8 +80,7 @@ pub fn random_multi_vec_segment(
         let point_id: PointIdType = id_gen.unique();
         let payload_value = rnd.gen_range(1..1_000);
         let random_keyword = format!("keyword_{}", rnd.gen_range(1..10));
-        let payload: Payload =
-            json!({ payload_key: vec![payload_value], keyword_key: random_keyword}).into();
+        let payload = payload_json! {payload_key: vec![payload_value], keyword_key: random_keyword};
         segment
             .upsert_point(opnum, point_id, vectors, &hw_counter)
             .unwrap();
@@ -102,7 +101,7 @@ pub fn random_segment(path: &Path, opnum: SeqNumberType, num_vectors: u64, dim: 
         let random_vector: Vec<_> = (0..dim).map(|_| rnd.gen_range(0.0..1.0)).collect();
         let point_id: PointIdType = id_gen.unique();
         let payload_value = rnd.gen_range(1..1_000);
-        let payload: Payload = json!({ payload_key: vec![payload_value] }).into();
+        let payload = payload_json! {payload_key: vec![payload_value]};
         segment
             .upsert_point(
                 opnum,
@@ -147,10 +146,9 @@ pub fn build_segment_1(path: &Path) -> Segment {
 
     let payload_key = "color";
 
-    let payload_option1: Payload = json!({ payload_key: vec!["red".to_owned()] }).into();
-    let payload_option2: Payload =
-        json!({ payload_key: vec!["red".to_owned(), "blue".to_owned()] }).into();
-    let payload_option3: Payload = json!({ payload_key: vec!["blue".to_owned()] }).into();
+    let payload_option1 = payload_json! {payload_key: vec!["red".to_owned()]};
+    let payload_option2 = payload_json! {payload_key: vec!["red".to_owned(), "blue".to_owned()]};
+    let payload_option3 = payload_json! {payload_key: vec!["blue".to_owned()]};
 
     segment1
         .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1357,8 +1357,8 @@ mod tests {
 
     use common::counter::hardware_accumulator::HwMeasurementAcc;
     use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
+    use segment::payload_json;
     use segment::types::{FieldCondition, PayloadSchemaType};
-    use serde_json::json;
     use tempfile::{Builder, TempDir};
 
     use super::*;
@@ -1682,7 +1682,7 @@ mod tests {
             .set_payload(
                 101,
                 3.into(),
-                &json!({ "color": vec!["red".to_owned()] }).into(),
+                &payload_json! { "color": vec!["red".to_owned()] },
                 &None,
                 &hw_cell,
             )

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1399,9 +1399,10 @@ mod tests {
     use rand::Rng;
     use segment::data_types::vectors::{VectorInternal, DEFAULT_VECTOR_NAME};
     use segment::json_path::JsonPath;
+    use segment::payload_json;
     use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
     use segment::types::{Distance, PayloadContainer};
-    use serde_json::{json, Value};
+    use serde_json::Value;
     use tempfile::Builder;
 
     use super::*;
@@ -1700,17 +1701,17 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         segment1
-            .set_payload(100, 1.into(), &json!({}).into(), &None, &hw_counter)
+            .set_payload(100, 1.into(), &payload_json! {}, &None, &hw_counter)
             .unwrap();
         segment1
-            .set_payload(100, 2.into(), &json!({}).into(), &None, &hw_counter)
+            .set_payload(100, 2.into(), &payload_json! {}, &None, &hw_counter)
             .unwrap();
 
         segment2
-            .set_payload(200, 4.into(), &json!({}).into(), &None, &hw_counter)
+            .set_payload(200, 4.into(), &payload_json! {}, &None, &hw_counter)
             .unwrap();
         segment2
-            .set_payload(200, 5.into(), &json!({}).into(), &None, &hw_counter)
+            .set_payload(200, 5.into(), &payload_json! {}, &None, &hw_counter)
             .unwrap();
 
         let mut holder = SegmentHolder::default();

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -294,8 +294,8 @@ mod tests {
     use segment::fixtures::index_fixtures::random_vector;
     use segment::index::hnsw_index::num_rayon_threads;
     use segment::json_path::JsonPath;
-    use segment::types::{Distance, Payload, PayloadSchemaType, VectorNameBuf};
-    use serde_json::json;
+    use segment::payload_json;
+    use segment::types::{Distance, PayloadSchemaType, VectorNameBuf};
     use tempfile::Builder;
 
     use super::*;
@@ -612,7 +612,7 @@ mod tests {
             );
         }
 
-        let point_payload: Payload = json!({"number":10000i64}).into();
+        let point_payload = payload_json! {"number": 10000i64};
 
         let batch = BatchPersisted {
             ids: vec![501.into(), 502.into(), 503.into()],

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -218,8 +218,9 @@ mod tests {
     use parking_lot::RwLock;
     use segment::entry::entry_point::SegmentEntry;
     use segment::index::hnsw_index::num_rayon_threads;
+    use segment::payload_json;
     use segment::types::{Distance, PayloadContainer, PayloadSchemaType, VectorName};
-    use serde_json::{json, Value};
+    use serde_json::Value;
     use tempfile::Builder;
 
     use super::*;
@@ -287,7 +288,7 @@ mod tests {
                 .set_payload(
                     102,
                     point_id,
-                    &json!({ "color": "red" }).into(),
+                    &payload_json! {"color": "red"},
                     &None,
                     &hw_counter,
                 )
@@ -301,7 +302,7 @@ mod tests {
                 .set_payload(
                     102,
                     point_id,
-                    &json!({"size": 0.42}).into(),
+                    &payload_json! {"size": 0.42},
                     &None,
                     &hw_counter,
                 )

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -8,8 +8,8 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::data_types::vectors::{only_default_vector, VectorStructInternal};
 use segment::entry::entry_point::SegmentEntry;
-use segment::types::{Payload, PointIdType, WithPayload, WithVector};
-use serde_json::json;
+use segment::payload_json;
+use segment::types::{PointIdType, WithPayload, WithVector};
 use tempfile::Builder;
 
 use super::holders::proxy_segment;
@@ -261,8 +261,8 @@ fn test_proxy_shared_updates() {
     let old_vec = vec![1.0, 0.0, 0.0, 1.0];
     let new_vec = vec![1.0, 0.0, 1.0, 0.0];
 
-    let old_payload: Payload = json!({ "size": vec!["small"] }).into();
-    let new_payload: Payload = json!({ "size": vec!["big"] }).into();
+    let old_payload = payload_json! {"size": vec!["small"]};
+    let new_payload = payload_json! {"size": vec!["big"]};
     // let newest_vec = vec![1.0, 1.0, 0.0, 0.0];
 
     let write_segment = LockedSegment::new(empty_segment(dir.path()));
@@ -323,7 +323,7 @@ fn test_proxy_shared_updates() {
     holder.add_new(proxy_segment_1);
     holder.add_new(proxy_segment_2);
 
-    let payload: Payload = json!({ "color": vec!["yellow"] }).into();
+    let payload = payload_json! {"color": vec!["yellow"]};
 
     let ids = vec![idx1, idx2];
 
@@ -346,7 +346,7 @@ fn test_proxy_shared_updates() {
     )
     .unwrap();
 
-    let expected_payload: Payload = json!({ "size": vec!["big"], "color": vec!["yellow"] }).into();
+    let expected_payload = payload_json! {"size": vec!["big"], "color": vec!["yellow"]};
 
     for (point_id, record) in result {
         if let Some(payload) = record.payload {

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -201,7 +201,7 @@ impl GroupsAggregator {
 mod unit_tests {
 
     use common::types::ScoreType;
-    use segment::types::Payload;
+    use segment::payload_json;
     use serde_json::json;
 
     use super::*;
@@ -211,7 +211,7 @@ mod unit_tests {
             id: idx.into(),
             version: 0,
             score,
-            payload: Some(Payload::from(serde_json::json!({ "docId": payloads }))),
+            payload: Some(payload_json! { "docId": payloads }),
             vector: None,
             shard_key: None,
             order_value: None,

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -557,6 +557,7 @@ mod tests {
     use std::collections::HashMap;
 
     use segment::data_types::groups::GroupId;
+    use segment::payload_json;
     use segment::types::{Payload, ScoredPoint};
 
     use crate::grouping::types::Group;
@@ -602,8 +603,8 @@ mod tests {
             groups.push(group);
         });
 
-        let payload_a = Payload::from(serde_json::json!({"some_key": "some value a"}));
-        let payload_b = Payload::from(serde_json::json!({"some_key": "some value b"}));
+        let payload_a = payload_json! {"some_key": "some value a"};
+        let payload_b = payload_json! {"some_key": "some value b"};
 
         let hydrated = vec![
             make_scored_point(1, 1.0, Some(payload_a.clone())),

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -9,7 +9,7 @@ use rand::rngs::ThreadRng;
 use rand::Rng;
 use segment::data_types::vectors::DenseVector;
 use segment::json_path::JsonPath;
-use segment::types::{Filter, Payload, WithPayloadInterface, WithVector};
+use segment::types::{Filter, WithPayloadInterface, WithVector};
 use serde_json::json;
 
 use crate::common::simple_collection_fixture;
@@ -25,6 +25,7 @@ mod group_by {
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
     };
     use common::counter::hardware_accumulator::HwMeasurementAcc;
+    use segment::payload_json;
 
     use super::*;
 
@@ -66,9 +67,7 @@ mod group_by {
             payloads: (0..docs)
                 .flat_map(|x| {
                     (0..chunks).map(move |_| {
-                        Some(Payload::from(
-                            json!({ "docId": x , "other_stuff": x.to_string() + "foo" }),
-                        ))
+                        Some(payload_json! { "docId": x , "other_stuff": x.to_string() + "foo" })
                     })
                 })
                 .collect_vec()
@@ -479,6 +478,7 @@ mod group_by_builder {
     };
     use common::counter::hardware_accumulator::HwMeasurementAcc;
     use segment::json_path::JsonPath;
+    use segment::payload_json;
     use tokio::sync::RwLock;
 
     use super::*;
@@ -523,7 +523,7 @@ mod group_by_builder {
                 ),
                 payloads: (0..docs)
                     .flat_map(|x| {
-                        (0..chunks_per_doc).map(move |_| Some(Payload::from(json!({ "docId": x }))))
+                        (0..chunks_per_doc).map(move |_| Some(payload_json! {"docId": x}))
                     })
                     .collect_vec()
                     .into(),
@@ -554,11 +554,7 @@ mod group_by_builder {
                         .collect_vec(),
                 ),
                 payloads: (0..docs)
-                    .map(|x| {
-                        Some(Payload::from(
-                            json!({ "docId": x, "body": format!("{x} {BODY_TEXT}") }),
-                        ))
-                    })
+                    .map(|x| Some(payload_json! {"docId": x, "body": format!("{x} {BODY_TEXT}")}))
                     .collect_vec()
                     .into(),
             };

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -14,8 +14,8 @@ use rand::rngs::SmallRng;
 use rand::{self, Rng, SeedableRng};
 use rstest::*;
 use segment::data_types::vectors::VectorStructInternal;
-use segment::types::{Payload, PointIdType};
-use serde_json::json;
+use segment::payload_json;
+use segment::types::PointIdType;
 use tempfile::Builder;
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -56,7 +56,7 @@ async fn setup() -> Resources {
 
     let payloads = ids
         .iter()
-        .map(|i| Some(Payload::from(json!({ "foo": format!("bar {}", i) }))))
+        .map(|i| Some(payload_json! {"foo": format!("bar {}", i)}))
         .collect_vec();
 
     let batch = BatchPersisted {
@@ -150,7 +150,7 @@ async fn happy_lookup_ids() {
         assert_eq!(record.id, PointIdType::try_from(id_value.clone()).unwrap());
         assert_eq!(
             record.payload,
-            Some(Payload::from(json!({ "foo": format!("bar {}", id_value) })))
+            Some(payload_json! { "foo": format!("bar {}", id_value) })
         );
         assert_eq!(record.vector, Some(vector));
     }

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -13,12 +13,12 @@ use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::fixtures::payload_fixtures::{FLT_KEY, INT_KEY};
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::PayloadIndex;
+use segment::payload_json;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::payload_storage::PayloadStorage;
 use segment::types::{
     Condition, FieldCondition, Filter, PayloadSchemaType, Range as RangeCondition,
 };
-use serde_json::json;
 use tempfile::Builder;
 
 const NUM_POINTS: usize = 100_000;
@@ -50,11 +50,10 @@ fn range_filtering(c: &mut Criterion) {
     // generate points with payload
     let mut payload_storage = InMemoryPayloadStorage::default();
     for id in 0..NUM_POINTS {
-        let payload = json!({
+        let payload = payload_json! {
             INT_KEY: rng.gen_range(0..MAX_RANGE.round() as usize),
             FLT_KEY: rng.gen_range(0.0..MAX_RANGE),
-        })
-        .into();
+        };
         payload_storage
             .set(id as PointOffsetType, &payload, &hw_counter)
             .unwrap();

--- a/lib/segment/benches/serde_formats.rs
+++ b/lib/segment/benches/serde_formats.rs
@@ -3,15 +3,15 @@ mod prof;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
+use segment::payload_json;
 use segment::types::Payload;
-use serde_json::json;
 
 fn serde_formats_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("serde-formats-group");
 
     let payloads = (0..1000)
         .map(|x| {
-            let payload: Payload = json!({"val":format!("val_{x}"),}).into();
+            let payload = payload_json! {"val": format!("val_{x}")};
             payload
         })
         .collect_vec();

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -14,9 +14,9 @@ use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
 use segment::index::{PayloadIndex, VectorIndex};
+use segment::payload_json;
 use segment::types::PayloadSchemaType::Keyword;
-use segment::types::{Condition, FieldCondition, Filter, Payload};
-use serde_json::json;
+use segment::types::{Condition, FieldCondition, Filter};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_positive_sparse_vector, random_sparse_vector};
 use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
@@ -84,10 +84,7 @@ fn sparse_vector_index_search_benchmark_impl(
     // adding payload on field
     let field_name = "field";
     let field_value = "important value";
-    let payload: Payload = json!({
-        field_name: field_value,
-    })
-    .into();
+    let payload = payload_json! {field_name: field_value};
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -9,6 +9,7 @@ use rand::Rng;
 use serde_json::{json, Value};
 
 use crate::data_types::vectors::{DenseVector, MultiDenseVectorInternal, VectorElementType};
+use crate::payload_json;
 use crate::types::{
     AnyVariants, Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition,
     IsEmptyCondition, Match, MatchAny, Payload, PayloadField, Range as RangeCondition, ValuesCount,
@@ -304,9 +305,9 @@ pub fn random_nested_filter<R: Rng + ?Sized>(rnd_gen: &mut R) -> Filter {
     Filter::new_should(condition)
 }
 
-fn random_json<R: Rng + ?Sized>(rnd_gen: &mut R) -> Value {
+pub fn generate_diverse_payload<R: Rng + ?Sized>(rnd_gen: &mut R) -> Payload {
     if rnd_gen.gen_range(0.0..1.0) < 0.5 {
-        json!({
+        payload_json! {
             STR_KEY: random_keyword_payload(rnd_gen, 1..=3),
             INT_KEY: random_int_payload(rnd_gen, 1..=3),
             INT_KEY_2: random_int_payload(rnd_gen, 1..=2),
@@ -315,9 +316,9 @@ fn random_json<R: Rng + ?Sized>(rnd_gen: &mut R) -> Value {
             GEO_KEY: random_geo_payload(rnd_gen, 1..=3),
             TEXT_KEY: random_keyword_payload(rnd_gen, 1..=1),
             BOOL_KEY: random_bool_payload(rnd_gen, 1..=1),
-        })
+        }
     } else {
-        json!({
+        payload_json! {
             STR_KEY: random_keyword_payload(rnd_gen, 1..=2),
             INT_KEY: random_int_payload(rnd_gen, 1..=3),
             INT_KEY_2: random_int_payload(rnd_gen, 1..=2),
@@ -327,16 +328,12 @@ fn random_json<R: Rng + ?Sized>(rnd_gen: &mut R) -> Value {
             TEXT_KEY: random_keyword_payload(rnd_gen, 1..=1),
             BOOL_KEY: random_bool_payload(rnd_gen, 1..=2),
             FLICKING_KEY: random_int_payload(rnd_gen, 1..=3)
-        })
+        }
     }
 }
 
-pub fn generate_diverse_payload<R: Rng + ?Sized>(rnd_gen: &mut R) -> Payload {
-    random_json(rnd_gen).into()
-}
-
 pub fn generate_diverse_nested_payload<R: Rng + ?Sized>(rnd_gen: &mut R) -> Payload {
-    json!({
+    payload_json! {
         STR_KEY: {
             "nested_1": {
                 "nested_2": random_keyword_payload(rnd_gen, 1..=3)
@@ -354,6 +351,5 @@ pub fn generate_diverse_nested_payload<R: Rng + ?Sized>(rnd_gen: &mut R) -> Payl
                 ]
             }
         ],
-    })
-    .into()
+    }
 }

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -313,7 +313,6 @@ mod tests {
     use std::collections::HashSet;
     use std::str::FromStr;
 
-    use serde_json::json;
     use tempfile::Builder;
 
     use super::*;
@@ -321,6 +320,7 @@ mod tests {
     use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
     use crate::id_tracker::IdTracker;
     use crate::json_path::JsonPath;
+    use crate::payload_json;
     use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
     use crate::payload_storage::PayloadStorage;
     use crate::types::{
@@ -332,11 +332,10 @@ mod tests {
         let dir = Builder::new().prefix("db_dir").tempdir().unwrap();
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
 
-        let payload: Payload = json!(
-            {
-                "location":{
-                    "lon": 13.404954,
-                    "lat": 52.520008,
+        let payload = payload_json! {
+            "location": {
+                "lon": 13.404954,
+                "lat": 52.520008,
             },
             "price": 499.90,
             "amount": 10,
@@ -346,9 +345,8 @@ mod tests {
             "shipped_at": "2020-02-15T00:00:00Z",
             "parts": [],
             "packaging": null,
-            "not_null": [null]
-        })
-        .into();
+            "not_null": [null],
+        };
 
         let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -116,13 +116,13 @@ pub fn build_multivec_segment(
 #[cfg(test)]
 mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
-    use serde_json::json;
     use tempfile::Builder;
 
     use super::*;
     use crate::common::operation_error::OperationError;
     use crate::data_types::vectors::only_default_vector;
     use crate::entry::entry_point::SegmentEntry;
+    use crate::payload_json;
 
     #[test]
     fn test_create_simple_segment() {
@@ -172,7 +172,7 @@ mod tests {
             .set_payload(
                 3,
                 1.into(),
-                &json!({ "color": vec!["red".to_owned(), "green".to_owned()] }).into(),
+                &payload_json! {"color": vec!["red".to_owned(), "green".to_owned()]},
                 &None,
                 &hw_counter,
             )
@@ -182,7 +182,7 @@ mod tests {
             .set_payload(
                 3,
                 2.into(),
-                &json!({ "color": vec!["red".to_owned(), "blue".to_owned()] }).into(),
+                &payload_json! {"color": vec!["red".to_owned(), "blue".to_owned()]},
                 &None,
                 &hw_counter,
             )
@@ -192,7 +192,7 @@ mod tests {
             .set_payload(
                 3,
                 3.into(),
-                &json!({ "color": vec!["red".to_owned(), "yellow".to_owned()] }).into(),
+                &payload_json! {"color": vec!["red".to_owned(), "yellow".to_owned()]},
                 &None,
                 &hw_counter,
             )
@@ -202,7 +202,7 @@ mod tests {
             .set_payload(
                 3,
                 4.into(),
-                &json!({ "color": vec!["red".to_owned(), "green".to_owned()] }).into(),
+                &payload_json! {"color": vec!["red".to_owned(), "green".to_owned()]},
                 &None,
                 &hw_counter,
             )

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1287,15 +1287,6 @@ impl IntoIterator for Payload {
     }
 }
 
-impl From<Value> for Payload {
-    fn from(value: Value) -> Self {
-        match value {
-            Value::Object(map) => Payload(map),
-            _ => panic!("cannot convert from {value:?}"),
-        }
-    }
-}
-
 impl From<Map<String, Value>> for Payload {
     fn from(value: serde_json::Map<String, Value>) -> Self {
         Payload(value)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1203,6 +1203,19 @@ pub trait PayloadContainer {
     fn get_value(&self, path: &JsonPath) -> MultiValue<&Value>;
 }
 
+/// Construct a [`Payload`] value from a JSON literal.
+///
+/// Similar to [`serde_json::json!`] but only allows objects (aka maps).
+#[macro_export]
+macro_rules! payload_json {
+    ($($tt:tt)*) => {
+        match ::serde_json::json!( { $($tt)* } ) {
+            ::serde_json::Value::Object(map) => $crate::types::Payload(map),
+            _ => unreachable!(),
+        }
+    };
+}
+
 #[allow(clippy::unnecessary_wraps)] // Used as schemars example
 fn payload_example() -> Option<Payload> {
     Some(Payload::from(serde_json::json!({

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -15,12 +15,12 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::VectorIndex;
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType,
     SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType, WithPayload,
 };
-use serde_json::json;
 use tempfile::Builder;
 
 #[test]
@@ -68,7 +68,7 @@ fn test_batch_and_single_request_equivalency() {
         let vector = random_vector(&mut rnd, dim);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -15,12 +15,11 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::segment_constructor::build_segment;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, Range, SearchParams,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Range, SearchParams,
     SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use segment::vector_storage::VectorStorageEnum;
-use serde_json::json;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 4;
@@ -98,6 +97,7 @@ fn test_byte_storage_hnsw(
     use common::counter::hardware_counter::HardwareCounterCell;
     use segment::index::hnsw_index::num_rayon_threads;
     use segment::json_path::JsonPath;
+    use segment::payload_json;
     use segment::segment_constructor::VectorIndexBuildArgs;
     use segment::types::PayloadSchemaType;
 
@@ -174,7 +174,7 @@ fn test_byte_storage_hnsw(
         let vector = random_dense_byte_vector(&mut rnd, dim);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -20,14 +20,13 @@ use segment::index::{PayloadIndex, VectorIndex};
 use segment::segment_constructor::build_segment;
 use segment::types::{
     BinaryQuantizationConfig, CompressionRatio, Condition, Distance, FieldCondition, Filter,
-    HnswConfig, Indexes, Payload, PayloadSchemaType, ProductQuantizationConfig,
-    QuantizationSearchParams, Range, ScalarQuantizationConfig, SearchParams, SegmentConfig,
-    SeqNumberType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
+    HnswConfig, Indexes, PayloadSchemaType, ProductQuantizationConfig, QuantizationSearchParams,
+    Range, ScalarQuantizationConfig, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
+    VectorStorageDatatype, VectorStorageType,
 };
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use segment::vector_storage::VectorStorageEnum;
-use serde_json::json;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 4;
@@ -228,6 +227,7 @@ fn test_byte_storage_binary_quantization_hnsw(
 ) {
     use common::counter::hardware_counter::HardwareCounterCell;
     use segment::json_path::JsonPath;
+    use segment::payload_json;
     use segment::segment_constructor::VectorIndexBuildArgs;
 
     let stopped = AtomicBool::new(false);
@@ -283,7 +283,7 @@ fn test_byte_storage_binary_quantization_hnsw(
         let vector = random_vector(&mut rnd, dim, storage_data_type);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         segment_byte
             .upsert_point(

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -14,12 +14,12 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
-    Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType, Range,
+    SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
-use serde_json::json;
 use tempfile::Builder;
 
 #[test]
@@ -68,7 +68,7 @@ fn exact_search_test() {
         let vector = random_vector(&mut rnd, dim);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         segment
             .upsert_point(

--- a/lib/segment/tests/integration/fail_recovery_test.rs
+++ b/lib/segment/tests/integration/fail_recovery_test.rs
@@ -2,7 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::{OperationError, SegmentFailedState};
 use segment::data_types::vectors::only_default_vector;
 use segment::entry::entry_point::SegmentEntry;
-use serde_json::json;
+use segment::payload_json;
 use tempfile::Builder;
 
 use crate::fixtures::segment::empty_segment;
@@ -34,7 +34,7 @@ fn test_insert_fail_recovery() {
     let fail_res = segment.set_payload(
         3,
         1.into(),
-        &json!({ "color": vec!["red".to_string()] }).into(),
+        &payload_json! {"color": vec!["red".to_string()]},
         &None,
         &hw_counter,
     );
@@ -44,7 +44,7 @@ fn test_insert_fail_recovery() {
     let fail_res = segment.set_payload(
         3,
         2.into(),
-        &json!({ "color": vec!["red".to_string()] }).into(),
+        &payload_json! {"color": vec!["red".to_string()]},
         &None,
         &hw_counter,
     );
@@ -54,7 +54,7 @@ fn test_insert_fail_recovery() {
     let ok_res = segment.set_payload(
         2,
         2.into(),
-        &json!({ "color": vec!["red".to_string()] }).into(),
+        &payload_json! {"color": vec!["red".to_string()]},
         &None,
         &hw_counter,
     );
@@ -65,7 +65,7 @@ fn test_insert_fail_recovery() {
     let recover_res = segment.set_payload(
         2,
         1.into(),
-        &json!({ "color": vec!["red".to_string()] }).into(),
+        &payload_json! {"color": vec!["red".to_string()]},
         &None,
         &hw_counter,
     );

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -16,13 +16,13 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
-    Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType, Range,
+    SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
-use serde_json::json;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 4;
@@ -129,7 +129,7 @@ fn _test_filterable_hnsw(
         let vector = random_vector(&mut rnd, dim);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         segment
             .upsert_point(

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -6,6 +6,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{only_default_vector, DenseVector, VectorRef};
 use segment::entry::entry_point::SegmentEntry;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::payload_json;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
@@ -13,7 +14,6 @@ use segment::types::{
     Distance, Indexes, SegmentConfig, SparseVectorDataConfig, SparseVectorStorageType,
     VectorDataConfig, VectorName, VectorStorageType,
 };
-use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
 
 pub fn empty_segment(path: &Path) -> Segment {
@@ -52,9 +52,9 @@ pub fn build_segment_1(path: &Path) -> Segment {
 
     let payload_key = PAYLOAD_KEY;
 
-    let payload_option1 = json!({ payload_key: vec!["red".to_owned()] }).into();
-    let payload_option2 = json!({ payload_key: vec!["red".to_owned(), "blue".to_owned()] }).into();
-    let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
+    let payload_option1 = payload_json! {payload_key: vec!["red".to_owned()]};
+    let payload_option2 = payload_json! {payload_key: vec!["red".to_owned(), "blue".to_owned()]};
+    let payload_option3 = payload_json! {payload_key: vec!["blue".to_owned()]};
 
     segment1
         .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)
@@ -104,9 +104,9 @@ pub fn build_segment_2(path: &Path) -> Segment {
 
     let payload_key = PAYLOAD_KEY;
 
-    let payload_option1 = json!({ payload_key: vec!["red".to_owned()] }).into();
-    let payload_option2 = json!({ payload_key: vec!["red".to_owned(), "blue".to_owned()] }).into();
-    let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
+    let payload_option1 = payload_json! {payload_key: vec!["red".to_owned()]};
+    let payload_option2 = payload_json! {payload_key: vec!["red".to_owned(), "blue".to_owned()]};
+    let payload_option3 = payload_json! {payload_key: vec!["blue".to_owned()]};
 
     segment2
         .set_payload(16, 11.into(), &payload_option1, &None, &hw_counter)
@@ -230,9 +230,9 @@ pub fn build_segment_3(path: &Path) -> Segment {
 
     let payload_key = PAYLOAD_KEY;
 
-    let payload_option1 = json!({ payload_key: vec!["red".to_owned()] }).into();
-    let payload_option2 = json!({ payload_key: vec!["red".to_owned(), "blue".to_owned()] }).into();
-    let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
+    let payload_option1 = payload_json! {payload_key: vec!["red".to_owned()]};
+    let payload_option2 = payload_json! {payload_key: vec!["red".to_owned(), "blue".to_owned()]};
+    let payload_option3 = payload_json! {payload_key: vec!["blue".to_owned()]};
 
     segment3
         .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)
@@ -322,9 +322,9 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
 
     let payload_key = PAYLOAD_KEY;
 
-    let payload_option1 = json!({ payload_key: vec!["red".to_owned()] }).into();
-    let payload_option2 = json!({ payload_key: vec!["red".to_owned(), "blue".to_owned()] }).into();
-    let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
+    let payload_option1 = payload_json! {payload_key: vec!["red".to_owned()]};
+    let payload_option2 = payload_json! {payload_key: vec!["red".to_owned(), "blue".to_owned()]};
+    let payload_option3 = payload_json! {payload_key: vec!["blue".to_owned()]};
 
     segment1
         .set_payload(6, 1.into(), &payload_option1, &None, &hw_counter)
@@ -414,9 +414,9 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
 
     let payload_key = PAYLOAD_KEY;
 
-    let payload_option1 = json!({ payload_key: vec!["red".to_owned()] }).into();
-    let payload_option2 = json!({ payload_key: vec!["red".to_owned(), "blue".to_owned()] }).into();
-    let payload_option3 = json!({ payload_key: vec!["blue".to_owned()] }).into();
+    let payload_option1 = payload_json! {payload_key: vec!["red".to_owned()]};
+    let payload_option2 = payload_json! {payload_key: vec!["red".to_owned(), "blue".to_owned()]};
+    let payload_option3 = payload_json! {payload_key: vec!["blue".to_owned()]};
 
     segment2
         .set_payload(16, 11.into(), &payload_option1, &None, &hw_counter)

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -16,12 +16,12 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
-    Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType, Range,
+    SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
-use serde_json::json;
 use tempfile::Builder;
 
 /// Captured logs from env_logger. It's used to check that indexing was performed using GPU correctly.
@@ -96,7 +96,7 @@ fn test_gpu_filterable_hnsw() {
         let vector = random_vector(&mut rnd, dim);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -14,13 +14,13 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType,
     SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
-use serde_json::json;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 3;
@@ -218,7 +218,7 @@ fn filtered_hnsw_discover_precision() {
         let vector = random_vector(&mut rnd, dim);
 
         let keyword_payload = get_random_keyword_of(num_payload_values, &mut rnd);
-        let payload: Payload = json!({keyword_key:keyword_payload,}).into();
+        let payload = payload_json! {keyword_key: keyword_payload};
 
         segment
             .upsert_point(

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -16,17 +16,17 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{VectorIndex, VectorIndexEnum};
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::segment::Segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
-    CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload,
+    CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes,
     ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams,
     ScalarQuantizationConfig, SearchParams, SegmentConfig, VectorDataConfig, VectorStorageType,
 };
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use serde_json::json;
 use tempfile::Builder;
 
 use crate::fixtures::segment::build_segment_1;
@@ -97,12 +97,7 @@ fn hnsw_quantized_search_test(
     op_num += 1;
     for n in 0..payloads_count {
         let idx = n.into();
-        let payload: Payload = json!(
-            {
-                STR_KEY: STR_KEY,
-            }
-        )
-        .into();
+        let payload = payload_json! {STR_KEY: STR_KEY};
         segment
             .set_full_payload(op_num, idx, &payload, &hw_counter)
             .unwrap();

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -16,13 +16,12 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::segment_constructor::build_segment;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, MultiVectorConfig, Payload,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, MultiVectorConfig,
     PayloadSchemaType, Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
     VectorStorageType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use segment::vector_storage::VectorStorage;
-use serde_json::json;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 4;
@@ -103,6 +102,7 @@ fn test_multi_filterable_hnsw(
 ) {
     use common::counter::hardware_counter::HardwareCounterCell;
     use segment::json_path::JsonPath;
+    use segment::payload_json;
     use segment::segment_constructor::VectorIndexBuildArgs;
 
     let stopped = AtomicBool::new(false);
@@ -149,7 +149,7 @@ fn test_multi_filterable_hnsw(
         let multi_vec = random_multi_vector(&mut rnd, vector_dim, num_vector_for_point);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         let named_vectors = only_default_multi_vector(&multi_vec);
         segment

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -18,16 +18,16 @@ use segment::fixtures::payload_fixtures::random_int_payload;
 use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::VectorIndex;
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, MultiVectorConfig, Payload,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, MultiVectorConfig,
     PayloadSchemaType, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
 use segment::vector_storage::multi_dense::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
 use segment::vector_storage::VectorStorage;
-use serde_json::json;
 use tempfile::Builder;
 
 #[test]
@@ -104,7 +104,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         let vector_multi = MultiDenseVectorInternal::new(preprocessed_vector, vector.len());
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         segment
             .upsert_point(

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -22,13 +22,12 @@ use segment::json_path::JsonPath;
 use segment::segment_constructor::build_segment;
 use segment::types::{
     BinaryQuantizationConfig, CompressionRatio, Condition, Distance, FieldCondition, Filter,
-    HnswConfig, Indexes, MultiVectorConfig, Payload, PayloadSchemaType, ProductQuantizationConfig,
+    HnswConfig, Indexes, MultiVectorConfig, PayloadSchemaType, ProductQuantizationConfig,
     QuantizationSearchParams, Range, ScalarQuantizationConfig, SearchParams, SegmentConfig,
     SeqNumberType, VectorDataConfig, VectorStorageType,
 };
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
-use serde_json::json;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 4;
@@ -199,6 +198,7 @@ fn test_multivector_quantization_hnsw(
     #[case] on_disk: bool,
     #[case] min_acc: f64, // out of 100
 ) {
+    use segment::payload_json;
     use segment::segment_constructor::VectorIndexBuildArgs;
 
     let stopped = AtomicBool::new(false);
@@ -248,7 +248,7 @@ fn test_multivector_quantization_hnsw(
         let vector = random_vector(&mut rnd, dim);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
-        let payload: Payload = json!({int_key:int_payload,}).into();
+        let payload = payload_json! {int_key: int_payload};
 
         segment
             .upsert_point(

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -8,10 +8,10 @@ use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::PayloadIndex;
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::payload_storage::PayloadStorage;
 use segment::types::{Condition, FieldCondition, Filter, Match, Payload, PayloadSchemaType, Range};
-use serde_json::json;
 use tempfile::Builder;
 
 const NUM_POINTS: usize = 200;
@@ -19,33 +19,30 @@ const NUM_POINTS: usize = 200;
 fn nested_payloads() -> Vec<Payload> {
     let mut res = Vec::new();
     for i in 0..NUM_POINTS {
-        let payload: Payload = json!(
+        let payload = payload_json! {
+            "arr1": [
+                {"a": 1, "b": i % 10 + 1, "c": i % 2 + 1, "d": i % 3, "text": format!("a1 b{} c{} d{}", i, i % 10 + 1,  i % 3) },
+                {"a": 2, "b": i % 10 + 2, "c": i % 2 + 1, "d": i % 3, "text": format!("a2 b{} c{} d{}", i, i % 10 + 2,  i % 3) },
+                {"a": 3, "b": i % 10 + 3, "c": i % 2 + 2, "d": i % 3, "text": format!("a3 b{} c{} d{}", i, i % 10 + 3,  i % 3) },
+                {"a": 4, "b": i % 10 + 4, "c": i % 2 + 2, "d": i % 3, "text": format!("a4 b{} c{} d{}", i, i % 10 + 4,  i % 3) },
+                {"a": [5, 6], "b": i % 10 + 5, "c": i % 2 + 2, "d": i % 3, "text": format!("a5 b{} c{} d{}", i, i % 10 + 5,  i % 3) },
+            ],
+            "f": i % 10,
+            "arr2": [
                 {
-                    "arr1": [
-                        {"a": 1, "b": i % 10 + 1, "c": i % 2 + 1, "d": i % 3, "text": format!("a1 b{} c{} d{}", i, i % 10 + 1,  i % 3) },
-                        {"a": 2, "b": i % 10 + 2, "c": i % 2 + 1, "d": i % 3, "text": format!("a2 b{} c{} d{}", i, i % 10 + 2,  i % 3) },
-                        {"a": 3, "b": i % 10 + 3, "c": i % 2 + 2, "d": i % 3, "text": format!("a3 b{} c{} d{}", i, i % 10 + 3,  i % 3) },
-                        {"a": 4, "b": i % 10 + 4, "c": i % 2 + 2, "d": i % 3, "text": format!("a4 b{} c{} d{}", i, i % 10 + 4,  i % 3) },
-                        {"a": [5, 6], "b": i % 10 + 5, "c": i % 2 + 2, "d": i % 3, "text": format!("a5 b{} c{} d{}", i, i % 10 + 5,  i % 3) },
-                    ],
-                    "f": i % 10,
-                    "arr2": [
-                        {
-                            "arr3": [
-                                { "a": 1, "b": i % 7 + 1 },
-                                { "a": 2, "b": i % 7 + 2 },
-                            ]
-                        },
-                        {
-                            "arr3": [
-                                { "a": 3, "b": i % 7 + 3 },
-                                { "a": 4, "b": i % 7 + 4 },
-                            ]
-                        }
-                    ],
+                    "arr3": [
+                        { "a": 1, "b": i % 7 + 1 },
+                        { "a": 2, "b": i % 7 + 2 },
+                    ]
+                },
+                {
+                    "arr3": [
+                        { "a": 3, "b": i % 7 + 3 },
+                        { "a": 4, "b": i % 7 + 4 },
+                    ]
                 }
-            )
-            .into();
+            ]
+        };
         res.push(payload);
     }
     res

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -30,6 +30,7 @@ use segment::index::field_index::{FieldIndex, PrimaryCondition};
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::PayloadIndex;
 use segment::json_path::JsonPath;
+use segment::payload_json;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::payload_storage::PayloadStorage;
 use segment::segment::Segment;
@@ -44,7 +45,6 @@ use segment::types::{
     VectorDataConfig, VectorStorageType, WithPayload,
 };
 use segment::utils::scored_point_ties::ScoredPointTies;
-use serde_json::json;
 use tempfile::{Builder, TempDir};
 
 const DIM: usize = 5;
@@ -1079,10 +1079,7 @@ fn test_update_payload_index_type() {
 
     let mut payloads: Vec<Payload> = vec![];
     for i in 0..point_num {
-        let payload = json!({
-            "field": i,
-        });
-        payloads.push(payload.into());
+        payloads.push(payload_json! {"field": i});
     }
 
     let hw_counter = HardwareCounterCell::new();

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -13,7 +13,6 @@ use segment::common::operation_error::OperationResult;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 use segment::entry::entry_point::SegmentEntry;
-use segment::fixture_for_all_indices;
 use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::fixtures::sparse_fixtures::{fixture_sparse_index, fixture_sparse_index_from_iter};
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
@@ -27,12 +26,12 @@ use segment::segment_constructor::{build_segment, load_segment};
 use segment::types::PayloadFieldSchema::FieldType;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
-    Condition, FieldCondition, Filter, Payload, ScoredPoint, SegmentConfig, SeqNumberType,
+    Condition, FieldCondition, Filter, ScoredPoint, SegmentConfig, SeqNumberType,
     SparseVectorDataConfig, SparseVectorStorageType, VectorName, VectorStorageDatatype,
     DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
 use segment::vector_storage::VectorStorage;
-use serde_json::json;
+use segment::{fixture_for_all_indices, payload_json};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_full_sparse_vector, random_sparse_vector};
 use sparse::common::types::DimId;
@@ -404,10 +403,7 @@ fn sparse_vector_index_ram_filtered_search() {
 
     // add payload on the first half of the points
     let half_indexed_count = sparse_vector_index.indexed_vector_count() / 2;
-    let payload: Payload = json!({
-        field_name: field_value,
-    })
-    .into();
+    let payload = payload_json! {field_name: field_value};
     let hw_counter = HardwareCounterCell::new();
     let mut payload_index = sparse_vector_index.payload_index().borrow_mut();
     for idx in 0..half_indexed_count {
@@ -477,10 +473,7 @@ fn sparse_vector_index_plain_search() {
     assert_eq!(before_plain_results.len(), 1);
     assert_eq!(before_plain_results[0].len(), 0);
 
-    let payload: Payload = json!({
-        field_name: field_value,
-    })
-    .into();
+    let payload = payload_json! {field_name: field_value};
 
     let hw_counter = HardwareCounterCell::new();
 


### PR DESCRIPTION
We have this impl:
https://github.com/qdrant/qdrant/blob/a72a5f43e8574ad7810dc45967c393cf6acf4163/lib/segment/src/types.rs#L1243-L1250

A `From` implementation that panics violates [this trait basic assumption](https://doc.rust-lang.org/std/convert/trait.From.html#when-to-implement-from). To avoid that, we could replace it with `TryFrom` and use `.try_into().unwrap()` instead of `.into()`. But in our code, this conversion is used solely to convert from `json!({…})` literals. So, a cleaner approach: introduce a macro `payload_json!` that couldn't fail.

This PR introduces a new macro `payload_json!` and replaces replaces usages like `json!({ "some": "thing" }).into()` with `payload_json! { "some": "thing" }`. The `From` impl is removed.