### PR TITLE
Use dynamic windows with sliding head/tail in find_fitting_gap

### DIFF
--- a/lib/blob_store/src/bitmask/gaps.rs
+++ b/lib/blob_store/src/bitmask/gaps.rs
@@ -186,13 +186,13 @@ impl BitmaskGaps {
     /// Find a gap in the bitmask that is large enough to fit `num_blocks` blocks.
     /// Returns the range of regions where the gap is.
     pub fn find_fitting_gap(&self, num_blocks: u32) -> Option<Range<RegionId>> {
-        if self.len() == 0 {
-            return None;
-        }
-
         let min_regions_needed =
             num_blocks.div_ceil(self.config.region_size_blocks as u32) as usize;
         let max_regions_needed = min_regions_needed + 1;
+
+        if self.len() < min_regions_needed {
+            return None;
+        }
 
         let (mut head, mut tail) = (0, 0);
 


### PR DESCRIPTION
Improvement on <https://github.com/qdrant/qdrant/pull/5882>
Alternative for <https://github.com/qdrant/qdrant/pull/5883>

Tweaks the `find_fitting_gap` and implements the dynamic sliding window with head/tail pointer as discussed in a call.

This _seeks_ the head and tail pointer forward until a range of regions is found with enough blocks to satisfy the requested size.

On each iteration, this scans backwards from the head (higher index) to the tail (lower index). This way we can jump the tail forward multiple steps if we find a region that is not fully empty.

All new tests added in <https://github.com/qdrant/qdrant/pull/5882> are included and succeed.

I did not benchmark this (yet).

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?