### PR TITLE
Bincode 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad1fa75f77bbd06f187540aa1d70ca50b80b27ce85e7f41c0ce7ff42b34ed3b"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1cef5dd4a4457dd11529e743d18ba4fabbd5f20b6895f4c865cb257337dcf9f"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,7 +3039,7 @@ name = "io"
 version = "0.0.0"
 dependencies = [
  "atomicwrites",
- "bincode",
+ "bincode 2.0.0",
  "nix 0.29.0",
  "semver",
  "serde",
@@ -3319,7 +3339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74508ffbb24e36905d1718b261460e378a748029b07bcd7e06f0d18500b8194c"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "encoding",
  "kanaria",
@@ -3361,7 +3381,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c35944000d05a177e981f037b5f0805f283b32f05a0c35713003bef136ca8cb4"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "lindera-cc-cedict-builder",
  "lindera-core",
@@ -3399,7 +3419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c28191456debc98af6aa5f7db77872471983e9fa2a737b1c232b6ef543aed62"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "encoding_rs",
  "log",
@@ -3427,7 +3447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf5f91725e32b9a21b1656baa7030766c9bafc4de4b4ddeb8ffdde7224dd2f6"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "lindera-cc-cedict",
  "lindera-cc-cedict-builder",
@@ -3452,7 +3472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e41f00ba7ac541b0ffd8c30e7a73f2dd197546cc5780462ec4f2e4782945a780"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "csv",
  "derive_builder",
@@ -3498,7 +3518,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97a52ff0af5acb700093badaf7078051ab9ffd9071859724445a60193995f1f"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "lindera-core",
  "lindera-decompress",
@@ -3524,7 +3544,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b36764b27b169aa11d24888141f206a6c246a5b195c1e67127485bac512fb6"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "lindera-core",
  "lindera-decompress",
@@ -3550,7 +3570,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c92a1a3564b531953f0238cbcea392f2905f7b27b449978cf9e702a80e1086d"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "lindera-assets",
  "lindera-core",
@@ -3577,7 +3597,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903e558981bcb6f59870aa7d6b4bcb09e8f7db778886a6a70f67fd74c9fa2ca3"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "lindera-core",
  "lindera-dictionary",
  "once_cell",
@@ -3591,7 +3611,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d227c3ce9cbd905f865c46c65a0470fd04e89b71104d7f92baa71a212ffe1d4b"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "lindera-assets",
  "lindera-core",
@@ -5358,7 +5378,7 @@ checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
 dependencies = [
  "antidote",
  "backtrace",
- "bincode",
+ "bincode 1.3.3",
  "lazy_static",
  "libc",
  "rstack",
@@ -5742,7 +5762,7 @@ dependencies = [
  "anyhow",
  "atomic_refcell",
  "atomicwrites",
- "bincode",
+ "bincode 2.0.0",
  "bitpacking",
  "bitvec",
  "bytemuck",
@@ -6178,7 +6198,7 @@ dependencies = [
 name = "sparse"
 version = "0.1.0"
 dependencies = [
- "bincode",
+ "bincode 2.0.0",
  "bitpacking",
  "common",
  "criterion",
@@ -7096,6 +7116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a88342087869553c259588a3ec9ca73ce9b2d538b7051ba5789ff236b6c129"
+
+[[package]]
 name = "unwind"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7225,6 +7251,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ private_intra_doc_links = "allow"
 [workspace.dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"
+bincode = { version = "2.0.0", features = ["serde"] }
 bytemuck = { version = "1.22.0", features = ["extern_crate_alloc", "must_cast", "transparentwrapper_extra"] }
 bytes = "1.10.0"
 chrono = { version = "0.4.39", features = ["serde"] }

--- a/lib/common/io/Cargo.toml
+++ b/lib/common/io/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 atomicwrites = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 nix = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -56,7 +56,7 @@ rocksdb = { version = "0.23.0", default-features = false, features = [
     "lz4",
 ] }
 uuid = { workspace = true }
-bincode = "1.3"
+bincode = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_cbor = { workspace = true }

--- a/lib/segment/benches/id_type_benchmark.rs
+++ b/lib/segment/benches/id_type_benchmark.rs
@@ -34,7 +34,7 @@ fn id_serialization_speed(c: &mut Criterion) {
     group.bench_function("u64", |b| {
         b.iter(|| {
             let key: u64 = rng.random_range(0..100000000);
-            bincode::serialize(&key).unwrap();
+            bincode::serde::encode_to_vec(key, bincode::config::standard()).unwrap();
         });
     });
 
@@ -42,7 +42,7 @@ fn id_serialization_speed(c: &mut Criterion) {
         b.iter(|| {
             let key: u64 = rng.random_range(0..100000000);
             let new_key = u128::from(key);
-            bincode::serialize(&new_key).unwrap();
+            bincode::serde::encode_to_vec(new_key, bincode::config::standard()).unwrap();
         });
     });
 
@@ -53,7 +53,7 @@ fn id_serialization_speed(c: &mut Criterion) {
                 id: Some(key),
                 uuid: None,
             };
-            bincode::serialize(&new_key).unwrap();
+            bincode::serde::encode_to_vec(new_key, bincode::config::standard()).unwrap();
         });
     });
 
@@ -64,7 +64,7 @@ fn id_serialization_speed(c: &mut Criterion) {
                 id: None,
                 uuid: Some(Uuid::from_u128(u128::from(key))),
             };
-            bincode::serialize(&new_key).unwrap();
+            bincode::serde::encode_to_vec(new_key, bincode::config::standard()).unwrap();
         });
     });
 
@@ -72,7 +72,7 @@ fn id_serialization_speed(c: &mut Criterion) {
         b.iter(|| {
             let key: u64 = rng.random_range(0..100000000);
             let new_key = EnumIdTagged::Num(key);
-            bincode::serialize(&new_key).unwrap();
+            bincode::serde::encode_to_vec(new_key, bincode::config::standard()).unwrap();
         });
     });
 
@@ -80,7 +80,7 @@ fn id_serialization_speed(c: &mut Criterion) {
         b.iter(|| {
             let key: u64 = rng.random_range(0..100000000);
             let new_key = EnumIdTagged::Uuid(Uuid::from_u128(u128::from(key)));
-            bincode::serialize(&new_key).unwrap();
+            bincode::serde::encode_to_vec(new_key, bincode::config::standard()).unwrap();
         });
     });
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -159,11 +159,13 @@ impl FullTextIndex {
     }
 
     pub(super) fn store_key(id: PointOffsetType) -> Vec<u8> {
-        bincode::serialize(&id).unwrap()
+        bincode::serde::encode_to_vec(id, bincode::config::standard()).unwrap()
     }
 
     pub(super) fn restore_key(data: &[u8]) -> PointOffsetType {
-        bincode::deserialize(data).unwrap()
+        bincode::serde::decode_from_slice(data, bincode::config::standard())
+            .unwrap()
+            .0
     }
 
     pub(super) fn serialize_document_tokens(tokens: BTreeSet<String>) -> OperationResult<Vec<u8>> {

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -135,10 +135,14 @@ fn open_simple_multi_dense_vector_storage_impl<T: PrimitiveVectorElement>(
     let db_wrapper = DatabaseColumnWrapper::new(database, database_column_name);
     db_wrapper.lock_db().iter()?;
     for (key, value) in db_wrapper.lock_db().iter()? {
-        let point_id: PointOffsetType = bincode::deserialize(&key)
-            .map_err(|_| OperationError::service_error("cannot deserialize point id from db"))?;
-        let stored_record: StoredMultiDenseVector<T> = bincode::deserialize(&value)
-            .map_err(|_| OperationError::service_error("cannot deserialize record from db"))?;
+        let point_id: PointOffsetType =
+            bincode::serde::decode_from_slice(&key, bincode::config::standard())
+                .map_err(|_| OperationError::service_error("cannot deserialize point id from db"))?
+                .0;
+        let stored_record: StoredMultiDenseVector<T> =
+            bincode::serde::decode_from_slice(&value, bincode::config::standard())
+                .map_err(|_| OperationError::service_error("cannot deserialize record from db"))?
+                .0;
 
         // Propagate deleted flag
         if stored_record.deleted {
@@ -219,8 +223,9 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
                 .extend_from_slice(vector.flattened_vectors);
         }
 
-        let key_enc = bincode::serialize(&key).unwrap();
-        let record_enc = bincode::serialize(&record).unwrap();
+        let key_enc = bincode::serde::encode_to_vec(key, bincode::config::standard()).unwrap();
+        let record_enc =
+            bincode::serde::encode_to_vec(&record, bincode::config::standard()).unwrap();
 
         hw_counter
             .vector_io_write_counter()

--- a/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
+++ b/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
@@ -65,10 +65,13 @@ impl TryFrom<StoredSparseVector> for SparseVector {
 
 impl Blob for StoredSparseVector {
     fn to_bytes(&self) -> Vec<u8> {
-        bincode::serialize(&self).expect("Sparse vector serialization should not fail")
+        bincode::serde::encode_to_vec(self, bincode::config::standard())
+            .expect("Sparse vector serialization should not fail")
     }
 
     fn from_bytes(data: &[u8]) -> Self {
-        bincode::deserialize(data).expect("Sparse vector deserialization should not fail")
+        bincode::serde::decode_from_slice(data, bincode::config::standard())
+            .expect("Sparse vector deserialization should not fail")
+            .0
     }
 }

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -17,7 +17,7 @@ testing = ["common/testing"]
 [dependencies]
 bitpacking = "0.9.2"
 gridstore = { path = "../gridstore" }
-bincode = "1.3"
+bincode = { workspace = true }
 common = { path = "../common/common" }
 half = { workspace = true }
 io = { path = "../common/io" }

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -244,11 +244,14 @@ impl TryFrom<Vec<(u32, f32)>> for SparseVector {
 
 impl Blob for SparseVector {
     fn to_bytes(&self) -> Vec<u8> {
-        bincode::serialize(&self).expect("Sparse vector serialization should not fail")
+        bincode::serde::encode_to_vec(self, bincode::config::standard())
+            .expect("Sparse vector serialization should not fail")
     }
 
     fn from_bytes(data: &[u8]) -> Self {
-        bincode::deserialize(data).expect("Sparse vector deserialization should not fail")
+        bincode::serde::decode_from_slice(data, bincode::config::standard())
+            .expect("Sparse vector deserialization should not fail")
+            .0
     }
 }
 


### PR DESCRIPTION
https://github.com/bincode-org/bincode/releases/tag/v2.0.0

https://github.com/bincode-org/bincode/blob/trunk/docs/migration_guide.md

The performance seems to have regressed.

The upgrade requires a more thorough investigation

```
❯ cargo bench -p segment --bench id_type_benchmark
...
     Running benches/id_type_benchmark.rs (target/release/deps/id_type_benchmark-b8c6468ebd03ccab)
serialization-group/u64 time:   [27.632 ns 27.848 ns 28.198 ns]
                        change: [+286.70% +293.23% +300.22%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
serialization-group/u128
                        time:   [33.662 ns 35.325 ns 37.516 ns]
                        change: [+392.36% +401.06% +413.52%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
serialization-group/struct-u64
                        time:   [39.349 ns 39.530 ns 39.717 ns]
                        change: [+31.129% +32.441% +33.432%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
serialization-group/struct-uuid
                        time:   [55.749 ns 55.978 ns 56.226 ns]
                        change: [+80.372% +81.137% +81.976%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
serialization-group/enum-u64
                        time:   [38.662 ns 38.811 ns 38.960 ns]
                        change: [+37.094% +38.285% +39.843%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
serialization-group/enum-uuid
                        time:   [55.653 ns 55.833 ns 56.001 ns]
                        change: [+76.008% +76.669% +77.362%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  12 (12.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
serialization-group/struct-cbor-u128
                        time:   [38.539 ns 38.674 ns 38.808 ns]
                        change: [-2.7241% -1.5580% -0.5006%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
serialization-group/struct-cbor-u64
                        time:   [90.770 ns 91.100 ns 91.436 ns]
                        change: [+0.4618% +1.1247% +1.7362%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
serialization-group/struct-cbor-uuid
                        time:   [145.32 ns 145.83 ns 146.36 ns]
                        change: [+0.7964% +1.2978% +1.8018%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
serialization-group/enum-cbor-u64
                        time:   [38.860 ns 38.994 ns 39.122 ns]
                        change: [+0.8668% +1.2565% +1.6624%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
serialization-group/enum-cbor-uuid
                        time:   [58.369 ns 58.567 ns 58.759 ns]
                        change: [-1.5286% -1.1061% -0.7223%] (p = 0.00 < 0.05)
                        Change within noise threshold.

hash-search-group/u128  time:   [43.355 ns 43.473 ns 43.583 ns]
                        change: [-0.1826% +0.0673% +0.3367%] (p = 0.64 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) low severe
  2 (2.00%) high mild
  7 (7.00%) high severe

hash-search-group/enum-u64
                        time:   [10.707 ns 10.733 ns 10.764 ns]
                        change: [-1.5200% -0.5299% +0.2729%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  9 (9.00%) high mild
  1 (1.00%) high severe
hash-search-group/enum-uuid
                        time:   [20.781 ns 20.865 ns 20.955 ns]
                        change: [+2.3592% +3.3680% +4.4384%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 18 outliers among 100 measurements (18.00%)
  2 (2.00%) low mild
  8 (8.00%) high mild
  8 (8.00%) high severe
```