### PR TITLE
Use MaybeUninit in vector storages and query scorers

### DIFF
--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod fixed_length_priority_queue;
 pub mod flags;
 pub mod iterator_ext;
 pub mod math;
+pub mod maybe_uninit;
 pub mod mmap_hashmap;
 pub mod num_traits;
 pub mod panic;

--- a/lib/common/common/src/maybe_uninit.rs
+++ b/lib/common/common/src/maybe_uninit.rs
@@ -1,0 +1,33 @@
+use std::mem::{MaybeUninit, transmute};
+
+/// [`MaybeUninit::fill_from`] backported to stable.
+///
+/// Unlike the standard library version, this function does not support [`Drop`]
+/// types, for simplicity of implementation.
+///
+/// TODO: remove in favor of [`MaybeUninit::fill_from`] once stabilized.
+/// <https://github.com/rust-lang/rust/issues/117428>
+pub fn maybe_uninit_fill_from<I: IntoIterator>(
+    this: &mut [MaybeUninit<I::Item>],
+    it: I,
+) -> (&mut [I::Item], &mut [MaybeUninit<I::Item>]) {
+    const { assert!(!std::mem::needs_drop::<I::Item>(), "Not supported") };
+
+    let iter = it.into_iter();
+
+    let mut initialized_len = 0;
+    for (element, val) in this.iter_mut().zip(iter) {
+        element.write(val);
+        initialized_len += 1;
+    }
+
+    // SAFETY: guard.initialized <= this.len()
+    let (initted, remainder) = unsafe { this.split_at_mut_unchecked(initialized_len) };
+
+    // SAFETY: Valid elements have just been written into `init`, so that portion
+    // of `this` is initialized.
+    (
+        unsafe { transmute::<&mut [MaybeUninit<I::Item>], &mut [I::Item]>(initted) },
+        remainder,
+    )
+}

--- a/lib/segment/src/vector_storage/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/chunked_vector_storage.rs
@@ -1,3 +1,4 @@
+use std::mem::MaybeUninit;
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -47,7 +48,11 @@ pub trait ChunkedVectorStorage<T> {
 
     /// Returns batch of vectors by keys.
     /// Underlying storage might apply some optimizations to prefetch vectors.
-    fn get_batch<'a>(&'a self, keys: &[VectorOffsetType], vectors: &mut [&'a [T]]);
+    fn get_batch<'a>(
+        &'a self,
+        keys: &[VectorOffsetType],
+        vectors: &'a mut [MaybeUninit<&'a [T]>],
+    ) -> &'a [&'a [T]];
 
     fn get_remaining_chunk_keys(&self, start_key: VectorOffsetType) -> usize;
 

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions, create_dir_all};
 use std::io::{self, Write};
+use std::mem::MaybeUninit;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -140,9 +141,13 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for MemmapDenseVectorStora
             .unwrap_or_else(|| panic!("vector not found: {key}"))
     }
 
-    fn get_dense_batch<'a>(&'a self, keys: &[PointOffsetType], vectors: &mut [&'a [T]]) {
+    fn get_dense_batch<'a>(
+        &'a self,
+        keys: &[PointOffsetType],
+        vectors: &'a mut [MaybeUninit<&'a [T]>],
+    ) -> &'a [&'a [T]] {
         let mmap_store = self.mmap_store.as_ref().unwrap();
-        mmap_store.get_vectors(keys, vectors);
+        mmap_store.get_vectors(keys, vectors)
     }
 }
 

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -1,3 +1,4 @@
+use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -91,7 +92,11 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
     }
 
     #[inline]
-    fn get_batch<'a>(&'a self, keys: &[VectorOffsetType], vectors: &mut [&'a [T]]) {
+    fn get_batch<'a>(
+        &'a self,
+        keys: &[VectorOffsetType],
+        vectors: &'a mut [MaybeUninit<&'a [T]>],
+    ) -> &'a [&'a [T]] {
         self.mmap_storage.get_batch(keys, vectors)
     }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -16,7 +16,6 @@ use crate::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType, Ve
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
-use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
 use crate::vector_storage::in_ram_persisted_vectors::InRamPersistedVectors;
 use crate::vector_storage::{MultiVectorStorage, VectorStorage, VectorStorageEnum};
@@ -103,18 +102,6 @@ impl<
                 flattened_vectors,
                 dim: self.vectors.dim(),
             })
-    }
-
-    fn get_batch_multi<'a>(
-        &'a self,
-        keys: &[PointOffsetType],
-        vectors: &mut [TypedMultiDenseVectorRef<'a, T>],
-    ) {
-        debug_assert_eq!(keys.len(), vectors.len());
-        debug_assert!(keys.len() <= VECTOR_READ_BATCH_SIZE);
-        for (idx, key) in keys.iter().enumerate() {
-            vectors[idx] = self.get_multi(*key);
-        }
     }
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -22,7 +22,7 @@ use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::bitvec::bitvec_set_deleted;
 use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
-use crate::vector_storage::common::{CHUNK_SIZE, StoredRecord, VECTOR_READ_BATCH_SIZE};
+use crate::vector_storage::common::{CHUNK_SIZE, StoredRecord};
 use crate::vector_storage::{MultiVectorStorage, VectorStorage, VectorStorageEnum};
 
 type StoredMultiDenseVector<T> = StoredRecord<TypedMultiDenseVector<T>>;
@@ -308,19 +308,6 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
                 dim: self.dim,
             }
         })
-    }
-
-    fn get_batch_multi<'a>(
-        &'a self,
-        keys: &[PointOffsetType],
-        vectors: &mut [TypedMultiDenseVectorRef<'a, T>],
-    ) {
-        debug_assert_eq!(keys.len(), vectors.len());
-        debug_assert!(keys.len() <= VECTOR_READ_BATCH_SIZE);
-
-        for (i, key) in keys.iter().enumerate() {
-            vectors[i] = self.get_multi(*key);
-        }
     }
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -11,7 +11,6 @@ use crate::data_types::vectors::{
 };
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
-use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -159,15 +158,6 @@ where
             self.quantized_storage
                 .score_point(this, idx, &self.hardware_counter)
         })
-    }
-
-    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
-        debug_assert_eq!(ids.len(), scores.len());
-        // no specific implementation for batch scoring
-        for (idx, id) in ids.iter().enumerate() {
-            scores[idx] = self.score_stored(*id);
-        }
     }
 
     fn score(&self, _v2: &[TElement]) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -8,7 +8,6 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{DenseVector, MultiDenseVectorInternal};
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
-use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query_scorer::QueryScorer;
 
 pub struct QuantizedQueryScorer<'a, TElement, TMetric, TEncodedQuery, TEncodedVectors>
@@ -94,15 +93,6 @@ where
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.quantized_data
             .score_point(&self.query, idx, &self.hardware_counter)
-    }
-
-    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
-        debug_assert_eq!(ids.len(), scores.len());
-        // no specific implementation for batch scoring
-        for (idx, id) in ids.iter().enumerate() {
-            scores[idx] = self.score_stored(*id);
-        }
     }
 
     fn score(&self, _v2: &[TElement]) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoreType};
@@ -92,9 +93,9 @@ impl<
         debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
         debug_assert_eq!(ids.len(), scores.len());
 
-        let mut vectors: [&[TElement]; VECTOR_READ_BATCH_SIZE] = [&[]; VECTOR_READ_BATCH_SIZE];
-
-        self.vector_storage
+        let mut vectors = [MaybeUninit::uninit(); VECTOR_READ_BATCH_SIZE];
+        let vectors = self
+            .vector_storage
             .get_dense_batch(ids, &mut vectors[..ids.len()]);
 
         self.hardware_counter.vector_io_read().incr_delta(ids.len());

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoreType};
@@ -73,9 +74,10 @@ impl<
         debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
         debug_assert_eq!(ids.len(), scores.len());
 
-        let mut vectors: [&[TElement]; VECTOR_READ_BATCH_SIZE] = [&[]; VECTOR_READ_BATCH_SIZE];
+        let mut vectors = [MaybeUninit::uninit(); VECTOR_READ_BATCH_SIZE];
 
-        self.vector_storage
+        let vectors = self
+            .vector_storage
             .get_dense_batch(ids, &mut vectors[..ids.len()]);
         self.hardware_counter.cpu_counter().incr_delta(ids.len());
         self.hardware_counter.vector_io_read().incr_delta(ids.len());

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoreType};
@@ -126,29 +127,21 @@ impl<
     }
 
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        let batch_size = ids.len();
+        debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
+        debug_assert_eq!(ids.len(), scores.len());
 
-        debug_assert!(batch_size <= VECTOR_READ_BATCH_SIZE);
-        debug_assert_eq!(batch_size, scores.len());
+        let mut vectors = [MaybeUninit::uninit(); VECTOR_READ_BATCH_SIZE];
+        let vectors = self
+            .vector_storage
+            .get_batch_multi(ids, &mut vectors[..ids.len()]);
 
-        let mut vectors = [TypedMultiDenseVectorRef {
-            flattened_vectors: &[],
-            dim: 1,
-        }; VECTOR_READ_BATCH_SIZE];
-
-        self.vector_storage
-            .get_batch_multi(ids, &mut vectors[..batch_size]);
-
-        let total_loaded_vectors: usize = vectors[..batch_size]
-            .iter()
-            .map(|v| v.vectors_count())
-            .sum();
+        let total_loaded_vectors: usize = vectors.iter().map(|v| v.vectors_count()).sum();
 
         self.hardware_counter
             .vector_io_read()
             .incr_delta(total_loaded_vectors);
 
-        for idx in 0..batch_size {
+        for idx in 0..ids.len() {
             scores[idx] = self.score_ref(vectors[idx]);
         }
     }

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -4,7 +4,6 @@ use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::{DimId, DimWeight};
 
 use crate::vector_storage::SparseVectorStorage;
-use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -70,16 +69,6 @@ impl<TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScor
             self.hardware_counter.cpu_counter().incr_delta(cpu_units);
             stored.score(example).unwrap_or(0.0)
         })
-    }
-
-    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
-        debug_assert_eq!(ids.len(), scores.len());
-
-        // no specific implementation for batch scoring
-        for (idx, id) in ids.iter().enumerate() {
-            scores[idx] = self.score_stored(*id);
-        }
     }
 
     fn score(&self, v: &SparseVector) -> ScoreType {


### PR DESCRIPTION
Inside batch getters/scorers, the following approach is common:

```rust
// Allocate a temporary array on stack and fill it with default values.
let mut vectors: [&[TElement]; VECTOR_READ_BATCH_SIZE] = [&[]; VECTOR_READ_BATCH_SIZE];

// Fill the array with values.
self.vector_storage
    .get_dense_batch(ids, &mut vectors[..ids.len()]);
```

Filling temporary array with default values is excessive as these values would be overwritten anyway; but it takes some amount of CPU cycles. If we decide to use batch score methods during search (as suggested in https://github.com/qdrant/qdrant/pull/6245#issuecomment-2751183795), we'll lose a few percents of performance during search on small vectors. To win this performance back, we need to avoid initializing values.

In this PR, these temporary arrays are not initialized, like this:
```rust
// Allocate a temporary array on stack, but do not initialize it.
let mut vectors: [&[MaybeUninit<TElement>]; VECTOR_READ_BATCH_SIZE] =
    [MaybeUninit::uninit(); VECTOR_READ_BATCH_SIZE];

// Pass `&[MaybeUninit<T>]`, get `&[T]` pointing to the same data.
let vectors: &[TElement] = self
    .vector_storage
    .get_dense_batch(ids, &mut vectors[..ids.len()]);
```

---

[`MaybeUninit::fill_from`] would be useful here, but it's not in the stable; so, I've backported a simplified version of it in this PR. An alternative option is to use the [`uninit::Out::fill_with_iter`], but I decided not to pull additional dependency for that.

[`MaybeUninit::fill_from`]: https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.fill_from
[`uninit::Out::fill_with_iter`]: https://docs.rs/uninit/latest/uninit/out_ref/struct.Out.html#method.fill_with_iter