### PR TITLE
Fix broken shard key mapping in consensus snapshot

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -47,6 +47,7 @@ use crate::shards::replica_set::{
     ChangePeerFromState, ChangePeerState, ReplicaState, ShardReplicaSet,
 };
 use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard_holder::shard_mapping::ShardKeyMappingWrapper;
 use crate::shards::shard_holder::{LockedShardHolder, ShardHolder, shard_not_found_error};
 use crate::shards::transfer::helpers::check_transfer_conflicts_strict;
 use crate::shards::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
@@ -557,7 +558,9 @@ impl Collection {
                 .collect(),
             resharding,
             transfers,
-            shards_key_mapping: shards_holder.get_shard_key_to_ids_mapping(),
+            shards_key_mapping: ShardKeyMappingWrapper::from(
+                shards_holder.get_shard_key_to_ids_mapping(),
+            ),
             payload_index_schema: self.payload_index_schema.read().clone(),
         }
     }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -47,7 +47,6 @@ use crate::shards::replica_set::{
     ChangePeerFromState, ChangePeerState, ReplicaState, ShardReplicaSet,
 };
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_holder::shard_mapping::ShardKeyMappingWrapper;
 use crate::shards::shard_holder::{LockedShardHolder, ShardHolder, shard_not_found_error};
 use crate::shards::transfer::helpers::check_transfer_conflicts_strict;
 use crate::shards::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
@@ -345,8 +344,6 @@ impl Collection {
             .await
             .get_shard_key_to_ids_mapping()
             .keys()
-            .cloned()
-            .collect()
     }
 
     /// Return a list of local shards, present on this peer
@@ -558,9 +555,7 @@ impl Collection {
                 .collect(),
             resharding,
             transfers,
-            shards_key_mapping: ShardKeyMappingWrapper::from(
-                shards_holder.get_shard_key_to_ids_mapping(),
-            ),
+            shards_key_mapping: shards_holder.get_shard_key_to_ids_mapping(),
             payload_index_schema: self.payload_index_schema.read().clone(),
         }
     }

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -32,7 +32,7 @@ impl Collection {
         self.apply_config(state.config).await?;
         self.apply_shard_transfers(state.transfers, this_peer_id, abort_transfer)
             .await?;
-        self.apply_shard_info(state.shards, state.shards_key_mapping)
+        self.apply_shard_info(state.shards, state.shards_key_mapping.to_map())
             .await?;
         self.apply_payload_index_schema(state.payload_index_schema)
             .await?;

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -7,7 +7,7 @@ use crate::config::CollectionConfigInternal;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::resharding::ReshardState;
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
+use crate::shards::shard_holder::shard_mapping::ShardKeyMappingWrapper;
 use crate::shards::transfer::ShardTransfer;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -23,7 +23,7 @@ pub struct State {
     #[serde(default)]
     pub transfers: HashSet<ShardTransfer>,
     #[serde(default)]
-    pub shards_key_mapping: ShardKeyMapping,
+    pub shards_key_mapping: ShardKeyMappingWrapper,
     #[serde(default)]
     pub payload_index_schema: PayloadIndexSchema,
 }
@@ -31,10 +31,9 @@ pub struct State {
 impl State {
     pub fn max_shard_id(&self) -> ShardId {
         self.shards_key_mapping
-            .values()
-            .flat_map(|shard_ids| shard_ids.iter())
+            .shard_ids()
+            .into_iter()
             .max()
-            .copied()
             .unwrap_or(0)
     }
 }

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -30,10 +30,6 @@ pub struct State {
 
 impl State {
     pub fn max_shard_id(&self) -> ShardId {
-        self.shards_key_mapping
-            .shard_ids()
-            .into_iter()
-            .max()
-            .unwrap_or(0)
+        self.shards_key_mapping.iter_shard_ids().max().unwrap_or(0)
     }
 }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -14,7 +14,7 @@ use futures::{Future, StreamExt, TryStreamExt as _, stream};
 use itertools::Itertools;
 use segment::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use segment::types::{ShardKey, SnapshotFormat};
-use shard_mapping::{SaveOnDiskShardKeyMappingWrapper, ShardKeyMapping};
+use shard_mapping::{SaveOnDiskShardKeyMappingWrapper, ShardKeyMapping, ShardKeyMappingWrapper};
 use tokio::runtime::Handle;
 use tokio::sync::{OwnedRwLockReadGuard, RwLock, broadcast};
 use tokio_util::codec::{BytesCodec, FramedRead};
@@ -118,8 +118,8 @@ impl ShardHolder {
         &self.shard_id_to_key_mapping
     }
 
-    pub fn get_shard_key_to_ids_mapping(&self) -> ShardKeyMapping {
-        self.key_mapping.read().clone()
+    pub fn get_shard_key_to_ids_mapping(&self) -> ShardKeyMappingWrapper {
+        ShardKeyMappingWrapper::from(self.key_mapping.read().clone())
     }
 
     pub async fn drop_and_remove_shard(

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -96,9 +96,9 @@ impl Deref for SaveOnDiskShardKeyMappingWrapper {
 /// This type functions as a compatibility layer between the two different persisted formats.
 ///
 /// Bug: <https://github.com/qdrant/qdrant/pull/5838>
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq)]
 #[serde(untagged)]
-pub(crate) enum ShardKeyMappingWrapper {
+pub enum ShardKeyMappingWrapper {
     /// The `Old` format is the original format from when shard key mappings were implemented
     // TODO(1.15): either fully remove support for the old format, or keep it a bit longer
     // TODO(1.15): if removing the old format, change back to regular SaveOnDisk<T> type
@@ -109,6 +109,11 @@ pub(crate) enum ShardKeyMappingWrapper {
 }
 
 impl ShardKeyMappingWrapper {
+    /// Convert shard key mappings into key to shard IDs map
+    pub fn to_map(&self) -> ShardKeyMapping {
+        ShardKeyMapping::from(self.clone())
+    }
+
     /// Return all shard IDs from the mappings
     pub fn shard_ids(&self) -> Vec<ShardId> {
         let ids: Vec<ShardId> = match self {
@@ -128,6 +133,47 @@ impl ShardKeyMappingWrapper {
         );
 
         ids
+    }
+
+    /// Get the shard IDs for a specific shard key
+    pub fn get(&self, shard_key: &ShardKey) -> Option<HashSet<ShardId>> {
+        match self {
+            ShardKeyMappingWrapper::Old(mapping) => mapping.get(shard_key).cloned(),
+            ShardKeyMappingWrapper::New(mappings) => {
+                let shards: HashSet<ShardId> = mappings
+                    .iter()
+                    .filter(|mapping| &mapping.key == shard_key)
+                    .flat_map(|mapping| &mapping.shard_ids)
+                    .copied()
+                    .collect();
+                (!shards.is_empty()).then_some(shards)
+            }
+        }
+    }
+
+    /// Whether this shard key mapping contains a specific key.
+    pub fn contains_key(&self, shard_key: &ShardKey) -> bool {
+        match self {
+            ShardKeyMappingWrapper::Old(mapping) => mapping.contains_key(shard_key),
+            ShardKeyMappingWrapper::New(mappings) => {
+                mappings.iter().any(|mapping| &mapping.key == shard_key)
+            }
+        }
+    }
+}
+
+impl PartialEq for ShardKeyMappingWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            // Old mappings we can compare directly
+            (ShardKeyMappingWrapper::Old(a), ShardKeyMappingWrapper::Old(b)) => a == b,
+            // New mappings and asymetric mappings must be compared in a stable format
+            (a, b) => {
+                let a = ShardKeyMapping::from(a.clone());
+                let b = ShardKeyMapping::from(b.clone());
+                a == b
+            }
+        }
     }
 }
 
@@ -174,7 +220,7 @@ impl From<ShardKeyMappingWrapper> for ShardKeyMapping {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 struct NewShardKeyMapping {
     /// Shard key
     ///

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -114,6 +114,21 @@ impl ShardKeyMappingWrapper {
         ShardKeyMapping::from(self.clone())
     }
 
+    /// Get list of shard keys
+    pub fn keys(&self) -> Vec<ShardKey> {
+        match self {
+            ShardKeyMappingWrapper::Old(mapping) => mapping.keys().cloned().collect(),
+            ShardKeyMappingWrapper::New(mappings) => {
+                // Collect into hash set first to deduplicate
+                let keys = mappings
+                    .iter()
+                    .map(|mapping| &mapping.key)
+                    .collect::<HashSet<_>>();
+                keys.into_iter().cloned().collect()
+            }
+        }
+    }
+
     /// Iterate over all shard IDs from the mappings
     pub fn iter_shard_ids<'a>(&'a self) -> Box<dyn Iterator<Item = ShardId> + 'a> {
         match self {

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -383,6 +383,7 @@ impl TableOfContent {
                     shards_key_mapping,
                     ..
                 } = collection.state().await;
+                let shards_key_mapping = shards_key_mapping.to_map();
                 let all_peers: HashSet<_> = self
                     .channel_service
                     .id_to_address

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -97,11 +97,11 @@ pub async fn handle_existing_collections(
                     collection_create_operation,
                 ));
 
-                for (shard_key, shards) in &collection_state.shards_key_mapping {
+                for (shard_key, shards) in collection_state.shards_key_mapping.to_map() {
                     let mut placement = Vec::new();
 
                     for shard_id in shards {
-                        let shard_info = collection_state.shards.get(shard_id).unwrap();
+                        let shard_info = collection_state.shards.get(&shard_id).unwrap();
                         placement.push(shard_info.replicas.keys().copied().collect());
                     }
 


### PR DESCRIPTION
Fix similar to <https://github.com/qdrant/qdrant/pull/5838>, but for shard key mappings in the consensus snapshot.

Our consensus snapshot also serializes shard key mappings in an unstable way. It may cause the data to be parsed differently during deserialization.

This PR fixes the problem with a wrapper type. It is used as compatibility layer because we still need to support older versions as well. Eventually we'll fully move to the new type to totally eliminate this problem.

Please see <https://github.com/qdrant/qdrant/pull/5838> for more details.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?