### PR TITLE
Rename GHA job names, so that `rust-cache` keys are unique for all workflows/jobs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ env:
   POETRY_VERSION: 1.8.5
 
 jobs:
-  test:
+  integration-tests:
 
     runs-on: ubuntu-latest
 
@@ -40,7 +40,7 @@ jobs:
         run: poetry -C tests run ./tests/integration-tests.sh
         shell: bash
 
-  test-consensus:
+  integration-tests-consensus:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test-gpu:
+  rust-gpu-tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
   # Failure of updating an issue is ignored because it fails for external contributors.
   process-gpu-results:
     runs-on: ubuntu-latest
-    needs: test-gpu
+    needs: rust-gpu-tests
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  rust-tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -43,7 +43,7 @@ jobs:
   # Failure of updating an issue is ignored because it fails for external contributors.
   process-results:
     runs-on: ubuntu-latest
-    needs: test
+    needs: rust-tests
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/storage-compat.yml
+++ b/.github/workflows/storage-compat.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  storage-compat-test:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
We have three jobs with the name `test` in `rust.yml`, `integration-tests.yml` and `storage-compat.yml` workflows.

The issue is that `rust-cache` action, that we use in these jobs, uses job name (e.g., `test`) as a key for GHA cache, and so this three jobs "conflict" on the same cache key. `rust.yml` job builds Rust uni-tests (`cargo build --tests`/`cargo test`), but `integration-tests.yml` and `storage-compat.yml` build Qdrant binary (`cargo build`/`cargo run`), and so `/target` dir between them are not fully reusable. E.g., if you do `cargo build` and then `cargo build --tests`, the second build would rebuild ~200 crates. Due to all of this, basically on every CI run, either `rust.yml` or `integration-tests.yml`/`storage-compat.yml` uses suboptimal cache, and waste extra time rebuilding stuff.

This PR tweaks job names in our workflows, so that they won't collide anymore.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
