### PR TITLE
Support gpu devices without half float

### DIFF
--- a/lib/gpu/src/basic_test.rs
+++ b/lib/gpu/src/basic_test.rs
@@ -23,13 +23,11 @@ fn basic_gpu_test() {
 
     // Panic if case of wrong Vulkan API calls.
     let debug_messenger = crate::PanicIfErrorMessenger {};
-    // Use default CPU allocator.
-    let allocation_callbacks = None;
-    // Don't dump Vulkan API calls.
-    let dump_api = false;
     // Create Vulkan API instance.
-    let instance =
-        crate::Instance::new(Some(&debug_messenger), allocation_callbacks, dump_api).unwrap();
+    let instance = crate::Instance::builder()
+        .with_debug_messenger(&debug_messenger)
+        .build()
+        .unwrap();
     // Choose any GPU hardware to use.
     let physical_device = &instance.physical_devices()[0];
     // Create GPU device.

--- a/lib/gpu/src/device.rs
+++ b/lib/gpu/src/device.rs
@@ -143,7 +143,7 @@ impl Device {
         let has_half_precision = !instance.skip_half_precision()
             && enabled_physical_device_features_1_2.shader_float16 == 1;
         if !has_half_precision {
-            log::warn!("Half precision is not supported");
+            log::warn!("Half precision is not supported, falling back to full precision floats");
         }
         if !enabled_physical_device_features_1_2.storage_buffer8_bit_access == 0 {
             return Err(GpuError::NotSupported(

--- a/lib/gpu/src/device.rs
+++ b/lib/gpu/src/device.rs
@@ -109,8 +109,6 @@ impl Device {
 
         let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
-        // TODO(gpu): check presence of features
-
         // Define Vulkan features that we need.
         let mut enabled_physical_device_features_1_1 =
             vk::PhysicalDeviceVulkan11Features::default();
@@ -142,8 +140,8 @@ impl Device {
         if !enabled_physical_device_features_1_2.shader_int8 == 0 {
             return Err(GpuError::NotSupported("Int8 is not supported".to_string()));
         }
-        let has_half_precision = instance.skip_half_precision()
-            && enabled_physical_device_features_1_2.shader_float16 == 0;
+        let has_half_precision = !instance.skip_half_precision()
+            && enabled_physical_device_features_1_2.shader_float16 == 1;
         if !has_half_precision {
             log::warn!("Half precision is not supported");
         }
@@ -154,7 +152,7 @@ impl Device {
         }
         let mut physical_device_features_1_2 = vk::PhysicalDeviceVulkan12Features::default()
             .shader_int8(true)
-            .shader_float16(true)
+            .shader_float16(has_half_precision)
             .storage_buffer8_bit_access(true);
 
         // From Vulkan 1.3 we need subgroup size control if it's dynamic.

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -37,7 +37,7 @@ impl GpuDevicesMaganer {
         wait_free: bool,
         parallel_indexes: usize,
     ) -> OperationResult<Self> {
-        let instance = gpu::Instance::new(None, None, false)?;
+        let instance = gpu::Instance::builder().build()?;
 
         // Device filter is case-insensitive and comma-separated.
         let filter = filter.to_lowercase();

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_graph_builder.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_graph_builder.rs
@@ -140,7 +140,10 @@ mod tests {
     ) -> GraphLayersBuilder {
         let num_vectors = test.graph_layers_builder.links_layers().len();
         let debug_messenger = gpu::PanicIfErrorMessenger {};
-        let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+        let instance = gpu::Instance::builder()
+            .with_debug_messenger(&debug_messenger)
+            .build()
+            .unwrap();
         let device = gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap();
 
         let gpu_vector_storage = GpuVectorStorage::new(

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_heap_tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_heap_tests.rs
@@ -66,7 +66,10 @@ fn test_gpu_nearest_heap(#[values(true, false)] linear: bool) {
         .collect();
 
     let debug_messenger = gpu::PanicIfErrorMessenger {};
-    let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+    let instance = gpu::Instance::builder()
+        .with_debug_messenger(&debug_messenger)
+        .build()
+        .unwrap();
     let device = gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap();
 
     let gpu_nearest_heap = GpuHeapTestConfig { ef, linear };
@@ -267,7 +270,10 @@ fn test_gpu_candidates_heap(#[values(true, false)] linear: bool) {
         .collect();
 
     let debug_messenger = gpu::PanicIfErrorMessenger {};
-    let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+    let instance = gpu::Instance::builder()
+        .with_debug_messenger(&debug_messenger)
+        .build()
+        .unwrap();
     let device = gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap();
 
     let gpu_candidates_heap = GpuHeapTestConfig {

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -529,7 +529,10 @@ mod tests {
 
         // Create GPU search context
         let debug_messenger = gpu::PanicIfErrorMessenger {};
-        let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+        let instance = gpu::Instance::builder()
+            .with_debug_messenger(&debug_messenger)
+            .build()
+            .unwrap();
         let device = gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap();
 
         let gpu_vector_storage =

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_level_builder.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_level_builder.rs
@@ -134,7 +134,10 @@ mod tests {
             create_graph_layers_builder(&batched_points, num_vectors, m, m0, ef, 1);
 
         let debug_messenger = gpu::PanicIfErrorMessenger {};
-        let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+        let instance = gpu::Instance::builder()
+            .with_debug_messenger(&debug_messenger)
+            .build()
+            .unwrap();
         let device = gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap();
 
         let gpu_vector_storage = GpuVectorStorage::new(

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -583,6 +583,7 @@ fn create_vector_storage_u8_multi(
 }
 
 #[cfg(test)]
+#[allow(clippy::too_many_arguments)]
 fn test_gpu_vector_storage_impl(
     storage_type: TestStorageType,
     num_vectors: usize,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -103,6 +103,7 @@ fn test_gpu_vector_storage_sq(
         distance,
         Some(quantization_config.clone()),
         false,
+        false,
         precision,
     );
 }
@@ -149,6 +150,7 @@ fn test_gpu_vector_storage_bq(
         distance,
         Some(quantization_config.clone()),
         false,
+        false,
         precision,
     );
 }
@@ -193,6 +195,7 @@ fn test_gpu_vector_storage_pq(
         dim,
         distance,
         Some(quantization_config.clone()),
+        false,
         false,
         precision,
     );
@@ -239,6 +242,7 @@ fn test_gpu_vector_storage(
         distance,
         None,
         false,
+        false,
         precision,
     );
 }
@@ -275,6 +279,45 @@ fn test_gpu_vector_storage_force_half(
         distance,
         None,
         true, // force half precision
+        false,
+        precision,
+    );
+}
+
+#[rstest]
+fn test_gpu_vector_storage_without_half(
+    #[values(Distance::Cosine)] distance: Distance,
+    #[values(
+        TestStorageType::Dense(TestElementType::Float32),
+        TestStorageType::Multi(TestElementType::Float32),
+        TestStorageType::Dense(TestElementType::Float16),
+        TestStorageType::Multi(TestElementType::Float16)
+    )]
+    storage_type: TestStorageType,
+    #[values(15)] dim: usize,
+    #[values(2048 + 17)] num_vectors: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let precision = 5.0 * get_precision(storage_type, dim, distance);
+    log::info!(
+        "Testing distance {:?}, element type {:?}, dim {} with precision {}",
+        distance,
+        storage_type,
+        dim,
+        precision
+    );
+    test_gpu_vector_storage_impl(
+        storage_type,
+        num_vectors,
+        dim,
+        distance,
+        None,
+        true, // force half precision
+        true, // skip half support
         precision,
     );
 }
@@ -547,6 +590,7 @@ fn test_gpu_vector_storage_impl(
     distance: Distance,
     quantization_config: Option<QuantizationConfig>,
     force_half_precision: bool,
+    skip_half_support: bool,
     precision: f32,
 ) {
     let test_point_id: PointOffsetType = 0;
@@ -560,7 +604,11 @@ fn test_gpu_vector_storage_impl(
     });
 
     let debug_messenger = gpu::PanicIfErrorMessenger {};
-    let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+    let instance = gpu::Instance::builder()
+        .with_debug_messenger(&debug_messenger)
+        .with_skip_half_precision(skip_half_support)
+        .build()
+        .unwrap();
     let device = gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap();
 
     let gpu_vector_storage = GpuVectorStorage::new(
@@ -580,13 +628,19 @@ fn test_gpu_vector_storage_impl(
         } else {
             match storage_type.element_type() {
                 TestElementType::Float32 => {
-                    if force_half_precision {
+                    if force_half_precision && device.has_half_precision() {
                         VectorStorageDatatype::Float16
                     } else {
                         VectorStorageDatatype::Float32
                     }
                 }
-                TestElementType::Float16 => VectorStorageDatatype::Float16,
+                TestElementType::Float16 => {
+                    if device.has_half_precision() {
+                        VectorStorageDatatype::Float16
+                    } else {
+                        VectorStorageDatatype::Float32
+                    }
+                }
                 TestElementType::Uint8 => VectorStorageDatatype::Uint8,
             }
         }

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -136,7 +136,10 @@ fn test_gpu_filterable_hnsw() {
     let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
 
     let debug_messenger = gpu::PanicIfErrorMessenger {};
-    let instance = gpu::Instance::new(Some(&debug_messenger), None, false).unwrap();
+    let instance = gpu::Instance::builder()
+        .with_debug_messenger(&debug_messenger)
+        .build()
+        .unwrap();
     let device =
         Mutex::new(gpu::Device::new(instance.clone(), &instance.physical_devices()[0]).unwrap());
     let locked_device = LockedGpuDevice::new(device.lock());


### PR DESCRIPTION
Fix https://github.com/qdrant/qdrant/issues/5872

If GPU does not support f16, use f32 instead.

This PR includes:
1. Fix the bug. Convert all `f16` into `f32` when GPU does not support `f16`.
2. Provide `skip_half_precision` to force disabled halfs in tests.
3. Unit test for this case.
4. Fix printing of missed GPU features.
5. Builder for `gpu::Instance` cause there are too many optional parameters.

GPU CI: https://github.com/qdrant/qdrant/actions/runs/12999767731