### PR TITLE
Use `simple_segment_constructor`

### DIFF
--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -11,9 +11,9 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::payload_json;
 use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::{
-    build_multivec_segment, build_simple_segment,
+    build_multivec_segment, build_simple_segment, VECTOR1_NAME, VECTOR2_NAME,
 };
-use segment::types::{Distance, Payload, PointIdType, SeqNumberType, VectorName};
+use segment::types::{Distance, Payload, PointIdType, SeqNumberType};
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
@@ -22,9 +22,6 @@ use crate::collection_manager::optimizers::segment_optimizer::OptimizerThreshold
 use crate::config::CollectionParams;
 use crate::operations::types::VectorsConfig;
 use crate::operations::vector_params_builder::VectorParamsBuilder;
-
-pub const VECTOR1_NAME: &VectorName = "vector1";
-pub const VECTOR2_NAME: &VectorName = "vector2";
 
 pub fn empty_segment(path: &Path) -> Segment {
     build_simple_segment(path, 4, Distance::Dot).unwrap()

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -295,13 +295,12 @@ mod tests {
     use segment::index::hnsw_index::num_rayon_threads;
     use segment::json_path::JsonPath;
     use segment::payload_json;
+    use segment::segment_constructor::simple_segment_constructor::{VECTOR1_NAME, VECTOR2_NAME};
     use segment::types::{Distance, PayloadSchemaType, VectorNameBuf};
     use tempfile::Builder;
 
     use super::*;
-    use crate::collection_manager::fixtures::{
-        random_multi_vec_segment, random_segment, VECTOR1_NAME, VECTOR2_NAME,
-    };
+    use crate::collection_manager::fixtures::{random_multi_vec_segment, random_segment};
     use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
     use crate::collection_manager::optimizers::config_mismatch_optimizer::ConfigMismatchOptimizer;
     use crate::collection_manager::segments_updater::{

--- a/lib/segment/benches/segment_info.rs
+++ b/lib/segment/benches/segment_info.rs
@@ -1,38 +1,18 @@
-use std::collections::HashMap;
-
 use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{criterion_group, criterion_main, Criterion};
-use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
+use segment::data_types::vectors::only_default_vector;
 use segment::entry::entry_point::SegmentEntry;
 use segment::json_path::JsonPath;
-use segment::segment_constructor::build_segment;
-use segment::types::{
-    Distance, Indexes, Payload, PayloadFieldSchema, PayloadSchemaType, SegmentConfig,
-    VectorDataConfig, VectorStorageType,
-};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::types::{Distance, Payload, PayloadFieldSchema, PayloadSchemaType};
 use serde_json::{Map, Value};
 use tempfile::Builder;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let dim = 400;
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance: Distance::Dot,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+
+    let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
 
     let vector = vec![0.1f32; 400];
 

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -13,11 +12,9 @@ use crate::entry::entry_point::SegmentEntry;
 use crate::fixtures::index_fixtures::random_vector;
 use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use crate::index::hnsw_index::num_rayon_threads;
-use crate::segment_constructor::{build_segment, VectorIndexBuildArgs};
-use crate::types::{
-    Distance, HnswConfig, Indexes, SegmentConfig, SeqNumberType, VectorDataConfig,
-    VectorStorageType,
-};
+use crate::segment_constructor::simple_segment_constructor::build_simple_segment;
+use crate::segment_constructor::VectorIndexBuildArgs;
+use crate::types::{Distance, HnswConfig, SeqNumberType};
 
 #[test]
 fn test_graph_connectivity() {
@@ -37,24 +34,7 @@ fn test_graph_connectivity() {
 
     let hw_counter = HardwareCounterCell::new();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        payload_storage_type: Default::default(),
-        sparse_vector_data: Default::default(),
-    };
-
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -6,8 +6,12 @@ use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::segment::Segment;
 use crate::segment_constructor::build_segment;
 use crate::types::{
-    Distance, Indexes, PayloadStorageType, SegmentConfig, VectorDataConfig, VectorStorageType,
+    Distance, Indexes, PayloadStorageType, SegmentConfig, VectorDataConfig, VectorName,
+    VectorStorageType,
 };
+
+pub const VECTOR1_NAME: &VectorName = "vector1";
+pub const VECTOR2_NAME: &VectorName = "vector2";
 
 /// Build new segment with plain index in given directory
 ///
@@ -78,7 +82,7 @@ pub fn build_multivec_segment(
 ) -> OperationResult<Segment> {
     let mut vectors_config = HashMap::new();
     vectors_config.insert(
-        "vector1".into(),
+        VECTOR1_NAME.into(),
         VectorDataConfig {
             size: dim1,
             distance,
@@ -90,7 +94,7 @@ pub fn build_multivec_segment(
         },
     );
     vectors_config.insert(
-        "vector2".into(),
+        VECTOR2_NAME.into(),
         VectorDataConfig {
             size: dim2,
             distance,

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -16,10 +15,11 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::VectorIndex;
 use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType,
-    SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType, WithPayload,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, SeqNumberType,
+    WithPayload,
 };
 use tempfile::Builder;
 
@@ -34,26 +34,9 @@ fn test_batch_and_single_request_equivalency() {
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-
     let int_key = "int";
 
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
 
     segment
         .create_field_index(

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -14,6 +14,7 @@ use segment::fixtures::payload_fixtures::{random_dense_byte_vector, random_int_p
 use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::segment_constructor::build_segment;
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Range, SearchParams,
     SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
@@ -120,22 +121,6 @@ fn test_byte_storage_hnsw(
     let dir_byte = Builder::new().prefix("segment_dir_byte").tempdir().unwrap();
     let hnsw_dir_byte = Builder::new().prefix("hnsw_dir_byte").tempdir().unwrap();
 
-    let config_float = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
     let config_byte = SegmentConfig {
         vector_data: HashMap::from([(
             DEFAULT_VECTOR_NAME.to_owned(),
@@ -155,7 +140,7 @@ fn test_byte_storage_hnsw(
 
     let int_key = "int";
 
-    let mut segment_float = build_segment(dir_float.path(), &config_float, true).unwrap();
+    let mut segment_float = build_simple_segment(dir_float.path(), dim, distance).unwrap();
     let mut segment_byte = build_segment(dir_byte.path(), &config_byte, true).unwrap();
     // check that `segment_byte` uses byte or half storage
     {

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -10,7 +10,9 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::segment::Segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::segment_constructor::simple_segment_constructor::build_multivec_segment;
+use segment::segment_constructor::simple_segment_constructor::{
+    build_multivec_segment, VECTOR1_NAME, VECTOR2_NAME,
+};
 use segment::types::Distance;
 use segment::vector_storage::VectorStorage;
 use tempfile::Builder;
@@ -33,8 +35,8 @@ fn test_rebuild_with_removed_vectors() {
                 1,
                 i.into(),
                 NamedVectors::from_pairs([
-                    ("vector1".into(), vec![i as f32, 0., 0., 0.]),
-                    ("vector2".into(), vec![0., i as f32, 0., 0., 0., 0.]),
+                    (VECTOR1_NAME.into(), vec![i as f32, 0., 0., 0.]),
+                    (VECTOR2_NAME.into(), vec![0., i as f32, 0., 0., 0., 0.]),
                 ]),
                 &hw_counter,
             )
@@ -43,11 +45,11 @@ fn test_rebuild_with_removed_vectors() {
 
     for i in 0..NUM_VECTORS_2 {
         let vectors = if i % 5 == 0 {
-            NamedVectors::from_pairs([("vector1".into(), vec![0., 0., i as f32, 0.])])
+            NamedVectors::from_pairs([(VECTOR1_NAME.into(), vec![0., 0., i as f32, 0.])])
         } else {
             NamedVectors::from_pairs([
-                ("vector1".into(), vec![0., 0., i as f32, 0.]),
-                ("vector2".into(), vec![0., 0., 0., i as f32, 0., 0.]),
+                (VECTOR1_NAME.into(), vec![0., 0., i as f32, 0.]),
+                (VECTOR2_NAME.into(), vec![0., 0., 0., i as f32, 0., 0.]),
             ])
         };
 
@@ -59,15 +61,15 @@ fn test_rebuild_with_removed_vectors() {
     for i in 0..NUM_VECTORS_2 {
         if i % 3 == 0 {
             segment2
-                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector1", &hw_counter)
+                .delete_vector(2, (NUM_VECTORS_1 + i).into(), VECTOR1_NAME, &hw_counter)
                 .unwrap();
             segment2
-                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2", &hw_counter)
+                .delete_vector(2, (NUM_VECTORS_1 + i).into(), VECTOR2_NAME, &hw_counter)
                 .unwrap();
         }
         if i % 3 == 1 {
             segment2
-                .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2", &hw_counter)
+                .delete_vector(2, (NUM_VECTORS_1 + i).into(), VECTOR2_NAME, &hw_counter)
                 .unwrap();
         }
         if i % 2 == 0 {
@@ -107,14 +109,14 @@ fn test_rebuild_with_removed_vectors() {
 
     let vec1_count = merged_segment
         .vector_data
-        .get("vector1")
+        .get(VECTOR1_NAME)
         .unwrap()
         .vector_storage
         .borrow()
         .available_vector_count();
     let vec2_count = merged_segment
         .vector_data
-        .get("vector2")
+        .get(VECTOR2_NAME)
         .unwrap()
         .vector_storage
         .borrow()

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -15,10 +15,11 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType, Range,
-    SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, Range,
+    SearchParams, SeqNumberType,
 };
 use tempfile::Builder;
 
@@ -41,28 +42,11 @@ fn exact_search_test() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-
     let int_key = "int";
 
     let hw_counter = HardwareCounterCell::new();
 
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -17,10 +17,11 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType, Range,
-    SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, Range,
+    SearchParams, SeqNumberType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use tempfile::Builder;
@@ -103,27 +104,10 @@ fn _test_filterable_hnsw(
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-
     let int_key = "int";
 
     let hw_counter = HardwareCounterCell::new();
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -17,10 +16,11 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType, Range,
-    SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, Range,
+    SearchParams, SeqNumberType,
 };
 use tempfile::Builder;
 
@@ -71,26 +71,9 @@ fn test_gpu_filterable_hnsw() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-
     let int_key = "int";
 
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -15,10 +14,11 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType,
-    SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, SearchParams,
+    SeqNumberType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use tempfile::Builder;
@@ -66,24 +66,7 @@ fn hnsw_discover_precision() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        payload_storage_type: Default::default(),
-        sparse_vector_data: Default::default(),
-    };
-
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -193,26 +176,9 @@ fn filtered_hnsw_discover_precision() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        payload_storage_type: Default::default(),
-        sparse_vector_data: Default::default(),
-    };
-
     let keyword_key = "keyword";
 
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::ops::Deref;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -19,12 +19,13 @@ use segment::json_path::JsonPath;
 use segment::payload_json;
 use segment::segment::Segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
     CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes,
     ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams,
-    ScalarQuantizationConfig, SearchParams, SegmentConfig, VectorDataConfig, VectorStorageType,
+    ScalarQuantizationConfig, SearchParams,
 };
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use tempfile::Builder;
@@ -62,26 +63,9 @@ fn hnsw_quantized_search_test(
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-
     let hw_counter = HardwareCounterCell::new();
 
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -19,12 +18,13 @@ use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::VectorIndex;
 use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::segment_constructor::{build_segment, VectorIndexBuildArgs};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, MultiVectorConfig,
-    PayloadSchemaType, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, MultiVectorConfig, PayloadSchemaType,
+    SeqNumberType,
 };
 use segment::vector_storage::multi_dense::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
 use segment::vector_storage::VectorStorage;
@@ -41,26 +41,9 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: dim,
-                distance,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-
     let int_key = "int";
 
-    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
 
     segment
         .create_field_index(

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -36,6 +36,7 @@ use segment::payload_storage::PayloadStorage;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::PayloadFieldSchema::{FieldParams, FieldType};
 use segment::types::PayloadSchemaType::{Integer, Keyword};
 use segment::types::{
@@ -339,25 +340,8 @@ impl TestSegments {
 fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> (Segment, Segment) {
     let mut rnd = StdRng::seed_from_u64(42);
 
-    let config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: DIM,
-                distance: Distance::Dot,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
-
-    let mut plain_segment = build_segment(path_plain, &config, true).unwrap();
-    let mut struct_segment = build_segment(path_struct, &config, true).unwrap();
+    let mut plain_segment = build_simple_segment(path_plain, DIM, Distance::Dot).unwrap();
+    let mut struct_segment = build_simple_segment(path_struct, DIM, Distance::Dot).unwrap();
 
     let num_points = 3000;
     let points_to_delete = 500;

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -11,8 +11,9 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::json_path::JsonPath;
 use segment::segment::Segment;
+use segment::segment_constructor::load_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::segment_constructor::{build_segment, load_segment};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
     Distance, HnswConfig, Indexes, PayloadFieldSchema, PayloadSchemaParams, PayloadStorageType,
     SegmentConfig, SnapshotFormat, VectorDataConfig, VectorStorageType,
@@ -39,24 +40,8 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
     }"#;
 
     let segment_builder_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-    let building_config = SegmentConfig {
-        vector_data: HashMap::from([(
-            DEFAULT_VECTOR_NAME.to_owned(),
-            VectorDataConfig {
-                size: 2,
-                distance: Distance::Dot,
-                storage_type: VectorStorageType::Memory,
-                index: Indexes::Plain {},
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-            },
-        )]),
-        sparse_vector_data: Default::default(),
-        payload_storage_type: Default::default(),
-    };
 
-    let mut segment = build_segment(segment_builder_dir.path(), &building_config, true).unwrap();
+    let mut segment = build_simple_segment(segment_builder_dir.path(), 2, Distance::Dot).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 


### PR DESCRIPTION
This PR removes a bit of boilerplate from our tests by replacing code like this:
```rust
let config = SegmentConfig {
    vector_data: HashMap::from([(
        DEFAULT_VECTOR_NAME.to_owned(),
        VectorDataConfig {
            size: dim,
            distance: Distance::Dot,
            storage_type: VectorStorageType::Memory,
            index: Indexes::Plain {},
            quantization_config: None,
            multivector_config: None,
            datatype: None,
        },
    )]),
    sparse_vector_data: Default::default(),
    payload_storage_type: Default::default(),
};
let mut segment = build_segment(dir.path(), &config, true).unwrap();
```

… with code line this:
```rust
let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
```

---

The second commit is performed automatically using the following `ast-grep` rules:

<details><summary><code>make_rules.py</code></summary>

```python
#!/usr/bin/env python3

import yaml


def mkrule(rule, fix):
    return {
        "language": "rust",
        "id": "id",
        "rule": rule,
        "fix": fix,
    }


def rules1(distance_var):
    let_config = """
        let $CONFIG = SegmentConfig {
            vector_data: HashMap::from([(
                DEFAULT_VECTOR_NAME.to_owned(),
                VectorDataConfig {
                    size: $DIM,
                    distance,
                    storage_type: VectorStorageType::Memory,
                    index: Indexes::Plain {},
                    quantization_config: None,
                    multivector_config: None,
                    datatype: None,
                },
            )]),
            $FOO: Default::default(),
            $BAR: Default::default(),
        };
    """
    let_build_segment = """
        let mut $SEGMENT = build_segment($DIR, &$CONFIG, true).unwrap();
    """
    if distance_var:
        let_config = let_config.replace("distance,", "distance: $DISTANCE,")

    return [
        mkrule(
            rule={
                "kind": "let_declaration",
                "pattern": let_config,
                "precedes": {
                    "kind": "let_declaration",
                    "stopBy": "end",
                    "pattern": let_build_segment,
                },
            },
            fix="",
        ),
        mkrule(
            rule={
                "kind": "let_declaration",
                "pattern": let_build_segment,
                "follows": {
                    "kind": "let_declaration",
                    "stopBy": "end",
                    "pattern": let_config,
                },
            },
            fix=(
                "let mut $SEGMENT = build_simple_segment($DIR, $DIM, $DISTANCE).unwrap();"
                if distance_var
                else "let mut $SEGMENT = build_simple_segment($DIR, $DIM, distance).unwrap();"
            ),
        ),
        mkrule(
            rule={
                "kind": "identifier",
                "pattern": "build_segment",
                "all": [
                    {"inside": {"kind": "use_declaration", "stopBy": "end"}},
                    {
                        "inside": {
                            "kind": "source_file",
                            "stopBy": "end",
                            "all": [
                                {
                                    "has": {
                                        "kind": "let_declaration",
                                        "pattern": let_config,
                                        "stopBy": "end",
                                    }
                                },
                                {
                                    "has": {
                                        "kind": "let_declaration",
                                        "pattern": let_build_segment,
                                        "stopBy": "end",
                                    }
                                },
                            ],
                        }
                    },
                ],
            },
            fix="{build_segment, simple_segment_constructor::build_simple_segment}",
        ),
    ]


def rules2():
    let_config = """
        let config = SegmentConfig {
            vector_data: HashMap::from([
                (
                    "a".into(),
                    VectorDataConfig {
                        size: $DIM1,
                        distance: $DISTANCE,
                        storage_type: VectorStorageType::Memory,
                        index: Indexes::Plain {},
                        quantization_config: None,
                        multivector_config: None,
                        datatype: None,
                    },
                ),
                (
                    "b".into(),
                    VectorDataConfig {
                        size: $DIM2,
                        distance: $DISTANCE,
                        storage_type: VectorStorageType::Memory,
                        index: Indexes::Plain {},
                        quantization_config: None,
                        multivector_config: None,
                        datatype: None,
                    },
                ),
            ]),
            $FOO: Default::default(),
            $BAR: Default::default(),
        };
    """
        
    let_build_segment = "let mut $SEGMENT = build_segment($DIR, &$CONFIG, true).unwrap();"

    return [
        mkrule(
            rule={
                "kind": "let_declaration",
                "pattern": let_config,
                "precedes": {
                    "kind": "let_declaration",
                    "stopBy": "end",
                    "pattern": let_build_segment,
                },
            },
            fix="",
        ),
        mkrule(
            rule={
                "kind": "let_declaration",
                "pattern": let_build_segment,
                "follows": {
                    "kind": "let_declaration",
                    "stopBy": "end",
                    "pattern": let_config,
                },
            },
            fix=(
                "let mut $SEGMENT = build_multivec_segment($DIR, $DIM1, $DIM2, $DISTANCE).unwrap();"
            ),
        ),
        mkrule(
            rule={
                "kind": "identifier",
                "pattern": "$CONFIG",
                "inside": {
                    "kind": "block",
                    "stopBy": "end",
                    "all": [
                        {
                            "has": {
                                "kind": "let_declaration",
                                "pattern": let_config,
                            }
                        },
                        {
                            "has": {
                                "kind": "let_declaration",
                                "pattern": let_build_segment,
                            }
                        },
                    ],
                },
            },
            fix="$SEGMENT.segment_config",
        ),
        mkrule(
            rule={
                "kind": "identifier",
                "pattern": "build_segment",
                "all": [
                    {"inside": {"kind": "use_declaration", "stopBy": "end"}},
                    {
                        "inside": {
                            "kind": "source_file",
                            "stopBy": "end",
                            "all": [
                                {
                                    "has": {
                                        "kind": "let_declaration",
                                        "pattern": let_config,
                                        "stopBy": "end",
                                    }
                                },
                                {
                                    "has": {
                                        "kind": "let_declaration",
                                        "pattern": let_build_segment,
                                        "stopBy": "end",
                                    }
                                },
                            ],
                        }
                    },
                ],
            },
            fix="{build_segment, simple_segment_constructor::{build_multivec_segment, VECTOR1_NAME, VECTOR2_NAME}}",
        ),
    ] + [
        mkrule(
            rule={
                "kind": "string_literal",
                "pattern": f'"{pattern}"',
                "inside": {
                    "kind": "block",
                    "stopBy": "end",
                    "all": [
                        {
                            "has": {
                                "kind": "let_declaration",
                                "pattern": let_config,
                            }
                        },
                        {
                            "has": {
                                "kind": "let_declaration",
                                "pattern": let_build_segment,
                            }
                        },
                    ],
                },
            },
            fix=fix,
        )
        for pattern, fix in [("a", "VECTOR1_NAME"), ("b", "VECTOR2_NAME")]
    ]


yaml.safe_dump_all(rules1(False) + rules1(True), open("tmp1.yaml", "w"))
yaml.safe_dump_all(rules2(), open("tmp2.yaml", "w"))
```

</details>

```sh
./make_rules.py
ast-grep scan --rule tmp1.yaml -U
ast-grep scan --rule tmp2.yaml -U
cargo clippy -p segment --all-targets --all-features --fix --allow-dirty
cargo clippy -p collection --all-targets --all-features --fix --allow-dirty
cargo fmt
```