### PR TITLE
Sparse vectors log

### DIFF
--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -47,6 +47,14 @@ impl InvertedIndexBuilder {
 
     /// Consumes the builder and returns an InvertedIndexRam
     pub fn build(self) -> InvertedIndexRam {
+        if self.posting_builders.is_empty() {
+            return InvertedIndexRam {
+                postings: vec![],
+                total_sparse_size: self.total_sparse_size,
+                vector_count: self.vector_count,
+            };
+        }
+
         let num_posting_lists = self.posting_builders.len();
         debug!(
             "building inverted index with {} posting lists",
@@ -61,12 +69,10 @@ impl InvertedIndexBuilder {
             postings.push(posting_list);
         }
 
-        if new_vectors_count > 0 {
-            debug!(
-                "built inverted index for {} new sparse vectors and {} posting lists",
-                new_vectors_count, num_posting_lists
-            );
-        }
+        debug!(
+            "built inverted index for {} sparse vectors from {} posting lists",
+            new_vectors_count, num_posting_lists
+        );
 
         let vector_count = self.vector_count;
         let total_sparse_size = self.total_sparse_size;

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -56,7 +56,7 @@ impl InvertedIndexBuilder {
         }
 
         debug!(
-            "building inverted index with {} in {} posting lists",
+            "building inverted index with {} sparse vectors in {} posting lists",
             self.vector_count,
             self.posting_builders.len(),
         );

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -47,7 +47,10 @@ impl InvertedIndexBuilder {
 
     /// Consumes the builder and returns an InvertedIndexRam
     pub fn build(self) -> InvertedIndexRam {
-        debug!("building inverted index for {} sparse vectors", self.vector_count);
+        debug!(
+            "building inverted index for {} sparse vectors",
+            self.vector_count
+        );
 
         let mut postings = Vec::with_capacity(self.posting_builders.len());
         for posting_builder in self.posting_builders {

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -55,24 +55,16 @@ impl InvertedIndexBuilder {
             };
         }
 
-        let num_posting_lists = self.posting_builders.len();
         debug!(
-            "building inverted index with {} posting lists",
-            num_posting_lists
+            "building inverted index with {} in {} posting lists",
+            self.vector_count,
+            self.posting_builders.len(),
         );
-        let mut new_vectors_count = 0;
 
         let mut postings = Vec::with_capacity(self.posting_builders.len());
         for posting_builder in self.posting_builders {
-            let posting_list = posting_builder.build();
-            new_vectors_count += posting_list.elements.len();
-            postings.push(posting_list);
+            postings.push(posting_builder.build());
         }
-
-        debug!(
-            "built inverted index for {} sparse vectors from {} posting lists",
-            new_vectors_count, num_posting_lists
-        );
 
         let vector_count = self.vector_count;
         let total_sparse_size = self.total_sparse_size;

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -47,14 +47,25 @@ impl InvertedIndexBuilder {
 
     /// Consumes the builder and returns an InvertedIndexRam
     pub fn build(self) -> InvertedIndexRam {
+        let num_posting_lists = self.posting_builders.len();
         debug!(
-            "building inverted index for {} sparse vectors",
-            self.vector_count
+            "building inverted index with {} posting lists",
+            num_posting_lists
         );
+        let mut new_vectors_count = 0;
 
         let mut postings = Vec::with_capacity(self.posting_builders.len());
         for posting_builder in self.posting_builders {
-            postings.push(posting_builder.build());
+            let posting_list = posting_builder.build();
+            new_vectors_count += posting_list.elements.len();
+            postings.push(posting_list);
+        }
+
+        if new_vectors_count > 0 {
+            debug!(
+                "built inverted index for {} new sparse vectors and {} posting lists",
+                new_vectors_count, num_posting_lists
+            );
         }
 
         let vector_count = self.vector_count;

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 
 use common::types::PointOffsetType;
+use log::debug;
 
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
@@ -46,6 +47,8 @@ impl InvertedIndexBuilder {
 
     /// Consumes the builder and returns an InvertedIndexRam
     pub fn build(self) -> InvertedIndexRam {
+        debug!("building inverted index for {} sparse vectors", self.vector_count);
+
         let mut postings = Vec::with_capacity(self.posting_builders.len());
         for posting_builder in self.posting_builders {
             postings.push(posting_builder.build());


### PR DESCRIPTION
Sparse vectors was causing OOM on chaos testing and it was not clear what's happening because of not having relevant logs. 

I propose to log it on a debug level similar to how we log `building HNSW for 11806 vectors with 1 CPUs`