### PR TITLE
[id_tracker] Don't introduce synthetic versions

### DIFF
--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -651,7 +651,7 @@ pub(super) mod test {
 
             assert_eq!(
                 id_tracker.internal_version(internal_id),
-                Some((*expect_version).into())
+                Some(*expect_version)
             );
 
             // Check that unmodified points still haven't changed.

--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -3,6 +3,7 @@ pub mod immutable_id_tracker;
 pub mod in_memory_id_tracker;
 pub mod point_mappings;
 pub mod simple_id_tracker;
+pub mod version_type;
 
 use common::types::PointOffsetType;
 pub use id_tracker_base::*;

--- a/lib/segment/src/id_tracker/version_type.rs
+++ b/lib/segment/src/id_tracker/version_type.rs
@@ -4,6 +4,7 @@ use crate::types::SeqNumberType;
 ///
 /// The only special thing about this is that SeqNumberType::MAX means no version. Make sure to always use [VersionType::none()] as default when resizing.
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(transparent)]
 pub struct VersionType(SeqNumberType);
 
 impl VersionType {

--- a/lib/segment/src/id_tracker/version_type.rs
+++ b/lib/segment/src/id_tracker/version_type.rs
@@ -1,0 +1,45 @@
+use crate::types::SeqNumberType;
+
+/// This version type ensures that the `internal_to_version` vector can safely grow without introducing synthetic versions
+///
+/// The only special thing about this is that SeqNumberType::MAX means no version. Make sure to always use [VersionType::none()] as default when resizing.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct VersionType(SeqNumberType);
+
+impl VersionType {
+    pub const fn none() -> Self {
+        Self(SeqNumberType::MAX)
+    }
+}
+
+impl From<SeqNumberType> for VersionType {
+    fn from(version: SeqNumberType) -> Self {
+        Self(version)
+    }
+}
+
+// This is the important conversion to distinguish between None and Some.
+impl From<VersionType> for Option<SeqNumberType> {
+    fn from(version: VersionType) -> Self {
+        match version.0 {
+            SeqNumberType::MAX => None,
+            v => Some(v),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_type() {
+        assert_eq!(VersionType::from(SeqNumberType::MAX), VersionType::none());
+        assert_eq!(Option::from(VersionType::from(42)), Some(42));
+
+        assert_eq!(Option::<SeqNumberType>::from(VersionType::none()), None);
+        assert_eq!(Option::from(VersionType(42)), Some(42));
+
+        assert_eq!(size_of::<VersionType>(), size_of::<SeqNumberType>());
+    }
+}

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -606,18 +606,14 @@ impl Segment {
                 {
                     let point_id = id_tracker.external_id(internal_id);
                     let point_version = id_tracker.internal_version(internal_id);
-                    // ignoring initial version because the WAL replay can resurrect un-flushed points by assigning them a new initial version
-                    // those points will be deleted by the next deduplication process
-                    if point_version != Some(0) {
-                        log::error!(
+                    log::error!(
                         "Vector storage '{}' is missing point {:?} point_offset: {} version: {:?}",
                         vector_name,
                         point_id,
                         internal_id,
                         point_version
                     );
-                        has_internal_ids_without_vector = true;
-                    }
+                    has_internal_ids_without_vector = true;
                 }
             }
         }


### PR DESCRIPTION
Our id trackers currently can't discriminate between version 0 as real version, and 0 as a not-yet-set version. 

The latter case happens when the `internal_to_version` vector gets resized. It gets filled with zeros, and there is no indication whether they represent actual versions or not. 

To fix this, I propose to grow the vector with `u64::MAX`, so that version 0 is still valid and don't break anything, but also to know which versions are not actually set yet. This special number is safe to use because I've introduced a wrapper type for this purpose:
```rust
#[repr(transparent)]
pub struct VersionType(SeqNumberType);
```

This PR swaps the type of `internal_to_version` to `Vec<VersionType>`, so that the newtype checks whether it has been synthetically initialized, or it is an actual version.

NOTE: this is potentially problematic if there is a qdrant rollback, as these versions would be considered as the latest.
