### PR TITLE
Log hardware reporting enabled at startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -465,6 +465,10 @@ fn main() -> anyhow::Result<()> {
         log::info!("Telemetry reporting disabled");
     }
 
+    if settings.service.hardware_reporting == Some(true) {
+        log::info!("Hardware reporting enabled");
+    }
+
     // Setup subscribers to listen for issue-able events
     issues_setup::setup_subscribers(&settings);
 


### PR DESCRIPTION
Follows our convention to log optional services being enabled at startup to help debugging.