### PR TITLE
Mutable ID tracker: implement storage for point versions

### DIFF
--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -594,15 +594,6 @@ fn store_version_changes(
         .write(true)
         .truncate(false)
         .open(versions_path)?;
-
-    // Grow file if needed
-    let highest_index = *changes.keys().max().unwrap();
-    let current_size = file.metadata()?.len();
-    let required_size = (u64::from(highest_index) + 1) * VERSION_ELEMENT_SIZE;
-    if required_size > current_size {
-        file.set_len(required_size)?;
-    }
-
     let mut writer = BufWriter::new(file);
 
     write_version_changes(&mut writer, changes).map_err(|err| {

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -320,7 +320,7 @@ fn versions_path(segment_path: &Path) -> PathBuf {
 
 /// Store new mapping changes, appending them to the given file
 fn store_mapping_changes(mappings_path: &Path, changes: Vec<MappingChange>) -> OperationResult<()> {
-    // Open file in append mode to write new changes to the end
+    // Create or open file in append mode to write new changes to the end
     let file = File::options()
         .create(true)
         .append(true)
@@ -367,9 +367,9 @@ fn write_mapping_changes<W: Write>(
 
 /// Load point mappings from the given file
 fn load_mappings(mappings_path: &Path) -> OperationResult<PointMappings> {
-    let mappings_file = File::open(mappings_path)?;
-    let mappings_reader = BufReader::new(mappings_file);
-    read_mappings(mappings_reader)
+    let file = File::open(mappings_path)?;
+    let reader = BufReader::new(file);
+    read_mappings(reader)
 }
 
 /// Iterate over mapping changes from the given reader


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/6157>
Depends on: <https://github.com/qdrant/qdrant/pull/6166>

Implement the new storage for point versions.

This changes the mapping of versions from external ID to version to internal ID to version.

Points are kept in memory for fast access. On load we read the full list of versions. On flush we store we write all changed versions directly to the versions file.

Writing changes is optimized to properly buffer all writes. This has a great effect if writing a big batch of versions, to use a lot less intermediate syscalls.

In terms of the file format, the file on disk is just a contiguous list of version numbers similar to an array.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/6166>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?