### PR TITLE
Delete collection dir on failed snapshot restore

### DIFF
--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -641,7 +641,7 @@ impl TableOfContent {
         Ok(path)
     }
 
-    fn get_collection_path(&self, collection_name: &str) -> PathBuf {
+    pub fn get_collection_path(&self, collection_name: &str) -> PathBuf {
         Path::new(&self.storage_config.storage_path)
             .join(COLLECTIONS_DIR)
             .join(collection_name)


### PR DESCRIPTION
Tackle https://github.com/qdrant/qdrant/issues/5983

In case of failed snapshot restore via the API, a malformed collection can be left behind preventing the service to properly restart.

This happens because in case of a restore of a non existing collection, we first create a collection and then restore shards into it.

We usually assume that all collection directory with configuration files are well formed but it is not the case anymore here.

Failing to restore a shard leaves behind a malformed collection.

The fix is to delete the whole collection directory IF it was absent before the recovery process.