### PR TITLE
gpu: zerocopy instead of transmute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "byteorder"
@@ -2321,6 +2335,7 @@ dependencies = [
  "memory",
  "parking_lot",
  "shaderc",
+ "zerocopy 0.8.18",
 ]
 
 [[package]]
@@ -2411,6 +2426,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -5729,6 +5745,7 @@ dependencies = [
  "bincode",
  "bitpacking",
  "bitvec",
+ "bytemuck",
  "byteorder",
  "cc",
  "cgroups-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ private_intra_doc_links = "allow"
 [workspace.dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"
-bytemuck = { version = "1.21.0", features = ["extern_crate_alloc", "transparentwrapper_extra"] }
+bytemuck = { version = "1.21.0", features = ["extern_crate_alloc", "must_cast", "transparentwrapper_extra"] }
 bytes = "1.10.0"
 chrono = { version = "0.4.39", features = ["serde"] }
 criterion = "0.5.1"
@@ -174,7 +174,7 @@ fnv = "1.0"
 futures = "0.3.31"
 futures-util = "0.3.31"
 generic-tests = "0.1.3"
-half = { version = "2.4.1", features = ["alloc", "serde", "num-traits"] }
+half = { version = "2.4.1", features = ["alloc", "bytemuck", "serde", "num-traits"] }
 http = "1.2.0"
 indexmap = { version = "2", features = ["serde"] }
 indicatif = { version = "0.17.11", features = ["rayon"] }

--- a/lib/common/common/src/types.rs
+++ b/lib/common/common/src/types.rs
@@ -1,13 +1,15 @@
 use std::cmp::Ordering;
 
 use ordered_float::OrderedFloat;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// Type of vector matching score
 pub type ScoreType = f32;
 /// Type of point index inside a segment
 pub type PointOffsetType = u32;
 
-#[derive(Copy, Clone, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, FromBytes, IntoBytes, KnownLayout, Immutable)]
+#[repr(C)]
 pub struct ScoredPointOffset {
     pub idx: PointOffsetType,
     pub score: ScoreType,

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -137,12 +137,6 @@ pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
     unsafe { std::slice::from_raw_parts(ptr::from_ref::<T>(v).cast::<u8>(), mem::size_of_val(v)) }
 }
 
-pub fn transmute_to_u8_mut<T>(v: &mut T) -> &mut [u8] {
-    unsafe {
-        std::slice::from_raw_parts_mut(ptr::from_mut::<T>(v).cast::<u8>(), mem::size_of_val(v))
-    }
-}
-
 pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
 
@@ -185,8 +179,4 @@ pub fn transmute_from_u8_to_mut_slice<T>(data: &mut [u8]) -> &mut [T] {
 
 pub fn transmute_to_u8_slice<T>(v: &[T]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(v.as_ptr().cast::<u8>(), mem::size_of_val(v)) }
-}
-
-pub fn transmute_to_u8_slice_mut<T>(v: &mut [T]) -> &mut [u8] {
-    unsafe { std::slice::from_raw_parts_mut(v.as_mut_ptr().cast::<u8>(), mem::size_of_val(v)) }
 }

--- a/lib/gpu/Cargo.toml
+++ b/lib/gpu/Cargo.toml
@@ -21,6 +21,7 @@ gpu = [
 ash = { version = "0.38.0", optional = true, default-features = false, features = ["loaded", "debug"] }
 gpu-allocator = { version = "0.27.0", optional = true }
 shaderc = { version = "0.8.3", optional = true, features = ["build-from-source"]}
+zerocopy = { workspace = true }
 
 log = { workspace = true }
 parking_lot = { workspace = true }

--- a/lib/gpu/src/basic_test.rs
+++ b/lib/gpu/src/basic_test.rs
@@ -76,7 +76,7 @@ fn basic_gpu_test() {
     )
     .unwrap();
     // Copy numbers.
-    upload_buffer.upload_slice(&numbers, 0).unwrap();
+    upload_buffer.upload(numbers.as_slice(), 0).unwrap();
     // Copy parameter to the end.
     upload_buffer.upload(&param, storage_buffer.size()).unwrap();
 
@@ -166,8 +166,9 @@ fn basic_gpu_test() {
     context.wait_finish(context_timeout).unwrap();
 
     // Download data from intermediate buffer.
-    let mut result = vec![0f32; numbers_count];
-    download_buffer.download_slice(&mut result, 0).unwrap();
+    let result = download_buffer
+        .download_vec::<f32>(0, numbers_count)
+        .unwrap();
 
     // Check results.
     for i in 0..numbers_count {

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -42,6 +42,7 @@ pprof = { workspace = true }
 
 [dependencies]
 bitpacking = "0.9.2"
+bytemuck = { workspace = true }
 data-encoding = { workspace = true }
 delegate = { workspace = true }
 tempfile = { workspace = true }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use common::types::PointOffsetType;
 use quantization::EncodedVectors;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::gpu_quantization::MAX_QUANTIZATION_BINDINGS;
 use super::STORAGES_COUNT;
@@ -19,6 +20,7 @@ use crate::vector_storage::MultiVectorStorage;
 const START_MULTIVECTORS_BINDING: usize = STORAGES_COUNT + MAX_QUANTIZATION_BINDINGS;
 
 /// Shader struct for multivector offsets with start id and count of vectors in multivector.
+#[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
 struct GpuMultivectorOffset {
     start: u32,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_quantization.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_quantization.rs
@@ -364,7 +364,7 @@ impl GpuProductQuantization {
 
         let mut centroids_offset = 0;
         for centroids in &quantized_storage.get_metadata().centroids {
-            centroids_staging_buffer.upload_slice(centroids, centroids_offset)?;
+            centroids_staging_buffer.upload(centroids.as_slice(), centroids_offset)?;
             centroids_offset += centroids.len() * std::mem::size_of::<f32>();
         }
 
@@ -382,7 +382,7 @@ impl GpuProductQuantization {
             .iter()
             .flat_map(|range| [range.start as u32, range.end as u32].into_iter())
             .collect();
-        vector_division_staging_buffer.upload_slice(&vector_division, 0)?;
+        vector_division_staging_buffer.upload(vector_division.as_slice(), 0)?;
 
         upload_context.copy_gpu_buffer(
             vector_division_staging_buffer,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -630,7 +630,7 @@ impl GpuVectorStorage {
         // fill staging buffer with zeros
         let zero_vector = vec![TElement::default(); gpu_vector_capacity];
         for i in 0..upload_points_count {
-            staging_buffer.upload_slice(&zero_vector, i * gpu_vector_capacity)?;
+            staging_buffer.upload(TElement::as_bytes(&zero_vector), i * gpu_vector_capacity)?;
         }
         log::trace!(
             "GPU staging buffer size {}, `upload_points_count` = {}",
@@ -647,7 +647,8 @@ impl GpuVectorStorage {
 
             for vector in vectors.clone().skip(storage_index).step_by(STORAGES_COUNT) {
                 check_process_stopped(stopped)?;
-                staging_buffer.upload_slice(vector.as_ref(), upload_points * gpu_vector_size)?;
+                staging_buffer
+                    .upload(TElement::as_bytes(&vector), upload_points * gpu_vector_size)?;
                 upload_size += gpu_vector_size;
                 upload_points += 1;
 

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -711,8 +711,7 @@ fn test_gpu_vector_storage_impl(
     context.run().unwrap();
     context.wait_finish(GPU_TIMEOUT).unwrap();
 
-    let mut gpu_scores = vec![0.0f32; num_vectors];
-    staging_buffer.download_slice(&mut gpu_scores, 0).unwrap();
+    let gpu_scores = staging_buffer.download_vec(0, num_vectors).unwrap();
 
     let stopped = false.into();
     let point_deleted = BitVec::repeat(false, num_vectors);

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_visited_flags.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_visited_flags.rs
@@ -2,11 +2,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use common::types::PointOffsetType;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::shader_builder::ShaderBuilderParameters;
 use super::GPU_TIMEOUT;
 use crate::common::operation_error::{OperationError, OperationResult};
 
+#[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
 struct GpuVisitedFlagsParamsBuffer {
     generation: u32,
@@ -177,7 +179,7 @@ impl GpuVisitedFlags {
         )?;
         let mut context = gpu::Context::new(device.clone())?;
         for chunk in points_remap.chunks(UPLOAD_REMAP_BUFFER_COUNT) {
-            remap_staging_buffer.upload_slice(chunk, 0)?;
+            remap_staging_buffer.upload(chunk, 0)?;
             context.copy_gpu_buffer(
                 remap_staging_buffer.clone(),
                 remap_buffer.clone(),


### PR DESCRIPTION
In this PR transmutes in the GPU-related code are replaced with the usage of `zerocopy`. See https://github.com/qdrant/qdrant/pull/5297/files/be387be795977cfe99fabe77694ba31c66226f32#r1836929158.

Note: `half::f16` is not compatible with the latest version of `zerocopy`, so `bytemuck` is used to convert it to `&[u8]`.

Also, since every usage of `download_slice()` was used to write into a newly allocated vector, I've introduced `download_vec()` to make usage a bit more convenient.