### PR TITLE
Alias shards_number to shard_number in shard key creation

### DIFF
--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -70,6 +70,7 @@ pub struct CreateShardingKey {
     pub shard_key: ShardKey,
     /// How many shards to create for this key
     /// If not specified, will use the default value from config
+    #[serde(alias = "shard_number")]
     pub shards_number: Option<NonZeroU32>,
     /// How many replicas to create for each shard
     /// If not specified, will use the default value from config


### PR DESCRIPTION
In user-defined shard key creation we have a [field](https://api.qdrant.tech/api-reference/distributed/create-shard-key#request.body.shards_number) called `shards_number`. In [other](https://api.qdrant.tech/api-reference/collections/create-collection#request.body.shard_number) places this field is called `shard_number`.

This adds an alias to support both flavors in shard key creation, because I've been rather confused by this for a bit.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?