### PR TITLE
Properly size Raft message buffer

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1301,10 +1301,7 @@ impl RaftMessageSender {
         let peer_id = message.to;
 
         let uri = self.uri(peer_id).await?;
-
-        let mut bytes = Vec::new();
-        <RaftMessage as prost_for_raft::Message>::encode(message, &mut bytes)
-            .context("failed to encode Raft message")?;
+        let bytes = <RaftMessage as prost_for_raft::Message>::encode_to_vec(message);
         let grpc_message = GrpcRaftMessage { message: bytes };
 
         let timeout = Duration::from_millis(


### PR DESCRIPTION
I do not understand why the current code has never failed on large RaftMessages.

```rust
    /// Encodes the message to a buffer.
    ///
    /// An error will be returned if the buffer does not have sufficient capacity.
    fn encode<B>(&self, buf: &mut B) -> Result<(), EncodeError>
    where
        B: BufMut,
        Self: Sized,
    {
        let required = self.encoded_len();
        let remaining = buf.remaining_mut();
        if required > buf.remaining_mut() {
            return Err(EncodeError::new(required, remaining));
        }

        self.encode_raw(buf);
        Ok(())
    }

    /// Encodes the message to a newly allocated buffer.
    fn encode_to_vec(&self) -> Vec<u8>
    where
        Self: Sized,
    {
        let mut buf = Vec::with_capacity(self.encoded_len());

        self.encode_raw(&mut buf);
        buf
    }
```    