### PR TITLE
[query] Optimize fetching payloads/vectors at local shard

### DIFF
--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -18,7 +18,7 @@ pub struct PlannedQuery {
     /// This retains the recursive structure of the original queries.
     ///
     /// One per each query in the batch
-    pub root_plans: Vec<MergePlan>,
+    pub root_plans: Vec<RootPlan>,
 
     /// All the leaf core searches
     pub searches: Vec<CoreSearchRequest>,
@@ -38,12 +38,6 @@ pub struct RescoreParams {
 
     /// Keep only points with better score than this threshold
     pub score_threshold: Option<ScoreType>,
-
-    /// The vector(s) to return
-    pub with_vector: WithVector,
-
-    /// The payload to return
-    pub with_payload: WithPayloadInterface,
 
     /// Parameters for the rescore search request
     pub params: Option<SearchParams>,
@@ -72,6 +66,13 @@ pub struct MergePlan {
     /// 1. It is a top-level query without prefetches, so sources must be of length 1.
     /// 2. It is a top-level fusion query, so sources will be returned as-is. They will be merged later at collection level
     pub rescore_params: Option<RescoreParams>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RootPlan {
+    pub merge_plan: MergePlan,
+    pub with_vector: WithVector,
+    pub with_payload: WithPayloadInterface,
 }
 
 impl PlannedQuery {
@@ -107,21 +108,25 @@ impl PlannedQuery {
             })?;
 
             if rescore.needs_intermediate_results() {
-                // pass `with_vector` and `with_payload` down one level, as the sources will be sent as intermediate results to the collection
                 let sources = recurse_prefetches(
                     &mut self.searches,
                     &mut self.scrolls,
                     prefetches,
                     offset,
                     &filter,
-                    Some((with_payload, with_vector)),
                 )?;
 
-                MergePlan {
+                let merge_plan = MergePlan {
                     sources,
                     // We will propagate the intermediate results, the fusion will take place at collection level.
                     // It is fine to lose this rescore information here.
                     rescore_params: None,
+                };
+
+                RootPlan {
+                    merge_plan,
+                    with_vector,
+                    with_payload,
                 }
             } else {
                 let sources = recurse_prefetches(
@@ -130,19 +135,22 @@ impl PlannedQuery {
                     prefetches,
                     offset,
                     &filter,
-                    None,
                 )?;
 
-                MergePlan {
+                let merge_plan = MergePlan {
                     sources,
                     rescore_params: Some(RescoreParams {
                         rescore,
                         limit,
                         score_threshold,
-                        with_vector,
-                        with_payload,
                         params,
                     }),
+                };
+
+                RootPlan {
+                    merge_plan,
+                    with_vector,
+                    with_payload,
                 }
             }
         } else {
@@ -153,8 +161,8 @@ impl PlannedQuery {
                         query,
                         filter,
                         score_threshold,
-                        with_vector: Some(with_vector),
-                        with_payload: Some(with_payload),
+                        with_vector: None, // will be fetched after aggregating from segments
+                        with_payload: None, // will be fetched after aggregating from segments
                         offset: 0, // offset is handled at collection level
                         params,
                         limit,
@@ -176,8 +184,8 @@ impl PlannedQuery {
                         scroll_order: ScrollOrder::ByField(order_by),
                         limit,
                         filter,
-                        with_vector,
-                        with_payload,
+                        with_vector: false.into(), // will be fetched after aggregating from segments
+                        with_payload: false.into(), // will be fetched after aggregating from segments
                     };
 
                     let idx = self.scrolls.len();
@@ -196,8 +204,8 @@ impl PlannedQuery {
                         scroll_order: ScrollOrder::Random,
                         limit,
                         filter,
-                        with_vector,
-                        with_payload,
+                        with_vector: false.into(), // will be fetched after aggregating from segments
+                        with_payload: false.into(), // will be fetched after aggregating from segments
                     };
 
                     let idx = self.scrolls.len();
@@ -211,8 +219,8 @@ impl PlannedQuery {
                         scroll_order: ScrollOrder::ById,
                         limit,
                         filter,
-                        with_vector,
-                        with_payload,
+                        with_vector: false.into(), // will be fetched after aggregating from segments
+                        with_payload: false.into(), // will be fetched after aggregating from segments
                     };
 
                     let idx = self.scrolls.len();
@@ -222,10 +230,16 @@ impl PlannedQuery {
                 }
             };
 
-            // Root-level query without prefetches is the only case where merge is `None`
-            MergePlan {
+            let merge_plan = MergePlan {
                 sources,
+                // Root-level query without prefetches means we won't do any extra rescoring
                 rescore_params: None,
+            };
+
+            RootPlan {
+                merge_plan,
+                with_vector,
+                with_payload,
             }
         };
 
@@ -242,14 +256,11 @@ fn recurse_prefetches(
     prefetches: Vec<ShardPrefetch>,
     root_offset: usize, // Offset is added to all prefetches, so we make sure we have enough
     propagate_filter: &Option<Filter>, // Global filter to apply to all prefetches
-    // Top-level fusion requests won't be merged on shard level, so we pass these params down one level to fetch on the sources.
-    // Otherwise we would miss to fetch the payload and vector.
-    with_payload_and_vector: Option<(WithPayloadInterface, WithVector)>,
 ) -> CollectionResult<Vec<Source>> {
     let mut sources = Vec::with_capacity(prefetches.len());
 
-    let (with_payload, with_vector) = with_payload_and_vector
-        .unwrap_or((WithPayloadInterface::Bool(false), WithVector::Bool(false)));
+    let with_payload = WithPayloadInterface::Bool(false);
+    let with_vector = WithVector::Bool(false);
 
     for prefetch in prefetches {
         let ShardPrefetch {
@@ -275,7 +286,6 @@ fn recurse_prefetches(
                 prefetches,
                 root_offset,
                 &filter,
-                None,
             )?;
 
             let rescore = query.ok_or_else(|| {
@@ -288,8 +298,6 @@ fn recurse_prefetches(
                     rescore,
                     limit,
                     score_threshold,
-                    with_vector: with_vector.clone(),
-                    with_payload: with_payload.clone(),
                     params,
                 }),
             };

--- a/lib/collection/src/shards/local_shard/formula_rescore.rs
+++ b/lib/collection/src/shards/local_shard/formula_rescore.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::query_context::FormulaContext;
 use segment::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
-use segment::types::{ScoredPoint, WithPayload, WithVector};
+use segment::types::ScoredPoint;
 
 use super::LocalShard;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
@@ -12,13 +12,10 @@ use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::types::{CollectionError, CollectionResult};
 
 impl LocalShard {
-    #[expect(clippy::too_many_arguments)]
     pub async fn rescore_with_formula(
         &self,
         formula: ParsedFormula,
         prefetches_results: Vec<Vec<ScoredPoint>>,
-        with_payload: WithPayload,
-        with_vector: WithVector,
         limit: usize,
         timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
@@ -28,8 +25,6 @@ impl LocalShard {
         let ctx = FormulaContext {
             formula,
             prefetches_results,
-            with_payload,
-            with_vector,
             limit,
             is_stopped: stopping_guard.get_is_stopped(),
         };

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -9,9 +9,7 @@ use futures::future::BoxFuture;
 use parking_lot::Mutex;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
 use segment::common::score_fusion::{ScoreFusion, score_fusion};
-use segment::types::{
-    Filter, HasIdCondition, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
-};
+use segment::types::{Filter, HasIdCondition, ScoredPoint, WithPayloadInterface, WithVector};
 use tokio::runtime::Handle;
 use tokio::time::error::Elapsed;
 
@@ -22,7 +20,7 @@ use crate::operations::types::{
     QueryScrollRequestInternal, ScrollOrder,
 };
 use crate::operations::universal_query::planned_query::{
-    MergePlan, PlannedQuery, RescoreParams, Source,
+    MergePlan, PlannedQuery, RescoreParams, RootPlan, Source,
 };
 use crate::operations::universal_query::shard_query::{
     FusionInternal, SampleInternal, ScoringQuery, ShardQueryResponse,
@@ -89,21 +87,17 @@ impl LocalShard {
         // decrease timeout by the time spent so far
         let timeout = timeout.saturating_sub(start_time.elapsed());
 
-        let merge_futures = request.root_plans.into_iter().map(|root_plan| Box::pin(Box::new(async move {
-            let results = self.recurse_prefetch(
-                root_plan.merge_plan,
+        let plans_futures = request.root_plans.into_iter().map(|root_plan| {
+            self.resolve_plan(
+                root_plan,
                 &prefetch_holder,
                 search_runtime_handle,
                 timeout,
-                0,
                 hw_counter_acc.clone(),
-            ).await?;
+            )
+        });
 
-            // self.fill_with_payload_or_vectors(query_response, with_payload, with_vector, timeout, hw_measurement_acc)
-            Ok(results)
-        })));
-
-        let batched_scored_points = futures::future::try_join_all(merge_futures).await?;
+        let batched_scored_points = futures::future::try_join_all(plans_futures).await?;
 
         Ok(batched_scored_points)
     }
@@ -111,12 +105,12 @@ impl LocalShard {
     /// Fetches the payload and/or vector if required. This will filter out points if they are deleted between search and retrieve.
     async fn fill_with_payload_or_vectors(
         &self,
-        query_response: Vec<ScoredPoint>,
+        query_response: ShardQueryResponse,
         with_payload: WithPayloadInterface,
         with_vector: WithVector,
         timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         if !with_payload.is_required() && !with_vector.is_enabled() {
             return Ok(query_response);
         }
@@ -124,6 +118,7 @@ impl LocalShard {
         // ids to retrieve (deduplication happens in the searcher)
         let point_ids: Vec<_> = query_response
             .iter()
+            .flatten()
             .map(|scored_point| scored_point.id)
             .collect();
 
@@ -144,18 +139,63 @@ impl LocalShard {
 
         // It might be possible, that we won't find all records,
         // so we need to re-collect the results
-        let query_response: Vec<_> = query_response
+        let query_response: ShardQueryResponse = query_response
             .into_iter()
-            .filter_map(|mut point| {
-                records_map.get(&point.id).map(|record| {
-                    point.payload.clone_from(&record.payload);
-                    point.vector.clone_from(&record.vector);
-                    point
-                })
+            .map(|points| {
+                points
+                    .into_iter()
+                    .filter_map(|mut point| {
+                        records_map.get(&point.id).map(|record| {
+                            point.payload.clone_from(&record.payload);
+                            point.vector.clone_from(&record.vector);
+                            point
+                        })
+                    })
+                    .collect()
             })
             .collect();
 
         Ok(query_response)
+    }
+
+    async fn resolve_plan<'shard, 'query>(
+        &'shard self,
+        root_plan: RootPlan,
+        prefetch_holder: &'query PrefetchResults,
+        search_runtime_handle: &'shard Handle,
+        timeout: Duration,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
+    where
+        'shard: 'query,
+    {
+        let RootPlan {
+            merge_plan,
+            with_payload,
+            with_vector,
+        } = root_plan;
+
+        // resolve merging plan
+        let results = self
+            .recurse_prefetch(
+                merge_plan,
+                prefetch_holder,
+                search_runtime_handle,
+                timeout,
+                0,
+                hw_measurement_acc.clone(),
+            )
+            .await?;
+
+        // fetch payloads and vectors if required
+        self.fill_with_payload_or_vectors(
+            results,
+            with_payload,
+            with_vector,
+            timeout,
+            hw_measurement_acc,
+        )
+        .await
     }
 
     fn recurse_prefetch<'shard, 'query>(
@@ -240,24 +280,13 @@ impl LocalShard {
             rescore,
             score_threshold,
             limit,
-            with_vector,
-            with_payload,
             params,
         } = rescore_params;
 
         match rescore {
             ScoringQuery::Fusion(fusion) => {
-                self.fusion_rescore(
-                    sources.into_iter(),
-                    fusion,
-                    score_threshold,
-                    limit,
-                    with_payload,
-                    with_vector,
-                    timeout,
-                    hw_counter_acc.clone(),
-                )
-                .await
+                self.fusion_rescore(sources.into_iter(), fusion, score_threshold, limit)
+                    .await
             }
             ScoringQuery::OrderBy(order_by) => {
                 // create single scroll request for rescoring query
@@ -268,8 +297,8 @@ impl LocalShard {
                 let scroll_request = QueryScrollRequestInternal {
                     limit,
                     filter: Some(filter),
-                    with_payload,
-                    with_vector,
+                    with_payload: false.into(),
+                    with_vector: false.into(),
                     scroll_order: ScrollOrder::ByField(order_by),
                 };
 
@@ -297,8 +326,8 @@ impl LocalShard {
                     params,
                     limit,
                     offset: 0,
-                    with_payload: Some(with_payload),
-                    with_vector: Some(with_vector),
+                    with_payload: None,
+                    with_vector: None,
                     score_threshold,
                 };
                 let rescoring_core_search_request = CoreSearchRequestBatch {
@@ -321,16 +350,8 @@ impl LocalShard {
                 })
             }
             ScoringQuery::Formula(formula) => {
-                self.rescore_with_formula(
-                    formula,
-                    sources,
-                    WithPayload::from(&with_payload),
-                    with_vector,
-                    limit,
-                    timeout,
-                    hw_counter_acc,
-                )
-                .await
+                self.rescore_with_formula(formula, sources, limit, timeout, hw_counter_acc)
+                    .await
             }
             ScoringQuery::Sample(sample) => match sample {
                 SampleInternal::Random => {
@@ -341,8 +362,8 @@ impl LocalShard {
                     let scroll_request = QueryScrollRequestInternal {
                         limit,
                         filter: Some(filter),
-                        with_payload,
-                        with_vector,
+                        with_payload: false.into(),
+                        with_vector: false.into(),
                         scroll_order: ScrollOrder::Random,
                     };
 
@@ -371,10 +392,6 @@ impl LocalShard {
         fusion: FusionInternal,
         score_threshold: Option<f32>,
         limit: usize,
-        with_payload: WithPayloadInterface,
-        with_vector: WithVector,
-        timeout: Duration,
-        hw_measurement_acc: HwMeasurementAcc,
     ) -> Result<Vec<ScoredPoint>, CollectionError> {
         let fused = match fusion {
             FusionInternal::Rrf => rrf_scoring(sources),
@@ -391,17 +408,7 @@ impl LocalShard {
             fused.into_iter().take(limit).collect()
         };
 
-        let filled_top_fused = self
-            .fill_with_payload_or_vectors(
-                top_fused,
-                with_payload,
-                with_vector,
-                timeout,
-                hw_measurement_acc,
-            )
-            .await?;
-
-        Ok(filled_top_fused)
+        Ok(top_fused)
     }
 }
 

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -10,7 +10,7 @@ use sparse::common::types::{DimId, DimWeight};
 
 use crate::data_types::tiny_map;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
-use crate::types::{ScoredPoint, VectorName, VectorNameBuf, WithPayload, WithVector};
+use crate::types::{ScoredPoint, VectorName, VectorNameBuf};
 
 #[derive(Debug)]
 pub struct QueryContext {
@@ -250,8 +250,6 @@ impl Default for VectorQueryContext<'_> {
 pub struct FormulaContext {
     pub formula: ParsedFormula,
     pub prefetches_results: Vec<Vec<ScoredPoint>>,
-    pub with_payload: WithPayload,
-    pub with_vector: WithVector,
     pub limit: usize,
     pub is_stopped: Arc<AtomicBool>,
 }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -85,8 +85,6 @@ impl SegmentEntry for Segment {
         let FormulaContext {
             formula,
             prefetches_results,
-            with_payload,
-            with_vector,
             limit,
             is_stopped,
         } = &*ctx;
@@ -99,7 +97,7 @@ impl SegmentEntry for Segment {
             hw_counter,
         )?;
 
-        self.process_search_result(internal_results, with_payload, with_vector, hw_counter)
+        self.process_search_result(internal_results, &false.into(), &false.into(), hw_counter)
     }
 
     fn upsert_point(


### PR DESCRIPTION
Changes the structure of the planned query to make sure we fetch payloads and vectors only at the last step before returning the results from a shard.

This improvement makes sure that the impact of fetching many large payloads is mitigated.

For instance, before this change, a single search of limit 100 in 500 segments would mean that 50,000 payloads would be fetched, while we only needed 100 of them