### PR TITLE
Temporarily run code coverage on merging to dev

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch: # Trigger from UI for selected branch
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches: [ dev ]
 
 jobs:
     coverage:


### PR DESCRIPTION
Coverage action didn't get scheduled or show up in https://github.com/qdrant/qdrant/actions because it's not part of master yet. I think triggering it once from dev branch should bring it there. Don't want to wait for next release