### PR TITLE
[order_by] Deprecate using `order_value` from payload, dedup by `(order_value, id)` tuple

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -343,7 +343,7 @@ impl Collection {
                     // Get top results
                     .kmerge_by(|a, b| match order_by.direction() {
                         Direction::Asc => (a.order_value, a.id) < (b.order_value, b.id),
-                        Direction::Desc => (b.order_value, b.id) > (a.order_value, a.id),
+                        Direction::Desc => (a.order_value, a.id) > (b.order_value, b.id),
                     })
                     // Only keep the point with the most "valuable" order value
                     // This means that the same point will be repeated only if there is an alternating order value with another point

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -345,20 +345,9 @@ impl Collection {
                         Direction::Asc => (a.order_value, a.id) < (b.order_value, b.id),
                         Direction::Desc => (a.order_value, a.id) > (b.order_value, b.id),
                     })
-                    // Only keep the point with the most "valuable" order value
-                    // This means that the same point will be repeated only if there is an alternating order value with another point
-                    // E.g.
-                    // For these points
-                    // { id: 1, values: [11, 21]}
-                    // { id: 2, values: [12, 22, 32]}
-                    //
-                    // The output will be
-                    // { id: 1, order_value: 11 }
-                    // { id: 2, order_value: 12 }
-                    // { id: 1, order_value: 21 }
-                    // { id: 2, order_value: 22 }
-                    // (no order_value 32)
-                    .dedup_by(|record_a, record_b| record_a.id == record_b.id)
+                    .dedup_by(|record_a, record_b| {
+                        (record_a.order_value, record_a.id) == (record_b.order_value, record_b.id)
+                    })
                     .map(api::rest::Record::from)
                     .take(limit)
                     .collect_vec()

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -140,30 +140,17 @@ impl ShardOperation for LocalShard {
                 .await
             }
             Some(order_by) => {
-                let (mut records, values) = self
-                    .scroll_by_field(
-                        limit,
-                        with_payload_interface,
-                        with_vector,
-                        filter,
-                        search_runtime_handle,
-                        order_by,
-                        timeout,
-                        hw_measurement_acc,
-                    )
-                    .await?;
-
-                records.iter_mut().zip(values).for_each(|(record, value)| {
-                    // TODO(1.11): stop inserting the value in the payload, only use the order_value
-                    // Add order_by value to the payload. It will be removed in the next step, after crossing the shard boundary.
-                    let new_payload =
-                        OrderBy::insert_order_value_in_payload(record.payload.take(), value);
-
-                    record.payload = Some(new_payload);
-                    record.order_value = Some(value);
-                });
-
-                Ok(records)
+                self.scroll_by_field(
+                    limit,
+                    with_payload_interface,
+                    with_vector,
+                    filter,
+                    search_runtime_handle,
+                    order_by,
+                    timeout,
+                    hw_measurement_acc,
+                )
+                .await
             }
         }
     }

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -731,9 +731,6 @@ impl ShardOperation for RemoteShard {
             .await?
             .into_inner();
 
-        // We need the `____ordered_with____` value even if the user didn't request payload
-        let parse_payload = with_payload_interface.is_required() || order_by.is_some();
-
         if let Some(hw_usage) = scroll_response.usage {
             hw_measurement_acc.accumulate_request(hw_usage);
         }
@@ -741,7 +738,7 @@ impl ShardOperation for RemoteShard {
         let result: Result<Vec<RecordInternal>, Status> = scroll_response
             .result
             .into_iter()
-            .map(|point| try_record_from_grpc(point, parse_payload))
+            .map(|point| try_record_from_grpc(point, with_payload_interface.is_required()))
             .collect();
 
         result.map_err(|e| e.into())

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -202,11 +202,13 @@ async fn test_scroll_dedup() {
     assert!(!result.points.is_empty(), "expected some points");
 
     let mut seen = HashSet::new();
-    for point_id in result.points.iter().map(|point| point.id) {
+    for record in result.points.iter() {
         assert!(
-            seen.insert(point_id),
-            "got point id {point_id:?} more than once, they should be deduplicated",
+            seen.insert((record.id, record.order_value)),
+            "got point id {:?} more than once, they should be deduplicated",
+            record.id,
         );
+        assert!(record.order_value.is_some());
     }
 }
 

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -205,8 +205,9 @@ async fn test_scroll_dedup() {
     for record in result.points.iter() {
         assert!(
             seen.insert((record.id, record.order_value)),
-            "got point id {:?} more than once, they should be deduplicated",
+            "got point id {:?} with order value {:?} more than once, they should be deduplicated",
             record.id,
+            record.order_value,
         );
         assert!(record.order_value.is_some());
     }

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -638,7 +638,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 let b = b.0.get(key).unwrap().as_f64();
                 a >= b
             }),
-            "got: {:#?}",
+            "Expected descending order when using {key} key, got: {:#?}",
             result_desc.points
         );
 

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -6,10 +6,8 @@ use validator::Validate;
 
 use crate::json_path::JsonPath;
 use crate::types::{
-    DateTimePayloadType, FloatPayloadType, IntPayloadType, Order, Payload, Range, RangeInterface,
+    DateTimePayloadType, FloatPayloadType, IntPayloadType, Order, Range, RangeInterface,
 };
-
-const INTERNAL_KEY_OF_ORDER_BY_VALUE: &str = "____ordered_with____";
 
 #[derive(Deserialize, Serialize, JsonSchema, Copy, Clone, Debug, Default, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -105,38 +103,6 @@ impl OrderBy {
                 Direction::Asc => OrderValue::MIN,
                 Direction::Desc => OrderValue::MAX,
             })
-    }
-
-    pub fn insert_order_value_in_payload(
-        payload: Option<Payload>,
-        value: impl Into<serde_json::Value>,
-    ) -> Payload {
-        let mut new_payload = payload.unwrap_or_default();
-        new_payload
-            .0
-            .insert(INTERNAL_KEY_OF_ORDER_BY_VALUE.to_string(), value.into());
-        new_payload
-    }
-
-    fn json_value_to_ordering_value(&self, value: Option<serde_json::Value>) -> OrderValue {
-        value
-            .and_then(|v| OrderValue::try_from(v).ok())
-            .unwrap_or_else(|| match self.direction() {
-                Direction::Asc => OrderValue::MAX,
-                Direction::Desc => OrderValue::MIN,
-            })
-    }
-
-    pub fn get_order_value_from_payload(&self, payload: Option<&Payload>) -> OrderValue {
-        self.json_value_to_ordering_value(
-            payload.and_then(|payload| payload.0.get(INTERNAL_KEY_OF_ORDER_BY_VALUE).cloned()),
-        )
-    }
-
-    pub fn remove_order_value_from_payload(&self, payload: Option<&mut Payload>) -> OrderValue {
-        self.json_value_to_ordering_value(
-            payload.and_then(|payload| payload.0.remove(INTERNAL_KEY_OF_ORDER_BY_VALUE)),
-        )
     }
 }
 


### PR DESCRIPTION
Initially, we started inserting the order_by value in the payload. Since version 1.11 we can already deprecate this behavior because now we have a dedicated field in the point struct.

This PR removes the legacy code which inserted and removed the order_by value in the payload.
