### PR TITLE
Prototype partial segment snapshots and `SegmentManifest` format

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -15,8 +15,10 @@ use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
+use segment::data_types::segment_manifest::SegmentManifest;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
-use segment::entry::entry_point::{SegmentEntry, SegmentManifest};
+use segment::entry::entry_point::SegmentEntry;
+use segment::entry::partial_snapshot_entry::PartialSnapshotEntry;
 use segment::index::field_index::{CardinalityEstimation, FieldIndex};
 use segment::json_path::JsonPath;
 use segment::telemetry::SegmentTelemetry;
@@ -346,6 +348,21 @@ impl ProxySegment {
         )?;
 
         Ok(result.into_iter().next().unwrap())
+    }
+}
+
+impl PartialSnapshotEntry for ProxySegment {
+    fn take_partial_snapshot(
+        &self,
+        _temp_path: &Path,
+        _tar: &tar_ext::BuilderExt,
+        _manifest: &SegmentManifest,
+    ) -> OperationResult<()> {
+        todo!()
+    }
+
+    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
+        todo!()
     }
 }
 
@@ -1266,19 +1283,6 @@ impl SegmentEntry for ProxySegment {
         )?;
 
         Ok(())
-    }
-
-    fn take_partial_snapshot(
-        &self,
-        _temp_path: &Path,
-        _tar: &tar_ext::BuilderExt,
-        _manifest: &SegmentManifest,
-    ) -> OperationResult<()> {
-        todo!()
-    }
-
-    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
-        todo!()
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -16,7 +16,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{QueryContext, SegmentQueryContext};
 use segment::data_types::vectors::{QueryVector, VectorInternal};
-use segment::entry::entry_point::SegmentEntry;
+use segment::entry::entry_point::{SegmentEntry, SegmentManifest};
 use segment::index::field_index::{CardinalityEstimation, FieldIndex};
 use segment::json_path::JsonPath;
 use segment::telemetry::SegmentTelemetry;
@@ -1266,6 +1266,19 @@ impl SegmentEntry for ProxySegment {
         )?;
 
         Ok(())
+    }
+
+    fn take_partial_snapshot(
+        &self,
+        _temp_path: &Path,
+        _tar: &tar_ext::BuilderExt,
+        _manifest: &SegmentManifest,
+    ) -> OperationResult<()> {
+        todo!()
+    }
+
+    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
+        todo!()
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -351,21 +351,6 @@ impl ProxySegment {
     }
 }
 
-impl PartialSnapshotEntry for ProxySegment {
-    fn take_partial_snapshot(
-        &self,
-        _temp_path: &Path,
-        _tar: &tar_ext::BuilderExt,
-        _manifest: &SegmentManifest,
-    ) -> OperationResult<()> {
-        todo!()
-    }
-
-    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
-        todo!()
-    }
-}
-
 impl SegmentEntry for ProxySegment {
     fn version(&self) -> SeqNumberType {
         cmp::max(
@@ -1295,6 +1280,21 @@ impl SegmentEntry for ProxySegment {
             .get()
             .read()
             .fill_query_context(query_context)
+    }
+}
+
+impl PartialSnapshotEntry for ProxySegment {
+    fn take_partial_snapshot(
+        &self,
+        _temp_path: &Path,
+        _tar: &tar_ext::BuilderExt,
+        _manifest: &SegmentManifest,
+    ) -> OperationResult<()> {
+        todo!()
+    }
+
+    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
+        todo!()
     }
 }
 

--- a/lib/segment/src/data_types/mod.rs
+++ b/lib/segment/src/data_types/mod.rs
@@ -7,3 +7,4 @@ pub mod primitive;
 pub mod query_context;
 pub mod tiny_map;
 pub mod vectors;
+pub mod segment_manifest;

--- a/lib/segment/src/data_types/mod.rs
+++ b/lib/segment/src/data_types/mod.rs
@@ -5,6 +5,6 @@ pub mod named_vectors;
 pub mod order_by;
 pub mod primitive;
 pub mod query_context;
+pub mod segment_manifest;
 pub mod tiny_map;
 pub mod vectors;
-pub mod segment_manifest;

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use crate::types::SeqNumberType;
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SegmentManifest {
+    pub segment_version: SeqNumberType,
+    pub file_versions: HashMap<PathBuf, FileVersion>,
+}
+
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
+#[serde(untagged)]
+pub enum FileVersion {
+    Version(SeqNumberType),
+    Unversioned,
+}
+
+impl FileVersion {
+    pub fn is_unversioned(self) -> bool {
+        self == Self::Unversioned
+    }
+
+    pub fn or_segment_version(self, segment_version: SeqNumberType) -> SeqNumberType {
+        match self {
+            FileVersion::Version(version) => version,
+            FileVersion::Unversioned => segment_version,
+        }
+    }
+}
+
+impl From<SeqNumberType> for FileVersion {
+    fn from(version: SeqNumberType) -> Self {
+        Self::Version(version)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::data_types::segment_manifest::FileVersion;
+    #[test]
+    fn file_version_serde() {
+        test_file_version_serde(FileVersion::Version(42), "42");
+        test_file_version_serde(FileVersion::Unversioned, "null");
+    }
+
+    fn test_file_version_serde(version: FileVersion, json: &str) {
+        let serialized =
+            serde_json::to_string(&version).expect("failed to serialize FileVersion to JSON");
+
+        assert_eq!(serialized, json);
+
+        let deserialized: FileVersion =
+            serde_json::from_str(json).expect("failed to deserialize FileVersion from JSON");
+
+        assert_eq!(deserialized, version);
+    }
+}

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -39,13 +39,16 @@ impl From<SeqNumberType> for FileVersion {
 
 #[cfg(test)]
 mod test {
-    use crate::data_types::segment_manifest::FileVersion;
+    use super::*;
+
+    /// Tests that `FileVersion` variants are uniquely represented in JSON
     #[test]
     fn file_version_serde() {
         test_file_version_serde(FileVersion::Version(42), "42");
         test_file_version_serde(FileVersion::Unversioned, "null");
     }
 
+    /// Tests that `FileVersion` serializes into/deserializes from provided JSON representation
     fn test_file_version_serde(version: FileVersion, json: &str) {
         let serialized =
             serde_json::to_string(&version).expect("failed to serialize FileVersion to JSON");

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+
 use crate::types::SeqNumberType;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -12,6 +12,7 @@ use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{QueryVector, VectorInternal};
+use crate::entry::partial_snapshot_entry::PartialSnapshotEntry;
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
 use crate::json_path::JsonPath;
 use crate::telemetry::SegmentTelemetry;
@@ -25,7 +26,7 @@ use crate::types::{
 ///
 /// Assume all operations are idempotent - which means that no matter how many times an operation
 /// is executed - the storage state will be the same.
-pub trait SegmentEntry {
+pub trait SegmentEntry: PartialSnapshotEntry {
     /// Get current update version of the segment
     fn version(&self) -> SeqNumberType;
 
@@ -316,74 +317,9 @@ pub trait SegmentEntry {
         snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()>;
 
-    fn take_partial_snapshot(
-        &self,
-        temp_path: &Path,
-        tar: &tar_ext::BuilderExt,
-        manifest: &SegmentManifest,
-    ) -> OperationResult<()>;
-
-    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest>;
-
     // Get collected telemetry data of segment
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry;
 
     fn fill_query_context(&self, query_context: &mut QueryContext);
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct SegmentManifest {
-    pub segment_version: SeqNumberType,
-    pub file_versions: HashMap<PathBuf, FileVersion>,
-}
-
-#[derive(
-    Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
-)]
-#[serde(untagged)]
-pub enum FileVersion {
-    Version(SeqNumberType),
-    Unversioned,
-}
-
-impl FileVersion {
-    pub fn is_unversioned(self) -> bool {
-        self == Self::Unversioned
-    }
-
-    pub fn or_segment_version(self, segment_version: SeqNumberType) -> SeqNumberType {
-        match self {
-            FileVersion::Version(version) => version,
-            FileVersion::Unversioned => segment_version,
-        }
-    }
-}
-
-impl From<SeqNumberType> for FileVersion {
-    fn from(version: SeqNumberType) -> Self {
-        Self::Version(version)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn file_version_serde() {
-        test_file_version_serde(FileVersion::Version(42), "42");
-        test_file_version_serde(FileVersion::Unversioned, "null");
-    }
-
-    fn test_file_version_serde(version: FileVersion, json: &str) {
-        let serialized =
-            serde_json::to_string(&version).expect("failed to serialize FileVersion to JSON");
-
-        assert_eq!(serialized, json);
-
-        let deserialized: FileVersion =
-            serde_json::from_str(json).expect("failed to deserialize FileVersion from JSON");
-
-        assert_eq!(deserialized, version);
-    }
-}

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -322,4 +322,3 @@ pub trait SegmentEntry: PartialSnapshotEntry {
 
     fn fill_query_context(&self, query_context: &mut QueryContext);
 }
-

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -316,8 +316,74 @@ pub trait SegmentEntry {
         snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()>;
 
+    fn take_partial_snapshot(
+        &self,
+        temp_path: &Path,
+        tar: &tar_ext::BuilderExt,
+        manifest: &SegmentManifest,
+    ) -> OperationResult<()>;
+
+    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest>;
+
     // Get collected telemetry data of segment
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry;
 
     fn fill_query_context(&self, query_context: &mut QueryContext);
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SegmentManifest {
+    pub segment_version: SeqNumberType,
+    pub file_versions: HashMap<PathBuf, FileVersion>,
+}
+
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
+#[serde(untagged)]
+pub enum FileVersion {
+    Version(SeqNumberType),
+    Unversioned,
+}
+
+impl FileVersion {
+    pub fn is_unversioned(self) -> bool {
+        self == Self::Unversioned
+    }
+
+    pub fn or_segment_version(self, segment_version: SeqNumberType) -> SeqNumberType {
+        match self {
+            FileVersion::Version(version) => version,
+            FileVersion::Unversioned => segment_version,
+        }
+    }
+}
+
+impl From<SeqNumberType> for FileVersion {
+    fn from(version: SeqNumberType) -> Self {
+        Self::Version(version)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn file_version_serde() {
+        test_file_version_serde(FileVersion::Version(42), "42");
+        test_file_version_serde(FileVersion::Unversioned, "null");
+    }
+
+    fn test_file_version_serde(version: FileVersion, json: &str) {
+        let serialized =
+            serde_json::to_string(&version).expect("failed to serialize FileVersion to JSON");
+
+        assert_eq!(serialized, json);
+
+        let deserialized: FileVersion =
+            serde_json::from_str(json).expect("failed to deserialize FileVersion from JSON");
+
+        assert_eq!(deserialized, version);
+    }
 }

--- a/lib/segment/src/entry/mod.rs
+++ b/lib/segment/src/entry/mod.rs
@@ -1,1 +1,2 @@
 pub mod entry_point;
+pub mod partial_snapshot_entry;

--- a/lib/segment/src/entry/partial_snapshot_entry.rs
+++ b/lib/segment/src/entry/partial_snapshot_entry.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
+
 use common::tar_ext;
+
 use crate::common::operation_error::OperationResult;
 use crate::data_types::segment_manifest::SegmentManifest;
 
@@ -12,5 +14,4 @@ pub trait PartialSnapshotEntry {
     ) -> OperationResult<()>;
 
     fn get_segment_manifest(&self) -> OperationResult<SegmentManifest>;
-
 }

--- a/lib/segment/src/entry/partial_snapshot_entry.rs
+++ b/lib/segment/src/entry/partial_snapshot_entry.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+use common::tar_ext;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::segment_manifest::SegmentManifest;
+
+pub trait PartialSnapshotEntry {
+    fn take_partial_snapshot(
+        &self,
+        temp_path: &Path,
+        tar: &tar_ext::BuilderExt,
+        manifest: &SegmentManifest,
+    ) -> OperationResult<()>;
+
+    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest>;
+
+}

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -162,6 +162,10 @@ pub trait IdTracker: fmt::Debug {
     fn cleanup_versions(&mut self) -> OperationResult<()>;
 
     fn files(&self) -> Vec<PathBuf>;
+
+    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+        Vec::new()
+    }
 }
 
 pub type IdTrackerSS = dyn IdTracker + Sync + Send;

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -163,7 +163,7 @@ pub trait IdTracker: fmt::Debug {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
         Vec::new()
     }
 }

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -11,7 +11,10 @@ use crate::common::Flusher;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::json_path::JsonPath;
 use crate::payload_storage::FilterContext;
-use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, SeqNumberType};
+use crate::types::{
+    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
+    SeqNumberType,
+};
 
 pub trait PayloadIndex {
     /// Get indexed fields

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -143,4 +143,8 @@ pub trait PayloadIndex {
     fn take_database_snapshot(&self, path: &Path) -> OperationResult<()>;
 
     fn files(&self) -> Vec<PathBuf>;
+
+    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+        Vec::new()
+    }
 }

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -11,9 +11,7 @@ use crate::common::Flusher;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::json_path::JsonPath;
 use crate::payload_storage::FilterContext;
-use crate::types::{
-    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
-};
+use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, SeqNumberType};
 
 pub trait PayloadIndex {
     /// Get indexed fields
@@ -144,7 +142,7 @@ pub trait PayloadIndex {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
         Vec::new()
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -35,6 +35,10 @@ pub trait VectorIndex {
 
     fn files(&self) -> Vec<PathBuf>;
 
+    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+        Vec::new()
+    }
+
     /// The number of indexed vectors, currently accessible
     fn indexed_vector_count(&self) -> usize;
 

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -17,7 +17,7 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::telemetry::VectorIndexSearchesTelemetry;
-use crate::types::{Filter, SearchParams};
+use crate::types::{Filter, SearchParams, SeqNumberType};
 
 /// Trait for vector searching
 pub trait VectorIndex {
@@ -35,7 +35,7 @@ pub trait VectorIndex {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
         Vec::new()
     }
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
 use crate::json_path::JsonPath;
-use crate::types::{Filter, Payload};
+use crate::types::{Filter, Payload, SeqNumberType};
 
 /// Trait for payload data storage. Should allow filter checks
 pub trait PayloadStorage {
@@ -75,7 +75,9 @@ pub trait PayloadStorage {
     /// RocksDB storages are captured outside of this trait.
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+    /// Returns a list of files, which have additional versioning information.
+    /// Versioned files should be a subset of `files()` result (with maybe exception of rocksdb).
+    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
         Vec::new()
     }
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -75,6 +75,10 @@ pub trait PayloadStorage {
     /// RocksDB storages are captured outside of this trait.
     fn files(&self) -> Vec<PathBuf>;
 
+    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+        Vec::new()
+    }
+
     /// Return storage size in bytes
     fn get_storage_size_bytes(&self) -> OperationResult<usize>;
 }

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -75,8 +75,8 @@ pub trait PayloadStorage {
     /// RocksDB storages are captured outside of this trait.
     fn files(&self) -> Vec<PathBuf>;
 
-    /// Returns a list of files, which have additional versioning information.
-    /// Versioned files should be a subset of `files()` result (with maybe exception of rocksdb).
+    /// Returns a list of files, which have additional versioning information. Versioned files
+    /// should be a subset of `PayloadStoreage::files` result (maybe with exception of RocksDB).
     fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
         Vec::new()
     }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -1,7 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{Seek, Write};
-use std::ops::Deref as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::thread::{self};
@@ -9,8 +7,6 @@ use std::thread::{self};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
-use io::storage_version::VERSION_FILE;
-use uuid::Uuid;
 
 use super::Segment;
 use crate::common::operation_error::OperationError::TypeInferenceError;
@@ -21,21 +17,19 @@ use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{QueryVector, VectorInternal};
-use crate::entry::entry_point::{FileVersion, SegmentEntry, SegmentManifest};
+use crate::entry::entry_point::SegmentEntry;
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorage;
-use crate::segment::{
-    DB_BACKUP_PATH, PAYLOAD_DB_BACKUP_PATH, SEGMENT_STATE_FILE, SNAPSHOT_FILES_PATH, SNAPSHOT_PATH,
-};
+use crate::segment::snapshot::snapshot_files;
+use crate::segment::SNAPSHOT_PATH;
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadIndexInfo, PayloadKeyType, PayloadKeyTypeRef,
     PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
     SnapshotFormat, VectorDataInfo, VectorName, VectorNameBuf, WithPayload, WithVector,
 };
-use crate::utils::path::strip_prefix;
 use crate::vector_storage::VectorStorage;
 
 /// This is a basic implementation of `SegmentEntry`,
@@ -850,124 +844,6 @@ impl SegmentEntry for Segment {
         Ok(())
     }
 
-    fn take_partial_snapshot(
-        &self,
-        temp_path: &Path,
-        tar: &tar_ext::BuilderExt,
-        manifest: &SegmentManifest,
-    ) -> OperationResult<()> {
-        let segment_id = self
-            .current_path
-            .file_stem()
-            .and_then(|f| f.to_str())
-            .unwrap();
-
-        let updated_manifest = self.get_segment_manifest()?;
-        let updated_files = updated_files(manifest, &updated_manifest);
-
-        let tar = tar.descend(Path::new(&segment_id))?;
-
-        let updated_manifest_json = serde_json::to_vec(&updated_manifest).map_err(|err| {
-            OperationError::service_error(format!(
-                "failed to serialize segment manifest into JSON: {err}"
-            ))
-        })?;
-
-        tar.blocking_append_data(&updated_manifest_json, Path::new("segment_manifest.json"))?;
-
-        snapshot_files(self, temp_path, &tar, |path| updated_files.contains(path))?;
-        Ok(())
-    }
-
-    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
-        let segment_version = self.version();
-
-        let all_files = self.files();
-        let versioned_files = self.versioned_files();
-
-        // Note, that `all_files` should already contain all `versioned_files`, so each versioned file
-        // would be iterated over *twice*:
-        // - first as `FileVersion::Unversioned`
-        // - and then with correct `FileVersion::Version`
-        //
-        // The loop below is structured to do safety-checks and work around this correctly.
-        let all_files = all_files
-            .into_iter()
-            .map(|path| (path, FileVersion::Unversioned))
-            .chain(
-                versioned_files
-                    .into_iter()
-                    .map(|(path, version)| (path, FileVersion::from(version))),
-            );
-
-        let mut file_versions = HashMap::new();
-
-        for (path, version) in all_files {
-            // All segment files should be contained within segment directory
-            debug_assert!(
-                path.starts_with(&self.current_path),
-                "segment file {} is not contained within segment directory {}",
-                path.display(),
-                self.current_path.display(),
-            );
-
-            let path = strip_prefix(&path, &self.current_path)?;
-            let prev_version = file_versions.insert(path.to_path_buf(), version);
-
-            // `all_files` should iterate over versioned files twice: first as unversioned,
-            // and then once again with correct file version.
-            //
-            // These assertions check that each file in the manifest is unique:
-            // - unversioned file can only be added once, it should *never* override existing entry
-            // - versioned file can only be added once, after same file was added as unversioned,
-            //   it should *always* override existing *unversioned* entry
-            // - no file can *ever* override existing *versioned* entry
-            if version.is_unversioned() {
-                // Unversioned file should never override existing entry
-                debug_assert_eq!(
-                    prev_version,
-                    None,
-                    "unversioned segment file {} overrode versioned entry {:?}",
-                    path.display(),
-                    prev_version.unwrap(),
-                );
-            } else {
-                // Versioned file should always override unversioned entry
-                //
-                // Split into two separate assertions to provide better error messages
-
-                debug_assert_ne!(
-                    prev_version,
-                    None,
-                    "segment file {} with version {:?} did not override existing entry",
-                    path.display(),
-                    version,
-                );
-
-                debug_assert_eq!(
-                    prev_version,
-                    Some(FileVersion::Unversioned),
-                    "segment file {} with version {:?} overrode versioned entry {:?}",
-                    path.display(),
-                    version,
-                    prev_version.unwrap(),
-                );
-            }
-        }
-
-        // TODO: Version RocksDB!? 🤯
-        file_versions.insert(PathBuf::from(ROCKS_DB_VIRT_FILE), FileVersion::Unversioned);
-        file_versions.insert(
-            PathBuf::from(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE),
-            FileVersion::Unversioned,
-        );
-
-        Ok(SegmentManifest {
-            segment_version,
-            file_versions,
-        })
-    }
-
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
         let vector_index_searches: Vec<_> = self
             .vector_data
@@ -996,187 +872,4 @@ impl SegmentEntry for Segment {
             }
         }
     }
-}
-
-impl Segment {
-    fn files(&self) -> Vec<PathBuf> {
-        let mut files = Vec::new();
-
-        for vector_data in self.vector_data.values() {
-            files.extend(vector_data.vector_index.borrow().files());
-            files.extend(vector_data.vector_storage.borrow().files());
-
-            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().deref() {
-                files.extend(quantized_vectors.files());
-            }
-        }
-
-        files.extend(self.payload_index.borrow().files());
-        files.extend(self.payload_storage.borrow().files());
-
-        files.extend(self.id_tracker.borrow().files());
-
-        files
-    }
-
-    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
-        let mut files = Vec::new();
-
-        for vector_data in self.vector_data.values() {
-            files.extend(vector_data.vector_index.borrow().versioned_files());
-            files.extend(vector_data.vector_storage.borrow().versioned_files());
-
-            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().deref() {
-                files.extend(quantized_vectors.versioned_files());
-            }
-        }
-
-        files.extend(self.payload_index.borrow().versioned_files());
-        files.extend(self.payload_storage.borrow().versioned_files());
-
-        files.extend(self.id_tracker.borrow().versioned_files());
-
-        files
-    }
-}
-
-fn updated_files(old: &SegmentManifest, current: &SegmentManifest) -> HashSet<PathBuf> {
-    // Compare two segment manifests, and return a list of files from `current` manifest, that
-    // should be included into partial snapshot.
-
-    let mut updated = HashSet::new();
-
-    for (path, &current_version) in &current.file_versions {
-        // Include file into partial snapshot if:
-        //
-        // 1. `old` manifest does not contain this file
-        let Some(old_version) = old.file_versions.get(path).copied() else {
-            updated.insert(path.clone());
-            continue;
-        };
-
-        // 2. if `old` manifest contains this file and file/segment in `current` manifest is *newer*:
-        //    - if file is `Unversioned` in both manifests, compare segment versions
-        //    - if file is versioned in *one* of the manifests only, compare *file* version against
-        //      other *segment* version
-        //    - if file is versioned in both manifests, compare file versions
-        let is_updated = old_version.or_segment_version(old.segment_version)
-            < current_version.or_segment_version(current.segment_version);
-
-        if is_updated {
-            updated.insert(path.clone());
-        }
-    }
-
-    updated
-}
-
-const ROCKS_DB_VIRT_FILE: &str = "__ROCKS_DB";
-const PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE: &str = "__PAYLOAD_INDEX_ROCKS_DB";
-
-fn snapshot_files(
-    segment: &Segment,
-    temp_path: &Path,
-    tar: &tar_ext::BuilderExt<impl Write + Seek>,
-    include_if: impl Fn(&Path) -> bool,
-) -> OperationResult<()> {
-    // use temp_path for intermediary files
-    let temp_path = temp_path.join(format!("segment-{}", Uuid::new_v4()));
-
-    // TODO: Version RocksDB!? 🤯
-
-    if include_if(ROCKS_DB_VIRT_FILE.as_ref()) {
-        let db_backup_path = temp_path.join(DB_BACKUP_PATH);
-
-        let db = segment.database.read();
-        crate::rocksdb_backup::create(&db, &db_backup_path)?;
-    }
-
-    if include_if(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE.as_ref()) {
-        let payload_index_db_backup_path = temp_path.join(PAYLOAD_DB_BACKUP_PATH);
-
-        segment
-            .payload_index
-            .borrow()
-            .take_database_snapshot(&payload_index_db_backup_path)?;
-    }
-
-    tar.blocking_append_dir_all(&temp_path, Path::new(""))?;
-
-    // remove tmp directory in background
-    let _ = thread::spawn(move || {
-        let res = fs::remove_dir_all(&temp_path);
-        if let Err(err) = res {
-            log::error!(
-                "Failed to remove tmp directory at {}: {err:?}",
-                temp_path.display(),
-            );
-        }
-    });
-
-    let tar = tar.descend(Path::new(SNAPSHOT_FILES_PATH))?;
-
-    for vector_data in segment.vector_data.values() {
-        for file in vector_data.vector_index.borrow().files() {
-            let stripped_path = strip_prefix(&file, &segment.current_path)?;
-
-            if include_if(stripped_path) {
-                tar.blocking_append_file(&file, stripped_path)?;
-            }
-        }
-
-        for file in vector_data.vector_storage.borrow().files() {
-            let stripped_path = strip_prefix(&file, &segment.current_path)?;
-
-            if include_if(stripped_path) {
-                tar.blocking_append_file(&file, stripped_path)?;
-            }
-        }
-
-        if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().as_ref() {
-            for file in quantized_vectors.files() {
-                let stripped_path = strip_prefix(&file, &segment.current_path)?;
-
-                if include_if(stripped_path) {
-                    tar.blocking_append_file(&file, stripped_path)?;
-                }
-            }
-        }
-    }
-
-    for file in segment.payload_index.borrow().files() {
-        let stripped_path = strip_prefix(&file, &segment.current_path)?;
-
-        if include_if(stripped_path) {
-            tar.blocking_append_file(&file, stripped_path)?;
-        }
-    }
-
-    for file in segment.payload_storage.borrow().files() {
-        let stripped_path = strip_prefix(&file, &segment.current_path)?;
-
-        if include_if(stripped_path) {
-            tar.blocking_append_file(&file, stripped_path)?;
-        }
-    }
-
-    for file in segment.id_tracker.borrow().files() {
-        let stripped_path = strip_prefix(&file, &segment.current_path)?;
-
-        if include_if(stripped_path) {
-            tar.blocking_append_file(&file, stripped_path)?;
-        }
-    }
-
-    tar.blocking_append_file(
-        &segment.current_path.join(SEGMENT_STATE_FILE),
-        Path::new(SEGMENT_STATE_FILE),
-    )?;
-
-    tar.blocking_append_file(
-        &segment.current_path.join(VERSION_FILE),
-        Path::new(VERSION_FILE),
-    )?;
-
-    Ok(())
 }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{Seek, Write};
+use std::ops::Deref as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::thread::{self};
@@ -20,7 +21,7 @@ use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{QueryContext, SegmentQueryContext};
 use crate::data_types::vectors::{QueryVector, VectorInternal};
-use crate::entry::entry_point::SegmentEntry;
+use crate::entry::entry_point::{FileVersion, SegmentEntry, SegmentManifest};
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::json_path::JsonPath;
@@ -837,16 +838,134 @@ impl SegmentEntry for Segment {
                 tar.blocking_write_fn(Path::new(&format!("{segment_id}.tar")), |writer| {
                     let tar = tar_ext::BuilderExt::new_streaming_borrowed(writer);
                     let tar = tar.descend(Path::new(SNAPSHOT_PATH))?;
-                    snapshot_files(self, temp_path, &tar)
+                    snapshot_files(self, temp_path, &tar, |_| true)
                 })??;
             }
             SnapshotFormat::Streamable => {
                 let tar = tar.descend(Path::new(&segment_id))?;
-                snapshot_files(self, temp_path, &tar)?;
+                snapshot_files(self, temp_path, &tar, |_| true)?;
             }
         }
 
         Ok(())
+    }
+
+    fn take_partial_snapshot(
+        &self,
+        temp_path: &Path,
+        tar: &tar_ext::BuilderExt,
+        manifest: &SegmentManifest,
+    ) -> OperationResult<()> {
+        let segment_id = self
+            .current_path
+            .file_stem()
+            .and_then(|f| f.to_str())
+            .unwrap();
+
+        let updated_manifest = self.get_segment_manifest()?;
+        let updated_files = updated_files(manifest, &updated_manifest);
+
+        let tar = tar.descend(Path::new(&segment_id))?;
+
+        let updated_manifest_json = serde_json::to_vec(&updated_manifest).map_err(|err| {
+            OperationError::service_error(format!(
+                "failed to serialize segment manifest into JSON: {err}"
+            ))
+        })?;
+
+        tar.blocking_append_data(&updated_manifest_json, Path::new("segment_manifest.json"))?;
+
+        snapshot_files(self, temp_path, &tar, |path| updated_files.contains(path))?;
+        Ok(())
+    }
+
+    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
+        let segment_version = self.version();
+
+        let all_files = self.files();
+        let versioned_files = self.versioned_files();
+
+        // Note, that `all_files` should already contain all `versioned_files`, so each versioned file
+        // would be iterated over *twice*:
+        // - first as `FileVersion::Unversioned`
+        // - and then with correct `FileVersion::Version`
+        //
+        // The loop below is structured to do safety-checks and work around this correctly.
+        let all_files = all_files
+            .into_iter()
+            .map(|path| (path, FileVersion::Unversioned))
+            .chain(
+                versioned_files
+                    .into_iter()
+                    .map(|(path, version)| (path, FileVersion::from(version))),
+            );
+
+        let mut file_versions = HashMap::new();
+
+        for (path, version) in all_files {
+            // All segment files should be contained within segment directory
+            debug_assert!(
+                path.starts_with(&self.current_path),
+                "segment file {} is not contained within segment directory {}",
+                path.display(),
+                self.current_path.display(),
+            );
+
+            let path = strip_prefix(&path, &self.current_path)?;
+            let prev_version = file_versions.insert(path.to_path_buf(), version);
+
+            // `all_files` should iterate over versioned files twice: first as unversioned,
+            // and then once again with correct file version.
+            //
+            // These assertions check that each file in the manifest is unique:
+            // - unversioned file can only be added once, it should *never* override existing entry
+            // - versioned file can only be added once, after same file was added as unversioned,
+            //   it should *always* override existing *unversioned* entry
+            // - no file can *ever* override existing *versioned* entry
+            if version.is_unversioned() {
+                // Unversioned file should never override existing entry
+                debug_assert_eq!(
+                    prev_version,
+                    None,
+                    "unversioned segment file {} overrode versioned entry {:?}",
+                    path.display(),
+                    prev_version.unwrap(),
+                );
+            } else {
+                // Versioned file should always override unversioned entry
+                //
+                // Split into two separate assertions to provide better error messages
+
+                debug_assert_ne!(
+                    prev_version,
+                    None,
+                    "segment file {} with version {:?} did not override existing entry",
+                    path.display(),
+                    version,
+                );
+
+                debug_assert_eq!(
+                    prev_version,
+                    Some(FileVersion::Unversioned),
+                    "segment file {} with version {:?} overrode versioned entry {:?}",
+                    path.display(),
+                    version,
+                    prev_version.unwrap(),
+                );
+            }
+        }
+
+        // TODO: Version RocksDB!? 🤯
+        file_versions.insert(PathBuf::from(ROCKS_DB_VIRT_FILE), FileVersion::Unversioned);
+        file_versions.insert(
+            PathBuf::from(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE),
+            FileVersion::Unversioned,
+        );
+
+        Ok(SegmentManifest {
+            segment_version,
+            file_versions,
+        })
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
@@ -879,25 +998,108 @@ impl SegmentEntry for Segment {
     }
 }
 
+impl Segment {
+    fn files(&self) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+
+        for vector_data in self.vector_data.values() {
+            files.extend(vector_data.vector_index.borrow().files());
+            files.extend(vector_data.vector_storage.borrow().files());
+
+            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().deref() {
+                files.extend(quantized_vectors.files());
+            }
+        }
+
+        files.extend(self.payload_index.borrow().files());
+        files.extend(self.payload_storage.borrow().files());
+
+        files.extend(self.id_tracker.borrow().files());
+
+        files
+    }
+
+    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+        let mut files = Vec::new();
+
+        for vector_data in self.vector_data.values() {
+            files.extend(vector_data.vector_index.borrow().versioned_files());
+            files.extend(vector_data.vector_storage.borrow().versioned_files());
+
+            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().deref() {
+                files.extend(quantized_vectors.versioned_files());
+            }
+        }
+
+        files.extend(self.payload_index.borrow().versioned_files());
+        files.extend(self.payload_storage.borrow().versioned_files());
+
+        files.extend(self.id_tracker.borrow().versioned_files());
+
+        files
+    }
+}
+
+fn updated_files(old: &SegmentManifest, current: &SegmentManifest) -> HashSet<PathBuf> {
+    // Compare two segment manifests, and return a list of files from `current` manifest, that
+    // should be included into partial snapshot.
+
+    let mut updated = HashSet::new();
+
+    for (path, &current_version) in &current.file_versions {
+        // Include file into partial snapshot if:
+        //
+        // 1. `old` manifest does not contain this file
+        let Some(old_version) = old.file_versions.get(path).copied() else {
+            updated.insert(path.clone());
+            continue;
+        };
+
+        // 2. if `old` manifest contains this file and file/segment in `current` manifest is *newer*:
+        //    - if file is `Unversioned` in both manifests, compare segment versions
+        //    - if file is versioned in *one* of the manifests only, compare *file* version against
+        //      other *segment* version
+        //    - if file is versioned in both manifests, compare file versions
+        let is_updated = old_version.or_segment_version(old.segment_version)
+            < current_version.or_segment_version(current.segment_version);
+
+        if is_updated {
+            updated.insert(path.clone());
+        }
+    }
+
+    updated
+}
+
+const ROCKS_DB_VIRT_FILE: &str = "__ROCKS_DB";
+const PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE: &str = "__PAYLOAD_INDEX_ROCKS_DB";
+
 fn snapshot_files(
     segment: &Segment,
     temp_path: &Path,
     tar: &tar_ext::BuilderExt<impl Write + Seek>,
+    include_if: impl Fn(&Path) -> bool,
 ) -> OperationResult<()> {
     // use temp_path for intermediary files
     let temp_path = temp_path.join(format!("segment-{}", Uuid::new_v4()));
-    let db_backup_path = temp_path.join(DB_BACKUP_PATH);
-    let payload_index_db_backup_path = temp_path.join(PAYLOAD_DB_BACKUP_PATH);
 
-    {
+    // TODO: Version RocksDB!? 🤯
+
+    if include_if(ROCKS_DB_VIRT_FILE.as_ref()) {
+        let db_backup_path = temp_path.join(DB_BACKUP_PATH);
+
         let db = segment.database.read();
         crate::rocksdb_backup::create(&db, &db_backup_path)?;
     }
 
-    segment
-        .payload_index
-        .borrow()
-        .take_database_snapshot(&payload_index_db_backup_path)?;
+    if include_if(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE.as_ref()) {
+        let payload_index_db_backup_path = temp_path.join(PAYLOAD_DB_BACKUP_PATH);
+
+        segment
+            .payload_index
+            .borrow()
+            .take_database_snapshot(&payload_index_db_backup_path)?;
+    }
 
     tar.blocking_append_dir_all(&temp_path, Path::new(""))?;
 
@@ -913,32 +1115,57 @@ fn snapshot_files(
     });
 
     let tar = tar.descend(Path::new(SNAPSHOT_FILES_PATH))?;
+
     for vector_data in segment.vector_data.values() {
         for file in vector_data.vector_index.borrow().files() {
-            tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
+            let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+            if include_if(stripped_path) {
+                tar.blocking_append_file(&file, stripped_path)?;
+            }
         }
 
         for file in vector_data.vector_storage.borrow().files() {
-            tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
+            let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+            if include_if(stripped_path) {
+                tar.blocking_append_file(&file, stripped_path)?;
+            }
         }
 
         if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().as_ref() {
             for file in quantized_vectors.files() {
-                tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
+                let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+                if include_if(stripped_path) {
+                    tar.blocking_append_file(&file, stripped_path)?;
+                }
             }
         }
     }
 
     for file in segment.payload_index.borrow().files() {
-        tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
+        let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+        if include_if(stripped_path) {
+            tar.blocking_append_file(&file, stripped_path)?;
+        }
     }
 
     for file in segment.payload_storage.borrow().files() {
-        tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
+        let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+        if include_if(stripped_path) {
+            tar.blocking_append_file(&file, stripped_path)?;
+        }
     }
 
     for file in segment.id_tracker.borrow().files() {
-        tar.blocking_append_file(&file, strip_prefix(&file, &segment.current_path)?)?;
+        let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+        if include_if(stripped_path) {
+            tar.blocking_append_file(&file, stripped_path)?;
+        }
     }
 
     tar.blocking_append_file(

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -6,8 +6,9 @@ mod scroll;
 mod search;
 mod segment_ops;
 
-mod partial_snapshots;
+mod partial_snapshot;
 mod snapshot;
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -6,10 +6,10 @@ mod scroll;
 mod search;
 mod segment_ops;
 
-#[cfg(test)]
-mod tests;
 mod partial_snapshots;
 mod snapshot;
+#[cfg(test)]
+mod tests;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -8,6 +8,8 @@ mod segment_ops;
 
 #[cfg(test)]
 mod tests;
+mod partial_snapshots;
+mod snapshot;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/lib/segment/src/segment/partial_snapshots.rs
+++ b/lib/segment/src/segment/partial_snapshots.rs
@@ -1,17 +1,21 @@
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use common::tar_ext;
+
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::segment_manifest::{FileVersion, SegmentManifest};
 use crate::entry::entry_point::SegmentEntry;
 use crate::entry::partial_snapshot_entry::PartialSnapshotEntry;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::payload_storage::PayloadStorage;
-use crate::segment::snapshot::{snapshot_files, PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE, ROCKS_DB_VIRT_FILE};
+use crate::segment::snapshot::{
+    snapshot_files, PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE, ROCKS_DB_VIRT_FILE,
+};
 use crate::segment::Segment;
 use crate::utils::path::strip_prefix;
 use crate::vector_storage::VectorStorage;
-use common::tar_ext;
-use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
-use std::path::{Path, PathBuf};
 
 impl Segment {
     fn files(&self) -> Vec<PathBuf> {
@@ -115,7 +119,6 @@ impl PartialSnapshotEntry for Segment {
         snapshot_files(self, temp_path, &tar, |path| updated_files.contains(path))?;
         Ok(())
     }
-
 
     fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
         let segment_version = self.version();

--- a/lib/segment/src/segment/partial_snapshots.rs
+++ b/lib/segment/src/segment/partial_snapshots.rs
@@ -1,0 +1,208 @@
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::segment_manifest::{FileVersion, SegmentManifest};
+use crate::entry::entry_point::SegmentEntry;
+use crate::entry::partial_snapshot_entry::PartialSnapshotEntry;
+use crate::index::{PayloadIndex, VectorIndex};
+use crate::payload_storage::PayloadStorage;
+use crate::segment::snapshot::{snapshot_files, PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE, ROCKS_DB_VIRT_FILE};
+use crate::segment::Segment;
+use crate::utils::path::strip_prefix;
+use crate::vector_storage::VectorStorage;
+use common::tar_ext;
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+impl Segment {
+    fn files(&self) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+
+        for vector_data in self.vector_data.values() {
+            files.extend(vector_data.vector_index.borrow().files());
+            files.extend(vector_data.vector_storage.borrow().files());
+
+            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().deref() {
+                files.extend(quantized_vectors.files());
+            }
+        }
+
+        files.extend(self.payload_index.borrow().files());
+        files.extend(self.payload_storage.borrow().files());
+
+        files.extend(self.id_tracker.borrow().files());
+
+        files
+    }
+
+    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+        let mut files = Vec::new();
+
+        for vector_data in self.vector_data.values() {
+            files.extend(vector_data.vector_index.borrow().versioned_files());
+            files.extend(vector_data.vector_storage.borrow().versioned_files());
+
+            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().deref() {
+                files.extend(quantized_vectors.versioned_files());
+            }
+        }
+
+        files.extend(self.payload_index.borrow().versioned_files());
+        files.extend(self.payload_storage.borrow().versioned_files());
+
+        files.extend(self.id_tracker.borrow().versioned_files());
+
+        files
+    }
+}
+
+fn updated_files(old: &SegmentManifest, current: &SegmentManifest) -> HashSet<PathBuf> {
+    // Compare two segment manifests, and return a list of files from `current` manifest, that
+    // should be included into partial snapshot.
+
+    let mut updated = HashSet::new();
+
+    for (path, &current_version) in &current.file_versions {
+        // Include file into partial snapshot if:
+        //
+        // 1. `old` manifest does not contain this file
+        let Some(old_version) = old.file_versions.get(path).copied() else {
+            updated.insert(path.clone());
+            continue;
+        };
+
+        // 2. if `old` manifest contains this file and file/segment in `current` manifest is *newer*:
+        //    - if file is `Unversioned` in both manifests, compare segment versions
+        //    - if file is versioned in *one* of the manifests only, compare *file* version against
+        //      other *segment* version
+        //    - if file is versioned in both manifests, compare file versions
+        let is_updated = old_version.or_segment_version(old.segment_version)
+            < current_version.or_segment_version(current.segment_version);
+
+        if is_updated {
+            updated.insert(path.clone());
+        }
+    }
+
+    updated
+}
+
+impl PartialSnapshotEntry for Segment {
+    fn take_partial_snapshot(
+        &self,
+        temp_path: &Path,
+        tar: &tar_ext::BuilderExt,
+        manifest: &SegmentManifest,
+    ) -> OperationResult<()> {
+        let segment_id = self
+            .current_path
+            .file_stem()
+            .and_then(|f| f.to_str())
+            .unwrap();
+
+        let updated_manifest = self.get_segment_manifest()?;
+        let updated_files = updated_files(manifest, &updated_manifest);
+
+        let tar = tar.descend(Path::new(&segment_id))?;
+
+        let updated_manifest_json = serde_json::to_vec(&updated_manifest).map_err(|err| {
+            OperationError::service_error(format!(
+                "failed to serialize segment manifest into JSON: {err}"
+            ))
+        })?;
+
+        tar.blocking_append_data(&updated_manifest_json, Path::new("segment_manifest.json"))?;
+
+        snapshot_files(self, temp_path, &tar, |path| updated_files.contains(path))?;
+        Ok(())
+    }
+
+
+    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
+        let segment_version = self.version();
+
+        let all_files = self.files();
+        let versioned_files = self.versioned_files();
+
+        // Note, that `all_files` should already contain all `versioned_files`, so each versioned file
+        // would be iterated over *twice*:
+        // - first as `FileVersion::Unversioned`
+        // - and then with correct `FileVersion::Version`
+        //
+        // The loop below is structured to do safety-checks and work around this correctly.
+        let all_files = all_files
+            .into_iter()
+            .map(|path| (path, FileVersion::Unversioned))
+            .chain(
+                versioned_files
+                    .into_iter()
+                    .map(|(path, version)| (path, FileVersion::from(version))),
+            );
+
+        let mut file_versions = HashMap::new();
+
+        for (path, version) in all_files {
+            // All segment files should be contained within segment directory
+            debug_assert!(
+                path.starts_with(&self.current_path),
+                "segment file {} is not contained within segment directory {}",
+                path.display(),
+                self.current_path.display(),
+            );
+
+            let path = strip_prefix(&path, &self.current_path)?;
+            let prev_version = file_versions.insert(path.to_path_buf(), version);
+
+            // `all_files` should iterate over versioned files twice: first as unversioned,
+            // and then once again with correct file version.
+            //
+            // These assertions check that each file in the manifest is unique:
+            // - unversioned file can only be added once, it should *never* override existing entry
+            // - versioned file can only be added once, after same file was added as unversioned,
+            //   it should *always* override existing *unversioned* entry
+            // - no file can *ever* override existing *versioned* entry
+            if version.is_unversioned() {
+                // Unversioned file should never override existing entry
+                debug_assert_eq!(
+                    prev_version,
+                    None,
+                    "unversioned segment file {} overrode versioned entry {:?}",
+                    path.display(),
+                    prev_version.unwrap(),
+                );
+            } else {
+                // Versioned file should always override unversioned entry
+                //
+                // Split into two separate assertions to provide better error messages
+
+                debug_assert_ne!(
+                    prev_version,
+                    None,
+                    "segment file {} with version {:?} did not override existing entry",
+                    path.display(),
+                    version,
+                );
+
+                debug_assert_eq!(
+                    prev_version,
+                    Some(FileVersion::Unversioned),
+                    "segment file {} with version {:?} overrode versioned entry {:?}",
+                    path.display(),
+                    version,
+                    prev_version.unwrap(),
+                );
+            }
+        }
+
+        // TODO: Version RocksDB!? 🤯
+        file_versions.insert(PathBuf::from(ROCKS_DB_VIRT_FILE), FileVersion::Unversioned);
+        file_versions.insert(
+            PathBuf::from(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE),
+            FileVersion::Unversioned,
+        );
+
+        Ok(SegmentManifest {
+            segment_version,
+            file_versions,
+        })
+    }
+}

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -1,0 +1,124 @@
+use crate::common::operation_error::OperationResult;
+use crate::index::{PayloadIndex, VectorIndex};
+use crate::payload_storage::PayloadStorage;
+use crate::segment::{
+    Segment, DB_BACKUP_PATH, PAYLOAD_DB_BACKUP_PATH, SEGMENT_STATE_FILE, SNAPSHOT_FILES_PATH,
+};
+use crate::utils::path::strip_prefix;
+use crate::vector_storage::VectorStorage;
+use common::tar_ext;
+use io::storage_version::VERSION_FILE;
+use std::io::{Seek, Write};
+use std::path::Path;
+use std::{fs, thread};
+use uuid::Uuid;
+
+pub const ROCKS_DB_VIRT_FILE: &str = "__ROCKS_DB";
+pub const PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE: &str = "__PAYLOAD_INDEX_ROCKS_DB";
+
+pub fn snapshot_files(
+    segment: &Segment,
+    temp_path: &Path,
+    tar: &tar_ext::BuilderExt<impl Write + Seek>,
+    include_if: impl Fn(&Path) -> bool,
+) -> OperationResult<()> {
+    // use temp_path for intermediary files
+    let temp_path = temp_path.join(format!("segment-{}", Uuid::new_v4()));
+
+    // TODO: Version RocksDB!? 🤯
+
+    if include_if(ROCKS_DB_VIRT_FILE.as_ref()) {
+        let db_backup_path = temp_path.join(DB_BACKUP_PATH);
+
+        let db = segment.database.read();
+        crate::rocksdb_backup::create(&db, &db_backup_path)?;
+    }
+
+    if include_if(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE.as_ref()) {
+        let payload_index_db_backup_path = temp_path.join(PAYLOAD_DB_BACKUP_PATH);
+
+        segment
+            .payload_index
+            .borrow()
+            .take_database_snapshot(&payload_index_db_backup_path)?;
+    }
+
+    tar.blocking_append_dir_all(&temp_path, Path::new(""))?;
+
+    // remove tmp directory in background
+    let _ = thread::spawn(move || {
+        let res = fs::remove_dir_all(&temp_path);
+        if let Err(err) = res {
+            log::error!(
+                "Failed to remove tmp directory at {}: {err:?}",
+                temp_path.display(),
+            );
+        }
+    });
+
+    let tar = tar.descend(Path::new(SNAPSHOT_FILES_PATH))?;
+
+    for vector_data in segment.vector_data.values() {
+        for file in vector_data.vector_index.borrow().files() {
+            let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+            if include_if(stripped_path) {
+                tar.blocking_append_file(&file, stripped_path)?;
+            }
+        }
+
+        for file in vector_data.vector_storage.borrow().files() {
+            let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+            if include_if(stripped_path) {
+                tar.blocking_append_file(&file, stripped_path)?;
+            }
+        }
+
+        if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().as_ref() {
+            for file in quantized_vectors.files() {
+                let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+                if include_if(stripped_path) {
+                    tar.blocking_append_file(&file, stripped_path)?;
+                }
+            }
+        }
+    }
+
+    for file in segment.payload_index.borrow().files() {
+        let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+        if include_if(stripped_path) {
+            tar.blocking_append_file(&file, stripped_path)?;
+        }
+    }
+
+    for file in segment.payload_storage.borrow().files() {
+        let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+        if include_if(stripped_path) {
+            tar.blocking_append_file(&file, stripped_path)?;
+        }
+    }
+
+    for file in segment.id_tracker.borrow().files() {
+        let stripped_path = strip_prefix(&file, &segment.current_path)?;
+
+        if include_if(stripped_path) {
+            tar.blocking_append_file(&file, stripped_path)?;
+        }
+    }
+
+    tar.blocking_append_file(
+        &segment.current_path.join(SEGMENT_STATE_FILE),
+        Path::new(SEGMENT_STATE_FILE),
+    )?;
+
+    tar.blocking_append_file(
+        &segment.current_path.join(VERSION_FILE),
+        Path::new(VERSION_FILE),
+    )?;
+
+    Ok(())
+}

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -1,3 +1,11 @@
+use std::io::{Seek, Write};
+use std::path::Path;
+use std::{fs, thread};
+
+use common::tar_ext;
+use io::storage_version::VERSION_FILE;
+use uuid::Uuid;
+
 use crate::common::operation_error::OperationResult;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::payload_storage::PayloadStorage;
@@ -6,12 +14,6 @@ use crate::segment::{
 };
 use crate::utils::path::strip_prefix;
 use crate::vector_storage::VectorStorage;
-use common::tar_ext;
-use io::storage_version::VERSION_FILE;
-use std::io::{Seek, Write};
-use std::path::Path;
-use std::{fs, thread};
-use uuid::Uuid;
 
 pub const ROCKS_DB_VIRT_FILE: &str = "__ROCKS_DB";
 pub const PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE: &str = "__PAYLOAD_INDEX_ROCKS_DB";

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -15,8 +15,8 @@ use crate::segment::{
 use crate::utils::path::strip_prefix;
 use crate::vector_storage::VectorStorage;
 
-pub const ROCKS_DB_VIRT_FILE: &str = "__ROCKS_DB";
-pub const PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE: &str = "__PAYLOAD_INDEX_ROCKS_DB";
+pub const ROCKS_DB_VIRT_FILE: &str = "::ROCKS_DB";
+pub const PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE: &str = "::PAYLOAD_INDEX_ROCKS_DB";
 
 pub fn snapshot_files(
     segment: &Segment,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -214,6 +214,10 @@ impl QuantizedVectors {
         files
     }
 
+    pub fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+        Vec::new() // TODO
+    }
+
     pub fn create(
         vector_storage: &VectorStorageEnum,
         quantization_config: &QuantizationConfig,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -21,7 +21,7 @@ use crate::data_types::vectors::{
     MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorElementTypeByte,
     VectorElementTypeHalf, VectorInternal, VectorRef,
 };
-use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
+use crate::types::{Distance, MultiVectorConfig, SeqNumberType, VectorStorageDatatype};
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::dense::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage;
 use crate::vector_storage::in_ram_persisted_vectors::InRamPersistedVectors;
@@ -77,6 +77,10 @@ pub trait VectorStorage {
     fn flusher(&self) -> Flusher;
 
     fn files(&self) -> Vec<PathBuf>;
+
+    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+        Vec::new()
+    }
 
     /// Flag the vector by the given key as deleted
     ///


### PR DESCRIPTION
This PR prototypes `Segment::take_partial_snapshot` implementation and `SegmentManifest` (structure that is used to calculate which files to include into partial snapshot) format.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
