### PR TITLE
Revert coverage test when merging into dev

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch: # Trigger from UI for selected branch
   schedule:
     - cron: "0 0 * * *"
-  push:
-    branches: [ dev ]
 
 jobs:
     coverage:


### PR DESCRIPTION
This reverts <https://github.com/qdrant/qdrant/pull/5911> because coverage tests now run on a schedule: https://github.com/qdrant/qdrant/actions/workflows/coverage.yml

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?