### PR TITLE
Fix consensus snapshot not applying shard key mappings

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -134,7 +134,7 @@ impl Collection {
 
             let shard_key = shard_key_mapping
                 .as_ref()
-                .and_then(|mapping| mapping.get_key(shard_id));
+                .and_then(|mapping| mapping.key(shard_id));
             let replica_set = ShardReplicaSet::build(
                 shard_id,
                 shard_key.clone(),

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -47,6 +47,7 @@ use crate::shards::replica_set::{
     ChangePeerFromState, ChangePeerState, ReplicaState, ShardReplicaSet,
 };
 use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard_holder::shard_mapping::ShardKeyMappingWrapper;
 use crate::shards::shard_holder::{LockedShardHolder, ShardHolder, shard_not_found_error};
 use crate::shards::transfer::helpers::check_transfer_conflicts_strict;
 use crate::shards::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
@@ -104,6 +105,7 @@ impl Collection {
         collection_config: &CollectionConfigInternal,
         shared_storage_config: Arc<SharedStorageConfig>,
         shard_distribution: CollectionShardDistribution,
+        shard_key_mapping: Option<ShardKeyMappingWrapper>,
         channel_service: ChannelService,
         on_replica_failure: ChangePeerFromState,
         request_shard_transfer: RequestShardTransfer,
@@ -116,6 +118,7 @@ impl Collection {
         let start_time = std::time::Instant::now();
 
         let mut shard_holder = ShardHolder::new(path)?;
+        shard_holder.set_shard_key_mappings(shard_key_mapping.clone().unwrap_or_default())?;
 
         let payload_index_schema = Arc::new(Self::load_payload_index_schema(path)?);
 
@@ -129,7 +132,9 @@ impl Collection {
                     optimizers_overwrite.update(&effective_optimizers_config)?;
             }
 
-            let shard_key = None;
+            let shard_key = shard_key_mapping
+                .as_ref()
+                .and_then(|mapping| mapping.get_key(shard_id));
             let replica_set = ShardReplicaSet::build(
                 shard_id,
                 shard_key.clone(),

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -193,13 +193,13 @@ impl Collection {
         for (shard_id, shard_info) in shards {
             match shards_holder.get_shard_mut(shard_id) {
                 Some(replica_set) => {
-                    let shard_key = shards_key_mapping.get_key(shard_id);
+                    let shard_key = shards_key_mapping.key(shard_id);
                     replica_set
                         .apply_state(shard_info.replicas, shard_key)
                         .await?;
                 }
                 None => {
-                    let shard_key = shards_key_mapping.get_key(shard_id);
+                    let shard_key = shards_key_mapping.key(shard_id);
                     let shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
                     let mut replica_set = self
                         .create_replica_set(shard_id, shard_key.clone(), &shard_replicas, None)

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -193,16 +193,20 @@ impl Collection {
         for (shard_id, shard_info) in shards {
             match shards_holder.get_shard_mut(shard_id) {
                 Some(replica_set) => {
-                    replica_set.apply_state(shard_info.replicas).await?;
-                    replica_set.shard_key = shards_key_mapping.get_key(shard_id);
+                    let shard_key = shards_key_mapping.get_key(shard_id);
+                    replica_set
+                        .apply_state(shard_info.replicas, shard_key)
+                        .await?;
                 }
                 None => {
                     let shard_key = shards_key_mapping.get_key(shard_id);
                     let shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
-                    let replica_set = self
-                        .create_replica_set(shard_id, shard_key, &shard_replicas, None)
+                    let mut replica_set = self
+                        .create_replica_set(shard_id, shard_key.clone(), &shard_replicas, None)
                         .await?;
-                    replica_set.apply_state(shard_info.replicas).await?;
+                    replica_set
+                        .apply_state(shard_info.replicas, shard_key)
+                        .await?;
                     extra_shards.insert(shard_id, replica_set);
                 }
             }

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -500,6 +500,7 @@ mod test {
             &config,
             storage_config.clone(),
             CollectionShardDistribution::all_local(None, 0),
+            None,
             ChannelService::default(),
             dummy_on_replica_failure(),
             dummy_request_shard_transfer(),

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -675,8 +675,9 @@ impl ShardReplicaSet {
     }
 
     pub async fn apply_state(
-        &self,
+        &mut self,
         replicas: HashMap<PeerId, ReplicaState>,
+        shard_key: Option<ShardKey>,
     ) -> CollectionResult<()> {
         let old_peers = self.replica_state.read().peers();
 
@@ -753,6 +754,10 @@ impl ShardReplicaSet {
             );
             self.remotes.write().await.push(new_remote);
         }
+
+        // Apply shard key
+        self.shard_key = shard_key;
+
         Ok(())
     }
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -284,6 +284,10 @@ impl ShardHolder {
         self.shards.get(&shard_id)
     }
 
+    pub fn get_shard_mut(&mut self, shard_id: ShardId) -> Option<&mut ShardReplicaSet> {
+        self.shards.get_mut(&shard_id)
+    }
+
     pub fn get_shards(&self) -> impl Iterator<Item = (ShardId, &ShardReplicaSet)> {
         self.shards.iter().map(|(id, shard)| (*id, shard))
     }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -260,8 +260,10 @@ impl ShardHolder {
 
         let all_shard_ids = self.shards.keys().cloned().collect::<HashSet<_>>();
 
+        // Update both shard key mappings
         self.key_mapping
             .write_optional(|_key_mapping| Some(shard_key_mapping.to_map()))?;
+        self.shard_id_to_key_mapping = shard_key_mapping.shards();
 
         for shard_id in all_shard_ids {
             if !shard_ids.contains(&shard_id) {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -14,7 +14,7 @@ use futures::{Future, StreamExt, TryStreamExt as _, stream};
 use itertools::Itertools;
 use segment::common::validate_snapshot_archive::open_snapshot_archive_with_validation;
 use segment::types::{ShardKey, SnapshotFormat};
-use shard_mapping::{SaveOnDiskShardKeyMappingWrapper, ShardKeyMapping, ShardKeyMappingWrapper};
+use shard_mapping::{SaveOnDiskShardKeyMappingWrapper, ShardKeyMappingWrapper};
 use tokio::runtime::Handle;
 use tokio::sync::{OwnedRwLockReadGuard, RwLock, broadcast};
 use tokio_util::codec::{BytesCodec, FramedRead};
@@ -253,7 +253,7 @@ impl ShardHolder {
     pub async fn apply_shards_state(
         &mut self,
         shard_ids: HashSet<ShardId>,
-        shard_key_mapping: ShardKeyMapping,
+        shard_key_mapping: ShardKeyMappingWrapper,
         extra_shards: HashMap<ShardId, ShardReplicaSet>,
     ) -> Result<(), CollectionError> {
         self.shards.extend(extra_shards.into_iter());
@@ -261,7 +261,7 @@ impl ShardHolder {
         let all_shard_ids = self.shards.keys().cloned().collect::<HashSet<_>>();
 
         self.key_mapping
-            .write_optional(|_key_mapping| Some(shard_key_mapping))?;
+            .write_optional(|_key_mapping| Some(shard_key_mapping.to_map()))?;
 
         for shard_id in all_shard_ids {
             if !shard_ids.contains(&shard_id) {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -57,8 +57,7 @@ pub struct ShardHolder {
     pub(crate) resharding_state: SaveOnDisk<Option<ReshardState>>,
     pub(crate) rings: HashMap<Option<ShardKey>, HashRingRouter>,
     key_mapping: SaveOnDiskShardKeyMappingWrapper,
-    // Duplicates the information from `key_mapping` for faster access
-    // Do not require locking
+    // Duplicates the information from `key_mapping` for faster access, does not use locking
     shard_id_to_key_mapping: HashMap<ShardId, ShardKey>,
 }
 

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -204,7 +204,7 @@ impl ShardKeyMappingWrapper {
     /// Get the shard key for a given shard ID
     ///
     /// `None` is returned if the shard ID has no key, or if the shard ID is unknown
-    pub fn get_key(&self, shard_id: ShardId) -> Option<ShardKey> {
+    pub fn key(&self, shard_id: ShardId) -> Option<ShardKey> {
         match self {
             ShardKeyMappingWrapper::Old(mapping) => mapping
                 .iter()

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -178,6 +178,22 @@ impl ShardKeyMappingWrapper {
         }
     }
 
+    /// Get the shard key for a given shard ID
+    ///
+    /// `None` is returned if the shard ID has no key, or if the shard ID is unknown
+    pub fn get_key(&self, shard_id: ShardId) -> Option<ShardKey> {
+        match self {
+            ShardKeyMappingWrapper::Old(mapping) => mapping
+                .iter()
+                .find(|(_, shard_ids)| shard_ids.contains(&shard_id))
+                .map(|(key, _)| key.clone()),
+            ShardKeyMappingWrapper::New(mappings) => mappings
+                .iter()
+                .find(|mapping| mapping.shard_ids.contains(&shard_id))
+                .map(|mapping| mapping.key.clone()),
+        }
+    }
+
     /// Whether this shard key mapping contains a specific key.
     pub fn contains_key(&self, shard_key: &ShardKey) -> bool {
         match self {

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -121,6 +121,29 @@ impl ShardKeyMappingWrapper {
         ShardKeyMapping::from(self.clone())
     }
 
+    /// Get a mapping of all shards and their key
+    pub fn shards(&self) -> HashMap<ShardId, ShardKey> {
+        match self {
+            ShardKeyMappingWrapper::Old(mapping) => mapping
+                .iter()
+                .flat_map(|(shard_key, shard_ids)| {
+                    shard_ids
+                        .iter()
+                        .map(|shard_id| (*shard_id, shard_key.clone()))
+                })
+                .collect(),
+            ShardKeyMappingWrapper::New(mappings) => mappings
+                .iter()
+                .flat_map(|mapping| {
+                    mapping
+                        .shard_ids
+                        .iter()
+                        .map(|shard_id| (*shard_id, mapping.key.clone()))
+                })
+                .collect(),
+        }
+    }
+
     /// Get list of shard keys
     pub fn keys(&self) -> Vec<ShardKey> {
         match self {

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -81,6 +81,7 @@ async fn fixture() -> Collection {
         &config,
         storage_config.clone(),
         CollectionShardDistribution { shards },
+        None,
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -80,6 +80,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         &config,
         Arc::new(storage_config),
         CollectionShardDistribution { shards },
+        None,
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -96,6 +96,7 @@ pub async fn new_local_collection(
         config,
         Default::default(),
         CollectionShardDistribution::all_local(Some(config.params.shard_number.into()), 0),
+        None,
         ChannelService::new(REST_PORT, None),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -74,6 +74,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         &config,
         Arc::new(storage_config),
         shard_distribution,
+        None,
         ChannelService::new(REST_PORT, None),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -186,6 +186,7 @@ impl TableOfContent {
                             .to_shared_storage_config(self.is_distributed())
                             .into(),
                         shard_distribution,
+                        Some(state.shards_key_mapping.clone()),
                         self.channel_service.clone(),
                         Self::change_peer_from_state_callback(
                             self.consensus_proposal_sender.clone(),

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -210,6 +210,10 @@ impl TableOfContent {
             strict_mode_config,
             uuid,
         };
+
+        // No shard key mapping on creation, shard keys are set up after creating the collection
+        let shard_key_mapping = None;
+
         let collection = Collection::new(
             collection_name.to_string(),
             self.this_peer_id,
@@ -218,6 +222,7 @@ impl TableOfContent {
             &collection_config,
             storage_config,
             collection_shard_distribution,
+            shard_key_mapping,
             self.channel_service.clone(),
             Self::change_peer_from_state_callback(
                 self.consensus_proposal_sender.clone(),


### PR DESCRIPTION
Similar to <https://github.com/qdrant/qdrant/pull/6210>.

Shard key mappings were not applied properly in some places when using a consensus snapshot. This fixes the issue.

Some key places that were forgotten:
- we have two fields for shard key mappings, one being the inverse - we only updated one of those fields
- replica sets also have a shard key field, we did not set it at all
- shard key mappings are sometimes known during collection creation, set it right away

A proper test for this is implemented in <https://github.com/qdrant/qdrant/pull/6213>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?