### PR TITLE
Add global feature flags

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,5 +1,8 @@
 log_level: DEBUG
 
+feature_flags:
+  use_new_shard_key_mapping_format: true
+
 inference:
   address: "http://localhost:2114/api/v1/infer"
   timeout: 10

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,7 +1,7 @@
 log_level: DEBUG
 
 feature_flags:
-  use_new_shard_key_mapping_format: true
+  use_new_shard_key_mapping_format: false
 
 inference:
   address: "http://localhost:2114/api/v1/infer"

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use common::flags::FEATURE_FLAGS;
+use common::flags::feature_flags;
 use common::tar_ext;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::types::ShardKey;
@@ -108,9 +108,7 @@ enum ShardKeyMappingWrapper {
 
 impl Default for ShardKeyMappingWrapper {
     fn default() -> Self {
-        let use_new_format = FEATURE_FLAGS
-            .get()
-            .is_some_and(|flags| flags.use_new_shard_key_mapping_format);
+        let use_new_format = feature_flags().use_new_shard_key_mapping_format;
         if use_new_format {
             Self::New(Default::default())
         } else {
@@ -125,9 +123,7 @@ impl From<ShardKeyMapping> for ShardKeyMappingWrapper {
         // The old format is broken and fails to deserialize shard key numbers
         let any_number = mapping.keys().any(|key| matches!(key, ShardKey::Number(_)));
 
-        let use_new_format = FEATURE_FLAGS
-            .get()
-            .is_some_and(|flags| flags.use_new_shard_key_mapping_format);
+        let use_new_format = feature_flags().use_new_shard_key_mapping_format;
         if use_new_format || any_number {
             Self::New(
                 mapping

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
+use common::flags::FEATURE_FLAGS;
 use common::tar_ext;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::types::ShardKey;
@@ -11,13 +12,6 @@ use crate::save_on_disk::{Error, SaveOnDisk};
 use crate::shards::shard::ShardId;
 
 pub type ShardKeyMapping = HashMap<ShardKey, HashSet<ShardId>>;
-
-/// Whether to use the new format to persist shard keys
-///
-/// The old format fails to persist shard key numbers correctly, converting them into strings on
-/// load. While this is false, the new format is only used if any shard key is a number.
-// TODO(1.14): set to true, remove other branches in code, and remove this constant
-const USE_NEW_SHARD_KEY_MAPPING_FORMAT: bool = false;
 
 /// A `SaveOnDisk`-like structure for the shard key mapping
 ///
@@ -114,7 +108,10 @@ enum ShardKeyMappingWrapper {
 
 impl Default for ShardKeyMappingWrapper {
     fn default() -> Self {
-        if USE_NEW_SHARD_KEY_MAPPING_FORMAT {
+        let use_new_format = FEATURE_FLAGS
+            .get()
+            .is_some_and(|flags| flags.use_new_shard_key_mapping_format);
+        if use_new_format {
             Self::New(Default::default())
         } else {
             Self::Old(Default::default())
@@ -128,7 +125,10 @@ impl From<ShardKeyMapping> for ShardKeyMappingWrapper {
         // The old format is broken and fails to deserialize shard key numbers
         let any_number = mapping.keys().any(|key| matches!(key, ShardKey::Number(_)));
 
-        if USE_NEW_SHARD_KEY_MAPPING_FORMAT || any_number {
+        let use_new_format = FEATURE_FLAGS
+            .get()
+            .is_some_and(|flags| flags.use_new_shard_key_mapping_format);
+        if use_new_format || any_number {
             Self::New(
                 mapping
                     .into_iter()

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -1,0 +1,9 @@
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+/// Global feature flags, normally initialized when starting Qdrant.
+pub static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
+
+#[derive(Default, Debug, Deserialize, Clone, Copy)]
+pub struct FeatureFlags {}

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -6,4 +6,12 @@ use serde::Deserialize;
 pub static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
 
 #[derive(Default, Debug, Deserialize, Clone, Copy)]
-pub struct FeatureFlags {}
+pub struct FeatureFlags {
+    /// Whether to use the new format to persist shard keys
+    ///
+    /// The old format fails to persist shard key numbers correctly, converting them into strings on
+    /// load. While this is false, the new format is only used if any shard key is a number.
+    // TODO(1.14): set to true, remove other branches in code, and remove this flag
+    #[serde(default)]
+    pub use_new_shard_key_mapping_format: bool,
+}

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use serde::Deserialize;
 
 /// Global feature flags, normally initialized when starting Qdrant.
-pub static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
+static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
 
 #[derive(Default, Debug, Deserialize, Clone, Copy)]
 pub struct FeatureFlags {
@@ -14,4 +14,24 @@ pub struct FeatureFlags {
     // TODO(1.14): set to true, remove other branches in code, and remove this flag
     #[serde(default)]
     pub use_new_shard_key_mapping_format: bool,
+}
+
+/// Initializes the global feature flags with `flags`. Must only be called once at
+/// startup or otherwise throws a warning and discards the values.
+pub fn init_feature_flags(flags: &FeatureFlags) {
+    let res = FEATURE_FLAGS.set(*flags);
+    if res.is_err() {
+        log::warn!("Feature flags already initialized!");
+    }
+}
+
+/// Returns the configured global feature flags.
+pub fn feature_flags() -> FeatureFlags {
+    if let Some(flags) = FEATURE_FLAGS.get() {
+        return *flags;
+    }
+
+    // They should always be initialized.
+    log::warn!("Feature flags not initialized!");
+    FeatureFlags::default()
 }

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod delta_pack;
 pub mod disk;
 pub mod ext;
 pub mod fixed_length_priority_queue;
+pub mod flags;
 pub mod iterator_ext;
 pub mod math;
 pub mod mmap_hashmap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use ::common::budget::{ResourceBudget, get_io_budget};
 use ::common::cpu::get_cpu_budget;
+use ::common::flags::FEATURE_FLAGS;
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
@@ -146,6 +147,9 @@ fn main() -> anyhow::Result<()> {
     }
 
     let settings = Settings::new(args.config_path)?;
+
+    // Set global feature flags, sourced from configuration
+    let _ = FEATURE_FLAGS.set(settings.feature_flags);
 
     let reporting_enabled = !settings.telemetry_disabled && !args.disable_telemetry;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use ::common::budget::{ResourceBudget, get_io_budget};
 use ::common::cpu::get_cpu_budget;
-use ::common::flags::FEATURE_FLAGS;
+use ::common::flags::init_feature_flags;
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
@@ -149,7 +149,7 @@ fn main() -> anyhow::Result<()> {
     let settings = Settings::new(args.config_path)?;
 
     // Set global feature flags, sourced from configuration
-    let _ = FEATURE_FLAGS.set(settings.feature_flags);
+    init_feature_flags(&settings.feature_flags);
 
     let reporting_enabled = !settings.telemetry_disabled && !args.disable_telemetry;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,6 +4,7 @@ use api::grpc::transport_channel_pool::{
     DEFAULT_CONNECT_TIMEOUT, DEFAULT_GRPC_TIMEOUT, DEFAULT_POOL_SIZE,
 };
 use collection::operations::validation;
+use common::flags::FeatureFlags;
 use config::{Config, ConfigError, Environment, File, FileFormat, Source};
 use serde::Deserialize;
 use storage::types::StorageConfig;
@@ -215,6 +216,8 @@ pub struct Settings {
     #[serde(default)]
     #[validate(nested)]
     pub gpu: Option<GpuConfig>,
+    #[serde(default)]
+    pub feature_flags: FeatureFlags,
 }
 
 impl Settings {


### PR DESCRIPTION
First iteration of a structure for configuring feature flags.

This allows us to explicitly set some flags during testing to enable new and upcoming features. It helps us test the features before releasing them, without having to change source code. I'd like to unify the interface for this. It's intentionally kept very simple.

For now this includes just one flag. I'd like to add a flag for using the [new immutable ID tracker](https://github.com/qdrant/qdrant/pull/6174) once merged.

In debug builds, all flags are enabled by default (as per `config/development.yaml`). In chaos testing we'll probably enable all features by setting the appropriate environment variables.

I chose to use this global structure because it turns out to be extremely cumbersome to propagate the flags to all places we might use it. I want to prevent having to propagate it (adding a lot of changes), having to undo all changes one or two  versions later when we remove the flag. While I normally hate a global/static structure, I think this is a fair exception.

Let's use this PR as a place to discuss this feature.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?