### PR TITLE
Improve shard transfer tracker, show fraction in case of resharding

### DIFF
--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -178,6 +179,58 @@ impl<T: Eq + Hash> HashRingRouter<T> {
         match self {
             HashRingRouter::Single(ring) => ring.nodes(),
             HashRingRouter::Resharding { new, .. } => new.nodes(),
+        }
+    }
+
+    /// Point count fraction in resharding shard transfer
+    ///
+    /// If we do a resharding shard transfer, what fraction of points in the source shard will be
+    /// transferred to the target shard.
+    ///
+    /// If not resharding, the fraction is 1.0.
+    pub fn resharding_transfer_fraction(&self) -> f32 {
+        match self {
+            HashRingRouter::Single(_) => 1.0,
+            HashRingRouter::Resharding { old, new } => {
+                let (from, to) = (old.len(), new.len());
+
+                debug_assert!(
+                    from.abs_diff(to) <= 1,
+                    "expects resharding to only move up or down by one shard",
+                );
+                debug_assert!(
+                    from == 0 || to == 0,
+                    "should never reshard from or to zero shards",
+                );
+
+                match from.cmp(&to) {
+                    Ordering::Equal => 1.0,
+                    // Resharding up:
+                    //
+                    // - shards: 1 -> 2
+                    //   points: 100 -> 50/50
+                    //   transfer fraction of each shard: 1/2/1 = 0.5
+                    // - shards: 2 -> 3
+                    //   points: 50/50 -> 33/33/33
+                    //   transfer fraction of each shard: 1/3/2 = 0.167
+                    // - shards: 3 -> 4
+                    //   points: 33/33/33 -> 25/25/25/25
+                    //   transfer fraction of each shard: 1/4/3 = 0.083
+                    Ordering::Less => (1.0 / to as f32) / (from as f32),
+                    // Resharding down:
+                    //
+                    // - shards: 2 -> 1
+                    //   points: 50/50 -> 100
+                    //   transfer fraction of each shard: 1/1 = 1.0
+                    // - shards: 3 -> 2
+                    //   points: 33/33/33 -> 50/50
+                    //   transfer fraction of each shard: 1/2 = 0.5
+                    // - shards: 4 -> 3
+                    //   points: 25/25/25/25 -> 33/33/33
+                    //   transfer fraction of each shard: 1/3 = 0.333
+                    Ordering::Greater => 1.0 / to as f32,
+                }
+            }
         }
     }
 }

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -198,10 +198,6 @@ impl<T: Eq + Hash> HashRingRouter<T> {
                     from.abs_diff(to) <= 1,
                     "expects resharding to only move up or down by one shard",
                 );
-                debug_assert!(
-                    from == 0 || to == 0,
-                    "should never reshard from or to zero shards",
-                );
 
                 match from.cmp(&to) {
                     Ordering::Equal => 1.0,

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -496,7 +496,7 @@ impl Inner {
         // Set initial progress on the first batch
         let is_first = transfer_from == self.started_at;
         if is_first {
-            self.update_progress(0, total as usize);
+            self.progress.lock().set(0, total as usize);
         }
 
         // Transfer batch with retries and store last transferred ID
@@ -508,7 +508,7 @@ impl Inner {
                         self.transfer_from.store(idx + 1, Ordering::Relaxed);
 
                         let transferred = (idx + 1 - self.started_at) as usize;
-                        self.update_progress(transferred, total as usize);
+                        self.progress.lock().set(transferred, total as usize);
                     }
                     break;
                 }
@@ -536,12 +536,6 @@ impl Inner {
     fn set_wal_keep_from(&self, version: Option<u64>) {
         let version = version.unwrap_or(u64::MAX);
         self.wal_keep_from.store(version, Ordering::Relaxed);
-    }
-
-    fn update_progress(&self, transferred: usize, total: usize) {
-        let mut progress = self.progress.lock();
-        progress.points_transferred = transferred;
-        progress.points_total = total;
     }
 }
 

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -333,6 +333,8 @@ impl ShardReplicaSet {
 
     /// Custom operation for transferring data from one shard to another during transfer
     ///
+    /// Returns new point offset and transferred count
+    ///
     /// # Cancel safety
     ///
     /// This method is cancel safe.
@@ -342,7 +344,7 @@ impl ShardReplicaSet {
         batch_size: usize,
         hashring_filter: Option<&HashRingRouter>,
         merge_points: bool,
-    ) -> CollectionResult<Option<PointIdType>> {
+    ) -> CollectionResult<(Option<PointIdType>, usize)> {
         let local = self.local.read().await;
 
         let Some(Shard::ForwardProxy(proxy)) = local.deref() else {

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -104,11 +104,12 @@ pub(crate) async fn transfer_resharding_stream_records(
             )));
         };
 
-        offset = replica_set
+        let (new_offset, count) = replica_set
             .transfer_batch(offset, TRANSFER_BATCH_SIZE, Some(&hashring), true)
             .await?;
 
-        progress.lock().add(TRANSFER_BATCH_SIZE);
+        offset = new_offset;
+        progress.lock().add(count);
 
         // If this is the last batch, finalize
         if offset.is_none() {

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -80,7 +80,8 @@ pub(crate) async fn transfer_resharding_stream_records(
                 "Shard {shard_id} not found"
             )));
         };
-        progress.lock().set(0, count_result.count);
+        let transfer_size = (count_result.count as f32 * hashring.resharding_transfer_fraction()) as usize;
+        progress.lock().set(0, transfer_size);
 
         replica_set.transfer_indexes().await?;
 

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -80,7 +80,8 @@ pub(crate) async fn transfer_resharding_stream_records(
                 "Shard {shard_id} not found"
             )));
         };
-        let transfer_size = (count_result.count as f32 * hashring.resharding_transfer_fraction()) as usize;
+        let transfer_size =
+            (count_result.count as f32 * hashring.resharding_transfer_fraction()) as usize;
         progress.lock().set(0, transfer_size);
 
         replica_set.transfer_indexes().await?;

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -90,11 +90,12 @@ pub(super) async fn transfer_stream_records(
             )));
         };
 
-        offset = replica_set
+        let (new_offset, count) = replica_set
             .transfer_batch(offset, TRANSFER_BATCH_SIZE, None, false)
             .await?;
 
-        progress.lock().add(TRANSFER_BATCH_SIZE);
+        offset = new_offset;
+        progress.lock().add(count);
 
         // If this is the last batch, finalize
         if offset.is_none() {


### PR DESCRIPTION
Extension of <https://github.com/qdrant/qdrant/pull/6074>

Improve tracking of records to transfer in shard transfers, specifically for stream records and resharding stream records transfer.

The main two improvements are:
- count records actually being transferred, not batch size
- in case of resharding, estimate number of records to transfer based on resharding fraction

For example, if we're resharding from one to two shards, a resharding transfer will only transfer ~50% of the records, not all of them.

The current resharding implementation still filters points with the hash ring after scrolling, not during scrolling itself. Using the hash ring filter during scrolling itself is very expensive and makes the transfer **significantly** slower, bumping transfer time from 28 to 500 seconds.
Branch with it implemented: https://github.com/qdrant/qdrant/commits/improve-transfer-progress-tracker-hashring-filter/

Example collection cluster info during resharding transfer (now shows 250k and correct record count):
```json
{
  "peer_id": 6294971774567105,
  "shard_count": 2,
  "local_shards": [
    {
      "shard_id": 0,
      "points_count": 500000,
      "state": "Active"
    },
    {
      "shard_id": 1,
      "points_count": 145399,
      "state": "Resharding"
    }
  ],
  "shard_transfers": [
    {
      "shard_id": 0,
      "to_shard_id": 1,
      "from": 6294971774567105,
      "to": 6294971774567105,
      "sync": true,
      "method": "resharding_stream_records",
      "comment": "Transferring records (145399/250000), started 16s ago, ETA: 11.68s"
    }
  ],
  // ...
}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?