### PR TITLE
Retry-After on rate limiter hit for REST API

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1120,7 +1120,10 @@ impl CollectionError {
                     tokens_available,
                     retry_after,
                 } = retry_error;
-                let description = format!("{rate_limiter_type} rate limit exceeded: Operation requires {cost} tokens but only {tokens_available} were available. Retry later");
+                let description = format!(
+                    "{rate_limiter_type} rate limit exceeded: Operation requires {cost} tokens but only {tokens_available} were available. Retry after {}s",
+                    retry_after.as_secs_f32().ceil() as u32,
+                );
                 (description, Some(retry_after))
             }
         };

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -4,7 +4,7 @@ use std::error::Error as _;
 use std::fmt::{Debug, Write as _};
 use std::iter;
 use std::num::NonZeroU64;
-use std::time::SystemTimeError;
+use std::time::{Duration, SystemTimeError};
 
 use api::grpc::transport_channel_pool::RequestError;
 use api::rest::{
@@ -13,7 +13,7 @@ use api::rest::{
 };
 use common::defaults;
 use common::ext::OptionExt;
-use common::rate_limiting::RateLimitError;
+use common::rate_limiting::{RateLimitError, RetryError};
 use common::types::ScoreType;
 use common::validation::validate_range_generic;
 use io::file_operations::FileStorageError;
@@ -1020,7 +1020,10 @@ pub enum CollectionError {
     #[error("{description}")]
     InferenceError { description: String },
     #[error("Rate limiting exceeded: {description}")]
-    RateLimitExceeded { description: String },
+    RateLimitExceeded {
+        description: String,
+        retry_after: Option<Duration>,
+    },
 }
 
 impl CollectionError {
@@ -1100,31 +1103,31 @@ impl CollectionError {
         Self::StrictMode { description }
     }
 
-    pub fn rate_limit_exceeded(description: impl Into<String>) -> Self {
-        Self::RateLimitExceeded {
-            description: description.into(),
-        }
-    }
-
     pub fn rate_limit_error(
         rate_limit_error: RateLimitError,
-        cost: Option<usize>,
+        cost: usize,
         write_limit_type: bool, // false = read rate limit; true = write rate limit.
     ) -> Self {
         let rate_limiter_type = if write_limit_type { "Write" } else { "Read" };
-        let description = match rate_limit_error {
-            RateLimitError::Message(msg) => {
-                format!("{rate_limiter_type} rate limit exceeded, {msg}",)
+        let (description, retry_after) = match rate_limit_error {
+            RateLimitError::AlwaysOverBudget(msg) => {
+                let description = format!("{rate_limiter_type} rate limit exceeded, {msg}",);
+                // no point in retrying this one
+                (description, None)
             }
-            RateLimitError::TokenLeft(token_available) => {
-                if cost.is_some() && cost.unwrap() > 1 {
-                    format!("{rate_limiter_type} rate limit exceeded: Operation requires {} tokens but only {token_available} were available. Retry later", cost.unwrap())
-                } else {
-                    format!("{rate_limiter_type} rate limit exceeded, retry later")
-                }
+            RateLimitError::Retry(retry_error) => {
+                let RetryError {
+                    tokens_available,
+                    retry_after,
+                } = retry_error;
+                let description = format!("{rate_limiter_type} rate limit exceeded: Operation requires {cost} tokens but only {tokens_available} were available. Retry later");
+                (description, Some(retry_after))
             }
         };
-        Self::RateLimitExceeded { description }
+        Self::RateLimitExceeded {
+            description,
+            retry_after,
+        }
     }
 
     /// Returns true if the error is transient and the operation can be retried.
@@ -1330,6 +1333,7 @@ impl From<tonic::Status> for CollectionError {
             },
             tonic::Code::ResourceExhausted => CollectionError::RateLimitExceeded {
                 description: format!("{err}"),
+                retry_after: None,
             },
             tonic::Code::Ok
             | tonic::Code::Unknown

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1150,7 +1150,7 @@ impl LocalShard {
             rate_limiter
                 .lock()
                 .try_consume(cost as f64)
-                .map_err(|err| CollectionError::rate_limit_error(err, Some(cost), false))?;
+                .map_err(|err| CollectionError::rate_limit_error(err, cost, false))?;
         }
         Ok(())
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -801,7 +801,7 @@ impl ShardReplicaSet {
             rate_limiter
                 .lock()
                 .try_consume(cost as f64)
-                .map_err(|err| CollectionError::rate_limit_error(err, Some(cost), true))?;
+                .map_err(|err| CollectionError::rate_limit_error(err, cost, true))?;
         }
         Ok(())
     }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -1,5 +1,6 @@
 use std::backtrace::Backtrace;
 use std::io::Error as IoError;
+use std::time::Duration;
 
 use collection::operations::types::CollectionError;
 use io::file_operations::FileStorageError;
@@ -37,7 +38,10 @@ pub enum StorageError {
     #[error("{description}")]
     InferenceError { description: String },
     #[error("Rate limiting exceeded: {description}")]
-    RateLimitExceeded { description: String },
+    RateLimitExceeded {
+        description: String,
+        retry_after: Option<Duration>,
+    },
 }
 
 impl StorageError {
@@ -147,9 +151,13 @@ impl StorageError {
             CollectionError::InferenceError { description } => {
                 StorageError::InferenceError { description }
             }
-            CollectionError::RateLimitExceeded { description } => {
-                StorageError::RateLimitExceeded { description }
-            }
+            CollectionError::RateLimitExceeded {
+                description,
+                retry_after,
+            } => StorageError::RateLimitExceeded {
+                description,
+                retry_after,
+            },
         }
     }
 }
@@ -202,9 +210,13 @@ impl From<CollectionError> for StorageError {
             CollectionError::InferenceError { description } => {
                 StorageError::InferenceError { description }
             }
-            CollectionError::RateLimitExceeded { description } => {
-                StorageError::RateLimitExceeded { description }
-            }
+            CollectionError::RateLimitExceeded {
+                description,
+                retry_after,
+            } => StorageError::RateLimitExceeded {
+                description,
+                retry_after,
+            },
         }
     }
 }

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -160,9 +160,11 @@ impl HttpError {
             } => {
                 if let Some(retry_after) = retry_after {
                     // Retry-After is expressed in seconds `https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After`
+                    // Ceil the value to the nearest second so clients don't retry too early
+                    let retry_after_sec = retry_after.as_secs_f32().ceil() as u32;
                     headers.insert(
                         header::RETRY_AFTER,
-                        header::HeaderValue::from(retry_after.as_secs()),
+                        header::HeaderValue::from(retry_after_sec),
                     );
                 }
             }

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -1,6 +1,8 @@
 use std::fmt::Debug;
 use std::future::Future;
 
+use actix_web::http::header;
+use actix_web::http::header::HeaderMap;
 use actix_web::rt::time::Instant;
 use actix_web::{http, HttpResponse, ResponseError};
 use api::rest::models::{ApiResponse, ApiStatus, HardwareUsage};
@@ -60,13 +62,20 @@ pub fn process_response_error(
     log_service_error(&err);
 
     let error = HttpError::from(err);
-
-    HttpResponse::build(error.status_code()).json(ApiResponse::<()> {
+    let http_code = error.status_code();
+    let headers = error.headers();
+    let json_body = ApiResponse::<()> {
         result: None,
         status: ApiStatus::Error(error.to_string()),
         time: timing.elapsed().as_secs_f64(),
         usage: hardware_usage,
-    })
+    };
+
+    let mut response_builder = HttpResponse::build(http_code);
+    for header_pair in headers {
+        response_builder.insert_header(header_pair);
+    }
+    response_builder.json(json_body)
 }
 
 /// Response wrapper for a `Future` returning `Result`.
@@ -140,6 +149,38 @@ fn log_service_error(err: &StorageError) {
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct HttpError(StorageError);
+
+impl HttpError {
+    fn headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        match &self.0 {
+            StorageError::RateLimitExceeded {
+                description: _,
+                retry_after,
+            } => {
+                if let Some(retry_after) = retry_after {
+                    // Retry-After is expressed in seconds `https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After`
+                    headers.insert(
+                        header::RETRY_AFTER,
+                        header::HeaderValue::from(retry_after.as_secs()),
+                    );
+                }
+            }
+            StorageError::BadInput { .. } => {}
+            StorageError::AlreadyExists { .. } => {}
+            StorageError::NotFound { .. } => {}
+            StorageError::ServiceError { .. } => {}
+            StorageError::BadRequest { .. } => {}
+            StorageError::Locked { .. } => {}
+            StorageError::Timeout { .. } => {}
+            StorageError::ChecksumMismatch { .. } => {}
+            StorageError::Forbidden { .. } => {}
+            StorageError::PreconditionFailed { .. } => {}
+            StorageError::InferenceError { .. } => {}
+        }
+        headers
+    }
+}
 
 impl ResponseError for HttpError {
     fn status_code(&self) -> http::StatusCode {

--- a/tests/consensus_tests/test_shard_transfer_rate_limiting.py
+++ b/tests/consensus_tests/test_shard_transfer_rate_limiting.py
@@ -115,7 +115,7 @@ def test_shard_transfer_rate_limiting(tmp_path: pathlib.Path):
         if not r.ok:
             rate_limited = True
             assert r.status_code == 429, f"Failure body {r.json()}"
-            assert "Rate limiting exceeded: Write rate limit exceeded, retry later" in r.json()['status']['error']
+            assert "Rate limiting exceeded: Write rate limit exceeded" in r.json()['status']['error']
             break
 
     assert rate_limited, "Expected write rate limit to be reached"

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -858,8 +858,8 @@ def test_strict_mode_read_rate_limiting(collection_name):
             assert response.status_code == 429
             assert "Rate limiting exceeded: Read rate limit exceeded" in response.json()['status']['error']
             assert response.headers['Retry-After'] is not None
-            # need to wait 60s for the single token available to be replenished
-            assert int(response.headers['Retry-After']) is 60
+            # need to wait about 60s for the single token available to be replenished
+            assert 55 <= int(response.headers['Retry-After']) <= 60
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
@@ -1015,8 +1015,8 @@ def test_strict_mode_write_rate_limiting(collection_name):
             assert response.status_code == 429
             assert "Rate limiting exceeded: Write rate limit exceeded" in response.json()['status']['error']
             assert response.headers['Retry-After'] is not None
-            # need to wait 60s for the single token available to be replenished
-            assert int(response.headers['Retry-After']) is 60
+            # need to wait about 60s for the single token available to be replenished
+            assert 55 <= int(response.headers['Retry-After']) <= 60
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -856,7 +856,10 @@ def test_strict_mode_read_rate_limiting(collection_name):
         if not response.ok:
             failed_count += 1
             assert response.status_code == 429
-            assert "Rate limiting exceeded: Read rate limit exceeded, retry later" in response.json()['status']['error']
+            assert "Rate limiting exceeded: Read rate limit exceeded" in response.json()['status']['error']
+            assert response.headers['Retry-After'] is not None
+            # need to wait 59s for the single token available to be replenished
+            assert int(response.headers['Retry-After']) is 59
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
@@ -1010,7 +1013,10 @@ def test_strict_mode_write_rate_limiting(collection_name):
         if not response.ok:
             failed_count += 1
             assert response.status_code == 429
-            assert "Rate limiting exceeded: Write rate limit exceeded, retry later" in response.json()['status']['error']
+            assert "Rate limiting exceeded: Write rate limit exceeded" in response.json()['status']['error']
+            assert response.headers['Retry-After'] is not None
+            # need to wait 59s for the single token available to be replenished
+            assert int(response.headers['Retry-After']) is 59
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -859,7 +859,7 @@ def test_strict_mode_read_rate_limiting(collection_name):
             assert "Rate limiting exceeded: Read rate limit exceeded" in response.json()['status']['error']
             assert response.headers['Retry-After'] is not None
             # need to wait about 60s for the single token available to be replenished
-            assert 55 <= int(response.headers['Retry-After']) <= 60
+            assert 55 < int(response.headers['Retry-After']) <= 60
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
@@ -1016,7 +1016,7 @@ def test_strict_mode_write_rate_limiting(collection_name):
             assert "Rate limiting exceeded: Write rate limit exceeded" in response.json()['status']['error']
             assert response.headers['Retry-After'] is not None
             # need to wait about 60s for the single token available to be replenished
-            assert 55 <= int(response.headers['Retry-After']) <= 60
+            assert 55 < int(response.headers['Retry-After']) <= 60
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
@@ -1234,3 +1234,46 @@ def test_filter_nested_condition(collection_name):
     assert "condition" in search_fail.json()['status']['error']
     assert "limit" in search_fail.json()['status']['error']
     assert not search_fail.ok
+
+
+def test_strict_mode_read_rate_limiting_small_replenish(collection_name):
+    """
+    If our read rate limit capacity is larger, test that when exhausting it
+    we're only instructed to wait one more second rather than a full minute.
+    """
+
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "read_rate_limit": 60,
+    })
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+
+    assert response.ok
+    new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
+    assert new_strict_mode_config['enabled']
+    assert new_strict_mode_config['read_rate_limit'] == 60
+
+    for _ in range(120):
+        response = request_with_validation(
+            api='/collections/{collection_name}/points/search',
+            method="POST",
+            path_params={'collection_name': collection_name},
+            body={
+                "vector": [0.2, 0.1, 0.9, 0.7],
+                "limit": 4
+            }
+        )
+        if not response.ok:
+            assert response.status_code == 429
+            assert "Rate limiting exceeded: Read rate limit exceeded" in response.json()['status']['error']
+            assert response.headers['Retry-After'] is not None
+            # need to wait about a second for one out of 100 tokens to be replenished
+            assert 1 <= int(response.headers['Retry-After']) <= 5
+            return
+
+    assert False, "rate limiter was never triggered"

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -858,8 +858,8 @@ def test_strict_mode_read_rate_limiting(collection_name):
             assert response.status_code == 429
             assert "Rate limiting exceeded: Read rate limit exceeded" in response.json()['status']['error']
             assert response.headers['Retry-After'] is not None
-            # need to wait 59s for the single token available to be replenished
-            assert int(response.headers['Retry-After']) is 59
+            # need to wait 60s for the single token available to be replenished
+            assert int(response.headers['Retry-After']) is 60
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"
@@ -1015,8 +1015,8 @@ def test_strict_mode_write_rate_limiting(collection_name):
             assert response.status_code == 429
             assert "Rate limiting exceeded: Write rate limit exceeded" in response.json()['status']['error']
             assert response.headers['Retry-After'] is not None
-            # need to wait 59s for the single token available to be replenished
-            assert int(response.headers['Retry-After']) is 59
+            # need to wait 60s for the single token available to be replenished
+            assert int(response.headers['Retry-After']) is 60
 
     # loose check, as the rate limiting might not be exact
     assert failed_count > 5, "Rate limiting did not work"


### PR DESCRIPTION
The rate limiter now computes a `retry-after` field in its error to feed to the `Retry-After` HTTP header.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After