### PR TITLE
Upgrade to object store 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,12 +2600,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.2.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -4107,18 +4107,21 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+checksum = "e9ce831b09395f933addbc56d894d889e4b226eba304d4e7adbab591e26daf1e"
 dependencies = [
  "async-trait",
  "base64 0.22.0",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures",
+ "http 1.2.0",
+ "http-body-util",
  "humantime",
  "hyper 1.4.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -4128,7 +4131,8 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
@@ -6166,27 +6170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "snafu"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ prost-build = { version = "0.12.6", features = ["cleanup-markdown"] }
 prost-wkt-types = "0.5"
 prost-for-raft = { package = "prost", version = "=0.11.9" } # version of prost used by raft
 rand = "0.9.0"
-reqwest = { version = "0.12.12", default-features = false, features = ["http2", "stream", "rustls-tls", "blocking"] }
+reqwest = { version = "0.12.12", default-features = false, features = ["json", "http2", "stream", "rustls-tls", "blocking"] }
 rstest = {  version = "0.24.0", default-features = false }
 schemars = { version = "0.8.22", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
 semver = { version = "1.0", features = ["serde"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -89,7 +89,7 @@ tracing = { workspace = true, optional = true }
 fs4 = "0.13.1"
 
 # AWS S3 support
-object_store = { version = "0.11.2", features = ["aws"] }
+object_store = { version = "0.12.0", features = ["aws"] }
 
 
 [[bench]]

--- a/lib/collection/src/operations/snapshot_storage_ops.rs
+++ b/lib/collection/src/operations/snapshot_storage_ops.rs
@@ -162,7 +162,7 @@ pub async fn list_snapshot_descriptions(
         snapshots.push(SnapshotDescription {
             name: get_filename(meta.location.as_ref())?,
             creation_time: Some(meta.last_modified.naive_local()),
-            size: meta.size as u64,
+            size: meta.size,
             checksum: None,
         });
     }


### PR DESCRIPTION
Replacing https://github.com/qdrant/qdrant/pull/6141 with all the necessary manual migration