### PR TITLE
[score boosting] fix proxy segment leakage

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -533,7 +533,7 @@ impl SegmentsSearcher {
                             segment
                                 .get()
                                 .read()
-                                .rescore_with_formula(arc_ctx, None, &hw_counter)
+                                .rescore_with_formula(arc_ctx, &hw_counter)
                         }
                     })
                 })

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
@@ -54,7 +53,6 @@ pub trait SegmentEntry: PartialSnapshotEntry {
     fn rescore_with_formula(
         &self,
         formula_ctx: Arc<FormulaContext>,
-        wrapped_deleted: Option<&BitSlice>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<ScoredPoint>>;
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::{fs, thread};
 
-use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
@@ -84,7 +83,6 @@ impl SegmentEntry for Segment {
     fn rescore_with_formula(
         &self,
         ctx: Arc<FormulaContext>,
-        wrapped_deleted: Option<&BitSlice>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<ScoredPoint>> {
         let FormulaContext {
@@ -99,7 +97,6 @@ impl SegmentEntry for Segment {
         let internal_results = self.do_rescore_with_formula(
             formula,
             prefetches_results,
-            wrapped_deleted,
             *limit,
             is_stopped,
             hw_counter,

--- a/lib/segment/src/segment/formula_rescore.rs
+++ b/lib/segment/src/segment/formula_rescore.rs
@@ -1,9 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use ahash::{AHashMap, AHashSet};
-use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::ext::BitSliceExt as _;
 use common::iterator_ext::IteratorExt;
 use common::types::ScoredPointOffset;
 use itertools::Itertools;
@@ -19,7 +17,6 @@ impl Segment {
         &self,
         formula: &ParsedFormula,
         prefetches_scores: &[Vec<ScoredPoint>],
-        wrapped_deleted: Option<&BitSlice>,
         limit: usize,
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
@@ -37,13 +34,6 @@ impl Segment {
                     .filter_map(|point| {
                         // Discard points without internal ids
                         let internal_id = self.get_internal_id(point.id)?;
-
-                        // Discard points that are marked as deleted in a wrapped segment
-                        if let Some(true) =
-                            wrapped_deleted.and_then(|slice| slice.get_bit(internal_id as usize))
-                        {
-                            return None;
-                        }
 
                         // filter_map side effect: keep all uniquely seen point offsets.
                         points_to_rescore.insert(internal_id);


### PR DESCRIPTION
The signature for `rescore_with_formula` included a deleted bitslice only because the proxy segment would introduce it to handle the write and wrapped results. 

In this PR, we remove the abstraction leak, and handle the logic to prefer write results only within the proxy segment.