### PR TITLE
Qdrant 1.14: skip RocksDB in immutable payload indices by default

### DIFF
--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -29,14 +29,6 @@ pub struct FeatureFlags {
     // TODO(1.14): set to true, remove other branches in code, and remove this flag
     #[serde(default)]
     pub use_mutable_id_tracker_without_rocksdb: bool,
-
-    /// Whether to skip usage of RocksDB in immutable payload indices.
-    ///
-    /// First implemented in Qdrant 1.13.5
-    // TODO(1.14): remove for release
-    // ToDo(mmap-payload-index): remove for release
-    #[serde(default)]
-    pub payload_index_skip_rocksdb: bool,
 }
 
 impl FeatureFlags {
@@ -46,11 +38,8 @@ impl FeatureFlags {
             all: _,
             use_new_shard_key_mapping_format,
             use_mutable_id_tracker_without_rocksdb,
-            payload_index_skip_rocksdb,
         } = self;
-        !use_new_shard_key_mapping_format
-            && !use_mutable_id_tracker_without_rocksdb
-            && !payload_index_skip_rocksdb
+        !use_new_shard_key_mapping_format && !use_mutable_id_tracker_without_rocksdb
     }
 }
 
@@ -61,14 +50,12 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         all,
         use_new_shard_key_mapping_format,
         use_mutable_id_tracker_without_rocksdb,
-        payload_index_skip_rocksdb,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags
     if *all {
         *use_new_shard_key_mapping_format = true;
         *use_mutable_id_tracker_without_rocksdb = true;
-        *payload_index_skip_rocksdb = true;
     }
 
     let res = FEATURE_FLAGS.set(flags);

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
-use common::flags::feature_flags;
 use common::types::PointOffsetType;
 use itertools::Either;
 use log::debug;
@@ -169,7 +168,7 @@ impl StructPayloadIndex {
             PayloadConfig::load(&config_path)?
         } else {
             let mut new_config = PayloadConfig::default();
-            if feature_flags().payload_index_skip_rocksdb && !is_appendable {
+            if !is_appendable {
                 new_config.skip_rocksdb = Some(true);
             }
             new_config


### PR DESCRIPTION
Note: this must only be merged as part of the Qdrant 1.14 release!

Enable <https://github.com/qdrant/qdrant/pull/6148> by default. Skip using RocksDB by default now in immutable payload indices.

This is the next step in our effort to eliminate RocksDB from our product.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?