### PR TITLE
Optimize vector/payload reads in large query batches, defer reads

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -245,7 +245,7 @@ impl Collection {
                 .do_query_batch_impl(
                     without_payload_batch,
                     read_consistency,
-                    shard_selection.clone(),
+                    &shard_selection,
                     timeout,
                     hw_measurement_acc.clone(),
                 )
@@ -271,7 +271,7 @@ impl Collection {
             self.do_query_batch_impl(
                 requests_batch,
                 read_consistency,
-                shard_selection,
+                &shard_selection,
                 timeout,
                 hw_measurement_acc.clone(),
             )
@@ -284,7 +284,7 @@ impl Collection {
         &self,
         requests_batch: Vec<ShardQueryRequest>,
         read_consistency: Option<ReadConsistency>,
-        shard_selection: ShardSelectorInternal,
+        shard_selection: &ShardSelectorInternal,
         timeout: Option<Duration>,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
@@ -296,7 +296,7 @@ impl Collection {
             .batch_query_shards_concurrently(
                 requests_batch.clone(),
                 read_consistency,
-                &shard_selection,
+                shard_selection,
                 timeout,
                 hw_measurement_acc,
             )

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -30,6 +30,10 @@ use crate::operations::universal_query::shard_query::{
     FusionInternal, ScoringQuery, ShardQueryRequest, ShardQueryResponse,
 };
 
+/// A factor which determines if we need to use the 2-step search or not.
+/// Should be adjusted based on usage statistics.
+pub(super) const PAYLOAD_TRANSFERS_FACTOR_THRESHOLD: usize = 10;
+
 struct IntermediateQueryInfo<'a> {
     scoring_query: Option<&'a ScoringQuery>,
     /// Limit + offset
@@ -208,9 +212,6 @@ impl Collection {
         if requests_batch.iter().all(|s| s.limit == 0) {
             return Ok(vec![]);
         }
-        // A factor which determines if we need to use the 2-step search or not
-        // Should be adjusted based on usage statistics.
-        const PAYLOAD_TRANSFERS_FACTOR_THRESHOLD: usize = 10;
 
         let is_payload_required = requests_batch.iter().all(|s| s.with_payload.is_required());
         let with_vectors = requests_batch.iter().all(|s| s.with_vector.is_enabled());

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -9,7 +9,7 @@ use itertools::{Either, Itertools};
 use rand::Rng;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
 use segment::common::score_fusion::{ScoreFusion, score_fusion};
-use segment::types::{Order, ScoredPoint};
+use segment::types::{Order, ScoredPoint, WithPayloadInterface, WithVector};
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tokio::sync::RwLockReadGuard;
 use tokio::time::Instant;
@@ -195,6 +195,92 @@ impl Collection {
 
     /// This function is used to query the collection. It will return a list of scored points.
     async fn do_query_batch(
+        &self,
+        requests_batch: Vec<ShardQueryRequest>,
+        read_consistency: Option<ReadConsistency>,
+        shard_selection: ShardSelectorInternal,
+        timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        let start = Instant::now();
+
+        // shortcuts batch if all requests with limit=0
+        if requests_batch.iter().all(|s| s.limit == 0) {
+            return Ok(vec![]);
+        }
+        // A factor which determines if we need to use the 2-step search or not
+        // Should be adjusted based on usage statistics.
+        const PAYLOAD_TRANSFERS_FACTOR_THRESHOLD: usize = 10;
+
+        let is_payload_required = requests_batch.iter().all(|s| s.with_payload.is_required());
+        let with_vectors = requests_batch.iter().all(|s| s.with_vector.is_enabled());
+
+        let metadata_required = is_payload_required || with_vectors;
+
+        let sum_limits: usize = requests_batch.iter().map(|s| s.limit).sum();
+        let sum_offsets: usize = requests_batch.iter().map(|s| s.offset).sum();
+
+        // Number of records we need to retrieve to fill the search result.
+        let require_transfers = self.shards_holder.read().await.len() * (sum_limits + sum_offsets);
+        // Actually used number of records.
+        let used_transfers = sum_limits;
+
+        let is_required_transfer_large_enough =
+            require_transfers > used_transfers.saturating_mul(PAYLOAD_TRANSFERS_FACTOR_THRESHOLD);
+
+        if metadata_required && is_required_transfer_large_enough {
+            // If there is a significant offset, we need to retrieve the whole result
+            // set without payload first and then retrieve the payload.
+            // It is required to do this because the payload might be too large to send over the
+            // network.
+            let mut without_payload_requests = Vec::with_capacity(requests_batch.len());
+            for query in &requests_batch {
+                let mut without_payload_request = query.clone();
+                without_payload_request.with_payload = WithPayloadInterface::Bool(false);
+                without_payload_request.with_vector = WithVector::Bool(false);
+                without_payload_requests.push(without_payload_request);
+            }
+            let without_payload_batch = without_payload_requests;
+            let without_payload_results = self
+                .do_query_batch_impl(
+                    without_payload_batch,
+                    read_consistency,
+                    shard_selection.clone(),
+                    timeout,
+                    hw_measurement_acc.clone(),
+                )
+                .await?;
+            // update timeout
+            let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
+            let filled_results = without_payload_results
+                .into_iter()
+                .zip(requests_batch.clone().into_iter())
+                .map(|(without_payload_result, req)| {
+                    self.fill_search_result_with_payload(
+                        without_payload_result,
+                        Some(req.with_payload),
+                        req.with_vector,
+                        read_consistency,
+                        &shard_selection,
+                        timeout,
+                        hw_measurement_acc.clone(),
+                    )
+                });
+            future::try_join_all(filled_results).await
+        } else {
+            self.do_query_batch_impl(
+                requests_batch,
+                read_consistency,
+                shard_selection,
+                timeout,
+                hw_measurement_acc.clone(),
+            )
+            .await
+        }
+    }
+
+    /// This function is used to query the collection. It will return a list of scored points.
+    async fn do_query_batch_impl(
         &self,
         requests_batch: Vec<ShardQueryRequest>,
         read_consistency: Option<ReadConsistency>,

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -254,7 +254,7 @@ impl Collection {
             let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
             let filled_results = without_payload_results
                 .into_iter()
-                .zip(requests_batch.clone().into_iter())
+                .zip(requests_batch.into_iter())
                 .map(|(without_payload_result, req)| {
                     self.fill_search_result_with_payload(
                         without_payload_result,

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -117,7 +117,7 @@ impl Collection {
             let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
             let filled_results = without_payload_results
                 .into_iter()
-                .zip(request.clone().searches.into_iter())
+                .zip(request.searches.into_iter())
                 .map(|(without_payload_result, req)| {
                     self.fill_search_result_with_payload(
                         without_payload_result,

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -66,13 +66,11 @@ impl Collection {
         let is_payload_required = request
             .searches
             .iter()
-            .all(|s| s.with_payload.clone().is_some_and(|p| p.is_required()));
-        let with_vectors = request.searches.iter().all(|s| {
-            s.with_vector
-                .as_ref()
-                .map(|wv| wv.is_enabled())
-                .unwrap_or(false)
-        });
+            .all(|s| s.with_payload.as_ref().is_some_and(|p| p.is_required()));
+        let with_vectors = request
+            .searches
+            .iter()
+            .all(|s| s.with_vector.as_ref().is_some_and(|wv| wv.is_enabled()));
 
         let metadata_required = is_payload_required || with_vectors;
 
@@ -95,8 +93,12 @@ impl Collection {
             let mut without_payload_requests = Vec::with_capacity(request.searches.len());
             for search in &request.searches {
                 let mut without_payload_request = search.clone();
-                without_payload_request.with_payload = None;
-                without_payload_request.with_vector = None;
+                without_payload_request
+                    .with_payload
+                    .replace(WithPayloadInterface::Bool(false));
+                without_payload_request
+                    .with_vector
+                    .replace(WithVector::Bool(false));
                 without_payload_requests.push(without_payload_request);
             }
             let without_payload_batch = CoreSearchRequestBatch {

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -19,6 +19,7 @@ use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::*;
 
 impl Collection {
+    #[cfg(feature = "testing")]
     pub async fn search(
         &self,
         request: CoreSearchRequest,

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -59,9 +59,6 @@ impl Collection {
         if request.searches.iter().all(|s| s.limit == 0) {
             return Ok(vec![]);
         }
-        // A factor which determines if we need to use the 2-step search or not
-        // Should be adjusted based on usage statistics.
-        const PAYLOAD_TRANSFERS_FACTOR_THRESHOLD: usize = 10;
 
         let is_payload_required = request
             .searches
@@ -82,8 +79,8 @@ impl Collection {
         // Actually used number of records.
         let used_transfers = sum_limits;
 
-        let is_required_transfer_large_enough =
-            require_transfers > used_transfers.saturating_mul(PAYLOAD_TRANSFERS_FACTOR_THRESHOLD);
+        let is_required_transfer_large_enough = require_transfers
+            > used_transfers.saturating_mul(super::query::PAYLOAD_TRANSFERS_FACTOR_THRESHOLD);
 
         if metadata_required && is_required_transfer_large_enough {
             // If there is a significant offset, we need to retrieve the whole result


### PR DESCRIPTION
Implements [this](https://github.com/qdrant/qdrant/blob/fbf1ce4d1725a9ef3de183be83eddafe6c03ac27/lib/collection/src/collection/search.rs#L62-L142) which we have in search, also for our query API.

If having a large number of shards or a large offset, prevent transferring a huge amount of payloads across the network within the cluster. Instead, defer reading vectors and payloads to a second step to greatly improve search performance.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?