### PR TITLE
Fix incorrect resharding transfer fraction for points to transfer

### DIFF
--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -180,64 +180,6 @@ impl<T: Eq + Hash> HashRingRouter<T> {
             HashRingRouter::Resharding { new, .. } => new.nodes(),
         }
     }
-
-    /// Point count fraction in resharding shard transfer
-    ///
-    /// If we do a resharding shard transfer, what fraction of points in the source shard will be
-    /// transferred to the target shard.
-    ///
-    /// Note: the fraction if points is relative to the point count in the source shard, not to the
-    /// point count of the whole collection.
-    ///
-    /// If not resharding, the fraction is 1.0.
-    pub fn resharding_transfer_fraction(&self) -> f32 {
-        match self {
-            HashRingRouter::Single(_) => 1.0,
-            HashRingRouter::Resharding { old, new } => {
-                let (from, to) = (old.len(), new.len());
-
-                debug_assert!(
-                    from.abs_diff(to) <= 1,
-                    "expects resharding to only move up or down by one shard",
-                );
-
-                if from == to {
-                    return 1.0;
-                }
-
-                // Resharding up:
-                //
-                // - shards: 1 -> 2
-                //   points: 100 -> 50/50
-                //   transfer points of each shard: 50/1 = 50 -> 50/100 = 50%
-                //   transfer fraction to each shard: 1/to = 1/2 = 0.5
-                // - shards: 2 -> 3
-                //   points: 50/50 -> 33/33/33
-                //   transfer points of each shard: 33/2 = 16.5 -> 16.5/50 = 33%
-                //   transfer fraction to each shard: 1/to = 1/3 = 0.33
-                // - shards: 3 -> 4
-                //   points: 33/33/33 -> 25/25/25/25
-                //   transfer points of each shard: 25/3 = 8.3 -> 8.3/33 = 25%
-                //   transfer fraction to each shard: 1/to = 1/4 = 0.25
-                //
-                // Resharding down:
-                //
-                // - shards: 2 -> 1
-                //   points: 50/50 -> 100
-                //   transfer points of each shard: 50/1 = 50 -> 50/50 = 100%
-                //   transfer fraction to each shard: 1/to = 1/1 = 1.0
-                // - shards: 3 -> 2
-                //   points: 33/33/33 -> 50/50
-                //   transfer points of each shard: 33/2 = 16.5 -> 16.5/33 = 50%
-                //   transfer fraction to each shard: 1/to = 1/2 = 0.5
-                // - shards: 4 -> 3
-                //   points: 25/25/25/25 -> 33/33/33
-                //   transfer points of each shard: 25/3 = 8.3 -> 8.3/25 = 33%
-                //   transfer fraction to each shard: 1/to = 1/3 = 0.33
-                1.0 / to as f32
-            }
-        }
-    }
 }
 
 /// List type for shard IDs

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -210,30 +210,30 @@ impl<T: Eq + Hash> HashRingRouter<T> {
                 // - shards: 1 -> 2
                 //   points: 100 -> 50/50
                 //   transfer points of each shard: 50/1 = 50 -> 50/100 = 50%
-                //   transfer fraction of each shard: 1/to = 1/2 = 0.5
+                //   transfer fraction to each shard: 1/to = 1/2 = 0.5
                 // - shards: 2 -> 3
                 //   points: 50/50 -> 33/33/33
                 //   transfer points of each shard: 33/2 = 16.5 -> 16.5/50 = 33%
-                //   transfer fraction of each shard: 1/to = 1/3 = 0.33
+                //   transfer fraction to each shard: 1/to = 1/3 = 0.33
                 // - shards: 3 -> 4
                 //   points: 33/33/33 -> 25/25/25/25
                 //   transfer points of each shard: 25/3 = 8.3 -> 8.3/33 = 25%
-                //   transfer fraction of each shard: 1/to = 1/4 = 0.25
+                //   transfer fraction to each shard: 1/to = 1/4 = 0.25
                 //
                 // Resharding down:
                 //
                 // - shards: 2 -> 1
                 //   points: 50/50 -> 100
                 //   transfer points of each shard: 50/1 = 50 -> 50/50 = 100%
-                //   transfer fraction of each shard: 1/to = 1/1 = 1.0
+                //   transfer fraction to each shard: 1/to = 1/1 = 1.0
                 // - shards: 3 -> 2
                 //   points: 33/33/33 -> 50/50
                 //   transfer points of each shard: 33/2 = 16.5 -> 16.5/33 = 50%
-                //   transfer fraction of each shard: 1/to = 1/2 = 0.5
+                //   transfer fraction to each shard: 1/to = 1/2 = 0.5
                 // - shards: 4 -> 3
                 //   points: 25/25/25/25 -> 33/33/33
                 //   transfer points of each shard: 25/3 = 8.3 -> 8.3/25 = 33%
-                //   transfer fraction of each shard: 1/to = 1/3 = 0.33
+                //   transfer fraction to each shard: 1/to = 1/3 = 0.33
                 1.0 / to as f32
             }
         }

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -201,6 +201,10 @@ impl<T: Eq + Hash> HashRingRouter<T> {
                     "expects resharding to only move up or down by one shard",
                 );
 
+                if from == to {
+                    return 1.0;
+                }
+
                 // Resharding up:
                 //
                 // - shards: 1 -> 2

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -187,6 +186,9 @@ impl<T: Eq + Hash> HashRingRouter<T> {
     /// If we do a resharding shard transfer, what fraction of points in the source shard will be
     /// transferred to the target shard.
     ///
+    /// Note: the fraction if points is relative to the point count in the source shard, not to the
+    /// point count of the whole collection.
+    ///
     /// If not resharding, the fraction is 1.0.
     pub fn resharding_transfer_fraction(&self) -> f32 {
         match self {
@@ -199,33 +201,36 @@ impl<T: Eq + Hash> HashRingRouter<T> {
                     "expects resharding to only move up or down by one shard",
                 );
 
-                match from.cmp(&to) {
-                    Ordering::Equal => 1.0,
-                    // Resharding up:
-                    //
-                    // - shards: 1 -> 2
-                    //   points: 100 -> 50/50
-                    //   transfer fraction of each shard: 1/2/1 = 0.5
-                    // - shards: 2 -> 3
-                    //   points: 50/50 -> 33/33/33
-                    //   transfer fraction of each shard: 1/3/2 = 0.167
-                    // - shards: 3 -> 4
-                    //   points: 33/33/33 -> 25/25/25/25
-                    //   transfer fraction of each shard: 1/4/3 = 0.083
-                    Ordering::Less => (1.0 / to as f32) / (from as f32),
-                    // Resharding down:
-                    //
-                    // - shards: 2 -> 1
-                    //   points: 50/50 -> 100
-                    //   transfer fraction of each shard: 1/1 = 1.0
-                    // - shards: 3 -> 2
-                    //   points: 33/33/33 -> 50/50
-                    //   transfer fraction of each shard: 1/2 = 0.5
-                    // - shards: 4 -> 3
-                    //   points: 25/25/25/25 -> 33/33/33
-                    //   transfer fraction of each shard: 1/3 = 0.333
-                    Ordering::Greater => 1.0 / to as f32,
-                }
+                // Resharding up:
+                //
+                // - shards: 1 -> 2
+                //   points: 100 -> 50/50
+                //   transfer points of each shard: 50/1 = 50 -> 50/100 = 50%
+                //   transfer fraction of each shard: 1/to = 1/2 = 0.5
+                // - shards: 2 -> 3
+                //   points: 50/50 -> 33/33/33
+                //   transfer points of each shard: 33/2 = 16.5 -> 16.5/50 = 33%
+                //   transfer fraction of each shard: 1/to = 1/3 = 0.33
+                // - shards: 3 -> 4
+                //   points: 33/33/33 -> 25/25/25/25
+                //   transfer points of each shard: 25/3 = 8.3 -> 8.3/33 = 25%
+                //   transfer fraction of each shard: 1/to = 1/4 = 0.25
+                //
+                // Resharding down:
+                //
+                // - shards: 2 -> 1
+                //   points: 50/50 -> 100
+                //   transfer points of each shard: 50/1 = 50 -> 50/50 = 100%
+                //   transfer fraction of each shard: 1/to = 1/1 = 1.0
+                // - shards: 3 -> 2
+                //   points: 33/33/33 -> 50/50
+                //   transfer points of each shard: 33/2 = 16.5 -> 16.5/33 = 50%
+                //   transfer fraction of each shard: 1/to = 1/2 = 0.5
+                // - shards: 4 -> 3
+                //   points: 25/25/25/25 -> 33/33/33
+                //   transfer points of each shard: 25/3 = 8.3 -> 8.3/25 = 33%
+                //   transfer fraction of each shard: 1/to = 1/3 = 0.33
+                1.0 / to as f32
             }
         }
     }

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -125,7 +125,7 @@ pub(crate) async fn transfer_resharding_stream_records(
                 new.len()
             }
         };
-        let transfer_size = (count_result.count as f64 / new_shard_count as f64) as usize;
+        let transfer_size = count_result.count / new_shard_count;
         progress.lock().set(0, transfer_size);
 
         replica_set.transfer_indexes().await?;

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -4,6 +4,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use parking_lot::Mutex;
 
 use super::transfer_tasks_pool::TransferTaskProgress;
+use crate::hash_ring::HashRingRouter;
 use crate::operations::types::{CollectionError, CollectionResult, CountRequestInternal};
 use crate::shards::CollectionId;
 use crate::shards::remote_shard::RemoteShard;
@@ -80,8 +81,51 @@ pub(crate) async fn transfer_resharding_stream_records(
                 "Shard {shard_id} not found"
             )));
         };
-        let transfer_size =
-            (count_result.count as f32 * hashring.resharding_transfer_fraction()) as usize;
+
+        // Resharding up:
+        //
+        // - shards: 1 -> 2
+        //   points: 100 -> 50/50
+        //   transfer points of each shard: 50/1 = 50 -> 50/100 = 50%
+        //   transfer fraction to each shard: 1/new_shard_count = 1/2 = 0.5
+        // - shards: 2 -> 3
+        //   points: 50/50 -> 33/33/33
+        //   transfer points of each shard: 33/2 = 16.5 -> 16.5/50 = 33%
+        //   transfer fraction to each shard: 1/new_shard_count = 1/3 = 0.33
+        // - shards: 3 -> 4
+        //   points: 33/33/33 -> 25/25/25/25
+        //   transfer points of each shard: 25/3 = 8.3 -> 8.3/33 = 25%
+        //   transfer fraction to each shard: 1/new_shard_count = 1/4 = 0.25
+        //
+        // Resharding down:
+        //
+        // - shards: 2 -> 1
+        //   points: 50/50 -> 100
+        //   transfer points of each shard: 50/1 = 50 -> 50/50 = 100%
+        //   transfer fraction to each shard: 1/new_shard_count = 1/1 = 1.0
+        // - shards: 3 -> 2
+        //   points: 33/33/33 -> 50/50
+        //   transfer points of each shard: 33/2 = 16.5 -> 16.5/33 = 50%
+        //   transfer fraction to each shard: 1/new_shard_count = 1/2 = 0.5
+        // - shards: 4 -> 3
+        //   points: 25/25/25/25 -> 33/33/33
+        //   transfer points of each shard: 25/3 = 8.3 -> 8.3/25 = 33%
+        //   transfer fraction to each shard: 1/new_shard_count = 1/3 = 0.33
+        let new_shard_count = match &hashring {
+            HashRingRouter::Single(_) => {
+                return Err(CollectionError::service_error(format!(
+                    "Failed to do resharding transfer, hash ring for shard {shard_id} not in resharding state",
+                )));
+            }
+            HashRingRouter::Resharding { old, new } => {
+                debug_assert!(
+                    old.len().abs_diff(new.len()) <= 1,
+                    "expects resharding to only move up or down by one shard",
+                );
+                new.len()
+            }
+        };
+        let transfer_size = (count_result.count as f64 / new_shard_count as f64) as usize;
         progress.lock().set(0, transfer_size);
 
         replica_set.transfer_indexes().await?;


### PR DESCRIPTION
Fixes incorrect implementation in <https://github.com/qdrant/qdrant/pull/6084>.

The function to calculate the fraction of points transferred during a resharding transfer was incorrect. For resharding up it gave us the wrong result.

For resharding up, the returned fraction was for the total number of points in the collection, not a fraction for the number of points in the current shard like the function describes.

Long story short, this fixed the fraction calculation. The documentation with examples has been updated as well.

In practice this fixes our point count estimate in shard transfers. It's not critical, but helpful to do proper transfer estimations.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?