### PR TITLE
Fix flaky test failed_snapshot_recovery

### DIFF
--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -185,6 +185,9 @@ def test_failed_snapshot_recovery(tmp_path: pathlib.Path):
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 
+    # Wait for all replicas to be active on the receiving peer
+    wait_for_all_replicas_active(peer_api_uris[-1], COLLECTION_NAME)
+
     # Assert that the local shard is active and not empty
     local_shards = get_local_shards(peer_api_uris[-1])
     assert len(local_shards) == 1


### PR DESCRIPTION
On a fast execution, the `Partial` state can be observed.

```
        # Assert that the local shard is active and not empty
        local_shards = get_local_shards(peer_api_uris[-1])
        assert len(local_shards) == 1
        assert local_shards[0]["shard_id"] == 0
>       assert local_shards[0]["state"] == "Active"
E       AssertionError: assert 'Partial' == 'Active'
E         - Active
E         + Partial

tests/consensus_tests/test_failed_snapshot_recovery.py:192: AssertionError
```

The fix is to wait for the `Active` replica status before asserting,