### PR TITLE
Move Bincode to workspace and comment version lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ private_intra_doc_links = "allow"
 [workspace.dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"
+bincode = "1.3.3" # no upgrade because 2.0.x is much slower https://github.com/qdrant/qdrant/pull/6134
 bytemuck = { version = "1.22.0", features = ["extern_crate_alloc", "must_cast", "transparentwrapper_extra"] }
 bytes = "1.10.1"
 chrono = { version = "0.4.40", features = ["serde"] }

--- a/lib/common/io/Cargo.toml
+++ b/lib/common/io/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 atomicwrites = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 nix = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -56,7 +56,7 @@ rocksdb = { version = "0.23.0", default-features = false, features = [
     "lz4",
 ] }
 uuid = { workspace = true }
-bincode = "1.3"
+bincode = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_cbor = { workspace = true }

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -17,7 +17,7 @@ testing = ["common/testing"]
 [dependencies]
 bitpacking = "0.9.2"
 gridstore = { path = "../gridstore" }
-bincode = "1.3"
+bincode = { workspace = true }
 common = { path = "../common/common" }
 half = { workspace = true }
 io = { path = "../common/io" }


### PR DESCRIPTION
The crate bincode 2.0 seems slower in the benchmark in https://github.com/qdrant/qdrant/pull/6134

This PR promotes the version at the workspace level and add a comment explaining why we do not upgrade.