### PR TITLE
Anonymize ShardKey in ReplicaSetTelemetry

### DIFF
--- a/lib/api/src/rest/models.rs
+++ b/lib/api/src/rest/models.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use schemars::JsonSchema;
+use segment::common::anonymize::Anonymize;
 use serde;
 use serde::Serialize;
 
@@ -88,4 +89,16 @@ fn example_collections_response() -> CollectionsResponse {
 #[schemars(example = "example_collections_response")]
 pub struct CollectionsResponse {
     pub collections: Vec<CollectionDescription>,
+}
+
+impl Anonymize for HardwareUsage {
+    fn anonymize(&self) -> Self {
+        HardwareUsage {
+            cpu: self.cpu,
+            payload_io_read: self.payload_io_read,
+            payload_io_write: self.payload_io_write,
+            vector_io_read: self.vector_io_read,
+            vector_io_write: self.vector_io_write,
+        }
+    }
 }

--- a/lib/collection/src/collection_manager/optimizers/mod.rs
+++ b/lib/collection/src/collection_manager/optimizers/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
 use schemars::JsonSchema;
+use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
 
 use super::holders::segment_holder::SegmentId;
@@ -174,4 +175,15 @@ pub enum TrackerStatus {
     Done,
     Cancelled(String),
     Error(String),
+}
+
+impl Anonymize for TrackerStatus {
+    fn anonymize(&self) -> Self {
+        match self {
+            Self::Optimizing => Self::Optimizing,
+            Self::Done => Self::Done,
+            Self::Cancelled(e) => Self::Cancelled(e.clone()),
+            Self::Error(e) => Self::Error(e.clone()),
+        }
+    }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -123,6 +123,15 @@ pub enum OptimizersStatus {
     Error(String),
 }
 
+impl Anonymize for OptimizersStatus {
+    fn anonymize(&self) -> Self {
+        match self {
+            Self::Ok => Self::Ok,
+            Self::Error(e) => Self::Error(e.clone()),
+        }
+    }
+}
+
 /// Point data
 #[derive(Clone, Debug, PartialEq)]
 pub struct RecordInternal {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1821,7 +1821,7 @@ fn missing_vector_error(vector_name: &VectorName) -> CollectionError {
 impl Anonymize for VectorsConfig {
     fn anonymize(&self) -> Self {
         match self {
-            VectorsConfig::Single(params) => VectorsConfig::Single(params.clone()),
+            VectorsConfig::Single(params) => VectorsConfig::Single(params.anonymize()),
             VectorsConfig::Multi(params) => VectorsConfig::Multi(params.anonymize()),
         }
     }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -76,7 +76,7 @@ impl Anonymize for TrackerTelemetry {
         TrackerTelemetry {
             name: self.name.clone(),
             segment_ids: self.segment_ids.anonymize(),
-            status: self.status.clone(),
+            status: self.status.anonymize(),
             start_at: self.start_at.anonymize(),
             end_at: self.end_at.anonymize(),
         }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -51,7 +51,7 @@ pub struct OptimizerTelemetry {
 impl Anonymize for OptimizerTelemetry {
     fn anonymize(&self) -> Self {
         Self {
-            status: self.status.clone(),
+            status: self.status.anonymize(),
             optimizations: self.optimizations.anonymize(),
             log: self.log.anonymize(),
         }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -98,7 +98,7 @@ impl Anonymize for ReplicaSetTelemetry {
     fn anonymize(&self) -> Self {
         ReplicaSetTelemetry {
             id: self.id,
-            key: self.key.clone(),
+            key: self.key.anonymize(),
             local: self.local.anonymize(),
             remote: self.remote.anonymize(),
             replicate_states: Default::default(),

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -49,12 +49,12 @@ impl Anonymize for CollectionTelemetry {
 impl Anonymize for CollectionConfigInternal {
     fn anonymize(&self) -> Self {
         CollectionConfigInternal {
-            params: self.params.clone(),
+            params: self.params.anonymize(),
             hnsw_config: self.hnsw_config.clone(),
             optimizer_config: self.optimizer_config.clone(),
             wal_config: self.wal_config.clone(),
             quantization_config: self.quantization_config.clone(),
-            strict_mode_config: self.strict_mode_config.clone(),
+            strict_mode_config: self.strict_mode_config.anonymize(),
             uuid: None,
         }
     }

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -102,13 +102,16 @@ impl Anonymize for OperationDurationStatistics {
         Self {
             count: self.count.anonymize(),
             fail_count: self.fail_count.anonymize(),
+            avg_duration_micros: self.avg_duration_micros,
+            min_duration_micros: self.min_duration_micros,
+            max_duration_micros: self.max_duration_micros,
+            total_duration_micros: self.total_duration_micros,
             last_responded: self.last_responded.anonymize(),
             duration_micros_histogram: self
                 .duration_micros_histogram
                 .iter()
                 .map(|&(le, count)| (le, count.anonymize()))
                 .collect(),
-            ..*self
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -4119,3 +4119,12 @@ impl Display for ShardKey {
         }
     }
 }
+
+impl Anonymize for ShardKey {
+    fn anonymize(&self) -> Self {
+        match self {
+            Self::Keyword(k) => Self::Keyword(k.anonymize()),
+            Self::Number(n) => Self::Number(*n),
+        }
+    }
+}

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 use validator::{Validate, ValidationError, ValidationErrors};
 use zerocopy::native_endian::U64;
 
+use crate::common::anonymize::Anonymize;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::{self, MaybeOneOrMany, MultiValue};
 use crate::data_types::index::{
@@ -710,6 +711,14 @@ pub struct StrictModeSparse {
     pub max_length: Option<usize>,
 }
 
+impl Anonymize for StrictModeSparse {
+    fn anonymize(&self) -> Self {
+        Self {
+            max_length: self.max_length,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Hash)]
 #[schemars(deny_unknown_fields)]
 pub struct StrictModeSparseConfig {
@@ -726,6 +735,14 @@ impl Merge for StrictModeSparseConfig {
     }
 }
 
+impl Anonymize for StrictModeSparseConfig {
+    fn anonymize(&self) -> Self {
+        Self {
+            config: self.config.anonymize(),
+        }
+    }
+}
+
 #[derive(
     Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Merge, Hash,
 )]
@@ -734,6 +751,14 @@ pub struct StrictModeMultivector {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
     pub max_vectors: Option<usize>,
+}
+
+impl Anonymize for StrictModeMultivector {
+    fn anonymize(&self) -> Self {
+        Self {
+            max_vectors: self.max_vectors,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Hash)]
@@ -749,6 +774,14 @@ impl Merge for StrictModeMultivectorConfig {
         for (key, value) in other.config {
             // overwrite value if key exists
             self.config.entry(key).or_default().merge(value);
+        }
+    }
+}
+
+impl Anonymize for StrictModeMultivectorConfig {
+    fn anonymize(&self) -> Self {
+        Self {
+            config: self.config.anonymize(),
         }
     }
 }
@@ -879,6 +912,31 @@ impl Hash for StrictModeConfig {
         condition_max_size.hash(state);
         multivector_config.hash(state);
         sparse_config.hash(state);
+    }
+}
+
+impl Anonymize for StrictModeConfig {
+    fn anonymize(&self) -> Self {
+        Self {
+            enabled: self.enabled,
+            max_query_limit: self.max_query_limit,
+            max_timeout: self.max_timeout,
+            unindexed_filtering_retrieve: self.unindexed_filtering_retrieve,
+            unindexed_filtering_update: self.unindexed_filtering_update,
+            search_max_hnsw_ef: self.search_max_hnsw_ef,
+            search_allow_exact: self.search_allow_exact,
+            search_max_oversampling: self.search_max_oversampling,
+            upsert_max_batchsize: self.upsert_max_batchsize,
+            max_collection_vector_size_bytes: self.max_collection_vector_size_bytes,
+            read_rate_limit: self.read_rate_limit,
+            write_rate_limit: self.write_rate_limit,
+            max_collection_payload_size_bytes: self.max_collection_payload_size_bytes,
+            max_points_count: self.max_points_count,
+            filter_max_conditions: self.filter_max_conditions,
+            condition_max_size: self.condition_max_size,
+            multivector_config: self.multivector_config.anonymize(),
+            sparse_config: self.sparse_config.anonymize(),
+        }
     }
 }
 

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -231,6 +231,18 @@ pub enum ConsensusThreadStatus {
     StoppedWithErr { err: String },
 }
 
+impl Anonymize for ConsensusThreadStatus {
+    fn anonymize(&self) -> Self {
+        match self {
+            Self::Working { last_update } => Self::Working {
+                last_update: *last_update,
+            },
+            Self::Stopped => Self::Stopped,
+            Self::StoppedWithErr { err } => Self::StoppedWithErr { err: err.clone() },
+        }
+    }
+}
+
 impl Anonymize for PeerInfo {
     fn anonymize(&self) -> Self {
         PeerInfo {
@@ -262,7 +274,7 @@ impl Anonymize for ClusterInfo {
                 .map(|(key, value)| (*key, value.anonymize()))
                 .collect(),
             raft_info: self.raft_info.anonymize(),
-            consensus_thread_status: self.consensus_thread_status.clone(),
+            consensus_thread_status: self.consensus_thread_status.anonymize(),
             message_send_failures: self.message_send_failures.clone(),
         }
     }

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -142,7 +142,7 @@ impl Anonymize for ClusterStatusTelemetry {
             role: self.role,
             is_voter: self.is_voter,
             peer_id: None,
-            consensus_thread_status: self.consensus_thread_status.clone(),
+            consensus_thread_status: self.consensus_thread_status.anonymize(),
         }
     }
 }

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -124,8 +124,8 @@ impl Anonymize for ClusterTelemetry {
     fn anonymize(&self) -> Self {
         ClusterTelemetry {
             enabled: self.enabled,
-            status: self.status.clone().map(|x| x.anonymize()),
-            config: self.config.clone().map(|x| x.anonymize()),
+            status: self.status.anonymize(),
+            config: self.config.anonymize(),
             peers: None,
             metadata: None,
         }

--- a/src/common/telemetry_ops/collections_telemetry.rs
+++ b/src/common/telemetry_ops/collections_telemetry.rs
@@ -100,7 +100,7 @@ impl Anonymize for CollectionTelemetryEnum {
 impl Anonymize for CollectionsAggregatedTelemetry {
     fn anonymize(&self) -> Self {
         CollectionsAggregatedTelemetry {
-            optimizers_status: self.optimizers_status.clone(),
+            optimizers_status: self.optimizers_status.anonymize(),
             vectors: self.vectors.anonymize(),
             params: self.params.anonymize(),
         }

--- a/src/common/telemetry_ops/hardware.rs
+++ b/src/common/telemetry_ops/hardware.rs
@@ -38,11 +38,8 @@ impl HardwareTelemetry {
 
 impl Anonymize for HardwareTelemetry {
     fn anonymize(&self) -> Self {
-        let collection_data = self
-            .collection_data
-            .iter()
-            .map(|i| (i.0.anonymize(), i.1.clone()))
-            .collect();
-        Self { collection_data }
+        Self {
+            collection_data: self.collection_data.anonymize(),
+        }
     }
 }


### PR DESCRIPTION
I've audited all `Anonymize` implementations and added a few missing anonymizations:
- Vector names inside `CollectionConfigInternal::{params, strict_mode_config}`.
- String shard keys.

# No-op implementations

Also, in this PR, I've added a few no-op `Anonymize` implementations. The reasoning is explained below.

In our codebase, we just call `.clone()` for structures that do not require anonymization, like this:

```rust
struct Foo {
   some_structure: SomeStructure,
   …
}
impl Anonymize for Foo {
   fn anonymize(&self) -> Self {
      Self {
          some_structure: self.some_structure.clone(), // !
          …
      }
   }
}
```

However, even if we don't need to anonymize the contents of `SomeStructure` right now, it is possible that we could add some sensitive field in the future. Such additions could be slip by unnoticed during code review.

A better approach is to implement `Anonymize` explicitly, even if the result is a clone. Let the anonymization (or lack thereof) be the responsibility of the structure itself, not of the holders of that structure, like this:
```rust
impl Anonymize for Foo {
   fn anonymize(&self) -> Self {
      Self {
          some_structure: self.some_structure.anonymize(), // !
          …
      }
   }
}

impl Anonymize for SomeStructure {
   fn anonymize(&self) -> Self {
      // no-op
      Self {
          field1: self.field1,
          field2: self.field2,
          …
      }
   }
}
```

In this PR, commits with such changes are prefixed as `no-op`.
And I suggest to treat every `.clone()` inside `Anonymize` as suspicious.

# Error messages

These no-op changes revealed that we do not anonymize error messages. Potentially, some sensitive strings could be included in them (e.g., file paths containing collection names). I'm not sure whether we should anonymize/clear them, or keep them as is. However, if we keep them, I believe, it should be stated explicitly. In this PR, they're explicitly cloned (but behavior is unchanged).
