### PR TITLE
Scroll lock: make sure no segments are modified between scroll and retrieve

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -47,8 +47,7 @@ impl CollectionUpdater {
         let scroll_lock = segments.read().scroll_read_lock.clone();
 
         // Use block_in_place here to avoid blocking the current async executor
-        let _scroll_lock =
-            tokio::task::block_in_place(|| tokio::sync::RwLock::write_owned(scroll_lock));
+        let _scroll_lock = tokio::task::block_in_place(|| scroll_lock.blocking_write());
 
         let operation_result = match operation {
             CollectionUpdateOperations::PointOperation(point_operation) => {

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -44,6 +44,9 @@ impl CollectionUpdater {
     ) -> CollectionResult<usize> {
         // Allow only one update at a time, ensure no data races between segments.
         // let _lock = self.update_lock.lock().unwrap();
+        let scroll_lock = segments.read().scroll_read_lock.clone();
+        let _scroll_lock = futures::executor::block_on(scroll_lock.write());
+
         let operation_result = match operation {
             CollectionUpdateOperations::PointOperation(point_operation) => {
                 process_point_operation(segments, op_num, point_operation, hw_counter)

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -156,6 +156,14 @@ pub struct SegmentHolder {
 
     /// Holds the first uncorrected error happened with optimizer
     pub optimizer_errors: Option<CollectionError>,
+
+    /// Scroll read lock
+    /// The lock, which must prevent updates during scroll + retrieve operations
+    /// Consistency of scroll operations is especially important for internal processes like
+    /// re-sharding and shard transfer, so explicit lock for those operations is required.
+    ///
+    /// Write lock must be held for updates, while read lock must be held for scroll
+    pub scroll_read_lock: Arc<tokio::sync::RwLock<()>>,
 }
 
 pub type LockedSegmentHolder = Arc<RwLock<SegmentHolder>>;

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -20,7 +20,7 @@ use crate::collection::Collection;
 // want to be able to access `TableOfContent` using `.toc()`.
 // If you're not implementing a new point-api endpoint for which a strict mode check
 // is required, this is safe to use.
-pub fn new_unchecked_verification_pass() -> VerificationPass {
+pub const fn new_unchecked_verification_pass() -> VerificationPass {
     VerificationPass { _inner: () }
 }
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -59,10 +59,16 @@ pub async fn do_recover_from_snapshot(
     let dispatcher = dispatcher.clone();
     let collection_pass = multipass.issue_pass(collection_name).into_static();
 
-    let res = tokio::spawn(async move {
-        _do_recover_from_snapshot(dispatcher, access, collection_pass, source, &client).await
-    })
-    .await??;
+    let toc = dispatcher
+        .toc(&access, &new_unchecked_verification_pass())
+        .clone();
+
+    let res = toc
+        .general_runtime_handle()
+        .spawn(async move {
+            _do_recover_from_snapshot(dispatcher, access, collection_pass, source, &client).await
+        })
+        .await??;
 
     Ok(res)
 }

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -32,7 +32,7 @@ use common::counter::hardware_accumulator::HwSharedDrain;
 use common::cpu::get_num_cpus;
 use common::types::TelemetryDetail;
 use dashmap::DashMap;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Handle, Runtime};
 use tokio::sync::{Mutex, RwLock, RwLockReadGuard, Semaphore};
 
 use self::dispatcher::TocDispatcher;
@@ -685,5 +685,9 @@ impl TableOfContent {
                 (key, hw_usage)
             })
             .collect()
+    }
+
+    pub(crate) fn general_runtime_handle(&self) -> &Handle {
+        self.general_runtime.handle()
     }
 }


### PR DESCRIPTION
This PR fixes rare but possible loss of points in scroll results:

due to 2-stage search+retrieve approach in scroll, we can't guarantee that points retrieved on the first stage will be available and/or unchanged on the second stage. This might create a problem of either returning changed payload, which doesn't satisfy filters anymore, or compromise number of returned points.

It is especially critical for scroll request, which relies on number of returned points to generate a "next_page" offset, and is used in internal operations like shard streaming.

What I have tried and didn't work:

- use segments lock and https://amanieu.github.io/parking_lot/parking_lot/struct.RwLock.html#method.read_recursive - didn't work because it would require to have sync locks which live between await blocks.
- Read version along with point ids and check version on retrieve - won't help with  deleted points
- Move read points with payloads right away - reading payloads in advance is too expensive disk-wise

Current approach drawbacks:

- Usage of the scroll-lock is not enforced by the compiler. Have to rely on carefulness
- Update operations might be slightly delayed compared to original version



