### PR TITLE
Asymmetric quantization params in query encoder

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -57,6 +57,7 @@
     - [ProductQuantization](#qdrant-ProductQuantization)
     - [QuantizationConfig](#qdrant-QuantizationConfig)
     - [QuantizationConfigDiff](#qdrant-QuantizationConfigDiff)
+    - [QueryQuantizationConfig](#qdrant-QueryQuantizationConfig)
     - [RemoteShardInfo](#qdrant-RemoteShardInfo)
     - [RenameAlias](#qdrant-RenameAlias)
     - [Replica](#qdrant-Replica)
@@ -101,6 +102,7 @@
     - [MultiVectorComparator](#qdrant-MultiVectorComparator)
     - [PayloadSchemaType](#qdrant-PayloadSchemaType)
     - [QuantizationType](#qdrant-QuantizationType)
+    - [QueryQuantizationConfig.Setting](#qdrant-QueryQuantizationConfig-Setting)
     - [ReplicaState](#qdrant-ReplicaState)
     - [ReshardingDirection](#qdrant-ReshardingDirection)
     - [ShardTransferMethod](#qdrant-ShardTransferMethod)
@@ -390,6 +392,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | always_ram | [bool](#bool) | optional | If true - quantized vectors always will be stored in RAM, ignoring the config of main storage |
+| query_quantization | [QueryQuantizationConfig](#qdrant-QueryQuantizationConfig) | optional | Asymmetric quantization configuration allows a query to have different quantization than stored vectors. It can increase the accuracy of search at the cost of performance. |
 
 
 
@@ -1234,6 +1237,21 @@ Note: 1kB = 1 vector of size 256. |
 
 
 
+<a name="qdrant-QueryQuantizationConfig"></a>
+
+### QueryQuantizationConfig
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| setting | [QueryQuantizationConfig.Setting](#qdrant-QueryQuantizationConfig-Setting) |  |  |
+
+
+
+
+
+
 <a name="qdrant-RemoteShardInfo"></a>
 
 ### RemoteShardInfo
@@ -1947,6 +1965,19 @@ Note: 1kB = 1 vector of size 256. |
 | ---- | ------ | ----------- |
 | UnknownQuantization | 0 |  |
 | Int8 | 1 |  |
+
+
+
+<a name="qdrant-QueryQuantizationConfig-Setting"></a>
+
+### QueryQuantizationConfig.Setting
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| Default | 0 |  |
+| Binary | 1 |  |
+| Scalar | 2 |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7016,8 +7016,27 @@
           "always_ram": {
             "type": "boolean",
             "nullable": true
+          },
+          "query_quantization": {
+            "description": "Asymmetric quantization configuration allows a query to have different quantization than stored vectors. It can increase the accuracy of search at the cost of performance.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QueryQuantizationConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
+      },
+      "QueryQuantizationConfig": {
+        "type": "string",
+        "enum": [
+          "default",
+          "binary",
+          "scalar"
+        ]
       },
       "Datatype": {
         "type": "string",

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -297,6 +297,12 @@ message ProductQuantization {
 
 message BinaryQuantization {
   optional bool always_ram = 1; // If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+
+  /*
+  Asymmetric quantization configuration allows a query to have different quantization than stored vectors.
+  It can increase the accuracy of search at the cost of performance.
+  */
+  optional QueryQuantizationConfig query_quantization = 2;
 }
 
 message QuantizationConfig {
@@ -305,6 +311,18 @@ message QuantizationConfig {
     ProductQuantization product = 2;
     BinaryQuantization binary = 3;
   }
+}
+
+message QueryQuantizationConfig {
+    enum Setting {
+      Default = 0;
+      Binary = 1;
+      Scalar = 2;
+    }
+
+    oneof variant {
+        Setting setting = 3;
+    }
 }
 
 message Disabled {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -430,6 +430,10 @@ pub struct BinaryQuantization {
     /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
     #[prost(bool, optional, tag = "1")]
     pub always_ram: ::core::option::Option<bool>,
+    /// Asymmetric quantization configuration allows a query to have different quantization than stored vectors.
+    /// It can increase the accuracy of search at the cost of performance.
+    #[prost(message, optional, tag = "2")]
+    pub query_quantization: ::core::option::Option<QueryQuantizationConfig>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -452,6 +456,63 @@ pub mod quantization_config {
         Product(super::ProductQuantization),
         #[prost(message, tag = "3")]
         Binary(super::BinaryQuantization),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryQuantizationConfig {
+    #[prost(oneof = "query_quantization_config::Variant", tags = "3")]
+    pub variant: ::core::option::Option<query_quantization_config::Variant>,
+}
+/// Nested message and enum types in `QueryQuantizationConfig`.
+pub mod query_quantization_config {
+    #[derive(serde::Serialize)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum Setting {
+        Default = 0,
+        Binary = 1,
+        Scalar = 2,
+    }
+    impl Setting {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Setting::Default => "Default",
+                Setting::Binary => "Binary",
+                Setting::Scalar => "Scalar",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "Default" => Some(Self::Default),
+                "Binary" => Some(Self::Binary),
+                "Scalar" => Some(Self::Scalar),
+                _ => None,
+            }
+        }
+    }
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(enumeration = "Setting", tag = "3")]
+        Setting(i32),
     }
 }
 #[derive(validator::Validate)]

--- a/lib/quantization/benches/binary.rs
+++ b/lib/quantization/benches/binary.rs
@@ -44,7 +44,7 @@ fn binary_bench(c: &mut Criterion) {
     .unwrap();
 
     let query = generate_vector(vector_dim, &mut rng);
-    let encoded_query = encoded_u128.encode_query(&query);
+    let encoded_query = encoded_u128.encode_query(&query, &Default::default());
 
     let hardware_counter = HardwareCounterCell::new();
 
@@ -83,7 +83,7 @@ fn binary_bench(c: &mut Criterion) {
     .unwrap();
 
     let query = generate_vector(vector_dim, &mut rng);
-    let encoded_query = encoded_u8.encode_query(&query);
+    let encoded_query = encoded_u8.encode_query(&query, &Default::default());
 
     group.bench_function("score binary linear access u8", |b| {
         b.iter(|| {

--- a/lib/quantization/benches/encode.rs
+++ b/lib/quantization/benches/encode.rs
@@ -33,7 +33,7 @@ fn encode_dot_bench(c: &mut Criterion) {
     .unwrap();
 
     let query: Vec<f32> = (0..vector_dim).map(|_| rng.random()).collect();
-    let encoded_query = i8_encoded.encode_query(&query);
+    let encoded_query = i8_encoded.encode_query(&query, &Default::default());
 
     #[cfg(target_arch = "x86_64")]
     group.bench_function("score all u8 avx", |b| {
@@ -126,7 +126,7 @@ fn encode_l1_bench(c: &mut Criterion) {
     .unwrap();
 
     let query: Vec<f32> = (0..vector_dim).map(|_| rng.random()).collect();
-    let encoded_query = i8_encoded.encode_query(&query);
+    let encoded_query = i8_encoded.encode_query(&query, &Default::default());
 
     #[cfg(target_arch = "x86_64")]
     group.bench_function("score all u8 avx", |b| {

--- a/lib/quantization/benches/pq.rs
+++ b/lib/quantization/benches/pq.rs
@@ -34,7 +34,7 @@ fn encode_bench(c: &mut Criterion) {
     .unwrap();
 
     let query: Vec<f32> = (0..vector_dim).map(|_| rng.random()).collect();
-    let encoded_query = pq_encoded.encode_query(&query);
+    let encoded_query = pq_encoded.encode_query(&query, &Default::default());
 
     let mut total = 0.0;
 

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -21,6 +21,8 @@ pub struct VectorParameters {
 }
 
 pub trait EncodedVectors<TEncodedQuery: Sized>: Sized {
+    type QueryEncodingParams;
+
     fn save(&self, data_path: &Path, meta_path: &Path) -> std::io::Result<()>;
 
     fn load(
@@ -29,7 +31,7 @@ pub trait EncodedVectors<TEncodedQuery: Sized>: Sized {
         vector_parameters: &VectorParameters,
     ) -> std::io::Result<Self>;
 
-    fn encode_query(&self, query: &[f32]) -> TEncodedQuery;
+    fn encode_query(&self, query: &[f32], params: &Self::QueryEncodingParams) -> TEncodedQuery;
 
     fn score_point(&self, query: &TEncodedQuery, i: u32, hw_counter: &HardwareCounterCell) -> f32;
 

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -23,6 +23,13 @@ pub struct EncodedBinVector<TBitsStoreType: BitsStoreType> {
     encoded_vector: Vec<TBitsStoreType>,
 }
 
+#[derive(Default)]
+pub enum BinaryQueryEncodingParams {
+    #[default]
+    Binary,
+    Scalar,
+}
+
 #[derive(Serialize, Deserialize)]
 struct Metadata {
     vector_parameters: VectorParameters,
@@ -275,6 +282,8 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
     EncodedVectors<EncodedBinVector<TBitsStoreType>>
     for EncodedVectorsBin<TBitsStoreType, TStorage>
 {
+    type QueryEncodingParams = BinaryQueryEncodingParams;
+
     fn save(&self, data_path: &Path, meta_path: &Path) -> std::io::Result<()> {
         meta_path.parent().map(std::fs::create_dir_all);
         atomic_save_json(meta_path, &self.metadata)?;
@@ -302,7 +311,11 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         Ok(result)
     }
 
-    fn encode_query(&self, query: &[f32]) -> EncodedBinVector<TBitsStoreType> {
+    fn encode_query(
+        &self,
+        query: &[f32],
+        _params: &Self::QueryEncodingParams,
+    ) -> EncodedBinVector<TBitsStoreType> {
         debug_assert!(query.len() == self.metadata.vector_parameters.dim);
         Self::encode_vector(query)
     }

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -445,6 +445,8 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
 }
 
 impl<TStorage: EncodedStorage> EncodedVectors<EncodedQueryPQ> for EncodedVectorsPQ<TStorage> {
+    type QueryEncodingParams = ();
+
     fn save(&self, data_path: &Path, meta_path: &Path) -> std::io::Result<()> {
         meta_path.parent().map(std::fs::create_dir_all);
         atomic_save_json(meta_path, &self.metadata)?;
@@ -471,7 +473,7 @@ impl<TStorage: EncodedStorage> EncodedVectors<EncodedQueryPQ> for EncodedVectors
         Ok(result)
     }
 
-    fn encode_query(&self, query: &[f32]) -> EncodedQueryPQ {
+    fn encode_query(&self, query: &[f32], _params: &Self::QueryEncodingParams) -> EncodedQueryPQ {
         let lut_capacity = self.metadata.vector_division.len() * self.metadata.centroids.len();
         let mut lut = Vec::with_capacity(lut_capacity);
         for range in &self.metadata.vector_division {

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -288,6 +288,8 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
 }
 
 impl<TStorage: EncodedStorage> EncodedVectors<EncodedQueryU8> for EncodedVectorsU8<TStorage> {
+    type QueryEncodingParams = ();
+
     fn save(&self, data_path: &Path, meta_path: &Path) -> std::io::Result<()> {
         meta_path.parent().map(std::fs::create_dir_all);
         atomic_save_json(meta_path, &self.metadata)?;
@@ -314,7 +316,7 @@ impl<TStorage: EncodedStorage> EncodedVectors<EncodedQueryU8> for EncodedVectors
         Ok(result)
     }
 
-    fn encode_query(&self, query: &[f32]) -> EncodedQueryU8 {
+    fn encode_query(&self, query: &[f32], _params: &Self::QueryEncodingParams) -> EncodedQueryU8 {
         let dim = query.len();
         let mut query: Vec<_> = query
             .iter()

--- a/lib/quantization/tests/integration/test_avx2.rs
+++ b/lib/quantization/tests/integration/test_avx2.rs
@@ -36,7 +36,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_avx(&query_u8, index as u32);
@@ -72,7 +72,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_avx(&query_u8, index as u32);
@@ -112,7 +112,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_avx(&query_u8, index as u32);

--- a/lib/quantization/tests/integration/test_binary.rs
+++ b/lib/quantization/tests/integration/test_binary.rs
@@ -54,7 +54,7 @@ mod tests {
         .unwrap();
 
         let query: Vec<f32> = generate_vector(vector_dim, &mut rng);
-        let query_encoded = encoded.encode_query(&query);
+        let query_encoded = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {
@@ -100,7 +100,7 @@ mod tests {
         .unwrap();
 
         let query: Vec<f32> = generate_vector(vector_dim, &mut rng);
-        let query_encoded = encoded.encode_query(&query);
+        let query_encoded = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {
@@ -231,7 +231,7 @@ mod tests {
         .unwrap();
 
         let query: Vec<f32> = generate_vector(vector_dim, &mut rng);
-        let query_b = encoded.encode_query(&query);
+        let query_b = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         let mut scores: Vec<_> = vector_data
@@ -292,7 +292,7 @@ mod tests {
         .unwrap();
 
         let query: Vec<f32> = generate_vector(vector_dim, &mut rng);
-        let query_b = encoded.encode_query(&query);
+        let query_b = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         let mut scores: Vec<_> = vector_data
@@ -469,7 +469,7 @@ mod tests {
         .unwrap();
 
         let query: Vec<f32> = generate_vector(vector_dim, &mut rng);
-        let query_b = encoded.encode_query(&query);
+        let query_b = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         let mut scores: Vec<_> = vector_data
@@ -530,7 +530,7 @@ mod tests {
         .unwrap();
 
         let query: Vec<f32> = generate_vector(vector_dim, &mut rng);
-        let query_b = encoded.encode_query(&query);
+        let query_b = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         let mut scores: Vec<_> = vector_data

--- a/lib/quantization/tests/integration/test_neon.rs
+++ b/lib/quantization/tests/integration/test_neon.rs
@@ -36,7 +36,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_neon(&query_u8, index as u32);
@@ -72,7 +72,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_neon(&query_u8, index as u32);
@@ -108,7 +108,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_neon(&query_u8, index as u32);

--- a/lib/quantization/tests/integration/test_pq.rs
+++ b/lib/quantization/tests/integration/test_pq.rs
@@ -37,7 +37,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {
@@ -70,7 +70,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {
@@ -103,7 +103,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {
@@ -136,7 +136,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {
@@ -169,7 +169,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {
@@ -202,7 +202,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         let counter = HardwareCounterCell::new();
         for (index, vector) in vector_data.iter().enumerate() {

--- a/lib/quantization/tests/integration/test_simple.rs
+++ b/lib/quantization/tests/integration/test_simple.rs
@@ -36,7 +36,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_simple(&query_u8, index as u32);
@@ -72,7 +72,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_simple(&query_u8, index as u32);
@@ -112,7 +112,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_simple(&query_u8, index as u32);
@@ -148,7 +148,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_simple(&query_u8, index as u32);
@@ -184,7 +184,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_simple(&query_u8, index as u32);
@@ -224,7 +224,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_simple(&query_u8, index as u32);
@@ -330,7 +330,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_simple(&query_u8, index as u32);

--- a/lib/quantization/tests/integration/test_sse.rs
+++ b/lib/quantization/tests/integration/test_sse.rs
@@ -36,7 +36,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_sse(&query_u8, index as u32);
@@ -72,7 +72,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_sse(&query_u8, index as u32);
@@ -108,7 +108,7 @@ mod tests {
             &AtomicBool::new(false),
         )
         .unwrap();
-        let query_u8 = encoded.encode_query(&query);
+        let query_u8 = encoded.encode_query(&query, &Default::default());
 
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point_sse(&query_u8, index as u32);

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -132,6 +132,7 @@ fn test_gpu_vector_storage_bq(
     let quantization_config = QuantizationConfig::Binary(BinaryQuantization {
         binary: BinaryQuantizationConfig {
             always_ram: Some(true),
+            query_quantization: None,
         },
     });
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -703,7 +703,7 @@ impl Validate for QuantizationConfig {
 #[derive(
     Default, Debug, Deserialize, Serialize, JsonSchema, Anonymize, Clone, PartialEq, Eq, Hash,
 )]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 #[anonymize(false)]
 pub enum QueryQuantizationConfig {
     #[default]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -657,6 +657,11 @@ impl Eq for ScalarQuantizationConfig {}
 pub struct BinaryQuantizationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub always_ram: Option<bool>,
+
+    /// Asymmetric quantization configuration allows a query to have different quantization than stored vectors.
+    /// It can increase the accuracy of search at the cost of performance.
+    #[serde(skip_serializing_if = "QueryQuantizationConfig::serde_skip_condition")]
+    pub query_quantization: Option<QueryQuantizationConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq, Hash)]
@@ -692,6 +697,24 @@ impl Validate for QuantizationConfig {
             QuantizationConfig::Product(product) => product.validate(),
             QuantizationConfig::Binary(binary) => binary.validate(),
         }
+    }
+}
+
+#[derive(
+    Default, Debug, Deserialize, Serialize, JsonSchema, Anonymize, Clone, PartialEq, Eq, Hash,
+)]
+#[serde(untagged, rename_all = "snake_case")]
+#[anonymize(false)]
+pub enum QueryQuantizationConfig {
+    #[default]
+    Default,
+    Binary,
+    Scalar,
+}
+
+impl QueryQuantizationConfig {
+    pub fn serde_skip_condition(config: &Option<Self>) -> bool {
+        config.is_none() || matches!(config, Some(Self::Default))
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -42,6 +42,7 @@ where
         raw_query: TInputQuery,
         quantized_storage: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
+        query_encoding_params: &TEncodedVectors::QueryEncodingParams,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
@@ -67,7 +68,8 @@ where
                     TMetric::distance(),
                     &original_vector,
                 );
-                Ok(quantized_storage.encode_query(&original_vector_prequantized))
+                Ok(quantized_storage
+                    .encode_query(&original_vector_prequantized, query_encoding_params))
             })
             .unwrap();
 
@@ -87,6 +89,7 @@ where
         raw_query: TInputQuery,
         quantized_storage: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
+        query_encoding_params: &TEncodedVectors::QueryEncodingParams,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
@@ -117,7 +120,8 @@ where
                     TMetric::distance(),
                     &original_vector.flattened_vectors,
                 );
-                Ok(quantized_storage.encode_query(&original_vector_prequantized))
+                Ok(quantized_storage
+                    .encode_query(&original_vector_prequantized, query_encoding_params))
             })
             .unwrap();
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -234,6 +234,8 @@ where
     QuantizedStorage: EncodedVectors<TEncodedQuery>,
     TMultivectorOffsetsStorage: MultivectorOffsetsStorage,
 {
+    type QueryEncodingParams = QuantizedStorage::QueryEncodingParams;
+
     // TODO(colbert): refactor `EncodedVectors` to support multi vector storage after quantization migration
     fn save(&self, _data_path: &Path, _meta_path: &Path) -> std::io::Result<()> {
         unreachable!("multivector quantized storage should be saved using `self.save_multi` method")
@@ -250,14 +252,18 @@ where
         )
     }
 
-    fn encode_query(&self, query: &[VectorElementType]) -> Vec<TEncodedQuery> {
+    fn encode_query(
+        &self,
+        query: &[VectorElementType],
+        params: &Self::QueryEncodingParams,
+    ) -> Vec<TEncodedQuery> {
         let multi_vector = TypedMultiDenseVectorRef {
             dim: self.dim,
             flattened_vectors: query,
         };
         multi_vector
             .multi_vectors()
-            .map(|inner_vector| self.quantized_storage.encode_query(inner_vector))
+            .map(|inner_vector| self.quantized_storage.encode_query(inner_vector, params))
             .collect()
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -35,6 +35,7 @@ where
         raw_query: DenseVector,
         quantized_data: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
+        query_encoding_params: &TEncodedVectors::QueryEncodingParams,
         hardware_counter: HardwareCounterCell,
     ) -> Self {
         let raw_preprocessed_query = TMetric::preprocess(raw_query);
@@ -44,7 +45,8 @@ where
             TMetric::distance(),
             original_query.as_ref(),
         );
-        let query = quantized_data.encode_query(&original_query_prequantized);
+        let query =
+            quantized_data.encode_query(&original_query_prequantized, query_encoding_params);
 
         Self {
             query,
@@ -59,6 +61,7 @@ where
         raw_query: &MultiDenseVectorInternal,
         quantized_data: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
+        query_encoding_params: &TEncodedVectors::QueryEncodingParams,
         hardware_counter: HardwareCounterCell,
     ) -> Self {
         let mut query = Vec::new();
@@ -73,7 +76,7 @@ where
             query.extend_from_slice(&inner_prequantized);
         }
 
-        let query = quantized_data.encode_query(&query);
+        let query = quantized_data.encode_query(&query, query_encoding_params);
 
         Self {
             query,

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -160,6 +160,7 @@ fn product_x4() -> WithQuantization {
 fn binary() -> WithQuantization {
     let config = BinaryQuantizationConfig {
         always_ram: Some(true),
+        query_quantization: None,
     }
     .into();
 

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -316,7 +316,11 @@ fn test_byte_storage_binary_quantization_hnsw(
             always_ram: None,
         }
         .into(),
-        QuantizationVariant::Binary => BinaryQuantizationConfig { always_ram: None }.into(),
+        QuantizationVariant::Binary => BinaryQuantizationConfig {
+            always_ram: None,
+            query_quantization: None,
+        }
+        .into(),
     };
 
     segment_byte

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -283,6 +283,7 @@ fn test_multivector_quantization_hnsw(
         .into(),
         QuantizationVariant::Binary => BinaryQuantizationConfig {
             always_ram: Some(false),
+            query_quantization: None,
         }
         .into(),
     };


### PR DESCRIPTION
Next step after https://github.com/qdrant/qdrant/pull/6201

This PR glues API for asymmetric quantization and quantization query encoding. It skips actual scoring, this PR is only about API integration.