### PR TITLE
Enable incremental_hnsw_building default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ fn main() -> anyhow::Result<()> {
 
     // Report feature flags that are enabled for easier debugging
     let flags = feature_flags();
-    if !flags.is_empty() {
+    if !flags.is_default() {
         log::debug!("Feature flags: {flags:?}");
     }
 


### PR DESCRIPTION
Follow-up for #6325. This PR sets `incremental_hnsw_building` by default.

In this PR, `#[derive(Default)]` for `FeatureFlags` is replaced with manual `impl Default` that sets the said flag. Tests are updated to make sure that `Default`, `Deserealize` and `.is_default()` are still in sync.