### PR TITLE
Suggestions for global feature flags

### DIFF
--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use common::flags::FEATURE_FLAGS;
+use common::flags::feature_flags;
 use common::tar_ext;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::types::ShardKey;
@@ -108,9 +108,7 @@ enum ShardKeyMappingWrapper {
 
 impl Default for ShardKeyMappingWrapper {
     fn default() -> Self {
-        let use_new_format = FEATURE_FLAGS
-            .get()
-            .is_some_and(|flags| flags.use_new_shard_key_mapping_format);
+        let use_new_format = feature_flags().use_new_shard_key_mapping_format;
         if use_new_format {
             Self::New(Default::default())
         } else {
@@ -125,9 +123,7 @@ impl From<ShardKeyMapping> for ShardKeyMappingWrapper {
         // The old format is broken and fails to deserialize shard key numbers
         let any_number = mapping.keys().any(|key| matches!(key, ShardKey::Number(_)));
 
-        let use_new_format = FEATURE_FLAGS
-            .get()
-            .is_some_and(|flags| flags.use_new_shard_key_mapping_format);
+        let use_new_format = feature_flags().use_new_shard_key_mapping_format;
         if use_new_format || any_number {
             Self::New(
                 mapping

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use serde::Deserialize;
 
 /// Global feature flags, normally initialized when starting Qdrant.
-pub static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
+static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
 
 #[derive(Default, Debug, Deserialize, Clone, Copy)]
 pub struct FeatureFlags {
@@ -14,4 +14,24 @@ pub struct FeatureFlags {
     // TODO(1.14): set to true, remove other branches in code, and remove this flag
     #[serde(default)]
     pub use_new_shard_key_mapping_format: bool,
+}
+
+/// Initializes the global feature flags with `flags`. Must only be called once at
+/// startup or otherwise throws a warning and discards the values.
+pub fn init_feature_flags(flags: &FeatureFlags) {
+    let res = FEATURE_FLAGS.set(*flags);
+    if res.is_err() {
+        log::warn!("Feature flags already initialized!");
+    }
+}
+
+/// Returns the configured global feature flags.
+pub fn feature_flags() -> FeatureFlags {
+    if let Some(flags) = FEATURE_FLAGS.get() {
+        return *flags;
+    }
+
+    // They should always be initialized.
+    log::warn!("Feature flags not initialized!");
+    FeatureFlags::default()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use ::common::budget::{ResourceBudget, get_io_budget};
 use ::common::cpu::get_cpu_budget;
-use ::common::flags::FEATURE_FLAGS;
+use ::common::flags::init_feature_flags;
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
@@ -149,7 +149,7 @@ fn main() -> anyhow::Result<()> {
     let settings = Settings::new(args.config_path)?;
 
     // Set global feature flags, sourced from configuration
-    let _ = FEATURE_FLAGS.set(settings.feature_flags);
+    init_feature_flags(&settings.feature_flags);
 
     let reporting_enabled = !settings.telemetry_disabled && !args.disable_telemetry;
 


### PR DESCRIPTION
Two minor suggestions for global feature flags in #6194:

- Private static Flags to have better control of initialization
- Public function for accessing global flags with fallback to default values to prevent unwrapping everywhere

This is just a suggestion and I'm happy to discuss or discard if not needed!
