### PR TITLE
Fix subtract overflow when counting consensus compact entries

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -788,7 +788,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             return Ok(false);
         };
 
-        if last_applied_index - first_entry.index < min_entries_to_compact {
+        if last_applied_index.saturating_sub(first_entry.index) < min_entries_to_compact {
             return Ok(false);
         }
 

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -788,6 +788,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             return Ok(false);
         };
 
+        debug_assert!(last_applied_index == 0 || last_applied_index >= first_entry.index - 1);
         if last_applied_index.saturating_sub(first_entry.index) < min_entries_to_compact {
             return Ok(false);
         }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -788,7 +788,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             return Ok(false);
         };
 
-        debug_assert!(last_applied_index == 0 || last_applied_index >= first_entry.index - 1);
+        debug_assert!(last_applied_index >= first_entry.index || last_applied_index == 0);
         if last_applied_index.saturating_sub(first_entry.index) < min_entries_to_compact {
             return Ok(false);
         }


### PR DESCRIPTION
Fix for new subtraction overflow in <https://github.com/qdrant/qdrant/pull/5900>.

Without this fix I get the following text failure in <https://github.com/qdrant/qdrant/pull/5903> when consensus snapshots are enabled:

```
2025-01-29T15:55:15.176888Z ERROR qdrant::startup: Panic occurred in file /home/timvisee/git/qdrant/lib/storage/src/content_manager/consensus_manager.rs at line 791: attempt to subtract with overflow
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command