### PR TITLE
Qdrant 1.14: enable mutable ID tracker by default

### DIFF
--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -22,12 +22,6 @@ pub struct FeatureFlags {
     // TODO(1.14): set to true, remove other branches in code, and remove this flag
     pub use_new_shard_key_mapping_format: bool,
 
-    /// Whether to use the new mutable ID tracker without RocksDB.
-    ///
-    /// First implemented in Qdrant 1.13.5
-    // TODO(1.14): set to true, remove other branches in code, and remove this flag
-    pub use_mutable_id_tracker_without_rocksdb: bool,
-
     /// Whether to skip usage of RocksDB in immutable payload indices.
     ///
     /// First implemented in Qdrant 1.13.5
@@ -44,7 +38,6 @@ impl Default for FeatureFlags {
         FeatureFlags {
             all: false,
             use_new_shard_key_mapping_format: false,
-            use_mutable_id_tracker_without_rocksdb: false,
             payload_index_skip_rocksdb: false,
             incremental_hnsw_building: true,
         }
@@ -64,7 +57,6 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
     let FeatureFlags {
         all,
         use_new_shard_key_mapping_format,
-        use_mutable_id_tracker_without_rocksdb,
         payload_index_skip_rocksdb,
         incremental_hnsw_building,
     } = &mut flags;
@@ -72,7 +64,6 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
     // If all is set, explicitly set all feature flags
     if *all {
         *use_new_shard_key_mapping_format = true;
-        *use_mutable_id_tracker_without_rocksdb = true;
         *payload_index_skip_rocksdb = true;
         *incremental_hnsw_building = true;
     }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -20,10 +20,9 @@ use tempfile::TempDir;
 use uuid::Uuid;
 
 use super::{
-    create_mutable_id_tracker, create_payload_storage, create_rocksdb_id_tracker,
-    create_sparse_vector_index, create_sparse_vector_storage, get_payload_index_path,
-    get_vector_index_path, get_vector_storage_path, new_segment_path, open_segment_db,
-    open_vector_storage,
+    create_mutable_id_tracker, create_payload_storage, create_sparse_vector_index,
+    create_sparse_vector_storage, get_payload_index_path, get_vector_index_path,
+    get_vector_storage_path, new_segment_path, open_segment_db, open_vector_storage,
 };
 use crate::common::error_logging::LogError;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
@@ -87,11 +86,7 @@ impl SegmentBuilder {
         let database = open_segment_db(temp_dir.path(), segment_config)?;
 
         let id_tracker = if segment_config.is_appendable() {
-            if feature_flags().use_mutable_id_tracker_without_rocksdb {
-                IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(temp_dir.path())?)
-            } else {
-                IdTrackerEnum::RocksDbIdTracker(create_rocksdb_id_tracker(database.clone())?)
-            }
+            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(temp_dir.path())?)
         } else {
             IdTrackerEnum::InMemoryIdTracker(InMemoryIdTracker::new())
         };

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
-use common::flags::{FeatureFlags, feature_flags};
+use common::flags::FeatureFlags;
 use io::storage_version::StorageVersion;
 use log::info;
 use parking_lot::{Mutex, RwLock};
@@ -19,7 +19,7 @@ use crate::common::operation_error::{OperationError, OperationResult, check_proc
 use crate::common::rocksdb_wrapper::{DB_MAPPING_CF, DB_VECTOR_CF, open_db};
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
-use crate::id_tracker::mutable_id_tracker::{self, MutableIdTracker};
+use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
 use crate::index::VectorIndexEnum;
@@ -543,11 +543,9 @@ fn create_segment(
         appendable_flag || !ImmutableIdTracker::mappings_file_path(segment_path).is_file();
 
     let id_tracker = if mutable_id_tracker {
-        let default_new_tracker = feature_flags().use_mutable_id_tracker_without_rocksdb;
-
         // Determine whether we use the new (file based) or old (RocksDB) mutable ID tracker
         // Decide based on the feature flag and state on disk
-        let use_new_mutable_tracker = if default_new_tracker {
+        let use_new_mutable_tracker = {
             // New ID tracker is enabled by default, but we still use the old tracker if we have
             // any mappings stored in RocksDB
             // TODO(1.15 or later): remove this check and use new mutable ID tracker unconditionally
@@ -566,9 +564,6 @@ fn create_segment(
                 }
                 None => true,
             }
-        } else {
-            // New ID tracker is not enabled by default, only use it if its mappings are already on disk
-            mutable_id_tracker::mappings_path(segment_path).is_file()
         };
 
         if use_new_mutable_tracker {


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/6157>

Note: this must only be merged as part of the Qdrant 1.14 release!

Enable the new [mutable ID tracker](https://github.com/qdrant/qdrant/issues/6157) by default, and remove the now obsolete feature flag for it.

This will now use the new mutable ID tracker using custom storage in new mutable segments. It replaces the old RocksDB based mutable ID tracker.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?