### PR TITLE
Enable integer overflow checks in perf mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,7 @@ inherits = "release"
 lto = false
 opt-level = 3
 codegen-units = 256 # restore default value for faster compilation
+overflow-checks = true # Enable integer overflow checks
 
 # Override for fast sha256 hashing in dev builds
 [profile.dev.package.sha2]


### PR DESCRIPTION
We often use the `perf` mode for local performance testing.

Enabling integer overflow check on this profile is a low hanging fruit to catch issues that cannot be observed in release mode.

Rust will panic in debug mode in case of overflow, but in release mode it will silently wrap around.

On a quick and dirty local test it seems to be more than 10% slower (bfb upsert) 

source: https://corrode.dev/blog/pitfalls-of-safe-rust/#protect-against-integer-overflow