### PR TITLE
Always delete old point versions when applying point operation

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -469,7 +469,7 @@ impl<'s> SegmentHolder {
 
         // Group points to update by segments
         let segment_count = self.len();
-        let mut to_update = AHashMap::with_capacity(segment_count);
+        let mut to_update = AHashMap::with_capacity(min(segment_count, latest_points.len()));
         let default_capacity = ids.len() / max(segment_count / 2, 1);
         for (point_id, (_point_version, segment_id)) in latest_points {
             to_update

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -482,6 +482,19 @@ impl<'s> SegmentHolder {
             debug_assert!(previous.is_none());
         });
 
+        // Assert each segment does not have overlapping updates and deletes
+        debug_assert!(
+            segment_points
+                .values()
+                .filter(|points| !points.to_update.is_empty() && !points.to_delete.is_empty())
+                .all(|points| {
+                    let updates: HashSet<&ExtendedPointId> = HashSet::from_iter(&points.to_update);
+                    let deletes = HashSet::from_iter(&points.to_delete);
+                    updates.is_disjoint(&deletes)
+                }),
+            "segments should not have overlapping updates and deletes",
+        );
+
         segment_points
     }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -593,7 +593,7 @@ impl<'s> SegmentHolder {
 
         let (to_update, to_delete) = self.find_points_to_update_and_delete(ids);
 
-        // Delete old points first
+        // Delete old points first, because we want to handle copy-on-write in multiple proxy segments properly
         for (segment_id, points) in to_delete {
             let segment = self.get(segment_id).unwrap();
             let segment_arc = segment.get();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -764,7 +764,10 @@ impl<'s> SegmentHolder {
                 applied_points.insert(point_id);
                 Ok(is_applied)
             },
-            |id, write_segment| write_segment.delete_point(op_num, id, hw_counter),
+            |id, write_segment| {
+                let version = write_segment.point_version(id).unwrap_or(op_num);
+                write_segment.delete_point(version, id, hw_counter)
+            },
         )?;
         Ok(applied_points)
     }

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -51,8 +51,7 @@ pub(crate) fn delete_points(
             batch,
             |_| (),
             |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
-            // Apply point delete to all point versions
-            true,
+            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
         )?;
 
         total_deleted_points += deleted_points;
@@ -127,8 +126,7 @@ pub(crate) fn delete_vectors(
                 }
                 Ok(res)
             },
-            // Only apply operation to latest point versions, operation does not delete points
-            false,
+            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
         )?;
 
         total_deleted_points += deleted_points;

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -51,10 +51,6 @@ pub(crate) fn delete_points(
             batch,
             |_| (),
             |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
-            |id, write_segment| {
-                let version = write_segment.point_version(id).unwrap_or(op_num);
-                write_segment.delete_point(version, id, hw_counter)
-            },
         )?;
 
         total_deleted_points += deleted_points;
@@ -128,10 +124,6 @@ pub(crate) fn delete_vectors(
                     res &= write_segment.delete_vector(op_num, id, name, hw_counter)?;
                 }
                 Ok(res)
-            },
-            |id, write_segment| {
-                let version = write_segment.point_version(id).unwrap_or(op_num);
-                write_segment.delete_point(version, id, hw_counter)
             },
         )?;
 

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -51,7 +51,10 @@ pub(crate) fn delete_points(
             batch,
             |_| (),
             |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
-            |id, write_segment| write_segment.delete_point(op_num, id, hw_counter),
+            |id, write_segment| {
+                let version = write_segment.point_version(id).unwrap_or(op_num);
+                write_segment.delete_point(version, id, hw_counter)
+            },
         )?;
 
         total_deleted_points += deleted_points;
@@ -126,7 +129,10 @@ pub(crate) fn delete_vectors(
                 }
                 Ok(res)
             },
-            |id, write_segment| write_segment.delete_point(op_num, id, hw_counter),
+            |id, write_segment| {
+                let version = write_segment.point_version(id).unwrap_or(op_num);
+                write_segment.delete_point(version, id, hw_counter)
+            },
         )?;
 
         total_deleted_points += deleted_points;

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -51,7 +51,7 @@ pub(crate) fn delete_points(
             batch,
             |_| (),
             |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
-            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
+            |id, write_segment| write_segment.delete_point(op_num, id, hw_counter),
         )?;
 
         total_deleted_points += deleted_points;
@@ -126,7 +126,7 @@ pub(crate) fn delete_vectors(
                 }
                 Ok(res)
             },
-            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
+            |id, write_segment| write_segment.delete_point(op_num, id, hw_counter),
         )?;
 
         total_deleted_points += deleted_points;

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -9,8 +9,9 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::data_types::vectors::{only_default_vector, VectorStructInternal};
 use segment::entry::entry_point::SegmentEntry;
+use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::types::{ExtendedPointId, PointIdType, WithPayload, WithVector};
+use segment::types::{ExtendedPointId, PayloadContainer, PointIdType, WithPayload, WithVector};
 use tempfile::Builder;
 
 use super::holders::proxy_segment;
@@ -470,10 +471,153 @@ fn test_proxy_shared_updates() {
     let expected_payload = payload_json! {"size": vec!["big"], "color": vec!["yellow"]};
 
     for (point_id, record) in result {
-        if let Some(payload) = record.payload {
-            assert_eq!(payload, expected_payload);
-        } else {
-            panic!("No payload for point_id = {point_id}");
-        }
+        let payload = record
+            .payload
+            .unwrap_or_else(|| panic!("No payload for point_id = {point_id}"));
+
+        assert_eq!(payload, expected_payload);
+    }
+}
+
+#[test]
+fn test_proxy_shared_updates_same_version() {
+    // Testing that multiple proxies that share point with the same id but the same versions
+    // are able to successfully apply and resolve update operation.
+    //
+    // It is undefined which instance of the point is picked if they have the exact same version.
+    // What we can check is that at least one instance of the point is selected, and that we don't
+    // accidentally lose points.
+    // This is especially important with merging <https://github.com/qdrant/qdrant/pull/5962>.
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut segment1 = empty_segment(dir.path());
+    let mut segment2 = empty_segment(dir.path());
+
+    let old_vec = vec![1.0, 0.0, 0.0, 1.0];
+    let new_vec = vec![1.0, 0.0, 1.0, 0.0];
+
+    let old_payload = payload_json! {"size": "small"};
+    let new_payload = payload_json! {"size": "big"};
+
+    let write_segment = LockedSegment::new(empty_segment(dir.path()));
+
+    let idx1 = PointIdType::from(1);
+    let idx2 = PointIdType::from(2);
+
+    let hw_counter = HardwareCounterCell::new();
+
+    segment1
+        .upsert_point(10, idx1, only_default_vector(&old_vec), &hw_counter)
+        .unwrap();
+    segment1
+        .set_payload(10, idx1, &old_payload, &None, &hw_counter)
+        .unwrap();
+    segment1
+        .upsert_point(10, idx2, only_default_vector(&new_vec), &hw_counter)
+        .unwrap();
+    segment1
+        .set_payload(10, idx2, &new_payload, &None, &hw_counter)
+        .unwrap();
+
+    segment2
+        .upsert_point(10, idx1, only_default_vector(&new_vec), &hw_counter)
+        .unwrap();
+    segment2
+        .set_payload(10, idx1, &new_payload, &None, &hw_counter)
+        .unwrap();
+    segment2
+        .upsert_point(10, idx2, only_default_vector(&old_vec), &hw_counter)
+        .unwrap();
+    segment2
+        .set_payload(10, idx2, &old_payload, &None, &hw_counter)
+        .unwrap();
+
+    let deleted_points = proxy_segment::LockedRmSet::default();
+    let changed_indexes = proxy_segment::LockedIndexChanges::default();
+
+    let locked_segment_1 = LockedSegment::new(segment1);
+    let locked_segment_2 = LockedSegment::new(segment2);
+
+    let proxy_segment_1 = ProxySegment::new(
+        locked_segment_1,
+        write_segment.clone(),
+        Arc::clone(&deleted_points),
+        Arc::clone(&changed_indexes),
+    );
+
+    let proxy_segment_2 = ProxySegment::new(
+        locked_segment_2,
+        write_segment.clone(),
+        deleted_points,
+        changed_indexes,
+    );
+
+    let mut holder = SegmentHolder::default();
+
+    let proxy_1_id = holder.add_new(proxy_segment_1);
+    let proxy_2_id = holder.add_new(proxy_segment_2);
+
+    let payload = payload_json! {"color": "yellow"};
+
+    let ids = vec![idx1, idx2];
+
+    set_payload(&holder, 20, &payload, &ids, &None, &hw_counter).unwrap();
+
+    // Points should still be accessible in both proxies through write segment
+    for &point_id in &ids {
+        assert!(holder
+            .get(proxy_1_id)
+            .unwrap()
+            .get()
+            .read()
+            .has_point(point_id));
+        assert!(holder
+            .get(proxy_2_id)
+            .unwrap()
+            .get()
+            .read()
+            .has_point(point_id));
+    }
+
+    let locked_holder = Arc::new(RwLock::new(holder));
+
+    let is_stopped = AtomicBool::new(false);
+
+    let with_payload = WithPayload::from(true);
+    let with_vector = WithVector::from(true);
+
+    let result = SegmentsSearcher::retrieve_blocking(
+        locked_holder.clone(),
+        &ids,
+        &with_payload,
+        &with_vector,
+        &is_stopped,
+        HwMeasurementAcc::new(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        result.keys().copied().collect::<HashSet<_>>(),
+        HashSet::from_iter(ids),
+        "must retrieve all point IDs",
+    );
+
+    for (point_id, record) in result {
+        let payload = record
+            .payload
+            .unwrap_or_else(|| panic!("No payload for point_id = {point_id}"));
+
+        dbg!(&payload);
+
+        let color = payload.get_value(&JsonPath::new("color"));
+        assert_eq!(color.len(), 1);
+        let color = color[0];
+        assert_eq!(color.as_str(), Some("yellow"));
+
+        let size = payload.get_value(&JsonPath::new("size"));
+        assert_eq!(size.len(), 1);
+        let size = size[0];
+        assert!(["small", "big"].contains(&size.as_str().unwrap()));
     }
 }

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -273,7 +273,7 @@ impl Segment {
     where
         F: FnOnce(&mut Segment) -> OperationResult<(bool, Option<PointOffsetType>)>,
     {
-        // Check if point not exists or have lower version
+        // If point does not exist or has lower version, ignore operation
         if let Some(point_offset) = op_point_offset {
             if self
                 .id_tracker


### PR DESCRIPTION
Continuation after <https://github.com/qdrant/qdrant/pull/5956> as suggested by <https://github.com/qdrant/qdrant/pull/5956#issuecomment-2645360891>.

An initial implementation for always deleting older point versions when an operation is applied. It cleans up duplicate points and prevents users retrieving old point data.

This is a first iteration, and I'm not super happy with the implementation yet. However, it is good enough to be included in a patch release.

This PR has the following properties:
- does not delete other point instances having the same version
- deletes old points with their existing version

In a future PR I'd like to change these properties to:
- do delete other point instances having the same version, keeping just one instance
- delete old point versions with the operation version (to also bump the segment version)

However, implementing these extra changes appears to be entirely non trivial. Naively implementing it makes many weird problem appear, such as losing points if we have multiple proxies using the same write segment.

I've added a test and adjusted an existing test to assert correct behavior of this change.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?