### PR TITLE
Fix strict mode query limit for distance matrix API

### DIFF
--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -5,7 +5,12 @@ use crate::collection::distance_matrix::CollectionSearchMatrixRequest;
 
 impl StrictModeVerification for SearchMatrixRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        self.limit
+        match (self.limit, self.sample) {
+            (Some(limit), Some(sample)) => Some(limit * sample),
+            (Some(limit), None) => Some(limit),
+            (None, Some(sample)) => Some(sample),
+            (None, None) => None,
+        }
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {
@@ -27,7 +32,7 @@ impl StrictModeVerification for SearchMatrixRequestInternal {
 
 impl StrictModeVerification for CollectionSearchMatrixRequest {
     fn query_limit(&self) -> Option<usize> {
-        Some(self.limit_per_sample)
+        Some(self.limit_per_sample * self.sample_size)
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -1698,3 +1698,33 @@ def test_strict_mode_group_limits(collection_name):
     )
     assert not response.ok
     assert "Forbidden: Limit exceeded 30 > 15 for \"limit\"" in response.json()['status']['error']
+
+def test_strict_mode_distance_matrix_limits(collection_name):
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/matrix/pairs",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "sample": 10,
+            "limit": 2,
+        },
+    )
+    assert response.ok
+
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "max_query_limit": 15,
+    })
+
+    # try again
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/matrix/pairs",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "sample": 10,
+            "limit": 2,
+        },
+    )
+    assert not response.ok
+    assert "Forbidden: Limit exceeded 20 > 15 for \"limit\"" in response.json()['status']['error']


### PR DESCRIPTION
Similar to https://github.com/qdrant/qdrant/pull/6353

For the distance matrix API with fetch limit elements per sample to return a sparse matrix.