### PR TITLE
Add codecov threshold

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 50

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,3 +3,4 @@ coverage:
     project:
       default:
         target: 50
+    patch: off


### PR DESCRIPTION
Avoid marking branch as failures if coverage is above 50%. Current is `55.26%` (only with unit tests)

Have triggered a run to see results: https://github.com/qdrant/qdrant/actions/runs/13386901276/job/37385582869