### PR TITLE
Use u32 index in compressed version store, doesn't support bigger values

### DIFF
--- a/lib/segment/src/id_tracker/compressed/versions_store.rs
+++ b/lib/segment/src/id_tracker/compressed/versions_store.rs
@@ -123,11 +123,11 @@ mod tests {
             // Check set()
             let mut rng = rand::rng();
             #[expect(clippy::needless_range_loop)]
-            for i in 0..model.len() as u32 {
+            for i in 0..model.len() {
                 let new_value = rng.random_range(model_test_range());
                 model[i] = new_value;
-                compressed.set(i, new_value);
-                assert_eq!(model[i], compressed.get(i).unwrap());
+                compressed.set(i as u32, new_value);
+                assert_eq!(model[i], compressed.get(i as u32).unwrap());
             }
 
             // Check len()

--- a/lib/segment/src/id_tracker/compressed/versions_store.rs
+++ b/lib/segment/src/id_tracker/compressed/versions_store.rs
@@ -29,13 +29,13 @@ impl CompressedVersions {
         (lower, upper)
     }
 
-    pub fn has(&self, index: usize) -> bool {
-        index < self.len()
+    pub fn has(&self, index: u32) -> bool {
+        index < self.len() as u32
     }
 
-    pub fn get(&self, index: usize) -> Option<SeqNumberType> {
-        self.lower_bytes.get(index).map(|&lower| {
-            let upper = *self.upper_bytes.get(&(index as u32)).unwrap_or(&0);
+    pub fn get(&self, index: u32) -> Option<SeqNumberType> {
+        self.lower_bytes.get(index as usize).map(|&lower| {
+            let upper = *self.upper_bytes.get(&index).unwrap_or(&0);
             Self::version_from_parts(lower, upper)
         })
     }
@@ -45,14 +45,14 @@ impl CompressedVersions {
     /// # Panics
     ///
     /// Panics if `index` is out of bounds. The internal structure will not grow.
-    pub fn set(&mut self, index: usize, value: SeqNumberType) {
+    pub fn set(&mut self, index: u32, value: SeqNumberType) {
         let (lower, upper) = Self::version_to_parts(value);
 
-        self.lower_bytes[index] = lower;
+        self.lower_bytes[index as usize] = lower;
         if upper > 0 {
-            self.upper_bytes.insert(index as u32, upper);
+            self.upper_bytes.insert(index, upper);
         } else {
-            self.upper_bytes.remove(&(index as u32));
+            self.upper_bytes.remove(&index);
         }
     }
 
@@ -117,13 +117,13 @@ mod tests {
 
             // Check get()
             for (i, model_value) in model.iter().enumerate() {
-                assert_eq!(*model_value, compressed.get(i).unwrap());
+                assert_eq!(*model_value, compressed.get(i as u32).unwrap());
             }
 
             // Check set()
             let mut rng = rand::rng();
             #[expect(clippy::needless_range_loop)]
-            for i in 0..model.len() {
+            for i in 0..model.len() as u32 {
                 let new_value = rng.random_range(model_test_range());
                 model[i] = new_value;
                 compressed.set(i, new_value);

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -370,7 +370,7 @@ fn bitmap_mmap_size(number_of_elements: usize) -> usize {
 
 impl IdTracker for ImmutableIdTracker {
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
-        self.internal_to_version.get(internal_id as usize)
+        self.internal_to_version.get(internal_id)
     }
 
     fn set_internal_version(
@@ -379,13 +379,13 @@ impl IdTracker for ImmutableIdTracker {
         version: SeqNumberType,
     ) -> OperationResult<()> {
         if self.external_id(internal_id).is_some() {
-            let has_version = self.internal_to_version.has(internal_id as usize);
+            let has_version = self.internal_to_version.has(internal_id);
             debug_assert!(
                 has_version,
                 "Can't extend version list in immutable tracker",
             );
             if has_version {
-                self.internal_to_version.set(internal_id as usize, version);
+                self.internal_to_version.set(internal_id, version);
                 self.internal_to_version_wrapper
                     .set(internal_id as usize, version);
             }
@@ -598,7 +598,7 @@ pub(super) mod test {
             old_versions.len(),
             loaded_id_tracker.internal_to_version.len()
         );
-        for i in 0..old_versions.len() {
+        for i in 0..old_versions.len() as u32 {
             assert_eq!(
                 old_versions.get(i),
                 loaded_id_tracker.internal_to_version.get(i),
@@ -669,7 +669,7 @@ pub(super) mod test {
                 .unwrap_or(DEFAULT_VERSION);
 
             assert_eq!(
-                id_tracker.internal_to_version.get(internal_id as usize),
+                id_tracker.internal_to_version.get(internal_id),
                 Some(expect_version)
             );
 


### PR DESCRIPTION
In the new compressed version store (<https://github.com/qdrant/qdrant/pull/6022>), use a `u32` based index instead of `usize`.

There are two reasons for this:
- the structure does not support higher indices, so lets prevent misuse by the type system
- the point offset we usually pass to it is `u32` already

Based on [this](https://github.com/qdrant/qdrant/pull/6022#discussion_r1963230617) comment.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?