### PR TITLE
refactor `QueryEnum::Nearest` for using `NamedQuery`

### DIFF
--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -6,7 +6,7 @@ use api::rest::{
     SearchMatrixRequestInternal,
 };
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedVectorStruct};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery};
 use segment::types::{
     Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, VectorNameBuf,
     WithVector,
@@ -218,7 +218,7 @@ impl Collection {
                 .expect("Vector not found in the point");
 
             // nearest query on the sample vector
-            let named_vector = NamedVectorStruct::new_from_vector(vector, using.clone());
+            let named_vector = NamedQuery::new_from_vector(vector, using.clone());
             let query = QueryEnum::Nearest(named_vector);
 
             searches.push(CoreSearchRequest {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -2029,7 +2029,7 @@ impl From<SearchRequestInternal> for CoreSearchRequest {
             with_payload,
         } = request;
         Self {
-            query: QueryEnum::Nearest(NamedVectorStruct::from(vector)),
+            query: QueryEnum::Nearest(NamedVectorStruct::from(vector).into()),
             filter,
             params,
             limit,
@@ -2056,7 +2056,9 @@ impl From<SearchRequestInternal> for ShardQueryRequest {
 
         Self {
             prefetches: vec![],
-            query: Some(ScoringQuery::Vector(QueryEnum::Nearest(vector.into()))),
+            query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
+                NamedVectorStruct::from(vector).into(),
+            ))),
             filter,
             score_threshold,
             limit,
@@ -2098,7 +2100,7 @@ impl From<CoreSearchRequest> for ShardQueryRequest {
 impl From<QueryEnum> for QueryVector {
     fn from(query: QueryEnum) -> Self {
         match query {
-            QueryEnum::Nearest(named) => QueryVector::Nearest(named.into()),
+            QueryEnum::Nearest(named) => QueryVector::Nearest(named.query),
             QueryEnum::RecommendBestScore(named) => QueryVector::RecommendBestScore(named.query),
             QueryEnum::RecommendSumScores(named) => QueryVector::RecommendSumScores(named.query),
             QueryEnum::Discover(named) => QueryVector::Discovery(named.query),

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -4,9 +4,7 @@ use api::rest::LookupLocation;
 use common::types::ScoreType;
 use itertools::Itertools;
 use segment::data_types::order_by::OrderBy;
-use segment::data_types::vectors::{
-    DEFAULT_VECTOR_NAME, NamedQuery, NamedVectorStruct, VectorInternal, VectorRef,
-};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery, VectorInternal, VectorRef};
 use segment::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use segment::json_path::JsonPath;
 use segment::types::{
@@ -316,7 +314,7 @@ impl VectorQuery<VectorInternal> {
     fn into_query_enum(self, using: VectorNameBuf) -> CollectionResult<QueryEnum> {
         let query_enum = match self {
             VectorQuery::Nearest(vector) => {
-                QueryEnum::Nearest(NamedVectorStruct::new_from_vector(vector, using))
+                QueryEnum::Nearest(NamedQuery::new_from_vector(vector, using))
             }
             VectorQuery::RecommendAverageVector(reco) => {
                 // Get average vector
@@ -324,7 +322,7 @@ impl VectorQuery<VectorInternal> {
                     reco.positives.iter().map(VectorRef::from),
                     reco.negatives.iter().map(VectorRef::from).peekable(),
                 )?;
-                QueryEnum::Nearest(NamedVectorStruct::new_from_vector(search_vector, using))
+                QueryEnum::Nearest(NamedQuery::new_from_vector(search_vector, using))
             }
             VectorQuery::RecommendBestScore(reco) => QueryEnum::RecommendBestScore(NamedQuery {
                 query: reco,

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -395,9 +395,7 @@ mod tests {
 
     use std::collections::HashSet;
 
-    use segment::data_types::vectors::{
-        MultiDenseVectorInternal, NamedVectorStruct, VectorInternal,
-    };
+    use segment::data_types::vectors::{MultiDenseVectorInternal, NamedQuery, VectorInternal};
     use segment::json_path::JsonPath;
     use segment::types::{
         Condition, FieldCondition, Filter, Match, SearchParams, WithPayloadInterface, WithVector,
@@ -426,7 +424,7 @@ mod tests {
                 prefetches: vec![ShardPrefetch {
                     prefetches: Default::default(),
                     query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                        NamedVectorStruct::new_from_vector(
+                        NamedQuery::new_from_vector(
                             VectorInternal::Dense(dummy_vector.clone()),
                             "byte",
                         ),
@@ -437,7 +435,7 @@ mod tests {
                     score_threshold: None,
                 }],
                 query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                    NamedVectorStruct::new_from_vector(
+                    NamedQuery::new_from_vector(
                         VectorInternal::Dense(dummy_vector.clone()),
                         "full",
                     ),
@@ -448,7 +446,7 @@ mod tests {
                 score_threshold: None,
             }],
             query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                NamedVectorStruct::new_from_vector(
+                NamedQuery::new_from_vector(
                     VectorInternal::MultiDense(MultiDenseVectorInternal::new_unchecked(vec![
                         dummy_vector.clone(),
                     ])),
@@ -472,7 +470,7 @@ mod tests {
         assert_eq!(
             planned_query.searches,
             vec![CoreSearchRequest {
-                query: QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+                query: QueryEnum::Nearest(NamedQuery::new_from_vector(
                     VectorInternal::Dense(dummy_vector.clone()),
                     "byte",
                 )),
@@ -500,7 +498,7 @@ mod tests {
                         sources: vec![Source::SearchesIdx(0)],
                         rescore_params: Some(RescoreParams {
                             rescore: ScoringQuery::Vector(QueryEnum::Nearest(
-                                NamedVectorStruct::new_from_vector(
+                                NamedQuery::new_from_vector(
                                     VectorInternal::Dense(dummy_vector.clone()),
                                     "full",
                                 )
@@ -512,7 +510,7 @@ mod tests {
                     }))],
                     rescore_params: Some(RescoreParams {
                         rescore: ScoringQuery::Vector(QueryEnum::Nearest(
-                            NamedVectorStruct::new_from_vector(
+                            NamedQuery::new_from_vector(
                                 VectorInternal::MultiDense(
                                     MultiDenseVectorInternal::new_unchecked(vec![dummy_vector])
                                 ),
@@ -537,10 +535,7 @@ mod tests {
         let request = ShardQueryRequest {
             prefetches: vec![], // No prefetch
             query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                NamedVectorStruct::new_from_vector(
-                    VectorInternal::Dense(dummy_vector.clone()),
-                    "full",
-                ),
+                NamedQuery::new_from_vector(VectorInternal::Dense(dummy_vector.clone()), "full"),
             ))),
             filter: Some(Filter::default()),
             score_threshold: Some(0.5),
@@ -556,7 +551,7 @@ mod tests {
         assert_eq!(
             planned_query.searches,
             vec![CoreSearchRequest {
-                query: QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+                query: QueryEnum::Nearest(NamedQuery::new_from_vector(
                     VectorInternal::Dense(dummy_vector),
                     "full",
                 )),
@@ -606,7 +601,7 @@ mod tests {
                 ShardPrefetch {
                     prefetches: Vec::new(),
                     query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                        NamedVectorStruct::new_from_vector(
+                        NamedQuery::new_from_vector(
                             VectorInternal::Dense(dummy_vector.clone()),
                             "dense",
                         ),
@@ -619,7 +614,7 @@ mod tests {
                 ShardPrefetch {
                     prefetches: Vec::new(),
                     query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                        NamedVectorStruct::new_from_vector(
+                        NamedQuery::new_from_vector(
                             VectorInternal::Sparse(dummy_sparse.clone()),
                             "sparse",
                         ),
@@ -646,7 +641,7 @@ mod tests {
             planned_query.searches,
             vec![
                 CoreSearchRequest {
-                    query: QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+                    query: QueryEnum::Nearest(NamedQuery::new_from_vector(
                         VectorInternal::Dense(dummy_vector),
                         "dense",
                     )),
@@ -659,7 +654,7 @@ mod tests {
                     score_threshold: None,
                 },
                 CoreSearchRequest {
-                    query: QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+                    query: QueryEnum::Nearest(NamedQuery::new_from_vector(
                         VectorInternal::Sparse(dummy_sparse),
                         "sparse",
                     )),
@@ -724,7 +719,7 @@ mod tests {
             prefetches: vec![ShardPrefetch {
                 prefetches: Vec::new(),
                 query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                    NamedVectorStruct::new_from_vector(
+                    NamedQuery::new_from_vector(
                         VectorInternal::Dense(dummy_vector.clone()),
                         "dense",
                     ),
@@ -766,7 +761,7 @@ mod tests {
         assert_eq!(
             planned_query.searches,
             vec![CoreSearchRequest {
-                query: QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+                query: QueryEnum::Nearest(NamedQuery::new_from_vector(
                     VectorInternal::Dense(dummy_vector),
                     "dense",
                 ),),
@@ -792,7 +787,7 @@ mod tests {
                     ShardPrefetch {
                         prefetches: vec![acc],
                         query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                            NamedVectorStruct::new_from_vector(
+                            NamedQuery::new_from_vector(
                                 VectorInternal::Dense(vec![1.0, 2.0, 3.0]),
                                 "dense",
                             ),
@@ -809,10 +804,7 @@ mod tests {
         let prefetch = ShardPrefetch {
             prefetches: Vec::new(),
             query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                NamedVectorStruct::new_from_vector(
-                    VectorInternal::Dense(vec![1.0, 2.0, 3.0]),
-                    "dense",
-                ),
+                NamedQuery::new_from_vector(VectorInternal::Dense(vec![1.0, 2.0, 3.0]), "dense"),
             ))),
             limit: 100,
             params: None,
@@ -828,10 +820,7 @@ mod tests {
         let mut request = ShardQueryRequest {
             prefetches: vec![],
             query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                NamedVectorStruct::new_from_vector(
-                    VectorInternal::Dense(vec![1.0, 2.0, 3.0]),
-                    "dense",
-                ),
+                NamedQuery::new_from_vector(VectorInternal::Dense(vec![1.0, 2.0, 3.0]), "dense"),
             ))),
             filter: None,
             score_threshold: None,
@@ -849,7 +838,7 @@ mod tests {
                 prefetches: vec![ShardPrefetch {
                     prefetches: vec![],
                     query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                        NamedVectorStruct::new_from_vector(
+                        NamedQuery::new_from_vector(
                             VectorInternal::Dense(vec![1.0, 2.0, 3.0]),
                             "dense",
                         ),
@@ -860,7 +849,7 @@ mod tests {
                     score_threshold: None,
                 }],
                 query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                    NamedVectorStruct::new_from_vector(
+                    NamedQuery::new_from_vector(
                         VectorInternal::Dense(vec![1.0, 2.0, 3.0]),
                         "dense",
                     ),
@@ -871,10 +860,7 @@ mod tests {
                 score_threshold: None,
             }],
             query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
-                NamedVectorStruct::new_from_vector(
-                    VectorInternal::Dense(vec![1.0, 2.0, 3.0]),
-                    "dense",
-                ),
+                NamedQuery::new_from_vector(VectorInternal::Dense(vec![1.0, 2.0, 3.0]), "dense"),
             ))),
             limit: 10,
             params: None,
@@ -922,7 +908,7 @@ mod tests {
     }
 
     fn nearest_query() -> ScoringQuery {
-        ScoringQuery::Vector(QueryEnum::Nearest(NamedVectorStruct::Default(vec![
+        ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::default_dense(vec![
             0.1, 0.2, 0.3, 0.4,
         ])))
     }

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -4,9 +4,7 @@ use api::grpc::{DecayParamsExpression, qdrant as grpc};
 use common::types::ScoreType;
 use itertools::Itertools;
 use segment::data_types::order_by::OrderBy;
-use segment::data_types::vectors::{
-    DEFAULT_VECTOR_NAME, NamedQuery, NamedVectorStruct, VectorInternal,
-};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery, VectorInternal};
 use segment::index::query_optimization::rescore_formula::parsed_formula::{
     DecayKind, ParsedFormula,
 };
@@ -298,7 +296,7 @@ impl QueryEnum {
                         DEFAULT_VECTOR_NAME.to_owned()
                     }
                 };
-                let named_vector = NamedVectorStruct::new_from_vector(vector, name);
+                let named_vector = NamedQuery::new_from_vector(vector, name);
                 QueryEnum::Nearest(named_vector)
             }
             Variant::RecommendBestScore(recommend) => QueryEnum::RecommendBestScore(
@@ -577,7 +575,7 @@ impl From<QueryEnum> for grpc::RawQuery {
         use api::grpc::qdrant::raw_query::Variant;
 
         let variant = match value {
-            QueryEnum::Nearest(named) => Variant::Nearest(grpc::RawVector::from(named.to_vector())),
+            QueryEnum::Nearest(named) => Variant::Nearest(grpc::RawVector::from(named.query)),
             QueryEnum::RecommendBestScore(named) => {
                 Variant::RecommendBestScore(grpc::raw_query::Recommend::from(named.query))
             }

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -6,8 +6,7 @@ use api::rest::RecommendStrategy;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::data_types::vectors::{
-    DEFAULT_VECTOR_NAME, DenseVector, NamedQuery, NamedVectorStruct, TypedMultiDenseVector,
-    VectorElementType, VectorInternal, VectorRef,
+    DenseVector, NamedQuery, TypedMultiDenseVector, VectorElementType, VectorInternal, VectorRef,
 };
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, ScoredPoint,
@@ -377,19 +376,14 @@ fn recommend_by_avg_vector(
         lookup_collection_name,
     );
 
-    let vector_name = match using {
-        None => DEFAULT_VECTOR_NAME.to_owned(),
-        Some(UsingVector::Name(name)) => name,
-    };
-
     let search_vector =
         avg_vector_for_recommendation(positive_vectors, negative_vectors.peekable())?;
 
     Ok(CoreSearchRequest {
-        query: QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
-            search_vector,
-            vector_name,
-        )),
+        query: QueryEnum::Nearest(NamedQuery {
+            query: search_vector,
+            using: using.map(|name| name.as_name()),
+        }),
         filter: Some(Filter {
             should: None,
             min_should: None,

--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -5,9 +5,7 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::{HwMeasurementAcc, HwSharedDrain};
 use rand::rngs::ThreadRng;
 use rand::{RngCore, rng};
-use segment::data_types::vectors::{
-    DEFAULT_VECTOR_NAME, NamedVector, NamedVectorStruct, VectorStructInternal,
-};
+use segment::data_types::vectors::{NamedQuery, VectorInternal, VectorStructInternal};
 use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
@@ -63,10 +61,10 @@ async fn test_hw_metrics_cancellation() {
     let mut rand = rng();
     let req = CoreSearchRequestBatch {
         searches: vec![CoreSearchRequest {
-            query: QueryEnum::Nearest(NamedVectorStruct::Dense(NamedVector {
-                name: DEFAULT_VECTOR_NAME.to_owned(),
-                vector: rand_vector(512, &mut rand),
-            })),
+            query: QueryEnum::Nearest(NamedQuery {
+                using: None,
+                query: VectorInternal::from(rand_vector(512, &mut rand)),
+            }),
             filter: None,
             params: None,
             limit: 1010,

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -6,7 +6,7 @@ use api::rest::OrderByInterface;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use rand::{Rng, rng};
-use segment::data_types::vectors::NamedVectorStruct;
+use segment::data_types::vectors::NamedQuery;
 use segment::types::{
     Distance, ExtendedPointId, Payload, PayloadFieldSchema, PayloadSchemaType, SearchParams,
 };
@@ -254,7 +254,7 @@ async fn test_search_dedup() {
     let points = collection
         .search(
             CoreSearchRequest {
-                query: QueryEnum::Nearest(NamedVectorStruct::Default(vec![0.1, 0.2, 0.3, 0.4])),
+                query: QueryEnum::Nearest(NamedQuery::default_dense(vec![0.1, 0.2, 0.3, 0.4])),
                 filter: None,
                 params: Some(SearchParams {
                     exact: true,

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedVectorStruct, VectorInternal};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery, VectorInternal};
 use segment::types::{PointIdType, WithPayloadInterface, WithVector};
 use tempfile::Builder;
 use tokio::runtime::Handle;
@@ -77,7 +77,7 @@ async fn test_shard_query_rrf_rescoring() {
     assert!(matches!(sources_scores, Err(err) if err == expected_error));
 
     // RRF query with single prefetch
-    let nearest_query = QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+    let nearest_query = QueryEnum::Nearest(NamedQuery::new_from_vector(
         VectorInternal::Dense(vec![1.0, 2.0, 3.0, 4.0]),
         DEFAULT_VECTOR_NAME,
     ));
@@ -247,7 +247,7 @@ async fn test_shard_query_vector_rescoring() {
         .await
         .unwrap();
 
-    let nearest_query = QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+    let nearest_query = QueryEnum::Nearest(NamedQuery::new_from_vector(
         VectorInternal::Dense(vec![1.0, 2.0, 3.0, 4.0]),
         DEFAULT_VECTOR_NAME,
     ));
@@ -385,7 +385,7 @@ async fn test_shard_query_payload_vector() {
         .await
         .unwrap();
 
-    let nearest_query = QueryEnum::Nearest(NamedVectorStruct::new_from_vector(
+    let nearest_query = QueryEnum::Nearest(NamedQuery::new_from_vector(
         VectorInternal::Dense(vec![1.0, 2.0, 3.0, 4.0]),
         DEFAULT_VECTOR_NAME,
     ));

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -658,6 +658,47 @@ pub struct NamedQuery<TQuery> {
     pub using: Option<VectorNameBuf>,
 }
 
+impl NamedQuery<VectorInternal> {
+    pub fn default_dense(vec: DenseVector) -> NamedQuery<VectorInternal> {
+        NamedQuery {
+            query: VectorInternal::Dense(vec),
+            using: None,
+        }
+    }
+}
+
+impl<TVector> NamedQuery<TVector> {
+    pub fn new_from_vector(vector: TVector, using: impl Into<String>) -> NamedQuery<TVector> {
+        NamedQuery {
+            query: vector,
+            using: Some(using.into()),
+        }
+    }
+}
+
+impl From<NamedVectorStruct> for NamedQuery<VectorInternal> {
+    fn from(named_vector: NamedVectorStruct) -> Self {
+        match named_vector {
+            NamedVectorStruct::Default(dense) => NamedQuery {
+                query: VectorInternal::Dense(dense),
+                using: None,
+            },
+            NamedVectorStruct::Dense(NamedVector { name, vector }) => NamedQuery {
+                query: VectorInternal::Dense(vector),
+                using: Some(name),
+            },
+            NamedVectorStruct::Sparse(NamedSparseVector { name, vector }) => NamedQuery {
+                query: VectorInternal::Sparse(vector),
+                using: Some(name),
+            },
+            NamedVectorStruct::MultiDense(NamedMultiDenseVector { name, vector }) => NamedQuery {
+                query: VectorInternal::MultiDense(vector),
+                using: Some(name),
+            },
+        }
+    }
+}
+
 impl<T> Named for NamedQuery<T> {
     fn get_name(&self) -> &VectorName {
         self.using.as_deref().unwrap_or(DEFAULT_VECTOR_NAME)

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -685,7 +685,7 @@ mod tests_ops {
         CollectionUpdateOperationsDiscriminants, CreateIndex, FieldIndexOperations,
         FieldIndexOperationsDiscriminants,
     };
-    use segment::data_types::vectors::NamedVectorStruct;
+    use segment::data_types::vectors::NamedQuery;
     use segment::types::{PointIdType, SearchParams, WithPayloadInterface, WithVector};
     use strum::IntoEnumIterator as _;
 
@@ -859,7 +859,7 @@ mod tests_ops {
     #[test]
     fn test_core_search_request() {
         let op = CoreSearchRequest {
-            query: QueryEnum::Nearest(NamedVectorStruct::Default(vec![0.0, 1.0, 2.0])),
+            query: QueryEnum::Nearest(NamedQuery::default_dense(vec![0.0, 1.0, 2.0])),
             filter: None,
             params: Some(SearchParams::default()),
             limit: 100,

--- a/src/tonic/api/query_common.rs
+++ b/src/tonic/api/query_common.rs
@@ -87,7 +87,7 @@ pub async fn search(
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector);
 
     let search_request = CoreSearchRequest {
-        query: QueryEnum::Nearest(vector_struct),
+        query: QueryEnum::Nearest(vector_struct.into()),
         filter: filter.map(|f| f.try_into()).transpose()?,
         params: params.map(|p| p.into()),
         limit: limit as usize,


### PR DESCRIPTION
Homogenizes the `QueryEnum` enum for using `NamedQuery<T>` for all variants. The only different variant was `Nearest`. Essentially this PR makes this change:

```diff
pub enum QueryEnum {
-   Nearest(NamedVectorStruct),
+   Nearest(NamedQuery<VectorInternal>),
    RecommendBestScore(NamedQuery<RecoQuery<VectorInternal>>),
    RecommendSumScores(NamedQuery<RecoQuery<VectorInternal>>),
    Discover(NamedQuery<DiscoveryQuery<VectorInternal>>),
    Context(NamedQuery<ContextQuery<VectorInternal>>),
}
```