### PR TITLE
Add test to ensure we don't panic if flags are undefined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "self_cell",
  "semver",
  "serde",
+ "serde_json",
  "tango-bench",
  "tap",
  "tar",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -42,6 +42,7 @@ criterion = { workspace = true }
 itertools = { workspace = true }
 rstest = { workspace = true }
 self_cell = "1.1.0"
+serde_json = { workspace = true }
 tango-bench = "0.6.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -87,3 +87,15 @@ pub fn feature_flags() -> FeatureFlags {
     log::warn!("Feature flags not initialized!");
     FeatureFlags::default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure we properly deserialize and don't crash on empty state
+    #[test]
+    fn test_deserialize_empty_flags() {
+        let empty: FeatureFlags = serde_json::from_str("{}").unwrap();
+        assert!(empty.is_empty());
+    }
+}


### PR DESCRIPTION
This simple test ensures that <https://github.com/qdrant/qdrant/pull/6234> cannot happen again.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?