### PR TITLE
Include `version` field in `Record` structs

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -4177,6 +4177,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | vectors | [VectorsOutput](#qdrant-VectorsOutput) | optional |  |
 | shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
 | order_value | [OrderValue](#qdrant-OrderValue) | optional | Order-by value |
+| version | [uint64](#uint64) |  | version of the point |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7898,11 +7898,17 @@
         "description": "Point data",
         "type": "object",
         "required": [
-          "id"
+          "id",
+          "version"
         ],
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ExtendedPointId"
+          },
+          "version": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           },
           "payload": {
             "description": "Payload - values assigned to the point",
@@ -9319,6 +9325,7 @@
             "example": [
               {
                 "id": 40,
+                "version": 12,
                 "payload": {
                   "city": "London",
                   "color": "green"
@@ -9332,6 +9339,7 @@
               },
               {
                 "id": 41,
+                "version": 13,
                 "payload": {
                   "city": "Paris",
                   "color": "red"

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -734,6 +734,7 @@ impl TryFrom<rest::Record> for RetrievedPoint {
     fn try_from(record: rest::Record) -> Result<Self, Self::Error> {
         let rest::Record {
             id,
+            version,
             payload,
             vector,
             shard_key,
@@ -741,6 +742,7 @@ impl TryFrom<rest::Record> for RetrievedPoint {
         } = record;
         let retrieved_point = Self {
             id: Some(PointId::from(id)),
+            version,
             payload: payload.map(json::payload_to_proto).unwrap_or_default(),
             vectors: vector.map(VectorsOutput::try_from).transpose()?,
             shard_key: shard_key.map(convert_shard_key_to_grpc),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -625,13 +625,13 @@ message PowExpression {
 
 message DecayParamsExpression {
     // The variable to decay
-    Expression x = 1; 
+    Expression x = 1;
     // The target value to start decaying from. Defaults to 0.
-    optional Expression target = 2; 
+    optional Expression target = 2;
     // The scale factor of the decay, in terms of `x`. Defaults to 1.0. Must be a non-zero positive number.
-    optional float scale = 3; 
+    optional float scale = 3;
     // The midpoint of the decay. Defaults to 0.5. Output will be this value when `|x - target| == scale`.
-    optional float midpoint = 4; 
+    optional float midpoint = 4;
 }
 
 message Query {
@@ -942,6 +942,7 @@ message RetrievedPoint {
   optional VectorsOutput vectors = 4;
   optional ShardKey shard_key = 5; // Shard key
   optional OrderValue order_value = 6; // Order-by value
+  uint64 version = 7; // version of the point
 }
 
 message GetResponse {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6055,6 +6055,9 @@ pub struct RetrievedPoint {
     /// Order-by value
     #[prost(message, optional, tag = "6")]
     pub order_value: ::core::option::Option<OrderValue>,
+    /// version of the point
+    #[prost(uint64, tag = "7")]
+    pub version: u64,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -300,6 +300,7 @@ pub struct ScoredPoint {
 pub struct Record {
     /// Id of the point
     pub id: segment::types::PointIdType,
+    pub version: segment::types::SeqNumberType,
     /// Payload - values assigned to the point
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<segment::types::Payload>,

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -434,6 +434,7 @@ impl SegmentsSearcher {
                     id,
                     RecordInternal {
                         id,
+                        version,
                         payload: if with_payload.enable {
                             if let Some(selector) = &with_payload.payload_selector {
                                 Some(selector.process(segment.payload(id, &hw_counter)?))

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -307,6 +307,7 @@ fn test_delete_all_point_versions() {
             point_id,
             RecordInternal {
                 id: point_id,
+                version: 101,
                 vector: Some(VectorStructInternal::Single(new_vector)),
                 payload: None,
                 shard_key: None,

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -133,6 +133,7 @@ pub fn try_record_from_grpc(
         vectors,
         shard_key,
         order_value,
+        version,
     } = point;
     let id = id
         .ok_or_else(|| Status::invalid_argument("retrieved point does not have an ID"))?
@@ -154,6 +155,7 @@ pub fn try_record_from_grpc(
 
     Ok(RecordInternal {
         id,
+        version,
         payload,
         vector,
         shard_key: convert_shard_key_from_grpc_opt(shard_key),
@@ -539,6 +541,7 @@ impl From<RecordInternal> for api::grpc::qdrant::RetrievedPoint {
     fn from(record: RecordInternal) -> Self {
         let RecordInternal {
             id,
+            version,
             payload,
             vector,
             shard_key,
@@ -546,6 +549,7 @@ impl From<RecordInternal> for api::grpc::qdrant::RetrievedPoint {
         } = record;
         Self {
             id: Some(id.into()),
+            version,
             payload: payload.map(payload_to_proto).unwrap_or_default(),
             vectors: vector.map(api::grpc::qdrant::VectorsOutput::from),
             shard_key: shard_key.map(convert_shard_key_to_grpc),

--- a/lib/collection/src/operations/conversions_rest.rs
+++ b/lib/collection/src/operations/conversions_rest.rs
@@ -4,6 +4,7 @@ impl From<RecordInternal> for api::rest::Record {
     fn from(value: RecordInternal) -> Self {
         let RecordInternal {
             id,
+            version,
             payload,
             vector,
             shard_key,
@@ -11,6 +12,7 @@ impl From<RecordInternal> for api::rest::Record {
         } = value;
         Self {
             id,
+            version,
             payload,
             vector: vector.map(api::rest::VectorStructOutput::from),
             shard_key,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -131,6 +131,8 @@ pub enum OptimizersStatus {
 pub struct RecordInternal {
     /// Id of the point
     pub id: PointIdType,
+    /// Version of the point
+    pub version: u64,
     /// Payload - values assigned to the point
     pub payload: Option<Payload>,
     /// Vector of the point
@@ -148,6 +150,7 @@ impl TryFrom<RecordInternal> for PointStructPersisted {
     fn try_from(record: RecordInternal) -> Result<Self, Self::Error> {
         let RecordInternal {
             id,
+            version: _,
             payload,
             vector,
             shard_key: _,
@@ -172,6 +175,7 @@ impl TryFrom<Record> for PointStructPersisted {
     fn try_from(record: Record) -> Result<Self, Self::Error> {
         let Record {
             id,
+            version: _,
             payload,
             vector,
             shard_key: _,
@@ -556,6 +560,7 @@ fn points_example() -> Vec<api::rest::Record> {
     vec![
         api::rest::Record {
             id: PointIdType::NumId(40),
+            version: 12,
             payload: Some(Payload(payload_map_1)),
             vector: Some(VectorStructOutput::Single(vec![0.875, 0.140625, 0.897_6])),
             shard_key: Some("region_1".into()),
@@ -563,6 +568,7 @@ fn points_example() -> Vec<api::rest::Record> {
         },
         api::rest::Record {
             id: PointIdType::NumId(41),
+            version: 13,
             payload: Some(Payload(payload_map_2)),
             vector: Some(VectorStructOutput::Single(vec![0.75, 0.640625, 0.8945])),
             shard_key: Some("region_1".into()),

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -120,7 +120,7 @@ impl LocalShard {
             .into_iter()
             .map(|record| ScoredPoint {
                 id: record.id,
-                version: 0,
+                version: record.version,
                 score: 0.0,
                 payload: record.payload,
                 vector: record.vector,


### PR DESCRIPTION
As part of a further refactoring, and to be consistent with query interface, I propose to include the point version for scrolls too. 

This is simple to add, since we were already resolving it, but we were discarding it right away.
This also fixes the fact that scroll-like queries would return a synthetic version 0 in the response.

This PR adds a `version` field to `RecordInternal`, `rest::Record` and `grpc::RetrievedPoint`