### PR TITLE
Parallelize large segment search batches

### DIFF
--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -33,6 +33,10 @@ impl LocalShard {
         timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        if batch.is_empty() {
+            return Ok(vec![]);
+        }
+
         let scrolls = batch.iter().map(|request| {
             self.query_scroll(
                 request,

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -19,6 +19,10 @@ impl LocalShard {
         timeout: Option<Duration>,
         hw_counter_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        if core_request.searches.is_empty() {
+            return Ok(vec![]);
+        }
+
         let is_stopped_guard = StoppingGuard::new();
 
         let (query_context, collection_params) = {

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -279,6 +279,8 @@ impl ShardOperation for LocalShard {
         //
         // We don't create smaller chunks than MIN_BATCH_SIZE to ensure our 'filter reuse
         // optimization' can be properly used.
+        // See: <https://github.com/qdrant/qdrant/pull/813>
+        // See: <https://github.com/qdrant/qdrant/pull/6326>
         const MIN_CHUNK_SIZE: usize = 10;
         let chunk_size = {
             let count = requests.len();

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -283,7 +283,7 @@ impl ShardOperation for LocalShard {
         const CHUNK_SIZE: usize = 16;
 
         // Calculate read cost if read rate limit is enabled
-        let mut read_cost = self.read_rate_limiter.is_some().then_some(0);
+        let mut read_cost = (!hw_measurement_acc.is_disposable() && self.read_rate_limiter.is_some()).then_some(0);
 
         let chunk_futures = requests
             .chunks(CHUNK_SIZE)


### PR DESCRIPTION
A batch query request - consisting of many queries - is only parallelized over segments in a collection. If you have just one segment, the full batch is processed on a single system thread. Depending on your use case there may be a lot of wasted resources here.

I don't this is unlikely to happen in practice. We sometimes recommend to have one (or very few) segments to speed up overall searches. Our Python client is not concurrent by default as it's commonly single threaded. This set up would only ever be fast if a user explicitly sends multiple concurrent requests from the client.

#### Implementation

In this PR I try to parallelize large query batches to make better use of the available resources. Ideally it speeds up batch queries when using a single client.

The idea is simple: chunk a large batch of queries, and execute them in parallel at local shard level. ~It applies some heuristic in an attempt to be efficient across all scenarios.~

Chunks have a fixed size now, see [this](https://github.com/qdrant/qdrant/pull/6326#discussion_r2035625927).

~Considerations:~
- ~If we have enough segments, there's no need to parallelize at all~
- ~We reuse filters, this should not destroy that optimization (<https://github.com/qdrant/qdrant/pull/813>)~

~Chunk size selection:~
- ~Minimum chunk size is 10~
  ~Don't make smaller chunks to prevent negating filter reuse optimization (<https://github.com/qdrant/qdrant/pull/813>).~
- ~If the number of segments is equal or larger than the CPU count, don't chunk~
  ~We already use a search thread per segment and so we will saturate the CPU, no additional chunking needed.~
- ~Calculate available CPUs per segment, pick chunk size to saturate CPUs~

#### Examples

~Examples of CPU saturation on a single batch when having 20 CPUs:~
- ~1 segment, 10 queries: 1 chunk of 10 saturating 1 CPU core (1 CPU before)~
- ~1 segment, 100 queries: 10 chunks of 10 saturating 10 CPU cores (1 CPU before)~
- ~1 segment, 200 queries: 20 chunks of 10 saturating 20 CPU cores (1 CPU before)~
- ~1 segment, 2000 queries: 20 chunks of 100 saturating 20 CPU cores (1 CPU before)~
- ~10 segments, 200 queries: 2 chunk of 100 saturating 20 CPU cores (10 CPU before)~
- ~20 segments, 200 queries: 1 chunk of 200 saturating 20 CPU cores (20 CPU before)~

#### Results

I create a collection with:

```bash
bfb -d 1500 --segments 1
```

I then send a huge request and report query time (240 queries with limit 5k):

```bash
curl -sSL 'http://localhost:6333/collections/benchmark/points/query/batch' -X POST --data-raw '{"searches":[{"query":1,"limit":5000},{"query":2,"limit":5000},{"query":3,"limit":5000},{"query":4,"limit":5000},{"query":5,"limit":5000},{"query":6,"limit":5000},{"query":7,"limit":5000},{"query":8,"limit":5000},{"query":9,"limit":5000},{"query":10,"limit":5000},{"query":11,"limit":5000},{"query":12,"limit":5000},{"query":13,"limit":5000},{"query":14,"limit":5000},{"query":15,"limit":5000},{"query":16,"limit":5000},{"query":17,"limit":5000},{"query":18,"limit":5000},{"query":19,"limit":5000},{"query":20,"limit":5000},{"query":21,"limit":5000},{"query":22,"limit":5000},{"query":23,"limit":5000},{"query":24,"limit":5000},{"query":25,"limit":5000},{"query":26,"limit":5000},{"query":27,"limit":5000},{"query":28,"limit":5000},{"query":29,"limit":5000},{"query":30,"limit":5000},{"query":31,"limit":5000},{"query":32,"limit":5000},{"query":33,"limit":5000},{"query":34,"limit":5000},{"query":35,"limit":5000},{"query":36,"limit":5000},{"query":37,"limit":5000},{"query":38,"limit":5000},{"query":39,"limit":5000},{"query":40,"limit":5000},{"query":41,"limit":5000},{"query":42,"limit":5000},{"query":43,"limit":5000},{"query":44,"limit":5000},{"query":45,"limit":5000},{"query":46,"limit":5000},{"query":47,"limit":5000},{"query":48,"limit":5000},{"query":49,"limit":5000},{"query":50,"limit":5000},{"query":51,"limit":5000},{"query":52,"limit":5000},{"query":53,"limit":5000},{"query":54,"limit":5000},{"query":55,"limit":5000},{"query":56,"limit":5000},{"query":57,"limit":5000},{"query":58,"limit":5000},{"query":59,"limit":5000},{"query":60,"limit":5000},{"query":61,"limit":5000},{"query":62,"limit":5000},{"query":63,"limit":5000},{"query":64,"limit":5000},{"query":65,"limit":5000},{"query":66,"limit":5000},{"query":67,"limit":5000},{"query":68,"limit":5000},{"query":69,"limit":5000},{"query":70,"limit":5000},{"query":71,"limit":5000},{"query":72,"limit":5000},{"query":73,"limit":5000},{"query":74,"limit":5000},{"query":75,"limit":5000},{"query":76,"limit":5000},{"query":77,"limit":5000},{"query":78,"limit":5000},{"query":79,"limit":5000},{"query":80,"limit":5000},{"query":81,"limit":5000},{"query":82,"limit":5000},{"query":83,"limit":5000},{"query":84,"limit":5000},{"query":85,"limit":5000},{"query":86,"limit":5000},{"query":87,"limit":5000},{"query":88,"limit":5000},{"query":89,"limit":5000},{"query":90,"limit":5000},{"query":91,"limit":5000},{"query":92,"limit":5000},{"query":93,"limit":5000},{"query":94,"limit":5000},{"query":95,"limit":5000},{"query":96,"limit":5000},{"query":97,"limit":5000},{"query":98,"limit":5000},{"query":99,"limit":5000},{"query":100,"limit":5000},{"query":101,"limit":5000},{"query":102,"limit":5000},{"query":103,"limit":5000},{"query":104,"limit":5000},{"query":105,"limit":5000},{"query":106,"limit":5000},{"query":107,"limit":5000},{"query":108,"limit":5000},{"query":109,"limit":5000},{"query":110,"limit":5000},{"query":111,"limit":5000},{"query":112,"limit":5000},{"query":113,"limit":5000},{"query":114,"limit":5000},{"query":115,"limit":5000},{"query":116,"limit":5000},{"query":117,"limit":5000},{"query":118,"limit":5000},{"query":119,"limit":5000},{"query":120,"limit":5000},{"query":121,"limit":5000},{"query":122,"limit":5000},{"query":123,"limit":5000},{"query":124,"limit":5000},{"query":125,"limit":5000},{"query":126,"limit":5000},{"query":127,"limit":5000},{"query":128,"limit":5000},{"query":129,"limit":5000},{"query":130,"limit":5000},{"query":131,"limit":5000},{"query":132,"limit":5000},{"query":133,"limit":5000},{"query":134,"limit":5000},{"query":135,"limit":5000},{"query":136,"limit":5000},{"query":137,"limit":5000},{"query":138,"limit":5000},{"query":139,"limit":5000},{"query":140,"limit":5000},{"query":141,"limit":5000},{"query":142,"limit":5000},{"query":143,"limit":5000},{"query":144,"limit":5000},{"query":145,"limit":5000},{"query":146,"limit":5000},{"query":147,"limit":5000},{"query":148,"limit":5000},{"query":149,"limit":5000},{"query":150,"limit":5000},{"query":151,"limit":5000},{"query":152,"limit":5000},{"query":153,"limit":5000},{"query":154,"limit":5000},{"query":155,"limit":5000},{"query":156,"limit":5000},{"query":157,"limit":5000},{"query":158,"limit":5000},{"query":159,"limit":5000},{"query":160,"limit":5000},{"query":161,"limit":5000},{"query":162,"limit":5000},{"query":163,"limit":5000},{"query":164,"limit":5000},{"query":165,"limit":5000},{"query":166,"limit":5000},{"query":167,"limit":5000},{"query":168,"limit":5000},{"query":169,"limit":5000},{"query":170,"limit":5000},{"query":171,"limit":5000},{"query":172,"limit":5000},{"query":173,"limit":5000},{"query":174,"limit":5000},{"query":175,"limit":5000},{"query":176,"limit":5000},{"query":177,"limit":5000},{"query":178,"limit":5000},{"query":179,"limit":5000},{"query":180,"limit":5000},{"query":181,"limit":5000},{"query":182,"limit":5000},{"query":183,"limit":5000},{"query":184,"limit":5000},{"query":185,"limit":5000},{"query":186,"limit":5000},{"query":187,"limit":5000},{"query":188,"limit":5000},{"query":189,"limit":5000},{"query":190,"limit":5000},{"query":191,"limit":5000},{"query":192,"limit":5000},{"query":193,"limit":5000},{"query":194,"limit":5000},{"query":195,"limit":5000},{"query":196,"limit":5000},{"query":197,"limit":5000},{"query":198,"limit":5000},{"query":199,"limit":5000},{"query":200,"limit":5000},{"query":201,"limit":5000},{"query":202,"limit":5000},{"query":203,"limit":5000},{"query":204,"limit":5000},{"query":205,"limit":5000},{"query":206,"limit":5000},{"query":207,"limit":5000},{"query":208,"limit":5000},{"query":209,"limit":5000},{"query":210,"limit":5000},{"query":211,"limit":5000},{"query":212,"limit":5000},{"query":213,"limit":5000},{"query":214,"limit":5000},{"query":215,"limit":5000},{"query":216,"limit":5000},{"query":217,"limit":5000},{"query":218,"limit":5000},{"query":219,"limit":5000},{"query":220,"limit":5000},{"query":221,"limit":5000},{"query":222,"limit":5000},{"query":223,"limit":5000},{"query":224,"limit":5000},{"query":225,"limit":5000},{"query":226,"limit":5000},{"query":227,"limit":5000},{"query":228,"limit":5000},{"query":229,"limit":5000},{"query":230,"limit":5000},{"query":231,"limit":5000},{"query":232,"limit":5000},{"query":233,"limit":5000},{"query":234,"limit":5000},{"query":235,"limit":5000},{"query":236,"limit":5000},{"query":237,"limit":5000},{"query":238,"limit":5000},{"query":239,"limit":5000},{"query":240,"limit":5000}]}' | jq .time
```

Before, this only saturated a single CPU and took **11 seconds**:

![Screenshot from 2025-04-07 10-55-59](https://github.com/user-attachments/assets/6c11d4d2-02e5-4a9e-8931-5bf686c0795e)

Now it saturates 23 CPUs (search threads = CPU count - 1) and took **4.5 seconds**:

![Screenshot from 2025-04-07 10-56-45](https://github.com/user-attachments/assets/c6acdf4f-f5aa-4a79-b5af-663590f7b206)

I now also tested the same large query on the following configurations:

- `bfb -n 100000 -d 1500 --segments 1 --shards 1`:
  - Before: 10.5s
  - After: 4.5s
- `bfb -n 100000 -d 1500 --segments 10 --shards 1`:
  - Before: 5.5s
  - After: 5.1s
- `bfb -n 100000 -d 1500 --segments 1 --shards 4`:
  - Before: 5.2s
  - After: 4.6s
- `bfb -n 100000 -d 1500 --segments 10 --shards 4 --indexing-threshold 1000`:
  - Before: 5.1s
  - After: 4.5s
- `bfb -n 100000 -d 1500 --segments 1 --shards 16 --indexing-threshold 1000`:
  - Before: 5.2s
  - After: 3.7s
- `bfb -n 100000 -d 1500 --segments 10 --shards 16 --indexing-threshold 1000`:
  - Before: 2.5s
  - After: 1.7s

#### Conclusion

While this scenario clearly is faster now, I did expect a bigger gain than just 2.5x.

This definitely needs a bit more testing.

~Shortcomings:~
- ~Minimum chunk size of 10 is arbitrary, but it seems reasonable~
- ~This does not consider having multiple local shards (and thus more segments per host)~
- ~This is not aware of the configured search thread count~

This contains some additional improvements, such as short cutting a search and scroll operation if the list of operations is empty.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
