### PR TITLE
Bump dev version to 1.13.7-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "api"
-version = "1.13.6-dev"
+version = "1.13.7-dev"
 dependencies = [
  "chrono",
  "common",
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.13.6-dev"
+version = "1.13.7-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.13.6-dev"
+version = "1.13.7-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.13.6-dev"
+version = "1.13.7-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.13.6-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.13.7-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to 1.13.7-dev for the [Qdrant 1.13.6](https://github.com/qdrant/qdrant/pull/6277) patch release.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/6219>.