### PR TITLE
Properly use shard snapshot initializing flag while recovering

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -240,23 +240,14 @@ impl Collection {
         //   Check that shard snapshot is compatible with the collection
         //   (see `VectorsConfig::check_compatible_with_segment_config`)
 
-        // set shard_id initialization flag
-        // the file is removed after full recovery to indicate a well-formed shard
-        let shard_flag = shard_initializing_flag_path(&self.path, shard_id);
-        let flag_file = tokio::fs::File::create(&shard_flag).await?;
-        flag_file.sync_all().await?;
-
         // `ShardHolder::recover_local_shard_from` is *not* cancel safe
         // (see `ShardReplicaSet::restore_local_replica_from`)
         let res = self
             .shards_holder
             .read()
             .await
-            .recover_local_shard_from(snapshot_shard_path, shard_id, cancel)
+            .recover_local_shard_from(snapshot_shard_path, &self.path, shard_id, cancel)
             .await?;
-
-        // remove shard_id initialization flag because shard is fully recovered
-        tokio::fs::remove_file(&shard_flag).await?;
 
         Ok(res)
     }
@@ -321,6 +312,7 @@ impl Collection {
             .await
             .restore_shard_snapshot(
                 snapshot_path,
+                &self.path,
                 &self.name(),
                 shard_id,
                 this_peer_id,

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -25,7 +25,7 @@ use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{self, ShardConfig};
 use crate::shards::shard_holder::shard_mapping::ShardKeyMappingWrapper;
 use crate::shards::shard_holder::{SHARD_KEY_MAPPING_FILE, ShardHolder, shard_not_found_error};
-use crate::shards::{shard_initializing_flag_path, shard_path};
+use crate::shards::shard_path;
 
 impl Collection {
     pub fn get_snapshots_storage_manager(&self) -> CollectionResult<SnapshotStorageManager> {

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -121,9 +121,6 @@ impl ShardReplicaSet {
 
             LocalShard::move_data(replica_path, &self.shard_path).await?;
 
-            // remove shard_id initialization flag because shard is fully recovered
-            tokio::fs::remove_file(&shard_flag).await?;
-
             LocalShard::load(
                 self.shard_id,
                 self.collection_id.clone(),
@@ -142,6 +139,8 @@ impl ShardReplicaSet {
         match restore.await {
             Ok(new_local) => {
                 local.replace(Shard::Local(new_local));
+                // remove shard_id initialization flag because shard is fully recovered
+                tokio::fs::remove_file(&shard_flag).await?;
                 Ok(true)
             }
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1052,7 +1052,7 @@ impl ShardHolder {
         // set shard_id initialization flag
         // the file is removed after full recovery to indicate a well-formed shard
         // for example: some of the files may go missing if node gets killed during shard directory move/replace
-        let shard_flag = shard_initializing_flag_path(&collection_path, shard_id);
+        let shard_flag = shard_initializing_flag_path(collection_path, shard_id);
         let flag_file = tokio::fs::File::create(&shard_flag).await?;
         flag_file.sync_all().await?;
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -963,6 +963,7 @@ impl ShardHolder {
     pub async fn restore_shard_snapshot(
         &self,
         snapshot_path: &Path,
+        collection_path: &Path,
         collection_name: &str,
         shard_id: ShardId,
         this_peer_id: PeerId,
@@ -1022,7 +1023,7 @@ impl ShardHolder {
         // `ShardHolder::recover_local_shard_from` is *not* cancel safe
         // (see `ShardReplicaSet::restore_local_replica_from`)
         let recovered = self
-            .recover_local_shard_from(snapshot_temp_dir.path(), shard_id, cancel)
+            .recover_local_shard_from(snapshot_temp_dir.path(), collection_path, shard_id, cancel)
             .await?;
 
         if !recovered {
@@ -1040,6 +1041,7 @@ impl ShardHolder {
     pub async fn recover_local_shard_from(
         &self,
         snapshot_shard_path: &Path,
+        collection_path: &Path,
         shard_id: ShardId,
         cancel: cancel::CancellationToken,
     ) -> CollectionResult<bool> {
@@ -1047,14 +1049,25 @@ impl ShardHolder {
         //   Check that shard snapshot is compatible with the collection
         //   (see `VectorsConfig::check_compatible_with_segment_config`)
 
+        // set shard_id initialization flag
+        // the file is removed after full recovery to indicate a well-formed shard
+        // for example: some of the files may go missing if node gets killed during shard directory move/replace
+        let shard_flag = shard_initializing_flag_path(&collection_path, shard_id);
+        let flag_file = tokio::fs::File::create(&shard_flag).await?;
+        flag_file.sync_all().await?;
+
         let replica_set = self
             .get_shard(shard_id)
             .ok_or_else(|| shard_not_found_error(shard_id))?;
 
         // `ShardReplicaSet::restore_local_replica_from` is *not* cancel safe
-        replica_set
+        let res = replica_set
             .restore_local_replica_from(snapshot_shard_path, cancel)
-            .await
+            .await?;
+
+        tokio::fs::remove_file(&shard_flag).await?; // remove shard_id initialization flag because shard is fully recovered
+
+        Ok(res)
     }
 
     /// # Cancel safety

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1053,11 +1053,9 @@ impl ShardHolder {
             .get_shard(shard_id)
             .ok_or_else(|| shard_not_found_error(shard_id))?;
 
-        let shard_initializing_flag_path = shard_initializing_flag_path(collection_path, shard_id);
-
         // `ShardReplicaSet::restore_local_replica_from` is *not* cancel safe
         let res = replica_set
-            .restore_local_replica_from(snapshot_shard_path, &shard_initializing_flag_path, cancel)
+            .restore_local_replica_from(snapshot_shard_path, collection_path, cancel)
             .await?;
 
         Ok(res)


### PR DESCRIPTION
We introduced shard initailizing flag to clean dirty snapshots after a failed shard snapshot recovery (for example: files missing after move/rename step in shard snapshot recovery due to node crash)

However, there are 2 functions that call `ShardHolder::recover_local_shard_from()` and we were creating/deleting this flag in only one of them which led to panics in chaos testing. This PR makes Qdrant use the snapshot flag in both places by making it a part of `ShardHolder::recover_local_shard_from` so Qdrant cleans up the dirty shard on its own.

More context of this can be found in https://github.com/qdrant/qdrant/pull/6199#issuecomment-2743350845

### All Submissions:
* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

