### PR TITLE
disk cache hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 tests/
 target/
 storage/
+qdrant-storage/
 snapshots/
 lib/segment/target
 lib/api/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,7 @@ name = "memory"
 version = "0.0.0"
 dependencies = [
  "bitvec",
+ "libc",
  "log",
  "memmap2",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
+ "memory",
  "num-traits",
  "num_cpus",
  "ordered-float 5.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,7 +3055,6 @@ version = "0.0.0"
 dependencies = [
  "atomicwrites",
  "bincode",
- "nix 0.29.0",
  "semver",
  "serde",
  "serde_json",
@@ -3825,9 +3824,9 @@ name = "memory"
 version = "0.0.0"
 dependencies = [
  "bitvec",
- "libc",
  "log",
  "memmap2",
+ "nix 0.29.0",
  "parking_lot",
  "rand 0.9.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,7 @@ zerocopy = { version = "0.8.24", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"
 thiserror = "2.0.12"
+libc = "0.2"
 bitvec = "1.0.1"
 merge = "0.1.0"
 dashmap = "6.1"

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -735,8 +735,6 @@ pub trait SegmentOptimizer {
                     .unwrap();
             }
 
-            optimized_segment.prefault_mmap_pages();
-
             let point_count = optimized_segment.available_point_count();
 
             let (_, proxies) = write_segments_guard.swap_new(optimized_segment, &proxy_ids);

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -36,6 +36,8 @@ thiserror = { workspace = true }
 zerocopy = { workspace = true }
 log = { workspace = true }
 
+memory = { path = "../memory" }
+
 [dev-dependencies]
 common = { path = ".", features = ["testing"] }
 criterion = { workspace = true }

--- a/lib/common/common/benches/mmap_hashmap.rs
+++ b/lib/common/common/benches/mmap_hashmap.rs
@@ -18,7 +18,7 @@ fn bench_mmap_hashmap(c: &mut Criterion) {
     )
     .unwrap();
 
-    let mmap = MmapHashMap::<str, u32>::open(&mmap_path).unwrap();
+    let mmap = MmapHashMap::<str, u32>::open(&mmap_path, true).unwrap();
 
     let mut it = keys.iter().cycle();
     c.bench_function("get", |b| {

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -1,6 +1,5 @@
 #[cfg(any(test, feature = "testing"))]
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::File;
 use std::hash::Hash;
 use std::io::{self, Cursor, Write};
 use std::marker::PhantomData;
@@ -8,15 +7,16 @@ use std::mem::{align_of, size_of};
 use std::path::Path;
 use std::str;
 
+use crate::zeros::WriteZerosExt as _;
 use memmap2::Mmap;
+use memory::madvise::{AdviceSetting, Madviseable};
+use memory::mmap_ops::open_read_mmap;
 use ph::fmph::Function;
 #[cfg(any(test, feature = "testing"))]
 use rand::Rng as _;
 #[cfg(any(test, feature = "testing"))]
 use rand::rngs::StdRng;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
-
-use crate::zeros::WriteZerosExt as _;
 
 type ValuesLen = u32;
 
@@ -193,12 +193,8 @@ impl<K: Key + ?Sized, V: Sized + FromBytes + Immutable + IntoBytes + KnownLayout
     }
 
     /// Load the hash map from file.
-    pub fn open(path: &Path) -> io::Result<Self> {
-        let file = File::open(path)?;
-
-        // SAFETY: Assume other processes do not modify the file.
-        // See https://docs.rs/memmap2/latest/memmap2/struct.Mmap.html#safety
-        let mmap = unsafe { Mmap::map(&file)? };
+    pub fn open(path: &Path, populate: bool) -> io::Result<Self> {
+        let mmap = open_read_mmap(path, AdviceSetting::Global, populate)?;
 
         let (header, _) =
             Header::read_from_prefix(mmap.as_ref()).map_err(|_| io::ErrorKind::InvalidData)?;
@@ -338,6 +334,13 @@ impl<K: Key + ?Sized, V: Sized + FromBytes + Immutable + IntoBytes + KnownLayout
                 format!("Can't read entry from mmap, bucket_val {entry_start} is out of bounds"),
             )
         })
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> io::Result<()> {
+        self.mmap.populate();
+        Ok(())
     }
 }
 
@@ -514,7 +517,7 @@ mod tests {
             map.iter().map(|(k, v)| (as_ref(k), v.iter().copied())),
         )
         .unwrap();
-        let mmap = MmapHashMap::<K, u32>::open(&tmpdir.path().join("map")).unwrap();
+        let mmap = MmapHashMap::<K, u32>::open(&tmpdir.path().join("map"), false).unwrap();
 
         // Non-existing keys should return None
         for _ in 0..1000 {
@@ -561,7 +564,7 @@ mod tests {
         )
         .unwrap();
 
-        let mmap = MmapHashMap::<i64, u64>::open(&tmpdir.path().join("map")).unwrap();
+        let mmap = MmapHashMap::<i64, u64>::open(&tmpdir.path().join("map"), true).unwrap();
 
         for (k, v) in map {
             assert_eq!(

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -7,7 +7,6 @@ use std::mem::{align_of, size_of};
 use std::path::Path;
 use std::str;
 
-use crate::zeros::WriteZerosExt as _;
 use memmap2::Mmap;
 use memory::madvise::{AdviceSetting, Madviseable};
 use memory::mmap_ops::open_read_mmap;
@@ -17,6 +16,8 @@ use rand::Rng as _;
 #[cfg(any(test, feature = "testing"))]
 use rand::rngs::StdRng;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+use crate::zeros::WriteZerosExt as _;
 
 type ValuesLen = u32;
 

--- a/lib/common/io/Cargo.toml
+++ b/lib/common/io/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 atomicwrites = { workspace = true }
 bincode = { workspace = true }
-nix = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/common/io/src/file_operations.rs
+++ b/lib/common/io/src/file_operations.rs
@@ -31,35 +31,6 @@ pub fn read_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
     Ok(value)
 }
 
-/// Advise the operating system that the file is no longer needed to be in the page cache.
-pub fn advise_dontneed(path: &Path) -> Result<()> {
-    // https://github.com/nix-rust/nix/blob/v0.29.0/src/fcntl.rs#L35-L42
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "freebsd",
-        target_os = "android",
-        target_os = "fuchsia",
-        target_os = "emscripten",
-        target_os = "wasi",
-        target_env = "uclibc",
-    ))]
-    {
-        use std::os::fd::AsRawFd as _;
-
-        use nix::fcntl;
-
-        let file = File::open(path)?;
-        let fd = file.as_raw_fd();
-
-        fcntl::posix_fadvise(fd, 0, 0, fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED)
-            .map_err(io::Error::from)?;
-    }
-
-    _ = path;
-
-    Ok(())
-}
-
 pub type FileOperationResult<T> = Result<T>;
 pub type FileStorageError = Error;
 

--- a/lib/common/memory/Cargo.toml
+++ b/lib/common/memory/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 bitvec = { workspace = true }
 thiserror = { workspace = true }
-libc = { workspace = true }
+nix = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/lib/common/memory/Cargo.toml
+++ b/lib/common/memory/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 bitvec = { workspace = true }
 thiserror = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/lib/common/memory/src/chunked_utils.rs
+++ b/lib/common/memory/src/chunked_utils.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::madvise::{Advice, AdviceSetting};
@@ -39,6 +40,10 @@ impl<T: Sized + 'static> UniversalMmapChunk<T> {
 
     pub fn is_empty(&self) -> bool {
         self.mmap.is_empty()
+    }
+
+    pub fn populate(&self) -> io::Result<()> {
+        self.mmap.populate()
     }
 }
 

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -193,4 +193,6 @@ pub fn clear_disk_cache(file_path: &Path) -> io::Result<()> {
             Ok(())
         }
     }
+    #[cfg(not(target_os = "linux"))]
+    Ok(())
 }

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -175,7 +175,7 @@ fn populate_simple(slice: &[u8]) {
 ///
 /// If `posix_fadvise` is not supported, this function does nothing.
 pub fn clear_disk_cache(file_path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     {
         use std::os::unix::io::AsRawFd;
 

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -1,11 +1,12 @@
 //! Platform-independent abstractions over [`memmap2::Mmap::advise`]/[`memmap2::MmapMut::advise`]
 //! and [`memmap2::Advice`].
 
-use serde::Deserialize;
 use std::hint::black_box;
 use std::io;
 use std::num::Wrapping;
 use std::path::Path;
+
+use serde::Deserialize;
 
 /// Global [`Advice`] value, to trivially set [`Advice`] value
 /// used by all memmaps created by the `segment` crate.
@@ -176,8 +177,9 @@ fn populate_simple(slice: &[u8]) {
 pub fn clear_disk_cache(file_path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
-        use libc::{POSIX_FADV_DONTNEED, posix_fadvise};
         use std::os::unix::io::AsRawFd;
+
+        use libc::{POSIX_FADV_DONTNEED, posix_fadvise};
 
         let file = std::fs::OpenOptions::new().read(true).open(file_path)?;
         let fd = file.as_raw_fd();

--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -30,7 +30,7 @@ use std::{fmt, mem, slice};
 use bitvec::slice::BitSlice;
 use memmap2::MmapMut;
 
-use crate::madvise::{Advice, AdviceSetting};
+use crate::madvise::{Advice, AdviceSetting, Madviseable};
 use crate::mmap_ops;
 
 /// Result for mmap errors.
@@ -182,6 +182,11 @@ where
     pub unsafe fn unchecked_advise(&self, advice: memmap2::UncheckedAdvice) -> std::io::Result<()> {
         unsafe { self.mmap.unchecked_advise(advice) }
     }
+
+    pub fn populate(&self) -> std::io::Result<()> {
+        self.mmap.populate();
+        Ok(())
+    }
 }
 
 impl<T> Deref for MmapType<T>
@@ -293,6 +298,13 @@ impl<T> MmapSlice<T> {
 
         Ok(())
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> std::io::Result<()> {
+        self.mmap.populate()?;
+        Ok(())
+    }
 }
 
 impl<T> Deref for MmapSlice<T> {
@@ -390,6 +402,13 @@ impl MmapBitSlice {
 
         mmap_bitslice.flusher()()?;
 
+        Ok(())
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> std::io::Result<()> {
+        self.mmap.populate()?;
         Ok(())
     }
 }

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, clear_disk_cache};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use memory::mmap_type::{self, MmapSlice};
 
@@ -252,6 +252,19 @@ impl BitmaskGaps {
                     None
                 }
             })
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> std::io::Result<()> {
+        self.mmap_slice.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> std::io::Result<()> {
+        clear_disk_cache(&self.path)?;
+        Ok(())
     }
 }
 

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use bitvec::slice::BitSlice;
 use gaps::{BitmaskGaps, RegionGaps};
 use itertools::Itertools;
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, clear_disk_cache};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use memory::mmap_type::{self, MmapBitSlice};
 
@@ -499,6 +499,21 @@ impl Bitmask {
         {
             RegionGaps::new(leading as u16, trailing as u16, max as u16)
         }
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> std::io::Result<()> {
+        self.bitslice.populate()?;
+        self.regions_gaps.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> std::io::Result<()> {
+        clear_disk_cache(&self.path)?;
+        self.regions_gaps.clear_cache()?;
+        Ok(())
     }
 }
 

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -7,6 +7,7 @@ use io::file_operations::atomic_save_json;
 use lz4_flex::compress_prepend_size;
 use memory::mmap_type;
 use parking_lot::RwLock;
+
 use crate::bitmask::Bitmask;
 use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig, StorageOptions};

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -7,7 +7,6 @@ use io::file_operations::atomic_save_json;
 use lz4_flex::compress_prepend_size;
 use memory::mmap_type;
 use parking_lot::RwLock;
-
 use crate::bitmask::Bitmask;
 use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig, StorageOptions};
@@ -525,6 +524,25 @@ impl<V> Gridstore<V> {
         });
         bitmask_guard.flush()?;
 
+        Ok(())
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> std::io::Result<()> {
+        for page in &self.pages {
+            page.populate();
+        }
+        self.bitmask.read().populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> std::io::Result<()> {
+        for page in &self.pages {
+            page.clear_cache()?;
+        }
+        self.bitmask.read().clear_cache()?;
         Ok(())
     }
 }

--- a/lib/gridstore/src/page.rs
+++ b/lib/gridstore/src/page.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use memmap2::MmapMut;
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, Madviseable, clear_disk_cache};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 
 use crate::tracker::BlockOffset;
@@ -111,5 +111,17 @@ impl Page {
     pub fn delete_page(self) {
         drop(self.mmap);
         std::fs::remove_file(&self.path).unwrap();
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) {
+        self.mmap.populate();
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> std::io::Result<()> {
+        clear_disk_cache(&self.path)?;
+        Ok(())
     }
 }

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -167,6 +167,10 @@ impl BitsStoreType for u128 {
 impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
     EncodedVectorsBin<TBitsStoreType, TStorage>
 {
+    pub fn storage(&self) -> &TStorage {
+        &self.encoded_vectors
+    }
+
     pub fn encode<'a>(
         orig_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
         mut storage_builder: impl EncodedStorageBuilder<TStorage>,

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -42,6 +42,10 @@ pub struct Metadata {
 }
 
 impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
+    pub fn storage(&self) -> &TStorage {
+        &self.encoded_vectors
+    }
+
     /// Encode vector data using product quantization.
     ///
     /// # Arguments

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -34,6 +34,10 @@ struct Metadata {
 }
 
 impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
+    pub fn storage(&self) -> &TStorage {
+        &self.encoded_vectors
+    }
+
     pub fn encode<'a>(
         orig_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
         mut storage_builder: impl EncodedStorageBuilder<TStorage>,

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -129,6 +129,7 @@ fn make_segment_index<R: Rng + ?Sized>(rnd: &mut R, distance: Distance) -> HNSWI
         },
     )
     .unwrap();
+    hnsw_index.populate().unwrap();
     hnsw_index
 }
 

--- a/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
@@ -280,6 +280,23 @@ impl MmapBoolIndex {
         .flatten()
         .collect()
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.trues_slice.populate()?;
+        self.falses_slice.populate()?;
+
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.trues_slice.clear_cache()?;
+        self.falses_slice.clear_cache()?;
+
+        Ok(())
+    }
 }
 
 /// Set or insert a flag in the given flags. Returns previous value.

--- a/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
@@ -281,6 +281,10 @@ impl MmapBoolIndex {
         .collect()
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        !self.populated
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -6,6 +6,7 @@ use simple_bool_index::SimpleBoolIndex;
 use super::facet_index::FacetIndex;
 use super::map_index::IdIter;
 use super::{PayloadFieldIndex, ValueIndexer};
+use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::telemetry::PayloadIndexTelemetry;
 
@@ -80,6 +81,25 @@ impl BoolIndex {
             BoolIndex::Simple(index) => index.values_is_empty(point_id),
             BoolIndex::Mmap(index) => index.values_is_empty(point_id),
         }
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            BoolIndex::Simple(_) => {} // Not a mmap
+            BoolIndex::Mmap(index) => index.populate()?,
+        }
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            BoolIndex::Simple(_) => {} // Not a mmap
+            BoolIndex::Mmap(index) => index.clear_cache()?,
+        }
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -83,6 +83,13 @@ impl BoolIndex {
         }
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            BoolIndex::Simple(_) => false,
+            BoolIndex::Mmap(index) => index.is_on_disk(),
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -420,6 +420,22 @@ impl FieldIndex {
         }
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            FieldIndex::IntIndex(index) => index.is_on_disk(),
+            FieldIndex::DatetimeIndex(index) => index.is_on_disk(),
+            FieldIndex::IntMapIndex(index) => index.is_on_disk(),
+            FieldIndex::KeywordIndex(index) => index.is_on_disk(),
+            FieldIndex::FloatIndex(index) => index.is_on_disk(),
+            FieldIndex::GeoIndex(index) => index.is_on_disk(),
+            FieldIndex::BoolIndex(index) => index.is_on_disk(),
+            FieldIndex::FullTextIndex(index) => index.is_on_disk(),
+            FieldIndex::UuidIndex(index) => index.is_on_disk(),
+            FieldIndex::UuidMapIndex(index) => index.is_on_disk(),
+            FieldIndex::NullIndex(index) => index.is_on_disk(),
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -1,9 +1,13 @@
 use std::fmt::Formatter;
 use std::path::PathBuf;
 
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use serde_json::Value;
+
+use super::bool_index::BoolIndex;
 use super::bool_index::mmap_bool_index::MmapBoolIndexBuilder;
 use super::bool_index::simple_bool_index::BoolIndexBuilder;
-use super::bool_index::BoolIndex;
 use super::facet_index::FacetIndexEnum;
 use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use super::full_text_index::text_index::{FullTextIndex, FullTextIndexBuilder};
@@ -12,8 +16,8 @@ use super::map_index::{MapIndex, MapIndexBuilder, MapIndexMmapBuilder};
 use super::numeric_index::{
     NumericIndex, NumericIndexBuilder, NumericIndexMmapBuilder, StreamRange,
 };
-use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::order_by::OrderValue;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::null_index::mmap_null_index::{MmapNullIndex, MmapNullIndexBuilder};
@@ -24,9 +28,6 @@ use crate::types::{
     DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchText,
     PayloadKeyType, RangeInterface, UuidIntType, UuidPayloadType,
 };
-use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::PointOffsetType;
-use serde_json::Value;
 
 pub trait PayloadFieldIndex {
     /// Return number of points with at least one value indexed in here
@@ -428,12 +429,12 @@ impl FieldIndex {
             FieldIndex::IntMapIndex(index) => index.populate(),
             FieldIndex::KeywordIndex(index) => index.populate(),
             FieldIndex::FloatIndex(index) => index.populate(),
-            FieldIndex::GeoIndex(_index) => todo!(),
-            FieldIndex::BoolIndex(_index) => todo!(),
-            FieldIndex::FullTextIndex(_index) => todo!(),
+            FieldIndex::GeoIndex(index) => index.populate(),
+            FieldIndex::BoolIndex(index) => index.populate(),
+            FieldIndex::FullTextIndex(index) => index.populate(),
             FieldIndex::UuidIndex(index) => index.populate(),
             FieldIndex::UuidMapIndex(index) => index.populate(),
-            FieldIndex::NullIndex(_index) => todo!(),
+            FieldIndex::NullIndex(index) => index.populate(),
         }
     }
 
@@ -445,12 +446,12 @@ impl FieldIndex {
             FieldIndex::IntMapIndex(index) => index.clear_cache(),
             FieldIndex::KeywordIndex(index) => index.clear_cache(),
             FieldIndex::FloatIndex(index) => index.clear_cache(),
-            FieldIndex::GeoIndex(_index) => todo!(),
-            FieldIndex::BoolIndex(_index) => todo!(),
-            FieldIndex::FullTextIndex(_index) => todo!(),
+            FieldIndex::GeoIndex(index) => index.clear_cache(),
+            FieldIndex::BoolIndex(index) => index.clear_cache(),
+            FieldIndex::FullTextIndex(index) => index.clear_cache(),
             FieldIndex::UuidIndex(index) => index.clear_cache(),
             FieldIndex::UuidMapIndex(index) => index.clear_cache(),
-            FieldIndex::NullIndex(_index) => todo!(),
+            FieldIndex::NullIndex(index) => index.clear_cache(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -1,13 +1,9 @@
 use std::fmt::Formatter;
 use std::path::PathBuf;
 
-use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::PointOffsetType;
-use serde_json::Value;
-
-use super::bool_index::BoolIndex;
 use super::bool_index::mmap_bool_index::MmapBoolIndexBuilder;
 use super::bool_index::simple_bool_index::BoolIndexBuilder;
+use super::bool_index::BoolIndex;
 use super::facet_index::FacetIndexEnum;
 use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use super::full_text_index::text_index::{FullTextIndex, FullTextIndexBuilder};
@@ -16,8 +12,8 @@ use super::map_index::{MapIndex, MapIndexBuilder, MapIndexMmapBuilder};
 use super::numeric_index::{
     NumericIndex, NumericIndexBuilder, NumericIndexMmapBuilder, StreamRange,
 };
-use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::common::Flusher;
 use crate::data_types::order_by::OrderValue;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::null_index::mmap_null_index::{MmapNullIndex, MmapNullIndexBuilder};
@@ -28,6 +24,9 @@ use crate::types::{
     DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchText,
     PayloadKeyType, RangeInterface, UuidIntType, UuidPayloadType,
 };
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use serde_json::Value;
 
 pub trait PayloadFieldIndex {
     /// Return number of points with at least one value indexed in here
@@ -417,6 +416,41 @@ impl FieldIndex {
             | FieldIndex::GeoIndex(_)
             | FieldIndex::FullTextIndex(_)
             | FieldIndex::NullIndex(_) => None,
+        }
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            FieldIndex::IntIndex(index) => index.populate(),
+            FieldIndex::DatetimeIndex(index) => index.populate(),
+            FieldIndex::IntMapIndex(index) => index.populate(),
+            FieldIndex::KeywordIndex(index) => index.populate(),
+            FieldIndex::FloatIndex(index) => index.populate(),
+            FieldIndex::GeoIndex(_index) => todo!(),
+            FieldIndex::BoolIndex(_index) => todo!(),
+            FieldIndex::FullTextIndex(_index) => todo!(),
+            FieldIndex::UuidIndex(index) => index.populate(),
+            FieldIndex::UuidMapIndex(index) => index.populate(),
+            FieldIndex::NullIndex(_index) => todo!(),
+        }
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            FieldIndex::IntIndex(index) => index.clear_cache(),
+            FieldIndex::DatetimeIndex(index) => index.clear_cache(),
+            FieldIndex::IntMapIndex(index) => index.clear_cache(),
+            FieldIndex::KeywordIndex(index) => index.clear_cache(),
+            FieldIndex::FloatIndex(index) => index.clear_cache(),
+            FieldIndex::GeoIndex(_index) => todo!(),
+            FieldIndex::BoolIndex(_index) => todo!(),
+            FieldIndex::FullTextIndex(_index) => todo!(),
+            FieldIndex::UuidIndex(index) => index.clear_cache(),
+            FieldIndex::UuidMapIndex(index) => index.clear_cache(),
+            FieldIndex::NullIndex(_index) => todo!(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -7,7 +7,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::zeros::WriteZerosExt;
 use memmap2::Mmap;
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, Madviseable};
 use memory::mmap_ops::open_read_mmap;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -233,5 +233,11 @@ impl MmapPostings {
             header,
             on_disk: !populate,
         })
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) {
+        self.mmap.populate();
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -137,6 +137,10 @@ impl MmapInvertedIndex {
         ]
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        self.is_on_disk
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -87,7 +87,7 @@ impl MmapInvertedIndex {
         let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
         let postings = MmapPostings::open(&postings_path, populate)?;
-        let vocab = MmapHashMap::<str, TokenId>::open(&vocab_path)?;
+        let vocab = MmapHashMap::<str, TokenId>::open(&vocab_path, false)?;
 
         let point_to_tokens_count = unsafe {
             MmapSlice::try_from(mmap_ops::open_write_mmap(

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -5,7 +5,7 @@ use bitvec::vec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap_hashmap::{MmapHashMap, READ_ENTRY_OVERHEAD};
 use common::types::PointOffsetType;
-use memory::madvise::AdviceSetting;
+use memory::madvise::{AdviceSetting, clear_disk_cache};
 use memory::mmap_ops;
 use memory::mmap_type::{MmapBitSlice, MmapSlice};
 use mmap_postings::MmapPostings;
@@ -135,6 +135,25 @@ impl MmapInvertedIndex {
             self.path.join(POINT_TO_TOKENS_COUNT_FILE),
             self.path.join(DELETED_POINTS_FILE),
         ]
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.postings.populate();
+        self.vocab.populate()?;
+        self.point_to_tokens_count.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        let files = self.files();
+        for file in files {
+            clear_disk_cache(&file)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -61,6 +61,10 @@ impl MmapFullTextIndex {
         self.inverted_index.deleted_points.flusher()
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        self.inverted_index.is_on_disk()
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -60,6 +60,19 @@ impl MmapFullTextIndex {
     pub fn flusher(&self) -> Flusher {
         self.inverted_index.deleted_points.flusher()
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.inverted_index.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.inverted_index.clear_cache()?;
+        Ok(())
+    }
 }
 
 pub struct FullTextMmapIndexBuilder {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -260,6 +260,27 @@ impl FullTextIndex {
         let parsed_query = self.parse_query(query, hw_counter);
         self.filter(parsed_query, hw_counter)
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            FullTextIndex::Mutable(_) => {}   // Not a mmap
+            FullTextIndex::Immutable(_) => {} // Not a mmap
+            FullTextIndex::Mmap(index) => index.populate()?,
+        }
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            FullTextIndex::Mutable(_) => {}   // Not a mmap
+            FullTextIndex::Immutable(_) => {} // Not a mmap
+            FullTextIndex::Mmap(index) => index.clear_cache()?,
+        }
+        Ok(())
+    }
 }
 
 pub struct FullTextIndexBuilder(FullTextIndex);

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -261,6 +261,14 @@ impl FullTextIndex {
         self.filter(parsed_query, hw_counter)
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            FullTextIndex::Mutable(_) => false,
+            FullTextIndex::Immutable(_) => false,
+            FullTextIndex::Mmap(index) => index.is_on_disk(),
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -398,6 +398,10 @@ impl MmapGeoMapIndex {
         ConditionedCounter::new(self.is_on_disk, hw_counter)
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        self.is_on_disk
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use memmap2::MmapMut;
-use memory::madvise::AdviceSetting;
+use memory::madvise::{AdviceSetting, clear_disk_cache};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use memory::mmap_type::{MmapBitSlice, MmapSlice};
 use serde::{Deserialize, Serialize};
@@ -396,5 +396,32 @@ impl MmapGeoMapIndex {
         hw_counter: &'a HardwareCounterCell,
     ) -> ConditionedCounter<'a> {
         ConditionedCounter::new(self.is_on_disk, hw_counter)
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.counts_per_hash.populate()?;
+        self.points_map.populate()?;
+        self.points_map_ids.populate()?;
+        self.point_to_values.populate();
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        let deleted_path = self.path.join(DELETED_PATH);
+        let counts_per_hash_path = self.path.join(COUNTS_PER_HASH);
+        let points_map_path = self.path.join(POINTS_MAP);
+        let points_map_ids_path = self.path.join(POINTS_MAP_IDS);
+
+        clear_disk_cache(&deleted_path)?;
+        clear_disk_cache(&counts_per_hash_path)?;
+        clear_disk_cache(&points_map_path)?;
+        clear_disk_cache(&points_map_ids_path)?;
+
+        self.point_to_values.clear_cache()?;
+
+        Ok(())
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -224,7 +224,7 @@ impl MmapGeoMapIndex {
                 populate,
             )?)?
         };
-        let point_to_values = MmapPointToValues::open(path)?;
+        let point_to_values = MmapPointToValues::open(path, true)?;
 
         let deleted = open_write_mmap(&deleted_path, AdviceSetting::Global, populate)?;
         let deleted = MmapBitSlice::from(deleted, 0);

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -343,6 +343,14 @@ impl GeoMapIndex {
         self.values_count(idx) == 0
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            GeoMapIndex::Mutable(_) => false,
+            GeoMapIndex::Immutable(_) => false,
+            GeoMapIndex::Mmap(index) => index.is_on_disk(),
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -342,6 +342,27 @@ impl GeoMapIndex {
     pub fn values_is_empty(&self, idx: PointOffsetType) -> bool {
         self.values_count(idx) == 0
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            GeoMapIndex::Mutable(_) => {}   // Not a mmap
+            GeoMapIndex::Immutable(_) => {} // Not a mmap
+            GeoMapIndex::Mmap(index) => index.populate()?,
+        }
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            GeoMapIndex::Mutable(_) => {}   // Not a mmap
+            GeoMapIndex::Immutable(_) => {} // Not a mmap
+            GeoMapIndex::Mmap(index) => index.clear_cache()?,
+        }
+        Ok(())
+    }
 }
 
 pub struct GeoMapIndexBuilder(GeoMapIndex);

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -13,7 +13,7 @@ use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use itertools::Itertools;
 use memmap2::MmapMut;
-use memory::madvise::AdviceSetting;
+use memory::madvise::{AdviceSetting, clear_disk_cache};
 use memory::mmap_ops::{self, create_and_ensure_length};
 use memory::mmap_type::MmapBitSlice;
 use serde::{Deserialize, Serialize};
@@ -51,10 +51,11 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
 
         let config: MmapMapIndexConfig = read_json(&config_path)?;
 
-        let hashmap = MmapHashMap::open(&hashmap_path)?;
-        let point_to_values = MmapPointToValues::open(path)?;
-
         let do_populate = !is_on_disk;
+
+        let hashmap = MmapHashMap::open(&hashmap_path, do_populate)?;
+        let point_to_values = MmapPointToValues::open(path, do_populate)?;
+
         let deleted = mmap_ops::open_write_mmap(&deleted_path, AdviceSetting::Global, do_populate)?;
         let deleted = MmapBitSlice::from(deleted, 0);
         let deleted_count = deleted.count_ones();
@@ -331,5 +332,21 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         hw_counter: &'a HardwareCounterCell,
     ) -> ConditionedCounter<'a> {
         ConditionedCounter::new(self.is_on_disk, hw_counter)
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.value_to_points.populate()?;
+        self.point_to_values.populate();
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        let value_to_points_path = self.path.join(HASHMAP_PATH);
+        clear_disk_cache(&value_to_points_path)?;
+        self.point_to_values.clear_cache()?;
+        Ok(())
     }
 }

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -345,7 +345,11 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let value_to_points_path = self.path.join(HASHMAP_PATH);
+        let deleted_path = self.path.join(DELETED_PATH);
+
         clear_disk_cache(&value_to_points_path)?;
+        clear_disk_cache(&deleted_path)?;
+
         self.point_to_values.clear_cache()?;
         Ok(())
     }

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -334,6 +334,10 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         ConditionedCounter::new(self.is_on_disk, hw_counter)
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        self.is_on_disk
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -7,19 +7,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use ahash::HashMap;
-use common::counter::hardware_counter::HardwareCounterCell;
-use common::mmap_hashmap::Key;
-use common::types::PointOffsetType;
-use indexmap::IndexSet;
-use itertools::Itertools;
-use mmap_map_index::MmapMapIndex;
-use parking_lot::RwLock;
-use rocksdb::DB;
-use serde_json::Value;
-use smol_str::SmolStr;
-use uuid::Uuid;
-
 use self::immutable_map_index::ImmutableMapIndex;
 use self::mutable_map_index::MutableMapIndex;
 use super::FieldIndexBuilderTrait;
@@ -38,6 +25,18 @@ use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
     PayloadKeyType, UuidIntType, ValueVariants,
 };
+use ahash::HashMap;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::mmap_hashmap::Key;
+use common::types::PointOffsetType;
+use indexmap::IndexSet;
+use itertools::Itertools;
+use mmap_map_index::MmapMapIndex;
+use parking_lot::RwLock;
+use rocksdb::DB;
+use serde_json::Value;
+use smol_str::SmolStr;
+use uuid::Uuid;
 
 pub mod immutable_map_index;
 pub mod mmap_map_index;
@@ -433,6 +432,27 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
                 .flat_map(move |key| self.get_iterator(key.borrow(), hw_counter).copied())
                 .unique(),
         )
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            MapIndex::Mutable(_) => {}   // Not a mmap
+            MapIndex::Immutable(_) => {} // Not a mmap
+            MapIndex::Mmap(index) => index.populate()?,
+        }
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            MapIndex::Mutable(_) => {}   // Not a mmap
+            MapIndex::Immutable(_) => {} // Not a mmap
+            MapIndex::Mmap(index) => index.clear_cache()?,
+        }
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -7,6 +7,19 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
+use ahash::HashMap;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::mmap_hashmap::Key;
+use common::types::PointOffsetType;
+use indexmap::IndexSet;
+use itertools::Itertools;
+use mmap_map_index::MmapMapIndex;
+use parking_lot::RwLock;
+use rocksdb::DB;
+use serde_json::Value;
+use smol_str::SmolStr;
+use uuid::Uuid;
+
 use self::immutable_map_index::ImmutableMapIndex;
 use self::mutable_map_index::MutableMapIndex;
 use super::FieldIndexBuilderTrait;
@@ -25,18 +38,6 @@ use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
     PayloadKeyType, UuidIntType, ValueVariants,
 };
-use ahash::HashMap;
-use common::counter::hardware_counter::HardwareCounterCell;
-use common::mmap_hashmap::Key;
-use common::types::PointOffsetType;
-use indexmap::IndexSet;
-use itertools::Itertools;
-use mmap_map_index::MmapMapIndex;
-use parking_lot::RwLock;
-use rocksdb::DB;
-use serde_json::Value;
-use smol_str::SmolStr;
-use uuid::Uuid;
 
 pub mod immutable_map_index;
 pub mod mmap_map_index;

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -435,6 +435,15 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
         )
     }
 
+
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            MapIndex::Mutable(_) => false,
+            MapIndex::Immutable(_) => false,
+            MapIndex::Mmap(index) => index.is_on_disk(),
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -435,7 +435,6 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
         )
     }
 
-
     pub fn is_on_disk(&self) -> bool {
         match self {
             MapIndex::Mutable(_) => false,

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -177,6 +177,22 @@ impl MmapNullIndex {
             histogram_bucket_size: None,
         }
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.is_null_slice.populate()?;
+        self.has_values_slice.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.is_null_slice.clear_cache()?;
+        self.has_values_slice.clear_cache()?;
+
+        Ok(())
+    }
 }
 
 impl PayloadFieldIndex for MmapNullIndex {

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -178,6 +178,10 @@ impl MmapNullIndex {
         }
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        !POPULATE_NULL_INDEX
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -367,7 +367,10 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let pairs_path = self.path.join(PAIRS_PATH);
+        let deleted_path = self.path.join(DELETED_PATH);
+
         clear_disk_cache(&pairs_path)?;
+        clear_disk_cache(&deleted_path)?;
 
         self.point_to_values.clear_cache()?;
 

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -8,7 +8,7 @@ use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use memmap2::MmapMut;
-use memory::madvise::AdviceSetting;
+use memory::madvise::{AdviceSetting, clear_disk_cache};
 use memory::mmap_ops::{self, create_and_ensure_length};
 use memory::mmap_type::{MmapBitSlice, MmapSlice};
 use serde::{Deserialize, Serialize};
@@ -168,7 +168,7 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
                 do_populate,
             )?)?
         };
-        let point_to_values = MmapPointToValues::open(path)?;
+        let point_to_values = MmapPointToValues::open(path, do_populate)?;
 
         Ok(Self {
             pairs: map,
@@ -354,5 +354,23 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         hw_counter: &'a HardwareCounterCell,
     ) -> ConditionedCounter<'a> {
         ConditionedCounter::new(self.is_on_disk, hw_counter)
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.pairs.populate()?;
+        self.point_to_values.populate();
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        let pairs_path = self.path.join(PAIRS_PATH);
+        clear_disk_cache(&pairs_path)?;
+
+        self.point_to_values.clear_cache()?;
+
+        Ok(())
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -356,6 +356,10 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         ConditionedCounter::new(self.is_on_disk, hw_counter)
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        self.is_on_disk
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -422,6 +422,14 @@ impl<T: Encodable + Numericable + MmapValue + Default> NumericIndexInner<T> {
         }
     }
 
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            NumericIndexInner::Mutable(_) => false,
+            NumericIndexInner::Immutable(_) => false,
+            NumericIndexInner::Mmap(index) => index.is_on_disk(),
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
@@ -516,6 +524,7 @@ impl<T: Encodable + Numericable + MmapValue + Default, P> NumericIndex<T, P> {
             pub fn values_count(&self, idx: PointOffsetType) -> usize;
             pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>>;
             pub fn values_is_empty(&self, idx: PointOffsetType) -> bool;
+            pub fn is_on_disk(&self) -> bool;
             pub fn populate(&self) -> OperationResult<()>;
             pub fn clear_cache(&self) -> OperationResult<()>;
         }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -25,6 +25,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use uuid::Uuid;
+
 use self::immutable_numeric_index::ImmutableNumericIndex;
 use super::FieldIndexBuilderTrait;
 use super::histogram::Point;
@@ -425,8 +426,8 @@ impl<T: Encodable + Numericable + MmapValue + Default> NumericIndexInner<T> {
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
         match self {
-            NumericIndexInner::Mutable(_) => {}, // Not a mmap
-            NumericIndexInner::Immutable(_) => {}, // Not a mmap
+            NumericIndexInner::Mutable(_) => {}   // Not a mmap
+            NumericIndexInner::Immutable(_) => {} // Not a mmap
             NumericIndexInner::Mmap(index) => index.populate()?,
         }
         Ok(())
@@ -435,7 +436,7 @@ impl<T: Encodable + Numericable + MmapValue + Default> NumericIndexInner<T> {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         match self {
-            NumericIndexInner::Mutable(_) => {} // Not a mmap
+            NumericIndexInner::Mutable(_) => {}   // Not a mmap
             NumericIndexInner::Immutable(_) => {} // Not a mmap
             NumericIndexInner::Mmap(index) => index.clear_cache()?,
         }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -345,6 +345,11 @@ impl GraphLayers {
     pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
         self.links.prefault_mmap_pages(path)
     }
+
+    pub fn populate(&self) -> OperationResult<()> {
+        self.links.populate()?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -6,7 +6,6 @@ use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoredPointOffset};
 use io::file_operations::read_bin;
 use itertools::Itertools;
-use memory::mmap_ops;
 use serde::{Deserialize, Serialize};
 
 use super::entry_points::EntryPoint;
@@ -340,10 +339,6 @@ impl GraphLayers {
             self.m0,
         )
         .to_graph_links_ram();
-    }
-
-    pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
-        self.links.prefault_mmap_pages(path)
     }
 
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use common::types::PointOffsetType;
 use memmap2::Mmap;
 use memory::madvise::{Advice, AdviceSetting, Madviseable};
-use memory::mmap_ops;
 use memory::mmap_ops::open_read_mmap;
 
 use crate::common::operation_error::OperationResult;
@@ -143,16 +142,6 @@ impl GraphLinks {
             edges.push(levels);
         }
         edges
-    }
-
-    pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
-        match self.borrow_owner() {
-            GraphLinksEnum::Mmap(mmap) => Some(mmap_ops::PrefaultMmapPages::new(
-                Arc::clone(mmap),
-                Some(path.to_owned()),
-            )),
-            GraphLinksEnum::Ram(_) => None,
-        }
     }
 
     /// Populate the disk cache with data, if applicable.

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use common::types::PointOffsetType;
 use memmap2::Mmap;
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, Madviseable};
 use memory::mmap_ops;
 use memory::mmap_ops::open_read_mmap;
 
@@ -153,6 +153,16 @@ impl GraphLinks {
             )),
             GraphLinksEnum::Ram(_) => None,
         }
+    }
+
+    /// Populate the disk cache with data, if applicable.
+    /// This is a blocking operation.
+    pub fn populate(&self) -> OperationResult<()> {
+        match self.borrow_owner() {
+            GraphLinksEnum::Mmap(mmap) => mmap.populate(),
+            GraphLinksEnum::Ram(_) => {}
+        };
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -483,7 +483,10 @@ impl HNSWIndex {
 
         config.indexed_vector_count.replace(indexed_vectors);
 
-        let is_on_disk = hnsw_config.on_disk.unwrap_or(false);
+
+        // Always skip loading graph to RAM on build
+        // as it will be discarded anyway
+        let is_on_disk = true;
 
         let graph: GraphLayers =
             graph_layers_builder.into_graph_layers(path, LINK_COMPRESSION_FORMAT, is_on_disk)?;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -15,7 +15,6 @@ use common::ext::BitSliceExt as _;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use log::debug;
 use memory::madvise::clear_disk_cache;
-use memory::mmap_ops;
 use parking_lot::Mutex;
 use rayon::ThreadPool;
 use rayon::prelude::*;
@@ -1130,10 +1129,6 @@ impl HNSWIndex {
         };
         postprocess_result.truncate(top);
         Ok(postprocess_result)
-    }
-
-    pub fn prefault_mmap_pages(&self) -> Option<mmap_ops::PrefaultMmapPages> {
-        self.graph.prefault_mmap_pages(&self.path)
     }
 
     /// Read underlying data from disk into disk cache.

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -483,7 +483,6 @@ impl HNSWIndex {
 
         config.indexed_vector_count.replace(indexed_vectors);
 
-
         // Always skip loading graph to RAM on build
         // as it will be discarded anyway
         let is_on_disk = true;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -5,6 +5,21 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::thread;
 
+use atomic_refcell::AtomicRefCell;
+use bitvec::prelude::BitSlice;
+use bitvec::vec::BitVec;
+use common::counter::hardware_counter::HardwareCounterCell;
+#[cfg(target_os = "linux")]
+use common::cpu::linux_low_thread_priority;
+use common::ext::BitSliceExt as _;
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use log::debug;
+use memory::madvise::clear_disk_cache;
+use memory::mmap_ops;
+use parking_lot::Mutex;
+use rayon::ThreadPool;
+use rayon::prelude::*;
+
 #[cfg(feature = "gpu")]
 use super::gpu::gpu_devices_manager::LockedGpuDevice;
 use super::gpu::gpu_vector_storage::GpuVectorStorage;
@@ -43,20 +58,6 @@ use crate::vector_storage::query::DiscoveryQuery;
 use crate::vector_storage::{
     RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer, new_stoppable_raw_scorer,
 };
-use atomic_refcell::AtomicRefCell;
-use bitvec::prelude::BitSlice;
-use bitvec::vec::BitVec;
-use common::counter::hardware_counter::HardwareCounterCell;
-#[cfg(target_os = "linux")]
-use common::cpu::linux_low_thread_priority;
-use common::ext::BitSliceExt as _;
-use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
-use log::debug;
-use memory::madvise::clear_disk_cache;
-use memory::mmap_ops;
-use parking_lot::Mutex;
-use rayon::ThreadPool;
-use rayon::prelude::*;
 
 const HNSW_USE_HEURISTIC: bool = true;
 const FINISH_MAIN_GRAPH_LOG_MESSAGE: &str = "Finish main graph in time";

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -74,10 +74,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         &self.payload_index
     }
 
-    pub fn inverted_index(&self) -> &TInvertedIndex {
-        &self.inverted_index
-    }
-
     pub fn indices_tracker(&self) -> &IndicesTracker {
         &self.indices_tracker
     }
@@ -242,6 +238,10 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             TInvertedIndex::from_ram_index(Cow::Owned(ram_index_builder.build()), path)?,
             indices_tracker,
         ))
+    }
+
+    pub fn inverted_index(&self) -> &TInvertedIndex {
+        &self.inverted_index
     }
 
     /// Returns the maximum number of results that can be returned by the index for a given sparse vector

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -441,6 +441,35 @@ impl StructPayloadIndex {
                 key: key.to_string(),
             })
     }
+
+    pub fn populate(&self) -> OperationResult<()> {
+        for (_, field_indexes) in self.field_indexes.iter() {
+            for index in field_indexes {
+                index.populate()?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        for (_, field_indexes) in self.field_indexes.iter() {
+            for index in field_indexes {
+                index.clear_cache()?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn clear_cache_if_on_disk(&self) -> OperationResult<()> {
+        for (_, field_indexes) in self.field_indexes.iter() {
+            for index in field_indexes {
+                if index.is_on_disk() {
+                    index.clear_cache()?;
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 impl PayloadIndex for StructPayloadIndex {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -1,14 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use super::hnsw_index::hnsw::HNSWIndex;
-use super::plain_vector_index::PlainVectorIndex;
-use super::sparse_index::sparse_vector_index::SparseVectorIndex;
-use crate::common::operation_error::OperationResult;
-use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
-use crate::telemetry::VectorIndexSearchesTelemetry;
-use crate::types::{Filter, SearchParams, SeqNumberType};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use half::f16;
@@ -19,6 +11,15 @@ use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndex
 use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+
+use super::hnsw_index::hnsw::HNSWIndex;
+use super::plain_vector_index::PlainVectorIndex;
+use super::sparse_index::sparse_vector_index::SparseVectorIndex;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::telemetry::VectorIndexSearchesTelemetry;
+use crate::types::{Filter, SearchParams, SeqNumberType};
 
 /// Trait for vector searching
 pub trait VectorIndex {

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -59,6 +59,19 @@ impl MmapPayloadStorage {
         let storage = Arc::new(RwLock::new(storage));
         Ok(Self { storage })
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.storage.read().populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.storage.read().clear_cache()?;
+        Ok(())
+    }
 }
 
 impl PayloadStorage for MmapPayloadStorage {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -207,6 +207,33 @@ impl PayloadStorage for PayloadStorageEnum {
     }
 }
 
+impl PayloadStorageEnum {
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(_) => {}
+            PayloadStorageEnum::SimplePayloadStorage(_) => {}
+            PayloadStorageEnum::OnDiskPayloadStorage(_) => {}
+            PayloadStorageEnum::MmapPayloadStorage(s) => s.populate()?,
+        }
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(_) => {}
+            PayloadStorageEnum::SimplePayloadStorage(_) => {}
+            PayloadStorageEnum::OnDiskPayloadStorage(_) => {}
+            PayloadStorageEnum::MmapPayloadStorage(s) => s.clear_cache()?,
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::Builder;

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -20,7 +20,6 @@ use std::thread::JoinHandle;
 
 use atomic_refcell::AtomicRefCell;
 use io::storage_version::StorageVersion;
-use memory::mmap_ops;
 use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
 
@@ -91,22 +90,6 @@ pub struct VectorData {
 impl fmt::Debug for VectorData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VectorData").finish_non_exhaustive()
-    }
-}
-
-impl VectorData {
-    pub fn prefault_mmap_pages(&self) -> impl Iterator<Item = mmap_ops::PrefaultMmapPages> {
-        let index_task = match &*self.vector_index.borrow() {
-            VectorIndexEnum::Hnsw(index) => index.prefault_mmap_pages(),
-            _ => None,
-        };
-
-        let storage_task = match &*self.vector_storage.borrow() {
-            VectorStorageEnum::DenseMemmap(storage) => storage.prefault_mmap_pages(),
-            _ => None,
-        };
-
-        index_task.into_iter().chain(storage_task)
     }
 }
 

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -2,13 +2,12 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
-use std::thread::{self, JoinHandle};
+use std::thread::JoinHandle;
 
 use bitvec::prelude::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
-use memory::mmap_ops;
 
 use super::{
     DB_BACKUP_PATH, PAYLOAD_DB_BACKUP_PATH, SEGMENT_STATE_FILE, SNAPSHOT_FILES_PATH, SNAPSHOT_PATH,
@@ -651,21 +650,6 @@ impl Segment {
 
     pub fn total_point_count(&self) -> usize {
         self.id_tracker.borrow().total_point_count()
-    }
-
-    pub fn prefault_mmap_pages(&self) {
-        let tasks: Vec<_> = self
-            .vector_data
-            .values()
-            .flat_map(|data| data.prefault_mmap_pages())
-            .collect();
-
-        let _ = thread::Builder::new()
-            .name(format!(
-                "segment-{:?}-prefault-mmap-pages",
-                self.current_path,
-            ))
-            .spawn(move || tasks.iter().for_each(mmap_ops::PrefaultMmapPages::exec));
     }
 
     pub fn cleanup_versions(&mut self) -> OperationResult<()> {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -534,7 +534,7 @@ impl SegmentBuilder {
             let payload_index_path = get_payload_index_path(temp_dir.path());
 
             let mut payload_index = StructPayloadIndex::open(
-                payload_storage_arc,
+                payload_storage_arc.clone(),
                 id_tracker_arc.clone(),
                 vector_storages_arc.clone(),
                 &payload_index_path,
@@ -564,12 +564,14 @@ impl SegmentBuilder {
             let permit = Arc::new(permit);
 
             for (vector_name, vector_config) in &segment_config.vector_data {
-                build_vector_index(
+                let vector_storage = vector_storages_arc.remove(vector_name).unwrap();
+
+                let index = build_vector_index(
                     vector_config,
                     VectorIndexOpenArgs {
                         path: &get_vector_index_path(temp_dir.path(), vector_name),
                         id_tracker: id_tracker_arc.clone(),
-                        vector_storage: vector_storages_arc.remove(vector_name).unwrap(),
+                        vector_storage: vector_storage.clone(),
                         payload_index: payload_index_arc.clone(),
                         quantized_vectors: Arc::new(AtomicRefCell::new(
                             quantized_vectors.remove(vector_name),
@@ -582,6 +584,16 @@ impl SegmentBuilder {
                         stopped,
                     },
                 )?;
+
+                if vector_storage.borrow().is_on_disk() {
+                    // If vector storage is expected to be on-disk, we need to clear cache
+                    // to avoid cache pollution
+                    vector_storage.borrow().clear_cache()?;
+                }
+
+                // Index if always loaded on-disk=true from build function
+                // So we may clear unconditionally
+                index.clear_cache()?;
             }
 
             for (vector_name, sparse_vector_config) in &segment_config.sparse_vector_data {
@@ -589,7 +601,7 @@ impl SegmentBuilder {
 
                 let vector_storage_arc = vector_storages_arc.remove(vector_name).unwrap();
 
-                create_sparse_vector_index(SparseVectorIndexOpenArgs {
+                let index = create_sparse_vector_index(SparseVectorIndexOpenArgs {
                     config: sparse_vector_config.index,
                     id_tracker: id_tracker_arc.clone(),
                     vector_storage: vector_storage_arc.clone(),
@@ -598,7 +610,26 @@ impl SegmentBuilder {
                     stopped,
                     tick_progress: || (),
                 })?;
+
+                if sparse_vector_config.storage_type.is_on_disk() {
+                    // If vector storage is expected to be on-disk, we need to clear cache
+                    // to avoid cache pollution
+                    vector_storage_arc.borrow().clear_cache()?;
+                }
+
+                if sparse_vector_config.index.index_type.is_on_disk() {
+                    index.clear_cache()?;
+                }
             }
+
+            if segment_config.payload_storage_type.is_on_disk() {
+                // If payload storage is expected to be on-disk, we need to clear cache
+                // to avoid cache pollution
+                payload_storage_arc.borrow().clear_cache()?;
+            }
+
+            // Clear cache for payload index to avoid cache pollution
+            payload_index_arc.borrow().clear_cache_if_on_disk()?;
 
             // We're done with CPU-intensive tasks, release CPU permit
             debug_assert_eq!(

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -548,6 +548,13 @@ impl Indexes {
             Indexes::Hnsw(_) => true,
         }
     }
+
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            Indexes::Plain {} => false,
+            Indexes::Hnsw(config) => config.on_disk.unwrap_or_default(),
+        }
+    }
 }
 
 /// Config of HNSW index
@@ -1373,6 +1380,18 @@ pub enum SparseVectorStorageType {
     // (gridstore storage)
     #[default]
     Mmap,
+}
+
+impl SparseVectorStorageType {
+    /// Whether this storage type is a mmap on disk
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            // Both options are on disk, but we keep it explicit for the case if someone adds a new
+            // storage type in the future
+            Self::OnDisk => true,
+            Self::Mmap => true,
+        }
+    }
 }
 
 /// Config of single sparse vector data storage

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -8,7 +8,7 @@ use common::maybe_uninit::maybe_uninit_fill_from;
 use io::file_operations::atomic_save_json;
 use memmap2::MmapMut;
 use memory::chunked_utils::{UniversalMmapChunk, chunk_name, create_chunk, read_mmaps};
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, clear_disk_cache};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use memory::mmap_type::MmapType;
 use num_traits::AsPrimitive;
@@ -337,6 +337,16 @@ impl<T: Sized + Copy + 'static> ChunkedMmapVectors<T> {
             files.push(chunk_name(&self.directory, chunk_idx));
         }
         files
+    }
+}
+
+impl<T: Sized + 'static> ChunkedMmapVectors<T> {
+    fn clear_cache(&self) -> OperationResult<()> {
+        for chunk_idx in 0..self.chunks.len() {
+            let file_path = chunk_name(&self.directory, chunk_idx);
+            clear_disk_cache(&file_path)?;
+        }
+        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -340,16 +340,6 @@ impl<T: Sized + Copy + 'static> ChunkedMmapVectors<T> {
     }
 }
 
-impl<T: Sized + 'static> ChunkedMmapVectors<T> {
-    fn clear_cache(&self) -> OperationResult<()> {
-        for chunk_idx in 0..self.chunks.len() {
-            let file_path = chunk_name(&self.directory, chunk_idx);
-            clear_disk_cache(&file_path)?;
-        }
-        Ok(())
-    }
-}
-
 impl<T: Sized + Copy + 'static> ChunkedVectorStorage<T> for ChunkedMmapVectors<T> {
     #[inline]
     fn len(&self) -> usize {
@@ -432,6 +422,21 @@ impl<T: Sized + Copy + 'static> ChunkedVectorStorage<T> for ChunkedMmapVectors<T
 
     fn is_on_disk(&self) -> bool {
         true
+    }
+
+    fn populate(&self) -> OperationResult<()> {
+        for chunk in &self.chunks {
+            chunk.populate()?;
+        }
+        Ok(())
+    }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        for chunk_idx in 0..self.chunks.len() {
+            let file_path = chunk_name(&self.directory, chunk_idx);
+            clear_disk_cache(&file_path)?;
+        }
+        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/chunked_vector_storage.rs
@@ -60,4 +60,11 @@ pub trait ChunkedVectorStorage<T> {
 
     /// True, if this storage is on-disk by default.
     fn is_on_disk(&self) -> bool;
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    fn populate(&self) -> OperationResult<()>;
+
+    /// Drop disk cache.
+    fn clear_cache(&self) -> OperationResult<()>;
 }

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -55,6 +55,21 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> AppendableMmapDenseV
         }
         Ok(previous)
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.deleted.populate()?;
+        self.vectors.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.deleted.clear_cache()?;
+        self.vectors.clear_cache()?;
+        Ok(())
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> DenseVectorStorage<T>

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -8,7 +8,7 @@ use bitvec::prelude::BitSlice;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::types::PointOffsetType;
 use memmap2::MmapMut;
-use memory::madvise::{self, AdviceSetting, Madviseable as _};
+use memory::madvise::{self, clear_disk_cache, AdviceSetting, Madviseable as _};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use memory::mmap_type::{MmapBitSlice, MmapFlusher, MmapType};
 use parking_lot::Mutex;
@@ -283,6 +283,20 @@ impl DynamicMmapFlags {
     /// Iterate over all "true" flags
     pub fn iter_trues(&self) -> impl Iterator<Item = PointOffsetType> + '_ {
         self.flags.iter_ones().map(|x| x as PointOffsetType)
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.flags.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        let flags_file = self.directory.join(FLAGS_FILE);
+        clear_disk_cache(&flags_file)?;
+        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -8,7 +8,7 @@ use bitvec::prelude::BitSlice;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::types::PointOffsetType;
 use memmap2::MmapMut;
-use memory::madvise::{self, clear_disk_cache, AdviceSetting, Madviseable as _};
+use memory::madvise::{self, AdviceSetting, Madviseable as _, clear_disk_cache};
 use memory::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use memory::mmap_type::{MmapBitSlice, MmapFlusher, MmapType};
 use parking_lot::Mutex;

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -127,14 +127,6 @@ fn open_memmap_vector_storage_with_async_io_impl<T: PrimitiveVectorElement>(
 }
 
 impl<T: PrimitiveVectorElement> MemmapDenseVectorStorage<T> {
-    pub fn prefault_mmap_pages(&self) -> Option<mmap_ops::PrefaultMmapPages> {
-        Some(
-            self.mmap_store
-                .as_ref()?
-                .prefault_mmap_pages(&self.vectors_path),
-        )
-    }
-
     pub fn get_mmap_vectors(&self) -> &MmapDenseVectors<T> {
         self.mmap_store.as_ref().unwrap()
     }

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -9,7 +9,7 @@ use common::ext::BitSliceExt as _;
 use common::maybe_uninit::maybe_uninit_fill_from;
 use common::types::PointOffsetType;
 use memmap2::Mmap;
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, Madviseable};
 use memory::mmap_ops;
 use memory::mmap_type::{MmapBitSlice, MmapFlusher};
 use parking_lot::Mutex;
@@ -246,6 +246,11 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
             self.process_points_simple(points, callback);
             Ok(())
         }
+    }
+
+    pub fn populate(&self) -> OperationResult<()> {
+        self.mmap.populate();
+        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -199,10 +199,6 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
         &self.deleted
     }
 
-    pub fn prefault_mmap_pages(&self, path: &Path) -> mmap_ops::PrefaultMmapPages {
-        mmap_ops::PrefaultMmapPages::new(self.mmap.clone(), Some(path))
-    }
-
     #[cfg(target_os = "linux")]
     fn process_points_uring(
         &self,

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -112,4 +112,12 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
     fn is_on_disk(&self) -> bool {
         false
     }
+
+    fn populate(&self) -> OperationResult<()> {
+        self.mmap_storage.populate()
+    }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        self.mmap_storage.clear_cache()
+    }
 }

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -70,6 +70,21 @@ impl<
         }
         Ok(previous)
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.vectors.populate()?;
+        self.offsets.populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.vectors.clear_cache()?;
+        self.offsets.clear_cache()?;
+        Ok(())
+    }
 }
 
 impl<

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -2,10 +2,17 @@ use std::path::Path;
 
 use memmap2::{Mmap, MmapMut};
 use memory::madvise;
+use memory::madvise::Madviseable;
 
 #[derive(Debug)]
 pub struct QuantizedMmapStorage {
     mmap: Mmap,
+}
+
+impl QuantizedMmapStorage {
+    pub fn populate(&self) {
+        self.mmap.populate();
+    }
 }
 
 pub struct QuantizedMmapStorageBuilder {

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -118,6 +118,10 @@ where
     QuantizedStorage: EncodedVectors<TEncodedQuery>,
     TMultivectorOffsetsStorage: MultivectorOffsetsStorage,
 {
+    pub fn storage(&self) -> &QuantizedStorage {
+        &self.quantized_storage
+    }
+
     pub fn new(
         dim: usize,
         quantized_storage: QuantizedStorage,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -2,6 +2,17 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use bitvec::slice::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use io::file_operations::{atomic_save_json, read_json};
+use memory::madvise::clear_disk_cache;
+use quantization::encoded_vectors_binary::{EncodedBinVector, EncodedVectorsBin};
+use quantization::{
+    EncodedQueryPQ, EncodedQueryU8, EncodedVectors, EncodedVectorsPQ, EncodedVectorsU8,
+};
+use serde::{Deserialize, Serialize};
+
 use super::quantized_multivector_storage::{
     MultivectorOffset, MultivectorOffsetsStorage, MultivectorOffsetsStorageMmap,
     QuantizedMultivectorStorage, create_offsets_file_from_iter,
@@ -23,16 +34,6 @@ use crate::vector_storage::quantized::quantized_mmap_storage::{
 use crate::vector_storage::{
     DenseVectorStorage, MultiVectorStorage, RawScorer, VectorStorage, VectorStorageEnum,
 };
-use bitvec::slice::BitSlice;
-use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::PointOffsetType;
-use io::file_operations::{atomic_save_json, read_json};
-use memory::madvise::clear_disk_cache;
-use quantization::encoded_vectors_binary::{EncodedBinVector, EncodedVectorsBin};
-use quantization::{
-    EncodedQueryPQ, EncodedQueryU8, EncodedVectors, EncodedVectorsPQ, EncodedVectorsU8,
-};
-use serde::{Deserialize, Serialize};
 
 pub const QUANTIZED_CONFIG_PATH: &str = "quantized.config.json";
 pub const QUANTIZED_DATA_PATH: &str = "quantized.data";

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -938,7 +938,7 @@ impl QuantizedVectors {
         &self.storage_impl
     }
 
-    pub fn pupulate(&self) -> OperationResult<()> {
+    pub fn populate(&self) -> OperationResult<()> {
         match &self.storage_impl {
             QuantizedVectorStorage::ScalarRam(_) => {} // not mmap
             QuantizedVectorStorage::ScalarMmap(storage) => storage.storage().populate(),

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -174,6 +174,21 @@ impl MmapSparseVectorStorage {
 
         Ok(())
     }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.deleted.populate()?;
+        self.storage.read().populate()?;
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.deleted.clear_cache()?;
+        self.storage.read().clear_cache()?;
+        Ok(())
+    }
 }
 
 impl SparseVectorStorage for MmapSparseVectorStorage {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -432,35 +432,60 @@ impl VectorStorageEnum {
 
     pub fn populate(&self) -> OperationResult<()> {
         match self {
-            VectorStorageEnum::DenseSimple(_) => {}
-            VectorStorageEnum::DenseSimpleByte(_) => {}
-            VectorStorageEnum::DenseSimpleHalf(_) => {}
+            VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::DenseMemmap(vs) => vs.populate()?,
             VectorStorageEnum::DenseMemmapByte(vs) => vs.populate()?,
             VectorStorageEnum::DenseMemmapHalf(vs) => vs.populate()?,
-            VectorStorageEnum::DenseAppendableMemmap(_) => {}
-            VectorStorageEnum::DenseAppendableMemmapByte(_) => todo!(),
-            VectorStorageEnum::DenseAppendableMemmapHalf(_) => {}
-            VectorStorageEnum::DenseAppendableInRam(_) => {}
-            VectorStorageEnum::DenseAppendableInRamByte(_) => {}
-            VectorStorageEnum::DenseAppendableInRamHalf(_) => {}
-            VectorStorageEnum::SparseSimple(_) => {}
-            VectorStorageEnum::SparseMmap(_) => {}
-            VectorStorageEnum::MultiDenseSimple(_) => {}
-            VectorStorageEnum::MultiDenseSimpleByte(_) => {}
-            VectorStorageEnum::MultiDenseSimpleHalf(_) => {}
-            VectorStorageEnum::MultiDenseAppendableMemmap(_) => {}
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(_) => {}
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(_) => {}
-            VectorStorageEnum::MultiDenseAppendableInRam(_) => {}
-            VectorStorageEnum::MultiDenseAppendableInRamByte(_) => {}
-            VectorStorageEnum::MultiDenseAppendableInRamHalf(_) => {}
+            VectorStorageEnum::DenseAppendableMemmap(vs) => vs.populate()?,
+            VectorStorageEnum::DenseAppendableMemmapByte(vs) => vs.populate()?,
+            VectorStorageEnum::DenseAppendableMemmapHalf(vs) => vs.populate()?,
+            VectorStorageEnum::DenseAppendableInRam(vs) => vs.populate()?,
+            VectorStorageEnum::DenseAppendableInRamByte(vs) => vs.populate()?,
+            VectorStorageEnum::DenseAppendableInRamHalf(vs) => vs.populate()?,
+            VectorStorageEnum::SparseSimple(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::SparseMmap(vs) => vs.populate()?,
+            VectorStorageEnum::MultiDenseSimple(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::MultiDenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::MultiDenseSimpleHalf(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::MultiDenseAppendableMemmap(vs) => vs.populate()?,
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(vs) => vs.populate()?,
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(vs) => vs.populate()?,
+            VectorStorageEnum::MultiDenseAppendableInRam(vs) => vs.populate()?,
+            VectorStorageEnum::MultiDenseAppendableInRamByte(vs) => vs.populate()?,
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(vs) => vs.populate()?,
         }
         Ok(())
     }
 
     pub fn clear_cache(&self) -> OperationResult<()> {
-        todo!()
+        match self {
+            VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::DenseMemmap(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseMemmapByte(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseMemmapHalf(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseAppendableMemmap(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseAppendableMemmapByte(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseAppendableMemmapHalf(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseAppendableInRam(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseAppendableInRamByte(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseAppendableInRamHalf(vs) => vs.clear_cache()?,
+            VectorStorageEnum::SparseSimple(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::SparseMmap(vs) => vs.clear_cache()?,
+            VectorStorageEnum::MultiDenseSimple(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::MultiDenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::MultiDenseSimpleHalf(_) => {} // Can't populate as it is not mmap
+            VectorStorageEnum::MultiDenseAppendableMemmap(vs) => vs.clear_cache()?,
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(vs) => vs.clear_cache()?,
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(vs) => vs.clear_cache()?,
+            VectorStorageEnum::MultiDenseAppendableInRam(vs) => vs.clear_cache()?,
+            VectorStorageEnum::MultiDenseAppendableInRamByte(vs) => vs.clear_cache()?,
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(vs) => vs.clear_cache()?,
+        }
+        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -521,7 +521,6 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-
     /// If false - data is stored in RAM (and persisted on disk)
     /// If true - data is stored on disk, and is not forced to be in RAM
     fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -429,6 +429,39 @@ impl VectorStorageEnum {
             }
         }
     }
+
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            VectorStorageEnum::DenseSimple(_) => {}
+            VectorStorageEnum::DenseSimpleByte(_) => {}
+            VectorStorageEnum::DenseSimpleHalf(_) => {}
+            VectorStorageEnum::DenseMemmap(vs) => vs.populate()?,
+            VectorStorageEnum::DenseMemmapByte(vs) => vs.populate()?,
+            VectorStorageEnum::DenseMemmapHalf(vs) => vs.populate()?,
+            VectorStorageEnum::DenseAppendableMemmap(_) => {}
+            VectorStorageEnum::DenseAppendableMemmapByte(_) => todo!(),
+            VectorStorageEnum::DenseAppendableMemmapHalf(_) => {}
+            VectorStorageEnum::DenseAppendableInRam(_) => {}
+            VectorStorageEnum::DenseAppendableInRamByte(_) => {}
+            VectorStorageEnum::DenseAppendableInRamHalf(_) => {}
+            VectorStorageEnum::SparseSimple(_) => {}
+            VectorStorageEnum::SparseMmap(_) => {}
+            VectorStorageEnum::MultiDenseSimple(_) => {}
+            VectorStorageEnum::MultiDenseSimpleByte(_) => {}
+            VectorStorageEnum::MultiDenseSimpleHalf(_) => {}
+            VectorStorageEnum::MultiDenseAppendableMemmap(_) => {}
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(_) => {}
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(_) => {}
+            VectorStorageEnum::MultiDenseAppendableInRam(_) => {}
+            VectorStorageEnum::MultiDenseAppendableInRamByte(_) => {}
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(_) => {}
+        }
+        Ok(())
+    }
+
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        todo!()
+    }
 }
 
 impl VectorStorage for VectorStorageEnum {
@@ -488,6 +521,9 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
+
+    /// If false - data is stored in RAM (and persisted on disk)
+    /// If true - data is stored on disk, and is not forced to be in RAM
     fn is_on_disk(&self) -> bool {
         match self {
             VectorStorageEnum::DenseSimple(v) => v.is_on_disk(),

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -10,7 +10,7 @@ use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use io::storage_version::StorageVersion;
 use memmap2::Mmap;
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, Madviseable, clear_disk_cache};
 use memory::mmap_ops::{
     create_and_ensure_length, open_read_mmap, transmute_from_u8_to_slice, transmute_to_u8,
     transmute_to_u8_slice,
@@ -345,6 +345,18 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
                     .map(|posting| posting.store_size().total)
             })
             .sum()
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> std::io::Result<()> {
+        self.mmap.populate();
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> std::io::Result<()> {
+        clear_disk_cache(&self.path)
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -8,7 +8,7 @@ use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use io::storage_version::StorageVersion;
 use memmap2::{Mmap, MmapMut};
-use memory::madvise::{Advice, AdviceSetting};
+use memory::madvise::{Advice, AdviceSetting, Madviseable, clear_disk_cache};
 use memory::mmap_ops::{
     create_and_ensure_length, open_read_mmap, open_write_mmap, transmute_from_u8,
     transmute_from_u8_to_slice, transmute_to_u8, transmute_to_u8_slice,
@@ -275,6 +275,18 @@ impl InvertedIndexMmap {
                 .copy_from_slice(posting_elements_bytes);
             offset += posting_elements_bytes.len();
         }
+    }
+
+    /// Populate all pages in the mmap.
+    /// Block until all pages are populated.
+    pub fn populate(&self) -> std::io::Result<()> {
+        self.mmap.populate();
+        Ok(())
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> std::io::Result<()> {
+        clear_disk_cache(&self.path)
     }
 }
 


### PR DESCRIPTION
Done:

- explicit functions for populate and clear mmap cache for: Vector storage, Vector Index, Payload Storage, Payload Index, QuantizedVectorStorage
- Remove delayed mmap population, as it seems it pollutes cache
- Implement cache clearing for dropping segment



How it was tested:

1. Create collection with bfb:

```
docker run --rm -it --network=host qdrant/bfb:dev ./bfb -n 500000 --segments 20 --quantization scalar --quantization-in-ram true -d 128 --indexing-threshold 100 --on-disk-vectors true --on-disk-payload
```

2. Reload service with clear caches and mem limit:

```
sudo bash -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
docker run --rm -it -m 600Mb --network=host -v $(pwd)/qdrant-storage:/qdrant/storage qdrant-cache-test
```

(here caches are full)

```
sudo python3 smaps-view.py $(pidof qdrant) '.*/vector_index/.*' -v
```

3. Run single-threaded indexation:

```
PATCH collections/benchmark
{
  "hnsw_config": {
    "ef_construct": 101
  },
  "optimizers_config": {
    "max_optimization_threads": 1
  }
}
```

4. Wait indexation finish, observe loss of disk cache:

```
sudo python3 smaps-view.py $(pidof qdrant) '.*/vector_index/.*' -v

> Cache percentages for pattern '.*/vector_index/.*':
>  r--s: 33.23%
```

With this PR cache is not lost.