### PR TITLE
Apply point deletions to all point versions

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -650,6 +650,15 @@ impl<'s> SegmentHolder {
     /// It's always safe to pass a closure that always returns false (i.e. `|_| false`).
     ///
     /// Returns set of point ids which were successfully (already) applied to segments.
+    ///
+    /// # Warning
+    ///
+    /// This function must not be used to apply point deletions, and [`apply_points`] must be used
+    /// instead. There are two reasons for this:
+    ///
+    /// 1. moving a point first and deleting it after is unnecessary overhead.
+    /// 2. this leaves older point versions in place, which may accidentally be revived by some
+    ///    other operation later.
     pub fn apply_points_with_conditional_move<F, G, H>(
         &self,
         op_num: SeqNumberType,
@@ -711,7 +720,7 @@ impl<'s> SegmentHolder {
                 applied_points.insert(point_id);
                 Ok(is_applied)
             },
-            // TODO: define whether to only apply to latest point versions
+            // Only apply operation to latest point versions, these are not delete operations
             true,
         )?;
         Ok(applied_points)

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -526,6 +526,7 @@ impl<'s> SegmentHolder {
     /// A point may exist in multiple segments, having multiple versions. Depending on the kind of
     /// operation, it either needs to be applied to just the latest point version, or to all of
     /// them. This is controllable by the `all_point_versions` flag.
+    /// See: <https://github.com/qdrant/qdrant/pull/5956>
     ///
     /// In case of operations that may do a copy-on-write, we must only apply the operation to the
     /// latest point version. Otherwise our copy on write mechanism may repurpose old point data.

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -449,11 +449,12 @@ impl<'s> SegmentHolder {
         let segment_count = self.len();
         let mut segment_points: AHashMap<SegmentId, Vec<PointIdType>> =
             AHashMap::with_capacity(segment_count);
+        // Preallocate point IDs vector with rough estimate of size
+        let default_capacity = ids.len() / max(segment_count / 2, 1);
         for (point_id, (_point_version, segment_id)) in points {
             segment_points
                 .entry(segment_id)
-                // Preallocate point IDs vector with rough estimate of size
-                .or_insert_with(|| Vec::with_capacity(ids.len() / max(segment_count / 2, 1)))
+                .or_insert_with(|| Vec::with_capacity(default_capacity))
                 .push(point_id);
         }
 

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -127,8 +127,8 @@ pub(crate) fn delete_vectors(
                 }
                 Ok(res)
             },
-            // Apply delete to all point versions
-            true,
+            // Only apply operation to latest point versions, operation does not delete points
+            false,
         )?;
 
         total_deleted_points += deleted_points;

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -51,6 +51,8 @@ pub(crate) fn delete_points(
             batch,
             |_| (),
             |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
+            // Apply point delete to all point versions
+            false,
         )?;
 
         total_deleted_points += deleted_points;
@@ -125,6 +127,8 @@ pub(crate) fn delete_vectors(
                 }
                 Ok(res)
             },
+            // Apply delete to all point versions
+            false,
         )?;
 
         total_deleted_points += deleted_points;

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -52,7 +52,7 @@ pub(crate) fn delete_points(
             |_| (),
             |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
             // Apply point delete to all point versions
-            false,
+            true,
         )?;
 
         total_deleted_points += deleted_points;
@@ -128,7 +128,7 @@ pub(crate) fn delete_vectors(
                 Ok(res)
             },
             // Apply delete to all point versions
-            false,
+            true,
         )?;
 
         total_deleted_points += deleted_points;


### PR DESCRIPTION
Fix a critical problem which could result in us reviving (partial) already deleted points.

A point may exist in multiple segments, having multiple versions. This is normal behavior and can happen due to a myriad of reasons.

Normally, point operations are only [applied](https://github.com/qdrant/qdrant/blob/997ef849ae983282e7bbf804c8aba702c47da6bb/lib/collection/src/collection_manager/holders/segment_holder.rs#L487-L511) to the latest point version. This is done on [purpose](https://github.com/qdrant/qdrant/blob/997ef849ae983282e7bbf804c8aba702c47da6bb/lib/collection/src/collection_manager/holders/segment_holder.rs#L464-L466), so that any copy-on-write operation always uses the latest point data as source.

The problem is in deleting points though. If we only delete the latest point version, we may leave older point versions behind. We never use these older versions, but we might now accidentally revive them if we forget the newer deleted version. To prevent this problem, we now delete all point versions.

To accommodate this change, I've extracted the point/segment selection logic into a separate function. It takes care of either selecting all point versions, or just the latest.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
