### PR TITLE
Experiment: grid store flusher closure

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -817,6 +817,11 @@ impl<'s> SegmentHolder {
 
         drop(proxy_segments);
 
+        debug_assert!(
+            min_unsaved_version == SeqNumberType::MAX || min_unsaved_version <= max_persisted_version,
+            "min_unsaved_version cannot be greater than max_persisted_version ({min_unsaved_version:?} > {max_persisted_version:?})",
+        );
+
         if has_unsaved {
             log::trace!(
                 "Some segments have unsaved changes, lowest unsaved version: {min_unsaved_version}"

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -34,7 +34,7 @@ use crate::madvise::{Advice, AdviceSetting};
 use crate::mmap_ops;
 
 /// Result for mmap errors.
-type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 pub type MmapFlusher = Box<dyn FnOnce() -> Result<()> + Send>;
 

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use itertools::Itertools;
 use memory::madvise::{Advice, AdviceSetting};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
-use memory::mmap_type::{self, MmapSlice};
+use memory::mmap_type::{MmapFlusher, MmapSlice};
 
 use super::{RegionId, StorageConfig};
 
@@ -126,8 +126,9 @@ impl BitmaskGaps {
         })
     }
 
-    pub fn flush(&self) -> Result<(), mmap_type::Error> {
-        self.mmap_slice.flusher()()
+    /// Get flusher to explicitly flush mmap at a later time
+    pub fn flusher(&self) -> MmapFlusher {
+        self.mmap_slice.flusher()
     }
 
     /// Extends the mmap file to fit the new regions

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -250,7 +250,7 @@ impl<V: Blob> Gridstore<V> {
     /// If size is None, the page will have the default size
     ///
     /// Returns the new page id
-    fn create_new_page(&mut self) -> Result<u32> {
+    fn create_new_page(&self) -> Result<u32> {
         let new_page_id = self.next_page_id();
         let path = self.page_path(new_page_id);
         let page = Page::new(&path, self.config.page_size_bytes)?;
@@ -266,10 +266,7 @@ impl<V: Blob> Gridstore<V> {
         self.tracker.read().get(point_offset)
     }
 
-    fn find_or_create_available_blocks(
-        &mut self,
-        num_blocks: u32,
-    ) -> Result<(PageId, BlockOffset)> {
+    fn find_or_create_available_blocks(&self, num_blocks: u32) -> Result<(PageId, BlockOffset)> {
         debug_assert!(num_blocks > 0, "num_blocks must be greater than 0");
 
         let bitmask_guard = self.bitmask.read();
@@ -301,12 +298,7 @@ impl<V: Blob> Gridstore<V> {
     }
 
     /// Write value into a new cell, considering that it can span more than one page
-    fn write_into_pages(
-        &mut self,
-        value: &[u8],
-        start_page_id: PageId,
-        mut block_offset: BlockOffset,
-    ) {
+    fn write_into_pages(&self, value: &[u8], start_page_id: PageId, mut block_offset: BlockOffset) {
         let value_size = value.len();
 
         // Track the number of bytes that still need to be written
@@ -790,7 +782,7 @@ mod tests {
     #[test]
     fn test_write_across_pages() {
         let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
-        let (_dir, mut storage) = empty_storage_sized(page_size);
+        let (_dir, storage) = empty_storage_sized(page_size);
 
         storage.create_new_page().unwrap();
 

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -501,7 +501,7 @@ impl<V> Gridstore<V> {
     /// Flush all mmaps and pending updates to disk
     pub fn flush(&self) -> std::result::Result<(), mmap_type::Error> {
         let mut bitmask_guard = self.bitmask.upgradable_read();
-        bitmask_guard.flush()?;
+        bitmask_guard.flusher()()?;
         for page in &self.pages {
             page.flush()?;
         }
@@ -519,7 +519,7 @@ impl<V> Gridstore<V> {
                 );
             }
         });
-        bitmask_guard.flush()?;
+        bitmask_guard.flusher()()?;
 
         Ok(())
     }

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -28,7 +28,7 @@ pub struct Gridstore<V> {
     /// Holds mapping from `PointOffset` -> `ValuePointer`
     ///
     /// Stored in a separate file
-    tracker: RwLock<Tracker>,
+    tracker: Arc<RwLock<Tracker>>,
     /// Mapping from page_id -> mmap page
     pub(super) pages: Arc<RwLock<Vec<Page>>>,
     /// Bitmask to represent which "blocks" of data in the pages are used and which are free.
@@ -126,7 +126,7 @@ impl<V: Blob> Gridstore<V> {
         let config_path = base_path.join(CONFIG_FILENAME);
 
         let storage = Self {
-            tracker: RwLock::new(Tracker::new(&base_path, None)),
+            tracker: Arc::new(RwLock::new(Tracker::new(&base_path, None))),
             pages: Default::default(),
             bitmask: RwLock::new(Bitmask::create(&base_path, config.clone())?),
             base_path,
@@ -169,7 +169,7 @@ impl<V: Blob> Gridstore<V> {
         let num_pages = bitmask.infer_num_pages();
 
         let storage = Self {
-            tracker: RwLock::new(page_tracker),
+            tracker: Arc::new(RwLock::new(page_tracker)),
             config,
             pages: Arc::new(RwLock::new(Vec::with_capacity(num_pages))),
             bitmask: RwLock::new(bitmask),

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -171,9 +171,9 @@ impl PayloadStorage for MmapPayloadStorage {
     }
 
     fn flusher(&self) -> Flusher {
-        let storage = self.storage.clone();
+        let storage_flusher = self.storage.read().flusher();
         Box::new(move || {
-            storage.read().flush().map_err(|err| {
+            storage_flusher().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to flush mmap payload storage: {err}"
                 ))

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -248,11 +248,11 @@ impl VectorStorage for MmapSparseVectorStorage {
     }
 
     fn flusher(&self) -> crate::common::Flusher {
-        let storage = self.storage.clone();
+        let storage_flusher = self.storage.read().flusher();
         let deleted_flags_flusher = self.deleted.flusher();
         Box::new(move || {
             deleted_flags_flusher()?;
-            storage.read().flush().map_err(|err| {
+            storage_flusher().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to flush mmap sparse vector storage: {err}"
                 ))


### PR DESCRIPTION
_WIP_

A hacked together async flusher implementation for grid store, to match the other storage flushers.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
