### PR TITLE
Ignore hidden files while restoring shard segments from snapshot

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -838,9 +838,25 @@ impl LocalShard {
     }
 
     pub fn restore_snapshot(snapshot_path: &Path) -> CollectionResult<()> {
-        // Read dir first as the directory contents would change during restore.
+        // Read dir first as the directory contents would change during restore
         let entries = std::fs::read_dir(LocalShard::segments_path(snapshot_path))?
+            .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
+
+        // Filter out hidden entries
+        let entries = entries.into_iter().filter(|entry| {
+            let is_hidden = entry
+                .file_name()
+                .to_str()
+                .is_some_and(|s| s.starts_with('.'));
+            if is_hidden {
+                log::debug!(
+                    "Ignoring hidden segment in local shard during snapshot recovery: {}",
+                    entry.path().display(),
+                );
+            }
+            !is_hidden
+        });
 
         for entry in entries {
             Segment::restore_snapshot_in_place(&entry.path())?;

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -840,7 +840,6 @@ impl LocalShard {
     pub fn restore_snapshot(snapshot_path: &Path) -> CollectionResult<()> {
         // Read dir first as the directory contents would change during restore
         let entries = std::fs::read_dir(LocalShard::segments_path(snapshot_path))?
-            .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
 
         // Filter out hidden entries


### PR DESCRIPTION
Simple extension to <https://github.com/qdrant/qdrant/pull/6032>.

Also ignore hidden segments when recovering them from a shard snapshot.

This is not strictly necessary. But I felt it's nice to keep both (loading segments, and recovering segments) in sync.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?