### PR TITLE
Add NormalizePath middleware to cleanup url

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -115,7 +115,7 @@ pub fn init(
                 .wrap(ConditionEx::from_option(auth_keys.as_ref().map(
                     |auth_keys| Auth::new(auth_keys.clone(), api_key_whitelist.clone()),
                 )))
-                // Normalize path to avoid path traversal attacks
+                // Normalize path
                 .wrap(NormalizePath::trim())
                 .wrap(Condition::new(settings.service.enable_cors, cors))
                 .wrap(

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -12,7 +12,7 @@ use ::api::rest::models::{ApiResponse, ApiStatus, VersionInfo};
 use actix_cors::Cors;
 use actix_multipart::form::tempfile::TempFileConfig;
 use actix_multipart::form::MultipartFormConfig;
-use actix_web::middleware::{Compress, Condition, Logger};
+use actix_web::middleware::{Compress, Condition, Logger, NormalizePath};
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use actix_web_extras::middleware::Condition as ConditionEx;
 use api::facet_api::config_facet_api;
@@ -115,6 +115,8 @@ pub fn init(
                 .wrap(ConditionEx::from_option(auth_keys.as_ref().map(
                     |auth_keys| Auth::new(auth_keys.clone(), api_key_whitelist.clone()),
                 )))
+                // Normalize path to avoid path traversal attacks
+                .wrap(NormalizePath::trim())
                 .wrap(Condition::new(settings.service.enable_cors, cors))
                 .wrap(
                     // Set up logger, but avoid logging hot status endpoints

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -148,7 +148,7 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/search" 
   }' | jq
 
 # test double forward slash handling
-curl -L -X POST "http://$QDRANT_HOST//collections/test_collection/points/search" \
+curl -L -X POST "http://$QDRANT_HOST//collections/test_collection/points/search/" \
   -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
   --fail -s \
   --data-raw '{

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -146,3 +146,22 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/search" 
       "vector": [0.2, 0.1, 0.9, 0.7],
       "top": 3
   }' | jq
+
+# test double forward slash handling
+curl -L -X POST "http://$QDRANT_HOST//collections/test_collection/points/search" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --fail -s \
+  --data-raw '{
+      "filter": {
+          "should": [
+              {
+                  "key": "city", 
+                  "match": {
+                      "value": "London"
+                  }
+              }
+          ]
+      },
+      "vector": [0.2, 0.1, 0.9, 0.7],
+      "top": 3
+  }' | jq


### PR DESCRIPTION
This PR adds an actix middleware that remove double slashes from API requests.

This should fix #5826 and also as an addition, help avoid path traversal attacks

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
