### PR TITLE
Fix mix ups in read/write rate limit settings

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1714,7 +1714,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
                 .max_collection_vector_size_bytes
                 .map(|i| i as usize),
             read_rate_limit: value.read_rate_limit.map(|i| i as usize),
-            write_rate_limit: value.read_rate_limit.map(|i| i as usize),
+            write_rate_limit: value.write_rate_limit.map(|i| i as usize),
             max_collection_payload_size_bytes: value
                 .max_collection_payload_size_bytes
                 .map(|i| i as usize),

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -90,7 +90,7 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
         max_collection_vector_size_bytes: value
             .max_collection_vector_size_bytes
             .map(|i| i as usize),
-        read_rate_limit: value.write_rate_limit.map(|i| i as usize),
+        read_rate_limit: value.read_rate_limit.map(|i| i as usize),
         write_rate_limit: value.write_rate_limit.map(|i| i as usize),
         max_collection_payload_size_bytes: value
             .max_collection_payload_size_bytes


### PR DESCRIPTION
We mixed up read/write rate limit values in two places.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?