### PR TITLE
Add fallback for missing all feature_flag

### DIFF
--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -10,6 +10,7 @@ pub struct FeatureFlags {
     /// Magic feature flag that enables all features.
     ///
     /// Note that this will only be applied to all flags when passed into [`init_feature_flags`].
+    #[serde(default)]
     all: bool,
 
     /// Whether to use the new format to persist shard keys


### PR DESCRIPTION
If you pass:

```yaml
feature_flags:
  use_new_shard_key_mapping_format: true
  use_mutable_id_tracker_without_rocksdb: true
  payload_index_skip_rocksdb: true
```

Qdrant throws error because `all` field is not passed. 

```
Error: missing field `all` for key `feature_flags`
```

We should add a fallback for it (false) so other vars can be set independently. This was detected by chaos testing.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
