### PR TITLE
Separate StrictModeConfig output structure

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11416,7 +11416,7 @@
             "minimum": 0
           },
           "config": {
-            "$ref": "#/components/schemas/CollectionConfigInternal"
+            "$ref": "#/components/schemas/CollectionConfigTelemetry"
           },
           "shards": {
             "type": "array",
@@ -11444,7 +11444,7 @@
           }
         }
       },
-      "CollectionConfigInternal": {
+      "CollectionConfigTelemetry": {
         "type": "object",
         "required": [
           "hnsw_config",
@@ -11479,7 +11479,7 @@
           "strict_mode_config": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeConfig"
+                "$ref": "#/components/schemas/StrictModeConfigOutput"
               },
               {
                 "nullable": true

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6704,7 +6704,7 @@
           "strict_mode_config": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeConfig"
+                "$ref": "#/components/schemas/StrictModeConfigOutput"
               },
               {
                 "nullable": true
@@ -7253,7 +7253,7 @@
           }
         }
       },
-      "StrictModeConfig": {
+      "StrictModeConfigOutput": {
         "type": "object",
         "properties": {
           "enabled": {
@@ -7276,12 +7276,12 @@
             "nullable": true
           },
           "unindexed_filtering_retrieve": {
-            "description": "Allow usage of unindexed fields in retrieval based (eg. search) filters.",
+            "description": "Allow usage of unindexed fields in retrieval based (e.g. search) filters.",
             "type": "boolean",
             "nullable": true
           },
           "unindexed_filtering_update": {
-            "description": "Allow usage of unindexed fields in filtered updates (eg. delete by payload).",
+            "description": "Allow usage of unindexed fields in filtered updates (e.g. delete by payload).",
             "type": "boolean",
             "nullable": true
           },
@@ -7321,14 +7321,14 @@
             "description": "Max number of read operations per minute per replica",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           },
           "write_rate_limit": {
             "description": "Max number of write operations per minute per replica",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           },
           "max_collection_payload_size_bytes": {
@@ -7342,7 +7342,7 @@
             "description": "Max number of points estimated in a collection",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           },
           "filter_max_conditions": {
@@ -7363,7 +7363,7 @@
             "description": "Multivector configuration",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeMultivectorConfig"
+                "$ref": "#/components/schemas/StrictModeMultivectorConfigOutput"
               },
               {
                 "nullable": true
@@ -7383,20 +7383,20 @@
           }
         }
       },
-      "StrictModeMultivectorConfig": {
+      "StrictModeMultivectorConfigOutput": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/components/schemas/StrictModeMultivector"
+          "$ref": "#/components/schemas/StrictModeMultivectorOutput"
         }
       },
-      "StrictModeMultivector": {
+      "StrictModeMultivectorOutput": {
         "type": "object",
         "properties": {
           "max_vectors": {
             "description": "Max number of vectors in a multivector",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           }
         }
@@ -9595,6 +9595,154 @@
         "properties": {
           "collection": {
             "type": "string"
+          }
+        }
+      },
+      "StrictModeConfig": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "description": "Whether strict mode is enabled for a collection or not.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "max_query_limit": {
+            "description": "Max allowed `limit` parameter for all APIs that don't have their own max limit.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "max_timeout": {
+            "description": "Max allowed `timeout` parameter.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "unindexed_filtering_retrieve": {
+            "description": "Allow usage of unindexed fields in retrieval based (e.g. search) filters.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "unindexed_filtering_update": {
+            "description": "Allow usage of unindexed fields in filtered updates (e.g. delete by payload).",
+            "type": "boolean",
+            "nullable": true
+          },
+          "search_max_hnsw_ef": {
+            "description": "Max HNSW value allowed in search parameters.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "search_allow_exact": {
+            "description": "Whether exact search is allowed or not.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "search_max_oversampling": {
+            "description": "Max oversampling value allowed in search.",
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "upsert_max_batchsize": {
+            "description": "Max batchsize when upserting",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "max_collection_vector_size_bytes": {
+            "description": "Max size of a collections vector storage in bytes, ignoring replicas.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "read_rate_limit": {
+            "description": "Max number of read operations per minute per replica",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "write_rate_limit": {
+            "description": "Max number of write operations per minute per replica",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "max_collection_payload_size_bytes": {
+            "description": "Max size of a collections payload storage in bytes",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "max_points_count": {
+            "description": "Max number of points estimated in a collection",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
+          "filter_max_conditions": {
+            "description": "Max conditions a filter can have.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "condition_max_size": {
+            "description": "Max size of a condition, eg. items in `MatchAny`.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "multivector_config": {
+            "description": "Multivector configuration",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeMultivectorConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "sparse_config": {
+            "description": "Sparse vector configuration",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StrictModeSparseConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "StrictModeMultivectorConfig": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/StrictModeMultivector"
+        }
+      },
+      "StrictModeMultivector": {
+        "type": "object",
+        "properties": {
+          "max_vectors": {
+            "description": "Max number of vectors in a multivector",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7374,7 +7374,7 @@
             "description": "Sparse vector configuration",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StrictModeSparseConfig"
+                "$ref": "#/components/schemas/StrictModeSparseConfigOutput"
               },
               {
                 "nullable": true
@@ -7401,20 +7401,20 @@
           }
         }
       },
-      "StrictModeSparseConfig": {
+      "StrictModeSparseConfigOutput": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/components/schemas/StrictModeSparse"
+          "$ref": "#/components/schemas/StrictModeSparseOutput"
         }
       },
-      "StrictModeSparse": {
+      "StrictModeSparseOutput": {
         "type": "object",
         "properties": {
           "max_length": {
             "description": "Max length of sparse vector",
             "type": "integer",
             "format": "uint",
-            "minimum": 1,
+            "minimum": 0,
             "nullable": true
           }
         }
@@ -9739,6 +9739,24 @@
         "properties": {
           "max_vectors": {
             "description": "Max number of vectors in a multivector",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          }
+        }
+      },
+      "StrictModeSparseConfig": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/StrictModeSparse"
+        }
+      },
+      "StrictModeSparse": {
+        "type": "object",
+        "properties": {
+          "max_length": {
+            "description": "Max length of sparse vector",
             "type": "integer",
             "format": "uint",
             "minimum": 1,

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::str::FromStr as _;
 use std::time::Instant;
 
@@ -1982,9 +1982,9 @@ impl From<segment::types::StrictModeSparseConfig> for StrictModeSparseConfig {
     }
 }
 
-impl From<segment::types::StrictModeConfig> for StrictModeConfig {
-    fn from(value: segment::types::StrictModeConfig) -> Self {
-        let segment::types::StrictModeConfig {
+impl From<segment::types::StrictModeConfigOutput> for StrictModeConfig {
+    fn from(value: segment::types::StrictModeConfigOutput) -> Self {
+        let segment::types::StrictModeConfigOutput {
             enabled,
             max_query_limit,
             max_timeout,
@@ -2027,9 +2027,91 @@ impl From<segment::types::StrictModeConfig> for StrictModeConfig {
     }
 }
 
+impl From<StrictModeConfig> for segment::types::StrictModeConfigOutput {
+    fn from(value: StrictModeConfig) -> Self {
+        let StrictModeConfig {
+            enabled,
+            max_query_limit,
+            max_timeout,
+            unindexed_filtering_retrieve,
+            unindexed_filtering_update,
+            search_max_hnsw_ef,
+            search_allow_exact,
+            search_max_oversampling,
+            upsert_max_batchsize,
+            max_collection_vector_size_bytes,
+            read_rate_limit,
+            write_rate_limit,
+            max_collection_payload_size_bytes,
+            max_points_count,
+            filter_max_conditions,
+            condition_max_size,
+            multivector_config,
+            sparse_config,
+        } = value;
+        Self {
+            enabled,
+            max_query_limit: max_query_limit.map(|i| i as usize),
+            max_timeout: max_timeout.map(|i| i as usize),
+            unindexed_filtering_retrieve,
+            unindexed_filtering_update,
+            search_max_hnsw_ef: search_max_hnsw_ef.map(|i| i as usize),
+            search_allow_exact,
+            search_max_oversampling: search_max_oversampling.map(f64::from),
+            upsert_max_batchsize: upsert_max_batchsize.map(|i| i as usize),
+            max_collection_vector_size_bytes: max_collection_vector_size_bytes.map(|i| i as usize),
+            read_rate_limit: read_rate_limit.map(|i| i as usize),
+            write_rate_limit: write_rate_limit.map(|i| i as usize),
+            max_collection_payload_size_bytes: max_collection_payload_size_bytes
+                .map(|i| i as usize),
+            max_points_count: max_points_count.map(|i| i as usize),
+            filter_max_conditions: filter_max_conditions.map(|i| i as usize),
+            condition_max_size: condition_max_size.map(|i| i as usize),
+            multivector_config: multivector_config
+                .map(segment::types::StrictModeMultivectorConfigOutput::from),
+            sparse_config: sparse_config.map(segment::types::StrictModeSparseConfig::from),
+        }
+    }
+}
+
+impl From<StrictModeMultivectorConfig> for segment::types::StrictModeMultivectorConfigOutput {
+    fn from(value: StrictModeMultivectorConfig) -> Self {
+        let StrictModeMultivectorConfig { multivector_config } = value;
+        let mut config = BTreeMap::new();
+        for (name, strict_config) in multivector_config {
+            config.insert(
+                name,
+                segment::types::StrictModeMultivectorOutput {
+                    max_vectors: strict_config.max_vectors.map(|i| i as usize),
+                },
+            );
+        }
+        Self { config }
+    }
+}
+
 impl From<segment::types::StrictModeMultivectorConfig> for StrictModeMultivectorConfig {
     fn from(value: segment::types::StrictModeMultivectorConfig) -> Self {
         let segment::types::StrictModeMultivectorConfig { config } = value;
+        Self {
+            multivector_config: config
+                .iter()
+                .map(|(name, config)| {
+                    (
+                        name.clone(),
+                        StrictModeMultivector {
+                            max_vectors: config.max_vectors.map(|i| i as u64),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<segment::types::StrictModeMultivectorConfigOutput> for StrictModeMultivectorConfig {
+    fn from(value: segment::types::StrictModeMultivectorConfigOutput) -> Self {
+        let segment::types::StrictModeMultivectorConfigOutput { config } = value;
         Self {
             multivector_config: config
                 .iter()

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1982,6 +1982,25 @@ impl From<segment::types::StrictModeSparseConfig> for StrictModeSparseConfig {
     }
 }
 
+impl From<segment::types::StrictModeSparseConfigOutput> for StrictModeSparseConfig {
+    fn from(value: segment::types::StrictModeSparseConfigOutput) -> Self {
+        let segment::types::StrictModeSparseConfigOutput { config } = value;
+        Self {
+            sparse_config: config
+                .into_iter()
+                .map(|(name, config)| {
+                    (
+                        name,
+                        StrictModeSparse {
+                            max_length: config.max_length.map(|i| i as u64),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
 impl From<segment::types::StrictModeConfigOutput> for StrictModeConfig {
     fn from(value: segment::types::StrictModeConfigOutput) -> Self {
         let segment::types::StrictModeConfigOutput {
@@ -2069,7 +2088,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfigOutput {
             condition_max_size: condition_max_size.map(|i| i as usize),
             multivector_config: multivector_config
                 .map(segment::types::StrictModeMultivectorConfigOutput::from),
-            sparse_config: sparse_config.map(segment::types::StrictModeSparseConfig::from),
+            sparse_config: sparse_config.map(segment::types::StrictModeSparseConfigOutput::from),
         }
     }
 }
@@ -2125,6 +2144,22 @@ impl From<segment::types::StrictModeMultivectorConfigOutput> for StrictModeMulti
                 })
                 .collect(),
         }
+    }
+}
+
+impl From<StrictModeSparseConfig> for segment::types::StrictModeSparseConfigOutput {
+    fn from(value: StrictModeSparseConfig) -> Self {
+        let StrictModeSparseConfig { sparse_config } = value;
+        let mut config = BTreeMap::new();
+        for (name, strict_config) in sparse_config {
+            config.insert(
+                name,
+                segment::types::StrictModeSparseOutput {
+                    max_length: strict_config.max_length.map(|i| i as usize),
+                },
+            );
+        }
+        Self { config }
     }
 }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -52,7 +52,7 @@ use crate::shards::transfer::helpers::check_transfer_conflicts_strict;
 use crate::shards::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
 use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
 use crate::shards::{CollectionId, replica_set};
-use crate::telemetry::CollectionTelemetry;
+use crate::telemetry::{CollectionConfigTelemetry, CollectionTelemetry};
 
 /// Collection's data is split into several shards.
 pub struct Collection {
@@ -785,7 +785,7 @@ impl Collection {
         CollectionTelemetry {
             id: self.name(),
             init_time_ms: self.init_time.as_millis() as u64,
-            config: self.collection_config.read().await.clone(),
+            config: CollectionConfigTelemetry::from(self.collection_config.read().await.clone()),
             shards: shards_telemetry,
             transfers,
             resharding,

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -204,7 +204,7 @@ pub const fn default_on_disk_payload() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Validate, Clone, PartialEq)]
 pub struct CollectionConfigInternal {
     #[validate(nested)]
     pub params: CollectionParams,

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -21,7 +21,7 @@ use segment::data_types::vectors::{
 };
 use segment::types::{
     Distance, Filter, HnswConfig, MultiVectorConfig, QuantizationConfig, SearchParams,
-    StrictModeConfig, WithPayloadInterface, WithVector,
+    StrictModeConfigOutput, WithPayloadInterface, WithVector,
 };
 use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::{SparseVector, validate_sparse_vector_impl};
@@ -2093,7 +2093,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                     None
                 }
             },
-            strict_mode_config: strict_mode_config.map(StrictModeConfig::from),
+            strict_mode_config: strict_mode_config.map(StrictModeConfigOutput::from),
         })
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -31,8 +31,8 @@ use segment::data_types::vectors::{
 use segment::types::{
     Distance, Filter, HnswConfig, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType,
     PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey,
-    SparseVectorStorageType, StrictModeConfig, VectorName, VectorNameBuf, VectorStorageDatatype,
-    WithPayloadInterface, WithVector,
+    SparseVectorStorageType, StrictModeConfigOutput, VectorName, VectorNameBuf,
+    VectorStorageDatatype, WithPayloadInterface, WithVector,
 };
 use semver::Version;
 use serde;
@@ -207,7 +207,7 @@ pub struct CollectionConfig {
     #[serde(default)]
     pub quantization_config: Option<QuantizationConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub strict_mode_config: Option<StrictModeConfig>,
+    pub strict_mode_config: Option<StrictModeConfigOutput>,
 }
 
 impl From<CollectionConfigInternal> for CollectionConfig {
@@ -229,7 +229,7 @@ impl From<CollectionConfigInternal> for CollectionConfig {
             optimizer_config,
             wal_config: Some(wal_config),
             quantization_config,
-            strict_mode_config,
+            strict_mode_config: strict_mode_config.map(StrictModeConfigOutput::from),
         }
     }
 }


### PR DESCRIPTION
Separate the whole struct tree of `StrictModeConfig` used in the `CollectionInfo` in order to enable the Python REST client to to tag those types as accepting extra keys during deserialization.

This is required to keep the [backward compatibility](https://github.com/qdrant/qdrant-client/issues/906) between the Python client 1.13.2 and the upcoming 1.14.0 version.

We have used a similar pattern in the past for `OptimizerConfig` and `OptimizerConfigDiff` for the same issue.

As a final test I validated that the new output classes are tagged properly in the [client generation](https://github.com/qdrant/qdrant-client/pull/916)