### PR TITLE
Do not rate limit resharding shard cleaning

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -329,7 +329,6 @@ async fn clean_task(
             .collect();
 
         // Delete points from local shard
-        // TODO(ratelimiter): do not rate limit or bill this delete, part of internals
         let delete_operation =
             OperationWithClockTag::from(CollectionUpdateOperations::PointOperation(
                 crate::operations::point_ops::PointOperations::DeletePoints { ids },

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -55,7 +55,7 @@ impl ShardReplicaSet {
             ReplicaState::Active => {
                 // Rate limit update operations on Active replica
                 // TODO(ratelimits) determine cost of update based on operation
-                self.check_write_rate_limiter(1)?;
+                self.check_write_rate_limiter(1, &hw_measurement)?;
                 local.get().update(operation, wait, hw_measurement).await
             }
 
@@ -298,7 +298,7 @@ impl ShardReplicaSet {
                     // Check write rate limiter before proceeding if replica active
                     // TODO(ratelimits) determine cost of update based on operation
 
-                    self.check_write_rate_limiter_lazy(|| {
+                    self.check_write_rate_limiter_lazy(&hw_measurement_acc, || {
                         let mut ratelimiter_cost = 1;
 
                         // Estimate the cost based on affected points if filter is available.


### PR DESCRIPTION
This PR removes the check for write rate limits when cleaning up a shard after resharding.

It relies on detecting a disposable hardware counter like in https://github.com/qdrant/qdrant/pull/6118 