### PR TITLE
Add `all` feature flag, report enabled flags on start

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,9 +1,7 @@
 log_level: DEBUG
 
 feature_flags:
-  use_new_shard_key_mapping_format: true
-  use_mutable_id_tracker_without_rocksdb: true
-  payload_index_skip_rocksdb: true
+  all: true
 
 inference:
   address: "http://localhost:2114/api/v1/infer"

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -8,7 +8,9 @@ static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
 #[derive(Default, Debug, Deserialize, Clone, Copy)]
 pub struct FeatureFlags {
     /// Magic feature flag that enables all features.
-    pub all: bool,
+    ///
+    /// Note that this will only be applied to all flags when passed into [`init_feature_flags`].
+    all: bool,
 
     /// Whether to use the new format to persist shard keys
     ///

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -42,12 +42,12 @@ impl FeatureFlags {
     /// Check if no flag is set at all
     pub fn is_empty(self) -> bool {
         let FeatureFlags {
-            all,
+            all: _,
             use_new_shard_key_mapping_format,
             use_mutable_id_tracker_without_rocksdb,
             payload_index_skip_rocksdb,
         } = self;
-        !all && !use_new_shard_key_mapping_format
+        !use_new_shard_key_mapping_format
             && !use_mutable_id_tracker_without_rocksdb
             && !payload_index_skip_rocksdb
     }

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -36,6 +36,21 @@ pub struct FeatureFlags {
     pub payload_index_skip_rocksdb: bool,
 }
 
+impl FeatureFlags {
+    /// Check if no flag is set at all
+    pub fn is_empty(self) -> bool {
+        let FeatureFlags {
+            all,
+            use_new_shard_key_mapping_format,
+            use_mutable_id_tracker_without_rocksdb,
+            payload_index_skip_rocksdb,
+        } = self;
+        !all && !use_new_shard_key_mapping_format
+            && !use_mutable_id_tracker_without_rocksdb
+            && !payload_index_skip_rocksdb
+    }
+}
+
 /// Initializes the global feature flags with `flags`. Must only be called once at
 /// startup or otherwise throws a warning and discards the values.
 pub fn init_feature_flags(mut flags: FeatureFlags) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn main() -> anyhow::Result<()> {
     let settings = Settings::new(args.config_path)?;
 
     // Set global feature flags, sourced from configuration
-    init_feature_flags(&settings.feature_flags);
+    init_feature_flags(settings.feature_flags);
 
     let reporting_enabled = !settings.telemetry_disabled && !args.disable_telemetry;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use ::common::budget::{ResourceBudget, get_io_budget};
 use ::common::cpu::get_cpu_budget;
-use ::common::flags::init_feature_flags;
+use ::common::flags::{feature_flags, init_feature_flags};
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
@@ -213,6 +213,12 @@ fn main() -> anyhow::Result<()> {
 
     // Validate as soon as possible, but we must initialize logging first
     settings.validate_and_warn();
+
+    // Report feature flags that are enabled for easier debugging
+    let flags = feature_flags();
+    if !flags.is_empty() {
+        log::debug!("Feature flags: {flags:?}");
+    }
 
     let bootstrap = if args.bootstrap == args.uri {
         if args.bootstrap.is_some() {


### PR DESCRIPTION
Extends <https://github.com/qdrant/qdrant/pull/6194>

This extends feature flags a bit, adding two useful improvements:

1. add magic `all` flag that enables everything
2. if any feature flags are set, log them on start

The `all` flag is especially useful on chaos testing to always enable the feature flags we set up. This prevents us from constantly having to bump environment variables for new flags we add. It also keeps our development configuration file a bit cleaner.

The log entry for enabled feature flags is rather basic and looks like this:

```log
2025-03-21T15:53:59.394753Z DEBUG qdrant: Feature flags: FeatureFlags { all: true, use_new_shard_key_mapping_format: true, use_mutable_id_tracker_without_rocksdb: true }
```

I've again tried to keep this as simple as possible.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
4. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
5. [x] Have you checked your code using `cargo clippy --all --all-features` command?