### PR TITLE
[recommend avg_vector] combine multivectors into a single averaged vector

### DIFF
--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -150,14 +150,19 @@ fn merge_positive_and_negative_avg(
 }
 
 pub fn avg_vector_for_recommendation<'a>(
-    positive: impl IntoIterator<Item = VectorRef<'a>>,
+    positive: impl Iterator<Item = VectorRef<'a>>,
     mut negative: Peekable<impl Iterator<Item = VectorRef<'a>>>,
 ) -> CollectionResult<VectorInternal> {
-    let avg_positive = avg_vectors(positive)?;
-
     let search_vector = if negative.peek().is_none() {
-        avg_positive
+        // If there is just one positive vector, return it without any modifications
+        let positive_vec = positive.collect_vec();
+        if positive_vec.len() == 1 {
+            positive_vec[0].to_owned()
+        } else {
+            avg_vectors(positive_vec)?
+        }
     } else {
+        let avg_positive = avg_vectors(positive)?;
         let avg_negative = avg_vectors(negative)?;
         merge_positive_and_negative_avg(avg_positive, avg_negative)?
     };

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -241,6 +241,11 @@ impl<T> TypedMultiDenseVector<T> {
 
         Ok(multi_dense)
     }
+
+    /// Amount of vectors in the multivector
+    pub fn len(&self) -> usize {
+        self.flattened_vectors.len() / self.dim
+    }
 }
 
 pub type MultiDenseVectorInternal = TypedMultiDenseVector<VectorElementType>;
@@ -309,26 +314,7 @@ impl<T: PrimitiveVectorElement> TryFrom<Vec<TypedDenseVector<T>>> for TypedMulti
     type Error = OperationError;
 
     fn try_from(value: Vec<TypedDenseVector<T>>) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(OperationError::ValidationError {
-                description: "MultiDenseVector cannot be empty".to_string(),
-            });
-        }
-        let dim = value[0].len();
-        // assert all vectors have the same dimension
-        if let Some(bad_vec) = value.iter().find(|v| v.len() != dim) {
-            Err(OperationError::WrongVectorDimension {
-                expected_dim: dim,
-                received_dim: bad_vec.len(),
-            })
-        } else {
-            let flattened_vectors = value.into_iter().flatten().collect_vec();
-            let multi_dense = TypedMultiDenseVector {
-                flattened_vectors,
-                dim,
-            };
-            Ok(multi_dense)
-        }
+        Self::try_from_matrix(value)
     }
 }
 

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sparse::common::sparse_vector::SparseVector;
+use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::named_vectors::NamedVectors;
@@ -15,7 +16,8 @@ use crate::common::utils::transpose_map_into_named_vector;
 use crate::types::{VectorName, VectorNameBuf};
 use crate::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
 pub enum VectorInternal {
     Dense(DenseVector),
     Sparse(SparseVector),


### PR DESCRIPTION
This PR changes the implementation from concatenating all the multivectors in the input, to averaging them into a single one, same as we do for dense vectors.

For example , instead of combining `[ [],[] ]` and `[ [],[],[] ]` into a `[ [],[],[],[],[] ]` multivector, we now average all the individual vectors and produce an averaged multivector of just one vector: `[ [] ]`.

The idea behind this is that average vector strategy should combine all examples into a single one for a more optimized search. In the case of multivectors, we will still do MaxSim against the documents, but now only with a single vector in the multivector query.