### PR TITLE
Don't do exact point count at start of shard transfers

### DIFF
--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -69,7 +69,7 @@ pub(crate) async fn transfer_resharding_stream_records(
             .count_local(
                 Arc::new(CountRequestInternal {
                     filter: None,
-                    exact: true,
+                    exact: false,
                 }),
                 None,
                 hw_acc,

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -55,7 +55,7 @@ pub(super) async fn transfer_stream_records(
             .count_local(
                 Arc::new(CountRequestInternal {
                     filter: None,
-                    exact: true,
+                    exact: false,
                 }),
                 None, // no timeout
                 hw_acc,

--- a/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
+++ b/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::sync::Arc;
@@ -71,7 +72,7 @@ impl TransferTasksPool {
         let mut comment = format!(
             "Transferring records ({}/{}), started {}s ago, ETA: ",
             progress.points_transferred,
-            progress.points_total,
+            max(progress.points_transferred, progress.points_total),
             chrono::Utc::now()
                 .signed_duration_since(task.started_at)
                 .num_seconds(),


### PR DESCRIPTION
The exact count at the start of stream records transfers may be expensive, and can time out.

As a side effect our transfer ETA estimation might be a bit off. But that's totally worth it versus potentially timing out instead.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?