### PR TITLE
Mark dummy shard as dead after snapshot restore failure

### DIFF
--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -153,7 +153,7 @@ impl ShardReplicaSet {
                 // Mark this peer as "locally disabled"...
                 //
                 // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!
-                let has_other_active_peers = self.active_remote_shards().is_empty();
+                let has_other_active_peers = !self.active_remote_shards().is_empty();
 
                 // ...if this peer is *not* the last active replica
                 if has_other_active_peers {


### PR DESCRIPTION
Found this mistake while working on https://github.com/qdrant/qdrant/pull/6293. 

This `has_other_active_peers` needed a negation (`!`). So far, we kept the replica as `Active` despite loading as dummy shard and having other "real" replicas.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

