### PR TITLE
Fix flaky `test_keyword_facet` test

### DIFF
--- a/lib/segment/src/id_tracker/compressed/compressed_point_mappings.rs
+++ b/lib/segment/src/id_tracker/compressed/compressed_point_mappings.rs
@@ -30,9 +30,10 @@ pub type FileEndianess = LittleEndian;
 
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct CompressedPointMappings {
-    // `deleted` specifies which points of internal_to_external was deleted.
-    // It is possible that `deleted` can be longer or shorter than `internal_to_external`.
-    // - if `deleted` is longer, then extra bits should be set to `false` and ignored.
+    /// `deleted` specifies which points of internal_to_external was deleted.
+    /// It is possible that `deleted` can be longer or shorter than `internal_to_external`.
+    /// - if `deleted` is longer, then extra bits should be set to `false` and ignored.
+    /// - if `deleted` is shorter, then extra indices are as if the bits were set to `true`.
     deleted: BitVec,
     internal_to_external: CompressedInternalToExternal,
 

--- a/lib/segment/src/id_tracker/compressed/compressed_point_mappings.rs
+++ b/lib/segment/src/id_tracker/compressed/compressed_point_mappings.rs
@@ -31,9 +31,7 @@ pub type FileEndianess = LittleEndian;
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct CompressedPointMappings {
     /// `deleted` specifies which points of internal_to_external was deleted.
-    /// It is possible that `deleted` can be longer or shorter than `internal_to_external`.
-    /// - if `deleted` is longer, then extra bits should be set to `false` and ignored.
-    /// - if `deleted` is shorter, then extra indices are as if the bits were set to `true`.
+    /// Its size is exactly the same as `internal_to_external`.
     deleted: BitVec,
     internal_to_external: CompressedInternalToExternal,
 

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -25,9 +25,10 @@ pub type FileEndianess = LittleEndian;
 
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct PointMappings {
-    // `deleted` specifies which points of internal_to_external was deleted.
-    // It is possible that `deleted` can be longer or shorter than `internal_to_external`.
-    // - if `deleted` is longer, then extra bits should be set to `false` and ignored.
+    /// `deleted` specifies which points of internal_to_external was deleted.
+    /// It is possible that `deleted` can be longer or shorter than `internal_to_external`.
+    /// - if `deleted` is longer, then extra bits should be set to `false` and ignored.
+    /// - if `deleted` is shorter, then extra indices are as if the bits were set to `true`.
     deleted: BitVec,
     internal_to_external: Vec<PointIdType>,
 

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -1,11 +1,8 @@
 use common::types::PointOffsetType;
-use itertools::Itertools;
 
 use super::bool_index::BoolIndex;
 use super::map_index::{IdIter, MapIndex};
 use crate::data_types::facets::{FacetHit, FacetValueRef};
-use crate::index::struct_filter_context::StructFilterContext;
-use crate::payload_storage::FilterContext;
 use crate::types::{IntPayloadType, UuidIntType};
 
 pub trait FacetIndex {
@@ -56,30 +53,13 @@ impl<'a> FacetIndexEnum<'a> {
         }
     }
 
-    fn iter_values_map(&self) -> Box<dyn Iterator<Item = (FacetValueRef, IdIter<'_>)> + '_> {
+    pub fn iter_values_map(&self) -> Box<dyn Iterator<Item = (FacetValueRef, IdIter<'_>)> + '_> {
         match self {
             FacetIndexEnum::Keyword(index) => Box::new(FacetIndex::iter_values_map(*index)),
             FacetIndexEnum::Int(index) => Box::new(FacetIndex::iter_values_map(*index)),
             FacetIndexEnum::Uuid(index) => Box::new(FacetIndex::iter_values_map(*index)),
             FacetIndexEnum::Bool(index) => Box::new(FacetIndex::iter_values_map(*index)),
         }
-    }
-
-    pub fn iter_filtered_counts_per_value<'c>(
-        &'a self,
-        context: &'c StructFilterContext,
-    ) -> impl Iterator<Item = FacetHit<FacetValueRef<'a>>> + 'c
-    where
-        'a: 'c,
-    {
-        self.iter_values_map()
-            .map(|(value, internal_ids_iter)| FacetHit {
-                value,
-                count: internal_ids_iter
-                    .unique()
-                    .filter(|&point_id| context.check(point_id))
-                    .count(),
-            })
     }
 
     pub fn iter_counts_per_value(

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -247,8 +247,15 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     }
 
     pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> + '_ {
-        self.value_to_points
-            .iter()
-            .map(|(k, v)| (k, Box::new(v.iter().copied()) as IdIter))
+        self.value_to_points.iter().map(|(k, v)| {
+            (
+                k,
+                Box::new(
+                    v.iter()
+                        .copied()
+                        .filter(|idx| !self.deleted.get(*idx as usize).unwrap_or(true)),
+                ) as IdIter,
+            )
+        })
     }
 }


### PR DESCRIPTION
This flaky test didn't get enough love for a looong time, sorry. 

There was a bug hidden in the map mmap index, which didn't consider the deleted bitslice when iterating over the point offsets of each value.

This fixes it and improves the tests.