### PR TITLE
[score boosting] Value retrievers return multivalues

### DIFF
--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -241,14 +241,16 @@ impl FormulaScorer<'_> {
     }
 
     fn get_payload_value(&self, json_path: &JsonPath, point_id: PointOffsetType) -> Option<Value> {
-        self.payload_retrievers.get(json_path).and_then(|retriever| {
-            let mut multi_value = retriever(point_id);
-            match multi_value.len() {
-                0 => None,
-                1 => Some(multi_value.pop().unwrap()),
-                _ => Some(Value::Array(multi_value.into_iter().collect()))
-            }
-        })
+        self.payload_retrievers
+            .get(json_path)
+            .and_then(|retriever| {
+                let mut multi_value = retriever(point_id);
+                match multi_value.len() {
+                    0 => None,
+                    1 => Some(multi_value.pop().unwrap()),
+                    _ => Some(Value::Array(multi_value.into_iter().collect())),
+                }
+            })
     }
 
     /// Tries to get a value from payload or from the defaults. Then tries to convert it to the desired type.
@@ -319,10 +321,15 @@ mod tests {
 
         ScorerFixture::new(scores, |prefetches_scores| {
             let mut payload_retrievers: HashMap<JsonPath, VariableRetrieverFn> = HashMap::new();
-            payload_retrievers.insert(JsonPath::new(FIELD_NAME), Box::new(|_| smallvec![json!(85.0)]));
+            payload_retrievers.insert(
+                JsonPath::new(FIELD_NAME),
+                Box::new(|_| smallvec![json!(85.0)]),
+            );
             payload_retrievers.insert(
                 JsonPath::new(GEO_FIELD_NAME),
-                Box::new(|_| smallvec![json!({"lat": 25.628482424190565, "lon": -100.23881855976})]),
+                Box::new(|_| {
+                    smallvec![json!({"lat": 25.628482424190565, "lon": -100.23881855976})]
+                }),
             );
 
             let condition_checkers = vec![

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -241,9 +241,14 @@ impl FormulaScorer<'_> {
     }
 
     fn get_payload_value(&self, json_path: &JsonPath, point_id: PointOffsetType) -> Option<Value> {
-        self.payload_retrievers
-            .get(json_path)
-            .and_then(|retriever| retriever(point_id))
+        self.payload_retrievers.get(json_path).and_then(|retriever| {
+            let mut multi_value = retriever(point_id);
+            match multi_value.len() {
+                0 => None,
+                1 => Some(multi_value.pop().unwrap()),
+                _ => Some(Value::Array(multi_value.into_iter().collect()))
+            }
+        })
     }
 
     /// Tries to get a value from payload or from the defaults. Then tries to convert it to the desired type.
@@ -287,6 +292,7 @@ mod tests {
 
     use rstest::rstest;
     use serde_json::json;
+    use smallvec::smallvec;
 
     use super::*;
     use crate::json_path::JsonPath;
@@ -313,10 +319,10 @@ mod tests {
 
         ScorerFixture::new(scores, |prefetches_scores| {
             let mut payload_retrievers: HashMap<JsonPath, VariableRetrieverFn> = HashMap::new();
-            payload_retrievers.insert(JsonPath::new(FIELD_NAME), Box::new(|_| Some(json!(85.0))));
+            payload_retrievers.insert(JsonPath::new(FIELD_NAME), Box::new(|_| smallvec![json!(85.0)]));
             payload_retrievers.insert(
                 JsonPath::new(GEO_FIELD_NAME),
-                Box::new(|_| Some(json!({"lat": 25.628482424190565, "lon": -100.23881855976}))),
+                Box::new(|_| smallvec![json!({"lat": 25.628482424190565, "lon": -100.23881855976})]),
             );
 
             let condition_checkers = vec![

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -199,8 +199,9 @@ mod tests {
     use std::sync::Arc;
 
     use atomic_refcell::AtomicRefCell;
-    use serde_json::{from_value, json};
+    use serde_json::{from_value, json, Value};
 
+    use crate::common::utils::MultiValue;
     use crate::index::field_index::geo_index::GeoMapIndex;
     use crate::index::field_index::numeric_index::NumericIndex;
     use crate::index::field_index::{FieldIndex, FieldIndexBuilderTrait};
@@ -269,9 +270,9 @@ mod tests {
         for id in 0..=2 {
             let value = retriever(id);
             match id {
-                0 => assert_eq!(value, Some(json!(42))),
-                1 => assert_eq!(value, None),
-                2 => assert_eq!(value, Some(json!(99))),
+                0 => assert_eq!(value, [json!(42)].into()),
+                1 => assert_eq!(value, MultiValue::<Value>::new()),
+                2 => assert_eq!(value, [json!(99), json!(55)].into()),
                 _ => unreachable!(),
             }
         }
@@ -286,9 +287,9 @@ mod tests {
         for id in 0..=2 {
             let value = retriever(id);
             match id {
-                0 => assert_eq!(value, None),
-                1 => assert_eq!(value, Some(json!({ "lat": 10.0, "lon": 20.0 }))),
-                2 => assert_eq!(value, Some(json!({ "lat": 15.5, "lon": 25.5 }))),
+                0 => assert_eq!(value, MultiValue::<Value>::new()),
+                1 => assert_eq!(value, [json!({ "lat": 10.0, "lon": 20.0 })].into()),
+                2 => assert_eq!(value, [json!({ "lat": 15.5, "lon": 25.5 })].into()),
                 _ => unreachable!(),
             }
         }
@@ -340,9 +341,9 @@ mod tests {
         for id in 0..=2 {
             let value = retriever(id);
             match id {
-                0 => assert_eq!(value, Some(json!(42))),
-                1 => assert_eq!(value, None),
-                2 => assert_eq!(value, Some(json!(99))),
+                0 => assert_eq!(value, [json!(42)].into()),
+                1 => assert_eq!(value, MultiValue::<Value>::new()),
+                2 => assert_eq!(value, [json!(99), json!(55)].into()),
                 _ => unreachable!(),
             }
         }
@@ -357,9 +358,9 @@ mod tests {
         for id in 0..=2 {
             let value = retriever(id);
             match id {
-                0 => assert_eq!(value, None),
-                1 => assert_eq!(value, Some(json!({ "lat": 10.0, "lon": 20.0 }))),
-                2 => assert_eq!(value, Some(json!({ "lat": 15.5, "lon": 25.5 }))),
+                0 => assert_eq!(value, MultiValue::<Value>::new()),
+                1 => assert_eq!(value, [json!({ "lat": 10.0, "lon": 20.0 })].into()),
+                2 => assert_eq!(value, [json!({ "lat": 15.5, "lon": 25.5 })].into()),
                 _ => unreachable!(),
             }
         }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1450,6 +1450,10 @@ pub trait PayloadContainer {
     /// Return value from payload by path.
     /// If value is not present in the payload, returns empty vector.
     fn get_value(&self, path: &JsonPath) -> MultiValue<&Value>;
+
+    fn get_value_cloned(&self, path: &JsonPath) -> MultiValue<Value> {
+        self.get_value(path).into_iter().cloned().collect()
+    }
 }
 
 /// Construct a [`Payload`] value from a JSON literal.


### PR DESCRIPTION
This changes the behavior of retrievers from extracting always the first value of a multivalue, to returning the multivalue itself.

After retrieving, the evaluation will translate single value as value (`[x]` as `x`), and more than one value as array (`[x, y]` as `[x, y]`)

This table exemplifies the change:
| payload value | retrieved multivalue | evaluated before | evaluated now |
| ---- | ---- | ---- | ---- |
| 0.5 | [0.5] | 0.5 | 0.5 |
| [0.5] | [0.5] | 0.5 | 0.5 |
| [0.5, 0.6] | [0.5, 0.6] | 0.5 | [0.5, 0.6] |