### PR TITLE
Add default log format properties to configuration file

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,10 +4,14 @@ log_level: INFO
 # Qdrant logs to stdout. You may configure to also write logs to a file on disk.
 # Be aware that this file may grow indefinitely.
 # logger:
+#   # Logging format, supports `text` and `json`
+#   format: text
 #   on_disk:
 #     enabled: true
 #     log_file: path/to/log/file.log
 #     log_level: INFO
+#     # Logging format, supports `text` and `json`
+#     format: text
 
 storage:
   # Where to store all the data


### PR DESCRIPTION
Fixes <https://github.com/qdrant/landing_page/pull/1448>
Add docs for <https://github.com/qdrant/qdrant/pull/5602>

Add the logging format property to the configuration file by default.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?