### PR TITLE
[score boosting] extract first element of arrays

### DIFF
--- a/lib/collection/src/operations/universal_query/formula.rs
+++ b/lib/collection/src/operations/universal_query/formula.rs
@@ -92,6 +92,7 @@ impl ExpressionInternal {
                 by_zero_default,
             ),
             ExpressionInternal::GeoDistance { origin, to } => {
+                payload_vars.insert(to.clone());
                 ParsedExpression::new_geo_distance(origin, to)
             }
             ExpressionInternal::Sqrt(expression_internal) => ParsedExpression::Sqrt(Box::new(

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -171,6 +171,10 @@ impl JsonPath {
         result
     }
 
+    pub fn has_wildcard_suffix(&self) -> bool {
+        self.rest.last() == Some(&JsonPathItem::WildcardIndex)
+    }
+
     /// Check if a path is included in a list of patterns.
     ///
     /// Basically, it checks if either the pattern or path is a prefix of the other.


### PR DESCRIPTION
Tests were set up to assert this behavior, but an off-by-one error wasn't running this specific case 🤦‍♂️

This PR fixes it by checking if the payload key has a wildcard index `[]`. If it doesn't and it is an array, it reads the first element.