### PR TITLE
Fix incorrect assertions in immutable ID tracker test

### DIFF
--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -959,11 +959,11 @@ pub(super) mod test {
         for (external_id, internal_id) in immutable_id_tracker.iter_from(None) {
             assert_eq!(
                 simple_id_tracker.internal_version(internal_id).unwrap(),
-                simple_id_tracker.internal_version(internal_id).unwrap()
+                immutable_id_tracker.internal_version(internal_id).unwrap()
             );
             assert_eq!(
                 simple_id_tracker.external_id(internal_id),
-                simple_id_tracker.external_id(internal_id)
+                immutable_id_tracker.external_id(internal_id)
             );
             assert_eq!(
                 external_id,


### PR DESCRIPTION
The immutable ID tracker congruence test had two assertions comparing the same value.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?