### PR TITLE
[score boosting] Add formula to internal gRPC API

### DIFF
--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -10,6 +10,8 @@ pub mod grpc_health_v1;
 pub mod transport_channel_pool;
 pub mod validate;
 
+pub use qdrant::*;
+
 pub const fn api_crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -244,6 +244,7 @@ message QueryShardPoints {
       Fusion fusion = 2; // One of the fusion methods
       OrderBy order_by = 3; // Order by a field
       Sample sample = 4; // Sample points
+      Formula formula = 5; // Use an arbitrary formula to rescore points
     }
   }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -9634,7 +9634,7 @@ pub mod query_shard_points {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Query {
-        #[prost(oneof = "query::Score", tags = "1, 2, 3, 4")]
+        #[prost(oneof = "query::Score", tags = "1, 2, 3, 4, 5")]
         pub score: ::core::option::Option<query::Score>,
     }
     /// Nested message and enum types in `Query`.
@@ -9655,6 +9655,9 @@ pub mod query_shard_points {
             /// Sample points
             #[prost(enumeration = "super::super::Sample", tag = "4")]
             Sample(i32),
+            /// Use an arbitrary formula to rescore points
+            #[prost(message, tag = "5")]
+            Formula(super::super::Formula),
         }
     }
     #[derive(serde::Serialize)]

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -66,6 +66,16 @@ pub enum VariableId {
     Condition(ConditionId),
 }
 
+impl VariableId {
+    pub fn unparse(self) -> String {
+        match self {
+            VariableId::Score(index) => format!("${SCORE_KEYWORD}[{index}]"),
+            VariableId::Payload(path) => path.to_string(),
+            VariableId::Condition(_) => unreachable!("there are no defaults for conditions"),
+        }
+    }
+}
+
 impl ParsedExpression {
     /// Default value for division by zero
     const fn by_zero_default() -> ScoreType {


### PR DESCRIPTION
Adds the formula query to the internal gRPC API, as well as the necessary conversions.

I decided to convert from `ParsedFormula` to `grpc::Formula` by "unparsing" the structure, rather than adding a parsed equivalent in the internal interface surface to avoid leaking the parsing implementation.