### PR TITLE
Fix strict mode query limit for group APIs

### DIFF
--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -131,7 +131,7 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        Some(self.limit)
+        Some(self.limit * self.group_size)
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/recommend.rs
+++ b/lib/collection/src/operations/verification/recommend.rs
@@ -27,7 +27,7 @@ impl StrictModeVerification for RecommendRequestInternal {
 
 impl StrictModeVerification for RecommendGroupsRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        Some(self.group_request.limit as usize)
+        Some(self.group_request.limit as usize * self.group_request.group_size as usize)
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {

--- a/lib/collection/src/operations/verification/search.rs
+++ b/lib/collection/src/operations/verification/search.rs
@@ -87,7 +87,7 @@ impl StrictModeVerification for SearchRequestBatch {
 
 impl StrictModeVerification for SearchGroupsRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        Some(self.group_request.limit as usize)
+        Some(self.group_request.limit as usize * self.group_request.group_size as usize)
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {


### PR DESCRIPTION
For the group APIs, the effective limit is equal to `query.limit` * `group_size` as we generate limit elements per group.