### PR TITLE
Bump dev version to 1.13.4-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "api"
-version = "1.13.4-dev"
+version = "1.13.5-dev"
 dependencies = [
  "chrono",
  "common",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.13.4-dev"
+version = "1.13.5-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.13.4-dev"
+version = "1.13.5-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.13.4-dev"
+version = "1.13.5-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.13.4-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.13.5-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to `1.13.5-dev` after publishing <https://github.com/qdrant/qdrant/pull/5995>.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/5972>.