### PR TITLE
Turn for_each_packed_link into iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "ph",
  "rand 0.9.0",
+ "rstest",
  "self_cell",
  "semver",
  "serde",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -39,6 +39,7 @@ log = { workspace = true }
 common = { path = ".", features = ["testing"] }
 criterion = { workspace = true }
 itertools = { workspace = true }
+rstest = { workspace = true }
 self_cell = "1.1.0"
 tango-bench = "0.6.0"
 

--- a/lib/common/common/benches/bitpacking.rs
+++ b/lib/common/common/benches/bitpacking.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use common::bitpacking::{BitReader, BitWriter};
-use common::bitpacking_links::{for_each_packed_link, pack_links};
+use common::bitpacking_links::{iterate_packed_links, pack_links};
 use common::bitpacking_ordered;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use itertools::Itertools as _;
@@ -94,7 +94,7 @@ pub fn bench_bitpacking_links(c: &mut Criterion) {
                 (&links[pos[idx - 1].0..pos[idx].0], pos[idx].1, pos[idx].2)
             },
             |(links, bits_per_unsorted, sorted_count)| {
-                for_each_packed_link(links, bits_per_unsorted, sorted_count, |x| {
+                iterate_packed_links(links, bits_per_unsorted, sorted_count).for_each(|x| {
                     black_box(x);
                 });
             },

--- a/lib/common/common/benches/bitpacking_tango.rs
+++ b/lib/common/common/benches/bitpacking_tango.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 use std::rc::Rc;
 
 use common::bitpacking::{BitReader, BitWriter};
-use common::bitpacking_links::for_each_packed_link;
+use common::bitpacking_links::iterate_packed_links;
 use common::bitpacking_ordered;
 use itertools::Itertools as _;
 use rand::rngs::StdRng;
@@ -114,14 +114,14 @@ fn benchmarks_bitpacking_links() -> impl IntoBenchmarks {
         let mut rng = rand::rng();
         b.iter(move || {
             let idx = rng.random_range(1..state.items.len());
-            for_each_packed_link(
+            iterate_packed_links(
                 &state.links[state.items[idx - 1].offset..state.items[idx].offset],
                 state.items[idx].bits_per_unsorted,
                 state.items[idx].sorted_count,
-                |x| {
-                    black_box(x);
-                },
-            );
+            )
+            .for_each(|x| {
+                black_box(x);
+            });
         })
     })]
 }

--- a/lib/common/common/src/bitpacking.rs
+++ b/lib/common/common/src/bitpacking.rs
@@ -104,6 +104,14 @@ impl<'a> BitReader<'a> {
         self.mask = make_bitmask(bits);
     }
 
+    /// Returns the number of bits set with [`set_bits()`].
+    ///
+    /// [`set_bits()`]: Self::set_bits
+    #[inline]
+    pub fn bits(&self) -> u8 {
+        self.bits
+    }
+
     /// Read next `bits` bits from the input. The amount of bits must be set
     /// with [`set_bits()`] before calling this method.
     ///

--- a/lib/common/common/src/bitpacking_links.rs
+++ b/lib/common/common/src/bitpacking_links.rs
@@ -194,6 +194,8 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::iterator_ext::{check_exact_size_iterator_len, check_iterator_fold};
+
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum Cases {
         OnlyUnsorted = 0,
@@ -249,12 +251,18 @@ mod tests {
             );
 
             let mut unpacked = Vec::new();
-            for_each_packed_link(&links, bits_per_unsorted, sorted_count, |value| {
-                unpacked.push(value);
-            });
+            let iter = iterate_packed_links(&links, bits_per_unsorted, sorted_count);
+            iter.for_each(|value| unpacked.push(value));
 
             raw_links[..sorted_count.min(total_count)].sort_unstable();
             assert_eq!(raw_links, unpacked);
+
+            check_iterator_fold(|| iterate_packed_links(&links, bits_per_unsorted, sorted_count));
+            check_exact_size_iterator_len(iterate_packed_links(
+                &links,
+                bits_per_unsorted,
+                sorted_count,
+            ));
         }
     }
 

--- a/lib/common/common/src/bitpacking_links.rs
+++ b/lib/common/common/src/bitpacking_links.rs
@@ -65,41 +65,126 @@ pub fn for_each_packed_link(
     links: &[u8],
     bits_per_unsorted: u8,
     sorted_count: usize,
-    mut f: impl FnMut(u32),
+    f: impl FnMut(u32),
 ) {
-    if links.is_empty() {
-        return;
-    }
+    iterate_packed_links(links, bits_per_unsorted, sorted_count).for_each(f)
+}
 
-    let mut r = BitReader::new(links);
+/// Returns an iterator over packed links.
+/// See [`pack_links`] for parameter descriptions.
+#[inline]
+pub fn iterate_packed_links(
+    links: &[u8],
+    bits_per_unsorted: u8,
+    sorted_count: usize,
+) -> PackedLinksIterator {
+    let mut reader = BitReader::new(links);
 
     let mut remaining_bits = links.len() * u8::BITS as usize;
-    if sorted_count != 0 {
+    let mut remaining_bits_target = remaining_bits;
+    if sorted_count != 0 && !links.is_empty() {
         // 1. Header.
-        r.set_bits(HEADER_BITS);
-        let bits_per_sorted = r.read::<u8>() + MIN_BITS_PER_VALUE;
+        reader.set_bits(HEADER_BITS);
+        let bits_per_sorted = reader.read::<u8>() + MIN_BITS_PER_VALUE;
         remaining_bits -= HEADER_BITS as usize;
 
-        // 2. First `sorted_count` values, sorted and delta-encoded.
-        r.set_bits(bits_per_sorted);
-        let remaining_bits_target = remaining_bits
-            - sorted_count.min(remaining_bits / bits_per_sorted as usize)
-                * bits_per_sorted as usize;
-        let mut value = 0;
-        while remaining_bits > remaining_bits_target {
-            value += r.read::<u32>();
-            f(value);
-            remaining_bits -= bits_per_sorted as usize;
-        }
+        // Prepare for reading sorted values.
+        reader.set_bits(bits_per_sorted);
+        let max_sorted = remaining_bits / bits_per_sorted as usize;
+        remaining_bits_target -= sorted_count.min(max_sorted) * bits_per_sorted as usize;
+    } else {
+        // Prepare for reading unsorted values.
+        reader.set_bits(bits_per_unsorted);
     }
 
-    // 3. The rest of the values, unsorted.
-    r.set_bits(bits_per_unsorted);
-    while remaining_bits >= bits_per_unsorted as usize {
-        f(r.read());
-        remaining_bits -= bits_per_unsorted as usize;
+    PackedLinksIterator {
+        reader,
+        bits_per_unsorted,
+        remaining_bits,
+        remaining_bits_target,
+        current_delta: 0,
     }
 }
+
+/// Iterator over links packed with [`pack_links`].
+/// Created by [`iterate_packed_links`].
+pub struct PackedLinksIterator<'a> {
+    reader: BitReader<'a>,
+    bits_per_unsorted: u8,
+    remaining_bits: usize,
+    remaining_bits_target: usize,
+    current_delta: u32,
+}
+
+impl PackedLinksIterator<'_> {
+    #[inline]
+    fn next_sorted(&mut self) -> u32 {
+        self.current_delta = self.current_delta.wrapping_add(self.reader.read::<u32>());
+        self.remaining_bits -= self.reader.bits() as usize;
+        self.current_delta
+    }
+
+    #[inline]
+    fn next_unsorted(&mut self) -> Option<u32> {
+        if let Some(rb) = self.remaining_bits.checked_sub(self.reader.bits() as usize) {
+            self.remaining_bits = rb;
+            Some(self.reader.read::<u32>())
+        } else {
+            None
+        }
+    }
+}
+
+impl Iterator for PackedLinksIterator<'_> {
+    type Item = u32;
+
+    #[inline]
+    fn next(&mut self) -> Option<u32> {
+        if self.remaining_bits > self.remaining_bits_target {
+            let value = self.next_sorted();
+            if self.remaining_bits <= self.remaining_bits_target {
+                // It was the last sorted value.
+                self.reader.set_bits(self.bits_per_unsorted);
+            }
+            return Some(value);
+        }
+
+        self.next_unsorted()
+    }
+
+    /// Optimized [`Iterator::fold()`]. Should be faster than calling
+    /// [`Iterator::next()`] in a loop.
+    ///
+    /// It is used in a hot loop during HNSW search, so performance is critical.
+    #[inline]
+    fn fold<Acc, F: FnMut(Acc, u32) -> Acc>(mut self, mut acc: Acc, mut f: F) -> Acc {
+        while self.remaining_bits > self.remaining_bits_target {
+            acc = f(acc, self.next_sorted());
+        }
+
+        self.reader.set_bits(self.bits_per_unsorted);
+        while let Some(value) = self.next_unsorted() {
+            acc = f(acc, value);
+        }
+
+        acc
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (sorted, unsorted);
+        if let Some(sorted_bits) = self.remaining_bits.checked_sub(self.remaining_bits_target) {
+            let sorted_bits = sorted_bits.next_multiple_of(self.reader.bits() as usize);
+            sorted = sorted_bits / self.reader.bits() as usize;
+            unsorted = (self.remaining_bits - sorted_bits) / self.bits_per_unsorted as usize;
+        } else {
+            sorted = 0;
+            unsorted = self.remaining_bits / self.reader.bits() as usize;
+        }
+        (sorted + unsorted, Some(sorted + unsorted))
+    }
+}
+
+impl ExactSizeIterator for PackedLinksIterator<'_> {}
 
 #[cfg(test)]
 mod tests {

--- a/lib/common/common/src/bitpacking_links.rs
+++ b/lib/common/common/src/bitpacking_links.rs
@@ -58,18 +58,6 @@ pub fn pack_links(
     w.finish();
 }
 
-/// Iterate over packed links and apply a function to each value.
-/// See [`pack_links`] for parameter descriptions.
-#[inline]
-pub fn for_each_packed_link(
-    links: &[u8],
-    bits_per_unsorted: u8,
-    sorted_count: usize,
-    f: impl FnMut(u32),
-) {
-    iterate_packed_links(links, bits_per_unsorted, sorted_count).for_each(f)
-}
-
 /// Returns an iterator over packed links.
 /// See [`pack_links`] for parameter descriptions.
 #[inline]

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -180,11 +180,11 @@ impl GraphLayersBase for GraphLayers {
         self.visited_pool.get(self.links.num_points())
     }
 
-    fn links_map<F>(&self, point_id: PointOffsetType, level: usize, mut f: F)
+    fn links_map<F>(&self, point_id: PointOffsetType, level: usize, f: F)
     where
         F: FnMut(PointOffsetType),
     {
-        self.links.for_each_link(point_id, level, &mut f);
+        self.links.links(point_id, level).for_each(f);
     }
 
     fn get_m(&self, level: usize) -> usize {
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(main_entry.level, num_levels);
 
         let total_links_0 = (0..num_vectors)
-            .map(|i| graph_layers.links.links_vec(i as PointOffsetType, 0).len())
+            .map(|i| graph_layers.links.links(i as PointOffsetType, 0).len())
             .sum::<usize>();
 
         eprintln!("total_links_0 = {total_links_0:#?}");

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -750,7 +750,10 @@ mod tests {
         assert_eq!(orig_len, builder_len);
 
         for idx in 0..builder_len {
-            let links_orig = &graph_layers_orig.links.links_vec(idx as PointOffsetType, 0);
+            let links_orig = &graph_layers_orig
+                .links
+                .links(idx as PointOffsetType, 0)
+                .collect_vec();
             let links_builder = graph_layers_builder.links_layers[idx][0].read();
             let link_container_from_builder = links_builder.iter().copied().collect::<Vec<_>>();
             let m = match format {
@@ -851,12 +854,12 @@ mod tests {
 
         let layers910 = graph_layers.links.point_level(910);
         let links910 = (0..layers910 + 1)
-            .map(|i| graph_layers.links.links_vec(910, i))
-            .collect::<Vec<_>>();
+            .map(|i| graph_layers.links.links(910, i).collect())
+            .collect::<Vec<Vec<_>>>();
         eprintln!("graph_layers.links_layers[910] = {links910:#?}",);
 
         let total_edges: usize = (0..NUM_VECTORS)
-            .map(|i| graph_layers.links.links_vec(i as PointOffsetType, 0).len())
+            .map(|i| graph_layers.links.links(i as PointOffsetType, 0).len())
             .sum();
         let avg_connectivity = total_edges as f64 / NUM_VECTORS as f64;
         eprintln!("avg_connectivity = {avg_connectivity:#?}");

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -14,7 +14,7 @@ mod serializer;
 mod view;
 
 pub use serializer::GraphLinksSerializer;
-use view::{CompressionInfo, GraphLinksView};
+use view::{CompressionInfo, GraphLinksView, LinksIterator};
 
 /*
 Links data for whole graph layers.
@@ -118,17 +118,16 @@ impl GraphLinks {
         level: usize,
         f: impl FnMut(PointOffsetType),
     ) {
-        self.view().for_each_link(point_id, level, f)
+        self.links(point_id, level).for_each(f);
+    }
+
+    #[inline]
+    pub fn links(&self, point_id: PointOffsetType, level: usize) -> LinksIterator {
+        self.view().links(point_id, level)
     }
 
     pub fn point_level(&self, point_id: PointOffsetType) -> usize {
         self.view().point_level(point_id)
-    }
-
-    pub fn links_vec(&self, point_id: PointOffsetType, level: usize) -> Vec<PointOffsetType> {
-        let mut links = Vec::new();
-        self.for_each_link(point_id, level, |link| links.push(link));
-        links
     }
 
     /// Convert the graph links to a vector of edges, suitable for passing into
@@ -139,7 +138,7 @@ impl GraphLinks {
             let num_levels = self.point_level(point_id as PointOffsetType) + 1;
             let mut levels = Vec::with_capacity(num_levels);
             for level in 0..num_levels {
-                levels.push(self.links_vec(point_id as PointOffsetType, level));
+                levels.push(self.links(point_id as PointOffsetType, level).collect());
             }
             edges.push(levels);
         }

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -1,5 +1,5 @@
 use common::bitpacking::packed_bits;
-use common::bitpacking_links::{for_each_packed_link, MIN_BITS_PER_VALUE};
+use common::bitpacking_links::{iterate_packed_links, MIN_BITS_PER_VALUE};
 use common::bitpacking_ordered;
 use common::types::PointOffsetType;
 use itertools::Itertools as _;
@@ -120,12 +120,12 @@ impl GraphLinksView<'_> {
             } => {
                 let links_range =
                     offsets.get(idx).unwrap() as usize..offsets.get(idx + 1).unwrap() as usize;
-                for_each_packed_link(
+                iterate_packed_links(
                     &compressed_links[links_range],
                     bits_per_unsorted,
                     if level == 0 { m0 } else { m },
-                    f,
-                );
+                )
+                .for_each(f);
             }
         }
     }

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -1,8 +1,10 @@
+use std::iter::Copied;
+
 use common::bitpacking::packed_bits;
-use common::bitpacking_links::{iterate_packed_links, MIN_BITS_PER_VALUE};
+use common::bitpacking_links::{iterate_packed_links, PackedLinksIterator, MIN_BITS_PER_VALUE};
 use common::bitpacking_ordered;
 use common::types::PointOffsetType;
-use itertools::Itertools as _;
+use itertools::{Either, Itertools as _};
 use zerocopy::native_endian::U64 as NativeU64;
 use zerocopy::{FromBytes, Immutable};
 
@@ -22,6 +24,9 @@ pub(super) struct GraphLinksView<'a> {
     /// - Additional element is added during deserialization.
     pub(super) level_offsets: Vec<u64>,
 }
+
+/// An iterator type returned by [`GraphLinksView::links`].
+pub type LinksIterator<'a> = Either<Copied<std::slice::Iter<'a, u32>>, PackedLinksIterator<'a>>;
 
 #[derive(Debug)]
 pub(super) enum CompressionInfo<'a> {
@@ -94,12 +99,7 @@ impl GraphLinksView<'_> {
         })
     }
 
-    pub(super) fn for_each_link(
-        &self,
-        point_id: PointOffsetType,
-        level: usize,
-        f: impl FnMut(PointOffsetType),
-    ) {
+    pub(super) fn links(&self, point_id: PointOffsetType, level: usize) -> LinksIterator {
         let idx = if level == 0 {
             point_id as usize
         } else {
@@ -109,7 +109,7 @@ impl GraphLinksView<'_> {
         match self.compression {
             CompressionInfo::Uncompressed { links, offsets } => {
                 let links_range = offsets[idx].get() as usize..offsets[idx + 1].get() as usize;
-                links[links_range].iter().copied().for_each(f)
+                Either::Left(links[links_range].iter().copied())
             }
             CompressionInfo::Compressed {
                 compressed_links,
@@ -120,12 +120,11 @@ impl GraphLinksView<'_> {
             } => {
                 let links_range =
                     offsets.get(idx).unwrap() as usize..offsets.get(idx + 1).unwrap() as usize;
-                iterate_packed_links(
+                Either::Right(iterate_packed_links(
                     &compressed_links[links_range],
                     bits_per_unsorted,
                     if level == 0 { m0 } else { m },
-                )
-                .for_each(f);
+                ))
             }
         }
     }

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -106,11 +106,11 @@ fn test_graph_connectivity() {
     let mut reverse_links = vec![vec![]; num_vectors as usize];
 
     for point_id in 0..num_vectors {
-        let links = hnsw_index
+        for link in hnsw_index
             .graph()
             .links
-            .links_vec(point_id as PointOffsetType, 0);
-        for link in links {
+            .links(point_id as PointOffsetType, 0)
+        {
             reverse_links[link as usize].push(point_id);
         }
     }


### PR DESCRIPTION
Initially, a simple interface of `for_each_packed_link()` was enough for a search use case. However, it's not convenient for other cases (e.g. incremental HNSW); a proper `Iterator` is more convenient.

This PR replaces `fn for_each_packed_link()` with `fn iterate_packed_links()` which returns an `Iterator`.

<table><th>Old<th>New<tr><td>

```rust
pub fn for_each_packed_link(
    links: &[u8],
    bits_per_unsorted: u8,
    sorted_count: usize,
    mut f: impl FnMut(u32),
) {                               
```

<td>

```rust
pub fn iterate_packed_links(
    links: &[u8],
    bits_per_unsorted: u8,
    sorted_count: usize,
) -> PackedLinksIterator {        
```

</table>

A special care is taken to make the performance not worse by overriding the provided method `Iterator::fold()` instead of relying just on `Iterator::next()`.

Additionally, tests for `common::bitpacking_links` module are extended to cover more cases.

This PR could be reviewed on a per-commit basis.