### PR TITLE
Add BitSliceExt::get_bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
+ "bitvec",
  "bytemuck",
  "common",
  "criterion",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 testing = []
 
 [dependencies]
+bitvec = { workspace = true }
 bytemuck = { workspace = true }
 num-traits = { workspace = true }
 num_cpus = "1.16"

--- a/lib/common/common/src/ext.rs
+++ b/lib/common/common/src/ext.rs
@@ -1,3 +1,7 @@
+use bitvec::order::BitOrder;
+use bitvec::slice::BitSlice;
+use bitvec::store::BitStore;
+
 pub trait OptionExt {
     /// `replace` if the given `value` is `Some`
     fn replace_if_some(&mut self, value: Self);
@@ -9,5 +13,18 @@ impl<T> OptionExt for Option<T> {
         if let Some(value) = value {
             self.replace(value);
         }
+    }
+}
+
+pub trait BitSliceExt {
+    /// Get a single bit from the slice.
+    /// A convenience wrapper around [`BitSlice::get`].
+    fn get_bit(&self, index: usize) -> Option<bool>;
+}
+
+impl<T: BitStore, O: BitOrder> BitSliceExt for BitSlice<T, O> {
+    #[inline]
+    fn get_bit(&self, index: usize) -> Option<bool> {
+        self.get(index).as_deref().copied()
     }
 }

--- a/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::mem;
 use std::sync::Arc;
 
+use common::ext::BitSliceExt as _;
 use memory::mmap_type::MmapBitSlice;
 use parking_lot::{Mutex, RwLock};
 
@@ -43,7 +44,7 @@ impl MmapBitSliceBufferedUpdateWrapper {
         if let Some(value) = self.pending_updates.lock().get(&index) {
             Some(*value)
         } else {
-            self.bitslice.read().get(index).as_deref().copied()
+            self.bitslice.read().get_bit(index)
         }
     }
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use bitvec::prelude::BitSlice;
 use bitvec::vec::BitVec;
 use byteorder::{ReadBytesExt, WriteBytesExt};
+use common::ext::BitSliceExt as _;
 use common::types::PointOffsetType;
 use memory::madvise::AdviceSetting;
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
@@ -114,8 +115,7 @@ impl ImmutableIdTracker {
 
             internal_to_external.set(internal_id, external_id);
 
-            let point_deleted = deleted.get(i).as_deref().copied().unwrap_or(false);
-
+            let point_deleted = deleted.get_bit(i).unwrap_or(false);
             if point_deleted {
                 continue;
             }

--- a/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
@@ -22,6 +22,7 @@ use crate::types::{FieldCondition, Match, MatchValue, PayloadKeyType, ValueVaria
 
 mod memory {
     use bitvec::vec::BitVec;
+    use common::ext::BitSliceExt as _;
     use common::types::PointOffsetType;
 
     pub struct BooleanItem {
@@ -92,8 +93,8 @@ mod memory {
         pub fn get(&self, id: PointOffsetType) -> BooleanItem {
             debug_assert!(self.trues.len() == self.falses.len());
 
-            let has_true = self.trues.get(id as usize).map(|v| *v).unwrap_or(false);
-            let has_false = self.falses.get(id as usize).map(|v| *v).unwrap_or(false);
+            let has_true = self.trues.get_bit(id as usize).unwrap_or(false);
+            let has_false = self.falses.get_bit(id as usize).unwrap_or(false);
 
             BooleanItem::from_bools(has_true, has_false)
         }

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use bitvec::vec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -115,13 +116,7 @@ impl<T: Encodable + Numericable> Iterator for NumericKeySortedVecIterator<'_, T>
     fn next(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.set.data[self.start_index].clone();
-            let deleted = self
-                .set
-                .deleted
-                .get(self.start_index)
-                .as_deref()
-                .copied()
-                .unwrap_or(true);
+            let deleted = self.set.deleted.get_bit(self.start_index).unwrap_or(true);
             self.start_index += 1;
             if deleted {
                 continue;
@@ -136,13 +131,7 @@ impl<T: Encodable + Numericable> DoubleEndedIterator for NumericKeySortedVecIter
     fn next_back(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.set.data[self.end_index - 1].clone();
-            let deleted = self
-                .set
-                .deleted
-                .get(self.end_index - 1)
-                .as_deref()
-                .copied()
-                .unwrap_or(true);
+            let deleted = self.set.deleted.get_bit(self.end_index - 1).unwrap_or(true);
             self.end_index -= 1;
             if deleted {
                 continue;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -11,6 +11,7 @@ use bitvec::vec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 #[cfg(target_os = "linux")]
 use common::cpu::linux_low_thread_priority;
+use common::ext::BitSliceExt as _;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use log::debug;
 use memory::mmap_ops;
@@ -545,12 +546,7 @@ impl HNSWIndex {
                 &cardinality_estimation,
                 &disposed_hw_counter,
             )
-            .filter(|&point_id| {
-                !deleted_bitslice
-                    .get(point_id as usize)
-                    .map(|x| *x)
-                    .unwrap_or(false)
-            })
+            .filter(|&point_id| !deleted_bitslice.get_bit(point_id as usize).unwrap_or(false))
             .collect();
 
         for block_point_id in points_to_index.iter().copied() {

--- a/lib/segment/src/segment/formula_rescore.rs
+++ b/lib/segment/src/segment/formula_rescore.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use ahash::{AHashMap, AHashSet};
 use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
 use common::iterator_ext::IteratorExt;
 use common::types::ScoredPointOffset;
 use itertools::Itertools;
@@ -38,11 +39,9 @@ impl Segment {
                         let internal_id = self.get_internal_id(point.id)?;
 
                         // Discard points that are marked as deleted in a wrapped segment
-                        if let Some(true) = wrapped_deleted.and_then(|slice| {
-                            slice
-                                .get(internal_id as usize)
-                                .map(|is_deleted| *is_deleted)
-                        }) {
+                        if let Some(true) =
+                            wrapped_deleted.and_then(|slice| slice.get_bit(internal_id as usize))
+                        {
                             return None;
                         }
 

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use bitvec::prelude::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 
@@ -123,19 +124,11 @@ where
     fn check_vector(&self, point: PointOffsetType) -> bool {
         point < self.points_count
             // Deleted points propagate to vectors; check vector deletion for possible early return
-            && !self
-                .vec_deleted
-                .get(point as usize)
-                .map(|x| *x)
-                // Default to not deleted if our deleted flags failed grow
-                .unwrap_or(false)
+            // Default to not deleted if our deleted flags failed grow
+            && !self.vec_deleted.get_bit(point as usize).unwrap_or(false)
             // Additionally check point deletion for integrity if delete propagation to vector failed
-            && !self
-                .point_deleted
-                .get(point as usize)
-                .map(|x| *x)
-                // Default to deleted if the point mapping was removed from the ID tracker
-                .unwrap_or(true)
+            // Default to deleted if the point mapping was removed from the ID tracker
+            && !self.point_deleted.get_bit(point as usize).unwrap_or(true)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use bitvec::prelude::BitSlice;
+use common::ext::BitSliceExt as _;
 use common::types::PointOffsetType;
 use memmap2::Mmap;
 use memory::madvise::{Advice, AdviceSetting};
@@ -181,7 +182,7 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
     }
 
     pub fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+        self.deleted.get_bit(key as usize).unwrap_or(false)
     }
 
     /// Get [`BitSlice`] representation for deleted vectors with deletion flags

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 
 use bitvec::prelude::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
 use common::types::PointOffsetType;
 use log::debug;
 use parking_lot::RwLock;
@@ -283,7 +284,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+        self.deleted.get_bit(key as usize).unwrap_or(false)
     }
 
     fn deleted_vector_count(&self) -> usize {

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 
 use bitvec::prelude::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -422,7 +423,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+        self.deleted.get_bit(key as usize).unwrap_or(false)
     }
 
     fn deleted_vector_count(&self) -> usize {

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use bitvec::prelude::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 use sparse::common::sparse_vector::SparseVector;
@@ -1062,15 +1063,9 @@ pub fn check_deleted_condition(
     point_deleted: &BitSlice,
 ) -> bool {
     // Deleted points propagate to vectors; check vector deletion for possible early return
-    !vec_deleted
-            .get(point as usize)
-            .map(|x| *x)
-            // Default to not deleted if our deleted flags failed grow
-            .unwrap_or(false)
+    // Default to not deleted if our deleted flags failed grow
+    !vec_deleted.get_bit(point as usize).unwrap_or(false)
         // Additionally check point deletion for integrity if delete propagation to vector failed
-        && !point_deleted
-            .get(point as usize)
-            .map(|x| *x)
-            // Default to deleted if the point mapping was removed from the ID tracker
-            .unwrap_or(true)
+        // Default to deleted if the point mapping was removed from the ID tracker
+        && !point_deleted.get_bit(point as usize).unwrap_or(true)
 }

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use bitvec::prelude::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -256,7 +257,7 @@ impl VectorStorage for SimpleSparseVectorStorage {
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+        self.deleted.get_bit(key as usize).unwrap_or(false)
     }
 
     fn deleted_vector_count(&self) -> usize {


### PR DESCRIPTION
The `BitSlice::get()` method returns [`BitRef`] which requires additional gymnastics to convert it to `bool` to the point that `rustfmt` splits such long method call chains into multiple lines.

This PR adds `BitSliceExt::get_bit()`, making code working with it less bulky.

[`BitRef`]: https://docs.rs/bitvec/1.0.1/bitvec/ptr/struct.BitRef.html

The following queries were used to find usages to replace:
```shell
ast-grep -p '$_.get($_).as_deref().copied()'
ast-grep -p '$_.get($_).map(|$_| *$_)'
```