### PR TITLE
Use cargo --locked on CI for reproducible builds

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,7 +35,7 @@ jobs:
           poetry -C tests check --lock
           poetry -C tests install --no-root
       - name: Build
-        run: cargo build --features "service_debug data-consistency-check"
+        run: cargo build --features "service_debug data-consistency-check" --locked
       - name: Run integration tests
         run: poetry -C tests run ./tests/integration-tests.sh
         shell: bash
@@ -65,7 +65,7 @@ jobs:
           poetry -C tests check --lock
           poetry -C tests install --no-root
       - name: Build
-        run: cargo build --features "service_debug data-consistency-check"
+        run: cargo build --features "service_debug data-consistency-check" --locked
       - name: Run integration tests - 1 peer
         run: poetry -C tests run ./tests/integration-tests.sh distributed
         shell: bash
@@ -308,7 +308,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install clang jq
       - name: Build
-        run: cargo build --bin qdrant
+        run: cargo build --bin qdrant --locked
       - name: Run Shard Snapshot API Tests (local)
         shell: bash
         run: |

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -137,7 +137,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Build AppImage
         shell: bash

--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -32,10 +32,10 @@ jobs:
         sudo apt-get install mesa-vulkan-drivers libvulkan1 vulkan-tools vulkan-validationlayers
         /usr/bin/vulkaninfo --summary
     - name: Build
-      run: cargo build --tests --workspace --features gpu
+      run: cargo build --tests --workspace --features gpu --locked
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
-      run: cargo nextest run --workspace --features gpu --profile ci
+      run: cargo nextest run --workspace --features gpu --profile ci --locked
     - name: Upload test report
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,10 +28,10 @@ jobs:
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Build
-      run: cargo build --tests --workspace
+      run: cargo build --tests --workspace --locked
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
-      run: cargo nextest run --workspace --profile ci
+      run: cargo nextest run --workspace --profile ci --locked
     - name: Upload test report
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Without --locked, Cargo will:

1. Use the Cargo.lock file if it exists
2. Update the lock file if necessary to resolve dependencies
3. Create a new lock file if one doesn't exist

With --locked, Cargo will:

1. Use the exact versions specified in the existing Cargo.lock file
2. Fail if the lock file is missing
3. Fail if any changes to the lock file are required

The main difference is that --locked prevents any modifications to the lock file, ensuring deterministic builds, which is particularly useful in CI environments.

Without --locked, Cargo may update the lock file if needed, but it will still use the lock file as a starting point for dependency resolution.