### PR TITLE
Optimize cleanup of shards, used in resharding

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use cancel::{CancellationToken, DropGuard};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use parking_lot::RwLock;
-use segment::types::{Condition, Filter};
+use segment::types::ExtendedPointId;
 use tokio::sync::watch::{Receiver, Sender};
 use tokio::task::JoinHandle;
 
@@ -276,11 +276,7 @@ async fn clean_task(
             )));
         }
 
-        // Scroll batch of points with hash ring filter
-        let filter = shard_holder
-            .hash_ring_filter(shard_id)
-            .expect("hash ring filter");
-        let filter = Filter::new_must_not(Condition::CustomIdChecker(Arc::new(filter)));
+        // Scroll next batch of points
         let mut ids = match shard
             // TODO(ratelimiter): do not rate limit or bill this scroll, part of internals
             .scroll_by(
@@ -288,7 +284,7 @@ async fn clean_task(
                 CLEAN_BATCH_SIZE + 1,
                 &false.into(),
                 &false.into(),
-                Some(&filter),
+                None,
                 None,
                 true,
                 None,
@@ -309,6 +305,24 @@ async fn clean_task(
         offset = (ids.len() > CLEAN_BATCH_SIZE).then(|| ids.pop().unwrap());
         deleted_points += ids.len();
         let last_batch = offset.is_none();
+
+        // Filter list of point IDs after scrolling, delete points that don't belong in this shard
+        // Checking the hash ring to determine if a point belongs in the shard is very expensive.
+        // We scroll all point IDs and only filter points by the hash ring after scrolling on
+        // purpose, this way we check each point ID against the hash ring only once. Naively we
+        // might pass a hash ring filter into the scroll operation itself, but that will make it
+        // significantly slower, because then we'll do the expensive hash ring check on every
+        // point, in every segment.
+        let hashring = shard_holder.hash_ring_router(shard_id).ok_or_else(|| {
+            CollectionError::service_error(format!(
+                "Shard {shard_id} cannot be cleaned, failed to get shard hash ring"
+            ))
+        })?;
+        let ids: Vec<ExtendedPointId> = ids
+            .into_iter()
+            // TODO: run test with this inverted?
+            .filter(|id| !hashring.is_in_shard(id, shard_id))
+            .collect();
 
         // Delete points from local shard
         // TODO(ratelimiter): do not rate limit or bill this delete, part of internals

--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -313,6 +313,7 @@ async fn clean_task(
         // might pass a hash ring filter into the scroll operation itself, but that will make it
         // significantly slower, because then we'll do the expensive hash ring check on every
         // point, in every segment.
+        // See: <https://github.com/qdrant/qdrant/pull/6085>
         let hashring = shard_holder.hash_ring_router(shard_id).ok_or_else(|| {
             CollectionError::service_error(format!(
                 "Shard {shard_id} cannot be cleaned, failed to get shard hash ring"

--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -330,7 +330,7 @@ async fn clean_task(
             OperationWithClockTag::from(CollectionUpdateOperations::PointOperation(
                 crate::operations::point_ops::PointOperations::DeletePoints { ids },
             ));
-        if let Err(err) = shard.update_local(delete_operation, true).await {
+        if let Err(err) = shard.update_local(delete_operation, last_batch).await {
             return Err(CollectionError::service_error(format!(
                 "Failed to delete points from shard: {err}",
             )));

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -519,13 +519,18 @@ impl ShardHolder {
         self.hash_ring_filter(shard_id)
     }
 
-    pub fn hash_ring_filter(&self, shard_id: ShardId) -> Option<hash_ring::HashRingFilter> {
+    pub fn hash_ring_router(&self, shard_id: ShardId) -> Option<&HashRingRouter> {
         if !self.contains_shard(shard_id) {
             return None;
         }
 
         let shard_key = self.shard_id_to_key_mapping.get(&shard_id).cloned();
         let router = self.rings.get(&shard_key).expect("hashring exists");
+        Some(router)
+    }
+
+    pub fn hash_ring_filter(&self, shard_id: ShardId) -> Option<hash_ring::HashRingFilter> {
+        let router = self.hash_ring_router(shard_id)?;
         let ring = match router {
             HashRingRouter::Single(ring) => ring,
             HashRingRouter::Resharding { old, new } => {


### PR DESCRIPTION
Optimize the background task that takes care of cleaning up shards, specifically deleting points from it that don't belong in it anymore.

This change makes the cleanup process a lot faster, which means it'll complete in less wall clock time.

The primary change is about how we select what points to delete. Before, we used a hash ring filter during the scroll request to only scroll points that don't belong into the shard anymore. Now, we simply scroll all point IDs and filter  the list after the scroll request. The key thing here is that the hash ring check is very expensive. Before, the hash ring check was done a lot more often across all segments in the shard. Now we only check each point ID once.

To summarize, this PR does two things:
1. move hash ring check outside of scroll operation
2. use wait=false on all delete operations, except the last one

I don't have a fancy graph, but I do have performance numbers. This is on a single node, with 5 million points, resharding from 1 to 2 shards, with 2 or 100 segments.

Time for shard cleanup to complete:

0. Before this PR:
    - 2 segments: 115 seconds
    - 100 segments: 72 seconds
1. With hash ring check outside scroll operation:
    - 2 segments: 35 seconds
    - 100 segments: 53 seconds
2. With wait=false:
    - 2 segments: 20 seconds
    - 100 segments: 43 seconds

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

4. [x] Does your submission pass tests?
5. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
6. [x] Have you checked your code using `cargo clippy --all --all-features` command?