### PR TITLE
Extend partial segment snapshot to support `ProxySegment`s

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -16,7 +16,7 @@ use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use segment::data_types::segment_manifest::SegmentManifest;
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 use segment::entry::entry_point::SegmentEntry;
 use segment::entry::partial_snapshot_entry::PartialSnapshotEntry;
@@ -1324,15 +1324,35 @@ impl SegmentEntry for ProxySegment {
 impl PartialSnapshotEntry for ProxySegment {
     fn take_partial_snapshot(
         &self,
-        _temp_path: &Path,
-        _tar: &tar_ext::BuilderExt,
-        _manifest: &SegmentManifest,
+        temp_path: &Path,
+        tar: &tar_ext::BuilderExt,
+        manifest: &SegmentManifests,
     ) -> OperationResult<()> {
-        todo!()
+        self.wrapped_segment
+            .get()
+            .read()
+            .take_partial_snapshot(temp_path, tar, manifest)?;
+
+        self.write_segment
+            .get()
+            .read()
+            .take_partial_snapshot(temp_path, tar, manifest)?;
+
+        Ok(())
     }
 
-    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
-        todo!()
+    fn collect_segment_manifests(&self, manifests: &mut SegmentManifests) -> OperationResult<()> {
+        self.wrapped_segment
+            .get()
+            .read()
+            .collect_segment_manifests(manifests)?;
+
+        self.write_segment
+            .get()
+            .read()
+            .collect_segment_manifests(manifests)?;
+
+        Ok(())
     }
 }
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1327,16 +1327,21 @@ impl PartialSnapshotEntry for ProxySegment {
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
         manifest: &SegmentManifests,
+        snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()> {
-        self.wrapped_segment
-            .get()
-            .read()
-            .take_partial_snapshot(temp_path, tar, manifest)?;
+        self.wrapped_segment.get().read().take_partial_snapshot(
+            temp_path,
+            tar,
+            manifest,
+            snapshotted_segments,
+        )?;
 
-        self.write_segment
-            .get()
-            .read()
-            .take_partial_snapshot(temp_path, tar, manifest)?;
+        self.write_segment.get().read().take_partial_snapshot(
+            temp_path,
+            tar,
+            manifest,
+            snapshotted_segments,
+        )?;
 
         Ok(())
     }

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -5,6 +5,7 @@ use crate::types::SeqNumberType;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct SegmentManifest {
+    pub segment_id: String,
     pub segment_version: SeqNumberType,
     pub file_versions: HashMap<PathBuf, FileVersion>,
 }

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -3,7 +3,42 @@ use std::path::PathBuf;
 
 use crate::types::SeqNumberType;
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default)]
+pub struct SegmentManifests {
+    manifests: HashMap<String, SegmentManifest>,
+}
+
+impl SegmentManifests {
+    pub fn version(&self, segment_id: &str) -> Option<SeqNumberType> {
+        self.manifests
+            .get(segment_id)
+            .map(|manifest| manifest.segment_version)
+    }
+
+    pub fn get(&self, segment_id: &str) -> Option<&SegmentManifest> {
+        self.manifests.get(segment_id)
+    }
+
+    pub fn add(&mut self, new_manifest: SegmentManifest) -> bool {
+        let Some(current_manifest) = self.manifests.get_mut(&new_manifest.segment_id) else {
+            self.manifests
+                .insert(new_manifest.segment_id.clone(), new_manifest);
+
+            return true;
+        };
+
+        debug_assert_eq!(current_manifest.segment_id, new_manifest.segment_id);
+
+        if current_manifest.segment_version < new_manifest.segment_version {
+            *current_manifest = new_manifest;
+            return true;
+        }
+
+        false
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SegmentManifest {
     pub segment_id: String,
     pub segment_version: SeqNumberType,

--- a/lib/segment/src/entry/partial_snapshot_entry.rs
+++ b/lib/segment/src/entry/partial_snapshot_entry.rs
@@ -3,15 +3,15 @@ use std::path::Path;
 use common::tar_ext;
 
 use crate::common::operation_error::OperationResult;
-use crate::data_types::segment_manifest::SegmentManifest;
+use crate::data_types::segment_manifest::SegmentManifests;
 
 pub trait PartialSnapshotEntry {
     fn take_partial_snapshot(
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
-        manifest: &SegmentManifest,
+        manifest: &SegmentManifests,
     ) -> OperationResult<()>;
 
-    fn get_segment_manifest(&self) -> OperationResult<SegmentManifest>;
+    fn collect_segment_manifests(&self, manifests: &mut SegmentManifests) -> OperationResult<()>;
 }

--- a/lib/segment/src/entry/partial_snapshot_entry.rs
+++ b/lib/segment/src/entry/partial_snapshot_entry.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use common::tar_ext;
@@ -11,6 +12,7 @@ pub trait PartialSnapshotEntry {
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
         manifest: &SegmentManifests,
+        snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()>;
 
     fn collect_segment_manifests(&self, manifests: &mut SegmentManifests) -> OperationResult<()>;

--- a/lib/segment/src/segment/partial_snapshot.rs
+++ b/lib/segment/src/segment/partial_snapshot.rs
@@ -48,6 +48,17 @@ impl PartialSnapshotEntry for Segment {
     }
 
     fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
+        let segment_id = self
+            .current_path
+            .file_stem()
+            .and_then(|dir| dir.to_str())
+            .ok_or_else(|| {
+                OperationError::service_error(format!(
+                    "failed to extract segment ID from segment path {}",
+                    self.current_path.display(),
+                ))
+            })?;
+
         let segment_version = self.version();
 
         let all_files = self.files();
@@ -131,6 +142,7 @@ impl PartialSnapshotEntry for Segment {
         );
 
         Ok(SegmentManifest {
+            segment_id: segment_id.into(),
             segment_version,
             file_versions,
         })


### PR DESCRIPTION
Based on #5928. Changes `SegmentEntry::take_partial_snapshot` (and related methods) signature and implementation a bit, to support `ProxySegment`s.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
