### PR TITLE
Mutable ID tracker: improve version flushing, grow file in one shot

### DIFF
--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -692,7 +692,7 @@ fn store_version_changes(
         .open(versions_path)?;
 
     // Grow file if necessary in one shot
-    // Prevents potentially reallocating the file multiple times when progressivly writing changes
+    // Prevents potentially reallocating the file multiple times when progressively writing changes
     match file.metadata() {
         Ok(metadata) => {
             let (&max_internal_id, _) = changes.last_key_value().unwrap();
@@ -703,7 +703,7 @@ fn store_version_changes(
         }
         Err(err) => {
             log::warn!(
-                "Failed to get file length of immutable ID tracker versions file, ignoring: {err}"
+                "Failed to get file length of mutable ID tracker versions file, ignoring: {err}"
             );
         }
     }

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -680,12 +680,34 @@ fn store_version_changes(
     versions_path: &Path,
     changes: BTreeMap<PointOffsetType, SeqNumberType>,
 ) -> OperationResult<()> {
+    if changes.is_empty() {
+        return Ok(());
+    }
+
     // Create or open file
     let file = File::options()
         .create(true)
         .write(true)
         .truncate(false)
         .open(versions_path)?;
+
+    // Grow file if necessary in one shot
+    // Prevents potentially reallocating the file multiple times when progressivly writing changes
+    match file.metadata() {
+        Ok(metadata) => {
+            let (&max_internal_id, _) = changes.last_key_value().unwrap();
+            let required_size = u64::from(max_internal_id + 1) * VERSION_ELEMENT_SIZE;
+            if metadata.len() < required_size {
+                file.set_len(required_size)?;
+            }
+        }
+        Err(err) => {
+            log::warn!(
+                "Failed to get file length of immutable ID tracker versions file, ignoring: {err}"
+            );
+        }
+    }
+
     let mut writer = BufWriter::new(file);
 
     write_version_changes(&mut writer, changes).map_err(|err| {


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/6157>

An improvement to how we flush versions in the new mutable ID tracker.

With this PR we now check the required size for the versions file. If it isn't large enough to write new versions, we immediately grow it to allocate all required space with one syscall.

Previously, we just wrote new versions to the end of the file directly to automatically grow it. While that is fine, it can cause a lot of file re-allocations to progressively grow it in steps when writing new versions.

This now prevents that, and optimizes for that scenario.

In numbers, if we insert 10k new points, this reduces reallocating the file from 10 times to just once.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?