### PR TITLE
Incremental HNSW index building: append-only case 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5890,6 +5890,7 @@ dependencies = [
  "sparse",
  "strum",
  "sysinfo",
+ "tap",
  "tar",
  "tempfile",
  "thiserror 2.0.12",

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -37,6 +37,10 @@ pub struct FeatureFlags {
     // ToDo(mmap-payload-index): remove for release
     #[serde(default)]
     pub payload_index_skip_rocksdb: bool,
+
+    /// Whether to use incremental HNSW building.
+    #[serde(default)]
+    pub incremental_hnsw_building: bool,
 }
 
 impl FeatureFlags {
@@ -47,10 +51,12 @@ impl FeatureFlags {
             use_new_shard_key_mapping_format,
             use_mutable_id_tracker_without_rocksdb,
             payload_index_skip_rocksdb,
+            incremental_hnsw_building,
         } = self;
         !use_new_shard_key_mapping_format
             && !use_mutable_id_tracker_without_rocksdb
             && !payload_index_skip_rocksdb
+            && !incremental_hnsw_building
     }
 }
 
@@ -62,6 +68,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         use_new_shard_key_mapping_format,
         use_mutable_id_tracker_without_rocksdb,
         payload_index_skip_rocksdb,
+        incremental_hnsw_building,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags
@@ -69,6 +76,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         *use_new_shard_key_mapping_format = true;
         *use_mutable_id_tracker_without_rocksdb = true;
         *payload_index_skip_rocksdb = true;
+        *incremental_hnsw_building = true;
     }
 
     let res = FEATURE_FLAGS.set(flags);

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -95,6 +95,7 @@ smallvec = "1.14.0"
 is_sorted = "0.1.1"
 strum = { workspace = true }
 byteorder = { workspace = true }
+tap = { workspace = true }
 zerocopy = { workspace = true }
 lazy_static = "1.5.0"
 

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -126,6 +127,7 @@ fn make_segment_index<R: Rng + ?Sized>(rnd: &mut R, distance: Distance) -> HNSWI
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -403,12 +403,40 @@ impl GraphLayersBuilder {
             // New point is a new empty entry (for this filter, at least)
             // We can't do much here, so just quit
         }
-        self.ready_list.write().set(point_id as usize, true);
+        let was_ready = self.ready_list.write().replace(point_id as usize, true);
+        assert!(!was_ready);
         self.entry_points
             .lock()
             .new_point(point_id, level, |point_id| {
                 points_scorer.check_vector(point_id)
             });
+    }
+
+    /// Add a new point using pre-existing links.
+    /// Mutually exclusive with [`Self::link_new_point`].
+    pub fn add_new_point(&self, point_id: PointOffsetType, levels: Vec<Vec<PointOffsetType>>) {
+        let level = self.get_point_level(point_id);
+        assert_eq!(levels.len(), level + 1);
+
+        for (level, neighbours) in levels.iter().enumerate() {
+            let mut links = self.links_layers[point_id as usize][level].write();
+            links.clear();
+            links.extend_from_slice(neighbours);
+        }
+
+        let was_ready = self.ready_list.write().replace(point_id as usize, true);
+        assert!(!was_ready);
+        self.entry_points
+            .lock()
+            .new_point(point_id, level, |_| true);
+    }
+
+    pub fn link_new_point_complete_indexing(&self, point_id: PointOffsetType) {
+        let level = self.get_point_level(point_id);
+        self.ready_list.write().set(point_id as usize, true);
+        self.entry_points
+            .lock()
+            .new_point(point_id, level, |_| true);
     }
 
     /// Link a new point on a specific level.

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -431,14 +431,6 @@ impl GraphLayersBuilder {
             .new_point(point_id, level, |_| true);
     }
 
-    pub fn link_new_point_complete_indexing(&self, point_id: PointOffsetType) {
-        let level = self.get_point_level(point_id);
-        self.ready_list.write().set(point_id as usize, true);
-        self.entry_points
-            .lock()
-            .new_point(point_id, level, |_| true);
-    }
-
     /// Link a new point on a specific level.
     /// Returns an entry point for the level below.
     fn link_new_point_on_level(

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -404,7 +404,7 @@ impl GraphLayersBuilder {
             // We can't do much here, so just quit
         }
         let was_ready = self.ready_list.write().replace(point_id as usize, true);
-        assert!(!was_ready);
+        debug_assert!(!was_ready);
         self.entry_points
             .lock()
             .new_point(point_id, level, |point_id| {
@@ -416,7 +416,7 @@ impl GraphLayersBuilder {
     /// Mutually exclusive with [`Self::link_new_point`].
     pub fn add_new_point(&self, point_id: PointOffsetType, levels: Vec<Vec<PointOffsetType>>) {
         let level = self.get_point_level(point_id);
-        assert_eq!(levels.len(), level + 1);
+        debug_assert_eq!(levels.len(), level + 1);
 
         for (level, neighbours) in levels.iter().enumerate() {
             let mut links = self.links_layers[point_id as usize][level].write();
@@ -425,7 +425,7 @@ impl GraphLayersBuilder {
         }
 
         let was_ready = self.ready_list.write().replace(point_id as usize, true);
-        assert!(!was_ready);
+        debug_assert!(!was_ready);
         self.entry_points
             .lock()
             .new_point(point_id, level, |_| true);

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -14,7 +14,8 @@ mod serializer;
 mod view;
 
 pub use serializer::GraphLinksSerializer;
-use view::{CompressionInfo, GraphLinksView, LinksIterator};
+pub use view::LinksIterator;
+use view::{CompressionInfo, GraphLinksView};
 
 /*
 Links data for whole graph layers.

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -208,6 +208,7 @@ impl HNSWIndex {
             old_indices: _,
             gpu_device,
             stopped,
+            feature_flags: _,
         } = build_args;
 
         create_dir_all(path)?;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1411,6 +1411,12 @@ impl<'a> OldIndexCandidate<'a> {
         let new_deleted = vector_storage.deleted_vector_bitslice();
         let old_id_tracker = old_index.id_tracker.borrow();
 
+        if old_id_tracker.deleted_point_count() != 0 {
+            // Old index has deleted points.
+            // FIXME: Not supported yet.
+            return None;
+        }
+
         // Build old_to_new mapping.
         let mut valid_points = 0;
         let mut old_to_new = vec![None; old_id_tracker.total_point_count()];
@@ -1442,7 +1448,7 @@ impl<'a> OldIndexCandidate<'a> {
                 (_, None) => (),
                 (None, Some(_)) => {
                     // Vector was in the old index, but not in the new one.
-                    // Not supported yet.
+                    // FIXME: Not supported yet.
                     return None;
                 }
                 (Some(new_offset), Some(old_offset)) => {
@@ -1453,11 +1459,15 @@ impl<'a> OldIndexCandidate<'a> {
                         valid_points += 1;
                     } else {
                         // Vector is changed.
-                        // Not supported yet.
+                        // FIXME: Not supported yet.
                         return None;
                     }
                 }
             }
+        }
+
+        if valid_points == 0 {
+            return None;
         }
 
         drop(old_id_tracker);

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::thread;
 
-use atomic_refcell::AtomicRefCell;
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use bitvec::prelude::BitSlice;
 use bitvec::vec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -13,6 +13,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::cpu::linux_low_thread_priority;
 use common::ext::BitSliceExt as _;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use itertools::EitherOrBoth;
 use log::debug;
 use memory::mmap_ops;
 use parking_lot::Mutex;
@@ -42,7 +43,7 @@ use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
-use crate::index::{PayloadIndex, VectorIndex};
+use crate::index::{PayloadIndex, VectorIndex, VectorIndexEnum};
 #[cfg(feature = "gpu")]
 use crate::payload_storage::FilterContext;
 use crate::segment_constructor::VectorIndexBuildArgs;
@@ -205,10 +206,10 @@ impl HNSWIndex {
         } = open_args;
         let VectorIndexBuildArgs {
             permit,
-            old_indices: _,
+            old_indices,
             gpu_device,
             stopped,
-            feature_flags: _,
+            feature_flags,
         } = build_args;
 
         create_dir_all(path)?;
@@ -239,6 +240,19 @@ impl HNSWIndex {
             hnsw_config.payload_m,
             total_vector_count,
         );
+
+        let old_index = old_indices
+            .iter()
+            .filter_map(|old_index| {
+                feature_flags.incremental_hnsw_building.then_some(())?;
+                OldIndexCandidate::evaluate(
+                    old_index,
+                    &config,
+                    &vector_storage_ref,
+                    id_tracker_ref.deref(),
+                )
+            })
+            .max_by_key(|old_index| old_index.valid_points);
 
         // Build main index graph
         let mut rng = rand::rng();
@@ -301,12 +315,18 @@ impl HNSWIndex {
             })
             .build()?;
 
+        let old_index = old_index.map(|old_index| old_index.reuse(&config, total_vector_count));
+
         let mut indexed_vectors = 0;
         for vector_id in id_tracker_ref.iter_ids_excluding(deleted_bitslice) {
             check_process_stopped(stopped)?;
-            let level = graph_layers_builder.get_random_layer(&mut rng);
-            graph_layers_builder.set_levels(vector_id, level);
             indexed_vectors += 1;
+
+            let level = old_index
+                .as_ref()
+                .and_then(|old_index| old_index.point_level(vector_id))
+                .unwrap_or_else(|| graph_layers_builder.get_random_layer(&mut rng));
+            graph_layers_builder.set_levels(vector_id, level);
         }
 
         #[allow(unused_mut)]
@@ -350,13 +370,23 @@ impl HNSWIndex {
         if build_main_graph {
             let timer = std::time::Instant::now();
 
-            let mut ids_iterator = id_tracker_ref.iter_ids_excluding(deleted_bitslice);
+            let mut ids = Vec::with_capacity(total_vector_count);
+            if let Some(old_index) = &old_index {
+                for vector_id in id_tracker_ref.iter_ids_excluding(deleted_bitslice) {
+                    if let Some(links) = old_index.get_links(vector_id) {
+                        graph_layers_builder.add_new_point(vector_id, links);
+                    } else {
+                        ids.push(vector_id);
+                    }
+                }
+            } else {
+                ids.extend(id_tracker_ref.iter_ids_excluding(deleted_bitslice));
+            }
 
-            let first_few_ids: Vec<_> = ids_iterator
-                .by_ref()
-                .take(SINGLE_THREADED_HNSW_BUILD_THRESHOLD)
-                .collect();
-            let ids: Vec<_> = ids_iterator.collect();
+            let first_few_ids = ids.split_off(
+                ids.len()
+                    .saturating_sub(SINGLE_THREADED_HNSW_BUILD_THRESHOLD),
+            );
 
             let insert_point = |vector_id| {
                 check_process_stopped(stopped)?;
@@ -1326,5 +1356,156 @@ impl VectorIndex for HNSWIndex {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         Err(OperationError::service_error("Cannot update HNSW index"))
+    }
+}
+
+/// Contains enough information to decide which one old index to use.
+/// Once decided, it is converted to [`OldIndex`].
+struct OldIndexCandidate<'a> {
+    index: AtomicRef<'a, HNSWIndex>,
+    /// Mapping from old index to new index.
+    /// `old_to_new[old_idx] == Some(new_idx)`.
+    old_to_new: Vec<Option<PointOffsetType>>,
+    /// Count of successfully mapped points.
+    valid_points: usize,
+}
+
+struct OldIndex<'a> {
+    index: AtomicRef<'a, HNSWIndex>,
+    /// Mapping from old index to new index.
+    /// `old_to_new[old_idx] == Some(new_idx)`.
+    old_to_new: Vec<Option<PointOffsetType>>,
+    /// Mapping from new index to old index.
+    /// `new_to_old[new_idx] == Some(old_idx)`.
+    new_to_old: Vec<Option<PointOffsetType>>,
+    m: usize,
+    m0: usize,
+}
+
+impl<'a> OldIndexCandidate<'a> {
+    /// Evaluate whether we can use the old index.
+    fn evaluate(
+        old_index: &'a Arc<AtomicRefCell<VectorIndexEnum>>,
+        config: &HnswGraphConfig,
+        vector_storage: &VectorStorageEnum,
+        id_tracker: &IdTrackerSS,
+    ) -> Option<Self> {
+        let old_index = AtomicRef::filter_map(old_index.borrow(), |index| match index {
+            VectorIndexEnum::Hnsw(old_index) => Some(old_index),
+            _ => None,
+        })?;
+
+        let no_main_graph = config.m == 0;
+        let configuration_mismatch = config.m != old_index.config.m
+            || config.m0 != old_index.config.m0
+            || config.ef_construct != old_index.config.ef_construct;
+        if no_main_graph || configuration_mismatch {
+            return None;
+        }
+
+        let old_storage_ref = old_index.vector_storage.borrow();
+
+        let new_deleted = vector_storage.deleted_vector_bitslice();
+        let old_id_tracker = old_index.id_tracker.borrow();
+
+        // Build old_to_new mapping.
+        let mut valid_points = 0;
+        let mut old_to_new = vec![None; old_id_tracker.total_point_count()];
+        for item in itertools::merge_join_by(
+            id_tracker.iter_from(None),
+            old_id_tracker.iter_from(None),
+            |(new_external_id, _), (old_external_id, _)| new_external_id.cmp(old_external_id),
+        ) {
+            let (new_offset, old_offset): (Option<PointOffsetType>, Option<PointOffsetType>) =
+                match item {
+                    EitherOrBoth::Both((_, new_offset), (_, old_offset)) => {
+                        (Some(new_offset), Some(old_offset))
+                    }
+                    EitherOrBoth::Left((_, new_offset)) => (Some(new_offset), None),
+                    EitherOrBoth::Right((_, old_offset)) => (None, Some(old_offset)),
+                };
+
+            let new_offset =
+                new_offset.filter(|&id| !new_deleted.get_bit(id as usize).unwrap_or(false));
+
+            // Even if the old vector is marked as deleted, we still might want
+            // to reuse the graph built with this vector.
+            // Thus, instead of checking `deleted_vector_bitslice`, we check
+            // that the vector present in the graph, and it's value is the same.
+            let old_offset =
+                old_offset.filter(|&id| old_index.graph.links.links(id, 0).next().is_some());
+
+            match (new_offset, old_offset) {
+                (_, None) => (),
+                (None, Some(_)) => {
+                    // Vector was in the old index, but not in the new one.
+                    // Not supported yet.
+                    return None;
+                }
+                (Some(new_offset), Some(old_offset)) => {
+                    let new_vector = vector_storage.get_vector(new_offset);
+                    let old_vector = old_storage_ref.get_vector(old_offset);
+                    if old_vector == new_vector {
+                        old_to_new[old_offset as usize] = Some(new_offset);
+                        valid_points += 1;
+                    } else {
+                        // Vector is changed.
+                        // Not supported yet.
+                        return None;
+                    }
+                }
+            }
+        }
+
+        drop(old_id_tracker);
+        drop(old_storage_ref);
+
+        Some(OldIndexCandidate {
+            index: old_index,
+            old_to_new,
+            valid_points,
+        })
+    }
+
+    fn reuse(self, config: &HnswGraphConfig, total_vector_count: usize) -> OldIndex<'a> {
+        let mut new_to_old = vec![None; total_vector_count];
+        for (old_offset, new_offset) in self.old_to_new.iter().copied().enumerate() {
+            if let Some(new_offset) = new_offset {
+                new_to_old[new_offset as usize] = Some(old_offset as PointOffsetType);
+            }
+        }
+
+        log::debug!("Reusing {} points from the old index", self.valid_points);
+
+        OldIndex {
+            index: self.index,
+            old_to_new: self.old_to_new,
+            new_to_old,
+            m: config.m,
+            m0: config.m0,
+        }
+    }
+}
+
+impl OldIndex<'_> {
+    fn point_level(&self, new_id: PointOffsetType) -> Option<usize> {
+        let old_id = self.new_to_old[new_id as usize]?;
+        Some(self.index.graph.links.point_level(old_id))
+    }
+
+    fn get_links(&self, src_new: PointOffsetType) -> Option<Vec<Vec<PointOffsetType>>> {
+        let src_old = self.new_to_old[src_new as usize]?;
+
+        let links = &self.index.graph.links;
+        let point_level = links.point_level(src_old);
+
+        let links = (0..=point_level).map(|level| {
+            links
+                .links(src_old, level)
+                .take(if level == 0 { self.m0 } else { self.m })
+                .filter_map(|dst_old| self.old_to_new[dst_old as usize])
+                .collect()
+        });
+        Some(links.collect())
     }
 }

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use common::types::PointOffsetType;
 use rand::rng;
 use tempfile::Builder;
@@ -79,6 +80,7 @@ fn test_graph_connectivity() {
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -580,6 +580,7 @@ impl SegmentBuilder {
                         old_indices: &old_indices.remove(vector_name).unwrap(),
                         gpu_device: gpu_device.as_ref(),
                         stopped,
+                        feature_flags: feature_flags(),
                     },
                 )?;
             }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
-use common::flags::feature_flags;
+use common::flags::{FeatureFlags, feature_flags};
 use io::storage_version::StorageVersion;
 use log::info;
 use parking_lot::{Mutex, RwLock};
@@ -385,6 +385,7 @@ pub struct VectorIndexBuildArgs<'a> {
     pub old_indices: &'a [Arc<AtomicRefCell<VectorIndexEnum>>],
     pub gpu_device: Option<&'a LockedGpuDevice<'a>>,
     pub stopped: &'a AtomicBool,
+    pub feature_flags: FeatureFlags,
 }
 
 pub(crate) fn open_vector_index(

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use rand::SeedableRng;
 use rand::prelude::StdRng;
 use segment::data_types::query_context::QueryContext;
@@ -162,6 +163,7 @@ fn test_batch_and_single_request_equivalency() {
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
+use common::flags::FeatureFlags;
 use common::types::{ScoredPointOffset, TelemetryDetail};
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -193,6 +194,7 @@ fn test_byte_storage_hnsw(
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
+use common::flags::FeatureFlags;
 use common::types::ScoredPointOffset;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -338,6 +339,7 @@ fn test_byte_storage_binary_quantization_hnsw(
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use common::types::PointOffsetType;
 use itertools::Itertools;
 use rand::{Rng, rng};
@@ -141,6 +142,7 @@ fn exact_search_test() {
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use common::types::{PointOffsetType, TelemetryDetail};
 use itertools::Itertools;
 use rand::prelude::StdRng;
@@ -162,6 +163,7 @@ fn _test_filterable_hnsw(
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use rand::prelude::StdRng;
@@ -141,6 +142,7 @@ fn test_gpu_filterable_hnsw() {
             old_indices: &[],
             gpu_device: Some(&locked_device), // enable GPU
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -114,6 +115,7 @@ fn hnsw_discover_precision() {
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();
@@ -237,6 +239,7 @@ fn filtered_hnsw_discover_precision() {
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/hnsw_incremental_build.rs
+++ b/lib/segment/tests/integration/hnsw_incremental_build.rs
@@ -1,0 +1,160 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use atomic_refcell::AtomicRefCell;
+use common::budget::ResourcePermit;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
+use itertools::Itertools as _;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom as _;
+use rand::{Rng as _, SeedableRng as _};
+use segment::data_types::vectors::{
+    DEFAULT_VECTOR_NAME, QueryVector, VectorElementType, only_default_vector,
+};
+use segment::entry::SegmentEntry as _;
+use segment::fixtures::index_fixtures::random_vector;
+use segment::index::VectorIndexEnum;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
+use segment::index::hnsw_index::num_rayon_threads;
+use segment::segment::Segment;
+use segment::segment_constructor::VectorIndexBuildArgs;
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::types::{Distance, ExtendedPointId, HnswConfig, SeqNumberType};
+use tap::Tap as _;
+use tempfile::Builder;
+
+use crate::hnsw_quantized_search_test::check_matches;
+
+const NUM_POINTS: usize = 5_000;
+const ITERATIONS: usize = 10;
+
+const DIM: usize = 8;
+const M: usize = 16;
+const EF_CONSTRUCT: usize = 64;
+const DISTANCE: Distance = Distance::Cosine;
+
+#[test]
+fn hnsw_incremental_build() {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let dir = Builder::new()
+        .prefix("hnsw_incremental_build")
+        .tempdir()
+        .unwrap();
+
+    let ids = std::iter::repeat_with(|| ExtendedPointId::NumId(rnd.random()))
+        .unique()
+        .take(NUM_POINTS)
+        .collect_vec();
+    let vectors = std::iter::repeat_with(|| random_vector(&mut rnd, DIM))
+        .take(NUM_POINTS)
+        .collect_vec();
+
+    let vector_refs = vectors.iter().map(|v| v.as_slice()).collect_vec();
+
+    let num_queries = 10;
+    let query_vectors: Vec<QueryVector> = (0..num_queries)
+        .map(|_| random_vector(&mut rnd, DIM).into())
+        .collect();
+
+    let mut last_index = None;
+    for i in 1..=ITERATIONS {
+        log::info!(
+            "Building segment with {:.0}% of data",
+            i as f64 / ITERATIONS as f64 * 100.0
+        );
+
+        let num_points = i * NUM_POINTS / ITERATIONS;
+        let segment = make_segment(
+            &mut rnd,
+            &dir.path().join(format!("segment_{i}")),
+            &ids[0..num_points],
+            &vector_refs[0..num_points],
+        );
+
+        let index_path = dir.path().join(format!("hnsw_{i}"));
+        let old_indices = last_index
+            .as_ref()
+            .map_or(vec![], |idx| vec![Arc::clone(idx)]);
+
+        let index = build_hnsw_index(&index_path, &segment, &old_indices);
+
+        let ef = 64;
+        let top = 10;
+        check_matches(&query_vectors, &segment, &index, None, ef, top);
+
+        last_index = Some(Arc::new(AtomicRefCell::new(VectorIndexEnum::Hnsw(index))));
+    }
+}
+
+fn make_segment(
+    rnd: &mut StdRng,
+    path: &Path,
+    ids: &[ExtendedPointId],
+    vectors: &[&[VectorElementType]],
+) -> Segment {
+    let mut sequence = (0..ids.len()).collect_vec();
+    sequence.shuffle(rnd);
+
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut segment = build_simple_segment(path, DIM, DISTANCE).unwrap();
+    for n in sequence {
+        let vector = only_default_vector(vectors[n]);
+        segment
+            .upsert_point(n as SeqNumberType, ids[n], vector, &hw_counter)
+            .unwrap();
+    }
+
+    segment
+}
+
+fn build_hnsw_index(
+    path: &Path,
+    segment: &Segment,
+    old_indices: &[Arc<AtomicRefCell<VectorIndexEnum>>],
+) -> HNSWIndex {
+    log::info!("Building HNSW index for {:?}", path.file_name().unwrap());
+
+    let hnsw_config = HnswConfig {
+        m: M,
+        ef_construct: EF_CONSTRUCT,
+        full_scan_threshold: 1,
+        max_indexing_threads: 0,
+        on_disk: Some(false),
+        payload_m: None,
+    };
+
+    let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
+    let permit = Arc::new(ResourcePermit::dummy(permit_cpu_count as u32));
+
+    HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path,
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            quantized_vectors: Default::default(),
+            payload_index: Arc::clone(&segment.payload_index),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            old_indices,
+            gpu_device: None,
+            stopped: &AtomicBool::new(false),
+            feature_flags: FeatureFlags::default().tap_mut(|flags| {
+                flags.incremental_hnsw_building = true;
+            }),
+        },
+    )
+    .unwrap()
+}

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -33,7 +33,7 @@ use tempfile::Builder;
 
 use crate::fixtures::segment::build_segment_1;
 
-fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> usize {
+pub fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> usize {
     a[0].iter()
         .map(|x| x.idx)
         .collect::<BTreeSet<_>>()
@@ -180,7 +180,7 @@ fn hnsw_quantized_search_test(
     check_rescoring(&query_vectors, &hnsw_index, Some(&filter), ef, top);
 }
 
-fn check_matches(
+pub fn check_matches(
     query_vectors: &[QueryVector],
     segment: &Segment,
     hnsw_index: &HNSWIndex,

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use common::types::{ScoreType, ScoredPointOffset};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -135,6 +136,7 @@ fn hnsw_quantized_search_test(
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -10,6 +10,7 @@ mod fixtures;
 #[cfg(feature = "gpu")]
 mod gpu_hnsw_test;
 mod hnsw_discover_test;
+mod hnsw_incremental_build;
 mod hnsw_quantized_search_test;
 mod multivector_filtrable_hnsw_test;
 mod multivector_hnsw_test;

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
+use common::flags::FeatureFlags;
 use common::types::TelemetryDetail;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -144,6 +145,7 @@ fn test_multi_filterable_hnsw(
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use rand::SeedableRng;
 use rand::prelude::StdRng;
 use segment::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
@@ -148,6 +149,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
 use common::types::ScoredPointOffset;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -318,6 +319,7 @@ fn test_multivector_quantization_hnsw(
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            feature_flags: FeatureFlags::default(),
         },
     )
     .unwrap();


### PR DESCRIPTION
This PR implements incremental HNSW building for the append-only case.

A new feature flag is added, `incremental_hnsw_building`, disabled by default.

When enabled, it will try to reuse old graph as a starting point for building the new graph. When reusing, point levels and old graph links are copied as-is (but with reassigned IDs) before the regular HNSW point insertion process starts.

What is not supported as of now:
- GPU building. Only point levels are copied.
- Point/vector removal/overwriting. If a point or vector is removed, the old graph is discarded. Same if vector value is changed.


When old index is reused, the following log messages are printed:
```
DEBUG segment::index::hnsw_index::hnsw: building HNSW for 518500 vectors with 8 CPUs
DEBUG segment::index::hnsw_index::hnsw: Reusing 457700 points from the old index
```

Benchmarked using `bfb --indexing-threshold 400 --dim 32 --num-vectors 2000000 --throttle 500`.
Upload time: 40 seconds.
Upload+index (incremental): 40+17 = 57 seconds.
Upload+index (non-incremental): 40+84 = 124 seconds.
