### PR TITLE
Write rate limit cost always lazy

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -802,7 +802,7 @@ impl ShardReplicaSet {
         cost_fn: F,
     ) -> CollectionResult<()>
     where
-        F: Fn() -> usize,
+        F: FnOnce() -> usize,
     {
         // Do not rate limit internal operation tagged with disposable measurement
         if hw_measurement_acc.is_disposable() {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -792,33 +792,11 @@ impl ShardReplicaSet {
     }
 
     /// Check if the write rate limiter allows the operation to proceed
-    /// - cost: the cost of the operation
-    ///
-    /// Returns an error if the rate limit is exceeded.
-    fn check_write_rate_limiter(
-        &self,
-        cost: usize,
-        hw_measurement_acc: &HwMeasurementAcc,
-    ) -> CollectionResult<()> {
-        // Do not rate limit internal operation tagged with disposable measurement
-        if hw_measurement_acc.is_disposable() {
-            return Ok(());
-        }
-        if let Some(rate_limiter) = &self.write_rate_limiter {
-            rate_limiter
-                .lock()
-                .try_consume(cost as f64)
-                .map_err(|err| CollectionError::rate_limit_error(err, cost, true))?;
-        }
-        Ok(())
-    }
-
-    /// Check if the write rate limiter allows the operation to proceed
     /// - hw_measurement_acc: the current hardware measurement accumulator
-    /// - cost_fn: the cost function of the operation, evaluated lazily
+    /// - cost_fn: the cost of the operation called lazily
     ///
     /// Returns an error if the rate limit is exceeded.
-    fn check_write_rate_limiter_lazy<F>(
+    fn check_write_rate_limiter<F>(
         &self,
         hw_measurement_acc: &HwMeasurementAcc,
         cost_fn: F,
@@ -826,9 +804,17 @@ impl ShardReplicaSet {
     where
         F: Fn() -> usize,
     {
-        if self.write_rate_limiter.is_some() && !hw_measurement_acc.is_disposable() {
-            self.check_write_rate_limiter(cost_fn(), hw_measurement_acc)?;
-        };
+        // Do not rate limit internal operation tagged with disposable measurement
+        if hw_measurement_acc.is_disposable() {
+            return Ok(());
+        }
+        if let Some(rate_limiter) = &self.write_rate_limiter {
+            let cost = cost_fn();
+            rate_limiter
+                .lock()
+                .try_consume(cost as f64)
+                .map_err(|err| CollectionError::rate_limit_error(err, cost, true))?;
+        }
         Ok(())
     }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -541,7 +541,7 @@ impl ShardReplicaSet {
         local: &Shard,
         operation: &OperationWithClockTag,
     ) -> CollectionResult<()> {
-        self.check_write_rate_limiter_lazy(hw_measurement, || {
+        self.check_write_rate_limiter(hw_measurement, || {
             let mut ratelimiter_cost = 1;
 
             // Estimate the cost based on affected points if filter is available.


### PR DESCRIPTION
There are two reasons for unifying the implementation:
- the function with eager cost evaluation is never used directly
- the lazy function duplicates the guarding logic  