### PR TITLE
Add ConditionedCounter

### DIFF
--- a/lib/common/common/src/counter/conditioned_counter.rs
+++ b/lib/common/common/src/counter/conditioned_counter.rs
@@ -1,0 +1,114 @@
+use std::ops::Deref;
+
+use super::hardware_counter::HardwareCounterCell;
+use super::hardware_data::HardwareData;
+
+/// A counter that measures or disposes measurements based on a condition.
+/// This is needed in places where we need to decide at runtime whether to measure or not.
+/// Implements `Deref<Target=HardwareCounterCell>` so it can be directly passed to functions
+/// that need a `HardwareCounterCell` as parameter.
+pub struct ConditionedCounter<'a> {
+    condition: bool,
+    parent: &'a HardwareCounterCell,
+    tmp: HardwareCounterCell,
+}
+
+impl<'a> ConditionedCounter<'a> {
+    pub fn new(condition: bool, parent: &'a HardwareCounterCell) -> Self {
+        Self {
+            condition,
+            parent,
+            tmp: HardwareCounterCell::disposable(), // We manually accumulate collected values!
+        }
+    }
+}
+
+impl Deref for ConditionedCounter<'_> {
+    type Target = HardwareCounterCell;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tmp
+    }
+}
+
+impl Drop for ConditionedCounter<'_> {
+    fn drop(&mut self) {
+        if self.condition {
+            self.parent
+                .accumulator
+                .accumulate(HardwareData::from(&self.tmp));
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::counter::hardware_accumulator::HwMeasurementAcc;
+
+    #[test]
+    fn test_conditioned_counter_empty() {
+        let parent = HardwareCounterCell::new();
+
+        {
+            let condition = false;
+            let cc = ConditionedCounter::new(condition, &parent);
+            cc.cpu_counter().incr_delta(5);
+        }
+
+        assert_eq!(parent.cpu_counter().get(), 0);
+        assert_eq!(parent.accumulator.get_cpu(), 0);
+    }
+
+    #[test]
+    fn test_conditioned_counter_enabled() {
+        let parent = HardwareCounterCell::new();
+
+        {
+            let condition = true;
+            let cc = ConditionedCounter::new(condition, &parent);
+            cc.cpu_counter().incr_delta(5);
+        }
+
+        assert_eq!(parent.cpu_counter().get(), 0); // Parents accumulator gets written, not the counter cell!
+        assert_eq!(parent.accumulator.get_cpu(), 5);
+    }
+
+    #[test]
+    fn test_conditioned_counter_enabled_into_hw_acc() {
+        let parent = HardwareCounterCell::new();
+
+        {
+            let condition = true;
+            let cc = ConditionedCounter::new(condition, &parent);
+
+            // Indirect counting, a possible scenario.
+            cc.new_accumulator() // Cell->Acc
+                .get_counter_cell() // Acc->Cell
+                .cpu_counter()
+                .incr_delta(5);
+        }
+
+        assert_eq!(parent.cpu_counter().get(), 0); // Parents accumulator gets written, not the counter cell!
+        assert_eq!(parent.accumulator.get_cpu(), 5);
+    }
+
+    #[test]
+    fn test_conditioned_counter_enabled_parent_hw_acc() {
+        let parent = HwMeasurementAcc::new();
+
+        {
+            let condition = true;
+            let cell = parent.get_counter_cell();
+            let cc = ConditionedCounter::new(condition, &cell);
+
+            // Indirect counting, a possible scenario.
+            cc.new_accumulator() // Cell->Acc
+                .get_counter_cell() // Acc->Cell
+                .cpu_counter()
+                .incr_delta(5);
+        }
+
+        assert_eq!(parent.get_cpu(), 5);
+    }
+}

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -185,6 +185,28 @@ impl HwMeasurementAcc {
     pub fn get_vector_io_write(&self) -> usize {
         self.request_drain.get_vector_io_write()
     }
+
+    pub fn hw_data(&self) -> HardwareData {
+        let HwSharedDrain {
+            cpu_counter,
+            payload_io_read_counter,
+            payload_io_write_counter,
+            payload_index_io_read_counter,
+            payload_index_io_write_counter,
+            vector_io_read_counter,
+            vector_io_write_counter,
+        } = &self.request_drain;
+
+        HardwareData {
+            cpu: cpu_counter.load(Ordering::Relaxed),
+            payload_io_read: payload_io_read_counter.load(Ordering::Relaxed),
+            payload_io_write: payload_io_write_counter.load(Ordering::Relaxed),
+            vector_io_read: vector_io_read_counter.load(Ordering::Relaxed),
+            vector_io_write: vector_io_write_counter.load(Ordering::Relaxed),
+            payload_index_io_read: payload_index_io_read_counter.load(Ordering::Relaxed),
+            payload_index_io_write: payload_index_io_write_counter.load(Ordering::Relaxed),
+        }
+    }
 }
 
 #[cfg(feature = "testing")]

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -198,6 +198,14 @@ impl Drop for HardwareCounterCell {
     }
 }
 
+impl From<&HardwareCounterCell> for HardwareData {
+    fn from(value: &HardwareCounterCell) -> Self {
+        let counter_values = value.get_hw_data();
+        let acc_values = value.accumulator.hw_data();
+        counter_values + acc_values
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::counter::hardware_accumulator::HwMeasurementAcc;

--- a/lib/common/common/src/counter/hardware_data.rs
+++ b/lib/common/common/src/counter/hardware_data.rs
@@ -1,3 +1,5 @@
+use std::ops::Add;
+
 /// Contains all hardware metrics. Only serves as value holding structure without any semantics.
 #[derive(Copy, Clone)]
 pub struct HardwareData {
@@ -8,4 +10,20 @@ pub struct HardwareData {
     pub vector_io_write: usize,
     pub payload_index_io_read: usize,
     pub payload_index_io_write: usize,
+}
+
+impl Add for HardwareData {
+    type Output = HardwareData;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            cpu: self.cpu + rhs.cpu,
+            payload_io_read: self.payload_io_read + rhs.payload_io_read,
+            payload_io_write: self.payload_io_write + rhs.payload_io_write,
+            vector_io_read: self.vector_io_read + rhs.vector_io_read,
+            vector_io_write: self.vector_io_write + rhs.vector_io_write,
+            payload_index_io_read: self.payload_index_io_read + rhs.payload_index_io_read,
+            payload_index_io_write: self.payload_index_io_write + rhs.payload_index_io_write,
+        }
+    }
 }

--- a/lib/common/common/src/counter/mod.rs
+++ b/lib/common/common/src/counter/mod.rs
@@ -1,3 +1,4 @@
+pub mod conditioned_counter;
 pub mod counter_cell;
 pub mod hardware_accumulator;
 pub mod hardware_counter;


### PR DESCRIPTION
Adds a new wrapper for `HwCounterCell` that allows conditioned counting.
This is needed in places where we can't use a multiplier of 0 to disable counting, like mmap bool index.

An example of how this can be used can be found in #6296. 