### PR TITLE
Postprocess scores in max similarity

### DIFF
--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -133,7 +133,7 @@ impl ScoringQuery {
                     FusionInternal::Rrf | FusionInternal::Dbsf => Some(Order::LargeBetter),
                 },
                 // Score boosting formulas are always have descending order,
-                // euclidean scores can be negated within the formula
+                // Euclidean scores can be negated within the formula
                 ScoringQuery::Formula(_formula) => Some(Order::LargeBetter),
                 ScoringQuery::OrderBy(order_by) => Some(Order::from(order_by.direction())),
                 // Random sample does not require ordering

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::data_types::vectors::NamedVectorStruct;
-use segment::types::ScoredPoint;
+use segment::types::{Order, ScoredPoint};
 use tokio::runtime::Handle;
 
 use super::LocalShard;
@@ -77,7 +77,11 @@ impl LocalShard {
                                         distance.postprocess_score(scored_point.score);
                                 }
                                 NamedVectorStruct::MultiDense(_) => {
-                                    // no post-processing for multi dense vectors because 'maxsim' post-processes already
+                                    // no post-processing for multi vectors because 'maxsim' apply post-processing already
+                                    // however, we need to invert the score to match the distance order
+                                    if distance.distance_order() == Order::SmallBetter {
+                                        scored_point.score = -scored_point.score;
+                                    }
                                 }
                             }
                         }

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -77,7 +77,7 @@ impl LocalShard {
                                         distance.postprocess_score(scored_point.score);
                                 }
                                 NamedVectorStruct::MultiDense(_) => {
-                                    // no post-processing for multi dense vectors because 'maxsim' postprocesses already
+                                    // no post-processing for multi dense vectors because 'maxsim' post-processes already
                                 }
                             }
                         }

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -4,9 +4,9 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
-use criterion::{Criterion, criterion_group, criterion_main};
-use rand::SeedableRng;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_multi_vector};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_multi_vector;
@@ -14,10 +14,10 @@ use segment::index::VectorIndex;
 use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::segment_constructor::{VectorIndexBuildArgs, build_segment};
-use segment::types::Distance::Dot;
+use segment::types::Distance::{Dot, Euclid};
 use segment::types::{
-    HnswConfig, Indexes, MultiVectorConfig, SegmentConfig, SeqNumberType, VectorDataConfig,
-    VectorStorageType,
+    Distance, HnswConfig, Indexes, MultiVectorConfig, SegmentConfig, SeqNumberType,
+    VectorDataConfig, VectorStorageType,
 };
 use tempfile::Builder;
 
@@ -29,11 +29,44 @@ const NUM_VECTORS_PER_POINT: usize = 16;
 const VECTOR_DIM: usize = 128;
 const TOP: usize = 10;
 
+// intent: bench `search` without filter
 fn multi_vector_search_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("multi-vector-search-group");
-    let stopped = AtomicBool::new(false);
     let mut rnd = StdRng::seed_from_u64(42);
 
+    let hnsw_index = make_segment_index(&mut rnd, Dot);
+    group.bench_function("hnsw-multivec-search-dot", |b| {
+        b.iter_batched(
+            || random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into(),
+            |query| {
+                let results = hnsw_index
+                    .search(&[&query], None, TOP, None, &Default::default())
+                    .unwrap();
+                assert_eq!(results[0].len(), TOP);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    let hnsw_index = make_segment_index(&mut rnd, Euclid);
+    group.bench_function("hnsw-multivec-search-euclidean", |b| {
+        b.iter_batched(
+            || random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into(),
+            |query| {
+                let results = hnsw_index
+                    .search(&[&query], None, TOP, None, &Default::default())
+                    .unwrap();
+                assert_eq!(results[0].len(), TOP);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+fn make_segment_index<R: Rng + ?Sized>(rnd: &mut R, distance: Distance) -> HNSWIndex {
+    let stopped = AtomicBool::new(false);
     let segment_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
@@ -42,7 +75,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
             DEFAULT_VECTOR_NAME.to_owned(),
             VectorDataConfig {
                 size: VECTOR_DIM,
-                distance: Dot,
+                distance,
                 storage_type: VectorStorageType::Memory,
                 index: Indexes::Plain {},
                 quantization_config: None,
@@ -59,7 +92,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
     let mut segment = build_segment(segment_dir.path(), &segment_config, true).unwrap();
     for n in 0..NUM_POINTS {
         let idx = (n as u64).into();
-        let multi_vec = random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT);
+        let multi_vec = random_multi_vector(rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT);
         let named_vectors = only_default_multi_vector(&multi_vec);
         segment
             .upsert_point(n as SeqNumberType, idx, named_vectors, &hw_counter)
@@ -96,21 +129,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
         },
     )
     .unwrap();
-
-    // intent: bench `search` without filter
-    group.bench_function("hnsw-multivec-search", |b| {
-        b.iter(|| {
-            // new query to avoid caching effects
-            let query = random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into();
-
-            let results = hnsw_index
-                .search(&[&query], None, TOP, None, &Default::default())
-                .unwrap();
-            assert_eq!(results[0].len(), TOP);
-        })
-    });
-
-    group.finish();
+    hnsw_index
 }
 
 criterion_group! {

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -12,7 +12,7 @@ use super::query::{
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::{DenseVector, QueryVector, VectorElementType, VectorInternal};
-use crate::spaces::metric::Metric;
+use crate::spaces::metric::{Metric, MetricPostProcessing};
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::Distance;
 use crate::vector_storage::dense::memmap_dense_vector_storage::MemmapDenseVectorStorage;
@@ -249,7 +249,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
         self
     }
 
-    fn _build_with_metric<TMetric: Metric<VectorElementType> + 'a>(
+    fn _build_with_metric<TMetric: Metric<VectorElementType> + MetricPostProcessing + 'a>(
         self,
     ) -> OperationResult<Box<dyn RawScorer + 'a>> {
         let Self {

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -6,7 +6,7 @@ use common::types::{PointOffsetType, ScoreType};
 
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{TypedDenseVector, VectorElementType};
-use crate::spaces::metric::Metric;
+use crate::spaces::metric::{Metric, MetricPostProcessing};
 use crate::vector_storage::DenseVectorStorage;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -58,7 +58,7 @@ impl<
 
 impl<
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: DenseVectorStorage<TElement>,
 > QueryScorer<[TElement]> for MetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -43,12 +43,13 @@ pub fn score_max_similarity<
         // manual `max_by` for performance
         for dense_b in multi_dense_b.multi_vectors() {
             let sim = TMetric::similarity(dense_a, dense_b);
+            let sim = TMetric::postprocess(sim);
             if sim > max_sim {
                 max_sim = sim;
             }
         }
         // sum of max similarity
-        sum += TMetric::postprocess(max_sim);
+        sum += max_sim;
     }
     sum
 }
@@ -130,18 +131,15 @@ mod tests {
 
     #[test]
     fn test_score_multi_euclidean() {
-        let a = MultiDenseVectorInternal::try_from(vec![
+        let a = MultiDenseVectorInternal::try_from(vec![vec![3.0, 3.0, 3.0], vec![4.0, 2.0, 1.0]])
+            .unwrap();
+        let b = MultiDenseVectorInternal::try_from(vec![
             vec![1.0, 2.0, 3.0],
             vec![3.0, 3.0, 3.0],
             vec![4.0, 5.0, 6.0],
         ])
         .unwrap();
-        let b = MultiDenseVectorInternal::try_from(vec![vec![3.0, 3.0, 3.0], vec![4.0, 2.0, 1.0]])
-            .unwrap();
-        let config = MultiVectorConfig::default();
-        eprintln!("{:?}", a);
-        eprintln!("{:?}", b);
-        let score = score_multi::<f32, EuclidMetric>(&config, (&a).into(), (&b).into());
-        assert_eq!(score, 5.9777255);
+        let score = score_max_similarity::<f32, EuclidMetric>((&a).into(), (&b).into());
+        assert_eq!(score, 9.572609);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -131,15 +131,15 @@ mod tests {
 
     #[test]
     fn test_score_multi_euclidean() {
-        let a = MultiDenseVectorInternal::try_from(vec![vec![3.0, 3.0, 3.0], vec![4.0, 2.0, 1.0]])
-            .unwrap();
-        let b = MultiDenseVectorInternal::try_from(vec![
+        let a = MultiDenseVectorInternal::try_from(vec![
             vec![1.0, 2.0, 3.0],
             vec![3.0, 3.0, 3.0],
             vec![4.0, 5.0, 6.0],
         ])
         .unwrap();
+        let b = MultiDenseVectorInternal::try_from(vec![vec![3.0, 3.0, 3.0], vec![4.0, 2.0, 1.0]])
+            .unwrap();
         let score = score_max_similarity::<f32, EuclidMetric>((&a).into(), (&b).into());
-        assert_eq!(score, 9.572609);
+        assert_eq!(score, 11.885993);
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -9,7 +9,7 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef,
 };
-use crate::spaces::metric::Metric;
+use crate::spaces::metric::{Metric, MetricPostProcessing};
 use crate::vector_storage::MultiVectorStorage;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query::{Query, TransformInto};
@@ -18,7 +18,7 @@ use crate::vector_storage::query_scorer::QueryScorer;
 pub struct MultiCustomQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: MultiVectorStorage<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
     TInputQuery: Query<MultiDenseVectorInternal>,
@@ -34,7 +34,7 @@ pub struct MultiCustomQueryScorer<
 impl<
     'a,
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: MultiVectorStorage<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
     TInputQuery: Query<MultiDenseVectorInternal>
@@ -82,7 +82,7 @@ impl<
 
 impl<
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: MultiVectorStorage<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
     TInputQuery: Query<MultiDenseVectorInternal>,
@@ -108,7 +108,7 @@ impl<
 
 impl<
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: MultiVectorStorage<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
     TInputQuery: Query<MultiDenseVectorInternal>,

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -9,7 +9,7 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef,
 };
-use crate::spaces::metric::Metric;
+use crate::spaces::metric::{Metric, MetricPostProcessing};
 use crate::vector_storage::MultiVectorStorage;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -17,7 +17,7 @@ use crate::vector_storage::query_scorer::QueryScorer;
 pub struct MultiMetricQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: MultiVectorStorage<TElement>,
 > {
     vector_storage: &'a TVectorStorage,
@@ -29,7 +29,7 @@ pub struct MultiMetricQueryScorer<
 impl<
     'a,
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: MultiVectorStorage<TElement>,
 > MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
@@ -84,7 +84,7 @@ impl<
 
 impl<
     TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+    TMetric: Metric<TElement> + MetricPostProcessing,
     TVectorStorage: MultiVectorStorage<TElement>,
 > QueryScorer<TypedMultiDenseVector<TElement>>
     for MultiMetricQueryScorer<'_, TElement, TMetric, TVectorStorage>

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -19,7 +19,7 @@ use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, QueryVector, VectorElementType, VectorElementTypeByte,
     VectorElementTypeHalf,
 };
-use crate::spaces::metric::Metric;
+use crate::spaces::metric::{Metric, MetricPostProcessing};
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::Distance;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
@@ -357,7 +357,7 @@ pub fn raw_scorer_impl<'a, TVectorStorage: DenseVectorStorage<VectorElementType>
 
 fn new_scorer_with_metric<
     'a,
-    TMetric: Metric<VectorElementType> + 'a,
+    TMetric: Metric<VectorElementType> + MetricPostProcessing + 'a,
     TVectorStorage: DenseVectorStorage<VectorElementType>,
 >(
     query: QueryVector,
@@ -474,7 +474,7 @@ pub fn raw_scorer_byte_impl<'a, TVectorStorage: DenseVectorStorage<VectorElement
 
 fn new_scorer_byte_with_metric<
     'a,
-    TMetric: Metric<VectorElementTypeByte> + 'a,
+    TMetric: Metric<VectorElementTypeByte> + MetricPostProcessing + 'a,
     TVectorStorage: DenseVectorStorage<VectorElementTypeByte>,
 >(
     query: QueryVector,
@@ -591,7 +591,7 @@ pub fn raw_scorer_half_impl<'a, TVectorStorage: DenseVectorStorage<VectorElement
 
 fn new_scorer_half_with_metric<
     'a,
-    TMetric: Metric<VectorElementTypeHalf> + 'a,
+    TMetric: Metric<VectorElementTypeHalf> + MetricPostProcessing + 'a,
     TVectorStorage: DenseVectorStorage<VectorElementTypeHalf>,
 >(
     query: QueryVector,
@@ -727,7 +727,7 @@ pub fn raw_multi_scorer_impl<'a, TVectorStorage: MultiVectorStorage<VectorElemen
 
 fn new_multi_scorer_with_metric<
     'a,
-    TMetric: Metric<VectorElementType> + 'a,
+    TMetric: Metric<VectorElementType> + MetricPostProcessing + 'a,
     TVectorStorage: MultiVectorStorage<VectorElementType>,
 >(
     query: QueryVector,
@@ -846,7 +846,7 @@ pub fn raw_multi_scorer_byte_impl<'a, TVectorStorage: MultiVectorStorage<VectorE
 
 fn new_multi_scorer_byte_with_metric<
     'a,
-    TMetric: Metric<VectorElementTypeByte> + 'a,
+    TMetric: Metric<VectorElementTypeByte> + MetricPostProcessing + 'a,
     TVectorStorage: MultiVectorStorage<VectorElementTypeByte>,
 >(
     query: QueryVector,
@@ -965,7 +965,7 @@ pub fn raw_multi_scorer_half_impl<'a, TVectorStorage: MultiVectorStorage<VectorE
 
 fn new_multi_scorer_half_with_metric<
     'a,
-    TMetric: Metric<VectorElementTypeHalf> + 'a,
+    TMetric: Metric<VectorElementTypeHalf> + MetricPostProcessing + 'a,
     TVectorStorage: MultiVectorStorage<VectorElementTypeHalf>,
 >(
     query: QueryVector,

--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -455,4 +455,4 @@ def test_multi_with_euclidean(collection_name):
     assert response.ok
     assert len(response.json()['result']) == 1
     assert response.json()['result']['points'][0]['id'] == 1
-    assert response.json()['result']['points'][0]['score'] == 11.885993
+    assert response.json()['result']['points'][0]['score'] == 5.9777255

--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -413,9 +413,8 @@ def test_multi_with_euclidean(collection_name):
                     "id": 1,
                     "vector": {
                         "my-multivec": [
-                            [1.0, 2.0, 3.0],
                             [3.0, 3.0, 3.0],
-                            [4.0, 5.0, 6.0]
+                            [4.0, 2.0, 1.0]
                         ]
                     }
                 }
@@ -435,9 +434,8 @@ def test_multi_with_euclidean(collection_name):
     point = response.json()['result']
     assert point['id'] == 1
     assert point['vector']['my-multivec'] == [
-        [1.0, 2.0, 3.0],
         [3.0, 3.0, 3.0],
-        [4.0, 5.0, 6.0]
+        [4.0, 2.0, 1.0]
     ]
 
     response = request_with_validation(
@@ -446,8 +444,9 @@ def test_multi_with_euclidean(collection_name):
         path_params={'collection_name': collection_name},
         body={
             "query": [
+                [1.0, 2.0, 3.0],
                 [3.0, 3.0, 3.0],
-                [4.0, 2.0, 1.0]
+                [4.0, 5.0, 6.0]
             ],
             "using": "my-multivec",
             "limit": 10
@@ -455,6 +454,5 @@ def test_multi_with_euclidean(collection_name):
     )
     assert response.ok
     assert len(response.json()['result']) == 1
-    print(response.json())
     assert response.json()['result']['points'][0]['id'] == 1
-    assert response.json()['result']['points'][0]['score'] == 9.572609
+    assert response.json()['result']['points'][0]['score'] == 11.885993

--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -413,6 +413,16 @@ def test_multi_with_euclidean(collection_name):
                     "id": 1,
                     "vector": {
                         "my-multivec": [
+                            [1.0, 2.0, 3.0],
+                            [3.0, 3.0, 3.0],
+                            [4.0, 5.0, 6.0]
+                        ]
+                    }
+                },
+                {
+                    "id": 2,
+                    "vector": {
+                        "my-multivec": [
                             [3.0, 3.0, 3.0],
                             [4.0, 2.0, 1.0]
                         ]
@@ -423,7 +433,7 @@ def test_multi_with_euclidean(collection_name):
     )
     assert response.ok
 
-    # get by id
+    # get by id 1
     response = request_with_validation(
         api='/collections/{collection_name}/points/{id}',
         method="GET",
@@ -433,6 +443,22 @@ def test_multi_with_euclidean(collection_name):
     assert response.ok
     point = response.json()['result']
     assert point['id'] == 1
+    assert point['vector']['my-multivec'] == [
+        [1.0, 2.0, 3.0],
+        [3.0, 3.0, 3.0],
+        [4.0, 5.0, 6.0]
+    ]
+
+    # get by id 2
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 2},
+    )
+
+    assert response.ok
+    point = response.json()['result']
+    assert point['id'] == 2
     assert point['vector']['my-multivec'] == [
         [3.0, 3.0, 3.0],
         [4.0, 2.0, 1.0]
@@ -453,6 +479,9 @@ def test_multi_with_euclidean(collection_name):
         }
     )
     assert response.ok
-    assert len(response.json()['result']) == 1
+    assert len(response.json()['result']['points']) == 2
     assert response.json()['result']['points'][0]['id'] == 1
-    assert response.json()['result']['points'][0]['score'] == 5.9777255
+    assert response.json()['result']['points'][0]['score'] == 0.0
+
+    assert response.json()['result']['points'][1]['id'] == 2
+    assert response.json()['result']['points'][1]['score'] == 5.9777255


### PR DESCRIPTION
This PR fixes https://github.com/qdrant/qdrant/issues/6294

The max similarity currently does not run the post-processing phase on the distance scoring.

This creates a discrepancy for the `Euclidean` metric where the processing is significant.

The proposed solution is to run the postprocessing step as part of the max similarity computation instead of at the very end.

I included a new benchmarks, the impact of this change is not visible for other distance metrics but Euclidean gets 20% slower on multivector.

TODO before shipping the PR:
- [ ] check Python congruence tests