### PR TITLE
Gpu add memory barriers

### DIFF
--- a/lib/gpu/src/basic_test.rs
+++ b/lib/gpu/src/basic_test.rs
@@ -137,6 +137,8 @@ fn basic_gpu_test() {
     context.bind_pipeline(pipeline, &descriptor_sets).unwrap();
     // Run computeation command. Threads count is the inputs count.
     context.dispatch(numbers_count, 1, 1).unwrap();
+    // Add barrier to ensure that all writes to the storage buffer are visible to the next command.
+    context.barrier_buffers(&[storage_buffer.clone()]).unwrap();
     // Run GPU and wait finish.
     context.run().unwrap();
     context.wait_finish(context_timeout).unwrap();

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -323,6 +323,9 @@ impl<'a> GpuInsertContext<'a> {
             ],
         )?;
         self.context.dispatch(requests.len(), 1, 1)?;
+        self.context
+            .barrier_buffers(&[self.insert_resources.responses_buffer.clone()])
+            .unwrap();
         self.context.run()?;
         self.context.wait_finish(GPU_TIMEOUT)?;
 
@@ -388,6 +391,14 @@ impl<'a> GpuInsertContext<'a> {
             ],
         )?;
         self.context.dispatch(requests.len(), 1, 1)?;
+        self.context
+            .barrier_buffers(&[
+                self.insert_resources.responses_buffer.clone(),
+                self.insert_resources.insert_atomics_buffer.clone(),
+                self.gpu_links.links_buffer(),
+                self.gpu_visited_flags.visited_flags_buffer(),
+            ])
+            .unwrap();
         self.context.run()?;
         self.context.wait_finish(GPU_TIMEOUT)?;
 

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_links.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_links.rs
@@ -163,6 +163,10 @@ impl GpuLinks {
         Ok(())
     }
 
+    pub fn links_buffer(&self) -> Arc<gpu::Buffer> {
+        self.links_buffer.clone()
+    }
+
     pub fn upload_links(
         &mut self,
         level: usize,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_visited_flags.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_visited_flags.rs
@@ -138,6 +138,10 @@ impl GpuVisitedFlags {
         self.descriptor_set.clone()
     }
 
+    pub fn visited_flags_buffer(&self) -> Arc<gpu::Buffer> {
+        self.visited_flags_buffer.clone()
+    }
+
     fn create_flags_buffer(
         device: Arc<gpu::Device>,
         groups_count: usize,


### PR DESCRIPTION
This PR adds a vulkan memory barrier. Memory barrier is a sync primitive that adds guarantees about execution order. After this barrier, all changes must be available for downloading without race conditions or unflushed caches.