### PR TITLE
remove failty to_string conversion for InferenceToken

### DIFF
--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -10,7 +10,6 @@ use storage::rbac::Access;
 
 use super::helpers::HttpError;
 use crate::common::auth::{AuthError, AuthKeys};
-use crate::common::inference::InferenceToken;
 
 pub struct Auth {
     auth_keys: AuthKeys,
@@ -121,10 +120,9 @@ where
                 .validate_request(|key| req.headers().get(key).and_then(|val| val.to_str().ok()))
                 .await
             {
-                Ok((access, api_key)) => {
+                Ok((access, inference_token)) => {
                     let previous = req.extensions_mut().insert::<Access>(access);
-                    req.extensions_mut()
-                        .insert(InferenceToken::new(api_key.to_string()));
+                    req.extensions_mut().insert(inference_token);
                     debug_assert!(
                         previous.is_none(),
                         "Previous access object should not exist in the request"

--- a/src/common/inference/mod.rs
+++ b/src/common/inference/mod.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use std::convert::Infallible;
-use std::fmt;
 use std::future::{Ready, ready};
 
 use actix_web::{FromRequest, HttpMessage};
@@ -37,12 +36,6 @@ impl FromRequest for InferenceToken {
     ) -> Self::Future {
         let api_key = req.extensions().get::<InferenceToken>().cloned();
         ready(Ok(api_key.unwrap_or(InferenceToken(None))))
-    }
-}
-
-impl fmt::Display for InferenceToken {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.0)
     }
 }
 


### PR DESCRIPTION
Previously qdrant middleware converted JWT InferenceToken into `"None"`m which we overlooked