### PR TITLE
Add retry-after header for gRPC

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1131,7 +1131,7 @@ impl CollectionError {
                     retry_after,
                 } = retry_error;
                 let description = format!(
-                    "{rate_limiter_type} rate limit exceeded: Operation requires {cost} tokens but only {tokens_available} were available. Retry after {}s",
+                    "{rate_limiter_type} rate limit exceeded: Operation requires {cost} tokens but only {tokens_available:.1} were available. Retry after {}s",
                     retry_after.as_secs_f32().ceil() as u32,
                 );
                 (description, Some(retry_after))
@@ -1347,6 +1347,7 @@ impl From<tonic::Status> for CollectionError {
             },
             tonic::Code::ResourceExhausted => {
                 // extract retry-after from metadata
+                // the value is passed as a String containing an integer number of seconds
                 let retry_after = err.metadata().get("retry-after").and_then(|v| {
                     v.to_str()
                         .ok()

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1355,7 +1355,7 @@ impl From<tonic::Status> for CollectionError {
                         .and_then(|v| {
                             v.parse::<u64>()
                                 .inspect_err(|e| {
-                                    log::info!("Failed to parse retry-after header: {e}")
+                                    log::info!("Failed to parse retry-after value in gRPC metadata (value: {v}): {e}")
                                 })
                                 .ok()
                         })

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -57,6 +57,7 @@ impl RateLimiter {
         } else {
             let missing_tokens = tokens - self.tokens;
             let retry_after = Duration::from_secs_f64(missing_tokens / self.tokens_per_sec);
+            debug_assert!(retry_after > Duration::from_secs(0));
             let retry_error = RetryError {
                 tokens_available: self.tokens,
                 retry_after,

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
 use collection::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
 };
@@ -5,6 +8,7 @@ use collection::operations::conversions::sharding_method_from_proto;
 use collection::operations::types::{SparseVectorsConfig, VectorsConfigDiff};
 use segment::types::{StrictModeConfig, StrictModeMultivectorConfig, StrictModeSparseConfig};
 use tonic::Status;
+use tonic::metadata::MetadataValue;
 
 use crate::content_manager::collection_meta_ops::{
     AliasOperations, ChangeAliasesOperation, CollectionMetaOperations, CreateAlias,
@@ -16,6 +20,7 @@ use crate::content_manager::errors::StorageError;
 
 impl From<StorageError> for Status {
     fn from(error: StorageError) -> Self {
+        let mut metadata_headers = HashMap::new();
         let error_code = match &error {
             StorageError::BadInput { .. } => tonic::Code::InvalidArgument,
             StorageError::NotFound { .. } => tonic::Code::NotFound,
@@ -28,9 +33,28 @@ impl From<StorageError> for Status {
             StorageError::Forbidden { .. } => tonic::Code::PermissionDenied,
             StorageError::PreconditionFailed { .. } => tonic::Code::FailedPrecondition,
             StorageError::InferenceError { .. } => tonic::Code::InvalidArgument,
-            StorageError::RateLimitExceeded { .. } => tonic::Code::ResourceExhausted,
+            StorageError::RateLimitExceeded {
+                description: _,
+                retry_after,
+            } => {
+                if let Some(retry_after) = retry_after {
+                    // Retry-After is expressed in seconds `https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After`
+                    // Ceil the value to the nearest second so clients don't retry too early
+                    metadata_headers.insert("retry-after", retry_after.as_secs().to_string());
+                }
+                tonic::Code::ResourceExhausted
+            }
         };
-        Status::new(error_code, format!("{error}"))
+        let mut status = Status::new(error_code, format!("{error:?}"));
+        // add metadata headers
+        for (header_key, header_value) in metadata_headers {
+            if let Ok(metadata) = MetadataValue::from_str(&header_value) {
+                status.metadata_mut().insert(header_key, metadata);
+            } else {
+                log::info!("Failed to parse metadata header value: {}", header_value);
+            }
+        }
+        status
     }
 }
 

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -40,7 +40,8 @@ impl From<StorageError> for Status {
                 if let Some(retry_after) = retry_after {
                     // Retry-After is expressed in seconds `https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After`
                     // Ceil the value to the nearest second so clients don't retry too early
-                    metadata_headers.insert("retry-after", retry_after.as_secs().to_string());
+                    let retry_after_sec = retry_after.as_secs_f32().ceil() as u32;
+                    metadata_headers.insert("retry-after", retry_after_sec.to_string());
                 }
                 tonic::Code::ResourceExhausted
             }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -45,7 +45,7 @@ impl From<StorageError> for Status {
                 tonic::Code::ResourceExhausted
             }
         };
-        let mut status = Status::new(error_code, format!("{error:?}"));
+        let mut status = Status::new(error_code, format!("{error}"));
         // add metadata headers
         for (header_key, header_value) in metadata_headers {
             if let Ok(metadata) = MetadataValue::from_str(&header_value) {

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -1,6 +1,5 @@
 import logging
 import pathlib
-import time
 
 from .fixtures import create_collection, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode
 from .utils import *
@@ -188,3 +187,53 @@ def test_payload_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
 
     assert False, "Should have blocked upsert but didn't"
 
+
+def test_write_rate_limiting_across_node(tmp_path: pathlib.Path):
+    # 2 peers with a single shard without replica to make sure that one of the node is empty
+    n_peers = 2
+    n_shard = 1
+    n_replica = 1
+    peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, n_peers)
+
+    create_collection(peer_urls[0], collection=COLLECTION_NAME, shard_number=n_shard, replication_factor=n_replica)
+
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_urls)
+
+    empty_peer = None
+    for peer_url in peer_urls:
+        if 0 == get_collection_local_shards_count(peer_url, COLLECTION_NAME):
+            empty_peer = peer_url
+            break
+
+    # Make sure that one of the node is empty
+    assert empty_peer is not None
+
+    # No rate limiting until we enable it
+    for _ in range(32):
+        point = {"id": 1, "vector": random_dense_vector()}
+        upsert_points(empty_peer, [point], collection_name=COLLECTION_NAME).raise_for_status()
+
+    # Enable rate limiting
+    set_strict_mode(peer_urls[0], COLLECTION_NAME, {
+        "enabled": True,
+        "write_rate_limit": 60,
+    })
+
+    wait_for_strict_mode_enabled(peer_urls[1], COLLECTION_NAME)
+
+    # Rate limiting should be triggered, although we are sending requests to the empty node.
+    # This proves that the rate limiting error's `retry-after` field is propagated across the cluster from the node that triggered it.
+    for _ in range(120):
+        point = {"id": 1, "vector": random_dense_vector()}
+        response = upsert_points(empty_peer, [point], collection_name=COLLECTION_NAME)
+
+        if not response.ok:
+            print(response.json())
+            assert response.status_code == 429
+            assert "Rate limiting exceeded: Write rate limit exceeded" in response.json()['status']['error']
+            assert response.headers['Retry-After'] is not None
+            # need to wait about a second for one out of 100 tokens to be replenished
+            assert 1 <= int(response.headers['Retry-After']) <= 5
+            return
+
+    assert False, "rate limiter was never triggered"

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -391,7 +391,7 @@ def check_collection_local_shards_count(peer_api_uri: str, collection_name: str,
     return get_collection_local_shards_count(peer_api_uri, collection_name) == expected_local_shard_count
 
 
-def get_collection_local_shards_count(peer_api_uri: str, collection_name: str) -> bool:
+def get_collection_local_shards_count(peer_api_uri: str, collection_name: str) -> int:
     collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name)
     return len(collection_cluster_info["local_shards"])
 


### PR DESCRIPTION
Follow up to https://github.com/qdrant/qdrant/pull/5917 for the gRPC API.

The `retry-after` header is passed using the standard gRPC [metadata structure](https://grpc.io/docs/guides/metadata/).

The value can easily be extracted my clients. (e.g. Rust [client](https://github.com/qdrant/rust-client/pull/212))

This PR makes sure that the `retry-after` header is properly propagated during inter node communication.

There is a test to validate the end to end error propagation when querying an empty node.