### PR TITLE
Only implement verification for `CollectionQuery` types

### DIFF
--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -1,4 +1,3 @@
-use api::rest::{QueryGroupsRequestInternal};
 use segment::types::StrictModeConfig;
 
 use super::StrictModeVerification;
@@ -7,28 +6,6 @@ use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::collection_query::{
     CollectionPrefetch, CollectionQueryGroupsRequest, CollectionQueryRequest, Query,
 };
-
-impl StrictModeVerification for QueryGroupsRequestInternal {
-    fn query_limit(&self) -> Option<usize> {
-        self.group_request.limit
-    }
-
-    fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
-        self.filter.as_ref()
-    }
-
-    fn indexed_filter_write(&self) -> Option<&segment::types::Filter> {
-        None
-    }
-
-    fn request_exact(&self) -> Option<bool> {
-        None
-    }
-
-    fn request_search_params(&self) -> Option<&segment::types::SearchParams> {
-        self.params.as_ref()
-    }
-}
 
 impl Query {
     fn check_strict_mode(

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -1,4 +1,4 @@
-use api::rest::{Prefetch, QueryGroupsRequestInternal, QueryRequestInternal};
+use api::rest::{QueryGroupsRequestInternal};
 use segment::types::StrictModeConfig;
 
 use super::StrictModeVerification;
@@ -7,81 +7,6 @@ use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::collection_query::{
     CollectionPrefetch, CollectionQueryGroupsRequest, CollectionQueryRequest, Query,
 };
-
-impl StrictModeVerification for QueryRequestInternal {
-    async fn check_custom(
-        &self,
-        collection: &Collection,
-        strict_mode_config: &StrictModeConfig,
-    ) -> Result<(), crate::operations::types::CollectionError> {
-        if let Some(prefetch) = &self.prefetch {
-            for prefetch in prefetch {
-                prefetch
-                    .check_strict_mode(collection, strict_mode_config)
-                    .await?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn query_limit(&self) -> Option<usize> {
-        self.limit
-    }
-
-    fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
-        self.filter.as_ref()
-    }
-
-    fn indexed_filter_write(&self) -> Option<&segment::types::Filter> {
-        None
-    }
-
-    fn request_exact(&self) -> Option<bool> {
-        None
-    }
-
-    fn request_search_params(&self) -> Option<&segment::types::SearchParams> {
-        self.params.as_ref()
-    }
-}
-
-impl StrictModeVerification for Prefetch {
-    async fn check_custom(
-        &self,
-        collection: &Collection,
-        strict_mode_config: &StrictModeConfig,
-    ) -> Result<(), crate::operations::types::CollectionError> {
-        // Prefetch.prefetch is of type Prefetch (recursive type)
-        if let Some(prefetch) = &self.prefetch {
-            for prefetch in prefetch {
-                Box::pin(prefetch.check_strict_mode(collection, strict_mode_config)).await?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn query_limit(&self) -> Option<usize> {
-        self.limit
-    }
-
-    fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
-        self.filter.as_ref()
-    }
-
-    fn indexed_filter_write(&self) -> Option<&segment::types::Filter> {
-        None
-    }
-
-    fn request_exact(&self) -> Option<bool> {
-        None
-    }
-
-    fn request_search_params(&self) -> Option<&segment::types::SearchParams> {
-        self.params.as_ref()
-    }
-}
 
 impl StrictModeVerification for QueryGroupsRequestInternal {
     fn query_limit(&self) -> Option<usize> {

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -36,19 +36,6 @@ async fn query_points(
         shard_key,
     } = request.into_inner();
 
-    let pass = match check_strict_mode(
-        &query_request,
-        params.timeout_as_secs(),
-        &collection.name,
-        &dispatcher,
-        &access,
-    )
-    .await
-    {
-        Ok(pass) => pass,
-        Err(err) => return process_response_error(err, Instant::now(), None),
-    };
-
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
         collection.name.clone(),
@@ -64,6 +51,15 @@ async fn query_points(
     let hw_measurement_acc = request_hw_counter.get_counter();
     let result = async move {
         let request = convert_query_request_from_rest(query_request, &inference_token).await?;
+
+        let pass = check_strict_mode(
+            &request,
+            params.timeout_as_secs(),
+            &collection.name,
+            &dispatcher,
+            &access,
+        )
+        .await?;
 
         let points = dispatcher
             .toc(&access, &pass)
@@ -103,19 +99,6 @@ async fn query_points_batch(
 ) -> impl Responder {
     let QueryRequestBatch { searches } = request.into_inner();
 
-    let pass = match check_strict_mode_batch(
-        searches.iter().map(|i| &i.internal),
-        params.timeout_as_secs(),
-        &collection.name,
-        &dispatcher,
-        &access,
-    )
-    .await
-    {
-        Ok(pass) => pass,
-        Err(err) => return process_response_error(err, Instant::now(), None),
-    };
-
     let request_hw_counter = get_request_hardware_counter(
         &dispatcher,
         collection.name.clone(),
@@ -141,6 +124,15 @@ async fn query_points_batch(
 
             batch.push((request, shard_selection));
         }
+
+        let pass = check_strict_mode_batch(
+            batch.iter().map(|i| &i.0),
+            params.timeout_as_secs(),
+            &collection.name,
+            &dispatcher,
+            &access,
+        )
+        .await?;
 
         let res = dispatcher
             .toc(&access, &pass)


### PR DESCRIPTION
I noticed there was duplication in the implementation of `StrictModeVerification` trait for query request types.

We already have a converging type for rest and grpc for query requests, so we can implement the trait only for this converging type.

By unifying, this also fixes a hole where we were not checking the prefetches when using the grpc interface.