### PR TITLE
Enable consensus compaction by default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -320,6 +320,12 @@ cluster:
     # We encourage you NOT to change this parameter unless you know what you are doing.
     tick_period_ms: 100
 
+    # Compact consensus operations once we have this amount of applied
+    # operations. Allows peers to join quickly with a consensus snapshot without
+    # replaying a huge amount of operations.
+    # If 0 - disable compaction
+    compact_wal_entries: 128
+
 # Set to true to prevent service from sending usage statistics to the developers.
 # Read more: https://qdrant.tech/documentation/guides/telemetry
 telemetry_disabled: false

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -114,8 +114,9 @@ pub struct ConsensusConfig {
     #[validate(range(min = 1))]
     #[serde(default = "default_message_timeout_tics")]
     pub message_timeout_ticks: u64,
-    #[serde(default)]
-    pub compact_wal_entries: u64, // compact WAL when it grows to enough applied entries
+    /// Compact WAL when it grows to enough applied entries
+    #[serde(default = "default_compact_wal_entries")]
+    pub compact_wal_entries: u64,
 }
 
 impl Default for ConsensusConfig {
@@ -125,7 +126,7 @@ impl Default for ConsensusConfig {
             tick_period_ms: default_tick_period_ms(),
             bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
             message_timeout_ticks: default_message_timeout_tics(),
-            compact_wal_entries: 0,
+            compact_wal_entries: default_compact_wal_entries(),
         }
     }
 }
@@ -381,6 +382,10 @@ const fn default_connection_pool_size() -> usize {
 
 const fn default_message_timeout_tics() -> u64 {
     10
+}
+
+const fn default_compact_wal_entries() -> u64 {
+    128
 }
 
 #[allow(clippy::unnecessary_wraps)] // Used as serde default


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/5905>

Enable compaction of consensus operations by default. This imposes two key benefits:

- joining peers don't have to replay a huge amount of operations and can get up to speed quickly through a consensus snapshot
- more robust consensus because consensus snapshots provides a fixed state as new starting point

We should confirm if <https://github.com/qdrant/qdrant/pull/5900> fixes the current ongoing consensus problems in chaos testing before merging this PR.

I used 128 instead of 100 because it is a nice round number :smiley:

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?