### PR TITLE
Log consensus snapshot metadata when applying

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -900,10 +900,11 @@ impl Consensus {
 
         if !ready.snapshot().is_empty() {
             // This is a snapshot, we need to apply the snapshot at first.
-            log::debug!("Applying snapshot");
+            let snapshot = ready.snapshot().clone();
+            log::debug!("Applying snapshot {:?}", snapshot.get_metadata());
             is_idle = false;
 
-            if let Err(err) = store.apply_snapshot(&ready.snapshot().clone())? {
+            if let Err(err) = store.apply_snapshot(&snapshot)? {
                 log::error!("Failed to apply snapshot: {err}");
             }
         }


### PR DESCRIPTION
Improves logging a bit by logging the consensus snapshot metadata. Note that this shouldn't be confused with cluster metadata. 

This looks like this and tells us about the commit/term and votes/learners at which consensus snapshot was created:
```
2025-02-20T09:46:02.606475Z DEBUG qdrant::consensus: Applying snapshot SnapshotMetadata { conf_state: Some(ConfState { voters: [7781753388964844], learners: [1922819182303582], voters_outgoing: [], learners_next: [], auto_leave: false }), index: 15, term: 1 }) }
```