### PR TITLE
Fix query per vector to not generate an empty retrieve request

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -416,6 +416,9 @@ impl Collection {
         timeout: Option<Duration>,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
+        if request.ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let with_payload_interface = request
             .with_payload
             .as_ref()

--- a/lib/collection/src/common/fetch_vectors.rs
+++ b/lib/collection/src/common/fetch_vectors.rs
@@ -224,6 +224,10 @@ impl<'coll_name> ReferencedPoints<'coll_name> {
         let mut collections_names = Vec::new();
         let mut vector_retrieves = Vec::new();
         for (collection_name, reference_vectors_ids) in self.ids_per_collection {
+            // do not fetch vectors if there are no reference vectors
+            if reference_vectors_ids.is_empty() {
+                continue;
+            }
             collections_names.push(collection_name);
             let points: Vec<_> = reference_vectors_ids.into_iter().collect();
             let vector_names: Vec<_> = self


### PR DESCRIPTION
When running a query request per vector value such as

```http
POST collections/benchmark/points/query
{
  "query": [
      0.2,
      0.1,
      0.9,
      0.4
    ],
  "using": "dense",
  "limit": 4
}
```

we first try to find referenced vectors that need to be resolved.

In that case they are none.

However the implementation still generated a retrieve request for empty list for `ids`.

I discovered this while testing the rate limiter against the query endpoint which would mysteriously consume twice the amount of token per request.

The fix is two fold:
- for the query API, do not generate empty retrieve request
- for the collection API, shortcut all empty retrieve request to cover other potential misuses

The effects are:
- fixing read rate limiters
- increase performance of query per value by removing unnecessary segment and shard communication