### PR TITLE
Fixing failing CI due to missing liblzma

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -36,8 +36,10 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         key: clippy
+    - name: Update apt
+      run: sudo apt-get update
     - name: Install dependencies
-      run: sudo apt-get install clang
+      run: sudo apt-get install clang libunwind-dev
     - name: Check code formatting
       run: cargo +nightly fmt --all -- --check
     - name: Check cargo clippy warnings

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  lint:
 
     runs-on: ubuntu-latest
 
@@ -37,7 +37,7 @@ jobs:
       with:
         key: clippy
     - name: Install dependencies
-      run: sudo apt-get install clang libunwind-dev
+      run: sudo apt-get install clang
     - name: Check code formatting
       run: cargo +nightly fmt --all -- --check
     - name: Check cargo clippy warnings


### PR DESCRIPTION
Fixing lint CI step

```
Run sudo apt-get install clang libunwind-dev
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  liblzma-dev
Suggested packages:
  liblzma-doc
The following NEW packages will be installed:
  clang liblzma-dev libunwind-dev
0 upgraded, 3 newly installed, 0 to remove and 116 not upgraded.
Need to get 2088 kB of archives.
After this operation, 7007 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 clang amd64 1:18.0-59~exp2 [5846 B]
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liblzma-dev amd64 5.6.1+really5.4.5-1build0.1
Get:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libunwind-dev amd64 1.6.2-3build1.1 [1906 kB]
Ign:3 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 liblzma-dev amd64 5.6.1+really5.4.5-1build0.1
Err:3 http://security.ubuntu.com/ubuntu noble-updates/main amd64 liblzma-dev amd64 5.6.1+really5.4.5-1build0.1
  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/x/xz-utils/liblzma-dev_5.6.1%2breally5.4.5-1build0.1_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 1912 kB in 1s (3495 kB/s)
```