### PR TITLE
Remove is_stopped from RawScorer 

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -21,7 +21,7 @@ use issues::IssueRecord;
 use merge::Merge;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use segment::common::operation_error::OperationError;
+use segment::common::operation_error::{CancelledError, OperationError};
 use segment::data_types::groups::GroupId;
 use segment::data_types::order_by::{OrderBy, OrderValue};
 use segment::data_types::vectors::{
@@ -1259,6 +1259,12 @@ impl From<OperationError> for CollectionError {
                 backtrace: None,
             },
         }
+    }
+}
+
+impl From<CancelledError> for CollectionError {
+    fn from(error: CancelledError) -> Self {
+        OperationError::from(error).into()
     }
 }
 

--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -10,6 +10,7 @@ use segment::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::{CosineMetric, DotProductMetric};
+use segment::vector_storage::DEFAULT_STOPPED;
 
 const DIM: usize = 16;
 const M: usize = 16;
@@ -37,7 +38,9 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
-            graph_layers.search(TOP, EF, scorer, None);
+            graph_layers
+                .search(TOP, EF, scorer, None, &DEFAULT_STOPPED)
+                .unwrap();
         })
     });
 
@@ -56,7 +59,9 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
-            graph_layers.search(TOP, EF, scorer, None);
+            graph_layers
+                .search(TOP, EF, scorer, None, &DEFAULT_STOPPED)
+                .unwrap();
         })
     });
 

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -10,6 +10,7 @@ use rand::rngs::StdRng;
 use segment::fixtures::index_fixtures::{FakeFilterContext, random_vector};
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::simple::CosineMetric;
+use segment::vector_storage::DEFAULT_STOPPED;
 
 const NUM_VECTORS: usize = 1_000_000;
 const DIM: usize = 64;
@@ -39,7 +40,11 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
-            black_box(graph_layers.search(TOP, EF, scorer, None));
+            black_box(
+                graph_layers
+                    .search(TOP, EF, scorer, None, &DEFAULT_STOPPED)
+                    .unwrap(),
+            );
         })
     });
 
@@ -52,7 +57,11 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
-            black_box(graph_layers.search(TOP, EF, scorer, None));
+            black_box(
+                graph_layers
+                    .search(TOP, EF, scorer, None, &DEFAULT_STOPPED)
+                    .unwrap(),
+            );
         })
     });
 

--- a/lib/segment/benches/scorer_mmap.rs
+++ b/lib/segment/benches/scorer_mmap.rs
@@ -12,7 +12,9 @@ use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::types::Distance;
 use segment::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage;
-use segment::vector_storage::{VectorStorage, VectorStorageEnum, new_raw_scorer_for_test};
+use segment::vector_storage::{
+    DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer_for_test,
+};
 use tempfile::Builder;
 
 #[cfg(not(target_os = "windows"))]
@@ -68,7 +70,8 @@ fn benchmark_scorer_mmap(c: &mut Criterion) {
                     borrowed_id_tracker.deleted_point_bitslice(),
                 )
                 .unwrap()
-                .peek_top_all(10)
+                .peek_top_all(10, &DEFAULT_STOPPED)
+                .unwrap()
             },
             BatchSize::SmallInput,
         )

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -14,7 +14,9 @@ use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::types::Distance;
 use segment::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
-use segment::vector_storage::{VectorStorage, VectorStorageEnum, new_raw_scorer_for_test};
+use segment::vector_storage::{
+    DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer_for_test,
+};
 use tempfile::Builder;
 
 const NUM_VECTORS: usize = 100000;
@@ -71,7 +73,8 @@ fn benchmark_naive(c: &mut Criterion) {
                 borrowed_id_tracker.deleted_point_bitslice(),
             )
             .unwrap()
-            .peek_top_all(10)
+            .peek_top_all(10, &DEFAULT_STOPPED)
+            .unwrap();
         })
     });
 }

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -16,9 +16,7 @@ use crate::payload_storage::FilterContext;
 use crate::spaces::metric::Metric;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
-use crate::vector_storage::{
-    DEFAULT_STOPPED, DenseVectorStorage, RawScorer, VectorStorage, raw_scorer_impl,
-};
+use crate::vector_storage::{DenseVectorStorage, RawScorer, VectorStorage, raw_scorer_impl};
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> DenseVector {
     (0..size).map(|_| rnd_gen.random_range(-1.0..1.0)).collect()
@@ -147,7 +145,6 @@ where
             query,
             self,
             self.deleted_vector_bitslice(),
-            &DEFAULT_STOPPED,
             HardwareCounterCell::new(),
         )
     }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -477,9 +477,9 @@ mod tests {
     use crate::index::hnsw_index::point_scorer::FilteredScorer;
     use crate::spaces::simple::DotProductMetric;
     use crate::types::Distance;
-    use crate::vector_storage::VectorStorage;
     use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
     use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
+    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage};
 
     #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
     #[repr(C)]
@@ -758,7 +758,8 @@ mod tests {
             };
             let search_result = test
                 .graph_layers_builder
-                .search_on_level(entry, 0, ef, &mut scorer)
+                .search_on_level(entry, 0, ef, &mut scorer, &DEFAULT_STOPPED)
+                .unwrap()
                 .into_sorted_vec();
             for (cpu, (gpu_1, gpu_2)) in search_result
                 .iter()
@@ -983,9 +984,10 @@ mod tests {
                 idx: 0,
                 score: scorer.score_point(0),
             };
-            let search_result =
-                test.graph_layers_builder
-                    .search_on_level(entry, 0, ef, &mut scorer);
+            let search_result = test
+                .graph_layers_builder
+                .search_on_level(entry, 0, ef, &mut scorer, &DEFAULT_STOPPED)
+                .unwrap();
 
             let scorer_fn = |a, b| scorer.score_internal(a, b);
 

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -690,20 +690,13 @@ fn test_gpu_vector_storage_impl(
 
     let gpu_scores = staging_buffer.download_vec(0, num_vectors).unwrap();
 
-    let stopped = false.into();
     let point_deleted = BitVec::repeat(false, num_vectors);
     let query = QueryVector::Nearest(storage.get_vector(test_point_id).to_owned());
 
     let hardware_counter = HardwareCounterCell::new();
     let scorer: Box<dyn RawScorer> = if let Some(quantized_vectors) = quantized_vectors.as_ref() {
         quantized_vectors
-            .raw_scorer(
-                query,
-                &point_deleted,
-                &point_deleted,
-                &stopped,
-                hardware_counter,
-            )
+            .raw_scorer(query, &point_deleted, &point_deleted, hardware_counter)
             .unwrap()
     } else {
         new_raw_scorer_for_test(query, &storage, &point_deleted).unwrap()

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -113,7 +113,7 @@ mod tests {
     use crate::types::Distance;
     use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
     use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
-    use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
 
     pub struct GpuGraphTestData {
         pub _temp_dir: TempDir,
@@ -239,7 +239,9 @@ mod tests {
                 .unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
-            let search_result_gpu = graph.search(top, ef, scorer, None);
+            let search_result_gpu = graph
+                .search(top, ef, scorer, None, &DEFAULT_STOPPED)
+                .unwrap();
 
             let fake_filter_context = FakeFilterContext {};
             let raw_scorer = test
@@ -248,7 +250,9 @@ mod tests {
                 .unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
-            let search_result_cpu = ref_graph.search(top, ef, scorer, None);
+            let search_result_cpu = ref_graph
+                .search(top, ef, scorer, None, &DEFAULT_STOPPED)
+                .unwrap();
 
             let mut gpu_set = HashSet::default();
             let mut cpu_set = HashSet::default();

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::cmp::max;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoredPointOffset};
@@ -11,7 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use super::entry_points::EntryPoint;
 use super::graph_links::{GraphLinks, GraphLinksFormat};
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::{
+    CancellableResult, OperationError, OperationResult, check_process_stopped,
+};
 use crate::common::utils::rev_range;
 use crate::index::hnsw_index::entry_points::EntryPoints;
 use crate::index::hnsw_index::graph_links::GraphLinksSerializer;
@@ -61,11 +64,14 @@ pub trait GraphLayersBase {
         level: usize,
         visited_list: &mut VisitedListHandle,
         points_scorer: &mut FilteredScorer,
-    ) {
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<()> {
         let limit = self.get_m(level);
         let mut points_ids: Vec<PointOffsetType> = Vec::with_capacity(2 * limit);
 
         while let Some(candidate) = searcher.candidates.pop() {
+            check_process_stopped(is_stopped)?;
+
             if candidate.score < searcher.lower_bound() {
                 break;
             }
@@ -83,6 +89,8 @@ pub trait GraphLayersBase {
                 visited_list.check_and_update_visited(score_point.idx);
             });
         }
+
+        Ok(())
     }
 
     fn search_on_level(
@@ -91,13 +99,20 @@ pub trait GraphLayersBase {
         level: usize,
         ef: usize,
         points_scorer: &mut FilteredScorer,
-    ) -> FixedLengthPriorityQueue<ScoredPointOffset> {
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<FixedLengthPriorityQueue<ScoredPointOffset>> {
         let mut visited_list = self.get_visited_list_from_pool();
         visited_list.check_and_update_visited(level_entry.idx);
         let mut search_context = SearchContext::new(level_entry, ef);
 
-        self._search_on_level(&mut search_context, level, &mut visited_list, points_scorer);
-        search_context.nearest
+        self._search_on_level(
+            &mut search_context,
+            level,
+            &mut visited_list,
+            points_scorer,
+            is_stopped,
+        )?;
+        Ok(search_context.nearest)
     }
 
     /// Greedy searches for entry point of level `target_level`.
@@ -108,7 +123,8 @@ pub trait GraphLayersBase {
         top_level: usize,
         target_level: usize,
         points_scorer: &mut FilteredScorer,
-    ) -> ScoredPointOffset {
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<ScoredPointOffset> {
         let mut links: Vec<PointOffsetType> = Vec::with_capacity(2 * self.get_m(0));
 
         let mut current_point = ScoredPointOffset {
@@ -116,6 +132,8 @@ pub trait GraphLayersBase {
             score: points_scorer.score_point(entry_point),
         };
         for level in rev_range(top_level, target_level) {
+            check_process_stopped(is_stopped)?;
+
             let limit = self.get_m(level);
 
             let mut changed = true;
@@ -136,7 +154,7 @@ pub trait GraphLayersBase {
                 });
             }
         }
-        current_point
+        Ok(current_point)
     }
 
     #[cfg(test)]
@@ -231,9 +249,10 @@ impl GraphLayers {
         ef: usize,
         mut points_scorer: FilteredScorer,
         custom_entry_points: Option<&[PointOffsetType]>,
-    ) -> Vec<ScoredPointOffset> {
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<Vec<ScoredPointOffset>> {
         let Some(entry_point) = self.get_entry_point(&points_scorer, custom_entry_points) else {
-            return Vec::default();
+            return Ok(Vec::default());
         };
 
         let zero_level_entry = self.search_entry(
@@ -241,9 +260,16 @@ impl GraphLayers {
             entry_point.level,
             0,
             &mut points_scorer,
-        );
-        let nearest = self.search_on_level(zero_level_entry, 0, max(top, ef), &mut points_scorer);
-        nearest.into_iter_sorted().take(top).collect_vec()
+            is_stopped,
+        )?;
+        let nearest = self.search_on_level(
+            zero_level_entry,
+            0,
+            max(top, ef),
+            &mut points_scorer,
+            is_stopped,
+        )?;
+        Ok(nearest.into_iter_sorted().take(top).collect_vec())
     }
 
     pub fn get_path(path: &Path) -> PathBuf {
@@ -365,6 +391,7 @@ mod tests {
     };
     use crate::spaces::metric::Metric;
     use crate::spaces::simple::{CosineMetric, DotProductMetric};
+    use crate::vector_storage::DEFAULT_STOPPED;
     use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
 
     fn search_in_graph(
@@ -378,7 +405,9 @@ mod tests {
 
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
-        graph.search(top, ef, scorer, None)
+        graph
+            .search(top, ef, scorer, None, &DEFAULT_STOPPED)
+            .unwrap()
     }
 
     const M: usize = 8;
@@ -419,15 +448,18 @@ mod tests {
         let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
         let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
-        let nearest_on_level = graph_layers.search_on_level(
-            ScoredPointOffset {
-                idx: 0,
-                score: scorer.score_point(0),
-            },
-            0,
-            32,
-            &mut scorer,
-        );
+        let nearest_on_level = graph_layers
+            .search_on_level(
+                ScoredPointOffset {
+                    idx: 0,
+                    score: scorer.score_point(0),
+                },
+                0,
+                32,
+                &mut scorer,
+                &DEFAULT_STOPPED,
+            )
+            .unwrap();
 
         assert_eq!(nearest_on_level.len(), graph_links[0][0].len() + 1);
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -54,9 +54,7 @@ use crate::types::{
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::DiscoveryQuery;
-use crate::vector_storage::{
-    RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer, new_stoppable_raw_scorer,
-};
+use crate::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer};
 
 const HNSW_USE_HEURISTIC: bool = true;
 const FINISH_MAIN_GRAPH_LOG_MESSAGE: &str = "Finish main graph in time";
@@ -369,7 +367,6 @@ impl HNSWIndex {
                         vector,
                         id_tracker_ref.deleted_point_bitslice(),
                         vector_storage_ref.deleted_vector_bitslice(),
-                        stopped,
                         internal_hardware_counter,
                     )
                 } else {
@@ -377,7 +374,6 @@ impl HNSWIndex {
                         vector,
                         &vector_storage_ref,
                         id_tracker_ref.deleted_point_bitslice(),
-                        stopped,
                         internal_hardware_counter,
                     )
                 }?;
@@ -587,14 +583,12 @@ impl HNSWIndex {
                     vector,
                     id_tracker.deleted_point_bitslice(),
                     deleted_bitslice,
-                    stopped,
                     internal_hardware_counter,
                 ),
                 None => new_raw_scorer(
                     vector,
                     vector_storage,
                     id_tracker.deleted_point_bitslice(),
-                    stopped,
                     internal_hardware_counter,
                 ),
             }?;
@@ -653,7 +647,6 @@ impl HNSWIndex {
                     vector,
                     id_tracker.deleted_point_bitslice(),
                     vector_storage.deleted_vector_bitslice(),
-                    stopped,
                     hardware_counter,
                 )
             } else {
@@ -661,7 +654,6 @@ impl HNSWIndex {
                     vector,
                     vector_storage,
                     id_tracker.deleted_point_bitslice(),
-                    stopped,
                     hardware_counter,
                 )
             }?;
@@ -700,14 +692,12 @@ impl HNSWIndex {
                     vector,
                     id_tracker.deleted_point_bitslice(),
                     deleted_bitslice,
-                    stopped,
                     hardware_counter,
                 ),
                 None => new_raw_scorer(
                     vector,
                     vector_storage,
                     id_tracker.deleted_point_bitslice(),
-                    stopped,
                     hardware_counter,
                 ),
             }?;
@@ -838,7 +828,6 @@ impl HNSWIndex {
             quantized_vectors.as_ref(),
             deleted_points,
             params,
-            &is_stopped,
             vector_query_context.hardware_counter(),
         )?;
         let oversampled_top = Self::get_oversampled_top(quantized_vectors.as_ref(), params, top);
@@ -848,16 +837,19 @@ impl HNSWIndex {
         let filter_context = filter.map(|f| payload_index.filter_context(f, &hw_counter));
         let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
 
-        let search_result =
-            self.graph
-                .search(oversampled_top, ef, points_scorer, custom_entry_points);
+        let search_result = self.graph.search(
+            oversampled_top,
+            ef,
+            points_scorer,
+            custom_entry_points,
+            &is_stopped,
+        )?;
 
         let res = self.postprocess_search_result(
             search_result,
             vector,
             params,
             top,
-            &is_stopped,
             vector_query_context.hardware_counter(),
         )?;
 
@@ -913,19 +905,17 @@ impl HNSWIndex {
             quantized_vectors.as_ref(),
             deleted_points,
             params,
-            &is_stopped,
             vector_query_context.hardware_counter(),
         )?;
         let oversampled_top = Self::get_oversampled_top(quantized_vectors.as_ref(), params, top);
 
-        let search_result = raw_scorer.peek_top_iter(points, oversampled_top);
+        let search_result = raw_scorer.peek_top_iter(points, oversampled_top, &is_stopped)?;
 
         let res = self.postprocess_search_result(
             search_result,
             vector,
             params,
             top,
-            &is_stopped,
             vector_query_context.hardware_counter(),
         )?;
         Ok(res)
@@ -1034,7 +1024,6 @@ impl HNSWIndex {
         quantized_storage: Option<&'a QuantizedVectors>,
         deleted_points: &'a BitSlice,
         params: Option<&SearchParams>,
-        is_stopped: &'a AtomicBool,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Box<dyn RawScorer + 'a>> {
         let quantization_enabled = Self::is_quantized_search(quantized_storage, params);
@@ -1043,14 +1032,12 @@ impl HNSWIndex {
                 vector.to_owned(),
                 deleted_points,
                 vector_storage.deleted_vector_bitslice(),
-                is_stopped,
                 hardware_counter,
             ),
-            _ => new_stoppable_raw_scorer(
+            _ => new_raw_scorer(
                 vector.to_owned(),
                 vector_storage,
                 deleted_points,
-                is_stopped,
                 hardware_counter,
             ),
         }
@@ -1082,7 +1069,6 @@ impl HNSWIndex {
         vector: &QueryVector,
         params: Option<&SearchParams>,
         top: usize,
-        is_stopped: &AtomicBool,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
         let id_tracker = self.id_tracker.borrow();
@@ -1102,11 +1088,10 @@ impl HNSWIndex {
                 .unwrap_or(default_rescoring);
 
         let mut postprocess_result = if rescore {
-            let raw_scorer = new_stoppable_raw_scorer(
+            let raw_scorer = new_raw_scorer(
                 vector.to_owned(),
                 &vector_storage,
                 id_tracker.deleted_point_bitslice(),
-                is_stopped,
                 hardware_counter,
             )?;
 

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -13,6 +13,7 @@ use crate::index::hnsw_index::graph_links::GraphLinksFormat;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::tests::create_graph_layer_builder_fixture;
 use crate::spaces::simple::CosineMetric;
+use crate::vector_storage::DEFAULT_STOPPED;
 
 fn search_in_builder(
     builder: &GraphLayersBuilder,
@@ -28,14 +29,25 @@ fn search_in_builder(
         Some(ep) => ep,
     };
 
-    let zero_level_entry = builder.search_entry(
-        entry_point.point_id,
-        entry_point.level,
-        0,
-        &mut points_scorer,
-    );
+    let zero_level_entry = builder
+        .search_entry(
+            entry_point.point_id,
+            entry_point.level,
+            0,
+            &mut points_scorer,
+            &DEFAULT_STOPPED,
+        )
+        .unwrap();
 
-    let nearest = builder.search_on_level(zero_level_entry, 0, max(top, ef), &mut points_scorer);
+    let nearest = builder
+        .search_on_level(
+            zero_level_entry,
+            0,
+            max(top, ef),
+            &mut points_scorer,
+            &DEFAULT_STOPPED,
+        )
+        .unwrap();
     nearest.into_iter_sorted().take(top).collect_vec()
 }
 
@@ -76,7 +88,9 @@ fn test_compact_graph_layers(#[case] format: GraphLinksFormat) {
         .map(|query| {
             let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
-            graph_layers.search(top, ef, scorer, None)
+            graph_layers
+                .search(top, ef, scorer, None, &DEFAULT_STOPPED)
+                .unwrap()
         })
         .collect_vec();
 

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -297,8 +297,8 @@ mod tests {
     use crate::id_tracker::id_tracker_base::IdTracker;
     use crate::types::{PointIdType, QuantizationConfig, ScalarQuantizationConfig};
     use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
-    use crate::vector_storage::new_raw_scorer_for_test;
     use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+    use crate::vector_storage::{DEFAULT_STOPPED, new_raw_scorer_for_test};
 
     #[test]
     fn test_basic_persistence() {
@@ -406,13 +406,15 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
-        let res = raw_scorer.peek_top_all(2);
+        let res = raw_scorer.peek_top_all(2, &DEFAULT_STOPPED).unwrap();
 
         assert_eq!(res.len(), 2);
 
         assert_ne!(res[0].idx, 2);
 
-        let res = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
+        let res = raw_scorer
+            .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2, &DEFAULT_STOPPED)
+            .unwrap();
 
         assert_eq!(res.len(), 2);
         assert_ne!(res[0].idx, 2);
@@ -489,7 +491,9 @@ mod tests {
         )
         .unwrap();
 
-        let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        let closest = scorer
+            .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
+            .unwrap();
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
         assert_eq!(closest[0].idx, 0);
         assert_eq!(closest[1].idx, 1);
@@ -514,7 +518,9 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
-        let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        let closest = scorer
+            .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
+            .unwrap();
         assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
         assert_eq!(closest[0].idx, 4);
         assert_eq!(closest[1].idx, 0);
@@ -537,7 +543,7 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
-        let closest = scorer.peek_top_all(5);
+        let closest = scorer.peek_top_all(5, &DEFAULT_STOPPED).unwrap();
         assert!(closest.is_empty(), "must have no results, all deleted");
     }
 
@@ -604,7 +610,9 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
-        let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        let closest = scorer
+            .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
+            .unwrap();
 
         drop(scorer);
 
@@ -773,7 +781,6 @@ mod tests {
                 query.clone(),
                 borrowed_id_tracker.deleted_point_bitslice(),
                 storage.deleted_vector_bitslice(),
-                &stopped,
                 hardware_counter,
             )
             .unwrap();
@@ -808,7 +815,6 @@ mod tests {
                 query.clone(),
                 borrowed_id_tracker.deleted_point_bitslice(),
                 storage.deleted_vector_bitslice(),
-                &stopped,
                 hardware_counter,
             )
             .unwrap();

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::AtomicBool;
-
 use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use quantization::EncodedVectors;
@@ -27,7 +25,6 @@ pub(super) struct QuantizedScorerBuilder<'a> {
     query: QueryVector,
     point_deleted: &'a BitSlice,
     vec_deleted: &'a BitSlice,
-    is_stopped: &'a AtomicBool,
     distance: &'a Distance,
     datatype: VectorStorageDatatype,
     hardware_counter: HardwareCounterCell,
@@ -41,7 +38,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
         query: QueryVector,
         point_deleted: &'a BitSlice,
         vec_deleted: &'a BitSlice,
-        is_stopped: &'a AtomicBool,
         distance: &'a Distance,
         datatype: VectorStorageDatatype,
         hardware_counter: HardwareCounterCell,
@@ -52,7 +48,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
             query,
             point_deleted,
             vec_deleted,
-            is_stopped,
             distance,
             datatype,
             hardware_counter,
@@ -152,7 +147,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
             query,
             point_deleted,
             vec_deleted,
-            is_stopped,
             distance: _,
             datatype: _,
             hardware_counter,
@@ -166,7 +160,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::RecommendBestScore(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
@@ -176,7 +170,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
@@ -186,7 +180,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<DenseVector> =
@@ -197,7 +191,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
@@ -207,7 +201,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
         }
     }
@@ -227,7 +221,6 @@ impl<'a> QuantizedScorerBuilder<'a> {
             query,
             point_deleted,
             vec_deleted,
-            is_stopped,
             distance: _,
             datatype: _,
             hardware_counter,
@@ -241,7 +234,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantization_config,
                     hardware_counter,
                 );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::RecommendBestScore(reco_query) => {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
@@ -253,7 +246,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
@@ -265,7 +258,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
@@ -277,7 +270,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<MultiDenseVectorInternal> =
@@ -289,7 +282,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                         quantization_config,
                         hardware_counter,
                     );
-                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted)
             }
         }
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -149,7 +149,6 @@ impl QuantizedVectors {
         query: QueryVector,
         point_deleted: &'a BitSlice,
         vec_deleted: &'a BitSlice,
-        is_stopped: &'a AtomicBool,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Box<dyn RawScorer + 'a>> {
         QuantizedScorerBuilder::new(
@@ -158,7 +157,6 @@ impl QuantizedVectors {
             query,
             point_deleted,
             vec_deleted,
-            is_stopped,
             &self.distance,
             self.datatype,
             hardware_counter,

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -113,15 +113,8 @@ fn test_random_score(
 
     let raw_scorer = new_raw_scorer_for_test(query.clone(), storage, deleted_points).unwrap();
 
-    let is_stopped = AtomicBool::new(false);
     let async_raw_scorer = if let VectorStorageEnum::DenseMemmap(storage) = storage {
-        async_raw_scorer::new(
-            query,
-            storage,
-            deleted_points,
-            &is_stopped,
-            HardwareCounterCell::new(),
-        )?
+        async_raw_scorer::new(query, storage, deleted_points, HardwareCounterCell::new())?
     } else {
         unreachable!();
     };

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -189,15 +189,12 @@ fn scoring_equivalency(
         )
         .unwrap();
 
-        let is_stopped = AtomicBool::new(false);
-
         let other_scorer = match &quantized_vectors {
             Some(quantized_storage) => quantized_storage
                 .raw_scorer(
                     query.clone(),
                     id_tracker.deleted_point_bitslice(),
                     other_storage.deleted_vector_bitslice(),
-                    &is_stopped,
                     HardwareCounterCell::new(),
                 )
                 .unwrap(),

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -15,7 +15,9 @@ use crate::id_tracker::IdTrackerSS;
 use crate::vector_storage::query::RecoQuery;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use crate::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum, new_raw_scorer_for_test};
+use crate::vector_storage::{
+    DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer_for_test,
+};
 
 fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     let points: Vec<SparseVector> = vec![
@@ -83,7 +85,9 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap();
-    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    let closest = scorer
+        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, &DEFAULT_STOPPED)
+        .unwrap();
     drop(scorer);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
@@ -177,7 +181,9 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap();
-    let closest = scorer.peek_top_iter(&mut [0, 1, 2, 3, 4, 5].iter().cloned(), 5);
+    let closest = scorer
+        .peek_top_iter(&mut [0, 1, 2, 3, 4, 5].iter().cloned(), 5, &DEFAULT_STOPPED)
+        .unwrap();
     drop(scorer);
 
     assert_eq!(


### PR DESCRIPTION
Depends on #6299 as it touches the same benchmark. Ignore first commit during the review.

This PR removes `is_stopped` flag from `RawScorer` as suggested in https://github.com/qdrant/qdrant/pull/6245#issuecomment-2751183795. Instead, it is passed to search functions explicitly.