### PR TITLE
Compact Raft WAL until last *applied* entry, not until first *unapplied*

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -784,20 +784,15 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             return Ok(false);
         };
 
-        let Some(applied_index) = self.persistent.read().last_applied_entry() else {
+        let Some(last_applied_index) = self.persistent.read().last_applied_entry() else {
             return Ok(false);
         };
 
-        let first_unapplied_index = applied_index + 1;
-
-        // ToDo: it seems like a mistake, need to check if it's correct
-        // debug_assert!(first_unapplied_index <= first_entry.index);
-
-        if first_unapplied_index - first_entry.index < min_entries_to_compact {
+        if last_applied_index - first_entry.index < min_entries_to_compact {
             return Ok(false);
         }
 
-        self.wal.lock().compact(first_unapplied_index)?;
+        self.wal.lock().compact(last_applied_index)?;
         Ok(true)
     }
 


### PR DESCRIPTION
This PR should fix current issue we see on chaos-testing. Seems like Raft needs to be able to access the last committed (i.e., "applied") entry. My bad, documentation on compaction is not stellar. ¯\\\_(ツ)\_/¯

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
