### PR TITLE
Declare shard green if there can be no optimization threads

### DIFF
--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -405,13 +405,14 @@ async fn test_shard_status_based_on_optimization(
         collection_config_guard
             .optimizer_config
             .default_segment_number = 1;
+        drop(collection_config_guard);
+
+        let info = shard.local_shard_info().await;
+        assert_eq!(info.status, ShardStatus::Green);
+
+        // This recreates optimizers based on updated collection config
+        shard.on_optimizer_config_update().await.unwrap();
     }
-
-    let info = shard.local_shard_info().await;
-    assert_eq!(info.status, ShardStatus::Green);
-
-    // This recreates optimizers based on updated collection config
-    shard.on_optimizer_config_update().await.unwrap();
 
     let info = shard.local_shard_info().await;
     assert_eq!(info.status, expected_shard_status);

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -466,8 +466,8 @@ impl UpdateHandler {
         let has_triggered_any_optimizers = self.has_triggered_optimizers.load(Ordering::Relaxed);
 
         if self.max_optimization_threads == Some(0) {
-            // Collection cannot have optimization threads. So there can be no pending optimizations
-            // This eventually returns ShardStatus::Green
+            // Collection cannot have optimization threads. So we cannot have suboptimal optimizers
+            // This eventually leads to ShardStatus::Green
             return (has_triggered_any_optimizers, false);
         }
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -465,6 +465,12 @@ impl UpdateHandler {
         // Check if Qdrant triggered any optimizations since starting at all
         let has_triggered_any_optimizers = self.has_triggered_optimizers.load(Ordering::Relaxed);
 
+        if self.max_optimization_threads == Some(0) {
+            // Collection cannot have optimization threads. So there can be no pending optimizations
+            // This eventually returns ShardStatus::Green
+            return (has_triggered_any_optimizers, false);
+        }
+
         let excluded_ids = HashSet::<_>::default();
         let has_suboptimal_optimizers = self.optimizers.iter().any(|optimizer| {
             let nonoptimal_segment_ids =


### PR DESCRIPTION
One of the user clusters got stuck in replica wait on indexing stage. This happened because they had configured `max_optimization_threads == 0` which returns Yellow status for the collection as optimizations are possible but can't be triggered because of not having any optimization threads.

This PR makes Qdrant returns Green status in such scenario so we don't get stuck.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### TODO:
- [ ] Add test