### PR TITLE
Fix panic in shard cleanup task when timeout subtraction overflows

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -121,7 +121,8 @@ impl ShardCleanTasks {
             }
 
             let result = if let Some(timeout) = timeout {
-                tokio::time::timeout(timeout - start.elapsed(), receiver.changed()).await
+                tokio::time::timeout(timeout.saturating_sub(start.elapsed()), receiver.changed())
+                    .await
             } else {
                 Ok(receiver.changed().await)
             };


### PR DESCRIPTION
If the elapsed timeout is more than the timeout duration, this previously panicked.

Trace:

```
ERROR qdrant::startup: Panic backtrace: 

2025-02-28 10:49:18.518	
   0: qdrant::startup::setup_panic_hook::{{closure}}
2025-02-28 10:49:18.518	
   1: std::panicking::rust_panic_with_hook
2025-02-28 10:49:18.518	
   2: std::panicking::begin_panic_handler::{{closure}}
2025-02-28 10:49:18.518	
   3: std::sys::backtrace::__rust_end_short_backtrace
2025-02-28 10:49:18.518	
   4: rust_begin_unwind
2025-02-28 10:49:18.518	
   5: core::panicking::panic_fmt

2025-02-28 10:49:18.518	
   6: core::option::expect_failed
2025-02-28 10:49:18.518	
   7: collection::collection::clean::ShardCleanTasks::await_task::{{closure}}
2025-02-28 10:49:18.518	
   8: actix_web::handler::handler_service::{{closure}}::{{closure}}
2025-02-28 10:49:18.518	
   9: <actix_web::resource::Resource<T> as actix_web::service::HttpServiceFactory>::register::{{closure}}::{{closure}}
2025-02-28 10:49:18.518	
  10: <actix_utils::future::either::Either<L,R> as core::future::future::Future>::poll
2025-02-28 10:49:18.518	
  11: <qdrant::actix::auth::AuthMiddleware<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::{{closure}}
2025-02-28 10:49:18.518	
  12: <actix_web_extras::middleware::condition::ConditionMiddlewareFuture<E,D> as core::future::future::Future>::poll
2025-02-28 10:49:18.518	
  13: <actix_cors::middleware::CorsMiddleware<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::{{closure}}
2025-02-28 10:49:18.518	
  14: <qdrant::actix::actix_telemetry::ActixTelemetryService<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::{{closure}}
2025-02-28 10:49:18.518	
  15: <actix_service::map_err::MapErrFuture<A,Req,F,E> as core::future::future::Future>::poll
2025-02-28 10:49:18.518	
  16: actix_http::h1::dispatcher::InnerDispatcher<T,S,B,X,U>::poll_response
2025-02-28 10:49:18.518	
  17: <actix_http::h1::dispatcher::Dispatcher<T,S,B,X,U> as core::future::future::Future>::poll
2025-02-28 10:49:18.518	
  18: <actix_server::service::StreamService<S,I> as actix_service::Service<(actix_server::worker::WorkerCounterGuard,actix_server::socket::MioStream)>>::call::{{closure}}
2025-02-28 10:49:18.518	
  19: tokio::runtime::task::raw::poll
2025-02-28 10:49:18.518	
  20: tokio::task::local::LocalSet::tick
2025-02-28 10:49:18.518	
  21: tokio::task::local::LocalSet::run_until::{{closure}}
2025-02-28 10:49:18.518	
  22: std::sys::backtrace::__rust_begin_short_backtrace
2025-02-28 10:49:18.518	
  23: core::ops::function::FnOnce::call_once{{vtable.shim}}
2025-02-28 10:49:18.518	
  24: std::sys::pal::unix::thread::Thread::new::thread_start
2025-02-28 10:49:18.518	
  25: <unknown>
2025-02-28 10:49:18.518	
  26: <unknown>

2025-02-28 10:49:18.518	
    
2025-02-28 10:49:18.518	
2025-02-28T09:49:18.518411Z ERROR qdrant::startup: Panic occurred in file /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/time.rs at line 1138: overflow when subtracting durations    
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?