### PR TITLE
Fix codecov branch issue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ jobs:
           with:
             # If scheduled by cron, run for dev branch, Otherwise specified branch (for workflow dispatch & push)
             ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref_name }}
+            fetch-depth: 0
         - uses: Swatinem/rust-cache@v2
         - name: Install Protoc
           uses: arduino/setup-protoc@v3
@@ -34,3 +35,4 @@ jobs:
             files: lcov.info
             override_branch: ${{ github.event_name == 'schedule' && 'dev' || github.ref_name }}
             token: ${{ secrets.CODECOV_TOKEN }}
+            verbose: true


### PR DESCRIPTION
Unfortuantely https://github.com/qdrant/qdrant/pull/6262 didn't fix the codecov `dev` branch missing issue. I dug a little deeper and found that it's because Codecov action might not be able to access to rest of the commits when using `actions/checkout` since default cloning depth is 1. This means it doesn't attach the commit to the (dev) branch. I think this should fix the problem.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
