### PR TITLE
Coverage override branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,4 +32,5 @@ jobs:
           uses: codecov/codecov-action@v5
           with:
             files: lcov.info
+            override_branch: ${{ github.event_name == 'schedule' && 'dev' || github.ref_name }}
             token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Github schedules the coverage report cron via `master` branch. Although, we checkout the code of `dev` branch and push the coverage for `dev` branch, codecov action labels it as coming from the `master` branchi instead. This PR should fix the issue.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

