### PR TITLE
[mmap sparse vector storage] return cancelled error if stopped

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -83,7 +83,7 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
 
     fn update_from<'a>(
         &mut self,
-        _other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        _other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         _stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         todo!()

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -348,9 +348,10 @@ impl SegmentBuilder {
             match &new_internal_range {
                 Some(new_internal_range) => {
                     if new_internal_range != &internal_range {
-                        return Err(OperationError::service_error(
-                            "Internal ids range mismatch between self segment vectors and other segment vectors",
-                        ));
+                        return Err(OperationError::service_error( format!(
+                                "Internal ids range mismatch between self segment vectors and other segment vectors\n\
+                                vector_name: {vector_name}, self range: {new_internal_range:?}, other range: {internal_range:?}"
+                            )));
                     }
                 }
                 None => new_internal_range = Some(internal_range),

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -120,11 +120,11 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
-        for (other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -180,7 +180,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let dim = self.vector_dim();
@@ -196,7 +196,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         // Extend vectors file, write other vectors into it
         let mut vectors_file = open_append(&self.vectors_path)?;
         let mut deleted_ids = vec![];
-        for (offset, (other_vector, other_deleted)) in other_ids.enumerate() {
+        for (offset, (other_vector, other_deleted)) in other_vectors.enumerate() {
             check_process_stopped(stopped)?;
             let vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
             let raw_bites = mmap_ops::transmute_to_u8_slice(vector.as_ref());

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -232,11 +232,11 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
-        for (other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -232,11 +232,11 @@ impl<
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.offsets.len() as PointOffsetType;
-        for (other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector: VectorRef = other_vector.as_vec_ref();

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -370,11 +370,11 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors_metadata.len() as PointOffsetType;
-        for (other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector: VectorRef = other_vector.as_vec_ref();

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -13,7 +13,7 @@ use parking_lot::RwLock;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::simple_sparse_vector_storage::SPARSE_VECTOR_DISTANCE;
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::VectorStorageDatatype;
@@ -240,6 +240,10 @@ impl VectorStorage for MmapSparseVectorStorage {
             let vector = (!other_deleted).then_some(other_vector);
             self.update_stored(new_id, vector, &hw_counter)?;
         }
+
+        // return cancelled error if stopped
+        check_process_stopped(stopped)?;
+
         Ok(start_index..self.next_point_offset as PointOffsetType)
     }
 

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -205,11 +205,11 @@ impl VectorStorage for SimpleSparseVectorStorage {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.total_vector_count as PointOffsetType;
-        for (other_vector, other_deleted) in other_ids {
+        for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = other_vector.as_vec_ref().try_into()?;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -62,6 +62,12 @@ pub trait VectorStorage {
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()>;
 
+    /// Add the given vectors to the storage.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
     fn update_from<'a>(
         &mut self,
         other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
@@ -605,40 +611,48 @@ impl VectorStorage for VectorStorageEnum {
 
     fn update_from<'a>(
         &mut self,
-        other_ids: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         match self {
-            VectorStorageEnum::DenseSimple(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseSimpleByte(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseSimpleHalf(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseMemmap(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseMemmapByte(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseAppendableInRam(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseAppendableInRamByte(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::DenseAppendableInRamHalf(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::SparseSimple(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::SparseMmap(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::MultiDenseSimple(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::MultiDenseSimpleByte(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.update_from(other_ids, stopped),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.update_from(other_ids, stopped),
+            VectorStorageEnum::DenseSimple(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseSimpleByte(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseSimpleHalf(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseMemmap(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseMemmapByte(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                v.update_from(other_vectors, stopped)
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                v.update_from(other_vectors, stopped)
+            }
+            VectorStorageEnum::DenseAppendableInRam(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseAppendableInRamByte(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::DenseAppendableInRamHalf(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::SparseSimple(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::SparseMmap(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::MultiDenseSimple(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.update_from(other_vectors, stopped),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.update_from(other_vectors, stopped)
+            }
             VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
-                v.update_from(other_ids, stopped)
+                v.update_from(other_vectors, stopped)
             }
             VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
-                v.update_from(other_ids, stopped)
+                v.update_from(other_vectors, stopped)
             }
-            VectorStorageEnum::MultiDenseAppendableInRam(v) => v.update_from(other_ids, stopped),
+            VectorStorageEnum::MultiDenseAppendableInRam(v) => {
+                v.update_from(other_vectors, stopped)
+            }
             VectorStorageEnum::MultiDenseAppendableInRamByte(v) => {
-                v.update_from(other_ids, stopped)
+                v.update_from(other_vectors, stopped)
             }
             VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => {
-                v.update_from(other_ids, stopped)
+                v.update_from(other_vectors, stopped)
             }
         }
     }


### PR DESCRIPTION
This fixes a bug that happened when updating a mmap sparse vector storage is cancelled. 

An invariant was broken when handling the `stopped` flag. All other implementations stop midway and return `OperationError::Cancelled`, but this implementation just stopped iterating, and returned a partial updated range. 

This caused the range check to fail, don't handle cancellation nicely, and send a service error back all the way to the user.