### PR TITLE
[score boosting] Error on unexpected type

### DIFF
--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -14,7 +14,7 @@ use crate::utils::mem::Mem;
 
 pub const PROCESS_CANCELLED_BY_SERVICE_MESSAGE: &str = "process cancelled by service";
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq)]
 #[error("{0}")]
 pub enum OperationError {
     #[error("Vector dimension error: expected dim: {expected_dim}, got {received_dim}")]
@@ -62,10 +62,13 @@ pub enum OperationError {
         "No appropriate index for faceting: `{key}`. Please create one to facet on this field. Check https://qdrant.tech/documentation/concepts/indexing/#payload-index to see which payload schemas support Match conditions"
     )]
     MissingMapIndexForFacet { key: String },
-    #[error("The variable nor the default value for {field_name} is a {expected_type}")]
+    #[error(
+        "Expected {expected_type} value for {field_name} in the payload and/or in the formula defaults. Error: {description}"
+    )]
     VariableTypeError {
         field_name: PayloadKeyType,
         expected_type: String,
+        description: String,
     },
     #[error("The expression {expression} produced a non-finite number")]
     NonFiniteNumber { expression: String },

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -32,6 +32,22 @@ pub struct FormulaScorer<'a> {
     defaults: HashMap<VariableId, Value>,
 }
 
+pub trait FriendlyName {
+    fn friendly_name() -> &'static str;
+}
+
+impl FriendlyName for ScoreType {
+    fn friendly_name() -> &'static str {
+        "number"
+    }
+}
+
+impl FriendlyName for GeoPoint {
+    fn friendly_name() -> &'static str {
+        "geo point"
+    }
+}
+
 impl StructPayloadIndex {
     pub fn formula_scorer<'s, 'q>(
         &'s self,
@@ -97,16 +113,14 @@ impl FormulaScorer<'_> {
                             .map(|score| score as ScoreType)
                     })
                     .unwrap_or(DEFAULT_SCORE)),
-                VariableId::Payload(path) => Ok(self
-                    .get_payload_value(path, point_id)
-                    .and_then(|value| value.as_f64())
-                    .or_else(|| {
-                        self.defaults
-                            .get(&VariableId::Payload(path.clone()))
-                            .and_then(|value| value.as_f64())
+                VariableId::Payload(path) => {
+                    self.get_parsed_payload_value(path, point_id, |value| {
+                        value
+                            .as_f64()
+                            .map(|value| value as ScoreType)
+                            .ok_or_else(|| "Value is not a number")
                     })
-                    .map(|v| v as ScoreType)
-                    .unwrap_or(DEFAULT_SCORE)),
+                }
                 VariableId::Condition(id) => {
                     let value = check_condition(&self.condition_checkers[*id], point_id);
                     let score = if value { 1.0 } else { 0.0 };
@@ -114,21 +128,14 @@ impl FormulaScorer<'_> {
                 }
             },
             ParsedExpression::GeoDistance { origin, key } => {
-                let value: GeoPoint = self
-                    .get_payload_value(key, point_id)
-                    .and_then(|value| serde_json::from_value::<GeoPoint>(value).ok())
-                    .or_else(|| {
-                        self.defaults
-                            .get(&VariableId::Payload(key.clone()))
-                            .and_then(|value| serde_json::from_value(value.clone()).ok())
-                    })
-                    .ok_or_else(|| OperationError::VariableTypeError {
-                        field_name: key.clone(),
-                        expected_type: "geo point".into(),
-                    })?;
+                let value = self.get_parsed_payload_value(
+                    key,
+                    point_id,
+                    serde_json::from_value::<GeoPoint>,
+                )?;
 
                 Ok(Haversine::distance((*origin).into(), value.into()) as ScoreType)
-            },
+            }
             ParsedExpression::Mult(expressions) => {
                 let mut product = 1.0;
                 for expr in expressions {
@@ -238,6 +245,39 @@ impl FormulaScorer<'_> {
             .get(json_path)
             .and_then(|retriever| retriever(point_id))
     }
+
+    /// Tries to get a value from payload or from the defaults. Then tries to convert it to the desired type.
+    fn get_parsed_payload_value<T, F, E>(
+        &self,
+        json_path: &JsonPath,
+        point_id: PointOffsetType,
+        from_value: F,
+    ) -> OperationResult<T>
+    where
+        F: Fn(Value) -> Result<T, E>,
+        E: ToString,
+        T: FriendlyName,
+    {
+        self.get_payload_value(json_path, point_id)
+            .or_else(|| {
+                self.defaults
+                    .get(&VariableId::Payload(json_path.clone()))
+                    .cloned()
+            })
+            .map(|value| {
+                from_value(value).map_err(|e| OperationError::VariableTypeError {
+                    field_name: json_path.clone(),
+                    expected_type: T::friendly_name().to_owned(),
+                    description: e.to_string(),
+                })
+            })
+            .transpose()?
+            .ok_or_else(|| OperationError::VariableTypeError {
+                field_name: json_path.clone(),
+                expected_type: T::friendly_name().to_owned(),
+                description: "No value found in a payload nor defaults".to_string(),
+            })
+    }
 }
 
 #[cfg(test)]
@@ -324,7 +364,7 @@ mod tests {
         GeoPoint { lat: 25.717877679163667, lon: -100.43383200156751 }, JsonPath::new(GEO_FIELD_NAME)
     ), 21926.494)]
     #[should_panic(
-        expected = r#"VariableTypeError { field_name: JsonPath { first_key: "number", rest: [] }, expected_type: "geo point" }"#
+        expected = r#"VariableTypeError { field_name: JsonPath { first_key: "number", rest: [] }, expected_type: "geo point", "#
     )]
     #[case(ParsedExpression::new_geo_distance(GeoPoint { lat: 25.717877679163667, lon: -100.43383200156751 }, JsonPath::new(FIELD_NAME)), 0.0)]
     #[should_panic(expected = r#"NonFiniteNumber { expression: "-1^0.4 = NaN" }"#)]
@@ -357,23 +397,30 @@ mod tests {
     // Default values
     #[rstest]
     // Defined default score
-    #[case(ParsedExpression::new_score_id(3), 1.5)]
+    #[case(ParsedExpression::new_score_id(3), Ok(1.5))]
     // score idx not defined
-    #[case(ParsedExpression::new_score_id(10), DEFAULT_SCORE)]
+    #[case(ParsedExpression::new_score_id(10), Ok(DEFAULT_SCORE))]
     // missing value in payload
     #[case(
         ParsedExpression::new_payload_id(JsonPath::new(NO_VALUE_FIELD_NAME)),
-        85.0
+        Ok(85.0)
     )]
     // missing value and no default value provided
     #[case(
         ParsedExpression::new_payload_id(JsonPath::new("missing_field")),
-        DEFAULT_SCORE
+        Err(OperationError::VariableTypeError {
+            field_name: JsonPath::new("missing_field"),
+            expected_type: ScoreType::friendly_name().to_string(),
+            description: "No value found in a payload nor defaults".to_string(),
+        })
     )]
     // geo distance with default value
-    #[case(ParsedExpression::new_geo_distance(GeoPoint { lat: 25.717877679163667, lon: -100.43383200156751 }, JsonPath::new(NO_VALUE_GEO_POINT)), 90951.3)]
+    #[case(ParsedExpression::new_geo_distance(GeoPoint { lat: 25.717877679163667, lon: -100.43383200156751 }, JsonPath::new(NO_VALUE_GEO_POINT)), Ok(90951.3))]
     #[test]
-    fn test_default_values(#[case] expr: ParsedExpression, #[case] expected: ScoreType) {
+    fn test_default_values(
+        #[case] expr: ParsedExpression,
+        #[case] expected: OperationResult<ScoreType>,
+    ) {
         let defaults = [
             (VariableId::Score(3), json!(1.5)),
             (
@@ -392,6 +439,6 @@ mod tests {
 
         let scorer = scorer_fixture.borrow_dependent();
 
-        assert_eq!(scorer.eval_expression(&expr, 0).unwrap(), expected);
+        assert_eq!(scorer.eval_expression(&expr, 0), expected);
     }
 }

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -118,7 +118,7 @@ impl FormulaScorer<'_> {
                         value
                             .as_f64()
                             .map(|value| value as ScoreType)
-                            .ok_or_else(|| "Value is not a number")
+                            .ok_or("Value is not a number")
                     })
                 }
                 VariableId::Condition(id) => {

--- a/tests/openapi/test_query_formula.py
+++ b/tests/openapi/test_query_formula.py
@@ -61,7 +61,7 @@ def test_formula(collection_name, formula, expecting):
 
     query = {
         "prefetch": {"query": point_id},
-        "query": {"formula": formula},
+        "query": {"formula": formula, "defaults": {"price": 0.0}},
         "with_payload": True,
     }
 
@@ -77,9 +77,9 @@ def test_formula(collection_name, formula, expecting):
     # Assert that the response is in descending order
     points = response.json()["result"]["points"]
     scores = [point.get("score") for point in points]
-    assert all(
-        scores[i] >= scores[i + 1] for i in range(len(scores) - 1)
-    ), "Results should be ordered by score descending"
+    assert all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1)), (
+        "Results should be ordered by score descending"
+    )
 
     # Sanity check that the evaluation was correct
     for point in points:
@@ -100,9 +100,9 @@ def test_formula(collection_name, formula, expecting):
         point_score = point.get("score")
 
         # Compare with actual score within floating point precision
-        assert isclose(
-            point_score, expected_score, rel_tol=1e-5
-        ), f"Expected score {expected_score}, got {point_score}. Point: {point}"
+        assert isclose(point_score, expected_score, rel_tol=1e-5), (
+            f"Expected score {expected_score}, got {point_score}. Point: {point}"
+        )
 
     # Assert that the response contains all points
     assert len(points) == len(orig_scores), "Response should contain all points"


### PR DESCRIPTION
Changes the behavior to not use a silent 0.0 if the payload nor the defaults have a valid type.

This will error if the payload is not an expected value, even if the defined default is.