### PR TITLE
Read rate limiter charge per filter condition

### DIFF
--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -3,7 +3,7 @@ mod discovery;
 mod facet;
 mod local_shard;
 mod matrix;
-mod operation_rate_cost;
+pub mod operation_rate_cost;
 mod query;
 mod recommend;
 mod search;

--- a/lib/collection/src/operations/verification/operation_rate_cost.rs
+++ b/lib/collection/src/operations/verification/operation_rate_cost.rs
@@ -1,12 +1,21 @@
+use segment::types::Filter;
+
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::types::{CoreSearchRequest, QueryScrollRequestInternal};
 
+pub fn filter_rate_cost(filter: &Filter) -> usize {
+    filter.total_conditions_count()
+}
+
+/// Base cost for a read operation
+pub const BASE_COST: usize = 1;
+
 impl CoreSearchRequest {
-    pub fn rate_cost(&self) -> usize {
-        match &self.query {
+    pub fn search_rate_cost(&self) -> usize {
+        let mut cost = match &self.query {
             QueryEnum::Nearest(_nq) => {
                 // TODO(strict-mode) should the cost be adjusted here?
-                1
+                BASE_COST
             }
             QueryEnum::RecommendBestScore(rb) => {
                 rb.query.positives.len() + rb.query.negatives.len()
@@ -16,13 +25,20 @@ impl CoreSearchRequest {
             }
             QueryEnum::Discover(rd) => rd.query.pairs.len(),
             QueryEnum::Context(rc) => rc.query.pairs.len(),
+        };
+        if let Some(filter) = &self.filter {
+            cost += filter_rate_cost(filter);
         }
+        cost
     }
 }
 
 impl QueryScrollRequestInternal {
-    pub fn rate_cost(&self) -> usize {
-        // TODO(strict-mode) how much should a scroll cost?
-        1
+    pub fn scroll_rate_cost(&self) -> usize {
+        let mut cost = BASE_COST;
+        if let Some(filter) = &self.filter {
+            cost += filter_rate_cost(filter);
+        }
+        cost
     }
 }


### PR DESCRIPTION
This PR changes the read rate limiter to charge request additionally based on the number of filters they contain.

The main principle is that a user should not be send a lot of expensive queries over a long period of time.