### PR TITLE
Mutable ID tracker integration

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -2,6 +2,7 @@ log_level: DEBUG
 
 feature_flags:
   use_new_shard_key_mapping_format: false
+  use_mutable_id_tracker_without_rocksdb: true
 
 inference:
   address: "http://localhost:2114/api/v1/infer"

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -11,9 +11,18 @@ pub struct FeatureFlags {
     ///
     /// The old format fails to persist shard key numbers correctly, converting them into strings on
     /// load. While this is false, the new format is only used if any shard key is a number.
+    ///
+    /// First implemented in Qdrant 1.13.1
     // TODO(1.14): set to true, remove other branches in code, and remove this flag
     #[serde(default)]
     pub use_new_shard_key_mapping_format: bool,
+
+    /// Whether to use the new mutable ID tracker without RocksDB.
+    ///
+    /// First implemented in Qdrant 1.13.5
+    // TODO(1.14): set to true, remove other branches in code, and remove this flag
+    #[serde(default)]
+    pub use_mutable_id_tracker_without_rocksdb: bool,
 }
 
 /// Initializes the global feature flags with `flags`. Must only be called once at

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -8,6 +8,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
 use super::in_memory_id_tracker::InMemoryIdTracker;
+use super::mutable_id_tracker::MutableIdTracker;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
@@ -171,9 +172,12 @@ pub type IdTrackerSS = dyn IdTracker + Sync + Send;
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum IdTrackerEnum {
-    MutableIdTracker(SimpleIdTracker),
+    MutableIdTracker(MutableIdTracker),
     ImmutableIdTracker(ImmutableIdTracker),
     InMemoryIdTracker(InMemoryIdTracker),
+
+    // Deprecated since Qdrant 1.14
+    RocksDbIdTracker(SimpleIdTracker),
 }
 
 impl IdTracker for IdTrackerEnum {
@@ -186,6 +190,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.internal_version(internal_id)
             }
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.internal_version(internal_id),
         }
     }
 
@@ -204,6 +209,9 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.set_internal_version(internal_id, version)
             }
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
+                id_tracker.set_internal_version(internal_id, version)
+            }
         }
     }
 
@@ -212,6 +220,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.internal_id(external_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.internal_id(external_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.internal_id(external_id),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.internal_id(external_id),
         }
     }
 
@@ -220,6 +229,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.external_id(internal_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.external_id(internal_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.external_id(internal_id),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.external_id(internal_id),
         }
     }
 
@@ -238,6 +248,9 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.set_link(external_id, internal_id)
             }
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
+                id_tracker.set_link(external_id, internal_id)
+            }
         }
     }
 
@@ -246,6 +259,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.drop(external_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.drop(external_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.drop(external_id),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.drop(external_id),
         }
     }
 
@@ -254,6 +268,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_external(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_external(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_external(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_external(),
         }
     }
 
@@ -262,6 +277,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_internal(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_internal(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_internal(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_internal(),
         }
     }
 
@@ -273,6 +289,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_from(external_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_from(external_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_from(external_id),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_from(external_id),
         }
     }
 
@@ -281,6 +298,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_ids(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_ids(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_ids(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_ids(),
         }
     }
 
@@ -289,6 +307,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_random(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_random(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_random(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_random(),
         }
     }
 
@@ -297,6 +316,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.mapping_flusher(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.mapping_flusher(),
         }
     }
 
@@ -305,6 +325,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.versions_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.versions_flusher(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.versions_flusher(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.versions_flusher(),
         }
     }
 
@@ -313,6 +334,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.total_point_count(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.total_point_count(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.total_point_count(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.total_point_count(),
         }
     }
 
@@ -321,6 +343,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deleted_point_count(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deleted_point_count(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deleted_point_count(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.deleted_point_count(),
         }
     }
 
@@ -329,6 +352,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
         }
     }
 
@@ -341,6 +365,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.is_deleted_point(internal_id)
             }
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.is_deleted_point(internal_id),
         }
     }
 
@@ -349,6 +374,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.name(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.name(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.name(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.name(),
         }
     }
 
@@ -357,6 +383,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.cleanup_versions(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.cleanup_versions(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.cleanup_versions(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.cleanup_versions(),
         }
     }
 
@@ -365,6 +392,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.files(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.files(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.files(),
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.files(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -333,7 +333,7 @@ impl IdTracker for MutableIdTracker {
     }
 }
 
-fn mappings_path(segment_path: &Path) -> PathBuf {
+pub(crate) fn mappings_path(segment_path: &Path) -> PathBuf {
     segment_path.join(FILE_MAPPINGS)
 }
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -18,7 +18,7 @@ use crate::id_tracker::IdTracker;
 use crate::id_tracker::point_mappings::PointMappings;
 use crate::types::{PointIdType, SeqNumberType};
 
-const FILE_MAPPINGS: &str = "id_tracker.mappings";
+const FILE_MAPPINGS: &str = "id_tracker.mapping_changes";
 const FILE_VERSIONS: &str = "id_tracker.versions";
 
 const VERSION_ELEMENT_SIZE: u64 = size_of::<SeqNumberType>() as u64;

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -18,8 +18,8 @@ use crate::id_tracker::IdTracker;
 use crate::id_tracker::point_mappings::PointMappings;
 use crate::types::{PointIdType, SeqNumberType};
 
-const FILE_MAPPINGS: &str = "id_tracker.mapping_changes";
-const FILE_VERSIONS: &str = "id_tracker.versions";
+const FILE_MAPPINGS: &str = "mutable_id_tracker.mappings";
+const FILE_VERSIONS: &str = "mutable_id_tracker.versions";
 
 const VERSION_ELEMENT_SIZE: u64 = size_of::<SeqNumberType>() as u64;
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -323,10 +323,13 @@ impl IdTracker for MutableIdTracker {
     }
 
     fn files(&self) -> Vec<PathBuf> {
-        vec![
+        [
             mappings_path(&self.segment_path),
             versions_path(&self.segment_path),
         ]
+        .into_iter()
+        .filter(|path| path.is_file())
+        .collect()
     }
 }
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -85,7 +85,7 @@ impl SegmentBuilder {
         let database = open_segment_db(temp_dir.path(), segment_config)?;
 
         let id_tracker = if segment_config.is_appendable() {
-            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(database.clone())?)
+            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(temp_dir.path())?)
         } else {
             IdTrackerEnum::InMemoryIdTracker(InMemoryIdTracker::new())
         };
@@ -476,6 +476,7 @@ impl SegmentBuilder {
                 IdTrackerEnum::ImmutableIdTracker(_) => {
                     unreachable!("ImmutableIdTracker should not be used for building segment")
                 }
+                IdTrackerEnum::RocksDbIdTracker(_) => id_tracker,
             };
 
             id_tracker.mapping_flusher()()?;

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -11,13 +11,15 @@ use io::storage_version::StorageVersion;
 use log::info;
 use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
+use rocksdb::properties::ESTIMATE_NUM_KEYS;
 use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
-use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
+use crate::common::rocksdb_wrapper::{DB_MAPPING_CF, DB_VECTOR_CF, open_db};
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
+use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
 use crate::index::VectorIndexEnum;
@@ -348,7 +350,11 @@ pub(crate) fn create_payload_storage(
     Ok(payload_storage)
 }
 
-pub(crate) fn create_mutable_id_tracker(
+pub(crate) fn create_mutable_id_tracker(segment_path: &Path) -> OperationResult<MutableIdTracker> {
+    MutableIdTracker::open(segment_path)
+}
+
+pub(crate) fn create_rocksdb_id_tracker(
     database: Arc<RwLock<DB>>,
 ) -> OperationResult<SimpleIdTracker> {
     SimpleIdTracker::open(database)
@@ -536,9 +542,33 @@ fn create_segment(
         appendable_flag || !ImmutableIdTracker::mappings_file_path(segment_path).is_file();
 
     let id_tracker = if mutable_id_tracker {
-        sp(IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
-            database.clone(),
-        )?))
+        // Check if any point mappings are stored in RocksDB
+        let has_rocksdb_mappings = {
+            let db = database.read();
+            match db.cf_handle(DB_MAPPING_CF) {
+                Some(cf_handle) => {
+                    let count = db
+                        .property_int_value_cf(cf_handle, ESTIMATE_NUM_KEYS)
+                        .map_err(|err| {
+                            OperationError::service_error(format!(
+                                "Failed to get estimated number of keys from RocksDb: {err}"
+                            ))
+                        })?
+                        .unwrap_or_default();
+                    count > 0
+                }
+                None => false,
+            }
+        };
+        if !has_rocksdb_mappings {
+            sp(IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
+                segment_path,
+            )?))
+        } else {
+            sp(IdTrackerEnum::RocksDbIdTracker(create_rocksdb_id_tracker(
+                database.clone(),
+            )?))
+        }
     } else {
         sp(IdTrackerEnum::ImmutableIdTracker(
             create_immutable_id_tracker(segment_path)?,


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/6157>
Depends on: <https://github.com/qdrant/qdrant/pull/6173>

Add support for the new mutable ID tracker.

It is currently locked behind a feature flag, only enabled in development builds. In the next Qdrant release the new tracker will enabled globally.

- Feature flag disabled _(default in production build)_
  RocksDB based tracker is used by default, unless new mappings are stored on disk
- Feature flag enabled _(default in development build)_
  New tracker is used by default, unless there are RocksDB mappings on disk

Set `QDRANT__FEATURE_FLAGS__USE_MUTABLE_ID_TRACKER_WITHOUT_ROCKSDB=true` to prematurely enable the new ID tracker.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/6173>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?