### PR TITLE
Implement partial snapshot recovery

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -161,7 +161,7 @@ pub struct SegmentHolder {
 
 pub type LockedSegmentHolder = Arc<RwLock<SegmentHolder>>;
 
-impl<'s> SegmentHolder {
+impl SegmentHolder {
     pub fn segment_manifests(&self) -> OperationResult<SegmentManifests> {
         let mut manifests = SegmentManifests::default();
 
@@ -178,7 +178,7 @@ impl<'s> SegmentHolder {
     /// Iterate over all segments with their IDs
     ///
     /// Appendable first, then non-appendable.
-    pub fn iter(&'s self) -> impl Iterator<Item = (&'s SegmentId, &'s LockedSegment)> + 's {
+    pub fn iter(&self) -> impl Iterator<Item = (&SegmentId, &LockedSegment)> {
         self.appendable_segments
             .iter()
             .chain(self.non_appendable_segments.iter())
@@ -329,9 +329,7 @@ impl<'s> SegmentHolder {
     }
 
     /// Get all locked segments, non-appendable first, then appendable.
-    pub fn non_appendable_then_appendable_segments(
-        &'s self,
-    ) -> impl Iterator<Item = LockedSegment> + 's {
+    pub fn non_appendable_then_appendable_segments(&self) -> impl Iterator<Item = LockedSegment> {
         self.non_appendable_segments
             .values()
             .chain(self.appendable_segments.values())

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -18,6 +18,7 @@ use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWrit
 use rand::seq::IndexedRandom;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::named_vectors::NamedVectors;
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
@@ -161,6 +162,19 @@ pub struct SegmentHolder {
 pub type LockedSegmentHolder = Arc<RwLock<SegmentHolder>>;
 
 impl<'s> SegmentHolder {
+    pub fn segment_manifests(&self) -> OperationResult<SegmentManifests> {
+        let mut manifests = SegmentManifests::default();
+
+        for (_, segment) in self.iter() {
+            segment
+                .get()
+                .read()
+                .collect_segment_manifests(&mut manifests)?;
+        }
+
+        Ok(manifests)
+    }
+
     /// Iterate over all segments with their IDs
     ///
     /// Appendable first, then non-appendable.

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -7,6 +7,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::tar_ext;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, SnapshotFormat, WithPayload, WithPayloadInterface,
@@ -43,6 +44,10 @@ impl DummyShard {
         _format: SnapshotFormat,
         _save_wal: bool,
     ) -> CollectionResult<()> {
+        self.dummy()
+    }
+
+    pub fn segment_manifests(&self) -> CollectionResult<SegmentManifests> {
         self.dummy()
     }
 

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -9,6 +9,7 @@ use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, SnapshotFormat, WithPayload,
@@ -322,6 +323,10 @@ impl ForwardProxyShard {
         self.wrapped_shard
             .create_snapshot(temp_path, tar, format, save_wal)
             .await
+    }
+
+    pub fn segment_manifests(&self) -> CollectionResult<SegmentManifests> {
+        self.wrapped_shard.segment_manifests()
     }
 
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -26,6 +26,7 @@ use common::{panic, tar_ext};
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use parking_lot::{Mutex as ParkingMutex, RwLock};
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::data_types::vectors::VectorElementType;
 use segment::entry::entry_point::SegmentEntry as _;
 use segment::index::field_index::CardinalityEstimation;
@@ -990,6 +991,13 @@ impl LocalShard {
                 })?;
         }
         Ok(())
+    }
+
+    pub fn segment_manifests(&self) -> CollectionResult<SegmentManifests> {
+        self.segments()
+            .read()
+            .segment_manifests()
+            .map_err(CollectionError::from)
     }
 
     pub fn estimate_cardinality<'a>(

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -11,6 +11,7 @@ use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, SnapshotFormat, WithPayload,
@@ -81,6 +82,10 @@ impl ProxyShard {
         self.wrapped_shard
             .create_snapshot(temp_path, tar, format, save_wal)
             .await
+    }
+
+    pub fn segment_manifests(&self) -> CollectionResult<SegmentManifests> {
+        self.wrapped_shard.segment_manifests()
     }
 
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -11,6 +11,7 @@ use common::types::TelemetryDetail;
 use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, SnapshotFormat, WithPayload, WithPayloadInterface,
@@ -146,6 +147,10 @@ impl QueueProxyShard {
             .wrapped_shard
             .create_snapshot(temp_path, tar, format, save_wal)
             .await
+    }
+
+    pub fn segment_manifests(&self) -> CollectionResult<SegmentManifests> {
+        self.inner_unchecked().wrapped_shard.segment_manifests()
     }
 
     /// Transfer all updates that the remote missed from WAL

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -3,7 +3,7 @@ mod execute_read_operation;
 mod locally_disabled_peers;
 mod read_ops;
 mod shard_transfer;
-mod snapshots;
+pub mod snapshots;
 mod update;
 
 use std::collections::{HashMap, HashSet};

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -1,7 +1,13 @@
+use std::collections::HashSet;
 use std::ops::Deref as _;
 use std::path::Path;
+use std::{fs, io};
 
 use common::tar_ext;
+use segment::data_types::segment_manifest::{SegmentManifest, SegmentManifests};
+use segment::segment::destroy_rocksdb;
+use segment::segment::snapshot::{PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE, ROCKS_DB_VIRT_FILE};
+use segment::segment_constructor::PAYLOAD_INDEX_PATH;
 use segment::types::SnapshotFormat;
 
 use super::{REPLICA_STATE_FILE, ReplicaSetState, ReplicaState, ShardReplicaSet};
@@ -12,6 +18,22 @@ use crate::shards::local_shard::LocalShard;
 use crate::shards::shard::{PeerId, Shard};
 use crate::shards::shard_config::ShardConfig;
 use crate::shards::shard_initializing_flag_path;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RecoveryType {
+    Full,
+    Partial,
+}
+
+impl RecoveryType {
+    pub fn is_full(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    pub fn is_partial(self) -> bool {
+        matches!(self, Self::Partial)
+    }
+}
 
 impl ShardReplicaSet {
     pub async fn create_snapshot(
@@ -82,6 +104,7 @@ impl ShardReplicaSet {
     pub async fn restore_local_replica_from(
         &self,
         replica_path: &Path,
+        recovery_type: RecoveryType,
         collection_path: &Path,
         cancel: cancel::CancellationToken,
     ) -> CollectionResult<bool> {
@@ -89,6 +112,80 @@ impl ShardReplicaSet {
 
         if !LocalShard::check_data(replica_path) {
             return Ok(false);
+        }
+
+        let segments_path = LocalShard::segments_path(replica_path);
+
+        let mut snapshot_segments = HashSet::new();
+        let mut snapshot_manifests = SegmentManifests::default();
+
+        for segment_entry in segments_path.read_dir()? {
+            let segment_path = segment_entry?.path();
+
+            if !segment_path.is_dir() {
+                log::warn!(
+                    "segment path {} in extracted snapshot {} is not a directory",
+                    segment_path.display(),
+                    replica_path.display(),
+                );
+
+                continue;
+            }
+
+            let segment_id = segment_path
+                .file_name()
+                .and_then(|segment_id| segment_id.to_str())
+                .expect("segment path ends with a valid segment id");
+
+            let added = snapshot_segments.insert(segment_id.to_string());
+            debug_assert!(added);
+
+            let manifest_path = segment_path.join("segment_manifest.json");
+
+            if recovery_type.is_full() {
+                if manifest_path.exists() {
+                    return Err(CollectionError::bad_request(format!(
+                        "invalid shard snapshot: \
+                         segment {segment_id} contains segment manifest; \
+                         ensure you are not recovering partial snapshot on shard snapshot endpoint",
+                    )));
+                }
+
+                continue;
+            }
+
+            if !manifest_path.exists() {
+                return Err(CollectionError::bad_request(format!(
+                    "invalid partial snapshot: \
+                     segment {segment_id} does not contain segment manifest; \
+                     ensure you are not recovering shard snapshot on partial snapshot endpoint",
+                )));
+            }
+
+            let manifest = fs::File::open(&manifest_path).map_err(|err| {
+                CollectionError::service_error(format!(
+                    "failed to open segment {segment_id} manifest: {err}",
+                ))
+            })?;
+
+            let manifest = io::BufReader::new(manifest);
+
+            let manifest: SegmentManifest = serde_json::from_reader(manifest).map_err(|err| {
+                CollectionError::bad_request(format!(
+                    "failed to deserialize segment {segment_id} manifest: {err}",
+                ))
+            })?;
+
+            if segment_id != manifest.segment_id {
+                return Err(CollectionError::bad_request(format!(
+                    "invalid partial snapshot: \
+                     segment {segment_id} contains segment manifest with segment ID {}",
+                    manifest.segment_id,
+                )));
+            }
+
+            let added = snapshot_manifests.add(manifest);
+            debug_assert!(added);
         }
 
         // TODO:
@@ -109,12 +206,108 @@ impl ShardReplicaSet {
             return Err(cancel::Error::Cancelled.into());
         }
 
-        // Drop `LocalShard` instance to free resources and clear shard data
-        let clear = local.take().is_some();
+        let local_manifests = match local.take() {
+            _ if snapshot_manifests.is_empty() => None,
+
+            // TODO: Generalize to handle both local and proxy shards 🤔
+            Some(Shard::Local(shard)) => {
+                let local_manifests = shard.segments().read().segment_manifests();
+
+                match local_manifests {
+                    Ok(local_manifests) => {
+                        // TODO: Validate that all segments in `local_manifests` are *older* than segments in `snapshot_manifests` 😵‍💫
+
+                        Some(local_manifests)
+                    }
+
+                    Err(err) => {
+                        let _ = local.insert(Shard::Local(shard));
+
+                        return Err(CollectionError::service_error(format!(
+                            "failed to restore partial shard snapshot for shard {}:{}: \
+                             failed to collect segment manifests: \
+                             {err}",
+                            self.collection_id, self.shard_id,
+                        )));
+                    }
+                }
+            }
+
+            Some(shard) => {
+                let proxy_type = shard.variant_name();
+
+                let _ = local.insert(shard);
+
+                return Err(CollectionError::bad_request(format!(
+                    "failed to restore partial shard snapshot for shard {}:{}: \
+                     shard {}:{} is a {proxy_type}",
+                    self.collection_id, self.shard_id, self.collection_id, self.shard_id,
+                )));
+            }
+
+            None => {
+                return Err(CollectionError::bad_request(format!(
+                    "failed to restore partial shard snapshot for shard {}:{}: \
+                     shard does not exist on peer {}",
+                    self.collection_id,
+                    self.shard_id,
+                    self.this_peer_id(),
+                )));
+            }
+        };
 
         // Try to restore local replica from specified shard snapshot directory
         let restore = async {
-            if clear {
+            if let Some(local_manifests) = local_manifests {
+                for (segment_id, local_manifest) in local_manifests.iter() {
+                    let segment_path = segments_path.join(segment_id);
+
+                    // Delete local segment, if it's not present in partial snapshot
+                    let Some(snapshot_manifest) = snapshot_manifests.get(segment_id) else {
+                        tokio::fs::remove_dir_all(&segment_path).await?;
+                        continue;
+                    };
+
+                    for (file, &local_version) in &local_manifest.file_versions {
+                        let snapshot_version = snapshot_manifest.file_versions.get(file).copied();
+
+                        let is_removed = snapshot_version.is_none();
+
+                        let is_outdated = snapshot_version.is_none_or(|snapshot_version| {
+                            let local_version =
+                                local_version.or_segment_version(local_manifest.segment_version);
+
+                            let snapshot_version = snapshot_version
+                                .or_segment_version(snapshot_manifest.segment_version);
+
+                            // Compare versions to determine local file is outdated relative to snapshot
+                            local_version < snapshot_version
+                        });
+
+                        let is_rocksdb = file == Path::new(ROCKS_DB_VIRT_FILE);
+                        let is_payload_index_rocksdb =
+                            file == Path::new(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE);
+
+                        if is_removed {
+                            // If `file` is a regular file, delete it from disk, if it was
+                            // *removed* from the snapshot
+
+                            if !is_rocksdb && !is_payload_index_rocksdb {
+                                tokio::fs::remove_file(segment_path.join(file)).await?;
+                            }
+                        } else if is_outdated {
+                            // If `file` is a RocksDB "virtual" file, remove RocksDB from disk,
+                            // if it was *updated* in or *removed* from the snapshot
+
+                            if is_rocksdb {
+                                destroy_rocksdb(&segment_path)?;
+                            } else if is_payload_index_rocksdb {
+                                destroy_rocksdb(&segment_path.join(PAYLOAD_INDEX_PATH))?;
+                            }
+                        }
+                    }
+                }
+            } else {
                 // Remove shard data but not configuration files
                 LocalShard::clear(&self.shard_path).await?;
             }

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -344,7 +344,7 @@ impl ShardReplicaSet {
                 // Mark this peer as "locally disabled"...
                 //
                 // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!
-                let has_other_active_peers = self.active_remote_shards().is_empty();
+                let has_other_active_peers = !self.active_remote_shards().is_empty();
 
                 // ...if this peer is *not* the last active replica
                 if has_other_active_peers {

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
+use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{Filter, SnapshotFormat};
 
@@ -120,6 +121,16 @@ impl Shard {
                     .create_snapshot(temp_path, tar, format, save_wal)
                     .await
             }
+        }
+    }
+
+    pub fn segment_manifests(&self) -> CollectionResult<SegmentManifests> {
+        match self {
+            Shard::Local(local_shard) => local_shard.segment_manifests(),
+            Shard::Proxy(proxy_shard) => proxy_shard.segment_manifests(),
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.segment_manifests(),
+            Shard::QueueProxy(proxy_shard) => proxy_shard.segment_manifests(),
+            Shard::Dummy(dummy_shard) => dummy_shard.segment_manifests(),
         }
     }
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -49,7 +49,7 @@ pub enum Shard {
 }
 
 impl Shard {
-    pub fn variant_name(&self) -> &str {
+    pub fn variant_name(&self) -> &'static str {
         match self {
             Shard::Local(_) => "local shard",
             Shard::Proxy(_) => "proxy shard",

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -20,6 +20,7 @@ use tokio::sync::{OwnedRwLockReadGuard, RwLock, broadcast};
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tokio_util::io::SyncIoBridge;
 
+use super::replica_set::snapshots::RecoveryType;
 use super::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use super::resharding::{ReshardStage, ReshardState};
 use super::transfer::transfer_tasks_pool::TransferTasksPool;
@@ -1057,7 +1058,12 @@ impl ShardHolder {
 
         // `ShardReplicaSet::restore_local_replica_from` is *not* cancel safe
         let res = replica_set
-            .restore_local_replica_from(snapshot_shard_path, collection_path, cancel)
+            .restore_local_replica_from(
+                snapshot_shard_path,
+                RecoveryType::Full,
+                collection_path,
+                cancel,
+            )
             .await?;
 
         Ok(res)

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::types::SeqNumberType;
 
 #[derive(Clone, Debug, Default)]
@@ -9,6 +10,23 @@ pub struct SegmentManifests {
 }
 
 impl SegmentManifests {
+    pub fn validate(&self) -> OperationResult<()> {
+        for (segment_id, manifest) in &self.manifests {
+            for (file, version) in &manifest.file_versions {
+                if version.or_segment_version(manifest.segment_version) > manifest.segment_version {
+                    return Err(OperationError::validation_error(format!(
+                        "invalid snapshot manifest: \
+                         file {segment_id}/{} is newer than segment {segment_id} ({version:?} > {})",
+                        file.display(),
+                        manifest.segment_version,
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn version(&self, segment_id: &str) -> Option<SeqNumberType> {
         self.manifests
             .get(segment_id)

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -15,10 +15,6 @@ impl SegmentManifests {
             .map(|manifest| manifest.segment_version)
     }
 
-    pub fn get(&self, segment_id: &str) -> Option<&SegmentManifest> {
-        self.manifests.get(segment_id)
-    }
-
     pub fn add(&mut self, new_manifest: SegmentManifest) -> bool {
         let Some(current_manifest) = self.manifests.get_mut(&new_manifest.segment_id) else {
             self.manifests
@@ -35,6 +31,22 @@ impl SegmentManifests {
         }
 
         false
+    }
+
+    pub fn get(&self, segment_id: &str) -> Option<&SegmentManifest> {
+        self.manifests.get(segment_id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &SegmentManifest)> {
+        self.manifests.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.manifests.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.manifests.is_empty()
     }
 }
 

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -735,8 +735,10 @@ fn restore_snapshot_in_place(snapshot_path: &Path) -> OperationResult<()> {
 
 fn unpack_snapshot(segment_path: &Path) -> OperationResult<()> {
     let db_backup_path = segment_path.join(DB_BACKUP_PATH);
-    crate::rocksdb_backup::restore(&db_backup_path, segment_path)?;
-    std::fs::remove_dir_all(&db_backup_path)?;
+    if db_backup_path.is_dir() {
+        crate::rocksdb_backup::restore(&db_backup_path, segment_path)?;
+        std::fs::remove_dir_all(&db_backup_path)?;
+    }
 
     let payload_index_db_backup = segment_path.join(PAYLOAD_DB_BACKUP_PATH);
     if payload_index_db_backup.is_dir() {

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -62,7 +62,7 @@ impl SnapshotEntry for Segment {
                 let tar = tar.descend(Path::new(&segment_id))?;
                 tar.blocking_append_data(
                     &updated_manifest_json,
-                    Path::new("segment_manifest.json"),
+                    Path::new("files/segment_manifest.json"),
                 )?;
 
                 let mut empty_manifest = None;

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -36,12 +36,13 @@ impl SnapshotEntry for Segment {
     ) -> OperationResult<()> {
         let segment_id = self.segment_id()?;
 
+        log::debug!("Taking snapshot of segment {segment_id}");
+
         if !snapshotted_segments.insert(segment_id.to_string()) {
             // Already snapshotted.
+            log::debug!("Segment {segment_id} is already snapshotted!");
             return Ok(());
         }
-
-        log::debug!("Taking snapshot of segment {:?}", self.current_path);
 
         // flush segment to capture latest state
         self.flush(true, false)?;

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -291,18 +291,20 @@ pub fn snapshot_files(
             .take_database_snapshot(&payload_index_db_backup_path)?;
     }
 
-    tar.blocking_append_dir_all(&temp_path, Path::new(""))?;
+    if temp_path.exists() {
+        tar.blocking_append_dir_all(&temp_path, Path::new(""))?;
 
-    // remove tmp directory in background
-    let _ = thread::spawn(move || {
-        let res = fs::remove_dir_all(&temp_path);
-        if let Err(err) = res {
-            log::error!(
-                "Failed to remove tmp directory at {}: {err:?}",
-                temp_path.display(),
-            );
-        }
-    });
+        // remove tmp directory in background
+        let _ = thread::spawn(move || {
+            let res = fs::remove_dir_all(&temp_path);
+            if let Err(err) = res {
+                log::error!(
+                    "Failed to remove tmp directory at {}: {err:?}",
+                    temp_path.display(),
+                );
+            }
+        });
+    }
 
     let tar = tar.descend(Path::new(SNAPSHOT_FILES_PATH))?;
 


### PR DESCRIPTION
This PR extends `ShardReplicaSet::restore_local_replica_from` to support *partial* snapshot recovery.

APIs to create and recover partial snapshots and integration tests will be added in a follow-up PRs.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
