### PR TITLE
Fixes for Clippy 1.86

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -128,7 +128,7 @@ impl ShardCleanTasks {
             };
             match result {
                 // Status updated, loop again to check it another time
-                Ok(Ok(_)) => continue,
+                Ok(Ok(_)) => (),
                 // Channel dropped, return error
                 Ok(Err(_)) => {
                     return Err(CollectionError::service_error(

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -203,13 +203,11 @@ impl Collection {
                         RemoteShard::restore_snapshot(&shard_path)
                     }
                     shard_config::ShardType::Temporary => {}
-                    shard_config::ShardType::ReplicaSet { .. } => {
-                        ShardReplicaSet::restore_snapshot(
-                            &shard_path,
-                            this_peer_id,
-                            is_distributed,
-                        )?
-                    }
+                    shard_config::ShardType::ReplicaSet => ShardReplicaSet::restore_snapshot(
+                        &shard_path,
+                        this_peer_id,
+                        is_distributed,
+                    )?,
                 }
             } else {
                 return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -553,8 +553,7 @@ pub trait SegmentOptimizer {
     ///
     /// * `segments` - segments holder
     /// * `ids` - list of segment ids to perform optimization on. All segments will be merged into single one
-    /// * `stopped` - flag for early stopping of the optimization.
-    ///               If appears to be `true` - optimization process should be cancelled, all segments unwrapped
+    /// * `stopped` - flag for early stopping of the optimization. If appears to be `true` - optimization process should be cancelled, all segments unwrapped.
     ///
     /// # Result
     ///

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -116,7 +116,6 @@ impl GroupsAggregator {
             match self.add_point(point) {
                 Ok(()) | Err(AggregatorError::KeyNotFound | AggregatorError::BadKeyType) => {
                     // ignore points that don't have the group_by field
-                    continue;
                 }
             }
         }

--- a/lib/collection/src/operations/snapshot_storage_ops.rs
+++ b/lib/collection/src/operations/snapshot_storage_ops.rs
@@ -66,11 +66,11 @@ pub async fn get_snapshot_description(
 /// Note:
 ///
 /// * Amazon S3: <https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html>
-///     partsize: min 5 MB, max 5 GB, up to 10,000 parts.
+///   partsize: min 5 MB, max 5 GB, up to 10,000 parts.
 /// * Google Cloud Storage: <https://cloud.google.com/storage/quotas?hl=ja#objects>
-///     partsize: min 5 MB, max 5 GB, up to 10,000 parts.
+///   partsize: min 5 MB, max 5 GB, up to 10,000 parts.
 /// * Azure Storage: <https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob?tabs=microsoft-entra-id#remarks>
-///     TODO: It looks like Azure Storage has different limits for different service versions.
+///   TODO: It looks like Azure Storage has different limits for different service versions.
 pub async fn get_appropriate_chunk_size(local_source_path: &Path) -> CollectionResult<usize> {
     const DEFAULT_CHUNK_SIZE: usize = 50 * 1024 * 1024;
     const MAX_PART_NUMBER: usize = 10000;

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -520,7 +520,6 @@ impl Inner {
                         "Failed to transfer batch of updates to peer {}, retrying: {err}",
                         self.remote_shard.peer_id,
                     );
-                    continue;
                 }
                 Err(err) => return Err(err),
             }

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -211,7 +211,6 @@ pub trait ShardTransferConsensus: Send + Sync {
                 Ok(()) => break,
                 Err(err) => {
                     log::error!("Failed to confirm recovered operation on consensus: {err}");
-                    continue;
                 }
             }
         }
@@ -265,7 +264,6 @@ pub trait ShardTransferConsensus: Send + Sync {
                     log::error!(
                         "Failed to confirm start shard transfer operation on consensus: {err}"
                     );
-                    continue;
                 }
             }
         }
@@ -320,7 +318,6 @@ pub trait ShardTransferConsensus: Send + Sync {
                     log::error!(
                         "Failed to confirm restart shard transfer operation on consensus: {err}"
                     );
-                    continue;
                 }
             }
         }
@@ -377,7 +374,6 @@ pub trait ShardTransferConsensus: Send + Sync {
                     log::error!(
                         "Failed to confirm abort shard transfer operation on consensus: {err}"
                     );
-                    continue;
                 }
             }
         }
@@ -436,7 +432,6 @@ pub trait ShardTransferConsensus: Send + Sync {
                     log::error!(
                         "Failed to confirm set shard replica set state operation on consensus: {err}"
                     );
-                    continue;
                 }
             }
         }
@@ -491,7 +486,6 @@ pub trait ShardTransferConsensus: Send + Sync {
                     log::error!(
                         "Failed to confirm commit read hashring operation on consensus: {err}"
                     );
-                    continue;
                 }
             }
         }
@@ -546,7 +540,6 @@ pub trait ShardTransferConsensus: Send + Sync {
                     log::error!(
                         "Failed to confirm commit write hashring operation on consensus: {err}"
                     );
-                    continue;
                 }
             }
         }

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -165,7 +165,7 @@ where
             let mmap = self.mmap.clone();
             move || {
                 // flushing a zero-sized mmap can cause panicking on some systems
-                if mmap.len() > 0 {
+                if !mmap.is_empty() {
                     mmap.flush()?;
                 }
                 Ok(())

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -488,7 +488,7 @@ impl<V: Blob> Gridstore<V> {
                 },
             );
             match callback(point_offset, value.as_ref()) {
-                ControlFlow::Continue(()) => continue,
+                ControlFlow::Continue(()) => (),
                 ControlFlow::Break(message) => return Err(message),
             }
         }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -51,10 +51,10 @@ pub trait VectorIndex {
     /// # Arguments
     /// - `id` - sequential vector id, offset in the vector storage
     /// - `vector` - new vector value,
-    ///        if None - vector will be removed from the index marked as deleted in storage.
-    ///        Note: inserting None vector is not equal to removing vector from the storage.
-    ///              Unlike removing, it will always result in storage growth.
-    ///              Proper removing should be performed by the optimizer.
+    ///   if None - vector will be removed from the index marked as deleted in storage.
+    ///   Note: inserting None vector is not equal to removing vector from the storage.
+    ///   Unlike removing, it will always result in storage growth.
+    ///   Proper removing should be performed by the optimizer.
     fn update_vector(
         &mut self,
         id: PointOffsetType,

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -121,7 +121,7 @@ impl Segment {
     ///
     /// * `op_num` - sequential operation of the current operation
     /// * `op` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside)
-    ///     and optionally new offset of the changed point.
+    ///   and optionally new offset of the changed point.
     ///
     /// # Result
     ///
@@ -173,9 +173,8 @@ impl Segment {
     ///
     /// * `op_num` - sequential operation of the current operation
     /// * `op_point_offset` - If point offset is specified, handler will use point version for comparison.
-    ///     Otherwise, it will be applied without version checks.
-    /// * `op` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside)
-    ///     and optionally new offset of the changed point.
+    ///   Otherwise, it will be applied without version checks.
+    /// * `op` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside) and optionally new offset of the changed point.
     ///
     /// # Result
     ///

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -913,7 +913,7 @@ fn recover_first_voter(
                 }
             }
 
-            EntryType::EntryNormal => continue,
+            EntryType::EntryNormal => (),
         }
     }
 


### PR DESCRIPTION
Rust [1.86.0](https://releases.rs/docs/1.86.0/) will be out in two days (3 April, 2025).

There is nothing controversial in the fixes IMHO.