### PR TITLE
Qdrant 1.14: enable new shard key format by default

### DIFF
--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::ops;
 
-use common::flags::feature_flags;
 use itertools::Itertools;
 use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
@@ -106,20 +105,12 @@ enum SerdeHelper {
 
 impl From<ShardKeyMapping> for SerdeHelper {
     fn from(mapping: ShardKeyMapping) -> Self {
-        let number_key_used = mapping.keys().any(|key| matches!(key, ShardKey::Number(_)));
-
-        // TODO(1.14): use new format by default, even if not using shard key numbers
-        if feature_flags().use_new_shard_key_mapping_format || number_key_used {
-            let key_ids_pairs = mapping
-                .shard_key_to_shard_ids
-                .into_iter()
-                .map(KeyIdsPair::from)
-                .collect();
-
-            Self::New(key_ids_pairs)
-        } else {
-            Self::Old(mapping.shard_key_to_shard_ids)
-        }
+        let key_ids_pairs = mapping
+            .shard_key_to_shard_ids
+            .into_iter()
+            .map(KeyIdsPair::from)
+            .collect();
+        Self::New(key_ids_pairs)
     }
 }
 

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -13,15 +13,6 @@ pub struct FeatureFlags {
     /// Note that this will only be applied to all flags when passed into [`init_feature_flags`].
     all: bool,
 
-    /// Whether to use the new format to persist shard keys
-    ///
-    /// The old format fails to persist shard key numbers correctly, converting them into strings on
-    /// load. While this is false, the new format is only used if any shard key is a number.
-    ///
-    /// First implemented in Qdrant 1.13.1
-    // TODO(1.14): set to true, remove other branches in code, and remove this flag
-    pub use_new_shard_key_mapping_format: bool,
-
     /// Whether to skip usage of RocksDB in immutable payload indices.
     ///
     /// First implemented in Qdrant 1.13.5
@@ -37,7 +28,6 @@ impl Default for FeatureFlags {
     fn default() -> FeatureFlags {
         FeatureFlags {
             all: false,
-            use_new_shard_key_mapping_format: false,
             payload_index_skip_rocksdb: false,
             incremental_hnsw_building: true,
         }
@@ -56,14 +46,12 @@ impl FeatureFlags {
 pub fn init_feature_flags(mut flags: FeatureFlags) {
     let FeatureFlags {
         all,
-        use_new_shard_key_mapping_format,
         payload_index_skip_rocksdb,
         incremental_hnsw_building,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags
     if *all {
-        *use_new_shard_key_mapping_format = true;
         *payload_index_skip_rocksdb = true;
         *incremental_hnsw_building = true;
     }


### PR DESCRIPTION
Note: this must only be merged as part of the Qdrant 1.14 release!

Enable <https://github.com/qdrant/qdrant/pull/5838> by default, to utilize the new shard key format.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?