### PR TITLE
Bump version to 1.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "api"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "chrono",
  "common",
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.13.1"
+version = "1.13.2"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.13.1"
+version = "1.13.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.13.1";
+pub const QDRANT_VERSION_STRING: &str = "1.13.2";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=05e38230667f9b8d6222795c512ac9e6ca62d5a3
+IGNORE_UPTO=0af7be081ef53d9fb2063e17932d7063b2ccc90e
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Release PR for Qdrant 1.13.2.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/5864>.