### PR TITLE
[score boosting] Only accept finite numbers

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2662,7 +2662,7 @@ fn unparse_expression(
         } => Variant::Div(Box::new(DivExpression {
             left: Some(Box::new(unparse_expression(*left, conditions))),
             right: Some(Box::new(unparse_expression(*right, conditions))),
-            by_zero_default: Some(by_zero_default),
+            by_zero_default,
         })),
         ParsedExpression::Sqrt(expr) => {
             Variant::Sqrt(Box::new(unparse_expression(*expr, conditions)))

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1244,6 +1244,7 @@ impl From<OperationError> for CollectionError {
             OperationError::MissingRangeIndexForOrderBy { .. } => Self::bad_input(format!("{err}")),
             OperationError::MissingMapIndexForFacet { .. } => Self::bad_input(format!("{err}")),
             OperationError::VariableTypeError { .. } => Self::bad_input(format!("{err}")),
+            OperationError::NonFiniteNumber { .. } => Self::bad_input(format!("{err}")),
         }
     }
 }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -67,6 +67,8 @@ pub enum OperationError {
         field_name: PayloadKeyType,
         expected_type: String,
     },
+    #[error("The expression {expression} produced a non-finite number")]
+    NonFiniteNumber { expression: String },
 }
 
 impl OperationError {

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -156,22 +156,24 @@ impl FormulaScorer<'_> {
             ParsedExpression::Sqrt(expr) => {
                 let value = self.eval_expression(expr, point_id)?;
                 let sqrt_value = value.sqrt();
-                if sqrt_value.is_nan() {
-                    // Undefined: Send this point to the bottom of results
-                    Ok(f32::NEG_INFINITY)
-                } else {
+                if sqrt_value.is_finite() {
                     Ok(sqrt_value)
+                } else {
+                    Err(OperationError::NonFiniteNumber {
+                        expression: format!("√{value}"),
+                    })
                 }
             }
             ParsedExpression::Pow { base, exponent } => {
                 let base_value = self.eval_expression(base, point_id)?;
                 let exponent_value = self.eval_expression(exponent, point_id)?;
                 let power = base_value.powf(exponent_value);
-                if power.is_nan() {
-                    // Undefined: Send this point to the bottom of results
-                    Ok(f32::NEG_INFINITY)
-                } else {
+                if power.is_finite() {
                     Ok(power)
+                } else {
+                    Err(OperationError::NonFiniteNumber {
+                        expression: format!("{base_value}^{exponent_value}"),
+                    })
                 }
             }
             ParsedExpression::Exp(parsed_expression) => {
@@ -180,20 +182,24 @@ impl FormulaScorer<'_> {
             }
             ParsedExpression::Log10(expr) => {
                 let value = self.eval_expression(expr, point_id)?;
-                if value <= 0.0 {
-                    // Undefined: Send this point to the bottom of results
-                    Ok(f32::NEG_INFINITY)
+                let log_value = value.log10();
+                if log_value.is_finite() {
+                    Ok(log_value)
                 } else {
-                    Ok(value.log10())
+                    Err(OperationError::NonFiniteNumber {
+                        expression: format!("log10({})", value),
+                    })
                 }
             }
             ParsedExpression::Ln(expr) => {
                 let value = self.eval_expression(expr, point_id)?;
-                if value <= 0.0 {
-                    // Undefined: Send this point to the bottom of results
-                    Ok(f32::NEG_INFINITY)
+                let ln_value = value.ln();
+                if ln_value.is_finite() {
+                    Ok(ln_value)
                 } else {
-                    Ok(value.ln())
+                    Err(OperationError::NonFiniteNumber {
+                        expression: format!("ln({})", value),
+                    })
                 }
             }
             ParsedExpression::Abs(expr) => {

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -79,7 +79,7 @@ impl VariableId {
 impl ParsedExpression {
     /// Default value for division by zero
     const fn by_zero_default() -> ScoreType {
-        f32::INFINITY
+        1.0
     }
 
     pub fn new_div(

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -38,7 +38,7 @@ pub enum ParsedExpression {
     Div {
         left: Box<ParsedExpression>,
         right: Box<ParsedExpression>,
-        by_zero_default: ScoreType,
+        by_zero_default: Option<ScoreType>,
     },
     Neg(Box<ParsedExpression>),
     Sqrt(Box<ParsedExpression>),
@@ -77,11 +77,6 @@ impl VariableId {
 }
 
 impl ParsedExpression {
-    /// Default value for division by zero
-    const fn by_zero_default() -> ScoreType {
-        1.0
-    }
-
     pub fn new_div(
         left: ParsedExpression,
         right: ParsedExpression,
@@ -90,7 +85,7 @@ impl ParsedExpression {
         ParsedExpression::Div {
             left: Box::new(left),
             right: Box::new(right),
-            by_zero_default: by_zero_default.unwrap_or(Self::by_zero_default()),
+            by_zero_default,
         }
     }
 
@@ -100,6 +95,25 @@ impl ParsedExpression {
 
     pub fn new_geo_distance(origin: GeoPoint, key: JsonPath) -> Self {
         ParsedExpression::GeoDistance { origin, key }
+    }
+
+    pub fn new_pow(base: ParsedExpression, exponent: ParsedExpression) -> Self {
+        ParsedExpression::Pow {
+            base: Box::new(base),
+            exponent: Box::new(exponent),
+        }
+    }
+
+    pub fn new_sqrt(expression: ParsedExpression) -> Self {
+        ParsedExpression::Sqrt(Box::new(expression))
+    }
+
+    pub fn new_log10(expression: ParsedExpression) -> Self {
+        ParsedExpression::Log10(Box::new(expression))
+    }
+
+    pub fn new_ln(expression: ParsedExpression) -> Self {
+        ParsedExpression::Ln(Box::new(expression))
     }
 
     pub fn new_payload_id(path: JsonPath) -> Self {


### PR DESCRIPTION
We decided to only handle finite numbers in the formula evaluation. 

With these changes, we now return a new bad request error when the evaluation leads to infinite or NaN.

Test cases were added to assert the errors