### PR TITLE
Mutable in-memory ID tracker without RocksDB

### DIFF
--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -2,6 +2,7 @@ pub mod compressed;
 pub mod id_tracker_base;
 pub mod immutable_id_tracker;
 pub mod in_memory_id_tracker;
+pub mod mutable_id_tracker;
 pub mod point_mappings;
 pub mod simple_id_tracker;
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -310,7 +310,15 @@ impl IdTracker for MutableIdTracker {
     /// This function should be called _before_ flushing the version database.
     fn mapping_flusher(&self) -> Flusher {
         let mappings_path = Self::mappings_path(&self.segment_path);
-        let pending_mappings = mem::take(&mut *self.pending_mappings.lock());
+
+        // Take out pending mappings to flush and replace it with a preallocated vector to avoid
+        // frequent reallocation on a busy segment
+        let pending_mappings = {
+            let mut pending_mappings = self.pending_mappings.lock();
+            let count = pending_mappings.len();
+            mem::replace(&mut *pending_mappings, Vec::with_capacity(count))
+        };
+
         Box::new(move || {
             if pending_mappings.is_empty() {
                 return Ok(());
@@ -351,7 +359,14 @@ impl IdTracker for MutableIdTracker {
     /// This function should be called _after_ flushing the mapping database.
     fn versions_flusher(&self) -> Flusher {
         let versions_path = Self::versions_path(&self.segment_path);
-        let pending_versions = mem::take(&mut *self.pending_versions.lock());
+
+        // Take out pending versions to flush and replace it with a preallocated vector to avoid
+        // frequent reallocation on a busy segment
+        let pending_versions = {
+            let mut pending_versions = self.pending_versions.lock();
+            let count = pending_versions.len();
+            mem::replace(&mut *pending_versions, Vec::with_capacity(count))
+        };
 
         Box::new(move || {
             if pending_versions.is_empty() {

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -260,6 +260,12 @@ impl IdTracker for MutableIdTracker {
                 ))
             })?;
 
+            // Explicitly fsync file contents to ensure durability
+            let file = writer.into_inner().unwrap();
+            if let Err(err) = file.sync_all() {
+                log::warn!("Failed to fsync ID tracker point mappings: {err}");
+            }
+
             Ok(())
         })
     }
@@ -296,6 +302,12 @@ impl IdTracker for MutableIdTracker {
                     versions_path.display(),
                 ))
             })?;
+
+            // Explicitly fsync file contents to ensure durability
+            let file = writer.into_inner().unwrap();
+            if let Err(err) = file.sync_all() {
+                log::warn!("Failed to fsync ID tracker point versions: {err}");
+            }
 
             Ok(())
         })

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -262,9 +262,11 @@ impl IdTracker for MutableIdTracker {
 
             // Explicitly fsync file contents to ensure durability
             let file = writer.into_inner().unwrap();
-            if let Err(err) = file.sync_all() {
-                log::warn!("Failed to fsync ID tracker point mappings: {err}");
-            }
+            file.sync_all().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to fsync ID tracker point mappings: {err}",
+                ))
+            })?;
 
             Ok(())
         })
@@ -305,9 +307,11 @@ impl IdTracker for MutableIdTracker {
 
             // Explicitly fsync file contents to ensure durability
             let file = writer.into_inner().unwrap();
-            if let Err(err) = file.sync_all() {
-                log::warn!("Failed to fsync ID tracker point versions: {err}");
-            }
+            file.sync_all().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to fsync ID tracker point mappings: {err}",
+                ))
+            })?;
 
             Ok(())
         })

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -10,10 +10,10 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::Flusher;
-use crate::id_tracker::point_mappings::PointMappings;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::IdTracker;
+use crate::id_tracker::point_mappings::PointMappings;
 use crate::types::{PointIdType, SeqNumberType};
 
 const FILE_MAPPINGS: &str = "id_tracker.mappings";

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -1,0 +1,413 @@
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::mem;
+use std::path::{Path, PathBuf};
+
+use bitvec::prelude::{BitSlice, BitVec};
+use common::types::PointOffsetType;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
+use crate::id_tracker::IdTracker;
+use crate::id_tracker::point_mappings::PointMappings;
+use crate::types::{PointIdType, SeqNumberType};
+
+const FILE_MAPPINGS: &str = "id_tracker.mappings";
+const FILE_VERSIONS: &str = "id_tracker.versions";
+
+/// Point ID used in internal to external mapping if not set
+const UNSET_POINT_ID: PointIdType = PointIdType::NumId(u64::MAX);
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum MappingChange {
+    Insert(PointIdType, PointOffsetType),
+    Delete(PointIdType),
+}
+
+type VersionChange = (PointIdType, SeqNumberType);
+
+#[derive(Debug)]
+pub struct MutableIdTracker {
+    segment_path: PathBuf,
+    internal_to_version: Vec<SeqNumberType>,
+    mappings: PointMappings,
+
+    /// List of point versions pending to be persisted, will be persisted on flush
+    pending_versions: Mutex<Vec<VersionChange>>,
+
+    /// List of point mappings pending to be persisted, will be persisted on flush
+    pending_mappings: Mutex<Vec<MappingChange>>,
+}
+
+impl MutableIdTracker {
+    pub fn open(segment_path: PathBuf) -> OperationResult<Self> {
+        let mut deleted = BitVec::new();
+        let mut internal_to_external: Vec<PointIdType> = Default::default();
+        let mut external_to_internal_num: BTreeMap<u64, PointOffsetType> = Default::default();
+        let mut external_to_internal_uuid: BTreeMap<Uuid, PointOffsetType> = Default::default();
+
+        // Load point mappings
+        let mappings_path = Self::mappings_path(&segment_path);
+        if mappings_path.is_file() {
+            let mappings_file = File::open(mappings_path)?;
+            let mappings_reader = std::io::BufReader::new(mappings_file);
+
+            for entry in std::io::BufRead::lines(mappings_reader) {
+                let entry = entry.expect("failed to parse mapping change entry");
+                let change: MappingChange =
+                    serde_json::from_str(&entry).expect("failed to parse mapping change JSON");
+
+                match change {
+                    MappingChange::Insert(external_id, internal_id) => {
+                        // Update internal to external mapping
+                        if internal_id as usize >= internal_to_external.len() {
+                            internal_to_external.resize(internal_id as usize + 1, UNSET_POINT_ID);
+                        }
+                        let replaced_external_id = internal_to_external[internal_id as usize];
+                        internal_to_external[internal_id as usize] = external_id;
+
+                        // Remove left over point in internal to external mapping
+                        if replaced_external_id != UNSET_POINT_ID {
+                            // Fixing corrupted mapping - this id should be recovered from WAL
+                            // This should not happen in normal operation, but it can happen if
+                            // the database is corrupted.
+                            log::warn!(
+                                "removing duplicated external id {external_id} in internal id {replaced_external_id}"
+                            );
+                            debug_assert!(false, "should never have to remove");
+                            match replaced_external_id {
+                                PointIdType::NumId(num) => {
+                                    external_to_internal_num.remove(&num);
+                                }
+                                PointIdType::Uuid(uuid) => {
+                                    external_to_internal_uuid.remove(&uuid);
+                                }
+                            }
+                        }
+
+                        // Set external to internal mapping
+                        match external_id {
+                            PointIdType::NumId(num) => {
+                                external_to_internal_num.insert(num, internal_id);
+                            }
+                            PointIdType::Uuid(uuid) => {
+                                external_to_internal_uuid.insert(uuid, internal_id);
+                            }
+                        }
+
+                        // New point is not deleted
+                        if (internal_id as usize) < deleted.len() {
+                            deleted.set(internal_id as usize, false);
+                        }
+                    }
+                    MappingChange::Delete(external_id) => {
+                        // Remove external to internal mapping
+                        let internal_id = match external_id {
+                            PointIdType::NumId(idx) => external_to_internal_num.remove(&idx),
+                            PointIdType::Uuid(uuid) => external_to_internal_uuid.remove(&uuid),
+                        };
+
+                        let Some(internal_id) = internal_id else {
+                            continue;
+                        };
+
+                        // Set internal to external mapping to max int
+                        if (internal_id as usize) < internal_to_external.len() {
+                            internal_to_external[internal_id as usize] = UNSET_POINT_ID;
+                        }
+
+                        // Mark internal point as deleted
+                        if internal_id as usize >= deleted.len() {
+                            deleted.resize(internal_id as usize + 1, false);
+                        }
+                        deleted.set(internal_id as usize, true);
+                    }
+                }
+            }
+        }
+
+        // Load point versions
+        let mut internal_to_version: Vec<SeqNumberType> =
+            Vec::with_capacity(internal_to_external.len());
+        let versions_path = Self::versions_path(&segment_path);
+        if versions_path.is_file() {
+            let versions_file = File::open(versions_path)?;
+            let versions_reader = std::io::BufReader::new(versions_file);
+
+            for entry in std::io::BufRead::lines(versions_reader) {
+                let entry = entry.expect("failed to parse version change entry");
+                let (external_id, version): VersionChange =
+                    serde_json::from_str(&entry).expect("failed to parse version change JSON");
+
+                let internal_id = match external_id {
+                    PointIdType::NumId(num) => external_to_internal_num.get(&num).copied(),
+                    PointIdType::Uuid(uuid) => external_to_internal_uuid.get(&uuid).copied(),
+                };
+
+                let Some(internal_id) = internal_id else {
+                    log::debug!(
+                        "Found version: {version} without internal id, external id: {external_id}"
+                    );
+                    continue;
+                };
+
+                if internal_id as usize >= internal_to_version.len() {
+                    internal_to_version.resize(internal_id as usize + 1, 0);
+                }
+                internal_to_version[internal_id as usize] = version;
+            }
+        }
+
+        #[cfg(debug_assertions)]
+        for (idx, id) in external_to_internal_num.iter() {
+            debug_assert!(
+                internal_to_external[*id as usize] == PointIdType::NumId(*idx),
+                "Internal id {id} is mapped to external id {}, but should be {}",
+                internal_to_external[*id as usize],
+                PointIdType::NumId(*idx)
+            );
+        }
+
+        let mappings = PointMappings::new(
+            deleted,
+            internal_to_external,
+            external_to_internal_num,
+            external_to_internal_uuid,
+        );
+
+        Ok(Self {
+            segment_path,
+            internal_to_version,
+            mappings,
+            pending_versions: Mutex::new(vec![]),
+            pending_mappings: Mutex::new(vec![]),
+        })
+    }
+
+    fn mappings_path(segment_path: &Path) -> PathBuf {
+        segment_path.join(FILE_MAPPINGS)
+    }
+
+    fn versions_path(segment_path: &Path) -> PathBuf {
+        segment_path.join(FILE_VERSIONS)
+    }
+
+    fn persist_mapping(&self, external_id: PointIdType, internal_id: PointOffsetType) {
+        self.pending_mappings
+            .lock()
+            .push(MappingChange::Insert(external_id, internal_id));
+    }
+
+    fn delete_mapping(&self, external_id: PointIdType) {
+        self.pending_mappings
+            .lock()
+            .push(MappingChange::Delete(external_id));
+    }
+
+    fn persist_version(&self, external_id: PointIdType, version: SeqNumberType) {
+        self.pending_versions.lock().push((external_id, version));
+    }
+}
+
+impl IdTracker for MutableIdTracker {
+    fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
+        self.internal_to_version.get(internal_id as usize).copied()
+    }
+
+    fn set_internal_version(
+        &mut self,
+        internal_id: PointOffsetType,
+        version: SeqNumberType,
+    ) -> OperationResult<()> {
+        if let Some(external_id) = self.external_id(internal_id) {
+            if internal_id as usize >= self.internal_to_version.len() {
+                #[cfg(debug_assertions)]
+                {
+                    if internal_id as usize > self.internal_to_version.len() + 1 {
+                        log::info!(
+                            "Resizing versions is initializing larger range {} -> {}",
+                            self.internal_to_version.len(),
+                            internal_id + 1,
+                        );
+                    }
+                }
+                self.internal_to_version.resize(internal_id as usize + 1, 0);
+            }
+            self.internal_to_version[internal_id as usize] = version;
+            self.persist_version(external_id, version);
+        }
+        Ok(())
+    }
+
+    fn internal_id(&self, external_id: PointIdType) -> Option<PointOffsetType> {
+        self.mappings.internal_id(&external_id)
+    }
+
+    fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
+        self.mappings.external_id(internal_id)
+    }
+
+    fn set_link(
+        &mut self,
+        external_id: PointIdType,
+        internal_id: PointOffsetType,
+    ) -> OperationResult<()> {
+        self.mappings.set_link(external_id, internal_id);
+        self.persist_mapping(external_id, internal_id);
+        Ok(())
+    }
+
+    fn drop(&mut self, external_id: PointIdType) -> OperationResult<()> {
+        self.mappings.drop(external_id);
+        self.delete_mapping(external_id);
+        Ok(())
+    }
+
+    fn iter_external(&self) -> Box<dyn Iterator<Item = PointIdType> + '_> {
+        self.mappings.iter_external()
+    }
+
+    fn iter_internal(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+        self.mappings.iter_internal()
+    }
+
+    fn iter_from(
+        &self,
+        external_id: Option<PointIdType>,
+    ) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_> {
+        self.mappings.iter_from(external_id)
+    }
+
+    fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_> {
+        self.mappings.iter_random()
+    }
+
+    fn total_point_count(&self) -> usize {
+        self.mappings.total_point_count()
+    }
+
+    fn available_point_count(&self) -> usize {
+        self.mappings.available_point_count()
+    }
+
+    fn deleted_point_count(&self) -> usize {
+        self.total_point_count() - self.available_point_count()
+    }
+
+    fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+        self.iter_internal()
+    }
+
+    /// Creates a flusher function, that persists the removed points in the mapping database
+    /// and flushes the mapping to disk.
+    /// This function should be called _before_ flushing the version database.
+    fn mapping_flusher(&self) -> Flusher {
+        let mappings_path = Self::mappings_path(&self.segment_path);
+        let pending_mappings = mem::take(&mut *self.pending_mappings.lock());
+        Box::new(move || {
+            if pending_mappings.is_empty() {
+                return Ok(());
+            }
+
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(mappings_path)?;
+            let mut writer = BufWriter::new(file);
+
+            for change in pending_mappings {
+                let entry = serde_json::to_string(&change)?;
+                debug_assert!(
+                    !entry.contains('\n'),
+                    "serialized mapping change entry cannot contain new line",
+                );
+                writer.write_all(entry.as_bytes())?;
+                writer.write_all(b"\n")?;
+            }
+
+            writer.flush()?;
+            drop(writer);
+
+            Ok(())
+        })
+    }
+
+    /// Creates a flusher function, that persists the removed points in the version database
+    /// and flushes the version database to disk.
+    /// This function should be called _after_ flushing the mapping database.
+    fn versions_flusher(&self) -> Flusher {
+        let versions_path = Self::versions_path(&self.segment_path);
+        let pending_versions = mem::take(&mut *self.pending_versions.lock());
+        Box::new(move || {
+            if pending_versions.is_empty() {
+                return Ok(());
+            }
+
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(versions_path)?;
+            let mut writer = BufWriter::new(file);
+
+            for change in pending_versions {
+                let entry = serde_json::to_string(&change)?;
+                debug_assert!(
+                    !entry.contains('\n'),
+                    "serialized version change entry cannot contain new line",
+                );
+                writer.write_all(entry.as_bytes())?;
+                writer.write_all(b"\n")?;
+            }
+
+            writer.flush()?;
+            drop(writer);
+
+            Ok(())
+        })
+    }
+
+    fn is_deleted_point(&self, key: PointOffsetType) -> bool {
+        self.mappings.is_deleted_point(key)
+    }
+
+    fn deleted_point_bitslice(&self) -> &BitSlice {
+        self.mappings.deleted()
+    }
+
+    fn cleanup_versions(&mut self) -> OperationResult<()> {
+        let mut to_remove = Vec::new();
+        for internal_id in self.iter_internal() {
+            if self.internal_version(internal_id).is_none() {
+                if let Some(external_id) = self.external_id(internal_id) {
+                    to_remove.push(external_id);
+                } else {
+                    debug_assert!(false, "internal id {internal_id} has no external id");
+                }
+            }
+        }
+        for external_id in to_remove {
+            self.drop(external_id)?;
+            #[cfg(debug_assertions)]
+            {
+                log::debug!("dropped version for point {external_id} without version");
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "mutable id tracker"
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![
+            Self::mappings_path(&self.segment_path),
+            Self::versions_path(&self.segment_path),
+        ]
+    }
+}

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -47,11 +47,9 @@ pub struct MutableIdTracker {
     mappings: PointMappings,
 
     /// List of point versions pending to be persisted, will be persisted on flush
-    // TODO: change to hash map to persist frequent updates to same point more efficiently
     pending_versions: Mutex<Vec<VersionChange>>,
 
     /// List of point mappings pending to be persisted, will be persisted on flush
-    // TODO: change to hash map to persist frequent updates to same point more efficiently
     pending_mappings: Mutex<Vec<MappingChange>>,
 }
 
@@ -383,11 +381,9 @@ fn load_mappings(
                     // Fixing corrupted mapping - this id should be recovered from WAL
                     // This should not happen in normal operation, but it can happen if
                     // the database is corrupted.
-                    // TODO: remove warning for this type of storage?
                     log::warn!(
                         "removing duplicated external id {external_id} in internal id {replaced_external_id}",
                     );
-                    // TODO: keep debug assert?
                     debug_assert!(false, "should never have to remove");
                     match replaced_external_id {
                         PointIdType::NumId(num) => {

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::mem;
 use std::path::{Path, PathBuf};
@@ -247,7 +247,7 @@ impl IdTracker for MutableIdTracker {
             }
 
             // Open file in append mode to write new changes to the end
-            let file = OpenOptions::new()
+            let file = File::options()
                 .create(true)
                 .append(true)
                 .open(&mappings_path)?;
@@ -284,7 +284,7 @@ impl IdTracker for MutableIdTracker {
             }
 
             // Open file in append mode to write new changes to the end
-            let file = OpenOptions::new()
+            let file = File::options()
                 .create(true)
                 .append(true)
                 .open(&versions_path)?;


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/6157>

Add initial implementation of mutable ID tracker. It's in-memory and persisted on disk. The key selling point is that it does not rely on RocksDB, but on simple files.

The idea is simple: the ID tracker holds a list of mappings and a list of point versions. All changes are simply appended to a file on disk. When loading from disk we scroll through the whole file and deduplicate in memory so that only the last mappings are kept.

Obviously, this structure can grow forever if we're not careful. That's why it relies on Qdrant's optimizers. Once the ID tracker collects too many changes, the optimizer will pick it up and create a new ID tracker. The new ID tracker will start from scratch, dropping all the garbage we had collected along the way.

The new ID tracker is ported from our [simple ID tracker](https://github.com/qdrant/qdrant/blob/672835813317b6e067bf61e449edd8f404a830d6/lib/segment/src/id_tracker/simple_id_tracker.rs). What changed in this type is the backing storage - now using simple files.

I'm implementing this one step at a time. Tests are in the [next](https://github.com/qdrant/qdrant/pull/6158) PR, and there's more to come. Please see the [tracking issue](https://github.com/qdrant/qdrant/issues/6157) for more information.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] ~Have you written new tests for your core changes, as applicable?~
* [x] Have you successfully ran tests with your changes locally?
