### PR TITLE
`OnFinalCount` iterator adapter

### DIFF
--- a/lib/common/common/src/iterator_ext/mod.rs
+++ b/lib/common/common/src/iterator_ext/mod.rs
@@ -2,8 +2,10 @@
 use std::fmt::Debug;
 
 use check_stopped::CheckStopped;
+use on_final_count::OnFinalCount;
 
 mod check_stopped;
+mod on_final_count;
 
 pub trait IteratorExt: Iterator {
     /// Periodically check if the iteration should be stopped.
@@ -25,6 +27,20 @@ pub trait IteratorExt: Iterator {
         Self: Sized,
     {
         self.check_stop_every(500, f)
+    }
+
+    /// Will execute the callback when the iterator is dropped.
+    ///
+    /// The callback receives the total number of times `.next()` was called on the iterator,
+    /// including the final one where it usually returns `None`.
+    ///
+    /// Consider subtracting 1 if the final `None` is not needed.
+    fn on_final_count<F>(self, f: F) -> OnFinalCount<Self, F>
+    where
+        F: FnMut(usize),
+        Self: Sized,
+    {
+        OnFinalCount::new(self, f)
     }
 }
 

--- a/lib/common/common/src/iterator_ext/on_final_count.rs
+++ b/lib/common/common/src/iterator_ext/on_final_count.rs
@@ -1,0 +1,58 @@
+pub struct OnFinalCount<I, F>
+where
+    F: FnMut(usize),
+{
+    wrapped_iter: I,
+    callback: F,
+    counter: usize,
+}
+
+impl<I, F> OnFinalCount<I, F>
+where
+    F: FnMut(usize),
+{
+    pub fn new(iter: I, f: F) -> Self {
+        OnFinalCount {
+            wrapped_iter: iter,
+            callback: f,
+            counter: 0,
+        }
+    }
+}
+
+impl<I, F> Drop for OnFinalCount<I, F>
+where
+    F: FnMut(usize),
+{
+    fn drop(&mut self) {
+        (self.callback)(self.counter);
+    }
+}
+
+impl<I, F> Iterator for OnFinalCount<I, F>
+where
+    I: Iterator,
+    F: FnMut(usize),
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.counter += 1;
+        self.wrapped_iter.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::iterator_ext::IteratorExt;
+
+    #[test]
+    fn test_on_final_count() {
+        let mut iter_counter = 0;
+
+        let count = (0..10).on_final_count(|c| iter_counter = c).count();
+
+        assert_eq!(count, 10);
+        assert_eq!(iter_counter, 11);
+    }
+}


### PR DESCRIPTION
This PR adds an iterator adapter to make hardware usage counting easier when we are measuring iterators.

This adapter plugs in easily to an iterator. When the iterator gets dropped, it will execute the callback to do something with the final number of iterations the iterator was used for.

For example:
```rust
index.value_to_points.get_iter(value).on_final_count(|nexts| {
    hw_counter
        .payload_index_io_read_counter()
        .incr_delta(nexts * size_of::<PointOffsetType>)
});
```

I am not sure about the name, though. Feel free to propose another one :)