### PR TITLE
Strict mode prevents fullscan for multivector

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1544,7 +1544,7 @@ mod tests {
         eprintln!("search_result = {search_result:#?}");
 
         let hardware_accumulator = HwMeasurementAcc::new();
-        let query_context = QueryContext::new(10000, hardware_accumulator.clone());
+        let query_context = QueryContext::new(10000, hardware_accumulator.clone(), false);
         let segment_query_context = query_context.get_segment_query_context();
 
         let search_batch_result = proxy_segment

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -23,7 +23,6 @@ impl LocalShard {
 
         let (query_context, collection_params) = {
             let collection_config = self.collection_config.read().await;
-
             let query_context_opt = SegmentsSearcher::prepare_query_context(
                 self.segments.clone(),
                 &core_request,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -933,6 +933,11 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
+        if vector_query_context.strict_mode_enabled() && vector.is_multivector() {
+            return Err(OperationError::validation_error(
+                "Multivector full scan search not allowed in strict mode",
+            ));
+        }
         let id_tracker = self.id_tracker.borrow();
         let vector_storage = self.vector_storage.borrow();
         let quantized_vectors = self.quantized_vectors.borrow();
@@ -973,11 +978,6 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
-        if vector_query_context.strict_mode_enabled() && vector.is_multivector() {
-            return Err(OperationError::validation_error(
-                "Multivector full scan search not allowed in strict mode",
-            ));
-        }
         self.search_plain_iterator(
             vector,
             &mut filtered_points.iter().copied(),
@@ -994,11 +994,6 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
-        if vector_query_context.strict_mode_enabled() && vector.is_multivector() {
-            return Err(OperationError::validation_error(
-                "Multivector full scan search not allowed in strict mode",
-            ));
-        }
         let id_tracker = self.id_tracker.borrow();
         let mut ids_iterator = id_tracker.iter_internal();
         self.search_plain_iterator(vector, &mut ids_iterator, top, params, vector_query_context)

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -973,6 +973,11 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
+        if vector_query_context.strict_mode_enabled() && vector.is_multivector() {
+            return Err(OperationError::validation_error(
+                "Multivector full scan search not allowed in strict mode",
+            ));
+        }
         self.search_plain_iterator(
             vector,
             &mut filtered_points.iter().copied(),
@@ -989,6 +994,11 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
+        if vector_query_context.strict_mode_enabled() && vector.is_multivector() {
+            return Err(OperationError::validation_error(
+                "Multivector full scan search not allowed in strict mode",
+            ));
+        }
         let id_tracker = self.id_tracker.borrow();
         let mut ids_iterator = id_tracker.iter_internal();
         self.search_plain_iterator(vector, &mut ids_iterator, top, params, vector_query_context)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -964,6 +964,12 @@ pub struct StrictModeConfig {
     pub sparse_config: Option<StrictModeSparseConfig>,
 }
 
+impl StrictModeConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.enabled == Some(true)
+    }
+}
+
 impl Eq for StrictModeConfig {}
 
 impl Hash for StrictModeConfig {


### PR DESCRIPTION
This PR makes sure the multivector search will not use the full scan strategy as it is very expensive.