### PR TITLE
[flushing] take update buffers by reference

### DIFF
--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -68,9 +68,10 @@ impl DatabaseColumnScheduledDeleteWrapper {
     }
 
     pub fn flusher(&self) -> Flusher {
-        let ids_to_delete = mem::take(&mut *self.deleted_pending_persistence.lock());
+        let deleted_pending_persistence = Arc::clone(&self.deleted_pending_persistence);
         let wrapper = self.db.clone();
         Box::new(move || {
+            let ids_to_delete = mem::take(&mut *deleted_pending_persistence.lock());
             for id in ids_to_delete {
                 wrapper.remove(id)?;
             }


### PR DESCRIPTION
Our flushing sequence is very clearly defined, and it is important that some components get flushed before others. However, there are some buffered updates which introduce a bit of a different behavior. When we call `flusher()` of a particular component, we expect a closure which will be run at a different time. 

However, as @timvisee pointed out to me by chat, some of those flushers would capture the pending updates at the time the closure is created. This means that the closure they return is returning the state at which `flusher()` is called, not exactly a function which will flush the component at any time.

To fix this, this PR makes them return a reference to their buffers, so that we know for sure that when the closure is called, all its pending changes are also flushed up to that moment.

There are 4 structures which behave this way, and are updated in this PR:
- `MmapBitSliceBufferedUpdateWrapper`
- `MmapSliceBufferedUpdateWrapper`
- `DatabaseColumnScheduledDeleteWrapper`
- `DatabaseColumnScheduledUpdateWrapper`

These changes have already passed one crasher run. Currently testing with another 2 runs, one of 1hr and another one of 6hrs.