### PR TITLE
In ID tracker fixture, exclude deleted points

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -185,6 +185,8 @@ pub trait SegmentEntry {
     ) -> OperationResult<HashMap<FacetValue, usize>>;
 
     /// Check if there is point with `point_id` in this segment.
+    ///
+    /// Soft deleted points are excluded.
     fn has_point(&self, point_id: PointIdType) -> bool;
 
     /// Estimate available point count in this segment for given filter.

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -34,9 +34,13 @@ pub trait IdTracker: fmt::Debug {
     ) -> OperationResult<()>;
 
     /// Returns internal ID of the point, which is used inside this segment
+    ///
+    /// Excludes soft deleted points.
     fn internal_id(&self, external_id: PointIdType) -> Option<PointOffsetType>;
 
     /// Return external ID for internal point, defined by user
+    ///
+    /// Excludes soft deleted points.
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType>;
 
     /// Set mapping
@@ -51,15 +55,17 @@ pub trait IdTracker: fmt::Debug {
 
     /// Iterate over all external IDs
     ///
-    /// Count should match `available_point_count`.
+    /// Count should match `available_point_count`, excludes soft deleted points.
     fn iter_external(&self) -> Box<dyn Iterator<Item = PointIdType> + '_>;
 
     /// Iterate over all internal IDs
     ///
-    /// Count should match `total_point_count`.
+    /// Count should match `total_point_count`, excludes soft deleted points.
     fn iter_internal(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;
 
     /// Iterate starting from a given ID
+    ///
+    /// Excludes soft deleted points.
     fn iter_from(
         &self,
         external_id: Option<PointIdType>,
@@ -67,14 +73,17 @@ pub trait IdTracker: fmt::Debug {
 
     /// Iterate over internal IDs (offsets)
     ///
-    /// - excludes removed points
+    /// Excludes soft deleted points.
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;
 
+    /// Iterate over internal IDs in a random order
+    ///
+    /// Excludes soft deleted points.
     fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_>;
 
     /// Iterate over internal IDs (offsets)
     ///
-    /// - excludes removed points
+    /// - excludes soft deleted points
     /// - excludes flagged items from `exclude_bitslice`
     fn iter_ids_excluding<'a>(
         &'a self,


### PR DESCRIPTION
Our ID tracker fixture used in tests does not match the point delete behavior of our regular ID trackers.

All our real ID trackers internally use the same point mappings object. This point mapping structure ignores deleted points by [explicitly](https://github.com/qdrant/qdrant/blob/9d56dcfa7a87863a2f2fc511a847bd0f06a2c09e/lib/segment/src/id_tracker/point_mappings.rs#L71) checking for deletion, or by [dropping](https://github.com/qdrant/qdrant/blob/9d56dcfa7a87863a2f2fc511a847bd0f06a2c09e/lib/segment/src/id_tracker/point_mappings.rs#L80-L93) a mapping on point delete. All [getters](https://github.com/qdrant/qdrant/blob/9d56dcfa7a87863a2f2fc511a847bd0f06a2c09e/lib/segment/src/id_tracker/simple_id_tracker.rs#L257-L263) [rely](https://github.com/qdrant/qdrant/blob/9d56dcfa7a87863a2f2fc511a847bd0f06a2c09e/lib/segment/src/id_tracker/simple_id_tracker.rs#L281-L298) on this mapping structure, which means they are aware of deletions.

Our ID tracker fixture does not. It does not check for deletions, nor does it update our list of mappings.

This PR adjusts the ID tracker fixture to match its behavior with the others.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?