### PR TITLE
Implement `IdTracker::versioned_files`

### DIFF
--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -1,5 +1,8 @@
+use std::cmp;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic;
+use std::sync::atomic::AtomicU64;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::types::SeqNumberType;
@@ -100,12 +103,14 @@ impl SegmentManifest {
     }
 }
 
-#[derive(
-    Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
+// `Unknown` and `Untagged` both serialize into `null`, but `null` always deserializes as `Unknown`.
+// This is acceptable, because partial snapshots don't need to distinguish `Unknown` and `Untagged`
+// in deserialized manifests, and it makes serde format simpler.
 pub enum FileVersion {
     Version(SeqNumberType),
+    Unknown,
     Unversioned,
 }
 
@@ -114,17 +119,58 @@ impl FileVersion {
         self == Self::Unversioned
     }
 
-    pub fn or_segment_version(self, segment_version: SeqNumberType) -> SeqNumberType {
+    pub fn version(self) -> Option<SeqNumberType> {
         match self {
-            FileVersion::Version(version) => version,
-            FileVersion::Unversioned => segment_version,
+            Self::Version(version) => Some(version),
+            Self::Unknown => None,
+            Self::Unversioned => None,
         }
     }
-}
 
-impl From<SeqNumberType> for FileVersion {
-    fn from(version: SeqNumberType) -> Self {
-        Self::Version(version)
+    pub fn or_segment_version(self, segment_version: SeqNumberType) -> SeqNumberType {
+        self.version().unwrap_or(segment_version)
+    }
+
+    pub fn bump_to(&mut self, version: SeqNumberType) {
+        if let Self::Unversioned = self {
+            log::warn!("Bumping {self:?} to version {version}, {self:?} should never be bumped");
+        }
+
+        *self = Self::max(*self, version);
+    }
+
+    fn max(self, other: SeqNumberType) -> Self {
+        Self::Version(cmp::max(self.version().unwrap_or(0), other))
+    }
+
+    pub fn from_u64(version: u64) -> Self {
+        // When encoding FileVersion into u64:
+        // - FileVersion::Unknown encodes to 0
+        // - FileVersion::Version(n) encodes to n+1
+        //   - e.g., Version(0) encodes to 1, Version(1) to 2, etc.
+
+        if version == 0 {
+            Self::Unknown
+        } else {
+            Self::Version(version - 1)
+        }
+    }
+
+    pub fn into_u64(self) -> u64 {
+        // When encoding FileVersion into u64:
+        // - FileVersion::Unknown encodes to 0
+        // - FileVersion::Version(n) encodes to n+1
+        //   - e.g., Version(0) encodes to 1, Version(1) to 2, etc.
+
+        self.version().map_or(0, |version| version + 1)
+    }
+
+    pub fn load(atomic: &AtomicU64) -> Self {
+        Self::from_u64(atomic.load(atomic::Ordering::Relaxed))
+    }
+
+    pub fn store(atomic: &AtomicU64, version: Self) -> Self {
+        Self::from_u64(atomic.fetch_max(version.into_u64(), atomic::Ordering::Relaxed))
     }
 }
 
@@ -132,20 +178,35 @@ impl From<SeqNumberType> for FileVersion {
 mod test {
     use super::*;
 
-    /// Tests that `FileVersion` variants are uniquely represented in JSON
+    /// Tests `FileVersion` JSON format
     #[test]
     fn file_version_serde() {
         test_file_version_serde(FileVersion::Version(42), "42");
-        test_file_version_serde(FileVersion::Unversioned, "null");
+
+        // Both `FileVersion::Unknown` and `FileVersion::Unversioned` serialize into `null`
+        test_file_version_serialization(FileVersion::Unknown, "null");
+        test_file_version_serialization(FileVersion::Unversioned, "null");
+
+        // But `null` always deserializes into `FileVersion::Unknown`
+        test_file_version_deserialization("null", FileVersion::Unknown);
     }
 
-    /// Tests that `FileVersion` serializes into/deserializes from provided JSON representation
+    /// Tests that `FileVersion` serializes into/deserializes from expected JSON format
     fn test_file_version_serde(version: FileVersion, json: &str) {
+        test_file_version_serialization(version, json);
+        test_file_version_deserialization(json, version);
+    }
+
+    /// Tests that `FileVersion` serializes into expected JSON format
+    fn test_file_version_serialization(version: FileVersion, json: &str) {
         let serialized =
             serde_json::to_string(&version).expect("failed to serialize FileVersion to JSON");
 
         assert_eq!(serialized, json);
+    }
 
+    /// Tests that JSON deserializes into expected `FileVersion`
+    fn test_file_version_deserialization(json: &str, version: FileVersion) {
         let deserialized: FileVersion =
             serde_json::from_str(json).expect("failed to deserialize FileVersion from JSON");
 

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -11,6 +11,7 @@ use super::in_memory_id_tracker::InMemoryIdTracker;
 use super::mutable_id_tracker::MutableIdTracker;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::data_types::segment_manifest::FileVersion;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::types::{PointIdType, SeqNumberType};
@@ -162,7 +163,7 @@ pub trait IdTracker: fmt::Debug {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         Vec::new()
     }
 }
@@ -396,7 +397,7 @@ impl IdTracker for IdTrackerEnum {
         }
     }
 
-    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         match self {
             Self::MutableIdTracker(id_tracker) => id_tracker.versioned_files(),
             Self::ImmutableIdTracker(id_tracker) => id_tracker.versioned_files(),

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -395,4 +395,13 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.files(),
         }
     }
+
+    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+        match self {
+            Self::MutableIdTracker(id_tracker) => id_tracker.versioned_files(),
+            Self::ImmutableIdTracker(id_tracker) => id_tracker.versioned_files(),
+            Self::InMemoryIdTracker(id_tracker) => id_tracker.versioned_files(),
+            Self::RocksDbIdTracker(id_tracker) => id_tracker.versioned_files(),
+        }
+    }
 }

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -8,12 +8,11 @@ use serde_json::Value;
 use super::field_index::FieldIndex;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::data_types::segment_manifest::FileVersion;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::json_path::JsonPath;
 use crate::payload_storage::FilterContext;
-use crate::types::{
-    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, SeqNumberType,
-};
+use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 pub enum BuildIndexResult {
     /// Index was built
@@ -152,7 +151,7 @@ pub trait PayloadIndex {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         Vec::new()
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -17,9 +17,10 @@ use super::plain_vector_index::PlainVectorIndex;
 use super::sparse_index::sparse_vector_index::SparseVectorIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::segment_manifest::FileVersion;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::telemetry::VectorIndexSearchesTelemetry;
-use crate::types::{Filter, SearchParams, SeqNumberType};
+use crate::types::{Filter, SearchParams};
 
 /// Trait for vector searching
 pub trait VectorIndex {
@@ -37,7 +38,7 @@ pub trait VectorIndex {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         Vec::new()
     }
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -6,8 +6,9 @@ use serde_json::Value;
 
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::data_types::segment_manifest::FileVersion;
 use crate::json_path::JsonPath;
-use crate::types::{Filter, Payload, SeqNumberType};
+use crate::types::{Filter, Payload};
 
 /// Trait for payload data storage. Should allow filter checks
 pub trait PayloadStorage {
@@ -77,8 +78,8 @@ pub trait PayloadStorage {
     fn files(&self) -> Vec<PathBuf>;
 
     /// Returns a list of files, which have additional versioning information. Versioned files
-    /// should be a subset of `PayloadStoreage::files` result (maybe with exception of RocksDB).
-    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+    /// should be a subset of `PayloadStorage::files`.
+    fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         Vec::new()
     }
 

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -149,11 +149,7 @@ impl Segment {
         let all_files = all_files
             .into_iter()
             .map(|path| (path, FileVersion::Unversioned))
-            .chain(
-                versioned_files
-                    .into_iter()
-                    .map(|(path, version)| (path, FileVersion::from(version))),
-            );
+            .chain(versioned_files);
 
         let mut file_versions = HashMap::new();
 
@@ -244,7 +240,7 @@ impl Segment {
         files
     }
 
-    fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         let mut files = Vec::new();
 
         for vector_data in self.vector_data.values() {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -20,6 +20,7 @@ use super::quantized_scorer_builder::QuantizedScorerBuilder;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::vector_utils::TrySetCapacityExact;
 use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::segment_manifest::FileVersion;
 use crate::data_types::vectors::{QueryVector, VectorElementType};
 use crate::types::{
     BinaryQuantization, BinaryQuantizationConfig, CompressionRatio, Distance, MultiVectorConfig,
@@ -227,7 +228,7 @@ impl QuantizedVectors {
         files
     }
 
-    pub fn versioned_files(&self) -> Vec<(PathBuf, u64)> {
+    pub fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         Vec::new() // TODO
     }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -20,11 +20,12 @@ use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::segment_manifest::FileVersion;
 use crate::data_types::vectors::{
     MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorElementTypeByte,
     VectorElementTypeHalf, VectorInternal, VectorRef,
 };
-use crate::types::{Distance, MultiVectorConfig, SeqNumberType, VectorStorageDatatype};
+use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::dense::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage;
@@ -87,7 +88,7 @@ pub trait VectorStorage {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    fn versioned_files(&self) -> Vec<(PathBuf, SeqNumberType)> {
+    fn versioned_files(&self) -> Vec<(PathBuf, FileVersion)> {
         Vec::new()
     }
 


### PR DESCRIPTION
This PR adds `VersionTracker`s to `MutableIdTracker` and `ImmutableIdTracker`, that track versions of on-disk files backing these ID trackers, and implements `versioned_files` method for them.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
