### PR TITLE
Mutable ID tracker: show warning if mapping and versions count mismatch

### DIFF
--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -126,7 +126,7 @@ impl MutableIdTracker {
         }
         if has_mappings && !has_versions {
             log::warn!(
-                "Missing versions file for ID tracker, WAL should recover point mappings and versions",
+                "Missing versions file for ID tracker, assuming automatic point mappings and version recovery by WAL",
             );
         }
 
@@ -153,7 +153,7 @@ impl MutableIdTracker {
         );
         if mappings.total_point_count() != internal_to_version.len() {
             log::warn!(
-                "Mutable ID tracker mappings and versions count mismatch, could have been partially flushed, WAL should recover ({} mappings, {} versions)",
+                "Mutable ID tracker mappings and versions count mismatch, could have been partially flushed, assuming automatic recovery by WAL ({} mappings, {} versions)",
                 mappings.total_point_count(),
                 internal_to_version.len(),
             );
@@ -420,7 +420,7 @@ fn load_mappings(mappings_path: &Path) -> OperationResult<PointMappings> {
     debug_assert!(read_to <= file_len, "cannot read past the end of the file");
     if read_to < file_len {
         log::warn!(
-            "Mutable ID tracker mappings file ends with incomplete entry, removing last {} bytes and assuming WAL recovery",
+            "Mutable ID tracker mappings file ends with incomplete entry, removing last {} bytes and assuming automatic recovery by WAL",
             (file_len - read_to),
         );
         let file = File::options()
@@ -663,7 +663,7 @@ fn load_versions(versions_path: &Path) -> OperationResult<Vec<SeqNumberType>> {
     let file_len = file.metadata()?.len();
     if file_len % VERSION_ELEMENT_SIZE != 0 {
         log::warn!(
-            "Corrupted ID tracker versions storage, file size not a multiple of a version, assuming recovery by WAL"
+            "Corrupted ID tracker versions storage, file size not a multiple of a version, assuming automatic recovery by WAL"
         );
     }
     let version_count = file_len / VERSION_ELEMENT_SIZE;

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -146,6 +146,19 @@ impl MutableIdTracker {
             vec![]
         };
 
+        // Compare internal point mappings and versions count, report warning if we don't
+        debug_assert!(
+            mappings.total_point_count() >= internal_to_version.len(),
+            "can never have more versions than internal point mappings",
+        );
+        if mappings.total_point_count() != internal_to_version.len() {
+            log::warn!(
+                "Mutable ID tracker mappings and versions count mismatch, could have been partially flushed, WAL should recover ({} mappings, {} versions)",
+                mappings.total_point_count(),
+                internal_to_version.len(),
+            );
+        }
+
         #[cfg(debug_assertions)]
         mappings.assert_mappings();
 


### PR DESCRIPTION
Tracked in: #6157

Show a warning if the number of internal point mappings does not match with the number of versions. Their counts should normally be equal.

If a crash happens during flush, new versions may only be partially written or not at all. In such case we can expect the list of versions to be shorter.

This shows a warning to make us aware of this having happened, potentially allowing is to debug better. Under normal circumstances, the WAL should always recover this situation.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?