### PR TITLE
[id tracker] mark skipped versions as deleted

### DIFF
--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -94,7 +94,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
             .unwrap();
     }
 
-    // Upload 1000 random vectors to the collection
+    // Upload 100 random vectors to the collection
     let mut points = Vec::new();
     for i in 0..100 {
         points.push(PointStructPersisted {

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -7,7 +7,7 @@ use rand::Rng as _;
 #[cfg(test)]
 use rand::rngs::StdRng;
 
-use super::ensure_versions_len;
+use super::ensure_len_and_set_version;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTracker;
@@ -54,8 +54,9 @@ impl IdTracker for InMemoryIdTracker {
             if let Some(old_version) = self.internal_to_version.get_mut(internal_id as usize) {
                 *old_version = version;
             } else {
-                ensure_versions_len(
+                ensure_len_and_set_version(
                     internal_id,
+                    version,
                     &mut self.internal_to_version,
                     &mut self.mappings.deleted,
                 );

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -7,6 +7,7 @@ use rand::Rng as _;
 #[cfg(test)]
 use rand::rngs::StdRng;
 
+use super::ensure_versions_len;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTracker;
@@ -53,7 +54,11 @@ impl IdTracker for InMemoryIdTracker {
             if let Some(old_version) = self.internal_to_version.get_mut(internal_id as usize) {
                 *old_version = version;
             } else {
-                self.internal_to_version.resize(internal_id as usize + 1, 0);
+                ensure_versions_len(
+                    internal_id,
+                    &mut self.internal_to_version,
+                    &mut self.mappings.deleted,
+                );
                 self.internal_to_version[internal_id as usize] = version;
             }
         }

--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -82,7 +82,7 @@ fn ensure_len_and_set_version(
 ) {
     let internal_id = internal_id as usize;
     let versions_len = internal_to_version.len();
-    if internal_id as usize >= versions_len {
+    if internal_id >= versions_len {
         internal_to_version.resize(internal_id + 1, 0);
         // Make sure the deleted bitset considers the newly skipped range as deleted.
         // This will ensure that we don't have a synthetic version 0 for these points.

--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -70,22 +70,27 @@ pub fn for_each_unique_point<'a>(
     f(best_item);
 }
 
+/// Sets the version for the given internal_id.
 /// Makes sure the versions vec is long enough to store the given internal_id.
 ///
 /// If it grows, marks all skipped internal_ids as deleted.
-fn ensure_versions_len(
+fn ensure_len_and_set_version(
     internal_id: PointOffsetType,
+    version: SeqNumberType,
     internal_to_version: &mut Vec<SeqNumberType>,
     deleted: &mut BitVec,
 ) {
+    let internal_id = internal_id as usize;
     let versions_len = internal_to_version.len();
     if internal_id as usize >= versions_len {
-        internal_to_version.resize(internal_id as usize + 1, 0);
+        internal_to_version.resize(internal_id + 1, 0);
         // Make sure the deleted bitset considers the newly skipped range as deleted.
         // This will ensure that we don't have a synthetic version 0 for these points.
-        let skipped_internal_ids = versions_len..(internal_id as usize);
+        let skipped_internal_ids = versions_len..internal_id;
         deleted[skipped_internal_ids].fill(true);
     }
+    internal_to_version[internal_id] = version;
+    deleted.set(internal_id, false);
 }
 
 #[cfg(test)]

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -29,7 +29,7 @@ pub struct PointMappings {
     /// It is possible that `deleted` can be longer or shorter than `internal_to_external`.
     /// - if `deleted` is longer, then extra bits should be set to `false` and ignored.
     /// - if `deleted` is shorter, then extra indices are as if the bits were set to `true`.
-    deleted: BitVec,
+    pub(super) deleted: BitVec,
     internal_to_external: Vec<PointIdType>,
 
     // Having two separate maps allows us iterating only over one type at a time without having to filter.

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -29,7 +29,7 @@ pub struct PointMappings {
     /// It is possible that `deleted` can be longer or shorter than `internal_to_external`.
     /// - if `deleted` is longer, then extra bits should be set to `false` and ignored.
     /// - if `deleted` is shorter, then extra indices are as if the bits were set to `true`.
-    pub(super) deleted: BitVec,
+    deleted: BitVec,
     internal_to_external: Vec<PointIdType>,
 
     // Having two separate maps allows us iterating only over one type at a time without having to filter.

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -147,7 +147,8 @@ impl SimpleIdTracker {
             }
         }
 
-        let mut internal_to_version: Vec<SeqNumberType> = Default::default();
+        let mut internal_to_version: Vec<SeqNumberType> =
+            Vec::with_capacity(internal_to_external.len());
         let versions_db_wrapper = DatabaseColumnScheduledUpdateWrapper::new(
             DatabaseColumnWrapper::new(store, DB_VERSIONS_CF),
         );

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -607,14 +607,10 @@ impl Segment {
                 {
                     let point_id = id_tracker.external_id(internal_id);
                     let point_version = id_tracker.internal_version(internal_id);
-                    // ignoring initial version because the WAL replay can resurrect un-flushed points by assigning them a new initial version
-                    // those points will be deleted by the next deduplication process
-                    if point_version != Some(0) {
-                        log::error!(
-                            "Vector storage '{vector_name}' is missing point {point_id:?} point_offset: {internal_id} version: {point_version:?}",
-                        );
-                        has_internal_ids_without_vector = true;
-                    }
+                    log::error!(
+                        "Vector storage '{vector_name}' is missing point {point_id:?} point_offset: {internal_id} version: {point_version:?}",
+                    );
+                    has_internal_ids_without_vector = true;
                 }
             }
         }


### PR DESCRIPTION
Our id trackers currently can't discriminate between version 0 as real version, and 0 as a not-yet-set version.

The latter case happens when the internal_to_version vector gets resized. It gets filled with zeros, and there is no indication whether they represent actual versions or not.

To fix it, this PR makes sure that the corresponding skipped points are marked as deleted, so that a zero version can be known to be synthetic if the bitvec says it is deleted.