### PR TITLE
gpu: add coherent qualifier

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/shaders/links.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/links.comp
@@ -14,7 +14,7 @@ readonly uniform LinksParams {
 
 layout(set = LINKS_LAYOUT_SET, binding = 1)
 buffer Links {
-    POINT_ID data[];
+    coherent POINT_ID data[];
 } links;
 
 #define LEVEL_M links_params.m

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/run_greedy_search.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/run_greedy_search.comp
@@ -22,11 +22,11 @@ struct SearchRequest {
 };
 
 layout(set = 0, binding = 0) buffer SearchRequests {
-    SearchRequest data[];
+    readonly SearchRequest data[];
 } search_requests;
 
 layout(set = 0, binding = 1) buffer SearchResults {
-    uint data[];
+    writeonly uint data[];
 } search_results;
 
 void main() {

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/run_insert_vector.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/run_insert_vector.comp
@@ -22,15 +22,15 @@ struct Request {
 };
 
 layout(set = 0, binding = 0) buffer Requests {
-    Request data[];
+    readonly Request data[];
 } requests;
 
 layout(set = 0, binding = 1) buffer NewEntries {
-    uint data[];
+    writeonly uint data[];
 } new_entries;
 
 layout(set = 0, binding = 2) buffer Atomics {
-    uint data[];
+    coherent uint data[];
 } atomics;
 
 void main() {

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_candidates_heap.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_candidates_heap.comp
@@ -17,11 +17,11 @@ readonly uniform TestParams {
 } test_params;
 
 layout(set = 0, binding = 1) buffer ScoredPointsInput {
-    ScoredPoint data[];
+    readonly ScoredPoint data[];
 } input_points;
 
 layout(set = 0, binding = 2) buffer ScoresOuput {
-    ScoredPoint data[];
+    writeonly ScoredPoint data[];
 } scores_output;
 
 uint candidates_count = 0;

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_heuristic.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_heuristic.comp
@@ -22,11 +22,11 @@ struct SearchRequest {
 };
 
 layout(set = 0, binding = 0) buffer SearchRequests {
-    SearchRequest data[];
+    readonly SearchRequest data[];
 } search_requests;
 
 layout(set = 0, binding = 1) buffer SearchResults {
-    ScoredPoint data[];
+    writeonly ScoredPoint data[];
 } search_results;
 
 void main() {

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_hnsw_search.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_hnsw_search.comp
@@ -22,11 +22,11 @@ struct SearchRequest {
 };
 
 layout(set = 0, binding = 0) buffer SearchRequests {
-    SearchRequest data[];
+    readonly SearchRequest data[];
 } search_requests;
 
 layout(set = 0, binding = 1) buffer SearchResults {
-    ScoredPoint data[];
+    writeonly ScoredPoint data[];
 } search_results;
 
 void main() {

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_nearest_heap.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_nearest_heap.comp
@@ -17,15 +17,15 @@ readonly uniform TestParams {
 } test_params;
 
 layout(set = 0, binding = 1) buffer ScoredPointsInput {
-    ScoredPoint data[];
+    readonly ScoredPoint data[];
 } input_points;
 
 layout(set = 0, binding = 2) buffer ScoresOuput {
-    float data[];
+    writeonly float data[];
 } scores_output;
 
 layout(set = 0, binding = 3) buffer SortedOuput {
-    uint data[];
+    writeonly uint data[];
 } sorted_output;
 
 uint nearest_count = 0;

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_vector_storage.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/tests/test_vector_storage.comp
@@ -9,7 +9,7 @@ layout(local_size_x = SUBGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
 #include "vector_storage.comp"
 
 layout(set = 0, binding = 0) buffer ScoresData {
-    float data[];
+    writeonly float data[];
 } scores;
 
 void main() {

--- a/lib/segment/src/index/hnsw_index/gpu/shaders/visited_flags.comp
+++ b/lib/segment/src/index/hnsw_index/gpu/shaders/visited_flags.comp
@@ -15,13 +15,13 @@ readonly uniform VisitedFlagsParams {
 
 layout(set = VISITED_FLAGS_LAYOUT_SET, binding = 1)
 buffer VisitedFlagsBuffer {
-    uint8_t data[];
+    coherent uint8_t data[];
 } visited_flags;
 
 #ifdef VISITED_FLAGS_REMAP
 layout(set = VISITED_FLAGS_LAYOUT_SET, binding = 2)
 buffer VisitedFlagsRemapBuffer {
-    POINT_ID data[];
+    readonly POINT_ID data[];
 } visited_flags_remap;
 #endif
 


### PR DESCRIPTION
This fixes #5834 for NVIDIA cards.

## How to reproduce

The steps from #5834 works, but the following command catches the issue faster:
```shell
bfb -n 2000000 -d 4 --max-segment-size 200000 --indexing-threshold 1 --hnsw-m 4 --hnsw-ef-construct 8
```

Qdrant output:
```
WARN segment::index::hnsw_index::gpu::gpu_links: Incorrect links on level 2 were found. Amount of incorrect links: 1, zeroes: 1    
WARN segment::index::hnsw_index::gpu::gpu_links: Incorrect links on level 3 were found. Amount of incorrect links: 1, zeroes: 1    
WARN segment::index::hnsw_index::gpu::gpu_links: Incorrect links on level 3 were found. Amount of incorrect links: 1, zeroes: 1    
WARN segment::index::hnsw_index::gpu::gpu_links: Incorrect links on level 1 were found. Amount of incorrect links: 1, zeroes: 1  
```

## The issue

Code in question:
https://github.com/qdrant/qdrant/blob/b50a7027ec7757c68102b69dfe8622821e620b74/lib/segment/src/index/hnsw_index/gpu/shaders/run_insert_vector.comp#L68-L123

In a rough pseudo-code the algorithm is the following:
```python
# 1. Lock
if mutexes[other_id].try_lock() == already_locked:
    continue

# 2. Read links count
count = links[other_id].count
for i in 0..count:
    shared_buffer[i] = links[other_id].links[i]

# 3. Update links
new_count = update(shared_buffer)

# 4. Write link values
for i in 0..new_count:
    links[other_id].links[i] = shared_buffer[i]

# 5. Write links count
links[other_id].count = new_count

# 6. Unlock
mutexes[other_id].unlock()
```

It appears to be correct: it uses proper locking (steps 1 and 6); it writes the count (step 5) only after writing the values (step 4). However, other threads could see the order differently. In the step 2, it could be possible for them to read the new updated count, but old links (which could contain zero-initialized values). What happens here is an ["incoherent memory accesses"](https://www.khronos.org/opengl/wiki/Memory_Model#Incoherent_memory_access). To make it coherent, we just need add a `coherent` GLSL qualifier.

And actually, this issue happen far more frequently than reported; but in most cases these zero values are filtered out in the step 3.