### PR TITLE
Recover dirty shards using other replicas when marked Dead

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -681,9 +681,11 @@ impl Collection {
                 continue;
             }
 
-            if !(this_peer_state == Some(Dead) || replica_set.is_dirty().await) {
+            if !(this_peer_state == Some(Dead) && !replica_set.is_recovery().await) {
                 continue; // All good
             }
+
+            // Reaches here only if replica is Dead but not in recovery mode
 
             // Try to find dead replicas with no active transfers
             let transfers = shard_holder.get_transfers(|_| true);

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -683,7 +683,7 @@ impl Collection {
 
             #[allow(clippy::nonminimal_bool)]
             {
-                if !(this_peer_state == Some(Dead) && replica_set.is_dirty().await) {
+                if !(this_peer_state == Some(Dead) && !replica_set.is_dirty().await) {
                     continue; // All good
                 }
             }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -683,7 +683,7 @@ impl Collection {
 
             #[allow(clippy::nonminimal_bool)]
             {
-                if !(this_peer_state == Some(Dead) && !replica_set.is_dirty().await) {
+                if !(this_peer_state == Some(Dead) && replica_set.is_dirty().await) {
                     continue; // All good
                 }
             }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -681,9 +681,8 @@ impl Collection {
                 continue;
             }
 
-            // Don't recover our replicas if started in recovery mode
-            let is_recovery_mode = self.shared_storage_config.recovery_mode.is_some();
-            if is_recovery_mode {
+            // Don't automatically recover replicas if started in recovery mode
+            if self.shared_storage_config.recovery_mode.is_some() {
                 continue;
             }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -681,11 +681,14 @@ impl Collection {
                 continue;
             }
 
-            if !(this_peer_state == Some(Dead) && !replica_set.is_recovery().await) {
-                continue; // All good
+            #[allow(clippy::nonminimal_bool)]
+            {
+                if !(this_peer_state == Some(Dead) && replica_set.is_dirty().await) {
+                    continue; // All good
+                }
             }
 
-            // Reaches here only if replica is Dead but not in recovery mode
+            // Reaches here only if replica is Dead OR dirty
 
             // Try to find dead replicas with no active transfers
             let transfers = shard_holder.get_transfers(|_| true);

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -686,12 +686,11 @@ impl Collection {
                 continue;
             }
 
+            // Don't recover replicas if not dead
             let is_dead = this_peer_state == Some(Dead);
-            if !(is_dead || replica_set.is_dummy().await) {
-                continue; // All good
+            if !is_dead {
+                continue;
             }
-
-            // Reaches here only if replica is Dead OR dirty (dummy but not in recovery)
 
             // Try to find dead replicas with no active transfers
             let transfers = shard_holder.get_transfers(|_| true);

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -681,9 +681,11 @@ impl Collection {
                 continue;
             }
 
-            if this_peer_state != Some(Dead) || replica_set.is_dummy().await {
+            if this_peer_state != Some(Dead) {
                 continue; // All good
             }
+
+            // TODO: Skip transfers for dummy shards that aren't dirty
 
             // Try to find dead replicas with no active transfers
             let transfers = shard_holder.get_transfers(|_| true);

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -685,8 +685,6 @@ impl Collection {
                 continue; // All good
             }
 
-            // TODO: Skip transfers for dummy shards that aren't dirty
-
             // Try to find dead replicas with no active transfers
             let transfers = shard_holder.get_transfers(|_| true);
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -686,12 +686,12 @@ impl Collection {
                 continue;
             }
 
-            let is_dead = this_peer_state.is_none_or(|state| state == Dead);
+            let is_dead = this_peer_state == Some(Dead);
             if !(is_dead || replica_set.is_dummy().await) {
                 continue; // All good
             }
 
-            // Reaches here only if replica is Dead OR dummy
+            // Reaches here only if replica is Dead OR dirty (dummy but not in recovery)
 
             // Try to find dead replicas with no active transfers
             let transfers = shard_holder.get_transfers(|_| true);

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -683,7 +683,7 @@ impl Collection {
 
             #[allow(clippy::nonminimal_bool)]
             {
-                if !(this_peer_state == Some(Dead) && replica_set.is_dirty().await) {
+                if !(this_peer_state == Some(Dead) || replica_set.is_dirty().await) {
                     continue; // All good
                 }
             }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -681,7 +681,7 @@ impl Collection {
                 continue;
             }
 
-            if this_peer_state != Some(Dead) {
+            if !(this_peer_state == Some(Dead) || replica_set.is_dirty().await) {
                 continue; // All good
             }
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -422,7 +422,7 @@ impl Collection {
             if replica_set.is_dummy().await {
                 // We can reach here because of either of these:
                 // 1. Qdrant is in recovery mode, and user intentionally triggered a transfer
-                // 2. Shard is dirty (shard initializing flag), and Qdrant triggered a transfer to recover from Dead state after a an update fails
+                // 2. Shard is dirty (shard initializing flag), and Qdrant triggered a transfer to recover from Dead state after an update fails
                 //
                 // In both cases, it's safe to drop existing local shard data
                 log::debug!(

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -426,10 +426,15 @@ impl Collection {
                 //
                 // In both cases, it's safe to drop existing local shard data
                 let was_dirty = replica_set.is_dirty().await;
+                log::debug!(
+                    "Initiating transfer to dummy shard {} with dirty = {}. Initializing empty local shard first",
+                    replica_set.shard_id,
+                    was_dirty
+                );
                 replica_set.init_empty_local_shard().await?;
 
                 if was_dirty {
-                    // TODO: Shouldn't we do this after start the transfer?
+                    // TODO: Shouldn't we do this after we start the transfer?
                     let shard_flag = shard_initializing_flag_path(&collection_path, shard_id);
                     tokio::fs::remove_file(&shard_flag).await?;
                 }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -434,6 +434,8 @@ impl Collection {
                 let shard_flag = shard_initializing_flag_path(&collection_path, shard_id);
 
                 if tokio::fs::try_exists(&shard_flag).await.is_ok() {
+                    // We can delete initializing flag without waiting for transfer to finish
+                    // because if transfer fails in between, Qdrant will retry it.
                     tokio::fs::remove_file(&shard_flag).await?;
                     log::debug!("Removing shard initializing flag {shard_flag:?}");
                 }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -421,8 +421,9 @@ impl Collection {
 
             if replica_set.is_dummy().await {
                 // We can reach here because of either of these:
-                // 1. Qdrant is in recovery mode (shard not dirty), and user intentionally triggered a transfer
-                // 2. Shard is dirty (shard initializing flag), and Qdrant automatically triggered a transfer to fix it (note: initializing flag means there must be another replica)
+                // 1. Qdrant is in recovery mode, and user intentionally triggered a transfer
+                // 2. Shard is dirty (shard initializing flag), and Qdrant automatically triggered a transfer to recover dead state
+                //    (note: initializing flag means there must be another replica)
                 //
                 // In both cases, it's safe to drop existing local shard data
                 log::debug!(

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -422,8 +422,7 @@ impl Collection {
             if replica_set.is_dummy().await {
                 // We can reach here because of either of these:
                 // 1. Qdrant is in recovery mode, and user intentionally triggered a transfer
-                // 2. Shard is dirty (shard initializing flag), and Qdrant automatically triggered a transfer to recover dead state
-                //    (note: initializing flag means there must be another replica)
+                // 2. Shard is dirty (shard initializing flag), and Qdrant triggered a transfer to recover from Dead state after a an update fails
                 //
                 // In both cases, it's safe to drop existing local shard data
                 log::debug!(

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -28,13 +28,19 @@ use crate::shards::telemetry::LocalShardTelemetry;
 #[derive(Clone, Debug)]
 pub struct DummyShard {
     message: String,
+    is_dirty: bool,
 }
 
 impl DummyShard {
-    pub fn new(message: impl Into<String>) -> Self {
+    pub fn new(message: impl Into<String>, is_dirty: bool) -> Self {
         Self {
             message: message.into(),
+            is_dirty,
         }
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.is_dirty
     }
 
     pub async fn create_snapshot(

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -28,19 +28,13 @@ use crate::shards::telemetry::LocalShardTelemetry;
 #[derive(Clone, Debug)]
 pub struct DummyShard {
     message: String,
-    is_dirty: bool,
 }
 
 impl DummyShard {
-    pub fn new(message: impl Into<String>, is_dirty: bool) -> Self {
+    pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            is_dirty,
         }
-    }
-
-    pub fn is_dirty(&self) -> bool {
-        self.is_dirty
     }
 
     pub async fn create_snapshot(

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -401,6 +401,10 @@ impl ShardReplicaSet {
         matches!(*local_read, Some(Shard::Dummy(_)))
     }
 
+    pub async fn is_recovery(&self) -> bool {
+        self.shared_storage_config.recovery_mode.is_some()
+    }
+
     pub async fn is_dirty(&self) -> bool {
         let local_read = self.local.read().await;
         match local_read.as_ref() {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -427,7 +427,7 @@ impl ShardReplicaSet {
         let local_read = self.local.read().await;
         match local_read.as_ref() {
             Some(Shard::Dummy(dummy_shard)) => dummy_shard.is_dirty(),
-            _ => false
+            _ => false,
         }
     }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -318,7 +318,7 @@ impl ShardReplicaSet {
                         );
 
                         Shard::Dummy(DummyShard::new(format!(
-                            "Failed to load local shard {shard_path:?}: {err}",
+                            "Failed to load local shard {shard_path:?}: {err}"
                         )))
                     }
                 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -402,11 +402,6 @@ impl ShardReplicaSet {
         matches!(*local_read, Some(Shard::Dummy(_)))
     }
 
-    pub async fn is_dirty(&self) -> bool {
-        // Is dummy but not in recovery mode
-        self.is_dummy().await && self.shared_storage_config.recovery_mode.is_none()
-    }
-
     pub fn peers(&self) -> HashMap<PeerId, ReplicaState> {
         self.replica_state.read().peers()
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -422,16 +422,6 @@ impl ShardReplicaSet {
         matches!(*local_read, Some(Shard::Dummy(_)))
     }
 
-    #[allow(dead_code)]
-    pub async fn is_dummy_but_not_dirty(&self) -> bool {
-        // ToDo: Maybe add a boolean in DummyShard to mark if it's dirty.
-        let local_read = self.local.read().await;
-        match *local_read {
-            Some(Shard::Dummy(_)) => true,
-            _ => false
-        }
-    }
-
     pub fn peers(&self) -> HashMap<PeerId, ReplicaState> {
         self.replica_state.read().peers()
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -283,6 +283,7 @@ impl ShardReplicaSet {
                 log::error!(
                     "Shard {collection_id}:{shard_id} is not fully initialized - loading as dummy shard"
                 );
+                // This dummy shard will be replaced only when it rejects an update (marked as dead so recovery process kicks in)
                 Shard::Dummy(DummyShard::new("Shard is dirty", true))
             } else {
                 let res = LocalShard::load(
@@ -368,12 +369,6 @@ impl ShardReplicaSet {
                 .locally_disabled_peers
                 .write()
                 .disable_peer(this_peer_id);
-        }
-
-        if is_dirty_shard {
-            // Mark local replica as Dead since it's dummy and dirty
-            let replica_state = replica_set.replica_state.read();
-            replica_set.add_locally_disabled(&replica_state, replica_set.this_peer_id(), None);
         }
 
         replica_set

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -378,6 +378,8 @@ impl ShardReplicaSet {
     }
 
     pub fn mark_local_as_dead(&self) {
+        // ToDo: Can we just reuse self.add_locally_disabled()? instead
+
         // Mark this peer as "locally disabled"...
         //
         // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -341,26 +341,7 @@ impl ShardReplicaSet {
                     "Failed to restore local replica",
                 )));
 
-                // Mark this peer as "locally disabled"...
-                //
-                // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!
-                let has_other_active_peers = !self.active_remote_shards().is_empty();
-
-                // ...if this peer is *not* the last active replica
-                if has_other_active_peers {
-                    let notify = self
-                        .locally_disabled_peers
-                        .write()
-                        .disable_peer_and_notify_if_elapsed(self.this_peer_id(), None);
-
-                    if notify {
-                        self.notify_peer_failure_cb.deref()(
-                            self.this_peer_id(),
-                            self.shard_id,
-                            None,
-                        );
-                    }
-                }
+                self.mark_local_as_dead();
 
                 // Remove inner shard data but keep the shard folder with its configuration files.
                 // This way the shard can be read on startup and the user can decide what to do next.

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -339,6 +339,7 @@ impl ShardReplicaSet {
                 // Initialize "dummy" replica
                 local.replace(Shard::Dummy(DummyShard::new(
                     "Failed to restore local replica",
+                    true,
                 )));
 
                 self.mark_local_as_dead();

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -341,7 +341,11 @@ impl ShardReplicaSet {
                     true,
                 )));
 
-                self.mark_local_as_dead();
+                // Mark local replica as Dead since it's dummy and dirty
+                {
+                    let replica_state = self.replica_state.read();
+                    self.add_locally_disabled(&replica_state, self.this_peer_id(), None);
+                }
 
                 // Remove inner shard data but keep the shard folder with its configuration files.
                 // This way the shard can be read on startup and the user can decide what to do next.

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -338,7 +338,6 @@ impl ShardReplicaSet {
                 // Initialize "dummy" replica
                 local.replace(Shard::Dummy(DummyShard::new(
                     "Failed to restore local replica",
-                    true,
                 )));
 
                 // Mark local replica as Dead since it's dummy and dirty

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::ops::Deref as _;
 use std::path::Path;
 use std::{fs, io};
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -40,12 +40,11 @@ use crate::operations::{OperationToShard, SplitByShard};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
-use crate::shards::local_shard::LocalShard;
 use crate::shards::replica_set::{ReplicaState, ShardReplicaSet};
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::ShardConfig;
 use crate::shards::transfer::{ShardTransfer, ShardTransferKey};
-use crate::shards::{CollectionId, check_shard_path, shard_initializing_flag_path, shard_path};
+use crate::shards::{CollectionId, check_shard_path, shard_initializing_flag_path};
 
 const SHARD_TRANSFERS_FILE: &str = "shard_transfers";
 const RESHARDING_STATE_FILE: &str = "resharding_state.json";
@@ -634,23 +633,9 @@ impl ShardHolder {
             // Check if shard is fully initialized on disk
             // The initialization flag should be absent for a well-formed replica set
             let initializing_flag = shard_initializing_flag_path(collection_path, shard_id);
-            let dirty_shard_data = tokio::fs::try_exists(&initializing_flag)
+            let is_dirty_shard = tokio::fs::try_exists(&initializing_flag)
                 .await
                 .unwrap_or(false);
-
-            if dirty_shard_data {
-                log::error!(
-                    "Shard {collection_id}:{shard_id} is not fully initialized - deleting segments data"
-                );
-                let shard_path = shard_path(collection_path, shard_id);
-                LocalShard::clear(&shard_path).await.unwrap();
-                // Delete the initialized flag now that the shard is clean
-                tokio::fs::remove_file(&initializing_flag)
-                    .await
-                    .unwrap_or_else(|e| {
-                        log::error!("Failed to remove initializing flag for shard {collection_id}:{shard_id}: {e}");
-                    });
-            }
 
             // Validate that shard exists on disk
             let shard_path = check_shard_path(collection_path, shard_id)
@@ -664,6 +649,7 @@ impl ShardHolder {
                 shard_key.cloned(),
                 collection_id.clone(),
                 &shard_path,
+                is_dirty_shard,
                 collection_config.clone(),
                 effective_optimizers_config.clone(),
                 shared_storage_config.clone(),

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -1,6 +1,7 @@
 import pathlib
 import subprocess
 import tempfile
+import shutil
 import requests
 from time import sleep
 
@@ -74,6 +75,16 @@ def corrupt_snapshot(snapshot_path: pathlib.Path, segment_name: str):
 
             # Replace the original snapshot tar with the corrupted one
             os.rename(new_segment_archive, snapshot_path)
+
+def corrupt_shard_dir(shard_path: pathlib.Path):
+    segements_path = shard_path / "segments"
+    segment_names = filter(lambda x: x.is_dir(), pathlib.Path(segements_path).iterdir())
+
+    first_segment_path = next(segment_names)
+    shutil.rmtree(first_segment_path)
+
+    wal_path = shard_path / "wal"
+    shutil.rmtree(wal_path)
 
 def remove_file_from_tar(original_tar, file_to_remove, new_tar):
     file_to_remove = file_to_remove.replace(os.sep, "/")
@@ -218,11 +229,15 @@ def test_failed_snapshot_recovery(tmp_path: pathlib.Path):
 @pytest.mark.parametrize("transfer_method", ["snapshot", "stream_records", "wal_delta"])
 def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, transfer_method: str):
     assert_project_root()
+    extra_env = {
+        "QDRANT__STORAGE__SHARD_TRANSFER_METHOD": transfer_method,
+        "QDRANT__STORAGE__HANDLE_COLLECTION_LOAD_ERRORS": "false"
+    }
 
     peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(
         tmp_path,
         N_PEERS,
-        extra_env={"QDRANT__STORAGE__SHARD_TRANSFER_METHOD": transfer_method },
+        extra_env=extra_env,
     )
 
     create_collection(
@@ -244,11 +259,17 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     )
     assert len(initial_dense_search_result) > 0
 
-    # Create a shard initializing flag to trigger dirty shard fixing logic
+    # Simulate killing on snapshot recovery (corrupting shard dir and adding a shard initializing flag)
     # this can happen in practice when a node is killed while shard directory was being moved from /qdrant/snapshots to /qdrant/storage
     # the initializing flag is created but never deleted in such cases, when Qdrant restarts it considers it as dirty shard and tries to recover it
-    flag_path = shard_initializing_flag(peer_dirs[-1], COLLECTION_NAME, 0)
+    shard_id = 0
+    flag_path = shard_initializing_flag(peer_dirs[-1], COLLECTION_NAME, shard_id)
     Path(flag_path).touch()
+
+    # Delete some of the files from the shard:
+    shard_path = Path(peer_dirs[-1]) / "storage" / "collections" / COLLECTION_NAME / f"{shard_id}"
+    assert shard_path.exists()
+    # corrupt_shard_dir(shard_path)
 
     # Kill last peer
     p = processes.pop()
@@ -256,8 +277,12 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
 
     # Restart same peer
     peer_api_uris[-1] = start_peer(
-        peer_dirs[-1], f"peer_{N_PEERS}_restarted.log", bootstrap_uri
+        peer_dirs[-1], f"peer_{N_PEERS}_restarted.log", bootstrap_uri,
+        extra_env=extra_env
     )
+
+    # Last peer panics on restart because the recovery logic for dirty shards was broken (and we set handle_collection_load_errors=false like prod envs)
+    # Ideally Qdrant should try to recover this shard automatically using other replicas
 
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
@@ -270,10 +295,7 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     assert len(local_shards) == 1
     assert local_shards[0]["shard_id"] == 0
     assert local_shards[0]["state"] == "Active"
-    assert local_shards[0]["points_count"] == 1000  # FAILS because of dummy shard
-
-    # Qdrant loads a dummy shard (since handle_collection_load_errors=true) so we get 0 points instead of 1000 and test fails
-    # Ideally Qdrant should try to recover this shard automatically using other replicas
+    assert local_shards[0]["points_count"] == 1000
 
     # Assert that the remote shards are active and not empty
     # The peer used as source for the transfer is used as remote to have at least one

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -176,7 +176,7 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
     local_shards = get_local_shards(peer_api_uris[-1])
     assert len(local_shards) == 1
     assert local_shards[0]["shard_id"] == 0
-    assert local_shards[0]["state"] in ["Partial", "Recovery"]
+    assert local_shards[0]["state"] in ["Dead", "Partial", "Recovery"]
     assert local_shards[0]["points_count"] <= n_points
 
     # Assert storage does not contain initialized flag after restoring on restart

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -271,7 +271,8 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
         extra_env=extra_env
     )
 
-    # Qdrant loads a dummy shard. Shorty after the load, `sync_local_state` initiates a transfer from other replicas to recover dirty shard
+    # Upsert one point to mark dummy replica as dead, that will trigger recovery transfer
+    upsert_random_points(peer_api_uris[0], 1)
 
     # Wait for start of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 1)

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -146,6 +146,7 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
     # Kill last peer
     p = processes.pop()
     p.kill()
+    sleep(1) # Give killed peer time to release WAL lock
 
     # Restart same peer
     peer_api_uris[-1] = start_peer(peer_dirs[-1], f"peer_{N_PEERS}_restarted.log", bootstrap_uri)
@@ -271,6 +272,7 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     # Kill last peer
     p = processes.pop()
     p.kill()
+    sleep(1) # Give killed peer time to release WAL lock
 
     # Restart same peer
     peer_api_uris[-1] = start_peer(
@@ -287,6 +289,7 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     # Kill again after transfer starts (shard initializing flag has been deleted and shard is empty)
     p = processes.pop()
     p.kill()
+    sleep(1) # Give killed peer time to release WAL lock
 
     # Restart same peer again
     peer_api_uris[-1] = start_peer(

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -171,8 +171,8 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
     flag_path = shard_initializing_flag(peer_dirs[-1], COLLECTION_NAME, 0)
     try:
         wait_for(lambda : not os.path.exists(flag_path))
-    except TimeoutError:
-        assert False, f"Flag {flag_path} still exists after recovery"
+    except Exception as e:
+        raise Exception(f"Flag {flag_path} might still exists after recovery: {e}")
 
     # There are two other replicas, try moving shards into broken state
     local_shards = get_local_shards(peer_api_uris[0])

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -116,7 +116,7 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
 
     wait_for_same_commit(peer_api_uris=peer_api_uris)
 
-    n_points = 1_000
+    n_points = 2_000
     upsert_random_points(peer_api_uris[0], n_points)
 
     query_city = "London"
@@ -247,7 +247,7 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
 
     wait_for_same_commit(peer_api_uris=peer_api_uris)
 
-    n_points = 1_000
+    n_points = 2_000
     upsert_random_points(peer_api_uris[0], n_points)
 
     query_city = "London"

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -176,7 +176,7 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
     local_shards = get_local_shards(peer_api_uris[-1])
     assert len(local_shards) == 1
     assert local_shards[0]["shard_id"] == 0
-    assert local_shards[0]["state"] in ["Dead", "Partial", "Recovery"]
+    assert local_shards[0]["state"] in ["Active", "Dead", "Partial", "Recovery"]
     assert local_shards[0]["points_count"] <= n_points
 
     # Assert storage does not contain initialized flag after restoring on restart
@@ -293,7 +293,7 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     [local_shard] = get_local_shards(peer_api_uris[-1])
     assert local_shard["shard_id"] == 0
     shard_state = local_shard["state"]
-    assert shard_state in ["Dead", "Partial", "Recovery"]
+    assert shard_state in ["Active", "Dead", "Partial", "Recovery"]
     assert local_shard["points_count"] <= n_points, local_shard
 
     # Wait for end of shard transfer

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -284,6 +284,9 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     # Last peer panics on restart because the recovery logic for dirty shards was broken (and we set handle_collection_load_errors=false like prod envs)
     # Ideally Qdrant should try to recover this shard automatically using other replicas
 
+    # Wait for start of shard transfer
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 1)
+
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -189,11 +189,6 @@ def test_failed_snapshot_recovery(tmp_path: pathlib.Path):
     assert local_shards[0]["state"] == "Active"
     assert local_shards[0]["points_count"] == 1000
 
-    # Trigger replication to fix the broken shard
-    from_peer_id = get_peer_id(peer_api_uris[0])
-    to_peer_id = get_peer_id(peer_api_uris[-1])
-    replicate_shard(peer_api_uris[0], COLLECTION_NAME, 0, from_peer_id, to_peer_id)
-
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -475,13 +475,16 @@ def check_collection_shard_transfer_progress(peer_api_uri: str, collection_name:
 
 
 def check_all_replicas_active(peer_api_uri: str, collection_name: str, headers={}) -> bool:
-    collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
-    for shard in collection_cluster_info["local_shards"]:
-        if shard['state'] != 'Active':
-            return False
-    for shard in collection_cluster_info["remote_shards"]:
-        if shard['state'] != 'Active':
-            return False
+    try:
+        collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
+        for shard in collection_cluster_info["local_shards"]:
+            if shard['state'] != 'Active':
+                return False
+        for shard in collection_cluster_info["remote_shards"]:
+            if shard['state'] != 'Active':
+                return False
+    except requests.exceptions.ConnectionError:
+        return False
     return True
 
 


### PR DESCRIPTION
Fixes the bug demonstrated in https://github.com/qdrant/qdrant/pull/6292

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

TODO:
- [x] Delete the shard initializing flag after initiating transfer to the dummy shard for recovery
- ~Try to load shards even if they are dirty instead of directly recreating as empty shard - especially important when we have 0 replicas?~ Not desirable anymore.