### PR TITLE
Fix gap finding logic

### DIFF
--- a/lib/blob_store/src/bitmask/gaps.rs
+++ b/lib/blob_store/src/bitmask/gaps.rs
@@ -261,7 +261,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::config::{StorageOptions, DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS};
+    use crate::config::{StorageOptions, DEFAULT_REGION_SIZE_BLOCKS};
 
     prop_compose! {
         fn arbitrary_region_gaps(region_size_blocks: u16)(
@@ -496,10 +496,9 @@ mod tests {
             .is_some());
 
         // No space for blocks covering more than 1.5 regions
-        assert!(
-            dbg!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS + (REGION_SIZE_BLOCKS / 1)))
-                .is_none()
-        );
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS + (REGION_SIZE_BLOCKS / 2) + 1)
+            .is_none());
     }
 
     #[test]

--- a/lib/blob_store/src/bitmask/gaps.rs
+++ b/lib/blob_store/src/bitmask/gaps.rs
@@ -184,13 +184,8 @@ impl BitmaskGaps {
     }
 
     /// Find a gap in the bitmask that is large enough to fit `num_blocks` blocks.
-    /// Returns the region id of the gap.
-    /// In case of boundary gaps, returns the region id of the left gap.
+    /// Returns the range of regions where the gap is.
     pub fn find_fitting_gap(&self, num_blocks: u32) -> Option<Range<RegionId>> {
-        let regions_needed = num_blocks.div_ceil(self.config.region_size_blocks as u32) as usize;
-
-        let window_size = regions_needed + 1;
-
         if self.mmap_slice.len() == 1 {
             return if self.get(0).unwrap().max as usize >= num_blocks as usize {
                 Some(0..1)
@@ -199,61 +194,52 @@ impl BitmaskGaps {
             };
         }
 
+        // try to find gap in the minimum regions needed
+        let regions_needed = num_blocks.div_ceil(self.config.region_size_blocks as u32) as usize;
+
+        let fits_in_min_regions = match regions_needed {
+            0 => unreachable!("num_blocks should be at least 1"),
+            // we might not need to merge any regions, just check the `max` field
+            1 => self
+                .as_slice()
+                .iter()
+                .enumerate()
+                .find_map(|(region_id, gap)| {
+                    if gap.max as usize >= num_blocks as usize {
+                        Some(region_id as RegionId..(region_id + 1) as RegionId)
+                    } else {
+                        None
+                    }
+                }),
+            // we need to merge at least 2 regions
+            window_size => self.find_merged_gap(window_size, num_blocks),
+        };
+
+        if fits_in_min_regions.is_some() {
+            return fits_in_min_regions;
+        }
+
+        // try to find gap by merging one more region (which is the maximum regions we may need for the value)
+        let window_size = regions_needed + 1;
+
+        self.find_merged_gap(window_size, num_blocks)
+    }
+
+    /// Find a gap in the bitmask that is large enough to fit `num_blocks` blocks, in a merged window of regions.
+    fn find_merged_gap(&self, window_size: usize, num_blocks: u32) -> Option<Range<RegionId>> {
+        debug_assert!(window_size >= 2, "window size must be at least 2");
+
         self.as_slice()
             .windows(window_size)
             .enumerate()
             .find_map(|(start_region_id, gaps)| {
-                // cover the case of large number of blocks
-                if window_size >= 3 {
-                    // check that the middle regions are empty
-                    for gap in gaps.iter().take(window_size - 1).skip(1) {
-                        if gap.max as usize != self.config.region_size_blocks {
-                            return None;
-                        }
-                    }
-                    let trailing = gaps[0].trailing;
-                    let leading = gaps[window_size - 1].leading;
-                    let merged_gap = (trailing + leading) as usize
-                        + (window_size - 2) * self.config.region_size_blocks;
+                let first_trailing = gaps[0].trailing;
+                let last_leading = gaps[window_size - 1].leading;
+                let merged_gap = (first_trailing + last_leading) as usize
+                    + (window_size - 2) * self.config.region_size_blocks;
 
-                    return if merged_gap as u32 >= num_blocks {
-                        Some(
-                            start_region_id as RegionId
-                                ..(start_region_id + window_size) as RegionId,
-                        )
-                    } else {
-                        None
-                    };
-                }
-
-                // windows of 2
-                debug_assert!(window_size == 2, "Unexpected window size");
-                let left = &gaps[0];
-                let right = &gaps[1];
-
-                // check it fits in the left region
-                if u32::from(left.max) >= num_blocks {
-                    // if both gaps are large enough, choose the smaller one
-                    if u32::from(right.max) >= num_blocks {
-                        return if left.max <= right.max {
-                            Some(start_region_id as RegionId..start_region_id as RegionId + 1)
-                        } else {
-                            Some(start_region_id as RegionId + 1..start_region_id as RegionId + 2)
-                        };
-                    }
-                    return Some(start_region_id as RegionId..start_region_id as RegionId + 1);
-                }
-
-                // check it fits in the right region
-                if u32::from(right.max) >= num_blocks {
-                    return Some(start_region_id as RegionId + 1..start_region_id as RegionId + 2);
-                }
-
-                // Otherwise, check if the gap in between them is large enough
-                let in_between = left.trailing + right.leading;
-
-                if u32::from(in_between) >= num_blocks {
-                    Some(start_region_id as RegionId..start_region_id as RegionId + 2)
+                if merged_gap as u32 >= num_blocks {
+                    Some(start_region_id as RegionId..(start_region_id + window_size) as RegionId)
                 } else {
                     None
                 }
@@ -373,6 +359,37 @@ mod tests {
                 prop_assert!(max_gap >= num_blocks, "max_gap: {}, num_blocks: {}", max_gap, num_blocks);
             }
         }
+    }
+
+    /// Tests that it is possible to find a large gap in the end of the gaps list
+    #[test]
+    fn test_find_fitting_gap_large() {
+        let large_value_blocks = DEFAULT_REGION_SIZE_BLOCKS + 20;
+
+        let gaps = [
+            RegionGaps {
+                max: 0,
+                leading: 0,
+                trailing: 0,
+            },
+            RegionGaps {
+                max: 500,
+                leading: 0,
+                trailing: 500,
+            },
+            RegionGaps::all_free(DEFAULT_REGION_SIZE_BLOCKS as u16),
+        ];
+
+        let temp_dir = tempdir().unwrap();
+        let config = StorageOptions::default().try_into().unwrap();
+        let mut bitmask_gaps =
+            BitmaskGaps::create(temp_dir.path(), gaps.clone().into_iter(), config);
+        assert!(bitmask_gaps.mmap_slice.len() >= 3);
+        bitmask_gaps.mmap_slice[0..3].clone_from_slice(&gaps[..]);
+
+        assert!(bitmask_gaps
+            .find_fitting_gap(large_value_blocks as u32)
+            .is_some());
     }
 
     #[test]

--- a/lib/blob_store/src/bitmask/gaps.rs
+++ b/lib/blob_store/src/bitmask/gaps.rs
@@ -504,7 +504,7 @@ mod tests {
 
     #[test]
     fn test_find_fitting_gap_windows_middle() {
-        const BLOCKS_PER_REGION: u32 = (DEFAULT_REGION_SIZE_BLOCKS / DEFAULT_BLOCK_SIZE_BYTES) as _;
+        const REGION_SIZE_BLOCKS: u32 = DEFAULT_REGION_SIZE_BLOCKS as u32;
 
         let temp_dir = tempdir().unwrap();
         let config = StorageOptions::default().try_into().unwrap();
@@ -519,31 +519,31 @@ mod tests {
             },
             // Second region: first 25% is occupied
             RegionGaps {
-                max: (BLOCKS_PER_REGION / 4) as u16 * 3,
+                max: (REGION_SIZE_BLOCKS / 4) as u16 * 3,
                 leading: 0,
-                trailing: (BLOCKS_PER_REGION / 4) as u16 * 3,
+                trailing: (REGION_SIZE_BLOCKS / 4) as u16 * 3,
             },
             // Third region: last 25% is occupied
             RegionGaps {
-                max: (BLOCKS_PER_REGION / 4) as u16 * 3,
-                leading: (BLOCKS_PER_REGION / 4) as u16 * 3,
+                max: (REGION_SIZE_BLOCKS / 4) as u16 * 3,
+                leading: (REGION_SIZE_BLOCKS / 4) as u16 * 3,
                 trailing: 0,
             },
         ];
         let bitmask_gaps = BitmaskGaps::create(temp_dir.path(), gaps.clone().into_iter(), config);
 
         // Find space for blocks covering up to 1.5 region
-        assert!(bitmask_gaps.find_fitting_gap(BLOCKS_PER_REGION).is_some());
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
         assert!(bitmask_gaps
-            .find_fitting_gap(BLOCKS_PER_REGION + 1)
+            .find_fitting_gap(REGION_SIZE_BLOCKS + 1)
             .is_some());
         assert!(bitmask_gaps
-            .find_fitting_gap(BLOCKS_PER_REGION + BLOCKS_PER_REGION / 2)
+            .find_fitting_gap(REGION_SIZE_BLOCKS + REGION_SIZE_BLOCKS / 2)
             .is_some());
 
         // No space for blocks covering more than 1.5 regions
         assert!(bitmask_gaps
-            .find_fitting_gap(BLOCKS_PER_REGION + BLOCKS_PER_REGION / 2 + 1)
+            .find_fitting_gap(REGION_SIZE_BLOCKS + REGION_SIZE_BLOCKS / 2 + 1)
             .is_none());
     }
 

--- a/lib/blob_store/src/bitmask/gaps.rs
+++ b/lib/blob_store/src/bitmask/gaps.rs
@@ -233,6 +233,14 @@ impl BitmaskGaps {
             .windows(window_size)
             .enumerate()
             .find_map(|(start_region_id, gaps)| {
+                // make sure the middle regions are all free
+                let middle_regions = &gaps[1..window_size - 1];
+                if middle_regions
+                    .iter()
+                    .any(|gap| gap.max as usize != self.config.region_size_blocks)
+                {
+                    return None;
+                }
                 let first_trailing = gaps[0].trailing;
                 let last_leading = gaps[window_size - 1].leading;
                 let merged_gap = (first_trailing + last_leading) as usize
@@ -253,7 +261,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::config::{StorageOptions, DEFAULT_REGION_SIZE_BLOCKS};
+    use crate::config::{StorageOptions, DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS};
 
     prop_compose! {
         fn arbitrary_region_gaps(region_size_blocks: u16)(
@@ -390,6 +398,153 @@ mod tests {
         assert!(bitmask_gaps
             .find_fitting_gap(large_value_blocks as u32)
             .is_some());
+    }
+
+    #[test]
+    fn test_find_fitting_gap_windows_end() {
+        const REGION_SIZE_BLOCKS: u32 = DEFAULT_REGION_SIZE_BLOCKS as u32;
+
+        let temp_dir = tempdir().unwrap();
+        let config: StorageConfig = StorageOptions::default().try_into().unwrap();
+
+        // 3 regions, all empty
+        let gaps = vec![
+            RegionGaps::all_free(REGION_SIZE_BLOCKS as u16),
+            RegionGaps::all_free(REGION_SIZE_BLOCKS as u16),
+            RegionGaps::all_free(REGION_SIZE_BLOCKS as u16),
+        ];
+        let bitmask_gaps =
+            BitmaskGaps::create(temp_dir.path(), gaps.clone().into_iter(), config.clone());
+
+        // Find space for blocks covering up to 2 regions
+        assert!(bitmask_gaps.find_fitting_gap(1).is_some());
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS * 2)
+            .is_some());
+
+        // Find space for blocks covering 3 regions
+        // TODO: fails, windows size is 4 but we have just 3 regions
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS * 2 + 1)
+            .is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS * 3)
+            .is_some());
+
+        // No space for blocks covering 4 or more regions
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS * 4)
+            .is_none());
+
+        // 3 regions with first 0.5 regions occupied and last 2.5 regions available
+        let gaps = vec![
+            RegionGaps {
+                max: (REGION_SIZE_BLOCKS / 2) as u16,
+                leading: 0,
+                trailing: (REGION_SIZE_BLOCKS / 2) as u16,
+            },
+            RegionGaps::all_free(REGION_SIZE_BLOCKS as u16),
+            RegionGaps::all_free(REGION_SIZE_BLOCKS as u16),
+        ];
+        let bitmask_gaps =
+            BitmaskGaps::create(temp_dir.path(), gaps.clone().into_iter(), config.clone());
+
+        // Find space for blocks covering up to 2 regions
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS * 2)
+            .is_some());
+
+        // Find space for blocks covering more than 2 up to 2.5 regions
+        // TODO: fails, windows size is 4 but we have just 3 regions
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS * 2 + 1)
+            .is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap((REGION_SIZE_BLOCKS * 2) + (REGION_SIZE_BLOCKS / 2))
+            .is_some());
+
+        // No space for blocks covering more than 2.5 regions
+        assert!(bitmask_gaps
+            .find_fitting_gap((REGION_SIZE_BLOCKS * 2) + (REGION_SIZE_BLOCKS / 2) + 1)
+            .is_none());
+
+        // 3 regions with first 1.5 regions occupied and last 1.5 regions available
+        let gaps = vec![
+            RegionGaps {
+                max: 0,
+                leading: 0,
+                trailing: 0,
+            },
+            RegionGaps {
+                max: (REGION_SIZE_BLOCKS / 2) as u16,
+                leading: 0,
+                trailing: (REGION_SIZE_BLOCKS / 2) as u16,
+            },
+            RegionGaps::all_free(REGION_SIZE_BLOCKS as u16),
+        ];
+        let bitmask_gaps = BitmaskGaps::create(temp_dir.path(), gaps.clone().into_iter(), config);
+
+        // Find space for blocks covering more than 1 to 1.5 regions
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS + 1)
+            .is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap(REGION_SIZE_BLOCKS + (REGION_SIZE_BLOCKS / 2))
+            .is_some());
+
+        // No space for blocks covering more than 1.5 regions
+        assert!(
+            dbg!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS + (REGION_SIZE_BLOCKS / 1)))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_find_fitting_gap_windows_middle() {
+        const BLOCKS_PER_REGION: u32 = (DEFAULT_REGION_SIZE_BLOCKS / DEFAULT_BLOCK_SIZE_BYTES) as _;
+
+        let temp_dir = tempdir().unwrap();
+        let config = StorageOptions::default().try_into().unwrap();
+
+        // 3 regions with 1.5 regions occupied and 1.5 regions available
+        let gaps = vec![
+            // First region: occupied
+            RegionGaps {
+                max: 0,
+                leading: 0,
+                trailing: 0,
+            },
+            // Second region: first 25% is occupied
+            RegionGaps {
+                max: (BLOCKS_PER_REGION / 4) as u16 * 3,
+                leading: 0,
+                trailing: (BLOCKS_PER_REGION / 4) as u16 * 3,
+            },
+            // Third region: last 25% is occupied
+            RegionGaps {
+                max: (BLOCKS_PER_REGION / 4) as u16 * 3,
+                leading: (BLOCKS_PER_REGION / 4) as u16 * 3,
+                trailing: 0,
+            },
+        ];
+        let bitmask_gaps = BitmaskGaps::create(temp_dir.path(), gaps.clone().into_iter(), config);
+
+        // Find space for blocks covering up to 1.5 region
+        assert!(bitmask_gaps.find_fitting_gap(BLOCKS_PER_REGION).is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap(BLOCKS_PER_REGION + 1)
+            .is_some());
+        assert!(bitmask_gaps
+            .find_fitting_gap(BLOCKS_PER_REGION + BLOCKS_PER_REGION / 2)
+            .is_some());
+
+        // No space for blocks covering more than 1.5 regions
+        assert!(bitmask_gaps
+            .find_fitting_gap(BLOCKS_PER_REGION + BLOCKS_PER_REGION / 2 + 1)
+            .is_none());
     }
 
     #[test]

--- a/lib/blob_store/src/bitmask/gaps.rs
+++ b/lib/blob_store/src/bitmask/gaps.rs
@@ -424,7 +424,6 @@ mod tests {
             .is_some());
 
         // Find space for blocks covering 3 regions
-        // TODO: fails, windows size is 4 but we have just 3 regions
         assert!(bitmask_gaps
             .find_fitting_gap(REGION_SIZE_BLOCKS * 2 + 1)
             .is_some());
@@ -457,7 +456,6 @@ mod tests {
             .is_some());
 
         // Find space for blocks covering more than 2 up to 2.5 regions
-        // TODO: fails, windows size is 4 but we have just 3 regions
         assert!(bitmask_gaps
             .find_fitting_gap(REGION_SIZE_BLOCKS * 2 + 1)
             .is_some());
@@ -497,7 +495,7 @@ mod tests {
 
         // No space for blocks covering more than 1.5 regions
         assert!(bitmask_gaps
-            .find_fitting_gap(REGION_SIZE_BLOCKS + (REGION_SIZE_BLOCKS / 2) + 1)
+            .find_fitting_gap(REGION_SIZE_BLOCKS + REGION_SIZE_BLOCKS / 2 + 1)
             .is_none());
     }
 

--- a/lib/blob_store/src/bitmask/mod.rs
+++ b/lib/blob_store/src/bitmask/mod.rs
@@ -42,7 +42,14 @@ impl Bitmask {
 
     /// Calculate the amount of trailing free blocks in the bitmask.
     pub fn trailing_free_blocks(&self) -> u32 {
-        self.regions_gaps.trailing_free_blocks()
+        let trailing_gap = self.regions_gaps.trailing_free_blocks();
+        #[cfg(debug_assertions)]
+        {
+            let num_trailing_zeros = self.bitslice.trailing_zeros();
+            debug_assert_eq!(num_trailing_zeros, trailing_gap as usize);
+        }
+
+        trailing_gap
     }
 
     /// Calculate the amount of bytes needed for covering the blocks of a page.

--- a/lib/blob_store/src/blob_store.rs
+++ b/lib/blob_store/src/blob_store.rs
@@ -633,14 +633,16 @@ mod tests {
         assert_eq!(files[4].file_name().unwrap(), "config.json");
     }
 
-    #[test]
-    fn test_put_payload() {
+    #[rstest]
+    #[case(100000, 2)]
+    #[case(100, 2000)]
+    fn test_put_payload(#[case] num_payloads: u32, #[case] payload_size_factor: usize) {
         let (_dir, mut storage) = empty_storage();
 
         let rng = &mut rand::rngs::SmallRng::from_entropy();
 
-        let mut payloads = (0..100000u32)
-            .map(|point_offset| (point_offset, random_payload(rng, 2)))
+        let mut payloads = (0..num_payloads)
+            .map(|point_offset| (point_offset, random_payload(rng, payload_size_factor)))
             .collect::<Vec<_>>();
 
         let hw_counter = HardwareCounterCell::new();


### PR DESCRIPTION
There was a case, where we were missing to scan a section of the gaps to find a spot to write. 

Even when having enough space in the last region + next to last region, the logic was exiting earlier and causing a panic because there were "allegedly" no more pages even after giving the opportunity to create them.

This PR rewrites the logic and fixes it by ensuring all cases are covered before responding that there is no gap large enough. Now it does one pass with the minimum amount of regions, and another one with the maximum if needed.