### PR TITLE
Rate limit recommendation based on number of examples

### DIFF
--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -3,6 +3,7 @@ mod discovery;
 mod facet;
 mod local_shard;
 mod matrix;
+mod operation_rate_cost;
 mod query;
 mod recommend;
 mod search;

--- a/lib/collection/src/operations/verification/operation_rate_cost.rs
+++ b/lib/collection/src/operations/verification/operation_rate_cost.rs
@@ -1,0 +1,28 @@
+use crate::operations::query_enum::QueryEnum;
+use crate::operations::types::{CoreSearchRequest, QueryScrollRequestInternal};
+
+impl CoreSearchRequest {
+    pub fn rate_cost(&self) -> usize {
+        match &self.query {
+            QueryEnum::Nearest(_nq) => {
+                // TODO(strict-mode) should the cost be adjusted here?
+                1
+            }
+            QueryEnum::RecommendBestScore(rb) => {
+                rb.query.positives.len() + rb.query.negatives.len()
+            }
+            QueryEnum::RecommendSumScores(rs) => {
+                rs.query.positives.len() + rs.query.negatives.len()
+            }
+            QueryEnum::Discover(rd) => rd.query.pairs.len(),
+            QueryEnum::Context(rc) => rc.query.pairs.len(),
+        }
+    }
+}
+
+impl QueryScrollRequestInternal {
+    pub fn rate_cost(&self) -> usize {
+        // TODO(strict-mode) how much should a scroll cost?
+        1
+    }
+}

--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -37,7 +37,7 @@ impl RateLimiter {
         // Consumer wants more than maximum capacity, that's impossible
         if tokens > self.capacity_per_minute as f64 {
             return Err(RateLimitError::AlwaysOverBudget(
-                "request larger than than rate limiter capacity, please try to split your request",
+                "request larger than rate limiter capacity, please try to split your request",
             ));
         }
 


### PR DESCRIPTION
This PR adds rate limiting for the recommendation API (old & query) where the number of examples is used to price the query.
