### PR TITLE
Ca cert for snapshots

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -28,11 +28,3 @@ storage:
     default_segment_number: 2
 
   handle_collection_load_errors: true
-
-
-tls:
-  # Certificate chain file
-  cert: ./tests/tls/cert/cert.pem
-
-  # Private key file
-  key: ./tests/tls/cert/key.pem

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -28,3 +28,11 @@ storage:
     default_segment_number: 2
 
   handle_collection_load_errors: true
+
+
+tls:
+  # Certificate chain file
+  cert: ./tests/tls/cert/cert.pem
+
+  # Private key file
+  key: ./tests/tls/cert/key.pem

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -113,7 +113,13 @@ fn load_identity(tls_config: &TlsConfig) -> io::Result<Identity> {
 }
 
 fn load_ca_certificate(tls_config: &TlsConfig) -> io::Result<Certificate> {
-    let pem = fs::read_to_string(&tls_config.ca_cert)?;
+    let ca_cert_path = tls_config.ca_cert.as_ref().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "CA certificate is required for TLS configuration",
+        )
+    })?;
+    let pem = fs::read_to_string(ca_cert_path)?;
     Ok(Certificate::from_pem(pem))
 }
 

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -113,12 +113,12 @@ fn load_identity(tls_config: &TlsConfig) -> io::Result<Identity> {
 }
 
 fn load_ca_certificate(tls_config: &TlsConfig) -> io::Result<Certificate> {
-    let ca_cert_path = tls_config.ca_cert.as_ref().ok_or_else(|| {
-        io::Error::new(
+    let Some(ca_cert_path) = &tls_config.ca_cert else {
+        return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "CA certificate is required for TLS configuration",
-        )
-    })?;
+        ));
+    };
     let pem = fs::read_to_string(ca_cert_path)?;
     Ok(Certificate::from_pem(pem))
 }

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -65,7 +65,9 @@ fn https_client(
 
     // Configure TLS root certificate and validation
     if let Some(tls_config) = tls_config {
-        builder = builder.add_root_certificate(https_client_ca_cert(tls_config.ca_cert.as_ref())?);
+        if let Some(ca_cert) = tls_config.ca_cert.clone() {
+            builder = builder.add_root_certificate(https_client_ca_cert(ca_cert.as_ref())?);
+        }
 
         if verify_https_client_certificate {
             builder = builder.identity(https_client_identity(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -135,7 +135,7 @@ impl Default for ConsensusConfig {
 pub struct TlsConfig {
     pub cert: String,
     pub key: String,
-    pub ca_cert: String,
+    pub ca_cert: Option<String>,
     #[serde(default = "default_tls_cert_ttl")]
     #[validate(range(min = 1))]
     pub cert_ttl: Option<u64>,


### PR DESCRIPTION
I have a single node hybrid cloud cluster. I configured TLS directly in the DB (no P2P TLS) which sets this:

```
service:
  # Enable HTTPS for the REST and gRPC API
  enable_tls: true

# TLS configuration.
# Required if either service.enable_tls or cluster.p2p.enable_tls is true.
tls:
  # Server certificate chain file
  cert: ./tls/cert.pem

  # Server private key file
  key: ./tls/key.pem
```  

This works correctly when connecting to Qdrant.
But when I try to load a snapshots from a remote HTTP location:
```
PUT /collections/midjourney/snapshots/recover
{
  "location": "http://snapshots.qdrant.io/midlib.snapshot"
}
```
I get the following error returned from Qdrant
```
{
  "error": "Service internal error: failed to initialize HTTP(S) client: failed to read HTTPS client CA certificate file ./tls/cacert.pem: No such file or directory (os error 2)"
}
```
Why is a ./tls/cacert.pem mandatory for this operation?

---

Resolution:

Indeed, `./tls/cacert.pem` is not required. Not our config file can accept `null` as `ca_cert`. 
To covert for the case where default configuration is used, the download will no longer error out if certificate is not found.