### PR TITLE
Unify function for creating shard key, we had it in two places

### DIFF
--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -194,29 +194,6 @@ def create_field_index(
     assert_http_ok(r_batch)
 
 
-def create_shard_key(
-    peer_url,
-    collection="test_collection",
-    shard_key="shard_key",
-    shard_number=None,
-    replication_factor=None,
-    timeout=10,
-    headers=None,
-):
-    if headers is None:
-        headers = {}
-    r_create = requests.put(
-        f"{peer_url}/collections/{collection}/shards?timeout={timeout}",
-        json={
-            "shard_key": shard_key,
-            "shards_number": shard_number,
-            "replication_factor": replication_factor,
-        },
-        headers=headers,
-    )
-    assert_http_ok(r_create)
-
-
 def search(peer_url, vector, city, collection="test_collection"):
     q = {
         "vector": vector,

--- a/tests/consensus_tests/test_consensus_compaction.py
+++ b/tests/consensus_tests/test_consensus_compaction.py
@@ -4,8 +4,8 @@ import shutil
 from time import sleep
 from typing import Any
 
-from consensus_tests.fixtures import create_collection, create_shard_key, drop_collection
 import requests
+from consensus_tests.fixtures import create_collection, drop_collection
 from .utils import *
 
 N_PEERS = 3
@@ -96,7 +96,7 @@ def test_consensus_compaction_shard_keys(tmp_path: pathlib.Path):
 
     # Create shard keys
     for _, shard_key in SHARD_KEYS.items():
-        create_shard_key(peer_url=peer_api_uris[0], collection="test_collection", shard_key=shard_key)
+        create_shard_key(shard_key, peer_api_uris[0], collection="test_collection")
 
     # Validate shard keys on all peers
     wait_collection_exists_and_active_on_all_peers(collection_name="test_collection", peer_api_uris=peer_api_uris)

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -711,15 +711,28 @@ def wait_collection_exists_and_active_on_all_peers(collection_name: str, peer_ap
         wait_for_all_replicas_active(collection_name=collection_name, peer_api_uri=peer_uri, headers=headers)
 
 
-def create_shard_key(shard_key, peer_url, collection="test_collection", placement=None):
-    r_batch = requests.put(
-        f"{peer_url}/collections/{collection}/shards",
+def create_shard_key(
+    shard_key,
+    peer_url,
+    collection="test_collection",
+    shard_number=None,
+    replication_factor=None,
+    placement=None,
+    timeout=10,
+    headers={},
+):
+    r_create = requests.put(
+        f"{peer_url}/collections/{collection}/shards?timeout={timeout}",
         json={
             "shard_key": shard_key,
+            "shards_number": shard_number,
+            "replication_factor": replication_factor,
             "placement": placement,
         },
+        headers=headers,
     )
-    assert_http_ok(r_batch)
+    assert_http_ok(r_create)
+
 
 def move_shard(source_uri, collection_name, shard_id, source_peer_id, target_peer_id):
     r = requests.post(


### PR DESCRIPTION
In our consensus tests, we had two different functions to create a shard key. This unifies them.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?