### PR TITLE
[strict mode] verify number and size of vectors in query

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1482,6 +1482,7 @@ Note: 1kB = 1 vector of size 256. |
 | multivector_config | [StrictModeMultivectorConfig](#qdrant-StrictModeMultivectorConfig) | optional |  |
 | sparse_config | [StrictModeSparseConfig](#qdrant-StrictModeSparseConfig) | optional |  |
 | max_points_count | [uint64](#uint64) | optional |  |
+| max_query_vectors | [uint32](#uint32) | optional |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7268,6 +7268,13 @@
             "minimum": 1,
             "nullable": true
           },
+          "max_query_vectors": {
+            "description": "Max number of individual vectors allowed in a query, including vectors in a multivector and all vector inputs in special queries like recommend, discovery, etc.\n\nThis setting limits the amount of similarity calculations between a query and a point.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          },
           "max_timeout": {
             "description": "Max allowed `timeout` parameter.",
             "type": "integer",
@@ -9612,6 +9619,13 @@
             "type": "integer",
             "format": "uint",
             "minimum": 1,
+            "nullable": true
+          },
+          "max_query_vectors": {
+            "description": "Max number of individual vectors allowed in a query, including vectors in a multivector and all vector inputs in special queries like recommend, discovery, etc.\n\nThis setting limits the amount of similarity calculations between a query and a point.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
             "nullable": true
           },
           "max_timeout": {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1887,6 +1887,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
         let StrictModeConfig {
             enabled,
             max_query_limit,
+            max_query_vectors,
             max_timeout,
             unindexed_filtering_retrieve,
             unindexed_filtering_update,
@@ -1907,6 +1908,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
         Self {
             enabled,
             max_query_limit: max_query_limit.map(|i| i as usize),
+            max_query_vectors: max_query_vectors.map(|i| i as usize),
             max_timeout: max_timeout.map(|i| i as usize),
             unindexed_filtering_retrieve,
             unindexed_filtering_update,
@@ -2010,6 +2012,7 @@ impl From<segment::types::StrictModeConfigOutput> for StrictModeConfig {
         let segment::types::StrictModeConfigOutput {
             enabled,
             max_query_limit,
+            max_query_vectors,
             max_timeout,
             unindexed_filtering_retrieve,
             unindexed_filtering_update,
@@ -2030,6 +2033,7 @@ impl From<segment::types::StrictModeConfigOutput> for StrictModeConfig {
         Self {
             enabled,
             max_query_limit: max_query_limit.map(|i| i as u32),
+            max_query_vectors: max_query_vectors.map(|i| i as u32),
             max_timeout: max_timeout.map(|i| i as u32),
             unindexed_filtering_retrieve,
             unindexed_filtering_update,
@@ -2055,6 +2059,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfigOutput {
         let StrictModeConfig {
             enabled,
             max_query_limit,
+            max_query_vectors,
             max_timeout,
             unindexed_filtering_retrieve,
             unindexed_filtering_update,
@@ -2075,6 +2080,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfigOutput {
         Self {
             enabled,
             max_query_limit: max_query_limit.map(|i| i as usize),
+            max_query_vectors: max_query_vectors.map(|i| i as usize),
             max_timeout: max_timeout.map(|i| i as usize),
             unindexed_filtering_retrieve,
             unindexed_filtering_update,

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -345,6 +345,7 @@ message StrictModeConfig {
   optional StrictModeMultivectorConfig multivector_config = 16;
   optional StrictModeSparseConfig sparse_config = 17;
   optional uint64 max_points_count = 18;
+  optional uint32 max_query_vectors = 19;
 }
 
 message StrictModeSparseConfig {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -529,6 +529,8 @@ pub struct StrictModeConfig {
     pub sparse_config: ::core::option::Option<StrictModeSparseConfig>,
     #[prost(uint64, optional, tag = "18")]
     pub max_points_count: ::core::option::Option<u64>,
+    #[prost(uint32, optional, tag = "19")]
+    pub max_query_vectors: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -128,6 +128,8 @@ impl GroupRequest {
             }
         };
 
+        query_search.check_strict_mode(&collection.strict_mode_config().await)?;
+
         Ok(QueryGroupRequest {
             source: query_search,
             group_by: self.group_by,

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -1,9 +1,12 @@
 use std::fmt::Debug;
+use std::iter;
 
 use segment::data_types::vectors::{DenseVector, Named, NamedQuery, VectorInternal};
-use segment::types::VectorName;
+use segment::types::{StrictModeConfig, VectorName};
 use segment::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::SparseVector;
+
+use super::types::{CollectionError, CollectionResult};
 
 impl QueryEnum {
     pub fn get_vector_name(&self) -> &VectorName {
@@ -72,6 +75,56 @@ pub enum QueryEnum {
     RecommendSumScores(NamedQuery<RecoQuery<VectorInternal>>),
     Discover(NamedQuery<DiscoveryQuery<VectorInternal>>),
     Context(NamedQuery<ContextQuery<VectorInternal>>),
+}
+
+impl QueryEnum {
+    /// Iterate over all vectors in the query.
+    fn vectors(&self) -> Box<dyn Iterator<Item = &VectorInternal> + '_> {
+        match self {
+            QueryEnum::Nearest(named_query) => Box::new(iter::once(&named_query.query)),
+            QueryEnum::RecommendBestScore(named_query) => Box::new(named_query.query.flat_iter()),
+            QueryEnum::RecommendSumScores(named_query) => Box::new(named_query.query.flat_iter()),
+            QueryEnum::Discover(named_query) => Box::new(named_query.query.flat_iter()),
+            QueryEnum::Context(named_query) => Box::new(named_query.query.flat_iter()),
+        }
+    }
+
+    pub fn check_strict_mode(&self, strict_mode_config: &StrictModeConfig) -> CollectionResult<()> {
+        if !strict_mode_config.is_enabled() {
+            return Ok(());
+        }
+
+        let max_sparse_len = strict_mode_config
+            .sparse_config
+            .as_ref()
+            .and_then(|config| config.config.get(self.get_vector_name()))
+            .and_then(|sparse_config| sparse_config.max_length);
+        let max_multivec_size = strict_mode_config
+            .multivector_config
+            .as_ref()
+            .and_then(|config| config.config.get(self.get_vector_name()))
+            .and_then(|multivec_config| multivec_config.max_vectors);
+
+        let mut num_query_vectors = 0;
+        for vector in self.vectors() {
+            // check individual size
+            vector.check_strict_mode(max_sparse_len, max_multivec_size)?;
+
+            // aggregate num vectors
+            num_query_vectors += vector.num_vectors();
+        }
+
+        // Check total number of vectors
+        if let Some(max_query_vectors) = strict_mode_config.max_query_vectors {
+            if num_query_vectors > max_query_vectors {
+                return Err(CollectionError::strict_mode(
+                    format!("Query exceeds maximum number of vectors ({max_query_vectors})"),
+                    "Use less vectors in the query and/or make multivector(s) shorter",
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 impl From<DenseVector> for QueryEnum {

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -357,7 +357,7 @@ fn recommend_by_avg_vector(
         positive,
         negative,
         lookup_from,
-        ..
+        strategy: _,
     } = request;
 
     let lookup_collection_name = lookup_from.as_ref().map(|x| &x.collection);

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -22,6 +22,50 @@ pub enum VectorInternal {
     MultiDense(MultiDenseVectorInternal),
 }
 
+impl VectorInternal {
+    pub fn num_vectors(&self) -> usize {
+        match self {
+            VectorInternal::Dense(_dense) => 1,
+            VectorInternal::Sparse(_sparse) => 1,
+            VectorInternal::MultiDense(multivec) => multivec.len(),
+        }
+    }
+
+    pub fn check_strict_mode(
+        &self,
+        max_sparse_len: Option<usize>,
+        max_multivec_size: Option<usize>,
+    ) -> OperationResult<()> {
+        if max_sparse_len.is_none() && max_multivec_size.is_none() {
+            return Ok(());
+        }
+
+        match self {
+            VectorInternal::Dense(_vector) => {}
+            VectorInternal::Sparse(sparse) => {
+                if let Some(max_sparse_len) = max_sparse_len {
+                    if sparse.indices.len() > max_sparse_len {
+                        return Err(OperationError::validation_error(format!(
+                            "amount of dimensions in the sparse vector exceeds {max_sparse_len}"
+                        )));
+                    }
+                }
+            }
+            VectorInternal::MultiDense(multivec) => {
+                if let Some(max_vectors) = max_multivec_size {
+                    if multivec.len() > max_vectors {
+                        return Err(OperationError::validation_error(format!(
+                            "amount of vectors in the multivector exceeds {max_vectors}"
+                        )));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum VectorRef<'a> {
     Dense(&'a [VectorElementType]),
@@ -202,6 +246,11 @@ pub struct TypedMultiDenseVector<T> {
 
 impl<T> TypedMultiDenseVector<T> {
     pub fn try_from_flatten(vectors: Vec<T>, dim: usize) -> Result<Self, OperationError> {
+        if dim == 0 {
+            return Err(OperationError::ValidationError {
+                description: "MultiDenseVector cannot have zero dimension".to_string(),
+            });
+        }
         if vectors.len() % dim != 0 || vectors.is_empty() {
             return Err(OperationError::ValidationError {
                 description: format!(
@@ -225,6 +274,11 @@ impl<T> TypedMultiDenseVector<T> {
             });
         }
         let dim = matrix[0].len();
+        if dim == 0 {
+            return Err(OperationError::ValidationError {
+                description: "MultiDenseVector cannot have zero dimension".to_string(),
+            });
+        }
         // assert all vectors have the same dimension
         if let Some(bad_vec) = matrix.iter().find(|v| v.len() != dim) {
             return Err(OperationError::WrongVectorDimension {
@@ -240,6 +294,10 @@ impl<T> TypedMultiDenseVector<T> {
         };
 
         Ok(multi_dense)
+    }
+
+    pub fn len(&self) -> usize {
+        self.flattened_vectors.len() / self.dim
     }
 }
 
@@ -309,26 +367,7 @@ impl<T: PrimitiveVectorElement> TryFrom<Vec<TypedDenseVector<T>>> for TypedMulti
     type Error = OperationError;
 
     fn try_from(value: Vec<TypedDenseVector<T>>) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(OperationError::ValidationError {
-                description: "MultiDenseVector cannot be empty".to_string(),
-            });
-        }
-        let dim = value[0].len();
-        // assert all vectors have the same dimension
-        if let Some(bad_vec) = value.iter().find(|v| v.len() != dim) {
-            Err(OperationError::WrongVectorDimension {
-                expected_dim: dim,
-                received_dim: bad_vec.len(),
-            })
-        } else {
-            let flattened_vectors = value.into_iter().flatten().collect_vec();
-            let multi_dense = TypedMultiDenseVector {
-                flattened_vectors,
-                dim,
-            };
-            Ok(multi_dense)
-        }
+        Self::try_from_matrix(value)
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -885,6 +885,12 @@ pub struct StrictModeConfig {
     #[validate(range(min = 1))]
     pub max_query_limit: Option<usize>,
 
+    /// Max number of individual vectors allowed in a query, including vectors in a multivector
+    /// and all vector inputs in special queries like recommend, discovery, etc.
+    ///
+    /// This setting limits the amount of similarity calculations between a query and a point.
+    pub max_query_vectors: Option<usize>,
+
     /// Max allowed `timeout` parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
@@ -957,6 +963,12 @@ pub struct StrictModeConfig {
     pub sparse_config: Option<StrictModeSparseConfig>,
 }
 
+impl StrictModeConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.enabled == Some(true)
+    }
+}
+
 impl Eq for StrictModeConfig {}
 
 impl Hash for StrictModeConfig {
@@ -964,6 +976,7 @@ impl Hash for StrictModeConfig {
         let Self {
             enabled,
             max_query_limit,
+            max_query_vectors,
             max_timeout,
             unindexed_filtering_retrieve,
             unindexed_filtering_update,
@@ -984,6 +997,7 @@ impl Hash for StrictModeConfig {
         } = self;
         enabled.hash(state);
         max_query_limit.hash(state);
+        max_query_vectors.hash(state);
         max_timeout.hash(state);
         unindexed_filtering_retrieve.hash(state);
         unindexed_filtering_update.hash(state);
@@ -1015,6 +1029,15 @@ pub struct StrictModeConfigOutput {
     #[validate(range(min = 1))]
     #[anonymize(false)]
     pub max_query_limit: Option<usize>,
+
+    /// Max number of individual vectors allowed in a query, including vectors in a multivector
+    /// and all vector inputs in special queries like recommend, discovery, etc.
+    ///
+    /// This setting limits the amount of similarity calculations between a query and a point.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1))]
+    #[anonymize(false)]
+    pub max_query_vectors: Option<usize>,
 
     /// Max allowed `timeout` parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1099,6 +1122,7 @@ impl From<StrictModeConfig> for StrictModeConfigOutput {
         let StrictModeConfig {
             enabled,
             max_query_limit,
+            max_query_vectors,
             max_timeout,
             unindexed_filtering_retrieve,
             unindexed_filtering_update,
@@ -1120,6 +1144,7 @@ impl From<StrictModeConfig> for StrictModeConfigOutput {
         Self {
             enabled,
             max_query_limit,
+            max_query_vectors,
             max_timeout,
             unindexed_filtering_retrieve,
             unindexed_filtering_update,

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -115,6 +115,7 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
     let api::grpc::qdrant::StrictModeConfig {
         enabled,
         max_query_limit,
+        max_query_vectors,
         max_timeout,
         unindexed_filtering_retrieve,
         unindexed_filtering_update,
@@ -135,6 +136,7 @@ pub fn strict_mode_from_api(value: api::grpc::qdrant::StrictModeConfig) -> Stric
     StrictModeConfig {
         enabled,
         max_query_limit: max_query_limit.map(|i| i as usize),
+        max_query_vectors: max_query_vectors.map(|i| i as usize),
         max_timeout: max_timeout.map(|i| i as usize),
         unindexed_filtering_retrieve,
         unindexed_filtering_update,


### PR DESCRIPTION
Builds on top of #6349 for easier handling of `VectorInternal`

This PR:
- enforces `max_vectors` for each multivector in the query
- enforces `max_length` for each sparse vector in the query
- introduces and enforces `max_query_vectors`, which counts the total amount of vectors in a query
  - each vector in a multivector is accounted individually
  - covers all vector inputs in special queries like recommend, discover, context, etc.