### PR TITLE
Mutable ID tracker: truncate mappings file if last entry is partial

### DIFF
--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -534,7 +534,7 @@ where
 /// This function reads exact one entry which means after calling this function, the reader
 /// will be at the start of the next entry.
 ///
-/// The number of bytes read is returned on succesful read.
+/// The number of bytes read is returned on successful read.
 fn read_entry<R: Read>(reader: &mut R) -> io::Result<(MappingChange, u64)> {
     let change_type = reader.read_u8()?;
     let change_type = MappingChangeType::from_byte(change_type).ok_or_else(|| {

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -21,7 +21,7 @@ use crate::types::{PointIdType, SeqNumberType};
 const FILE_MAPPINGS: &str = "id_tracker.mappings";
 const FILE_VERSIONS: &str = "id_tracker.versions";
 
-const VERSION_ELEMENT_SIZE: u64 = mem::size_of::<SeqNumberType>() as u64;
+const VERSION_ELEMENT_SIZE: u64 = size_of::<SeqNumberType>() as u64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MappingChange {
@@ -405,7 +405,7 @@ fn load_mappings(mappings_path: &Path) -> OperationResult<PointMappings> {
     if read_to < file_len {
         log::warn!(
             "Mutable ID tracker mappings file ends with incomplete entry, removing last {} bytes and assuming WAL recovery",
-            (file_len - read_to).saturating_sub(1),
+            (file_len - read_to),
         );
         let file = File::options()
             .write(true)
@@ -457,7 +457,7 @@ where
 
 /// Read point mappings from the given reader
 ///
-/// Returns loaded point mappings and number of bytes read.
+/// Returns loaded point mappings.
 fn read_mappings<R>(reader: R) -> OperationResult<PointMappings>
 where
     R: Read + Seek,

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -50,7 +50,7 @@ enum MappingChangeType {
 }
 
 impl MappingChangeType {
-    fn from_byte(byte: u8) -> Option<Self> {
+    const fn from_byte(byte: u8) -> Option<Self> {
         match byte {
             x if x == Self::InsertNum as u8 => Some(Self::InsertNum),
             x if x == Self::InsertUuid as u8 => Some(Self::InsertUuid),
@@ -71,7 +71,7 @@ impl MappingChangeType {
     /// +-----------------------+-----------------------+
     /// | MappingChangeType: u8 | Number/UUID: u64/u128 |
     /// +-----------------------+-----------------------+
-    fn operation_size(&self) -> usize {
+    const fn operation_size(self) -> usize {
         match self {
             Self::InsertNum => size_of::<u8>() + size_of::<u64>() + size_of::<u32>(),
             Self::InsertUuid => size_of::<u8>() + size_of::<u128>() + size_of::<u32>(),


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/6157>
Depends on: <https://github.com/qdrant/qdrant/pull/6169>

If the last entry in the mappings file is partial, truncate the file.

It can happen if we crash during flush. We must truncate the file so that newly appended mappings don't get corrupted.

I don't particularly like the implementation, but the tools here are a bit limited. An alternative approach would require to load the full file in memory, or it would require to read over the file twice, which is why I implemented the current approach instead.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/6169>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
