### PR TITLE
Allow to set peer and boostrap URI through environment variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ itertools = { workspace = true }
 anyhow = "1.0.95"
 futures = { workspace = true }
 futures-util = { workspace = true }
-clap = { version = "4.5.27", features = ["derive"] }
+clap = { version = "4.5.27", features = ["derive", "env"] }
 serde_cbor = { workspace = true }
 uuid = { workspace = true }
 sys-info = "0.9.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ const FULL_ACCESS: Access = Access::full("For main");
 struct Args {
     /// Uri of the peer to bootstrap from in case of multi-peer deployment.
     /// If not specified - this peer will be considered as a first in a new deployment.
-    #[arg(long, value_parser, value_name = "URI")]
+    #[arg(long, value_parser, value_name = "URI", env = "QDRANT_BOOTSTRAP")]
     bootstrap: Option<Uri>,
     /// Uri of this peer.
     /// Other peers should be able to reach it by this uri.
@@ -78,7 +78,7 @@ struct Args {
     ///
     /// In case this is not the first peer and it bootstraps the value is optional.
     /// If not supplied then qdrant will take internal grpc port from config and derive the IP address of this peer on bootstrap peer (receiving side)
-    #[arg(long, value_parser, value_name = "URI")]
+    #[arg(long, value_parser, value_name = "URI", env = "QDRANT_URI")]
     uri: Option<Uri>,
 
     /// Force snapshot re-creation


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/5880>

This allows you to start Qdrant in cluster mode without any CLI arguments, like:

```bash
QDRANT__CLUSTER__ENABLED=true QDRANT_URI=https://localhost:6335/ ./qdrant
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?