### PR TITLE
Migrate WAL mutex from parking lot to tokio

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -625,9 +625,9 @@ impl LocalShard {
         bar.set_style(progress_style);
 
         log::debug!(
-            "Recovering shard {:?} starting reading WAL from {}",
-            &self.path,
-            wal.first_index()
+            "Recovering shard {} starting reading WAL from {}",
+            self.path.display(),
+            wal.first_index(),
         );
 
         bar.set_message(format!("Recovering collection {collection_id}"));

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -65,19 +65,14 @@ impl QueueProxyShard {
     /// Queue proxy the given local shard and point to the remote shard.
     ///
     /// This starts queueing all new updates on the local shard at the point of creation.
-    pub fn new(
+    pub async fn new(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,
         wal_keep_from: Arc<AtomicU64>,
         progress: Arc<ParkingMutex<TransferTaskProgress>>,
     ) -> Self {
         Self {
-            inner: Some(Inner::new(
-                wrapped_shard,
-                remote_shard,
-                wal_keep_from,
-                progress,
-            )),
+            inner: Some(Inner::new(wrapped_shard, remote_shard, wal_keep_from, progress).await),
         }
     }
 
@@ -92,7 +87,7 @@ impl QueueProxyShard {
     ///
     /// This fails if the given `version` is not in bounds of our current WAL. If the given
     /// `version` is too old or too new, queue proxy creation is rejected.
-    pub fn new_from_version(
+    pub async fn new_from_version(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,
         wal_keep_from: Arc<AtomicU64>,
@@ -101,7 +96,7 @@ impl QueueProxyShard {
     ) -> Result<Self, (LocalShard, CollectionError)> {
         // Lock WAL until we've successfully created the queue proxy shard
         let wal = wrapped_shard.wal.wal.clone();
-        let wal_lock = wal.lock();
+        let wal_lock = wal.lock().await;
 
         // If start version is not in current WAL bounds [first_idx, last_idx + 1], we cannot reliably transfer WAL
         // Allow it to be one higher than the last index to only send new updates
@@ -390,13 +385,13 @@ struct Inner {
 }
 
 impl Inner {
-    pub fn new(
+    pub async fn new(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,
         wal_keep_from: Arc<AtomicU64>,
         progress: Arc<ParkingMutex<TransferTaskProgress>>,
     ) -> Self {
-        let start_from = wrapped_shard.wal.wal.lock().last_index() + 1;
+        let start_from = wrapped_shard.wal.wal.lock().await.last_index() + 1;
         Self::new_from_version(
             wrapped_shard,
             remote_shard,
@@ -470,7 +465,7 @@ impl Inner {
 
         // Lock wall, count pending items to transfer, grab batch
         let (pending_count, total, batch) = {
-            let wal = self.wrapped_shard.wal.wal.lock();
+            let wal = self.wrapped_shard.wal.wal.lock().await;
             let items_left = (wal.last_index() + 1).saturating_sub(transfer_from);
             let items_total = (transfer_from - self.started_at) + items_left;
             let batch = wal.read(transfer_from).take(BATCH_SIZE).collect::<Vec<_>>();

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -177,19 +177,19 @@ impl ShardReplicaSet {
 
         // Try to queue proxify with or without version
         let proxy_shard = match from_version {
-            None => Ok(QueueProxyShard::new(
-                local_shard,
-                remote_shard,
-                wal_keep_from,
-                progress,
-            )),
-            Some(from_version) => QueueProxyShard::new_from_version(
-                local_shard,
-                remote_shard,
-                wal_keep_from,
-                from_version,
-                progress,
-            ),
+            None => {
+                Ok(QueueProxyShard::new(local_shard, remote_shard, wal_keep_from, progress).await)
+            }
+            Some(from_version) => {
+                QueueProxyShard::new_from_version(
+                    local_shard,
+                    remote_shard,
+                    wal_keep_from,
+                    from_version,
+                    progress,
+                )
+                .await
+            }
         };
 
         // Insert queue proxy shard on success or revert to local shard on failure
@@ -497,6 +497,6 @@ impl ShardReplicaSet {
             ));
         };
 
-        local_shard.wal_version()
+        local_shard.wal_version().await
     }
 }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -231,7 +231,7 @@ impl Shard {
             Ok(Some(version)) => {
                 log::debug!(
                     "Resolved WAL delta from {version}, which counts {} records",
-                    wal.wal.lock().last_index().saturating_sub(version),
+                    wal.wal.lock().await.last_index().saturating_sub(version),
                 );
                 Ok(Some(version))
             }
@@ -247,9 +247,9 @@ impl Shard {
         }
     }
 
-    pub fn wal_version(&self) -> CollectionResult<Option<u64>> {
+    pub async fn wal_version(&self) -> CollectionResult<Option<u64>> {
         match self {
-            Self::Local(local_shard) => local_shard.wal.wal_version().map_err(|err| {
+            Self::Local(local_shard) => local_shard.wal.wal_version().await.map_err(|err| {
                 CollectionError::service_error(format!(
                     "Cannot get WAL version on {}: {err}",
                     self.variant_name(),

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -133,6 +133,7 @@ impl RecoverableWal {
         let mut operations = other
             .wal
             .lock()
+            .await
             .read(append_from)
             .map(|(_, op)| op)
             .collect::<Vec<_>>();
@@ -261,7 +262,6 @@ mod tests {
     use std::ops::Range;
     use std::sync::Arc;
 
-    use parking_lot::Mutex as ParkingMutex;
     use rand::prelude::SliceRandom;
     use rand::rngs::StdRng;
     use rand::seq::IndexedRandom;
@@ -289,7 +289,7 @@ mod tests {
         let wal = SerdeWal::new(dir.path().to_str().unwrap(), options).unwrap();
         (
             RecoverableWal::new(
-                Arc::new(ParkingMutex::new(wal)),
+                Arc::new(Mutex::new(wal)),
                 Arc::new(Mutex::new(ClockMap::default())),
                 Arc::new(Mutex::new(ClockMap::default())),
             ),
@@ -375,7 +375,7 @@ mod tests {
         assert_eq!(delta_from, 1);
 
         // Diff should have 1 operation, as C missed just one
-        assert_eq!(b_wal.wal.lock().read(delta_from).count(), 1);
+        assert_eq!(b_wal.wal.lock().await.read(delta_from).count(), 1);
 
         // Recover WAL on node C by writing delta from node B to it
         c_wal.append_from(&b_wal, delta_from).await.unwrap();
@@ -384,9 +384,10 @@ mod tests {
         a_wal
             .wal
             .lock()
+            .await
             .read(0)
-            .zip(b_wal.wal.lock().read(0))
-            .zip(c_wal.wal.lock().read(0))
+            .zip(b_wal.wal.lock().await.read(0))
+            .zip(c_wal.wal.lock().await.read(0))
             .for_each(|((a, b), c)| {
                 assert_eq!(a, b);
                 assert_eq!(b, c);
@@ -483,7 +484,7 @@ mod tests {
         assert_eq!(delta_from, N as u64);
 
         // Diff should have N operation, as C missed just N of them
-        assert_eq!(b_wal.wal.lock().read(delta_from).count(), N);
+        assert_eq!(b_wal.wal.lock().await.read(delta_from).count(), N);
 
         // Recover WAL on node C by writing delta from node B to it
         c_wal.append_from(&b_wal, delta_from).await.unwrap();
@@ -492,9 +493,10 @@ mod tests {
         a_wal
             .wal
             .lock()
+            .await
             .read(0)
-            .zip(b_wal.wal.lock().read(0))
-            .zip(c_wal.wal.lock().read(0))
+            .zip(b_wal.wal.lock().await.read(0))
+            .zip(c_wal.wal.lock().await.read(0))
             .for_each(|((a, b), c)| {
                 assert_eq!(a, b);
                 assert_eq!(b, c);
@@ -578,7 +580,7 @@ mod tests {
         assert_eq!(delta_from, N as u64);
 
         // Diff should have M operations, as node C missed M operations
-        assert_eq!(b_wal.wal.lock().read(delta_from).count(), M);
+        assert_eq!(b_wal.wal.lock().await.read(delta_from).count(), M);
 
         // Recover WAL on node C by writing delta from node B to it
         c_wal.append_from(&b_wal, delta_from).await.unwrap();
@@ -587,9 +589,10 @@ mod tests {
         a_wal
             .wal
             .lock()
+            .await
             .read(0)
-            .zip(b_wal.wal.lock().read(0))
-            .zip(c_wal.wal.lock().read(0))
+            .zip(b_wal.wal.lock().await.read(0))
+            .zip(c_wal.wal.lock().await.read(0))
             .for_each(|((a, b), c)| {
                 assert_eq!(a, b);
                 assert_eq!(b, c);
@@ -683,7 +686,7 @@ mod tests {
         assert_eq!(delta_from, N as u64);
 
         // Diff should have M operations, as node C missed M operations
-        assert_eq!(b_wal.wal.lock().read(delta_from).count(), M);
+        assert_eq!(b_wal.wal.lock().await.read(delta_from).count(), M);
 
         // Recover WAL on node C by writing delta from node B to it
         c_wal.append_from(&b_wal, delta_from).await.unwrap();
@@ -692,9 +695,10 @@ mod tests {
         a_wal
             .wal
             .lock()
+            .await
             .read(0)
-            .zip(b_wal.wal.lock().read(0))
-            .zip(c_wal.wal.lock().read(0))
+            .zip(b_wal.wal.lock().await.read(0))
+            .zip(c_wal.wal.lock().await.read(0))
             .for_each(|((a, b), c)| {
                 assert_eq!(a, b);
                 assert_eq!(b, c);
@@ -787,8 +791,8 @@ mod tests {
         assert_eq!(delta_from, 1);
 
         // Diff should have 2 operations on both nodes
-        assert_eq!(a_wal.wal.lock().read(delta_from).count(), 2);
-        assert_eq!(b_wal.wal.lock().read(delta_from).count(), 2);
+        assert_eq!(a_wal.wal.lock().await.read(delta_from).count(), 2);
+        assert_eq!(b_wal.wal.lock().await.read(delta_from).count(), 2);
 
         // Recover WAL on node C by writing delta from node B to it
         c_wal.append_from(&b_wal, delta_from).await.unwrap();
@@ -798,23 +802,25 @@ mod tests {
             !a_wal
                 .wal
                 .lock()
+                .await
                 .read(0)
-                .zip(c_wal.wal.lock().read(0))
+                .zip(c_wal.wal.lock().await.read(0))
                 .all(|(a, c)| a == c),
         );
         assert!(
             b_wal
                 .wal
                 .lock()
+                .await
                 .read(0)
-                .zip(c_wal.wal.lock().read(0))
+                .zip(c_wal.wal.lock().await.read(0))
                 .all(|(b, c)| b == c),
         );
 
         // All WALs should have 3 operations
-        assert_eq!(a_wal.wal.lock().read(0).count(), 3);
-        assert_eq!(b_wal.wal.lock().read(0).count(), 3);
-        assert_eq!(c_wal.wal.lock().read(0).count(), 3);
+        assert_eq!(a_wal.wal.lock().await.read(0).count(), 3);
+        assert_eq!(b_wal.wal.lock().await.read(0).count(), 3);
+        assert_eq!(c_wal.wal.lock().await.read(0).count(), 3);
 
         // All WALs must have operations for point 1, 2 and 3
         let get_point = |op| match op {
@@ -830,18 +836,21 @@ mod tests {
         let a_wal_point_ids = a_wal
             .wal
             .lock()
+            .await
             .read(0)
             .map(|(_, op)| get_point(op).id)
             .collect::<HashSet<_>>();
         let b_wal_point_ids = b_wal
             .wal
             .lock()
+            .await
             .read(0)
             .map(|(_, op)| get_point(op).id)
             .collect::<HashSet<_>>();
         let c_wal_point_ids = c_wal
             .wal
             .lock()
+            .await
             .read(0)
             .map(|(_, op)| get_point(op).id)
             .collect::<HashSet<_>>();
@@ -1202,7 +1211,7 @@ mod tests {
             .unwrap();
 
         // Diff expected
-        assert_eq!(b_wal.wal.lock().read(delta_from).count(), 1);
+        assert_eq!(b_wal.wal.lock().await.read(delta_from).count(), 1);
 
         assert_wal_ordering_property(&a_wal, false).await;
         assert_wal_ordering_property(&b_wal, false).await;
@@ -1387,16 +1396,16 @@ mod tests {
             }
 
             // All WALs must be equal, having exactly the same entries
-            wals.iter()
-                .map(|wal| wal.0.wal.lock())
-                .collect::<Vec<_>>()
-                .windows(2)
-                .for_each(|wals| {
-                    assert!(
-                        wals[0].read(0).eq(wals[1].read(0)),
-                        "all WALs must have the same entries",
-                    );
-                });
+            let mut opened_wals = Vec::new();
+            for wal in &wals {
+                opened_wals.push(wal.0.wal.lock().await);
+            }
+            opened_wals.windows(2).for_each(|wals| {
+                assert!(
+                    wals[0].read(0).eq(wals[1].read(0)),
+                    "all WALs must have the same entries",
+                );
+            });
 
             // Release some kept clocks
             kept_clocks.retain(|(keep_for, _)| *keep_for > 1);
@@ -1478,7 +1487,7 @@ mod tests {
 
         let resolve_result = resolve_wal_delta(
             wal.wal
-                .lock()
+                .blocking_lock()
                 .read_all(true)
                 .map(|(op_num, op)| (op_num, op.clock_tag)),
             recovery_point,
@@ -1505,7 +1514,7 @@ mod tests {
 
         let resolve_result = resolve_wal_delta(
             wal.wal
-                .lock()
+                .blocking_lock()
                 .read_all(true)
                 .map(|(op_num, op)| (op_num, op.clock_tag)),
             recovery_point,
@@ -1531,7 +1540,7 @@ mod tests {
 
         let resolve_result = resolve_wal_delta(
             wal.wal
-                .lock()
+                .blocking_lock()
                 .read_all(true)
                 .map(|(op_num, op)| (op_num, op.clock_tag)),
             recovery_point,
@@ -1562,7 +1571,7 @@ mod tests {
 
         let resolve_result = resolve_wal_delta(
             wal.wal
-                .lock()
+                .blocking_lock()
                 .read_all(true)
                 .map(|(op_num, op)| (op_num, op.clock_tag)),
             recovery_point,
@@ -1588,7 +1597,7 @@ mod tests {
 
         let resolve_result = resolve_wal_delta(
             wal.wal
-                .lock()
+                .blocking_lock()
                 .read_all(true)
                 .map(|(op_num, op)| (op_num, op.clock_tag)),
             recovery_point,
@@ -1605,6 +1614,7 @@ mod tests {
             let cutoff = wal.oldest_clocks.lock().await;
             wal.wal
                 .lock()
+                .await
                 .read(0)
                 // Only take records with clock tags
                 .filter_map(|(_, operation)| operation.clock_tag)


### PR DESCRIPTION
Migrates the WAL lock from a sync parking lot mutex to an async tokio mutex.

The mutex is almost exclusively used in async context. I therefore suggest to make it an async mutex, so that we don't run into the constant issue of trying to hold this lock across await points.

This is the first step in a bigger attempt to more clearly define the boundary between our sync (segments) and async (the rest) code. Currently, this boundary is very vague because we constantly mix up the two flavors, which creates constant problems. I'd like to clean up this technical dept a bit.

Contains no logic changes. Purely mechanical to change the mutex type.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?