### PR TITLE
gpu: configure debugPrintfEXT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bustle"
@@ -2316,6 +2316,7 @@ name = "gpu"
 version = "0.1.0"
 dependencies = [
  "ash",
+ "bumpalo",
  "gpu-allocator",
  "log",
  "memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ private_intra_doc_links = "allow"
 [workspace.dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"
+bumpalo = "3.17.0"
 bytemuck = { version = "1.21.0", features = ["extern_crate_alloc", "transparentwrapper_extra"] }
 bytes = "1.10.0"
 chrono = { version = "0.4.39", features = ["serde"] }

--- a/lib/gpu/Cargo.toml
+++ b/lib/gpu/Cargo.toml
@@ -22,6 +22,7 @@ ash = { version = "0.38.0", optional = true, default-features = false, features 
 gpu-allocator = { version = "0.27.0", optional = true }
 shaderc = { version = "0.8.3", optional = true, features = ["build-from-source"]}
 
+bumpalo = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
 memory = { path = "../common/memory" }

--- a/lib/gpu/src/basic_test.rs
+++ b/lib/gpu/src/basic_test.rs
@@ -1,5 +1,7 @@
-static SHADER_CODE: &str = "
+static SHADER_CODE: &str = r#"
 #version 450
+
+#extension GL_EXT_debug_printf : enable
 
 layout(set = 0, binding = 0) buffer Numbers {
     float data[];
@@ -12,8 +14,12 @@ layout(set = 0, binding = 1) uniform Param {
 void main() {
     uint index = gl_GlobalInvocationID.x;
     numbers.data[index] += param.param;
+
+    if (gl_GlobalInvocationID.x == 0) {
+        debugPrintfEXT("Hello from shader! Param is %f.\n", param.param);
+    }
 }
-";
+"#;
 
 // Basic GPU test.
 // It takes list of numbers and adds parameter to each number.

--- a/lib/gpu/src/instance.rs
+++ b/lib/gpu/src/instance.rs
@@ -9,6 +9,8 @@ use crate::*;
 
 static APPLICATION_NAME: &std::ffi::CStr = c"qdrant";
 
+static VALIDATION_LAYER_NAME: &std::ffi::CStr = c"VK_LAYER_KHRONOS_validation";
+
 /// `Instance` is a Vulkan instance wrapper.
 /// It's a root structure for all Vulkan operations and provides access the API.
 /// It also manages all Vulkan API layers and API extensions.
@@ -174,6 +176,15 @@ impl Instance {
 
         if let Some(debug_utils_create_info) = &mut debug_utils_create_info {
             create_info = create_info.push_next(debug_utils_create_info);
+        }
+
+        let mut settings = LayerSettingsBuilder::default();
+        let mut settings_create_info;
+        if layers.contains(&VALIDATION_LAYER_NAME) {
+            Self::set_validation_settings(&mut settings);
+            settings_create_info =
+                vk::LayerSettingsCreateInfoEXT::default().settings(settings.settings());
+            create_info = create_info.push_next(&mut settings_create_info);
         }
 
         // Get CPU allocation callbacks if they are provided.
@@ -357,7 +368,7 @@ impl Instance {
     fn layers_list(validation: bool, dump_api: bool) -> Vec<&'static CStr> {
         let mut result = Vec::new();
         if validation {
-            result.push(c"VK_LAYER_KHRONOS_validation");
+            result.push(VALIDATION_LAYER_NAME);
         }
         if dump_api {
             result.push(c"VK_LAYER_LUNARG_api_dump");
@@ -377,6 +388,22 @@ impl Instance {
             extensions_list.push(ash::khr::get_physical_device_properties2::NAME);
         }
         extensions_list
+    }
+
+    /// Sets validation settings to enable the `debugPrintfEXT()` GLSL function.
+    ///
+    /// References:
+    /// - <https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/vulkan-sdk-1.4.304.1/docs/debug_printf.md>
+    /// - <https://github.com/KhronosGroup/GLSL/blob/9618e893003113a715a06094cf187cef865f8565/extensions/ext/GLSL_EXT_debug_printf.txt>
+    fn set_validation_settings(settings: &mut LayerSettingsBuilder) {
+        settings.str(
+            VALIDATION_LAYER_NAME,
+            c"validate_gpu_based",
+            c"GPU_BASED_DEBUG_PRINTF",
+        );
+        settings.bool(VALIDATION_LAYER_NAME, c"printf_to_stdout", true);
+        settings.bool(VALIDATION_LAYER_NAME, c"printf_verbose", false);
+        settings.uint32(VALIDATION_LAYER_NAME, c"printf_buffer_size", 16384);
     }
 
     fn check_extensions_list(entry: &ash::Entry, extensions: &[&CStr]) -> GpuResult<()> {
@@ -425,5 +452,92 @@ impl Drop for Instance {
             // Last step after all drops of all GPU resources: destroy vulkan instance.
             self.vk_instance.destroy_instance(allocation_callbacks);
         }
+    }
+}
+
+/// A builder for a slice of [`vk::LayerSettingEXT`], to be used in
+/// [`vk::LayerSettingsCreateInfoEXT`].
+///
+/// Using the Vulkan API is not the only way to set these settings. See
+/// <https://vulkan.lunarg.com/doc/view/1.4.304.1/linux/layer_configuration.html>.
+#[derive(Default)]
+pub struct LayerSettingsBuilder {
+    /// Setting values are copied into this arena.
+    bump: bumpalo::Bump,
+    /// It is marked as 'static to make appeasing the borrow checker less
+    /// miserable, but the actual pointers point to the [`Self::bump`] arena.
+    ///
+    /// We just need make sure that LayerSettingEXT<'static> is not exposed in
+    /// the public API.
+    settings: Vec<vk::LayerSettingEXT<'static>>,
+}
+
+impl LayerSettingsBuilder {
+    #[expect(
+        clippy::needless_lifetimes,
+        reason = "Make it clear that values are borrowed, not 'static."
+    )]
+    pub fn settings<'a>(&'a self) -> &'a [vk::LayerSettingEXT<'a>] {
+        &self.settings
+    }
+
+    /// Adds a [`BOOL32`](vk::LayerSettingTypeEXT::BOOL32) setting.
+    pub fn bool(&mut self, layer_name: &CStr, setting_name: &CStr, value: bool) {
+        self.add_setting(
+            layer_name,
+            setting_name,
+            vk::LayerSettingTypeEXT::BOOL32,
+            &[vk::Bool32::from(value)],
+        );
+    }
+
+    /// Adds an [`UINT32`](vk::LayerSettingTypeEXT::UINT32) setting.
+    pub fn uint32(&mut self, layer_name: &CStr, setting_name: &CStr, value: u32) {
+        self.add_setting(
+            layer_name,
+            setting_name,
+            vk::LayerSettingTypeEXT::UINT32,
+            &[value],
+        );
+    }
+
+    /// Adds a [`STRING`](vk::LayerSettingTypeEXT::STRING) setting.
+    pub fn str(&mut self, layer_name: &CStr, setting_name: &CStr, value: &CStr) {
+        let value = self.copy_str(value);
+        self.add_setting(
+            layer_name,
+            setting_name,
+            vk::LayerSettingTypeEXT::STRING,
+            &[value],
+        );
+    }
+
+    fn add_setting<T: Copy>(
+        &mut self,
+        layer_name: &CStr,
+        setting_name: &CStr,
+        ty: vk::LayerSettingTypeEXT,
+        values: &[T],
+    ) {
+        let p_layer_name = self.copy_str(layer_name);
+        let p_setting_name = self.copy_str(setting_name);
+        let p_values = self.bump.alloc_slice_copy(values).as_ptr().cast();
+        // Can't use builder methods, see https://github.com/ash-rs/ash/issues/986
+        self.settings.push(vk::LayerSettingEXT {
+            p_layer_name,
+            p_setting_name,
+            ty,
+            value_count: values.len() as u32,
+            p_values,
+            _marker: std::marker::PhantomData,
+        });
+    }
+
+    fn copy_str(&self, value: &CStr) -> *const i8 {
+        // Not a bottleneck, so don't bother with string interning.
+        self.bump
+            .alloc_slice_copy(value.to_bytes_with_nul())
+            .as_ptr()
+            .cast()
     }
 }


### PR DESCRIPTION
This PR hooks GLSL with the most powerful debugger in the market—the `printf` function.

It sets up required layer configurations options to make the `GL_EXT_debug_printf` work.
An usage example is added to the `basic_test`.

This setup could be helpful for someone diving into the GLSL code again.