### PR TITLE
Resolve clippy warnings for Rust 1.85 on dev

### DIFF
--- a/lib/segment/src/id_tracker/compressed/versions_store.rs
+++ b/lib/segment/src/id_tracker/compressed/versions_store.rs
@@ -20,7 +20,7 @@ pub struct CompressedVersions {
 
 impl CompressedVersions {
     fn version_from_parts(lower: u32, upper: u32) -> SeqNumberType {
-        u64::from(upper) << u32::BITS | u64::from(lower)
+        (u64::from(upper) << u32::BITS) | u64::from(lower)
     }
 
     fn version_to_parts(value: SeqNumberType) -> (u32, u32) {


### PR DESCRIPTION
This was newly introduced in <https://github.com/qdrant/qdrant/pull/6022> after <https://github.com/qdrant/qdrant/pull/6011> was already merged.

Fixes CI job:
- https://github.com/qdrant/qdrant/actions/runs/13441529560/job/37556915657

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?