### PR TITLE
Rate limit retrieve based on number of ids

### DIFF
--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -228,10 +228,7 @@ impl ShardOperation for LocalShard {
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         // Check read rate limiter before proceeding
-        self.check_read_rate_limiter(&hw_measurement_acc, "retrieve", || {
-            // TODO(strict-mode) how much should a retrieve cost? (request.ids.len()?)
-            1
-        })?;
+        self.check_read_rate_limiter(&hw_measurement_acc, "retrieve", || request.ids.len())?;
         let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
         let records_map = tokio::time::timeout(
             timeout,

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -1530,7 +1530,6 @@ def test_strict_mode_retrieve_read_rate_limiting(collection_name):
         path_params={"collection_name": collection_name},
         body={
             "ids": [1, 2, 3, 4, 5],
-
         },
     )
     assert response.ok, response.text
@@ -1559,7 +1558,6 @@ def test_strict_mode_retrieve_read_rate_limiting(collection_name):
         path_params={"collection_name": collection_name},
         body={
             "ids": [1, 2, 3, 4, 5],
-
         },
     )
     assert response.status_code == 429
@@ -1575,7 +1573,6 @@ def test_strict_mode_retrieve_read_rate_limiting(collection_name):
         path_params={"collection_name": collection_name},
         body={
             "ids": [1, 2, 3, 4, 5],
-
         },
     )
     assert response.ok, response.text

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -1521,3 +1521,61 @@ def test_strict_mode_recommendation_best_score_read_rate_limiting(collection_nam
         },
     )
     assert response.ok, response.text
+
+
+def test_strict_mode_retrieve_read_rate_limiting(collection_name):
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "ids": [1, 2, 3, 4, 5],
+
+        },
+    )
+    assert response.ok, response.text
+
+    # set read rate limit
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "read_rate_limit": 4,
+    })
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+
+    assert response.ok
+    new_strict_mode_config = response.json()['result']['config']['strict_mode_config']
+    assert new_strict_mode_config['enabled']
+    assert new_strict_mode_config['read_rate_limit'] == 4
+
+    # try max number of ids
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "ids": [1, 2, 3, 4, 5],
+
+        },
+    )
+    assert response.status_code == 429
+    assert "Read rate limit exceeded, request larger than rate limiter capacity, please try to split your request" in response.json()['status']['error']
+
+    set_strict_mode(collection_name, {
+        "enabled": False,
+    })
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "ids": [1, 2, 3, 4, 5],
+
+        },
+    )
+    assert response.ok, response.text


### PR DESCRIPTION
Large retrieve operation should consume more tokens in the rate limiter.