### PR TITLE
Document Multivector Euclidean scoring discrepancy

### DIFF
--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -133,7 +133,7 @@ impl ScoringQuery {
                     FusionInternal::Rrf | FusionInternal::Dbsf => Some(Order::LargeBetter),
                 },
                 // Score boosting formulas are always have descending order,
-                // euclidean scores can be negated within the formula
+                // Euclidean scores can be negated within the formula
                 ScoringQuery::Formula(_formula) => Some(Order::LargeBetter),
                 ScoringQuery::OrderBy(order_by) => Some(Order::from(order_by.direction())),
                 // Random sample does not require ordering

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -4,9 +4,9 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
-use criterion::{Criterion, criterion_group, criterion_main};
-use rand::SeedableRng;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_multi_vector};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_multi_vector;
@@ -14,10 +14,10 @@ use segment::index::VectorIndex;
 use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::segment_constructor::{VectorIndexBuildArgs, build_segment};
-use segment::types::Distance::Dot;
+use segment::types::Distance::{Dot, Euclid};
 use segment::types::{
-    HnswConfig, Indexes, MultiVectorConfig, SegmentConfig, SeqNumberType, VectorDataConfig,
-    VectorStorageType,
+    Distance, HnswConfig, Indexes, MultiVectorConfig, SegmentConfig, SeqNumberType,
+    VectorDataConfig, VectorStorageType,
 };
 use tempfile::Builder;
 
@@ -29,11 +29,44 @@ const NUM_VECTORS_PER_POINT: usize = 16;
 const VECTOR_DIM: usize = 128;
 const TOP: usize = 10;
 
+// intent: bench `search` without filter
 fn multi_vector_search_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("multi-vector-search-group");
-    let stopped = AtomicBool::new(false);
     let mut rnd = StdRng::seed_from_u64(42);
 
+    let hnsw_index = make_segment_index(&mut rnd, Dot);
+    group.bench_function("hnsw-multivec-search-dot", |b| {
+        b.iter_batched(
+            || random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into(),
+            |query| {
+                let results = hnsw_index
+                    .search(&[&query], None, TOP, None, &Default::default())
+                    .unwrap();
+                assert_eq!(results[0].len(), TOP);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    let hnsw_index = make_segment_index(&mut rnd, Euclid);
+    group.bench_function("hnsw-multivec-search-euclidean", |b| {
+        b.iter_batched(
+            || random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into(),
+            |query| {
+                let results = hnsw_index
+                    .search(&[&query], None, TOP, None, &Default::default())
+                    .unwrap();
+                assert_eq!(results[0].len(), TOP);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+fn make_segment_index<R: Rng + ?Sized>(rnd: &mut R, distance: Distance) -> HNSWIndex {
+    let stopped = AtomicBool::new(false);
     let segment_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
@@ -42,7 +75,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
             DEFAULT_VECTOR_NAME.to_owned(),
             VectorDataConfig {
                 size: VECTOR_DIM,
-                distance: Dot,
+                distance,
                 storage_type: VectorStorageType::Memory,
                 index: Indexes::Plain {},
                 quantization_config: None,
@@ -59,7 +92,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
     let mut segment = build_segment(segment_dir.path(), &segment_config, true).unwrap();
     for n in 0..NUM_POINTS {
         let idx = (n as u64).into();
-        let multi_vec = random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT);
+        let multi_vec = random_multi_vector(rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT);
         let named_vectors = only_default_multi_vector(&multi_vec);
         segment
             .upsert_point(n as SeqNumberType, idx, named_vectors, &hw_counter)
@@ -96,21 +129,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
         },
     )
     .unwrap();
-
-    // intent: bench `search` without filter
-    group.bench_function("hnsw-multivec-search", |b| {
-        b.iter(|| {
-            // new query to avoid caching effects
-            let query = random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into();
-
-            let results = hnsw_index
-                .search(&[&query], None, TOP, None, &Default::default())
-                .unwrap();
-            assert_eq!(results[0].len(), TOP);
-        })
-    });
-
-    group.finish();
+    hnsw_index
 }
 
 criterion_group! {

--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -372,3 +372,117 @@ def test_search_legacy_api(collection_name):
     )
     assert response.ok
     assert len(response.json()['result']) == 3
+
+# document special case for Euclidean distance
+def test_multi_with_euclidean(collection_name):
+    drop_collection(collection_name=collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "my-multivec": {
+                    "size": 3,
+                    "distance": "Euclid",
+                    "multivector_config": {
+                        "comparator": "max_sim"
+                    }
+                }
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    # insert vector
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "my-multivec": [
+                            [1.0, 2.0, 3.0],
+                            [3.0, 3.0, 3.0],
+                            [4.0, 5.0, 6.0]
+                        ]
+                    }
+                },
+                {
+                    "id": 2,
+                    "vector": {
+                        "my-multivec": [
+                            [3.0, 3.0, 3.0],
+                            [4.0, 2.0, 1.0]
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+    assert response.ok
+
+    # get by id 1
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+
+    assert response.ok
+    point = response.json()['result']
+    assert point['id'] == 1
+    assert point['vector']['my-multivec'] == [
+        [1.0, 2.0, 3.0],
+        [3.0, 3.0, 3.0],
+        [4.0, 5.0, 6.0]
+    ]
+
+    # get by id 2
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 2},
+    )
+
+    assert response.ok
+    point = response.json()['result']
+    assert point['id'] == 2
+    assert point['vector']['my-multivec'] == [
+        [3.0, 3.0, 3.0],
+        [4.0, 2.0, 1.0]
+    ]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/query',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "query": [
+                [1.0, 2.0, 3.0],
+                [3.0, 3.0, 3.0],
+                [4.0, 5.0, 6.0]
+            ],
+            "using": "my-multivec",
+            "limit": 10
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']['points']) == 2
+    assert response.json()['result']['points'][0]['id'] == 1
+    assert response.json()['result']['points'][0]['score'] == 0.0
+
+    assert response.json()['result']['points'][1]['id'] == 2
+    assert response.json()['result']['points'][1]['score'] == 4.358899 # see `score_max_similarity` for details


### PR DESCRIPTION
This PR documents the discrepancy for multivector scoring using Euclidean distance reported in https://github.com/qdrant/qdrant/issues/6294

I tried to fix it but the resulting [PR](https://github.com/qdrant/qdrant/pull/6298) is not [convincing](https://github.com/qdrant/qdrant/pull/6298#issuecomment-2776017334).

The most reasonable way forward is to adapt the local mode to use the same scoring as in core.

This PR makes sure that the knowledge from this investigation is captured.