### PR TITLE
[score boosting] Connect formula to query

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14081,6 +14081,9 @@
             "$ref": "#/components/schemas/FusionQuery"
           },
           {
+            "$ref": "#/components/schemas/FormulaQuery"
+          },
+          {
             "$ref": "#/components/schemas/SampleQuery"
           }
         ]
@@ -14250,6 +14253,103 @@
           "rrf",
           "dbsf"
         ]
+      },
+      "FormulaQuery": {
+        "type": "object",
+        "required": [
+          "defaults",
+          "formula"
+        ],
+        "properties": {
+          "formula": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "defaults": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "Expression": {
+        "anyOf": [
+          {
+            "type": "number",
+            "format": "float"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/Condition"
+          },
+          {
+            "$ref": "#/components/schemas/MultiplyExpression"
+          },
+          {
+            "$ref": "#/components/schemas/SumExpression"
+          },
+          {
+            "$ref": "#/components/schemas/NegExpression"
+          },
+          {
+            "$ref": "#/components/schemas/GeoDistance"
+          }
+        ]
+      },
+      "MultiplyExpression": {
+        "type": "object",
+        "required": [
+          "mult"
+        ],
+        "properties": {
+          "mult": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Expression"
+            }
+          }
+        }
+      },
+      "SumExpression": {
+        "type": "object",
+        "required": [
+          "sum"
+        ],
+        "properties": {
+          "sum": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Expression"
+            }
+          }
+        }
+      },
+      "NegExpression": {
+        "type": "object",
+        "required": [
+          "neg"
+        ],
+        "properties": {
+          "neg": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "GeoDistance": {
+        "type": "object",
+        "required": [
+          "origin",
+          "to"
+        ],
+        "properties": {
+          "origin": {
+            "$ref": "#/components/schemas/GeoPoint"
+          },
+          "to": {
+            "description": "Payload field with the destination geo point",
+            "type": "string"
+          }
+        }
       },
       "SampleQuery": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14283,7 +14283,7 @@
             "$ref": "#/components/schemas/Condition"
           },
           {
-            "$ref": "#/components/schemas/MultiplyExpression"
+            "$ref": "#/components/schemas/MultExpression"
           },
           {
             "$ref": "#/components/schemas/SumExpression"
@@ -14292,11 +14292,14 @@
             "$ref": "#/components/schemas/NegExpression"
           },
           {
+            "$ref": "#/components/schemas/DivExpression"
+          },
+          {
             "$ref": "#/components/schemas/GeoDistance"
           }
         ]
       },
-      "MultiplyExpression": {
+      "MultExpression": {
         "type": "object",
         "required": [
           "mult"
@@ -14335,7 +14338,49 @@
           }
         }
       },
+      "DivExpression": {
+        "type": "object",
+        "required": [
+          "div"
+        ],
+        "properties": {
+          "div": {
+            "$ref": "#/components/schemas/DivParams"
+          }
+        }
+      },
+      "DivParams": {
+        "type": "object",
+        "required": [
+          "by_zero_default",
+          "left",
+          "right"
+        ],
+        "properties": {
+          "left": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "right": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "by_zero_default": {
+            "type": "number",
+            "format": "float"
+          }
+        }
+      },
       "GeoDistance": {
+        "type": "object",
+        "required": [
+          "geo_distance"
+        ],
+        "properties": {
+          "geo_distance": {
+            "$ref": "#/components/schemas/GeoDistanceParams"
+          }
+        }
+      },
+      "GeoDistanceParams": {
         "type": "object",
         "required": [
           "origin",

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -465,6 +465,9 @@ pub enum Query {
     /// Fuse the results of multiple prefetches.
     Fusion(FusionQuery),
 
+    /// Score boosting via an arbitrary formula
+    Formula(FormulaQuery),
+
     /// Sample points from the collection, non-deterministically.
     Sample(SampleQuery),
 }
@@ -507,7 +510,8 @@ pub struct FusionQuery {
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct FormulaQuery {
-    pub formula: FormulaInput,
+    pub formula: Expression,
+    pub defaults: HashMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -626,13 +630,6 @@ impl ContextPair {
     pub fn iter(&self) -> impl Iterator<Item = &VectorInput> {
         std::iter::once(&self.positive).chain(std::iter::once(&self.negative))
     }
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct FormulaInput {
-    pub formula: Expression,
-    // TODO(score boosting): Validate defaults, particularly for score references
-    pub defaults: HashMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -7,6 +7,7 @@ use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{
     NamedQuery, NamedVectorStruct, VectorInternal, VectorRef, DEFAULT_VECTOR_NAME,
 };
+use segment::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use segment::json_path::JsonPath;
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, SearchParams, VectorName,
@@ -14,6 +15,7 @@ use segment::types::{
 };
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 
+use super::formula::FormulaInternal;
 use super::shard_query::{
     FusionInternal, SampleInternal, ScoringQuery, ShardPrefetch, ShardQueryRequest,
 };
@@ -91,9 +93,9 @@ pub enum Query {
     /// Order by a payload field
     OrderBy(OrderBy),
 
-    // TODO(score boosting): enable this
-    // /// Formula-based score fusion
-    // Formula(FormulaInternal),
+    /// Score boosting via an arbitrary formula
+    Formula(FormulaInternal),
+
     /// Sample points
     Sample(SampleInternal),
 }
@@ -117,8 +119,7 @@ impl Query {
             }
             Query::Fusion(fusion) => ScoringQuery::Fusion(fusion),
             Query::OrderBy(order_by) => ScoringQuery::OrderBy(order_by),
-            // TODO(score boosting): enable this
-            // Query::Formula(formula) => ScoringQuery::Formula(ParsedFormula::try_from(formula)?),
+            Query::Formula(formula) => ScoringQuery::Formula(ParsedFormula::try_from(formula)?),
             Query::Sample(sample) => ScoringQuery::Sample(sample),
         };
 

--- a/lib/collection/src/operations/universal_query/formula.rs
+++ b/lib/collection/src/operations/universal_query/formula.rs
@@ -32,9 +32,9 @@ pub enum ExpressionInternal {
     },
 }
 
-impl From<rest::FormulaInput> for FormulaInternal {
-    fn from(value: rest::FormulaInput) -> Self {
-        let rest::FormulaInput { formula, defaults } = value;
+impl From<rest::FormulaQuery> for FormulaInternal {
+    fn from(value: rest::FormulaQuery) -> Self {
+        let rest::FormulaQuery { formula, defaults } = value;
 
         FormulaInternal {
             formula: ExpressionInternal::from(formula),

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -185,6 +185,11 @@ impl PlannedQuery {
 
                     vec![Source::ScrollsIdx(idx)]
                 }
+                Some(ScoringQuery::Formula(_formula)) => {
+                    return Err(CollectionError::bad_request(
+                        "cannot apply Formula without prefetches".to_string(),
+                    ))
+                }
                 Some(ScoringQuery::Sample(SampleInternal::Random)) => {
                     // Everything should come from 1 scroll
                     let scroll = QueryScrollRequestInternal {
@@ -328,6 +333,11 @@ fn recurse_prefetches(
                     scrolls.push(scroll);
 
                     Source::ScrollsIdx(idx)
+                }
+                Some(ScoringQuery::Formula(_)) => {
+                    return Err(CollectionError::bad_request(
+                        "cannot apply Formula without prefetches".to_string(),
+                    ))
                 }
                 Some(ScoringQuery::Sample(SampleInternal::Random)) => {
                     let scroll = QueryScrollRequestInternal {

--- a/lib/collection/src/shards/local_shard/formula_rescore.rs
+++ b/lib/collection/src/shards/local_shard/formula_rescore.rs
@@ -1,28 +1,53 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::query_context::FormulaContext;
-use segment::types::ScoredPoint;
+use segment::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
+use segment::types::{ScoredPoint, WithPayload, WithVector};
 
 use super::LocalShard;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
-use crate::operations::types::CollectionResult;
+use crate::common::stopping_guard::StoppingGuard;
+use crate::operations::types::{CollectionError, CollectionResult};
 
 impl LocalShard {
+    #[expect(clippy::too_many_arguments)]
     pub async fn rescore_with_formula(
         &self,
-        ctx: FormulaContext,
+        formula: ParsedFormula,
+        prefetches_results: Vec<Vec<ScoredPoint>>,
+        with_payload: WithPayload,
+        with_vector: WithVector,
+        limit: usize,
+        timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ScoredPoint>> {
+        let stopping_guard = StoppingGuard::new();
+
+        let ctx = FormulaContext {
+            formula,
+            prefetches_results,
+            with_payload,
+            with_vector,
+            limit,
+            is_stopped: stopping_guard.get_is_stopped(),
+        };
+
         let arc_ctx = Arc::new(ctx);
 
-        let res = SegmentsSearcher::rescore_with_formula(
+        let future = SegmentsSearcher::rescore_with_formula(
             self.segments.clone(),
             arc_ctx,
             &self.search_runtime,
             hw_measurement_acc,
-        )
-        .await?;
+        );
+
+        let res = tokio::time::timeout(timeout, future)
+            .await
+            .map_err(|_elapsed| {
+                CollectionError::timeout(timeout.as_secs() as usize, "rescore_with_formula")
+            })??;
 
         Ok(res)
     }

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -9,7 +9,9 @@ use futures::FutureExt;
 use parking_lot::Mutex;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
 use segment::common::score_fusion::{score_fusion, ScoreFusion};
-use segment::types::{Filter, HasIdCondition, ScoredPoint, WithPayloadInterface, WithVector};
+use segment::types::{
+    Filter, HasIdCondition, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
+};
 use tokio::runtime::Handle;
 use tokio::time::error::Elapsed;
 
@@ -314,6 +316,18 @@ impl LocalShard {
                         "Rescoring with vector(s) query didn't return expected batch of results",
                     )
                 })
+            }
+            ScoringQuery::Formula(formula) => {
+                self.rescore_with_formula(
+                    formula,
+                    sources,
+                    WithPayload::from(&with_payload),
+                    with_vector,
+                    limit,
+                    timeout,
+                    hw_counter_acc,
+                )
+                .await
             }
             ScoringQuery::Sample(sample) => match sample {
                 SampleInternal::Random => {

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -253,5 +253,5 @@ pub struct FormulaContext {
     pub with_payload: WithPayload,
     pub with_vector: WithVector,
     pub limit: usize,
-    pub is_stopped: AtomicBool,
+    pub is_stopped: Arc<AtomicBool>,
 }

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -98,7 +98,7 @@ fn collect_query(query: &Query, batch: &mut BatchAccum) {
                 }
             }
         }
-        Query::OrderBy(_) | Query::Fusion(_) | Query::Sample(_) => {}
+        Query::OrderBy(_) | Query::Fusion(_) | Query::Formula(_) | Query::Sample(_) => {}
     }
 }
 

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -4,6 +4,7 @@ use collection::operations::universal_query::collection_query::{
     CollectionPrefetch, CollectionQueryGroupsRequest, CollectionQueryRequest, Query,
     VectorInputInternal, VectorQuery,
 };
+use collection::operations::universal_query::formula::FormulaInternal;
 use collection::operations::universal_query::shard_query::{FusionInternal, SampleInternal};
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{MultiDenseVectorInternal, VectorInternal, DEFAULT_VECTOR_NAME};
@@ -229,6 +230,7 @@ fn convert_query_with_inferred(
         }
         rest::Query::OrderBy(order_by) => Ok(Query::OrderBy(OrderBy::from(order_by.order_by))),
         rest::Query::Fusion(fusion) => Ok(Query::Fusion(FusionInternal::from(fusion.fusion))),
+        rest::Query::Formula(formula) => Ok(Query::Formula(FormulaInternal::from(formula))),
         rest::Query::Sample(sample) => Ok(Query::Sample(SampleInternal::from(sample.sample))),
     }
 }


### PR DESCRIPTION
Connects the score boosting structures to Query API.

It denies to use this method for base queries (leaf prefetches), and includes validation for defaults.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?