### PR TITLE
Reuse fixture in payload index test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,9 +483,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "api"
@@ -5724,6 +5724,7 @@ name = "segment"
 version = "0.6.0"
 dependencies = [
  "ahash",
+ "anyhow",
  "atomic_refcell",
  "atomicwrites",
  "bincode",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -36,6 +36,7 @@ walkdir = "2.5.0"
 rstest = { workspace = true }
 segment = { path = ".", features = ["testing"] }
 proptest = { workspace = true }
+anyhow = "1.0.96"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { workspace = true }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -65,7 +65,7 @@ macro_rules! ensure {
 }
 
 const DIM: usize = 5;
-const ATTEMPTS: usize = 100;
+const ATTEMPTS: usize = 20;
 
 struct TestSegments {
     _base_dir: TempDir,
@@ -448,9 +448,9 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
 
 fn validate_geo_filter(test_segments: &TestSegments, query_filter: Filter) -> Result<()> {
     let mut rnd = rand::rng();
-    let query = random_vector(&mut rnd, DIM).into();
 
     for _i in 0..ATTEMPTS {
+        let query = random_vector(&mut rnd, DIM).into();
         let plain_result = test_segments
             .plain_segment
             .search(
@@ -522,13 +522,12 @@ fn validate_geo_filter(test_segments: &TestSegments, query_filter: Filter) -> Re
     Ok(())
 }
 
+
+/// Test read operations on segments. 
+/// The segments fixtures are created only once to improve test speed.
 #[test]
 fn test_read_operations() -> Result<()> {
-    
-    let start = std::time::Instant::now();
     let test_segments = Arc::new(TestSegments::new());
-    eprintln!("TestSegments::new() took {:?}", start.elapsed());
-
     let mut handles = vec![];
 
     for test_fn in [
@@ -1289,7 +1288,7 @@ fn test_mmap_keyword_facet(test_segments: &TestSegments) -> Result<()> {
 fn test_struct_keyword_facet_filtered(test_segments: &TestSegments) -> Result<()> {
     let mut request = keyword_facet_request();
 
-    for _ in 0..10 {
+    for _ in 0..ATTEMPTS {
         let filter = random_filter(&mut rand::rng(), 3);
         request.filter = Some(filter.clone());
 
@@ -1306,7 +1305,7 @@ fn test_struct_keyword_facet_filtered(test_segments: &TestSegments) -> Result<()
 fn test_mmap_keyword_facet_filtered(test_segments: &TestSegments) -> Result<()> {
     let mut request = keyword_facet_request();
 
-    for _ in 0..10 {
+    for _ in 0..ATTEMPTS {
         let filter = random_filter(&mut rand::rng(), 3);
         request.filter = Some(filter.clone());
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -440,7 +440,7 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
 fn validate_geo_filter(query_filter: Filter) {
     let mut rnd = rand::rng();
     let query = random_vector(&mut rnd, DIM).into();
-    let test_segments = TestSegments::new();
+    let test_segments = get_read_only_segments();
 
     for _i in 0..ATTEMPTS {
         let plain_result = test_segments
@@ -517,7 +517,7 @@ fn validate_geo_filter(query_filter: Filter) {
 
 #[test]
 fn test_is_empty_conditions() {
-    let test_segments = TestSegments::new();
+    let test_segments = get_read_only_segments();
 
     let filter = Filter::new_must(Condition::IsEmpty(IsEmptyCondition {
         is_empty: PayloadField {
@@ -573,7 +573,7 @@ fn test_is_empty_conditions() {
 
 #[test]
 fn test_integer_index_types() {
-    let test_segments = TestSegments::new();
+    let test_segments = get_read_only_segments();
 
     for (kind, indexes) in [
         (
@@ -612,7 +612,7 @@ fn test_integer_index_types() {
 
 #[test]
 fn test_cardinality_estimation() {
-    let test_segments = TestSegments::new();
+    let test_segments = get_read_only_segments();
 
     let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
         JsonPath::new(INT_KEY),
@@ -777,7 +777,7 @@ fn test_nesting_nested_array_filter_cardinality_estimation() {
 fn test_struct_payload_index() {
     let mut rnd = rand::rng();
 
-    let test_segments = TestSegments::new();
+    let test_segments = get_read_only_segments();
 
     for _i in 0..ATTEMPTS {
         let query_vector = random_vector(&mut rnd, DIM).into();
@@ -1128,7 +1128,7 @@ fn test_update_payload_index_type() {
 
 #[test]
 fn test_any_matcher_cardinality_estimation() {
-    let test_segments = TestSegments::new();
+    let test_segments = get_read_only_segments();
 
     let keywords: IndexSet<String, FnvBuildHasher> = ["value1", "value2"]
         .iter()

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -522,8 +522,7 @@ fn validate_geo_filter(test_segments: &TestSegments, query_filter: Filter) -> Re
     Ok(())
 }
 
-
-/// Test read operations on segments. 
+/// Test read operations on segments.
 /// The segments fixtures are created only once to improve test speed.
 #[test]
 fn test_read_operations() -> Result<()> {
@@ -1297,7 +1296,8 @@ fn test_struct_keyword_facet_filtered(test_segments: &TestSegments) -> Result<()
             .facet(&request, &Default::default(), &Default::default())
             .unwrap();
 
-        validate_facet_result(&test_segments.struct_segment, facet_hits, Some(filter)).context(here!())?
+        validate_facet_result(&test_segments.struct_segment, facet_hits, Some(filter))
+            .context(here!())?
     }
     Ok(())
 }
@@ -1314,7 +1314,8 @@ fn test_mmap_keyword_facet_filtered(test_segments: &TestSegments) -> Result<()> 
             .facet(&request, &Default::default(), &Default::default())
             .unwrap();
 
-        validate_facet_result(&test_segments.mmap_segment, facet_hits, Some(filter)).context(here!())?
+        validate_facet_result(&test_segments.mmap_segment, facet_hits, Some(filter))
+            .context(here!())?
     }
     Ok(())
 }


### PR DESCRIPTION
This improves the execution speed of the module from around 20 secs down to 7.5 secs, at least with nextest. Command:

```shell
cargo nextest run  -p segment --test integration payload_index_test
```

- Refactors to run all tests within a single one to reuse the fixture
- Each test returns an `anyhow::Result` with an error stating the place of error, as what `assert!()` would do
- Runs the tests in parallel
- Reduces the amount of attempts for each test. And makes each attempt different in the case of geo filters (we were repeating the same request for 100 times 😱)