### PR TITLE
Bump version to 1.13.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "api"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "chrono",
  "common",
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.13.5"
+version = "1.13.6"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.13.5"
+version = "1.13.6"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.13.5";
+pub const QDRANT_VERSION_STRING: &str = "1.13.6";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Release PR or Qdrant 1.13.6.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/6223>.