### PR TITLE
Flush after moving snapshots

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -120,6 +120,8 @@ impl LocalShard {
 
         LocalShardClocks::move_data(from, to).await?;
 
+        std::fs::File::open(to)?.sync_all()?;
+
         Ok(())
     }
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -24,6 +24,7 @@ use common::rate_limiting::RateLimiter;
 use common::types::TelemetryDetail;
 use common::{panic, tar_ext};
 use indicatif::{ProgressBar, ProgressStyle};
+use io::fsync::fsync_dir_recursive;
 use itertools::Itertools;
 use parking_lot::{Mutex as ParkingMutex, RwLock};
 use segment::data_types::vectors::VectorElementType;
@@ -120,7 +121,7 @@ impl LocalShard {
 
         LocalShardClocks::move_data(from, to).await?;
 
-        std::fs::File::open(to)?.sync_all()?;
+        fsync_dir_recursive(to)?;
 
         Ok(())
     }

--- a/lib/common/io/src/fsync.rs
+++ b/lib/common/io/src/fsync.rs
@@ -1,0 +1,34 @@
+use std::{
+    fs::{self, OpenOptions},
+    io,
+    path::Path,
+};
+
+pub fn fsync_dir_recursive(path: &Path) -> io::Result<()> {
+    if path.is_dir() {
+        // Sync all files and subdirectories first
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+
+            if entry_path.is_dir() {
+                fsync_dir_recursive(&entry_path)?; // Recursively sync subdirectories
+            } else {
+                fsync_file(&entry_path)?; // Sync individual file
+            }
+        }
+        // Finally, sync the directory itself
+        fsync_dir(path)?;
+    }
+    Ok(())
+}
+
+pub fn fsync_file(path: &Path) -> io::Result<()> {
+    let file = OpenOptions::new().read(true).open(path)?;
+    file.sync_all() // Ensure file content is flushed
+}
+
+pub fn fsync_dir(path: &Path) -> io::Result<()> {
+    let file = OpenOptions::new().read(true).open(path)?; // Open directory
+    file.sync_all() // Flush directory metadata
+}

--- a/lib/common/io/src/fsync.rs
+++ b/lib/common/io/src/fsync.rs
@@ -1,8 +1,6 @@
-use std::{
-    fs::{self, OpenOptions},
-    io,
-    path::Path,
-};
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::Path;
 
 pub fn fsync_dir_recursive(path: &Path) -> io::Result<()> {
     if path.is_dir() {

--- a/lib/common/io/src/lib.rs
+++ b/lib/common/io/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod file_operations;
-pub mod storage_version;
 pub mod fsync;
+pub mod storage_version;

--- a/lib/common/io/src/lib.rs
+++ b/lib/common/io/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod file_operations;
 pub mod storage_version;
+pub mod fsync;

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -8,6 +8,7 @@ use bitvec::prelude::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
+use io::fsync::fsync_dir_recursive;
 use memory::mmap_ops;
 
 use super::{
@@ -729,6 +730,8 @@ fn unpack_snapshot(segment_path: &Path) -> OperationResult<()> {
     let files_path = segment_path.join(SNAPSHOT_FILES_PATH);
     utils::fs::move_all(&files_path, segment_path)?;
     std::fs::remove_dir(&files_path)?;
+
+    fsync_dir_recursive(segment_path)?;
 
     Ok(())
 }

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -730,7 +730,5 @@ fn unpack_snapshot(segment_path: &Path) -> OperationResult<()> {
     utils::fs::move_all(&files_path, segment_path)?;
     std::fs::remove_dir(&files_path)?;
 
-    std::fs::File::open(segment_path)?.sync_all()?;
-
     Ok(())
 }

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -730,5 +730,7 @@ fn unpack_snapshot(segment_path: &Path) -> OperationResult<()> {
     utils::fs::move_all(&files_path, segment_path)?;
     std::fs::remove_dir(&files_path)?;
 
+    std::fs::File::open(segment_path)?.sync_all()?;
+
     Ok(())
 }


### PR DESCRIPTION
In chaos testing, we found nodes be panicing when force killed during (streaming) snapshot transfers. We found that some of the files sometimes go missing from `/qdrant/storage/collections/<collection-name>/<shard-id>/segments/<segment-id>/vector_storage-<vector-name>` (happened with both dense + sparse vectors). This includes:
- `vectors/chunk_*.mmap`
- `deleted/{status,flags_a}.dat`
- `quantized.config.json`

These all files are however clearly present if we unarchive the received snapshot file found in `/qdrant/snapshots/tmp/<snapshot-name>.download`. This means that the streaming download is working fine. After that we restructure the files in place in `/qdrant/storage/tmp` directory. And then we finally move to shard directory at `/qdrant/storage/collections/<collection-name>/<shard-id>`. We suspect that the last move operation if terminated in between will lead to lost files because of not flushing to disk. So this PR adds flushing after that step.

<details>
<summary>
More details
</summary>

We found this in logs just before the node was killed:
```
2025-03-07T13:40:43.324481Z  INFO segment::segment::segment_ops: Snapshot format: Streamable
2025-03-07T13:40:43.396846Z  INFO segment::segment::segment_ops: Snapshot format: Streamable
2025-03-07T13:40:43.427133Z DEBUG collection::update_handler: Stopping flush worker.
```

While I could only see one of the segments in the `/qdrant/storage/collections/benchmark/2/segments` dir. One of the was entirely missing and another one was partially present with missing files (as described above)

This means the segment level snapshot restructing/unpacking step probably worked and persisted for both the segments. Till this step they are stored in `/qdrant/snapshots/tmp` and are moved to the `/qdrant/storage/collections/benchmark/2` which is a different network disk and I suspect that it's this movement between disks that wasn't persisted properly because of kill. So flushing there is important. 
</details>

TODO:
- [ ] Manually test that flushing logic works as expected

### All Submissions:
* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

