### PR TITLE
Tiny refactoring to reduce some boilerplate in update API

### DIFF
--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -30,9 +30,11 @@ struct FieldPath {
 }
 
 #[derive(Deserialize, Serialize, JsonSchema, Validate)]
-pub struct UpdateParam {
-    pub wait: Option<bool>,
-    pub ordering: Option<WriteOrdering>,
+pub struct UpdateParams {
+    #[serde(default)]
+    pub wait: bool,
+    #[serde(default)]
+    pub ordering: WriteOrdering,
 }
 
 #[put("/collections/{name}/points")]
@@ -40,7 +42,7 @@ async fn upsert_points(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<PointInsertOperations>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
     inference_token: InferenceToken,
@@ -52,8 +54,7 @@ async fn upsert_points(
         };
 
     let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
@@ -84,7 +85,7 @@ async fn delete_points(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<PointsSelector>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
     inference_token: InferenceToken,
@@ -96,8 +97,7 @@ async fn delete_points(
             Err(err) => return process_response_error(err, Instant::now(), None),
         };
 
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
@@ -128,14 +128,13 @@ async fn update_vectors(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<UpdateVectors>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
     inference_token: InferenceToken,
 ) -> impl Responder {
     let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let pass =
         match check_strict_mode(&operation, None, &collection.name, &dispatcher, &access).await {
@@ -172,7 +171,7 @@ async fn delete_vectors(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<DeleteVectors>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
@@ -185,8 +184,7 @@ async fn delete_vectors(
             Err(err) => return process_response_error(err, timing, None),
         };
 
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
@@ -216,7 +214,7 @@ async fn set_payload(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<SetPayload>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
@@ -228,8 +226,7 @@ async fn set_payload(
             Err(err) => return process_response_error(err, Instant::now(), None),
         };
 
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
@@ -259,7 +256,7 @@ async fn overwrite_payload(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<SetPayload>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
@@ -269,8 +266,7 @@ async fn overwrite_payload(
             Ok(pass) => pass,
             Err(err) => return process_response_error(err, Instant::now(), None),
         };
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
@@ -300,7 +296,7 @@ async fn delete_payload(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<DeletePayload>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
@@ -310,8 +306,7 @@ async fn delete_payload(
             Ok(pass) => pass,
             Err(err) => return process_response_error(err, Instant::now(), None),
         };
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
@@ -341,7 +336,7 @@ async fn clear_payload(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<PointsSelector>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
@@ -352,8 +347,7 @@ async fn clear_payload(
             Err(err) => return process_response_error(err, Instant::now(), None),
         };
 
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
@@ -383,7 +377,7 @@ async fn update_batch(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operations: Json<UpdateOperations>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
     inference_token: InferenceToken,
@@ -415,8 +409,7 @@ async fn update_batch(
 
     let timing = Instant::now();
 
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     // TODO(io_measurement): Measure upsertion io
     let response = do_batch_update_points(
@@ -439,13 +432,12 @@ async fn create_field_index(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<CreateFieldIndex>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let response = do_create_index(
         dispatcher.into_inner(),
@@ -466,12 +458,11 @@ async fn delete_field_index(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     field: Path<FieldPath>,
-    params: Query<UpdateParam>,
+    params: Query<UpdateParams>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
     let timing = Instant::now();
-    let wait = params.wait.unwrap_or(false);
-    let ordering = params.ordering.unwrap_or_default();
+    let UpdateParams { wait, ordering } = params.into_inner();
 
     let response = do_delete_index(
         dispatcher.into_inner(),

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -7,7 +7,6 @@ use collection::operations::payload_ops::{DeletePayload, SetPayload};
 use collection::operations::point_ops::{PointsSelector, WriteOrdering};
 use collection::operations::types::UpdateResult;
 use collection::operations::vector_ops::DeleteVectors;
-use schemars::JsonSchema;
 use segment::json_path::JsonPath;
 use serde::{Deserialize, Serialize};
 use storage::content_manager::collection_verification::check_strict_mode;
@@ -29,7 +28,7 @@ struct FieldPath {
     name: JsonPath,
 }
 
-#[derive(Deserialize, Serialize, JsonSchema, Validate)]
+#[derive(Deserialize, Serialize, Validate)]
 pub struct UpdateParams {
     #[serde(default)]
     pub wait: bool,

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -235,13 +235,14 @@ impl PointsInternal for PointsInternalService {
         validate_and_log(request.get_ref());
 
         let inference_token = extract_token(&request);
-        let request = request.into_inner();
 
-        let shard_id = request.shard_id;
-        let clock_tag = request.clock_tag;
+        let UpdateVectorsInternal {
+            update_vectors: update_vectors_req,
+            shard_id,
+            clock_tag,
+        } = request.into_inner();
 
-        let update_point_vectors = request
-            .update_vectors
+        let update_point_vectors = update_vectors_req
             .ok_or_else(|| Status::invalid_argument("UpdateVectors is missing"))?;
 
         update_vectors(
@@ -261,13 +262,13 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
-        let request = request.into_inner();
+        let DeleteVectorsInternal {
+            delete_vectors: delete_vectors_req,
+            shard_id,
+            clock_tag,
+        } = request.into_inner();
 
-        let shard_id = request.shard_id;
-        let clock_tag = request.clock_tag;
-
-        let delete_point_vectors = request
-            .delete_vectors
+        let delete_point_vectors = delete_vectors_req
             .ok_or_else(|| Status::invalid_argument("DeleteVectors is missing"))?;
 
         delete_vectors(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -29,7 +29,7 @@ use tonic::{Request, Response, Status};
 use super::query_common::*;
 use super::update_common::*;
 use super::validate_and_log;
-use crate::common::inference::InferenceToken;
+use crate::common::inference::extract_token;
 use crate::settings::ServiceConfig;
 use crate::tonic::verification::{StrictModeCheckedInternalTocProvider, UncheckedTocProvider};
 
@@ -178,11 +178,7 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
-        let inference_token = request
-            .extensions()
-            .get::<InferenceToken>()
-            .cloned()
-            .unwrap_or(InferenceToken(None));
+        let inference_token = extract_token(&request);
 
         let UpsertPointsInternal {
             upsert_points,
@@ -210,11 +206,7 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
-        let inference_token = request
-            .extensions()
-            .get::<InferenceToken>()
-            .cloned()
-            .unwrap_or(InferenceToken(None));
+        let inference_token = extract_token(&request);
 
         let DeletePointsInternal {
             delete_points,
@@ -242,11 +234,7 @@ impl PointsInternal for PointsInternalService {
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
 
-        let inference_token = request
-            .extensions()
-            .get::<InferenceToken>()
-            .cloned()
-            .unwrap_or(InferenceToken(None));
+        let inference_token = extract_token(&request);
         let request = request.into_inner();
 
         let shard_id = request.shard_id;
@@ -601,11 +589,7 @@ impl PointsInternal for PointsInternalService {
         request: Request<SyncPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-        let inference_token = request
-            .extensions()
-            .get::<InferenceToken>()
-            .cloned()
-            .unwrap_or(InferenceToken(None));
+        let inference_token = extract_token(&request);
 
         let SyncPointsInternal {
             sync_points,

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -569,11 +569,9 @@ impl PointsInternal for PointsInternalService {
             clock_tag,
         } = request.into_inner();
 
-        let sync_points =
-            sync_points.ok_or_else(|| Status::invalid_argument("SyncPoints is missing"))?;
         sync(
             self.toc.clone(),
-            sync_points,
+            extract_internal_request(sync_points)?,
             clock_tag.map(Into::into),
             shard_id,
             FULL_ACCESS.clone(),


### PR DESCRIPTION
Some trivial tweaks to update API to slash a few lines of boilerplate:

- simplify `wait` and `ordering` query parameters deserialization in REST API
  - this does not affect OpenAPI spec, because these parameters are *explicitly* described there
- use `common::inference::extract_token` in internal gRPC API
  - (as far as I can tell, it's *exactly* the same, as a copy-pasted snippet that was used in internal gRPC API before)
- destructure `UpdateVectorsInternal`/`DeleteVectorsInternal` requests instead of accessing fields individually
- add generic `extract_internal_request` helper

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
