### PR TITLE
Do not deactivate partial/recovery replica on missing point

### DIFF
--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -424,6 +424,15 @@ impl ShardReplicaSet {
                         .collect()
                 } else {
                     failures
+                        .into_iter()
+                        .filter(|(peer_id, err)| {
+                            let not_partial_recovery = self
+                                .peer_state(*peer_id)
+                                .is_none_or(|state| !state.is_partial_or_recovery());
+                            let is_transient = err.is_transient();
+                            not_partial_recovery || is_transient
+                        })
+                        .collect()
                 };
 
                 let wait_for_deactivation = self.handle_failed_replicas(

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -583,10 +583,7 @@ impl ShardReplicaSet {
             // Ignore missing point errors if replica is in partial or recovery state
             // Partial or recovery state indicates that the replica is receiving a shard transfer,
             // it might not have received all the points yet
-            let partial_or_recovery = self
-                .peer_state(*peer_id)
-                .is_some_and(|state| state.is_partial_or_recovery());
-            if partial_or_recovery && err.is_missing_point() {
+            if peer_state.is_partial_or_recovery() && err.is_missing_point() {
                 continue;
             }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -583,6 +583,7 @@ impl ShardReplicaSet {
             // Ignore missing point errors if replica is in partial or recovery state
             // Partial or recovery state indicates that the replica is receiving a shard transfer,
             // it might not have received all the points yet
+            // See: <https://github.com/qdrant/qdrant/pull/5991>
             if peer_state.is_partial_or_recovery() && err.is_missing_point() {
                 continue;
             }

--- a/tests/consensus_tests/test_shard_stream_transfer.py
+++ b/tests/consensus_tests/test_shard_stream_transfer.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import pathlib
+import random
 from time import sleep
 
 from .fixtures import upsert_random_points, create_collection
@@ -278,4 +279,110 @@ def test_shard_stream_transfer_fast_burst(tmp_path: pathlib.Path):
         check_data_consistency(data)
 
 
+# Move one replica between nodes a few times, update pending point and ensure
+# completion
+#
+# During the shard move we keep sending an operation that changes the very last
+# point in the collection. More specifically, we invoke the set payload
+# operation on the very last point.
+#
+# While the transfer is ongoing, the target replica might not have received the
+# last point yet. The set payload operation must not mark the target replica as
+# dead because it cannot find the point, as point may be transferred later as
+# part of the transfer.
+#
+# If the test runs successfully, we see that the replica is properly moved. If the
+# test does not run successfully, the point not found errors cascade into
+# cancelling the shard transfers, and the replica will stay on the source node.
+#
+# Tests bug: <https://github.com/qdrant/qdrant/pull/5991>
+#
+# Updates are throttled to prevent overloading the cluster during the test.
+def test_transfer_change_pending_point(tmp_path: pathlib.Path):
+    assert_project_root()
 
+    N_TRANSFERS = 5
+    N_POINTS = 5000
+
+    def set_payload_in_loop(peer_url, point_id):
+        while True:
+            r = requests.post(
+                f"{peer_url}/collections/{COLLECTION_NAME}/points/payload?wait=true",
+                json={
+                    "points": [point_id],
+                    "payload": {"n": random.random()},
+                },
+            )
+            assert_http_ok(r)
+            sleep(0.1)
+
+    def run_set_payload_in_background(peer_url, point_id):
+        p = multiprocessing.Process(target=set_payload_in_loop, args=(peer_url, point_id))
+        p.start()
+        return p
+
+    # seed port to reuse the same port for the restarted nodes
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, 20000)
+
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=1)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+
+    # Insert some initial number of points
+    upsert_random_points(peer_api_uris[0], N_POINTS)
+
+    # Start pushing points to the cluster
+    update_process_1 = run_update_points_in_background(peer_api_uris[0], COLLECTION_NAME, init_offset=100, throttle=True)
+    update_process_2 = run_set_payload_in_background(peer_api_uris[1], point_id=N_POINTS - 1)
+    update_process_3 = run_set_payload_in_background(peer_api_uris[2], point_id=N_POINTS - 1)
+
+    # Move the shard a few times as it may not always trigger
+    for _ in range(0, N_TRANSFERS):
+        # Find what peer shard is currently on, select next peer as target
+        from_index = None
+        for index, uri in enumerate(peer_api_uris):
+            collection_cluster_info = get_collection_cluster_info(uri, COLLECTION_NAME)
+            if len(collection_cluster_info['local_shards']) == 1:
+                from_index = index
+                break
+        assert from_index is not None, "No shard found"
+        to_index = (from_index + 1) % len(peer_api_uris)
+
+        # Grab peer IDs
+        from_peer_uri = peer_api_uris[from_index]
+        to_peer_uri = peer_api_uris[to_index]
+        from_info = get_collection_cluster_info(from_peer_uri, COLLECTION_NAME)
+        to_info = get_collection_cluster_info(to_peer_uri, COLLECTION_NAME)
+        from_peer_id = from_info['peer_id']
+        to_peer_id = to_info['peer_id']
+
+        # Move shard from source to target peer
+        r = requests.post(
+            f"{from_peer_uri}/collections/{COLLECTION_NAME}/cluster", json={
+                "move_shard": {
+                    "shard_id": 0,
+                    "from_peer_id": from_peer_id,
+                    "to_peer_id": to_peer_id,
+                    "method": "stream_records",
+                }
+            })
+        assert_http_ok(r)
+
+        # Wait both peers to have recognized end of transfer
+        wait_for_collection_shard_transfers_count(from_peer_uri, COLLECTION_NAME, 0)
+        wait_for_collection_shard_transfers_count(to_peer_uri, COLLECTION_NAME, 0)
+
+        # Assert shard is actually moved
+        # If the transfer succeeded, the replica is moved to the other node
+        # If the transfer failed due to a missing point error, the replica is not moved
+        from_info = get_collection_cluster_info(from_peer_uri, COLLECTION_NAME)
+        to_info = get_collection_cluster_info(to_peer_uri, COLLECTION_NAME)
+        assert len(from_info['local_shards']) == 0, "Shard must be moved off of source peer"
+        assert len(to_info['local_shards']) == 1, "Shard must be moved onto target peer"
+
+    # Cleanup
+    update_process_1.kill()
+    update_process_2.kill()
+    update_process_3.kill()


### PR DESCRIPTION
A replica that is receiving a shard transfer, might not have all points yet. A replica could have missed a bunch of insertions, which might be the reason why the shard transfer is ongoing - to recover the replica.

Our replica deactivation logic was a bit to eager, immediately marking a replica as dead if a point is not found.

Marking as dead cascades into other problems. If we mark the target shard of a transfer as dead, the transfer is immediately aborted. If we have a continuous stream of operations modifying points that aren't there yet, the transfer will never progress because it constantly gets aborted. It is exactly the scenario we've been seeing in a real cluster.

This PR relaxes the condition. It accepts a missing point error while the replica is undergoing recovery. We should accept it because it might not have all points yet. It prevents us from marking the replica as dead too eagerly, cascading into other problems. This change is safe because the ongoing shard transfer will take care of ensuring data consistency. If our recovering shard might not apply an incoming update now, it will apply it (again) later as part of the transfer.

I've added a test that asserts the new behavior. The test fails when running it without the changes in this PR. That shows the new behavior works as expected.

### Tasks

- [x] Decide whether this change is correct
- [x] Add test

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?