### PR TITLE
Do not rate limit scroll operations for shard transfers

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -282,7 +282,6 @@ async fn clean_task(
 
         // Scroll next batch of points
         let mut ids = match shard
-            // TODO(ratelimiter): do not rate limit or bill this scroll, part of internals
             .scroll_by(
                 offset,
                 CLEAN_BATCH_SIZE + 1,

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -130,7 +130,6 @@ impl ForwardProxyShard {
         debug_assert!(batch_size > 0);
         let limit = batch_size + 1;
         let _update_lock = self.update_lock.lock().await;
-        // TODO(ratelimits) this scroll should *not* be rate limited
         let mut batch = self
             .wrapped_shard
             .scroll_by(

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -100,6 +100,8 @@ impl Default for HwSharedDrain {
 pub struct HwMeasurementAcc {
     request_drain: HwSharedDrain,
     metrics_drain: HwSharedDrain,
+    /// If this is set to true, the accumulator will not accumulate any values.
+    disposable: bool,
 }
 
 impl HwMeasurementAcc {
@@ -108,6 +110,7 @@ impl HwMeasurementAcc {
         Self {
             request_drain: HwSharedDrain::default(),
             metrics_drain: HwSharedDrain::default(),
+            disposable: false,
         }
     }
 
@@ -118,7 +121,12 @@ impl HwMeasurementAcc {
         Self {
             request_drain: HwSharedDrain::default(),
             metrics_drain: HwSharedDrain::default(),
+            disposable: true,
         }
+    }
+
+    pub fn is_disposable(&self) -> bool {
+        self.disposable
     }
 
     /// Returns a new `HardwareCounterCell` that accumulates it's measurements to the same parent than this `HwMeasurementAcc`.
@@ -130,6 +138,7 @@ impl HwMeasurementAcc {
         Self {
             request_drain: HwSharedDrain::default(),
             metrics_drain,
+            disposable: false,
         }
     }
 
@@ -180,6 +189,7 @@ impl Clone for HwMeasurementAcc {
         Self {
             request_drain: self.request_drain.clone(),
             metrics_drain: self.metrics_drain.clone(),
+            disposable: self.disposable,
         }
     }
 }

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -500,6 +500,10 @@ def check_strict_mode_enabled(peer_api_uri: str, collection_name: str) -> bool:
     strict_mode_enabled = collection_info["config"]["strict_mode_config"]["enabled"]
     return strict_mode_enabled == True
 
+def check_strict_mode_disabled(peer_api_uri: str, collection_name: str) -> bool:
+    collection_info = get_collection_info(peer_api_uri, collection_name)
+    strict_mode_enabled = collection_info["config"]["strict_mode_config"]["enabled"]
+    return strict_mode_enabled == False
 
 def wait_peer_added(peer_api_uri: str, expected_size: int = 1, headers={}) -> str:
     wait_for(check_cluster_size, peer_api_uri, expected_size, headers=headers)
@@ -622,6 +626,13 @@ def wait_for_collection_local_shards_count(peer_api_uri: str, collection_name: s
 def wait_for_strict_mode_enabled(peer_api_uri: str, collection_name: str):
     try:
         wait_for(check_strict_mode_enabled, peer_api_uri, collection_name)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name)
+        raise e
+
+def wait_for_strict_mode_disabled(peer_api_uri: str, collection_name: str):
+    try:
+        wait_for(check_strict_mode_disabled, peer_api_uri, collection_name)
     except Exception as e:
         print_collection_cluster_info(peer_api_uri, collection_name)
         raise e


### PR DESCRIPTION
Do not apply read rate limit to scroll operation issued for shard transfers.

The fix relies on leveraging the work done by tagging internal operations with disposable hardware measurements.

Now all operations with disposable hardware measurements by-pass the read rate limiter.