### PR TITLE
deprecate old search api endpoints

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4761,6 +4761,7 @@
     },
     "/collections/{collection_name}/points/search": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -4872,6 +4873,7 @@
     },
     "/collections/{collection_name}/points/search/batch": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -4986,6 +4988,7 @@
     },
     "/collections/{collection_name}/points/search/groups": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5094,6 +5097,7 @@
     },
     "/collections/{collection_name}/points/recommend": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5205,6 +5209,7 @@
     },
     "/collections/{collection_name}/points/recommend/batch": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5319,6 +5324,7 @@
     },
     "/collections/{collection_name}/points/recommend/groups": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5427,6 +5433,7 @@
     },
     "/collections/{collection_name}/points/discover": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],
@@ -5538,6 +5545,7 @@
     },
     "/collections/{collection_name}/points/discover/batch": {
       "post": {
+        "deprecated": true,
         "tags": [
           "Search"
         ],

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -291,6 +291,7 @@ paths:
 
   /collections/{collection_name}/points/search:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Search points
@@ -327,6 +328,7 @@ paths:
 
   /collections/{collection_name}/points/search/batch:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Search batch points
@@ -363,6 +365,7 @@ paths:
 
   /collections/{collection_name}/points/search/groups:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Search point groups
@@ -399,6 +402,7 @@ paths:
 
   /collections/{collection_name}/points/recommend:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Recommend points
@@ -435,6 +439,7 @@ paths:
 
   /collections/{collection_name}/points/recommend/batch:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Recommend batch points
@@ -471,6 +476,7 @@ paths:
 
   /collections/{collection_name}/points/recommend/groups:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Recommend point groups
@@ -507,6 +513,7 @@ paths:
 
   /collections/{collection_name}/points/discover:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Discover points
@@ -558,6 +565,7 @@ paths:
 
   /collections/{collection_name}/points/discover/batch:
     post:
+      deprecated: true
       tags:
         - Search
       summary: Discover batch points


### PR DESCRIPTION
We've deprecated search, recommendation and discovery endpoints in favour of query endpoint, however, these endpoints have no difference in documentation and might cause ambiguity for the users.

In this PR I changed .ytt files and added `deprecated: true` for the corresponding endpoints to strike them through in the docs