### PR TITLE
Bump ordered-float 5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ dependencies = [
  "log",
  "merge",
  "object_store",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "parking_lot",
  "pprof",
  "proptest",
@@ -1242,7 +1242,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "ph",
  "rand 0.9.0",
  "rstest",
@@ -4169,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]
@@ -5834,7 +5834,7 @@ dependencies = [
  "num-cmp",
  "num-derive",
  "num-traits",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "parking_lot",
  "pprof",
  "procfs",
@@ -6223,7 +6223,7 @@ dependencies = [
  "log",
  "memmap2",
  "memory",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "parking_lot",
  "pprof",
  "rand 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ log = "0.4.26"
 memmap2 = "0.9.5"
 nix = { version = "0.29", features = ["fs"] }
 num-traits = "0.2.19"
-ordered-float = "4.6"
+ordered-float = "5.0.0"
 rayon = "1.10.0"
 parking_lot = { version = "0.12.3", features = ["deadlock_detection", "serde"] }
 ph = "0.8.5"


### PR DESCRIPTION
The update contains an alleged performance improvements which I want to bench.

https://github.com/reem/rust-ordered-float/releases/tag/v5.0.0

There is a slight improvement in indexing time.

## Comparison results
| Name                  | ghcr/dev       | ghcr/ordered-float-5       | Result     |
| --------------------- | ------------ | ------------ | ------------ |
| collection_load_time  | NULL | NULL | equal |
| rps                   | 235.57610090310894 | 233.89456816516474 | ghcr/dev > ghcr/ordered-float-5 by 1.68153273794420 (.71379597993932520800% greater) |
| mean_precisions       | 0.9648040000000001 | 0.9646520000000001 | ghcr/dev > ghcr/ordered-float-5 by .0001520000000000 (.01575449521353559700% greater) |
| p95_time              | 0.03742185626178975 | 0.03694567233324047 | ghcr/dev > ghcr/ordered-float-5 by .00047618392854928 (1.27247543579364352600% greater) |
| p99_time              | 0.04666998609900475 | 0.04665510527789593 | ghcr/dev > ghcr/ordered-float-5 by .00001488082110882 (.03188520578783145900% greater) |
| vm_rss_memory_usage   | 1546120 | 1546864 | ghcr/dev < ghcr/ordered-float-5 by 744 (.04809731172229749900% less) |
| rss_anon_memory_usage  | 464704 | 465064 | ghcr/dev < ghcr/ordered-float-5 by 360 (.07740870073796294700% less) |
| upload_time           | 55.677451491355896 | 55.355031065642834 | ghcr/dev > ghcr/ordered-float-5 by .322420425713062 (.57908617775567333800% greater) |
| indexing_time         | 692.0231321081519 | 686.7501722238958 | ghcr/dev > ghcr/ordered-float-5 by 5.2729598842561 (.76196295175751763600% greater) |
