### PR TITLE
Handle malformed shard after incomplete restore

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -708,6 +708,12 @@ impl Collection {
             // Try to find a replica to transfer from
             //
             // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!
+            if replica_set.active_remote_shards().is_empty() {
+                log::debug!(
+                    "No active remote replicas for shard {shard_id} on peer {this_peer_id} to recover from",
+                );
+                continue;
+            }
             for replica_id in replica_set.active_remote_shards() {
                 let transfer = ShardTransfer {
                     from: replica_id,

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -255,6 +255,15 @@ impl Collection {
 
                 if transfer.to == self.this_peer_id {
                     replica_set.set_replica_state(transfer.to, state)?;
+                    // Make sure the receiving shard has at least one remote shard in case of sync transfer
+                    if !is_resharding_transfer
+                        && transfer.sync
+                        && !replica_set.has_remote_shard().await
+                    {
+                        replica_set
+                            .add_remote(transfer.from, ReplicaState::Active)
+                            .await?;
+                    }
                 } else {
                     replica_set.add_remote(transfer.to, state).await?;
                 }

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -244,6 +244,7 @@ impl Collection {
         //   (see `VectorsConfig::check_compatible_with_segment_config`)
 
         // set shard_id initialization flag
+        // the file is removed after full recovery to indicate a well-formed shard
         let shard_flag = shard_initialized_flag_path(&self.path, shard_id);
         tokio::fs::write(&shard_flag, b"").await?;
 

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -250,7 +250,8 @@ impl Collection {
 
         // `ShardHolder::recover_local_shard_from` is *not* cancel safe
         // (see `ShardReplicaSet::restore_local_replica_from`)
-        self.shards_holder
+        let res = self
+            .shards_holder
             .read()
             .await
             .recover_local_shard_from(snapshot_shard_path, shard_id, cancel)
@@ -259,7 +260,7 @@ impl Collection {
         // remove shard_id initialization flag because shard is fully recovered
         tokio::fs::remove_file(&shard_flag).await?;
 
-        Ok(true)
+        Ok(res)
     }
 
     pub async fn list_shard_snapshots(

--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -41,6 +41,11 @@ pub fn shard_path(collection_path: &Path, shard_id: ShardId) -> PathBuf {
     collection_path.join(format!("{shard_id}"))
 }
 
+/// Path to a shard directory
+pub fn shard_initialized_flag_path(collection_path: &Path, shard_id: ShardId) -> PathBuf {
+    collection_path.join(format!("shard_{shard_id}.initialized"))
+}
+
 /// Verify that a shard exists by loading its configuration.
 /// Returns the path to the shard if it exists.
 pub async fn check_shard_path(

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -367,53 +367,6 @@ impl ShardReplicaSet {
         replica_set
     }
 
-    /// Create a shard replica set with a local dummy shard
-    #[allow(clippy::too_many_arguments)]
-    pub fn dummy_shard_replica_set(
-        reason: &str,
-        shard_id: ShardId,
-        shard_key: Option<ShardKey>,
-        collection_id: CollectionId,
-        shard_path: &Path,
-        collection_config: Arc<RwLock<CollectionConfigInternal>>,
-        effective_optimizers_config: OptimizersConfig,
-        shared_storage_config: Arc<SharedStorageConfig>,
-        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-        channel_service: ChannelService,
-        on_peer_failure: ChangePeerFromState,
-        abort_shard_transfer: AbortShardTransfer,
-        update_runtime: Handle,
-        search_runtime: Handle,
-        optimizer_cpu_budget: CpuBudget,
-    ) -> Self {
-        let local_dummy = Shard::Dummy(DummyShard::new(reason));
-        let replica_state: SaveOnDisk<ReplicaSetState> =
-            SaveOnDisk::load_or_init_default(shard_path.join(REPLICA_STATE_FILE)).unwrap();
-        ShardReplicaSet {
-            local: RwLock::new(Some(local_dummy)),
-            remotes: Default::default(),
-            replica_state: Arc::new(replica_state),
-            locally_disabled_peers: Default::default(),
-            shard_path: shard_path.to_path_buf(),
-            shard_id,
-            shard_key,
-            notify_peer_failure_cb: on_peer_failure,
-            abort_shard_transfer_cb: abort_shard_transfer,
-            channel_service,
-            collection_id,
-            collection_config,
-            optimizers_config: effective_optimizers_config,
-            shared_storage_config,
-            payload_index_schema,
-            update_runtime,
-            search_runtime,
-            optimizer_cpu_budget,
-            write_ordering_lock: Default::default(),
-            clock_set: Default::default(),
-            write_rate_limiter: None,
-        }
-    }
-
     pub fn this_peer_id(&self) -> PeerId {
         self.replica_state.read().this_peer_id
     }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -601,8 +601,6 @@ impl ShardHolder {
         };
 
         for shard_id in shard_ids_list {
-            let shard_key = self.get_shard_id_to_key_mapping().get(&shard_id);
-
             // Check if shard is fully initialized on disk
             // The initialization flag should be absent for a well-formed replica set
             let initialized_flag = shard_initialized_flag_path(collection_path, shard_id);
@@ -612,6 +610,7 @@ impl ShardHolder {
             {
                 log::error!("Shard {collection_id}:{} is not fully initialized - replacing with dummy shard", shard_id);
                 let shard_path = shard_path(collection_path, shard_id);
+                let shard_key = self.get_shard_id_to_key_mapping().get(&shard_id);
                 // Add dummy shard replica set for this shard id
                 let dummy_replica_set = ShardReplicaSet::dummy_shard_replica_set(
                     "Not fully initialized following a snapshot restore",
@@ -641,6 +640,7 @@ impl ShardHolder {
                 .expect("Failed to check shard path");
 
             // Load replica set
+            let shard_key = self.get_shard_id_to_key_mapping().get(&shard_id);
             let replica_set = ShardReplicaSet::load(
                 shard_id,
                 shard_key.cloned(),

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -610,6 +610,7 @@ impl ShardHolder {
                 .await
                 .unwrap_or(false)
             {
+                log::error!("Shard {collection_id}:{} is not fully initialized - replacing with dummy shard", shard_id);
                 let shard_path = shard_path(collection_path, shard_id);
                 // Add dummy shard replica set for this shard id
                 let dummy_replica_set = ShardReplicaSet::dummy_shard_replica_set(

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -111,11 +111,13 @@ pub fn validate_transfer(
         )));
     }
 
-    // We allow transfers *from* `ReshardingScaleDown` replicas, because they contain a *superset*
-    // of points in a regular replica
+    // We allow transfers *from*:
+    // - `Active` replicas
+    // - `ReshardingScaleDown` replicas, because they contain a *superset* of points in a regular replica
+    // - Unknown replicas, because the local replica state might be outdated
     let is_active = matches!(
         source_replicas.get(&transfer.from),
-        Some(ReplicaState::Active | ReplicaState::ReshardingScaleDown),
+        Some(ReplicaState::Active | ReplicaState::ReshardingScaleDown) | None,
     );
 
     if !is_active {

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -1,0 +1,172 @@
+import pathlib
+import subprocess
+import tempfile
+import requests
+from time import sleep
+
+from .fixtures import create_collection, upsert_random_points, random_dense_vector, search, random_sparse_vector
+from .utils import *
+
+N_PEERS = 3
+N_SHARDS = 1
+N_REPLICAS = 3
+COLLECTION_NAME = "test_collection"
+
+def create_snapshot(peer_api_uri):
+    r = requests.post(f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots")
+    assert_http_ok(r)
+    return r.json()["result"]["name"]
+
+
+def get_peer_id(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]["peer_id"]
+
+
+def get_local_shards(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]['local_shards']
+
+
+def get_remote_shards(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]['remote_shards']
+
+
+def fail_to_recover_snapshot(peer_api_uri, snapshot_url):
+    r = requests.put(f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/recover",
+                     json={"location": snapshot_url})
+    assert r.status_code == 500
+    assert "Failed to read segment state" in r.json()["status"]["error"]
+
+def first_segment_name(peer_storage: str, collection_name: str) -> str:
+    # get first segment name from storage
+    shard_path = f"{peer_storage}/storage/collections/{collection_name}/0/segments"
+    segment_name_path = next(filter(lambda x: x.is_dir(), pathlib.Path(shard_path).iterdir()))
+    return segment_name_path.name
+
+def shard_initialized_flag(peer_storage: str, collection_name: str, shard_id: int) -> str:
+    return f"{peer_storage}/storage/collections/{collection_name}/shard_{shard_id}.initialized"
+
+def corrupt_snapshot(snapshot_path: pathlib.Path, segment_name: str):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Extract the snapshot tar
+        subprocess.run(["tar", "--extract", "--sparse", "--file", snapshot_path, "--directory", temp_dir], check=True)
+
+        # Find the inner segment tar file
+        segment_archive = f"0/segments/{segment_name}.tar"
+        extracted_segment_tar = os.path.join(temp_dir, segment_archive)
+
+        if os.path.exists(extracted_segment_tar):
+            # Modify the segment tar to remove the `segment.json` file
+            corrupted_inner_tar = extracted_segment_tar + "-corrupted"
+            remove_file_from_tar(extracted_segment_tar, "snapshot/files/segment.json", corrupted_inner_tar)
+
+            # Replace the original inner segment tar with the corrupted one
+            os.rename(corrupted_inner_tar, extracted_segment_tar)
+
+            # Repack the snapshot tar after modifying the inner segment tar
+            new_segment_archive = f"{temp_dir}-corrupted"
+            subprocess.run(["tar", "--create", "--sparse", "--file", new_segment_archive, "-C", temp_dir, "."], check=True)
+
+            # Replace the original snapshot tar with the corrupted one
+            os.rename(new_segment_archive, snapshot_path)
+
+def remove_file_from_tar(original_tar, file_to_remove, new_tar):
+    file_to_remove = file_to_remove.replace(os.sep, "/")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Extract the inner tar
+        subprocess.run(["tar", "--extract", "--sparse", "--file", original_tar, "--directory", temp_dir], check=True)
+
+        # Remove the target file
+        file_path = os.path.join(temp_dir, file_to_remove)
+        if os.path.exists(file_path):
+            os.remove(file_path)
+        else:
+            assert False, f"File {file_to_remove} not found in {original_tar}"
+
+        # Repack the inner tar
+        subprocess.run(["tar", "--create", "--sparse", "--file", new_tar, "-C", temp_dir, "."], check=True)
+
+
+# The test validates that a node can recover from a corrupted snapshot
+def test_failed_snapshot_recovery(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICAS)
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris)
+
+    wait_for_same_commit(peer_api_uris=peer_api_uris)
+
+    upsert_random_points(peer_api_uris[0], 1_000)
+
+    query_city = "London"
+
+    dense_query_vector = random_dense_vector()
+    dense_search_result = search(peer_api_uris[0], dense_query_vector, query_city)
+    assert len(dense_search_result) > 0
+
+    snapshot_name = create_snapshot(peer_api_uris[-1])
+    assert snapshot_name is not None
+
+    snapshot_path = Path(peer_dirs[-1]) / "snapshots" / COLLECTION_NAME / snapshot_name
+    assert snapshot_path.exists()
+
+    # get first segment name from storage
+    segment_name = first_segment_name(peer_dirs[-1], COLLECTION_NAME)
+
+    # corrupt snapshot
+    corrupt_snapshot(snapshot_path=snapshot_path, segment_name=segment_name)
+
+    # All nodes share the same snapshot directory, so it is fine to use any
+    snapshot_url = f"{peer_api_uris[-1]}/collections/{COLLECTION_NAME}/snapshots/{snapshot_name}"
+
+    print(f"Recovering snapshot {snapshot_url} on {peer_api_uris[-1]}")
+
+    # Recover snapshot should fail because the snapshot is corrupted
+    fail_to_recover_snapshot(peer_api_uris[-1], snapshot_url)
+
+    # Assert storage contains initialized flag
+    flag_path = shard_initialized_flag(peer_dirs[-1], COLLECTION_NAME, 0)
+    assert os.path.exists(flag_path)
+
+    # Kill last peer
+    p = processes.pop()
+    p.kill()
+
+    # Restart same peer
+    peer_api_uris[-1] = start_peer(peer_dirs[-1], f"peer_{N_PEERS}_restarted.log", bootstrap_uri)
+
+    # Assert the node does not crash when starting with data from corrupted snapshot
+    while True:
+        try:
+            res = requests.get(f"{peer_api_uris[-1]}/collections")
+        except requests.exceptions.ConnectionError:
+            time.sleep(1)
+            continue
+        if not res.ok:
+            time.sleep(1)  # Wait to node is up
+            continue
+        collections = set(collection['name'] for collection in res.json()["result"]['collections'])
+        if COLLECTION_NAME not in collections:
+            time.sleep(1)  # Wait to sync with consensus
+            continue
+        break
+
+    # Assert storage does not contain initialized flag
+    flag_path  = shard_initialized_flag(peer_dirs[-1], COLLECTION_NAME, 0)
+    assert not os.path.exists(flag_path)
+
+    # Assert that the local shard is dead and empty
+    local_shards = get_local_shards(peer_api_uris[-1])
+    assert len(local_shards) == 1
+    assert local_shards[0]["shard_id"] == 0
+    assert local_shards[0]["state"] == "Dead"
+    assert local_shards[0]["points_count"] == 0
+

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -193,6 +193,14 @@ def test_failed_snapshot_recovery(tmp_path: pathlib.Path):
     assert local_shards[0]["points_count"] == 1000
 
     # Assert that the remote shards are active and not empty
+    # The peer used as source for the transfer is used as remote to have at least one
+    remote_shards = get_remote_shards(peer_api_uris[-1])
+    assert len(remote_shards) == 1
+    for shard in remote_shards:
+        assert shard["state"] == "Active"
+
+
+    # Assert that the remote shards are active and not empty
     remote_shards = get_remote_shards(peer_api_uris[0])
     assert len(remote_shards) == 2
     for shard in remote_shards:

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -719,3 +719,14 @@ def move_shard(source_uri, collection_name, shard_id, source_peer_id, target_pee
             }
         })
     assert_http_ok(r)
+
+def replicate_shard(source_uri, collection_name, shard_id, source_peer_id, target_peer_id):
+    r = requests.post(
+        f"{source_uri}/collections/{collection_name}/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": source_peer_id,
+                "to_peer_id": target_peer_id
+            }
+        })
+    assert_http_ok(r)


### PR DESCRIPTION
Alternative to https://github.com/qdrant/qdrant/pull/5984

This PR makes sure that a failed snapshot restore does not prevent the service from restarting.

This is achieved by making the restore process crash safe using a flag file.
The flag is created before the shard restore and deleted afterwards.

The presence of a flag at startup means that either:
- the restore process crashed midway
- the restore process failed and left the flag behind

When starting up, the presence of the flag is used to load an empty shard marked as dead.
This empty shard can be the target of a new snapshot restore.

There is an E2E integration test that generates a corrupted snapshot to prove the existence of the flag and the correct startup of the service.

## Status

At this point, it is possible to restart the service & try another non-corrupted snapshot to fix the shard.

However we want to be able to resync the node "automatically" which requires a shard transfer.
The absence of a proper replica state makes it difficult to achieve without hacks.
 