### PR TITLE
Fix snapshot restore with new shard key format

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,7 +1,7 @@
 log_level: DEBUG
 
 feature_flags:
-  use_new_shard_key_mapping_format: false
+  use_new_shard_key_mapping_format: true
   use_mutable_id_tracker_without_rocksdb: true
 
 inference:

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -23,7 +23,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{self, ShardConfig};
-use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
+use crate::shards::shard_holder::shard_mapping::ShardKeyMappingWrapper;
 use crate::shards::shard_holder::{SHARD_KEY_MAPPING_FILE, ShardHolder, shard_not_found_error};
 use crate::shards::{shard_initializing_flag_path, shard_path};
 
@@ -184,12 +184,9 @@ impl Collection {
                 if !mapping_path.exists() {
                     Vec::new()
                 } else {
-                    let shard_key_mapping: ShardKeyMapping = read_json(&mapping_path)?;
-                    shard_key_mapping
-                        .values()
-                        .flat_map(|v| v.iter())
-                        .copied()
-                        .collect()
+                    // Use wrapper type to support both formats
+                    let shard_key_mapping: ShardKeyMappingWrapper = read_json(&mapping_path)?;
+                    shard_key_mapping.shard_ids()
                 }
             }
         };

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -104,6 +104,7 @@ pub(crate) enum ShardKeyMappingWrapper {
     // TODO(1.15): if removing the old format, change back to regular SaveOnDisk<T> type
     Old(ShardKeyMapping),
     /// The `New` format is a more robust format, properly persisting shard key numbers
+    #[allow(private_interfaces)]
     New(Vec<NewShardKeyMapping>),
 }
 

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use common::flags::feature_flags;
 use common::tar_ext;
+use itertools::Itertools;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
@@ -97,13 +98,36 @@ impl Deref for SaveOnDiskShardKeyMappingWrapper {
 /// Bug: <https://github.com/qdrant/qdrant/pull/5838>
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(untagged)]
-enum ShardKeyMappingWrapper {
+pub(crate) enum ShardKeyMappingWrapper {
     /// The `Old` format is the original format from when shard key mappings were implemented
     // TODO(1.15): either fully remove support for the old format, or keep it a bit longer
     // TODO(1.15): if removing the old format, change back to regular SaveOnDisk<T> type
     Old(ShardKeyMapping),
     /// The `New` format is a more robust format, properly persisting shard key numbers
     New(Vec<NewShardKeyMapping>),
+}
+
+impl ShardKeyMappingWrapper {
+    /// Return all shard IDs from the mappings
+    pub fn shard_ids(&self) -> Vec<ShardId> {
+        let ids: Vec<ShardId> = match self {
+            ShardKeyMappingWrapper::Old(mapping) => mapping
+                .values()
+                .flat_map(|shard_ids| shard_ids.iter().copied())
+                .collect(),
+            ShardKeyMappingWrapper::New(mappings) => mappings
+                .iter()
+                .flat_map(|mapping| mapping.shard_ids.iter().copied())
+                .collect(),
+        };
+
+        debug_assert!(
+            ids.iter().all_unique(),
+            "shard mapping contains duplicate shard IDs"
+        );
+
+        ids
+    }
 }
 
 impl Default for ShardKeyMappingWrapper {


### PR DESCRIPTION
Fix snapshot restore with new shard key format introduced in <https://github.com/qdrant/qdrant/pull/5838>.

The new shard key storage format is now enabled by default in development builds through a feature flag.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?