### PR TITLE
Move filtering logic from RawScorer to FilteredScorer

### DIFF
--- a/lib/common/common/src/iterator_ext/mod.rs
+++ b/lib/common/common/src/iterator_ext/mod.rs
@@ -43,6 +43,16 @@ pub trait IteratorExt: Iterator {
     {
         OnFinalCount::new(self, f)
     }
+
+    /// Consume the iterator and call `black_box` on each item, for benchmarking purposes.
+    fn black_box(self)
+    where
+        Self: Sized,
+    {
+        self.for_each(|p| {
+            std::hint::black_box(p);
+        });
+    }
 }
 
 impl<I: Iterator> IteratorExt for I {}

--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -5,9 +5,8 @@ use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use segment::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer};
+use segment::fixtures::index_fixtures::TestRawScorerProducer;
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
-use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::simple::CosineMetric;
 use segment::vector_storage::chunked_vector_storage::VectorOffsetType;
 
@@ -27,11 +26,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let mut rng = rand::rng();
             let mut graph_layers_builder =
                 GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);
-            let fake_filter_context = FakeFilterContext {};
             for idx in 0..(NUM_VECTORS as PointOffsetType) {
                 let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
-                let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
-                let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
+                let scorer = vector_holder.get_scorer(added_vector);
                 let level = graph_layers_builder.get_random_layer(&mut rng);
                 graph_layers_builder.set_levels(idx, level);
                 graph_layers_builder.link_new_point(idx, scorer);

--- a/lib/segment/benches/scorer_mmap.rs
+++ b/lib/segment/benches/scorer_mmap.rs
@@ -10,11 +10,10 @@ use segment::data_types::named_vectors::CowVector;
 use segment::data_types::vectors::{DenseVector, QueryVector};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
+use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::types::Distance;
 use segment::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage;
-use segment::vector_storage::{
-    DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer_for_test,
-};
+use segment::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
 use tempfile::Builder;
 
 #[cfg(not(target_os = "windows"))]
@@ -64,12 +63,11 @@ fn benchmark_scorer_mmap(c: &mut Criterion) {
         b.iter_batched(
             || QueryVector::from(random_vector(DIM)),
             |vector| {
-                new_raw_scorer_for_test(
+                FilteredScorer::new_for_test(
                     vector,
                     &storage,
                     borrowed_id_tracker.deleted_point_bitslice(),
                 )
-                .unwrap()
                 .peek_top_all(10, &DEFAULT_STOPPED)
                 .unwrap()
             },

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -471,10 +471,9 @@ mod tests {
 
     use super::*;
     use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
-    use crate::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer};
+    use crate::fixtures::index_fixtures::TestRawScorerProducer;
     use crate::index::hnsw_index::graph_layers::GraphLayersBase;
     use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
-    use crate::index::hnsw_index::point_scorer::FilteredScorer;
     use crate::spaces::simple::DotProductMetric;
     use crate::types::Distance;
     use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
@@ -536,10 +535,8 @@ mod tests {
             graph_layers_builder.set_levels(idx, level);
         }
         for idx in 0..(num_vectors as PointOffsetType) {
-            let fake_filter_context = FakeFilterContext {};
             let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
-            let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
-            let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
+            let scorer = vector_holder.get_scorer(added_vector.clone());
             graph_layers_builder.link_new_point(idx, scorer);
         }
 
@@ -745,13 +742,8 @@ mod tests {
 
         // Check response
         for i in 0..groups_count {
-            let fake_filter_context = FakeFilterContext {};
             let added_vector = test.vector_holder.vectors.get(num_vectors + i).to_vec();
-            let raw_scorer = test
-                .vector_holder
-                .get_raw_scorer(added_vector.clone())
-                .unwrap();
-            let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
+            let mut scorer = test.vector_holder.get_scorer(added_vector.clone());
             let entry = ScoredPointOffset {
                 idx: 0,
                 score: scorer.score_point(0),
@@ -805,13 +797,8 @@ mod tests {
 
         // Check response
         for (i, &gpu_search_result) in gpu_responses.iter().enumerate() {
-            let fake_filter_context = FakeFilterContext {};
             let added_vector = test.vector_holder.vectors.get(num_vectors + i).to_vec();
-            let raw_scorer = test
-                .vector_holder
-                .get_raw_scorer(added_vector.clone())
-                .unwrap();
-            let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
+            let mut scorer = test.vector_holder.get_scorer(added_vector.clone());
             let search_result = test
                 .graph_layers_builder
                 .search_entry_on_level(0, 0, &mut scorer);
@@ -973,13 +960,8 @@ mod tests {
 
         // Check response
         for (i, gpu_group_result) in gpu_responses.iter().enumerate() {
-            let fake_filter_context = FakeFilterContext {};
             let added_vector = test.vector_holder.vectors.get(num_vectors + i).to_vec();
-            let raw_scorer = test
-                .vector_holder
-                .get_raw_scorer(added_vector.clone())
-                .unwrap();
-            let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
+            let mut scorer = test.vector_holder.get_scorer(added_vector.clone());
             let entry = ScoredPointOffset {
                 idx: 0,
                 score: scorer.score_point(0),

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -2,7 +2,6 @@
 
 use std::path::Path;
 
-use bitvec::vec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use parking_lot::RwLock;
 use rand::rngs::StdRng;
@@ -690,16 +689,15 @@ fn test_gpu_vector_storage_impl(
 
     let gpu_scores = staging_buffer.download_vec(0, num_vectors).unwrap();
 
-    let point_deleted = BitVec::repeat(false, num_vectors);
     let query = QueryVector::Nearest(storage.get_vector(test_point_id).to_owned());
 
     let hardware_counter = HardwareCounterCell::new();
     let scorer: Box<dyn RawScorer> = if let Some(quantized_vectors) = quantized_vectors.as_ref() {
         quantized_vectors
-            .raw_scorer(query, &point_deleted, &point_deleted, hardware_counter)
+            .raw_scorer(query, hardware_counter)
             .unwrap()
     } else {
-        new_raw_scorer_for_test(query, &storage, &point_deleted).unwrap()
+        new_raw_scorer_for_test(query, &storage).unwrap()
     };
 
     for (point_id, gpu_score) in gpu_scores.iter().enumerate() {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -13,7 +13,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::linux_low_thread_priority;
 use common::ext::BitSliceExt as _;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
-use itertools::EitherOrBoth;
+use itertools::{EitherOrBoth, Itertools as _};
 use log::debug;
 use memory::fadvise::clear_disk_cache;
 use parking_lot::Mutex;
@@ -1097,7 +1097,9 @@ impl HNSWIndex {
                 hardware_counter,
             )?;
 
-            scorer.rescore_points(&mut search_result);
+            search_result = scorer
+                .score_points(&mut search_result.iter().map(|x| x.idx).collect_vec(), 0)
+                .collect();
             search_result.sort_unstable();
             search_result.reverse();
         }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -38,13 +38,12 @@ use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::gpu::{get_gpu_groups_count, gpu_graph_builder::build_hnsw_on_gpu};
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
-use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::index::hnsw_index::point_scorer::{BoxCow, FilteredScorer};
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 use crate::index::{PayloadIndex, VectorIndex, VectorIndexEnum};
-#[cfg(feature = "gpu")]
 use crate::payload_storage::FilterContext;
 use crate::segment_constructor::VectorIndexBuildArgs;
 use crate::telemetry::VectorIndexSearchesTelemetry;
@@ -55,7 +54,7 @@ use crate::types::{
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::DiscoveryQuery;
-use crate::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 const HNSW_USE_HEURISTIC: bool = true;
 const FINISH_MAIN_GRAPH_LOG_MESSAGE: &str = "Finish main graph in time";
@@ -402,22 +401,14 @@ impl HNSWIndex {
                 // No need to accumulate hardware, since this is an internal operation
                 let internal_hardware_counter = HardwareCounterCell::disposable();
 
-                let raw_scorer = if let Some(quantized_storage) = quantized_vectors_ref.as_ref() {
-                    quantized_storage.raw_scorer(
-                        vector,
-                        id_tracker_ref.deleted_point_bitslice(),
-                        vector_storage_ref.deleted_vector_bitslice(),
-                        internal_hardware_counter,
-                    )
-                } else {
-                    new_raw_scorer(
-                        vector,
-                        &vector_storage_ref,
-                        id_tracker_ref.deleted_point_bitslice(),
-                        internal_hardware_counter,
-                    )
-                }?;
-                let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
+                let points_scorer = FilteredScorer::new(
+                    vector,
+                    vector_storage_ref.deref(),
+                    quantized_vectors_ref.as_ref(),
+                    None,
+                    id_tracker_ref.deleted_point_bitslice(),
+                    internal_hardware_counter,
+                )?;
 
                 graph_layers_builder.link_new_point(vector_id, points_scorer);
 
@@ -606,7 +597,6 @@ impl HNSWIndex {
             graph_layers_builder,
             block_filter_list,
             &points_to_index,
-            deleted_bitslice,
             stopped,
         )? {
             *graph_layers_builder = gpu_constructed_graph;
@@ -622,26 +612,18 @@ impl HNSWIndex {
             // This hardware counter can be discarded, since it is only used for internal operations
             let internal_hardware_counter = HardwareCounterCell::disposable();
 
-            let raw_scorer = match quantized_vectors.as_ref() {
-                Some(quantized_storage) => quantized_storage.raw_scorer(
-                    vector,
-                    id_tracker.deleted_point_bitslice(),
-                    deleted_bitslice,
-                    internal_hardware_counter,
-                ),
-                None => new_raw_scorer(
-                    vector,
-                    vector_storage,
-                    id_tracker.deleted_point_bitslice(),
-                    internal_hardware_counter,
-                ),
-            }?;
             let block_condition_checker = BuildConditionChecker {
                 filter_list: block_filter_list,
                 current_point: block_point_id,
             };
-            let points_scorer =
-                FilteredScorer::new(raw_scorer.as_ref(), Some(&block_condition_checker));
+            let points_scorer = FilteredScorer::new(
+                vector,
+                vector_storage,
+                quantized_vectors.as_ref(),
+                Some(BoxCow::Borrowed(&block_condition_checker)),
+                id_tracker.deleted_point_bitslice(),
+                internal_hardware_counter,
+            )?;
 
             graph_layers_builder.link_new_point(block_point_id, points_scorer);
 
@@ -686,22 +668,14 @@ impl HNSWIndex {
             let vector = vector_storage.get_vector(vector_id);
             let vector = vector.as_vec_ref().into();
             let hardware_counter = HardwareCounterCell::disposable();
-            let raw_scorer = if let Some(quantized_storage) = quantized_vectors.as_ref() {
-                quantized_storage.raw_scorer(
-                    vector,
-                    id_tracker.deleted_point_bitslice(),
-                    vector_storage.deleted_vector_bitslice(),
-                    hardware_counter,
-                )
-            } else {
-                new_raw_scorer(
-                    vector,
-                    vector_storage,
-                    id_tracker.deleted_point_bitslice(),
-                    hardware_counter,
-                )
-            }?;
-            Ok((raw_scorer, None))
+            FilteredScorer::new(
+                vector,
+                vector_storage,
+                quantized_vectors.as_ref(),
+                None,
+                id_tracker.deleted_point_bitslice(),
+                hardware_counter,
+            )
         };
 
         Self::build_graph_on_gpu(
@@ -724,32 +698,24 @@ impl HNSWIndex {
         graph_layers_builder: &GraphLayersBuilder,
         block_filter_list: &VisitedListHandle,
         points_to_index: &[PointOffsetType],
-        deleted_bitslice: &BitSlice,
         stopped: &AtomicBool,
     ) -> OperationResult<Option<GraphLayersBuilder>> {
         let points_scorer_builder = |block_point_id| -> OperationResult<_> {
             let vector = vector_storage.get_vector(block_point_id);
             let vector = vector.as_vec_ref().into();
             let hardware_counter = HardwareCounterCell::disposable();
-            let raw_scorer = match quantized_vectors.as_ref() {
-                Some(quantized_storage) => quantized_storage.raw_scorer(
-                    vector,
-                    id_tracker.deleted_point_bitslice(),
-                    deleted_bitslice,
-                    hardware_counter,
-                ),
-                None => new_raw_scorer(
-                    vector,
-                    vector_storage,
-                    id_tracker.deleted_point_bitslice(),
-                    hardware_counter,
-                ),
-            }?;
             let block_condition_checker: Box<dyn FilterContext> = Box::new(BuildConditionChecker {
                 filter_list: block_filter_list,
                 current_point: block_point_id,
             });
-            Ok((raw_scorer, Some(block_condition_checker)))
+            FilteredScorer::new(
+                vector,
+                vector_storage,
+                quantized_vectors.as_ref(),
+                Some(BoxCow::Boxed(block_condition_checker)),
+                id_tracker.deleted_point_bitslice(),
+                hardware_counter,
+            )
         };
 
         Self::build_graph_on_gpu(
@@ -769,12 +735,8 @@ impl HNSWIndex {
         graph_layers_builder: &GraphLayersBuilder,
         points_to_index: impl Iterator<Item = PointOffsetType>,
         entry_points_num: usize,
-        points_scorer_builder: impl Fn(
-            PointOffsetType,
-        ) -> OperationResult<(
-            Box<dyn RawScorer + 'a>,
-            Option<Box<dyn FilterContext + 'a>>,
-        )> + Send
+        points_scorer_builder: impl Fn(PointOffsetType) -> OperationResult<FilteredScorer<'a>>
+        + Send
         + Sync,
         stopped: &AtomicBool,
     ) -> OperationResult<Option<GraphLayersBuilder>> {
@@ -866,20 +828,18 @@ impl HNSWIndex {
             .deleted_points()
             .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
 
-        let raw_scorer = Self::construct_search_scorer(
+        let hw_counter = vector_query_context.hardware_counter();
+        let filter_context = filter.map(|f| payload_index.filter_context(f, &hw_counter));
+        let points_scorer = Self::construct_search_scorer(
             vector,
             &vector_storage,
             quantized_vectors.as_ref(),
             deleted_points,
             params,
             vector_query_context.hardware_counter(),
+            filter_context,
         )?;
         let oversampled_top = Self::get_oversampled_top(quantized_vectors.as_ref(), params, top);
-
-        let hw_counter = vector_query_context.hardware_counter();
-
-        let filter_context = filter.map(|f| payload_index.filter_context(f, &hw_counter));
-        let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
 
         let search_result = self.graph.search(
             oversampled_top,
@@ -943,17 +903,18 @@ impl HNSWIndex {
 
         let is_stopped = vector_query_context.is_stopped();
 
-        let raw_scorer = Self::construct_search_scorer(
+        let points_scorer = Self::construct_search_scorer(
             vector,
             &vector_storage,
             quantized_vectors.as_ref(),
             deleted_points,
             params,
             vector_query_context.hardware_counter(),
+            None,
         )?;
         let oversampled_top = Self::get_oversampled_top(quantized_vectors.as_ref(), params, top);
 
-        let search_result = raw_scorer.peek_top_iter(points, oversampled_top, &is_stopped)?;
+        let search_result = points_scorer.peek_top_iter(points, oversampled_top, &is_stopped)?;
 
         let res = self.postprocess_search_result(
             search_result,
@@ -1069,22 +1030,17 @@ impl HNSWIndex {
         deleted_points: &'a BitSlice,
         params: Option<&SearchParams>,
         hardware_counter: HardwareCounterCell,
-    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        filter_context: Option<Box<dyn FilterContext + 'a>>,
+    ) -> OperationResult<FilteredScorer<'a>> {
         let quantization_enabled = Self::is_quantized_search(quantized_storage, params);
-        match quantized_storage {
-            Some(quantized_storage) if quantization_enabled => quantized_storage.raw_scorer(
-                vector.to_owned(),
-                deleted_points,
-                vector_storage.deleted_vector_bitslice(),
-                hardware_counter,
-            ),
-            _ => new_raw_scorer(
-                vector.to_owned(),
-                vector_storage,
-                deleted_points,
-                hardware_counter,
-            ),
-        }
+        FilteredScorer::new(
+            vector.to_owned(),
+            vector_storage,
+            quantization_enabled.then_some(quantized_storage).flatten(),
+            filter_context.map(BoxCow::Boxed),
+            deleted_points,
+            hardware_counter,
+        )
     }
 
     fn get_oversampled_top(
@@ -1109,7 +1065,7 @@ impl HNSWIndex {
 
     fn postprocess_search_result(
         &self,
-        search_result: Vec<ScoredPointOffset>,
+        mut search_result: Vec<ScoredPointOffset>,
         vector: &QueryVector,
         params: Option<&SearchParams>,
         top: usize,
@@ -1131,25 +1087,22 @@ impl HNSWIndex {
                 .and_then(|q| q.rescore)
                 .unwrap_or(default_rescoring);
 
-        let mut postprocess_result = if rescore {
-            let raw_scorer = new_raw_scorer(
+        if rescore {
+            let mut scorer = FilteredScorer::new(
                 vector.to_owned(),
                 &vector_storage,
+                None,
+                None,
                 id_tracker.deleted_point_bitslice(),
                 hardware_counter,
             )?;
 
-            let mut ids_iterator = search_result.iter().map(|x| x.idx);
-            let mut re_scored = raw_scorer.score_points_unfiltered(&mut ids_iterator);
-
-            re_scored.sort_unstable();
-            re_scored.reverse();
-            re_scored
-        } else {
-            search_result
-        };
-        postprocess_result.truncate(top);
-        Ok(postprocess_result)
+            scorer.rescore_points(&mut search_result);
+            search_result.sort_unstable();
+            search_result.reverse();
+        }
+        search_result.truncate(top);
+        Ok(search_result)
     }
 
     /// Read underlying data from disk into disk cache.

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -1,30 +1,119 @@
-use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use std::ops::Deref;
+use std::sync::atomic::AtomicBool;
 
+use bitvec::slice::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
+use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use itertools::Itertools as _;
+
+use crate::common::operation_error::{CancellableResult, OperationResult, check_process_stopped};
+use crate::data_types::vectors::QueryVector;
 use crate::payload_storage::FilterContext;
-use crate::vector_storage::RawScorer;
+use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::{
+    RawScorer, VectorStorage, VectorStorageEnum, check_deleted_condition, new_raw_scorer,
+};
 
 pub struct FilteredScorer<'a> {
-    pub raw_scorer: &'a dyn RawScorer,
-    pub filter_context: Option<&'a dyn FilterContext>,
-    points_buffer: Vec<ScoredPointOffset>,
+    raw_scorer: Box<dyn RawScorer + 'a>,
+    filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
+
+    /// Point deleted flags should be explicitly present as `false`
+    /// for each existing point in the segment.
+    /// If there are no flags for some points, they are considered deleted.
+    /// [`BitSlice`] defining flags for deleted points (and thus these vectors).
+    point_deleted: &'a BitSlice,
+    /// [`BitSlice`] defining flags for deleted vectors in this segment.
+    vec_deleted: &'a BitSlice,
+
+    scores_buffer: Vec<ScoreType>,
 }
 
 impl<'a> FilteredScorer<'a> {
+    /// Create a new filtered scorer.
+    ///
+    /// If present, `quantized_vectors` will be used for scoring, otherwise `vectors` will be used.
     pub fn new(
-        raw_scorer: &'a dyn RawScorer,
-        filter_context: Option<&'a dyn FilterContext>,
+        query: QueryVector,
+        vectors: &'a VectorStorageEnum,
+        quantized_vectors: Option<&'a QuantizedVectors>,
+        filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
+        point_deleted: &'a BitSlice,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Self> {
+        let raw_scorer = match quantized_vectors {
+            Some(quantized_vectors) => quantized_vectors.raw_scorer(query, hardware_counter)?,
+            None => new_raw_scorer(query, vectors, hardware_counter)?,
+        };
+        Ok(FilteredScorer {
+            raw_scorer,
+            filter_context,
+            point_deleted,
+            vec_deleted: vectors.deleted_vector_bitslice(),
+            scores_buffer: Vec::new(),
+        })
+    }
+
+    /// Create a new filtered scorer from a raw scorer.
+    #[cfg(feature = "testing")]
+    pub fn new_from_raw(
+        raw_scorer: Box<dyn RawScorer + 'a>,
+        point_deleted: &'a BitSlice,
+        vec_deleted: &'a BitSlice,
     ) -> Self {
         FilteredScorer {
             raw_scorer,
-            filter_context,
-            points_buffer: Vec::new(),
+            filter_context: None,
+            point_deleted,
+            vec_deleted,
+            scores_buffer: Vec::new(),
         }
     }
 
+    /// Create a new filtered scorer for testing purposes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`new_raw_scorer`] fails.
+    #[cfg(feature = "testing")]
+    pub fn new_for_test(
+        vector: QueryVector,
+        vector_storage: &'a VectorStorageEnum,
+        point_deleted: &'a BitSlice,
+    ) -> Self {
+        let raw_scorer =
+            new_raw_scorer(vector, vector_storage, HardwareCounterCell::new()).unwrap();
+        FilteredScorer::new_from_raw(
+            raw_scorer,
+            point_deleted,
+            vector_storage.deleted_vector_bitslice(),
+        )
+    }
+
+    /// Return true if vector satisfies current search context for given point:
+    /// exists, not deleted, and satisfies filter context.
     pub fn check_vector(&self, point_id: PointOffsetType) -> bool {
-        match self.filter_context {
-            None => self.raw_scorer.check_vector(point_id),
-            Some(f) => f.check(point_id) && self.raw_scorer.check_vector(point_id),
+        match &self.filter_context {
+            None => self.simple_check_vector(point_id),
+            Some(f) => f.check(point_id) && self.simple_check_vector(point_id),
+        }
+    }
+
+    fn simple_check_vector(&self, point_id: PointOffsetType) -> bool {
+        check_deleted_condition(point_id, self.vec_deleted, self.point_deleted)
+    }
+
+    pub fn rescore_points(&mut self, points: &mut [ScoredPointOffset]) {
+        let point_ids = points.iter().map(|p| p.idx).collect_vec();
+        if self.scores_buffer.len() < point_ids.len() {
+            self.scores_buffer.resize(point_ids.len(), 0.0);
+        }
+        self.raw_scorer
+            .score_points(&point_ids, &mut self.scores_buffer[..point_ids.len()]);
+        for (point, score) in std::iter::zip(points, &self.scores_buffer) {
+            point.score = *score;
         }
     }
 
@@ -37,39 +126,26 @@ impl<'a> FilteredScorer<'a> {
     ///
     /// * `point_ids` - list of points to score. *Warn*: This input will be wrecked during the execution.
     /// * `limit` - limits the number of points to process after filtering.
-    ///
+    ///   `0` means no limit.
     pub fn score_points(
         &mut self,
-        point_ids: &mut [PointOffsetType],
+        point_ids: &mut Vec<PointOffsetType>,
         limit: usize,
-    ) -> &[ScoredPointOffset] {
-        // apply filter and store filtered ids to source slice memory
-        let filtered_point_ids = match self.filter_context {
-            None => point_ids,
-            Some(f) => {
-                let len = point_ids.len();
-                let mut filtered_len = 0;
-                for i in 0..len {
-                    let point_id = point_ids[i];
-                    if f.check(point_id) {
-                        point_ids[filtered_len] = point_id;
-                        filtered_len += 1;
-                    }
-                }
-                &point_ids[0..filtered_len]
-            }
-        };
-        if limit == 0 {
-            self.points_buffer
-                .resize_with(filtered_point_ids.len(), ScoredPointOffset::default);
-        } else {
-            self.points_buffer
-                .resize_with(limit, ScoredPointOffset::default);
+    ) -> impl Iterator<Item = ScoredPointOffset> {
+        point_ids.retain(|point_id| self.check_vector(*point_id));
+        if limit != 0 {
+            point_ids.truncate(limit);
         }
-        let count = self
-            .raw_scorer
-            .score_points(filtered_point_ids, &mut self.points_buffer);
-        &self.points_buffer[0..count]
+
+        if self.scores_buffer.len() < point_ids.len() {
+            self.scores_buffer.resize(point_ids.len(), 0.0);
+        }
+
+        self.raw_scorer
+            .score_points(point_ids, &mut self.scores_buffer[..point_ids.len()]);
+
+        std::iter::zip(&*point_ids, &self.scores_buffer)
+            .map(|(&idx, &score)| ScoredPointOffset { idx, score })
     }
 
     pub fn score_point(&self, point_id: PointOffsetType) -> ScoreType {
@@ -78,5 +154,82 @@ impl<'a> FilteredScorer<'a> {
 
     pub fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         self.raw_scorer.score_internal(point_a, point_b)
+    }
+
+    pub fn peek_top_all(
+        &self,
+        top: usize,
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<Vec<ScoredPointOffset>> {
+        let iter = self
+            .point_deleted
+            .iter_zeros()
+            .map(|p| p as PointOffsetType);
+        self.peek_top_iter(iter, top, is_stopped)
+    }
+
+    pub fn peek_top_iter(
+        &self,
+        mut points: impl Iterator<Item = PointOffsetType>,
+        top: usize,
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<Vec<ScoredPointOffset>> {
+        if top == 0 {
+            return Ok(vec![]);
+        }
+
+        let mut pq = FixedLengthPriorityQueue::new(top);
+
+        // Reuse the same buffer for all chunks, to avoid reallocation
+        let mut chunk = [0; VECTOR_READ_BATCH_SIZE];
+        let mut scores_buffer = [0.0; VECTOR_READ_BATCH_SIZE];
+
+        loop {
+            check_process_stopped(is_stopped)?;
+
+            let mut chunk_size = 0;
+            for point_id in &mut points {
+                if !self.check_vector(point_id) {
+                    continue;
+                }
+                chunk[chunk_size] = point_id;
+                chunk_size += 1;
+                if chunk_size == VECTOR_READ_BATCH_SIZE {
+                    break;
+                }
+            }
+
+            if chunk_size == 0 {
+                break;
+            }
+
+            self.raw_scorer
+                .score_points(&chunk[..chunk_size], &mut scores_buffer[..chunk_size]);
+
+            for i in 0..chunk_size {
+                pq.push(ScoredPointOffset {
+                    idx: chunk[i],
+                    score: scores_buffer[i],
+                });
+            }
+        }
+
+        Ok(pq.into_sorted_vec())
+    }
+}
+
+pub enum BoxCow<'a, T: ?Sized> {
+    Borrowed(&'a T),
+    Boxed(Box<T>),
+}
+
+impl<T: ?Sized> Deref for BoxCow<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            BoxCow::Borrowed(t) => t,
+            BoxCow::Boxed(t) => t,
+        }
     }
 }

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -5,7 +5,6 @@ use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
-use itertools::Itertools as _;
 
 use crate::common::operation_error::{CancellableResult, OperationResult, check_process_stopped};
 use crate::data_types::vectors::QueryVector;
@@ -16,10 +15,29 @@ use crate::vector_storage::{
     RawScorer, VectorStorage, VectorStorageEnum, check_deleted_condition, new_raw_scorer,
 };
 
+/// Scorers composition:
+///
+/// ```plaintext
+///                                                               Metric
+///                                                              ┌─────────────┐
+///                                                              │ - Cosine    │
+///  FilteredScorer      RawScorer          QueryScorer          │ - Dot       │
+/// ┌─────────────────┐ ┌───────────────┐   ┌────────────────┐ ┌─┤ - Euclidean │
+/// │ RawScorer ◄─────┼─┤ QueryScorer ◄─┼───│ Metric ◄───────┼─┘ └─────────────┘
+/// │                 │ └───────────────┘   │                │    - Vector Distance
+/// │ FilterContext   │  - Access patterns  │ Query  ◄───────┼─┐
+/// │                 │                     │                │ │  Query
+/// │ deleted_points  │                     │ TVectorStorage │ │ ┌──────────────────┐
+/// │ deleted_vectors │                     └────────────────┘ └─┤ - RecoQuery      │
+/// └─────────────────┘                                          │ - DiscoveryQuery │
+///                                                              │ - ContextQuery   │
+///                                                              └──────────────────┘
+///                                                              - Scoring logic
+///                                                              - Complex queries
+/// ```
 pub struct FilteredScorer<'a> {
     raw_scorer: Box<dyn RawScorer + 'a>,
     filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
-
     /// Point deleted flags should be explicitly present as `false`
     /// for each existing point in the segment.
     /// If there are no flags for some points, they are considered deleted.
@@ -27,7 +45,7 @@ pub struct FilteredScorer<'a> {
     point_deleted: &'a BitSlice,
     /// [`BitSlice`] defining flags for deleted vectors in this segment.
     vec_deleted: &'a BitSlice,
-
+    /// Temporary buffer for scores.
     scores_buffer: Vec<ScoreType>,
 }
 
@@ -95,36 +113,21 @@ impl<'a> FilteredScorer<'a> {
     /// Return true if vector satisfies current search context for given point:
     /// exists, not deleted, and satisfies filter context.
     pub fn check_vector(&self, point_id: PointOffsetType) -> bool {
-        match &self.filter_context {
-            None => self.simple_check_vector(point_id),
-            Some(f) => f.check(point_id) && self.simple_check_vector(point_id),
-        }
-    }
-
-    fn simple_check_vector(&self, point_id: PointOffsetType) -> bool {
         check_deleted_condition(point_id, self.vec_deleted, self.point_deleted)
+            && self
+                .filter_context
+                .as_ref()
+                .is_none_or(|f| f.check(point_id))
     }
 
-    pub fn rescore_points(&mut self, points: &mut [ScoredPointOffset]) {
-        let point_ids = points.iter().map(|p| p.idx).collect_vec();
-        if self.scores_buffer.len() < point_ids.len() {
-            self.scores_buffer.resize(point_ids.len(), 0.0);
-        }
-        self.raw_scorer
-            .score_points(&point_ids, &mut self.scores_buffer[..point_ids.len()]);
-        for (point, score) in std::iter::zip(points, &self.scores_buffer) {
-            point.score = *score;
-        }
-    }
-
-    /// Method filters and calculates scores for the given slice of points IDs
+    /// Filters and calculates scores for the given slice of points IDs.
     ///
-    /// For performance reasons this function mutates input values.
-    /// For result slice allocation this function mutates self.
+    /// For performance reasons this method mutates `point_ids`.
     ///
     /// # Arguments
     ///
-    /// * `point_ids` - list of points to score. *Warn*: This input will be wrecked during the execution.
+    /// * `point_ids` - list of points to score.
+    ///   **Warning**: This input will be wrecked during the execution.
     /// * `limit` - limits the number of points to process after filtering.
     ///   `0` means no limit.
     pub fn score_points(
@@ -189,6 +192,7 @@ impl<'a> FilteredScorer<'a> {
 
             let mut chunk_size = 0;
             for point_id in &mut points {
+                check_process_stopped(is_stopped)?;
                 if !self.check_vector(point_id) {
                     continue;
                 }

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -6,10 +6,9 @@ use rand::Rng;
 
 use super::graph_links::GraphLinksFormat;
 use crate::data_types::vectors::VectorElementType;
-use crate::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer};
+use crate::fixtures::index_fixtures::TestRawScorerProducer;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
-use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::spaces::metric::Metric;
 use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
 
@@ -38,11 +37,9 @@ where
     );
 
     for idx in 0..(num_vectors as PointOffsetType) {
-        let fake_filter_context = FakeFilterContext {};
         let added_vector = vector_holder.vectors.get(idx as VectorOffsetType).to_vec();
-        let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
+        let scorer = vector_holder.get_scorer(added_vector);
 
-        let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let level = graph_layers_builder.get_random_layer(rng);
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -75,8 +75,7 @@ fn test_compact_graph_layers(#[case] format: GraphLinksFormat) {
     let reference_results = queries
         .iter()
         .map(|query| {
-            let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
-            let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
+            let scorer = vector_holder.get_scorer(query.clone());
             search_in_builder(&graph_layers_builder, top, ef, scorer)
         })
         .collect_vec();
@@ -86,8 +85,7 @@ fn test_compact_graph_layers(#[case] format: GraphLinksFormat) {
     let results = queries
         .iter()
         .map(|query| {
-            let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
-            let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
+            let scorer = vector_holder.get_scorer(query.clone());
             graph_layers
                 .search(top, ef, scorer, None, &DEFAULT_STOPPED)
                 .unwrap()

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -6,6 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use parking_lot::Mutex;
 
+use super::hnsw_index::point_scorer::FilteredScorer;
 use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::{
@@ -18,7 +19,7 @@ use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::{VectorStorage, VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 #[derive(Debug)]
 pub struct PlainVectorIndex {
@@ -109,9 +110,11 @@ impl VectorIndex for PlainVectorIndex {
                 vectors
                     .iter()
                     .map(|&vector| {
-                        new_raw_scorer(
+                        FilteredScorer::new(
                             vector.to_owned(),
                             &vector_storage,
+                            None,
+                            None,
                             deleted_points,
                             query_context.hardware_counter(),
                         )
@@ -135,9 +138,11 @@ impl VectorIndex for PlainVectorIndex {
                 vectors
                     .iter()
                     .map(|&vector| {
-                        new_raw_scorer(
+                        FilteredScorer::new(
                             vector.to_owned(),
                             &vector_storage,
+                            None,
+                            None,
                             deleted_points,
                             query_context.hardware_counter(),
                         )

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -1,16 +1,11 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-
-use bitvec::prelude::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::ext::BitSliceExt as _;
-use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
-use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoreType};
 
 use super::query::{
     ContextQuery, DiscoveryQuery, RecoBestScoreQuery, RecoQuery, RecoSumScoresQuery, TransformInto,
 };
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
-use crate::common::operation_error::{CancellableResult, OperationError, OperationResult};
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::{DenseVector, QueryVector, VectorElementType, VectorInternal};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
@@ -24,37 +19,24 @@ use crate::vector_storage::{RawScorer, VectorStorage as _};
 pub fn new<'a>(
     query: QueryVector,
     storage: &'a MemmapDenseVectorStorage<VectorElementType>,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    AsyncRawScorerBuilder::new(query, storage, point_deleted, hardware_counter).build()
+    AsyncRawScorerBuilder::new(query, storage, hardware_counter).build()
 }
 
 pub struct AsyncRawScorerImpl<'a, TQueryScorer: QueryScorer<[VectorElementType]>> {
-    points_count: PointOffsetType,
     query_scorer: TQueryScorer,
     storage: &'a MmapDenseVectors<VectorElementType>,
-    point_deleted: &'a BitSlice,
-    vec_deleted: &'a BitSlice,
 }
 
 impl<'a, TQueryScorer> AsyncRawScorerImpl<'a, TQueryScorer>
 where
     TQueryScorer: QueryScorer<[VectorElementType]>,
 {
-    fn new(
-        points_count: PointOffsetType,
-        query_scorer: TQueryScorer,
-        storage: &'a MmapDenseVectors<VectorElementType>,
-        point_deleted: &'a BitSlice,
-        vec_deleted: &'a BitSlice,
-    ) -> Self {
+    fn new(query_scorer: TQueryScorer, storage: &'a MmapDenseVectors<VectorElementType>) -> Self {
         Self {
-            points_count,
             query_scorer,
             storage,
-            point_deleted,
-            vec_deleted,
         }
     }
 }
@@ -63,60 +45,15 @@ impl<TQueryScorer> RawScorer for AsyncRawScorerImpl<'_, TQueryScorer>
 where
     TQueryScorer: QueryScorer<[VectorElementType]>,
 {
-    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
-        let points_stream = points
-            .iter()
-            .copied()
-            .filter(|point_id| self.check_vector(*point_id));
-
-        let mut processed = 0;
-        self.storage
-            .read_vectors_async(points_stream, |idx, point_id, other_vector| {
-                scores[idx] = ScoredPointOffset {
-                    idx: point_id,
-                    score: self.query_scorer.score(other_vector),
-                };
-                processed += 1;
-            })
-            .unwrap();
-
-        // ToDo: io_uring is experimental, it can fail if it is not supported.
-        // Instead of silently falling back to the sync implementation, we prefer to panic
-        // and notify the user that they better use the default IO implementation.
-
-        processed
-    }
-
-    fn score_points_unfiltered(
-        &self,
-        points: &mut dyn Iterator<Item = PointOffsetType>,
-    ) -> Vec<ScoredPointOffset> {
-        let mut scores = vec![];
+    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoreType]) {
+        assert_eq!(points.len(), scores.len());
+        let points_stream = points.iter().copied();
 
         self.storage
-            .read_vectors_async(points, |_idx, point_id, other_vector| {
-                scores.push(ScoredPointOffset {
-                    idx: point_id,
-                    score: self.query_scorer.score(other_vector),
-                });
+            .read_vectors_async(points_stream, |idx, _point_id, other_vector| {
+                scores[idx] = self.query_scorer.score(other_vector);
             })
             .unwrap();
-
-        // ToDo: io_uring is experimental, it can fail if it is not supported.
-        // Instead of silently falling back to the sync implementation, we prefer to panic
-        // and notify the user that they better use the default IO implementation.
-
-        scores
-    }
-
-    fn check_vector(&self, point: PointOffsetType) -> bool {
-        point < self.points_count
-            // Deleted points propagate to vectors; check vector deletion for possible early return
-            // Default to not deleted if our deleted flags failed grow
-            && !self.vec_deleted.get_bit(point as usize).unwrap_or(false)
-            // Additionally check point deletion for integrity if delete propagation to vector failed
-            // Default to deleted if the point mapping was removed from the ID tracker
-            && !self.point_deleted.get_bit(point as usize).unwrap_or(true)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {
@@ -126,77 +63,11 @@ where
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         self.query_scorer.score_internal(point_a, point_b)
     }
-
-    fn peek_top_iter(
-        &self,
-        points: &mut dyn Iterator<Item = PointOffsetType>,
-        top: usize,
-        is_stopped: &AtomicBool,
-    ) -> CancellableResult<Vec<ScoredPointOffset>> {
-        if top == 0 {
-            return Ok(vec![]);
-        }
-
-        let mut pq = FixedLengthPriorityQueue::new(top);
-        let points_stream = points
-            .take_while(|_| !is_stopped.load(Ordering::Relaxed))
-            .filter(|point_id| self.check_vector(*point_id));
-
-        self.storage
-            .read_vectors_async(points_stream, |_, point_id, other_vector| {
-                let scored_point_offset = ScoredPointOffset {
-                    idx: point_id,
-                    score: self.query_scorer.score(other_vector),
-                };
-                pq.push(scored_point_offset);
-            })
-            .unwrap();
-
-        // ToDo: io_uring is experimental, it can fail if it is not supported.
-        // Instead of silently falling back to the sync implementation, we prefer to panic
-        // and notify the user that they better use the default IO implementation.
-
-        Ok(pq.into_sorted_vec())
-    }
-
-    fn peek_top_all(
-        &self,
-        top: usize,
-        is_stopped: &AtomicBool,
-    ) -> CancellableResult<Vec<ScoredPointOffset>> {
-        if top == 0 {
-            return Ok(vec![]);
-        }
-
-        let points_stream = (0..self.points_count)
-            .take_while(|_| !is_stopped.load(Ordering::Relaxed))
-            .filter(|point_id| self.check_vector(*point_id));
-
-        let mut pq = FixedLengthPriorityQueue::new(top);
-        self.storage
-            .read_vectors_async(points_stream, |_, point_id, other_vector| {
-                let scored_point_offset = ScoredPointOffset {
-                    idx: point_id,
-                    score: self.query_scorer.score(other_vector),
-                };
-                pq.push(scored_point_offset);
-            })
-            .unwrap();
-
-        // ToDo: io_uring is experimental, it can fail if it is not supported.
-        // Instead of silently falling back to the sync implementation, we prefer to panic
-        // and notify the user that they better use the default IO implementation.
-
-        Ok(pq.into_sorted_vec())
-    }
 }
 
 struct AsyncRawScorerBuilder<'a> {
-    points_count: PointOffsetType,
     query: QueryVector,
     storage: &'a MemmapDenseVectorStorage<VectorElementType>,
-    point_deleted: &'a BitSlice,
-    vec_deleted: &'a BitSlice,
     distance: Distance,
     hardware_counter: HardwareCounterCell,
 }
@@ -205,20 +76,15 @@ impl<'a> AsyncRawScorerBuilder<'a> {
     pub fn new(
         query: QueryVector,
         storage: &'a MemmapDenseVectorStorage<VectorElementType>,
-        point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
     ) -> Self {
-        let points_count = storage.total_vector_count() as _;
-        let vec_deleted = storage.deleted_vector_bitslice();
+        let _points_count = storage.total_vector_count(); // TODO: use it somehow on upper level
 
         let distance = storage.distance();
 
         Self {
-            points_count,
             query,
             storage,
-            point_deleted,
-            vec_deleted,
             distance,
             hardware_counter,
         }
@@ -237,11 +103,8 @@ impl<'a> AsyncRawScorerBuilder<'a> {
         self,
     ) -> OperationResult<Box<dyn RawScorer + 'a>> {
         let Self {
-            points_count,
             query,
             storage,
-            point_deleted,
-            vec_deleted,
             distance: _,
             hardware_counter,
         } = self;
@@ -255,13 +118,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                             storage,
                             hardware_counter,
                         );
-                        Ok(Box::new(AsyncRawScorerImpl::new(
-                            points_count,
-                            query_scorer,
-                            storage.get_mmap_vectors(),
-                            point_deleted,
-                            vec_deleted,
-                        )))
+                        Ok(async_raw_scorer_from_query_scorer(query_scorer, storage))
                     }
                     VectorInternal::Sparse(_sparse_vector) => Err(OperationError::service_error(
                         "sparse vectors are not supported for async scorer",
@@ -280,13 +137,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                     storage,
                     hardware_counter,
                 );
-                Ok(Box::new(AsyncRawScorerImpl::new(
-                    points_count,
-                    query_scorer,
-                    storage.get_mmap_vectors(),
-                    point_deleted,
-                    vec_deleted,
-                )))
+                Ok(async_raw_scorer_from_query_scorer(query_scorer, storage))
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
@@ -295,13 +146,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                     storage,
                     hardware_counter,
                 );
-                Ok(Box::new(AsyncRawScorerImpl::new(
-                    points_count,
-                    query_scorer,
-                    storage.get_mmap_vectors(),
-                    point_deleted,
-                    vec_deleted,
-                )))
+                Ok(async_raw_scorer_from_query_scorer(query_scorer, storage))
             }
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<DenseVector> =
@@ -311,13 +156,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                     storage,
                     hardware_counter,
                 );
-                Ok(Box::new(AsyncRawScorerImpl::new(
-                    points_count,
-                    query_scorer,
-                    storage.get_mmap_vectors(),
-                    point_deleted,
-                    vec_deleted,
-                )))
+                Ok(async_raw_scorer_from_query_scorer(query_scorer, storage))
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
@@ -326,14 +165,21 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                     storage,
                     hardware_counter,
                 );
-                Ok(Box::new(AsyncRawScorerImpl::new(
-                    points_count,
-                    query_scorer,
-                    storage.get_mmap_vectors(),
-                    point_deleted,
-                    vec_deleted,
-                )))
+                Ok(async_raw_scorer_from_query_scorer(query_scorer, storage))
             }
         }
     }
+}
+
+fn async_raw_scorer_from_query_scorer<'a, TQueryScorer>(
+    query_scorer: TQueryScorer,
+    storage: &'a MemmapDenseVectorStorage<VectorElementType>,
+) -> Box<dyn RawScorer + 'a>
+where
+    TQueryScorer: QueryScorer<[VectorElementType]> + 'a,
+{
+    Box::new(AsyncRawScorerImpl::new(
+        query_scorer,
+        storage.get_mmap_vectors(),
+    ))
 }

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -54,6 +54,10 @@ where
                 scores[idx] = self.query_scorer.score(other_vector);
             })
             .unwrap();
+
+        // ToDo: io_uring is experimental, it can fail if it is not supported.
+        // Instead of silently falling back to the sync implementation, we prefer to panic
+        // and notify the user that they better use the default IO implementation.
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -78,14 +78,10 @@ impl<'a> AsyncRawScorerBuilder<'a> {
         storage: &'a MemmapDenseVectorStorage<VectorElementType>,
         hardware_counter: HardwareCounterCell,
     ) -> Self {
-        let _points_count = storage.total_vector_count(); // TODO: use it somehow on upper level
-
-        let distance = storage.distance();
-
         Self {
             query,
             storage,
-            distance,
+            distance: storage.distance(),
             hardware_counter,
         }
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -1,4 +1,3 @@
-use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use quantization::EncodedVectors;
 
@@ -23,8 +22,6 @@ pub(super) struct QuantizedScorerBuilder<'a> {
     quantized_storage: &'a QuantizedVectorStorage,
     quantization_config: &'a QuantizationConfig,
     query: QueryVector,
-    point_deleted: &'a BitSlice,
-    vec_deleted: &'a BitSlice,
     distance: &'a Distance,
     datatype: VectorStorageDatatype,
     hardware_counter: HardwareCounterCell,
@@ -36,8 +33,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
         quantized_storage: &'a QuantizedVectorStorage,
         quantization_config: &'a QuantizationConfig,
         query: QueryVector,
-        point_deleted: &'a BitSlice,
-        vec_deleted: &'a BitSlice,
         distance: &'a Distance,
         datatype: VectorStorageDatatype,
         mut hardware_counter: HardwareCounterCell,
@@ -48,8 +43,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
             quantized_storage,
             quantization_config,
             query,
-            point_deleted,
-            vec_deleted,
             distance,
             datatype,
             hardware_counter,
@@ -147,8 +140,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
             quantized_storage: _same_as_quantized_storage_in_args,
             quantization_config,
             query,
-            point_deleted,
-            vec_deleted,
             distance: _,
             datatype: _,
             hardware_counter,
@@ -162,7 +153,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::RecommendBestScore(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
@@ -172,7 +163,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
@@ -182,7 +173,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<DenseVector> =
@@ -193,7 +184,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
@@ -203,7 +194,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
         }
     }
@@ -221,8 +212,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
             quantized_storage: _same_as_quantized_storage_in_args,
             quantization_config,
             query,
-            point_deleted,
-            vec_deleted,
             distance: _,
             datatype: _,
             hardware_counter,
@@ -236,7 +225,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::RecommendBestScore(reco_query) => {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
@@ -248,7 +237,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
@@ -260,7 +249,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
@@ -272,7 +261,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<MultiDenseVectorInternal> =
@@ -284,7 +273,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
+                raw_scorer_from_query_scorer(query_scorer)
             }
         }
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -2,7 +2,6 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
@@ -167,16 +166,12 @@ impl QuantizedVectors {
     pub fn raw_scorer<'a>(
         &'a self,
         query: QueryVector,
-        point_deleted: &'a BitSlice,
-        vec_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Box<dyn RawScorer + 'a>> {
         QuantizedScorerBuilder::new(
             &self.storage_impl,
             &self.config.quantization_config,
             query,
-            point_deleted,
-            vec_deleted,
             &self.distance,
             self.datatype,
             hardware_counter,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -3,8 +3,7 @@ use std::sync::atomic::AtomicBool;
 use bitvec::prelude::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::ext::BitSliceExt as _;
-use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
-use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoreType};
 use sparse::common::sparse_vector::SparseVector;
 
 use super::query::{
@@ -14,9 +13,7 @@ use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use super::query_scorer::multi_custom_query_scorer::MultiCustomQueryScorer;
 use super::query_scorer::sparse_custom_query_scorer::SparseCustomQueryScorer;
 use super::{DenseVectorStorage, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum};
-use crate::common::operation_error::{
-    CancellableResult, OperationError, OperationResult, check_process_stopped,
-};
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, QueryVector, VectorElementType, VectorElementTypeByte,
     VectorElementTypeHalf,
@@ -43,8 +40,8 @@ use crate::vector_storage::query_scorer::multi_metric_query_scorer::MultiMetricQ
 ///  │       └─────┘  │   │    └─────┘   │
 ///  │                │   │              │
 ///  └────────────────┘   │    ┌─────┐   │        Query
-///  - Deletions          │    │     │◄──┼───┐   ┌───────────────────┐
-///  - Access patterns    │    └─────┘   │   │   │  - RecoQuery      │
+///   - Access patterns   │    │     │◄──┼───┐   ┌───────────────────┐
+///                       │    └─────┘   │   │   │  - RecoQuery      │
 ///                       │              │   │   │  - DiscoveryQuery │
 ///                       └──────────────┘   └───┤  - ContextQuery   │
 ///                       - Query holding        │                   │
@@ -53,28 +50,8 @@ use crate::vector_storage::query_scorer::multi_metric_query_scorer::MultiMetricQ
 ///                                              - Complex queries
 ///
 /// ```
-///
-/// Optimized scorer for multiple scoring requests comparing with a single query
-/// Holds current query and params, receives only subset of points to score
 pub trait RawScorer {
-    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize;
-
-    /// Score points without excluding deleted and filtered points
-    ///
-    /// # Arguments
-    ///
-    /// * `points` - points to score
-    ///
-    /// # Returns
-    ///
-    /// Vector of scored points
-    fn score_points_unfiltered(
-        &self,
-        points: &mut dyn Iterator<Item = PointOffsetType>,
-    ) -> Vec<ScoredPointOffset>;
-
-    /// Return true if vector satisfies current search context for given point (exists and not deleted)
-    fn check_vector(&self, point: PointOffsetType) -> bool;
+    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoreType]);
 
     /// Score stored vector with vector under the given index
     fn score_point(&self, point: PointOffsetType) -> ScoreType;
@@ -85,58 +62,31 @@ pub trait RawScorer {
     ///
     /// Panics if any id is out of range
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType;
-
-    fn peek_top_iter(
-        &self,
-        points: &mut dyn Iterator<Item = PointOffsetType>,
-        top: usize,
-        is_stopped: &AtomicBool,
-    ) -> CancellableResult<Vec<ScoredPointOffset>>;
-
-    fn peek_top_all(
-        &self,
-        top: usize,
-        is_stopped: &AtomicBool,
-    ) -> CancellableResult<Vec<ScoredPointOffset>>;
 }
 
-pub struct RawScorerImpl<'a, TVector: ?Sized, TQueryScorer>
+pub struct RawScorerImpl<TVector: ?Sized, TQueryScorer>
 where
     TQueryScorer: QueryScorer<TVector>,
 {
     pub query_scorer: TQueryScorer,
-    /// Point deleted flags should be explicitly present as `false`
-    /// for each existing point in the segment.
-    /// If there are no flags for some points, they are considered deleted.
-    /// [`BitSlice`] defining flags for deleted points (and thus these vectors).
-    pub point_deleted: &'a BitSlice,
-    /// [`BitSlice`] defining flags for deleted vectors in this segment.
-    pub vec_deleted: &'a BitSlice,
-
     vector: std::marker::PhantomData<*const TVector>,
 }
 
 pub fn new_raw_scorer<'a>(
     query: QueryVector,
     vector_storage: &'a VectorStorageEnum,
-    point_deleted: &'a BitSlice,
     hc: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage {
-        VectorStorageEnum::DenseSimple(vs) => raw_scorer_impl(query, vs, point_deleted, hc),
-        VectorStorageEnum::DenseSimpleByte(vs) => {
-            raw_scorer_byte_impl(query, vs, point_deleted, hc)
-        }
-        VectorStorageEnum::DenseSimpleHalf(vs) => {
-            raw_scorer_half_impl(query, vs, point_deleted, hc)
-        }
+        VectorStorageEnum::DenseSimple(vs) => raw_scorer_impl(query, vs, hc),
+        VectorStorageEnum::DenseSimpleByte(vs) => raw_scorer_byte_impl(query, vs, hc),
+        VectorStorageEnum::DenseSimpleHalf(vs) => raw_scorer_half_impl(query, vs, hc),
 
         VectorStorageEnum::DenseMemmap(vs) => {
             if vs.has_async_reader() {
                 #[cfg(target_os = "linux")]
                 {
-                    let scorer_result =
-                        super::async_raw_scorer::new(query.clone(), vs, point_deleted, hc.fork());
+                    let scorer_result = super::async_raw_scorer::new(query.clone(), vs, hc.fork());
                     match scorer_result {
                         Ok(raw_scorer) => return Ok(raw_scorer),
                         Err(err) => log::error!("failed to initialize async raw scorer: {err}"),
@@ -147,63 +97,49 @@ pub fn new_raw_scorer<'a>(
                 log::warn!("async raw scorer is only supported on Linux");
             }
 
-            raw_scorer_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_scorer_impl(query, vs.as_ref(), hc)
         }
 
         // TODO(byte_storage): Implement async raw scorer for DenseMemmapByte and DenseMemmapHalf
-        VectorStorageEnum::DenseMemmapByte(vs) => {
-            raw_scorer_byte_impl(query, vs.as_ref(), point_deleted, hc)
-        }
-        VectorStorageEnum::DenseMemmapHalf(vs) => {
-            raw_scorer_half_impl(query, vs.as_ref(), point_deleted, hc)
-        }
+        VectorStorageEnum::DenseMemmapByte(vs) => raw_scorer_byte_impl(query, vs.as_ref(), hc),
+        VectorStorageEnum::DenseMemmapHalf(vs) => raw_scorer_half_impl(query, vs.as_ref(), hc),
 
-        VectorStorageEnum::DenseAppendableMemmap(vs) => {
-            raw_scorer_impl(query, vs.as_ref(), point_deleted, hc)
-        }
+        VectorStorageEnum::DenseAppendableMemmap(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseAppendableMemmapByte(vs) => {
-            raw_scorer_byte_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_scorer_byte_impl(query, vs.as_ref(), hc)
         }
         VectorStorageEnum::DenseAppendableMemmapHalf(vs) => {
-            raw_scorer_half_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_scorer_half_impl(query, vs.as_ref(), hc)
         }
-        VectorStorageEnum::DenseAppendableInRam(vs) => {
-            raw_scorer_impl(query, vs.as_ref(), point_deleted, hc)
-        }
+        VectorStorageEnum::DenseAppendableInRam(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseAppendableInRamByte(vs) => {
-            raw_scorer_byte_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_scorer_byte_impl(query, vs.as_ref(), hc)
         }
         VectorStorageEnum::DenseAppendableInRamHalf(vs) => {
-            raw_scorer_half_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_scorer_half_impl(query, vs.as_ref(), hc)
         }
-        VectorStorageEnum::SparseSimple(vs) => raw_sparse_scorer_impl(query, vs, point_deleted, hc),
-        VectorStorageEnum::SparseMmap(vs) => raw_sparse_scorer_impl(query, vs, point_deleted, hc),
-        VectorStorageEnum::MultiDenseSimple(vs) => {
-            raw_multi_scorer_impl(query, vs, point_deleted, hc)
-        }
-        VectorStorageEnum::MultiDenseSimpleByte(vs) => {
-            raw_multi_scorer_byte_impl(query, vs, point_deleted, hc)
-        }
-        VectorStorageEnum::MultiDenseSimpleHalf(vs) => {
-            raw_multi_scorer_half_impl(query, vs, point_deleted, hc)
-        }
+        VectorStorageEnum::SparseSimple(vs) => raw_sparse_scorer_impl(query, vs, hc),
+        VectorStorageEnum::SparseMmap(vs) => raw_sparse_scorer_impl(query, vs, hc),
+        VectorStorageEnum::MultiDenseSimple(vs) => raw_multi_scorer_impl(query, vs, hc),
+        VectorStorageEnum::MultiDenseSimpleByte(vs) => raw_multi_scorer_byte_impl(query, vs, hc),
+        VectorStorageEnum::MultiDenseSimpleHalf(vs) => raw_multi_scorer_half_impl(query, vs, hc),
         VectorStorageEnum::MultiDenseAppendableMemmap(vs) => {
-            raw_multi_scorer_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_multi_scorer_impl(query, vs.as_ref(), hc)
         }
         VectorStorageEnum::MultiDenseAppendableMemmapByte(vs) => {
-            raw_multi_scorer_byte_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_multi_scorer_byte_impl(query, vs.as_ref(), hc)
         }
         VectorStorageEnum::MultiDenseAppendableMemmapHalf(vs) => {
-            raw_multi_scorer_half_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_multi_scorer_half_impl(query, vs.as_ref(), hc)
         }
         VectorStorageEnum::MultiDenseAppendableInRam(vs) => {
-            raw_multi_scorer_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_multi_scorer_impl(query, vs.as_ref(), hc)
         }
         VectorStorageEnum::MultiDenseAppendableInRamByte(vs) => {
-            raw_multi_scorer_byte_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_multi_scorer_byte_impl(query, vs.as_ref(), hc)
         }
         VectorStorageEnum::MultiDenseAppendableInRamHalf(vs) => {
-            raw_multi_scorer_half_impl(query, vs.as_ref(), point_deleted, hc)
+            raw_multi_scorer_half_impl(query, vs.as_ref(), hc)
         }
     }
 }
@@ -213,61 +149,47 @@ pub static DEFAULT_STOPPED: AtomicBool = AtomicBool::new(false);
 pub fn raw_sparse_scorer_impl<'a, TVectorStorage: SparseVectorStorage>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
         QueryVector::Nearest(_vector) => Err(OperationError::service_error(
             "Raw scorer must not be used for nearest queries",
         )),
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<SparseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                SparseCustomQueryScorer::<_, _>::new(
-                    RecoBestScoreQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = SparseCustomQueryScorer::<_, _>::new(
+                RecoBestScoreQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<SparseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                SparseCustomQueryScorer::<_, _>::new(
-                    RecoSumScoresQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = SparseCustomQueryScorer::<_, _>::new(
+                RecoSumScoresQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<SparseVector> = discovery_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                SparseCustomQueryScorer::<_, _>::new(
-                    discovery_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = SparseCustomQueryScorer::<_, _>::new(
+                discovery_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<SparseVector> = context_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                SparseCustomQueryScorer::<_, _>::new(
-                    context_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = SparseCustomQueryScorer::<_, _>::new(
+                context_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
     }
 }
@@ -276,47 +198,28 @@ pub fn raw_sparse_scorer_impl<'a, TVectorStorage: SparseVectorStorage>(
 pub fn new_raw_scorer_for_test<'a>(
     vector: QueryVector,
     vector_storage: &'a VectorStorageEnum,
-    point_deleted: &'a BitSlice,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    new_raw_scorer(
-        vector,
-        vector_storage,
-        point_deleted,
-        HardwareCounterCell::new(),
-    )
+    new_raw_scorer(vector, vector_storage, HardwareCounterCell::new())
 }
 
 pub fn raw_scorer_impl<'a, TVectorStorage: DenseVectorStorage<VectorElementType>>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage.distance() {
-        Distance::Cosine => new_scorer_with_metric::<CosineMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
-        Distance::Euclid => new_scorer_with_metric::<EuclidMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
-        Distance::Dot => new_scorer_with_metric::<DotProductMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
-        Distance::Manhattan => new_scorer_with_metric::<ManhattanMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
+        Distance::Cosine => {
+            new_scorer_with_metric::<CosineMetric, _>(query, vector_storage, hardware_counter)
+        }
+        Distance::Euclid => {
+            new_scorer_with_metric::<EuclidMetric, _>(query, vector_storage, hardware_counter)
+        }
+        Distance::Dot => {
+            new_scorer_with_metric::<DotProductMetric, _>(query, vector_storage, hardware_counter)
+        }
+        Distance::Manhattan => {
+            new_scorer_with_metric::<ManhattanMetric, _>(query, vector_storage, hardware_counter)
+        }
     }
 }
 
@@ -327,67 +230,52 @@ fn new_scorer_with_metric<
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
-        QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MetricQueryScorer::<VectorElementType, TMetric, _>::new(
+        QueryVector::Nearest(vector) => {
+            let query_scorer = MetricQueryScorer::<VectorElementType, TMetric, _>::new(
                 vector.try_into()?,
                 vector_storage,
                 hardware_counter,
-            ),
-            point_deleted,
-            vec_deleted,
-        ),
+            );
+            raw_scorer_from_query_scorer(query_scorer)
+        }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    RecoBestScoreQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                RecoBestScoreQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    RecoSumScoresQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                RecoSumScoresQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    discovery_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                discovery_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    context_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                context_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
     }
 }
@@ -395,32 +283,23 @@ fn new_scorer_with_metric<
 pub fn raw_scorer_byte_impl<'a, TVectorStorage: DenseVectorStorage<VectorElementTypeByte>>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage.distance() {
-        Distance::Cosine => new_scorer_byte_with_metric::<CosineMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
-        Distance::Euclid => new_scorer_byte_with_metric::<EuclidMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
+        Distance::Cosine => {
+            new_scorer_byte_with_metric::<CosineMetric, _>(query, vector_storage, hardware_counter)
+        }
+        Distance::Euclid => {
+            new_scorer_byte_with_metric::<EuclidMetric, _>(query, vector_storage, hardware_counter)
+        }
         Distance::Dot => new_scorer_byte_with_metric::<DotProductMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Manhattan => new_scorer_byte_with_metric::<ManhattanMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
     }
@@ -433,67 +312,52 @@ fn new_scorer_byte_with_metric<
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
-        QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
+        QueryVector::Nearest(vector) => {
+            let query_scorer = MetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
                 vector.try_into()?,
                 vector_storage,
                 hardware_counter,
-            ),
-            point_deleted,
-            vec_deleted,
-        ),
+            );
+            raw_scorer_from_query_scorer(query_scorer)
+        }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    RecoBestScoreQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+                RecoBestScoreQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    RecoSumScoresQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+                RecoSumScoresQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    discovery_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+                discovery_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    context_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+                context_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
     }
 }
@@ -501,32 +365,23 @@ fn new_scorer_byte_with_metric<
 pub fn raw_scorer_half_impl<'a, TVectorStorage: DenseVectorStorage<VectorElementTypeHalf>>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage.distance() {
-        Distance::Cosine => new_scorer_half_with_metric::<CosineMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
-        Distance::Euclid => new_scorer_half_with_metric::<EuclidMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
+        Distance::Cosine => {
+            new_scorer_half_with_metric::<CosineMetric, _>(query, vector_storage, hardware_counter)
+        }
+        Distance::Euclid => {
+            new_scorer_half_with_metric::<EuclidMetric, _>(query, vector_storage, hardware_counter)
+        }
         Distance::Dot => new_scorer_half_with_metric::<DotProductMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Manhattan => new_scorer_half_with_metric::<ManhattanMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
     }
@@ -539,75 +394,58 @@ fn new_scorer_half_with_metric<
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter_cell: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
-        QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MetricQueryScorer::<VectorElementTypeHalf, TMetric, _>::new(
+        QueryVector::Nearest(vector) => {
+            let query_scorer = MetricQueryScorer::<VectorElementTypeHalf, TMetric, _>::new(
                 vector.try_into()?,
                 vector_storage,
                 hardware_counter_cell,
-            ),
-            point_deleted,
-            vec_deleted,
-        ),
+            );
+            raw_scorer_from_query_scorer(query_scorer)
+        }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    RecoBestScoreQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter_cell,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+                RecoBestScoreQuery::from(reco_query),
+                vector_storage,
+                hardware_counter_cell,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    RecoSumScoresQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter_cell,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+                RecoSumScoresQuery::from(reco_query),
+                vector_storage,
+                hardware_counter_cell,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    discovery_query,
-                    vector_storage,
-                    hardware_counter_cell,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+                discovery_query,
+                vector_storage,
+                hardware_counter_cell,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    context_query,
-                    vector_storage,
-                    hardware_counter_cell,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+                context_query,
+                vector_storage,
+                hardware_counter_cell,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
     }
 }
 
 pub fn raw_scorer_from_query_scorer<'a, TVector, TQueryScorer>(
     query_scorer: TQueryScorer,
-    point_deleted: &'a BitSlice,
-    vec_deleted: &'a BitSlice,
 ) -> OperationResult<Box<dyn RawScorer + 'a>>
 where
     TVector: ?Sized + 'a,
@@ -615,8 +453,6 @@ where
 {
     Ok(Box::new(RawScorerImpl::<TVector, TQueryScorer> {
         query_scorer,
-        point_deleted,
-        vec_deleted,
         vector: std::marker::PhantomData,
     }))
 }
@@ -624,32 +460,23 @@ where
 pub fn raw_multi_scorer_impl<'a, TVectorStorage: MultiVectorStorage<VectorElementType>>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage.distance() {
-        Distance::Cosine => new_multi_scorer_with_metric::<CosineMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
-        Distance::Euclid => new_multi_scorer_with_metric::<EuclidMetric, _>(
-            query,
-            vector_storage,
-            point_deleted,
-            hardware_counter,
-        ),
+        Distance::Cosine => {
+            new_multi_scorer_with_metric::<CosineMetric, _>(query, vector_storage, hardware_counter)
+        }
+        Distance::Euclid => {
+            new_multi_scorer_with_metric::<EuclidMetric, _>(query, vector_storage, hardware_counter)
+        }
         Distance::Dot => new_multi_scorer_with_metric::<DotProductMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Manhattan => new_multi_scorer_with_metric::<ManhattanMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
     }
@@ -662,69 +489,54 @@ fn new_multi_scorer_with_metric<
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
-        QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MultiMetricQueryScorer::<VectorElementType, TMetric, _>::new(
+        QueryVector::Nearest(vector) => {
+            let query_scorer = MultiMetricQueryScorer::<VectorElementType, TMetric, _>::new(
                 &vector.try_into()?,
                 vector_storage,
                 hardware_counter,
-            ),
-            point_deleted,
-            vec_deleted,
-        ),
+            );
+            raw_scorer_from_query_scorer(query_scorer)
+        }
         QueryVector::RecommendBestScore(reco_query) => {
-            let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    RecoBestScoreQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                RecoBestScoreQuery::from(query_scorer),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    RecoSumScoresQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                RecoSumScoresQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    discovery_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                discovery_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            raw_scorer_from_query_scorer(
-                MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
-                    context_query,
-                    vector_storage,
-                    hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                context_query,
+                vector_storage,
+                hardware_counter,
+            );
+            raw_scorer_from_query_scorer(query_scorer)
         }
     }
 }
@@ -732,32 +544,27 @@ fn new_multi_scorer_with_metric<
 pub fn raw_multi_scorer_byte_impl<'a, TVectorStorage: MultiVectorStorage<VectorElementTypeByte>>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage.distance() {
         Distance::Cosine => new_multi_scorer_byte_with_metric::<CosineMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Euclid => new_multi_scorer_byte_with_metric::<EuclidMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Dot => new_multi_scorer_byte_with_metric::<DotProductMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Manhattan => new_multi_scorer_byte_with_metric::<ManhattanMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
     }
@@ -770,69 +577,58 @@ fn new_multi_scorer_byte_with_metric<
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
-        QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MultiMetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
+        QueryVector::Nearest(vector) => {
+            let query_scorer = MultiMetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
                 &vector.try_into()?,
                 vector_storage,
                 hardware_counter,
-            ),
-            point_deleted,
-            vec_deleted,
-        ),
+            );
+            raw_scorer_from_query_scorer(query_scorer)
+        }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
                     RecoBestScoreQuery::from(reco_query),
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
                     RecoSumScoresQuery::from(reco_query),
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
                     discovery_query,
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
                     context_query,
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
     }
 }
@@ -840,32 +636,27 @@ fn new_multi_scorer_byte_with_metric<
 pub fn raw_multi_scorer_half_impl<'a, TVectorStorage: MultiVectorStorage<VectorElementTypeHalf>>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage.distance() {
         Distance::Cosine => new_multi_scorer_half_with_metric::<CosineMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Euclid => new_multi_scorer_half_with_metric::<EuclidMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Dot => new_multi_scorer_half_with_metric::<DotProductMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
         Distance::Manhattan => new_multi_scorer_half_with_metric::<ManhattanMetric, _>(
             query,
             vector_storage,
-            point_deleted,
             hardware_counter,
         ),
     }
@@ -878,113 +669,79 @@ fn new_multi_scorer_half_with_metric<
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
-    point_deleted: &'a BitSlice,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-    let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
-        QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MultiMetricQueryScorer::<VectorElementTypeHalf, TMetric, _>::new(
+        QueryVector::Nearest(vector) => {
+            let query_scorer = MultiMetricQueryScorer::<VectorElementTypeHalf, TMetric, _>::new(
                 &vector.try_into()?,
                 vector_storage,
                 hardware_counter,
-            ),
-            point_deleted,
-            vec_deleted,
-        ),
+            );
+            raw_scorer_from_query_scorer(query_scorer)
+        }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
                     RecoBestScoreQuery::from(reco_query),
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
                     RecoSumScoresQuery::from(reco_query),
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
                     discovery_query,
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            raw_scorer_from_query_scorer(
+            let query_scorer =
                 MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
                     context_query,
                     vector_storage,
                     hardware_counter,
-                ),
-                point_deleted,
-                vec_deleted,
-            )
+                );
+            raw_scorer_from_query_scorer(query_scorer)
         }
     }
 }
 
-impl<TVector, TQueryScorer> RawScorer for RawScorerImpl<'_, TVector, TQueryScorer>
+impl<TVector, TQueryScorer> RawScorer for RawScorerImpl<TVector, TQueryScorer>
 where
     TVector: ?Sized,
     TQueryScorer: QueryScorer<TVector>,
 {
-    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
-        let mut size: usize = 0;
-        for point_id in points.iter().copied() {
-            if !self.check_vector(point_id) {
-                continue;
-            }
-            scores[size] = ScoredPointOffset {
-                idx: point_id,
-                score: self.query_scorer.score_stored(point_id),
-            };
+    fn score_points(&self, mut points: &[PointOffsetType], mut scores: &mut [ScoreType]) {
+        assert_eq!(points.len(), scores.len());
 
-            size += 1;
-            if size == scores.len() {
-                return size;
-            }
+        while !points.is_empty() {
+            let chunk_size = points.len().min(VECTOR_READ_BATCH_SIZE);
+            let (chunk_points, rest_points) = points.split_at(chunk_size);
+            let (chunk_scores, rest_scores) = scores.split_at_mut(chunk_size);
+            self.query_scorer
+                .score_stored_batch(&chunk_points[..chunk_size], &mut chunk_scores[..chunk_size]);
+            points = rest_points;
+            scores = rest_scores;
         }
-        size
-    }
-
-    fn score_points_unfiltered(
-        &self,
-        points: &mut dyn Iterator<Item = PointOffsetType>,
-    ) -> Vec<ScoredPointOffset> {
-        let mut scores = vec![];
-        for point_id in points {
-            scores.push(ScoredPointOffset {
-                idx: point_id,
-                score: self.query_scorer.score_stored(point_id),
-            });
-        }
-        scores
-    }
-
-    fn check_vector(&self, point: PointOffsetType) -> bool {
-        check_deleted_condition(point, self.vec_deleted, self.point_deleted)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {
@@ -993,62 +750,6 @@ where
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         self.query_scorer.score_internal(point_a, point_b)
-    }
-
-    fn peek_top_iter(
-        &self,
-        points: &mut dyn Iterator<Item = PointOffsetType>,
-        top: usize,
-        is_stopped: &AtomicBool,
-    ) -> CancellableResult<Vec<ScoredPointOffset>> {
-        if top == 0 {
-            return Ok(vec![]);
-        }
-
-        let mut pq = FixedLengthPriorityQueue::new(top);
-
-        // Reuse the same buffer for all chunks, to avoid reallocation
-        let mut chunk = [0; VECTOR_READ_BATCH_SIZE];
-        let mut scores_buffer = [0.0; VECTOR_READ_BATCH_SIZE];
-        loop {
-            let mut chunk_size = 0;
-            for point_id in &mut *points {
-                check_process_stopped(is_stopped)?;
-                if !self.check_vector(point_id) {
-                    continue;
-                }
-                chunk[chunk_size] = point_id;
-                chunk_size += 1;
-                if chunk_size == VECTOR_READ_BATCH_SIZE {
-                    break;
-                }
-            }
-
-            if chunk_size == 0 {
-                break;
-            }
-
-            self.query_scorer
-                .score_stored_batch(&chunk[..chunk_size], &mut scores_buffer[..chunk_size]);
-
-            for i in 0..chunk_size {
-                pq.push(ScoredPointOffset {
-                    idx: chunk[i],
-                    score: scores_buffer[i],
-                });
-            }
-        }
-
-        Ok(pq.into_sorted_vec())
-    }
-
-    fn peek_top_all(
-        &self,
-        top: usize,
-        is_stopped: &AtomicBool,
-    ) -> CancellableResult<Vec<ScoredPointOffset>> {
-        let mut point_ids = 0..self.point_deleted.len() as PointOffsetType;
-        self.peek_top_iter(&mut point_ids, top, is_stopped)
     }
 }
 

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use rand::SeedableRng as _;
 use rand::seq::IteratorRandom as _;
 
-use super::utils::{Result, delete_random_vectors, insert_distributed_vectors, sampler, score};
+use super::utils::{Result, delete_random_vectors, insert_distributed_vectors, sampler};
 use crate::common::rocksdb_wrapper;
 use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
@@ -126,8 +126,10 @@ fn test_random_score(
     let points = rng.random_range(1..storage.total_vector_count());
     let points = (0..storage.total_vector_count() as _).choose_multiple(&mut rng, points);
 
-    let res = score(&mut scorer, &points);
-    let async_res = score(&mut async_scorer, &points);
+    let res = scorer.score_points(&mut points.clone(), 0).collect_vec();
+    let async_res = async_scorer
+        .score_points(&mut points.clone(), 0)
+        .collect_vec();
 
     assert_eq!(res, async_res);
     Ok(())

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -12,11 +12,12 @@ use crate::common::rocksdb_wrapper;
 use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTracker;
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::Distance;
+use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
 use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::vector_storage_base::VectorStorage;
-use crate::vector_storage::{VectorStorageEnum, async_raw_scorer, new_raw_scorer_for_test};
 
 #[test]
 fn async_raw_scorer_cosine() -> Result<()> {
@@ -111,19 +112,22 @@ fn test_random_score(
 ) -> Result<()> {
     let query: QueryVector = sampler(&mut rng).take(dim).collect_vec().into();
 
-    let raw_scorer = new_raw_scorer_for_test(query.clone(), storage, deleted_points).unwrap();
+    let mut scorer = FilteredScorer::new_for_test(query.clone(), storage, deleted_points);
 
-    let async_raw_scorer = if let VectorStorageEnum::DenseMemmap(storage) = storage {
-        async_raw_scorer::new(query, storage, deleted_points, HardwareCounterCell::new())?
-    } else {
-        unreachable!();
-    };
+    let mut async_scorer = FilteredScorer::new(
+        query,
+        storage,
+        None,
+        None,
+        deleted_points,
+        HardwareCounterCell::new(),
+    )?;
 
     let points = rng.random_range(1..storage.total_vector_count());
     let points = (0..storage.total_vector_count() as _).choose_multiple(&mut rng, points);
 
-    let res = score(&*raw_scorer, &points);
-    let async_res = score(&*async_raw_scorer, &points);
+    let res = score(&mut scorer, &points);
+    let async_res = score(&mut async_scorer, &points);
 
     assert_eq!(res, async_res);
     Ok(())

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -17,17 +17,18 @@ use crate::data_types::vectors::{QueryVector, VectorElementType};
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::fixtures::query_fixtures::QueryVariant;
 use crate::id_tracker::id_tracker_base::IdTracker;
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{
     BinaryQuantizationConfig, Distance, ProductQuantizationConfig, QuantizationConfig,
     ScalarQuantizationConfig,
 };
+use crate::vector_storage::VectorStorageEnum;
 #[cfg(target_os = "linux")]
 use crate::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
 use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::tests::utils::score;
 use crate::vector_storage::vector_storage_base::VectorStorage;
-use crate::vector_storage::{VectorStorageEnum, new_raw_scorer_for_test};
 
 const DIMS: usize = 128;
 const NUM_POINTS: usize = 600;
@@ -182,35 +183,26 @@ fn scoring_equivalency(
     for i in 0..attempts {
         let query = random_query(&query_variant, &mut rng, &gen_sampler);
 
-        let raw_scorer = new_raw_scorer_for_test(
+        let mut scorer = FilteredScorer::new_for_test(
             query.clone(),
             &raw_storage,
             id_tracker.deleted_point_bitslice(),
-        )
-        .unwrap();
+        );
 
-        let other_scorer = match &quantized_vectors {
-            Some(quantized_storage) => quantized_storage
-                .raw_scorer(
-                    query.clone(),
-                    id_tracker.deleted_point_bitslice(),
-                    other_storage.deleted_vector_bitslice(),
-                    HardwareCounterCell::new(),
-                )
-                .unwrap(),
-            None => new_raw_scorer_for_test(
-                query.clone(),
-                &other_storage,
-                id_tracker.deleted_point_bitslice(),
-            )
-            .unwrap(),
-        };
+        let mut other_scorer = FilteredScorer::new(
+            query.clone(),
+            &other_storage,
+            quantized_vectors.as_ref(),
+            None,
+            id_tracker.deleted_point_bitslice(),
+            HardwareCounterCell::new(),
+        )?;
 
         let points =
             (0..other_storage.total_vector_count() as _).choose_multiple(&mut rng, SAMPLE_SIZE);
 
-        let raw_scores = score(&*raw_scorer, &points);
-        let other_scores = score(&*other_scorer, &points);
+        let raw_scores = score(&mut scorer, &points);
+        let other_scores = score(&mut other_scorer, &points);
 
         // Compare scores
         if quantized_vectors.is_none() {

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -15,12 +15,13 @@ use crate::data_types::vectors::{
 };
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage;
 use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
 use crate::vector_storage::{
-    DEFAULT_STOPPED, MultiVectorStorage, VectorStorage, VectorStorageEnum, new_raw_scorer_for_test,
+    DEFAULT_STOPPED, MultiVectorStorage, VectorStorage, VectorStorageEnum,
 };
 
 #[derive(Clone, Copy)]
@@ -125,8 +126,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     let vector: Vec<Vec<f32>> = vec![vec![2.0; vector_dim]];
     let query = QueryVector::Nearest(vector.try_into().unwrap());
     let scorer =
-        new_raw_scorer_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-            .unwrap();
+        FilteredScorer::new_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice());
     let closest = scorer
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
         .unwrap();
@@ -148,8 +148,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     let vector: Vec<Vec<f32>> = vec![vec![1.0; vector_dim]];
     let query = QueryVector::Nearest(vector.try_into().unwrap());
     let scorer =
-        new_raw_scorer_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-            .unwrap();
+        FilteredScorer::new_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice());
     let closest = scorer
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
         .unwrap();
@@ -170,8 +169,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     let vector: Vec<Vec<f32>> = vec![vec![1.0; vector_dim]];
     let query = QueryVector::Nearest(vector.try_into().unwrap());
     let scorer =
-        new_raw_scorer_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-            .unwrap();
+        FilteredScorer::new_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice());
     let closest = scorer.peek_top_all(5, &DEFAULT_STOPPED).unwrap();
     assert!(closest.is_empty(), "must have no results, all deleted");
 }
@@ -233,8 +231,7 @@ fn do_test_update_from_delete_points(
     let query = QueryVector::Nearest(vector.try_into().unwrap());
 
     let scorer =
-        new_raw_scorer_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice())
-            .unwrap();
+        FilteredScorer::new_for_test(query, storage, borrowed_id_tracker.deleted_point_bitslice());
     let closest = scorer
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
         .unwrap();

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -12,12 +12,11 @@ use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
 use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::vector_storage::query::RecoQuery;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use crate::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
-use crate::vector_storage::{
-    DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer_for_test,
-};
+use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
 
 fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     let points: Vec<SparseVector> = vec![
@@ -79,12 +78,11 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         negatives: vec![],
     });
     // Because nearest search for raw scorer is incorrect,
-    let scorer = new_raw_scorer_for_test(
+    let scorer = FilteredScorer::new_for_test(
         query_vector,
         storage,
         borrowed_id_tracker.deleted_point_bitslice(),
-    )
-    .unwrap();
+    );
     let closest = scorer
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
         .unwrap();
@@ -175,12 +173,11 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         positives: vec![vector.into()],
         negatives: vec![],
     });
-    let scorer = new_raw_scorer_for_test(
+    let scorer = FilteredScorer::new_for_test(
         query_vector,
         storage,
         borrowed_id_tracker.deleted_point_bitslice(),
-    )
-    .unwrap();
+    );
     let closest = scorer
         .peek_top_iter(&mut [0, 1, 2, 3, 4, 5].iter().cloned(), 5, &DEFAULT_STOPPED)
         .unwrap();

--- a/lib/segment/src/vector_storage/tests/utils.rs
+++ b/lib/segment/src/vector_storage/tests/utils.rs
@@ -6,7 +6,8 @@ use rand::seq::IteratorRandom;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::id_tracker::IdTracker;
-use crate::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum};
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 pub type Result<T, E = Error> = result::Result<T, E>;
 pub type Error = Box<dyn error::Error>;
@@ -55,9 +56,8 @@ pub fn delete_random_vectors(
     Ok(())
 }
 
-pub fn score(scorer: &dyn RawScorer, points: &[PointOffsetType]) -> Vec<ScoredPointOffset> {
-    let mut scores = vec![Default::default(); points.len()];
-    let scored = scorer.score_points(points, &mut scores);
-    scores.resize_with(scored, Default::default);
-    scores
+pub fn score(scorer: &mut FilteredScorer, points: &[PointOffsetType]) -> Vec<ScoredPointOffset> {
+    scorer
+        .score_points(&mut points.to_vec(), 0)
+        .collect::<Vec<_>>()
 }

--- a/lib/segment/src/vector_storage/tests/utils.rs
+++ b/lib/segment/src/vector_storage/tests/utils.rs
@@ -1,12 +1,10 @@
 use std::{error, result};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{PointOffsetType, ScoredPointOffset};
 use rand::seq::IteratorRandom;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::id_tracker::IdTracker;
-use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 pub type Result<T, E = Error> = result::Result<T, E>;
@@ -54,10 +52,4 @@ pub fn delete_random_vectors(
     }
 
     Ok(())
-}
-
-pub fn score(scorer: &mut FilteredScorer, points: &[PointOffsetType]) -> Vec<ScoredPointOffset> {
-    scorer
-        .score_points(&mut points.to_vec(), 0)
-        .collect::<Vec<_>>()
 }


### PR DESCRIPTION
# Current version

Currently, we have the following traits/structs:
- `RawScorer` filters points by deletion flags, then scores them.
- `FilteredScorer` filters points by `FilterContext`, then pass them to `RawScorer` to score.
  Some methods of `FilteredScorer` simply call the corresponding methods of `RawScorer`.

Both `RawScorer` and `FilteredScorer` filter points, and both of them perform the scoring.

# In this PR

In this PR, I moved a lot of logic from `RawScorer` to `FilteredScorer`.

- `RawScorer::score_points()` doesn't filter points anymore.
- `point_deleted`, `vec_deleted` bitslices are moved to `FilteredScorer`.
   Consequence: `FilteredScorer::check_vector()` now should be a bit faster.
    - It no longer performs a dyn trait call to `RawScorer`.
    - Now these bitslices are checked before checking `FilterContext`, not after.
- `peek_top_iter()` and `peek_top_all()` methods are moved to `FilteredScorer`.
- A lot of tests that use `RawScorer` updated to use `FilteredScorer` instead.

## ~~Removed temporary buffer `FilteredScorer::points_buffer`~~

Not in this version of PR.

<details><summary>What was in this PR previously?</summary>

<strike>
Minor change: this PR changes the interface of the scorer and the filterer to avoid the need for a temporary buffer.

Previously:
1. Caller prepares a vector of `PointOffsetType` and passes it to `FilteredScorer`.
2. `FilteredScorer`
   - filters in-place this vector (destroying the original values)
   - allocates a buffer of type `Vec<ScoredPointOffset>` (reusable, stored in `FilteredScorer`)
   - calls `RawScorer::score_points` with both of these vectors.
3. `RawScorer::score_points` also performs its own filtering. It returns a number of scored points.
4. `FilteredScorer` returns buffer slice truncated by this number to the caller.

In this PR:
1. Caller prepares a vector of `ScoredPointOffset`.
   Only the `.idx` field should be set; the `.score` field should be set to an arbitrary meaningless value.
2. `PointsFilterer` filters this vector in-place using `Vec::retain()`.
3. `RawScorer::score_points` fills the `.score` values in-place.
</strike>

</details>

<details><summary>Why it is no longer in this PR?</summary>

In the current version of the PR, `RawScorerImpl::score_points` calls `QueryScorer::score_stored_batch`, which accepts two separate slices.

Doing the same for `QueryScorer` would be complicated (but possible I guess).
Illustrated: if you replace `ids: &[PointOffsetType], scores: &mut [ScoreType]` with `ids_with_scores: &mut [ScoredPointOffset]`, then you can't just pass `ids` to `get_dense_batch` in the following code:

https://github.com/qdrant/qdrant/blob/23b5f352f13e52fa002799e101d4e843ca4edac6/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs#L77-L81

</details>

# Performance

BFB on small (32 element) vectors: 3612 RPS -> 4721 RPS.
No significant changes on 1.5k vectors.

https://github.com/qdrant/vector-db-benchmark/actions/runs/14606832003

## Criterion benchmark results

A lot of benchmarks got a huge boost, but the benchmark logic it's not exactly the same, so take it with a grain of salt:
- Benchmarks that use `TestRawScorerProducer` no longer use `FakeFilterContext` (so one less dyn call in `FilteredScorer` for them).
- `FilteredScorer::score_points()` now returns an iterator, not a slice.

<details><summary>Results</summary>

`hnsw_build_graph`:
```
Benchmarking hnsw-index-build-group/hnsw_index: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.2s.
hnsw-index-build-group/hnsw_index
                        time:   [915.87 ms 920.81 ms 926.33 ms]
                        change: [-3.5310% -2.8506% -2.0601%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
```

`hnsw_build_asymptotic`:
```
hnsw-index-build-asymptotic/build-n-search-hnsw-5k
                        time:   [43.190 µs 43.231 µs 43.275 µs]
                        change: [-5.8648% -5.5461% -5.1992%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
hnsw-index-build-asymptotic/build-n-search-hnsw-1M
                        time:   [143.51 µs 143.76 µs 144.02 µs]
                        change: [-10.849% -10.650% -10.448%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
hnsw-index-build-asymptotic/build-n-search-hnsw-1M-score-point
                        time:   [68.044 µs 68.103 µs 68.162 µs]
                        change: [-18.860% -18.676% -18.505%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

scoring-vector/score-point
                        time:   [19.259 µs 19.275 µs 19.291 µs]
                        change: [-23.060% -22.902% -22.749%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
scoring-vector/score-point-10x
                        time:   [19.414 µs 19.448 µs 19.485 µs]
                        change: [-25.670% -25.517% -25.364%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
scoring-vector/score-point-50x
                        time:   [55.111 µs 55.168 µs 55.227 µs]
                        change: [-23.943% -23.653% -23.373%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

scoring-vector/basic-score-point
                        time:   [144.57 µs 144.70 µs 144.82 µs]
                        change: [-0.8233% -0.6519% -0.4308%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
scoring-vector/basic-score-point-10x
                        time:   [155.73 µs 155.89 µs 156.04 µs]
                        change: [-1.2111% -0.9589% -0.7167%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```

`hnsw_search_graph`:
```
hnsw-search-graph/uncompressed
                        time:   [357.41 µs 358.14 µs 358.86 µs]
                        change: [-17.125% -16.858% -16.586%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
hnsw-search-graph/compressed
                        time:   [360.08 µs 360.91 µs 361.75 µs]
                        change: [-16.297% -16.001% -15.667%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
hnsw-search-graph/plain time:   [19.076 ms 19.113 ms 19.156 ms]
                        change: [-5.7350% -5.5325% -5.3217%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

</details>

## Performance on glove-100

Made 30k unique batch search requests with 10 searches in each. Times for each batch are in ms.

<table><tr><td>

No filter:
|        | before | after  |
| ------ | -----: | -----: |
| min    | 10.017 |  8.731 |
| max    | 20.559 | 22.528 |
| mean   | 12.683 | 11.020 |
| median | 12.380 | 10.792 |
| p95    | 15.680 | 13.445 |
| p99    | 17.600 | 15.077 |

<td>

With no-op filter:
|        | before | after  |
| ------ | -----: | -----: |
| min    | 10.724 |  9.445 |
| max    | 20.958 | 22.160 |
| mean   | 13.595 | 11.986 |
| median | 13.267 | 11.700 |
| p95    | 16.967 | 14.755 |
| p99    | 19.192 | 16.051 |

</table>

Request for no filter:
```
POST collections/{collection}/points/search/batch
{
  "searches": [
    {"vector": <vector>, "limit": 10 },
    … (9 more) …
  ]
}
```

Request for no-op filter:
```
POST collections/{collection}/points/search/batch
{
  "searches": [
    {"vector": <vector>, "limit": 10, "filter": {"must_not": {"has_id": [1]}} },
    … (9 more) …
  ]
}
```

# Why

The new interface would be useful in incremental HNSW build as we would need to search without filtering.

Another potential improvement that this PR would allow described below. Suppose we perform an unfiltered search within a graph that has additional links. See this code:
https://github.com/qdrant/qdrant/blob/7abc684361fb81d8b62cf1554d8bf4fb65a706d7/lib/segment/src/index/hnsw_index/graph_layers.rs#L73-L80
This logic here is NOT: "use the first `m` neighbors aka main links";
Instead, the implemented logic is: "use the first `m` non-visited neighbors, i.e. take additional links if the main ones have already been visited".
It seems to me that the implemented logic imposes additional unnecessary work. I believe that we should flip filters like this (pseudo code):

```
// old
point_ids.filter(is_not_visited).filter(is_not_deleted).take(m)
// new
point_ids.filter(is_not_deleted).take(m).filter(is_not_visited)
```
