### PR TITLE
[rate limits] consider length of multivectors for query cost

### DIFF
--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::iter;
 
 use segment::data_types::vectors::{DenseVector, Named, NamedQuery, VectorInternal};
 use segment::types::VectorName;
@@ -72,6 +73,27 @@ pub enum QueryEnum {
     RecommendSumScores(NamedQuery<RecoQuery<VectorInternal>>),
     Discover(NamedQuery<DiscoveryQuery<VectorInternal>>),
     Context(NamedQuery<ContextQuery<VectorInternal>>),
+}
+
+impl QueryEnum {
+    /// Iterate over all vectors in the query.
+    fn vectors(&self) -> Box<dyn Iterator<Item = &VectorInternal> + '_> {
+        match self {
+            QueryEnum::Nearest(named_query) => Box::new(iter::once(&named_query.query)),
+            QueryEnum::RecommendBestScore(named_query) => Box::new(named_query.query.flat_iter()),
+            QueryEnum::RecommendSumScores(named_query) => Box::new(named_query.query.flat_iter()),
+            QueryEnum::Discover(named_query) => Box::new(named_query.query.flat_iter()),
+            QueryEnum::Context(named_query) => Box::new(named_query.query.flat_iter()),
+        }
+    }
+
+    /// Returns the estimated cost of using this query in terms of number of vectors.
+    /// The cost approximates how many similarity comparisons this query will make against one point.
+    pub fn search_cost(&self) -> usize {
+        self.vectors()
+            .map(|vector_internal| vector_internal.similarity_cost())
+            .sum()
+    }
 }
 
 impl From<DenseVector> for QueryEnum {

--- a/lib/collection/src/operations/verification/operation_rate_cost.rs
+++ b/lib/collection/src/operations/verification/operation_rate_cost.rs
@@ -1,6 +1,5 @@
 use segment::types::Filter;
 
-use crate::operations::query_enum::QueryEnum;
 use crate::operations::types::{CoreSearchRequest, QueryScrollRequestInternal};
 
 pub fn filter_rate_cost(filter: &Filter) -> usize {
@@ -12,20 +11,7 @@ pub const BASE_COST: usize = 1;
 
 impl CoreSearchRequest {
     pub fn search_rate_cost(&self) -> usize {
-        let mut cost = match &self.query {
-            QueryEnum::Nearest(_nq) => {
-                // TODO(strict-mode) should the cost be adjusted here?
-                BASE_COST
-            }
-            QueryEnum::RecommendBestScore(rb) => {
-                rb.query.positives.len() + rb.query.negatives.len()
-            }
-            QueryEnum::RecommendSumScores(rs) => {
-                rs.query.positives.len() + rs.query.negatives.len()
-            }
-            QueryEnum::Discover(rd) => rd.query.pairs.len(),
-            QueryEnum::Context(rc) => rc.query.pairs.len(),
-        };
+        let mut cost = self.query.search_cost();
         if let Some(filter) = &self.filter {
             cost += filter_rate_cost(filter);
         }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -16,7 +16,7 @@ use crate::types::{VectorName, VectorNameBuf};
 use crate::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 
 /// How many dimensions of a sparse vector are considered to be a single unit for cost estimation.
-const SPARSE_VECTOR_COST: usize = 64;
+const SPARSE_DIMS_COST_UNIT: usize = 64;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum VectorInternal {
@@ -30,9 +30,7 @@ impl VectorInternal {
     pub fn similarity_cost(&self) -> usize {
         match self {
             VectorInternal::Dense(_dense) => 1,
-            // TODO(ratelimits): Currently one sparse vector counts as one, regardless of number of dimensions.
-            //                   We should come up with a formula for adjusting its cost.
-            VectorInternal::Sparse(sparse) => sparse.indices.len().div_ceil(SPARSE_VECTOR_COST),
+            VectorInternal::Sparse(sparse) => sparse.indices.len().div_ceil(SPARSE_DIMS_COST_UNIT),
             VectorInternal::MultiDense(multivec) => multivec.len(),
         }
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -32,7 +32,7 @@ impl VectorInternal {
             VectorInternal::Dense(_dense) => 1,
             // TODO(ratelimits): Currently one sparse vector counts as one, regardless of number of dimensions.
             //                   We should come up with a formula for adjusting its cost.
-            VectorInternal::Sparse(sparse) => 1.max(sparse.indices.len() / SPARSE_VECTOR_COST),
+            VectorInternal::Sparse(sparse) => sparse.indices.len().div_ceil(SPARSE_VECTOR_COST),
             VectorInternal::MultiDense(multivec) => multivec.len(),
         }
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -15,6 +15,9 @@ use crate::common::utils::transpose_map_into_named_vector;
 use crate::types::{VectorName, VectorNameBuf};
 use crate::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 
+/// How many dimensions of a sparse vector are considered to be a single unit for cost estimation.
+const SPARSE_VECTOR_COST: usize = 64;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum VectorInternal {
     Dense(DenseVector),
@@ -29,7 +32,7 @@ impl VectorInternal {
             VectorInternal::Dense(_dense) => 1,
             // TODO(ratelimits): Currently one sparse vector counts as one, regardless of number of dimensions.
             //                   We should come up with a formula for adjusting its cost.
-            VectorInternal::Sparse(_sparse) => 1,
+            VectorInternal::Sparse(sparse) => 1.max(sparse.indices.len() / SPARSE_VECTOR_COST),
             VectorInternal::MultiDense(multivec) => multivec.len(),
         }
     }

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -1,21 +1,8 @@
 import logging
 import pathlib
 
-from .fixtures import (
-    create_collection,
-    random_dense_vector,
-    set_strict_mode,
-    upsert_points,
-    upsert_random_points,
-)
-from .utils import (
-    create_shard_key,
-    get_cluster_info,
-    get_collection_local_shards_count,
-    start_cluster,
-    wait_collection_exists_and_active_on_all_peers,
-    wait_for_strict_mode_enabled,
-)
+from .fixtures import create_collection, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode
+from .utils import *
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
@@ -50,7 +37,7 @@ def test_vector_storage_strict_mode_upsert(tmp_path: pathlib.Path):
                 assert "Max vector storage size" in res.json()['status']['error']
                 return
 
-    assert False, "Should have blocked upsert but didn't"
+    raise AssertionError("Should have blocked upsert but didn't")
 
 
 def test_vector_storage_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
@@ -93,7 +80,7 @@ def test_vector_storage_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path
             assert not res.ok
             return
 
-    assert False, "Should have blocked upsert but didn't"
+    raise AssertionError("Should have blocked upsert but didn't")
 
 
 def test_vector_storage_strict_mode_upsert_local_shard(tmp_path: pathlib.Path):
@@ -126,7 +113,8 @@ def test_vector_storage_strict_mode_upsert_local_shard(tmp_path: pathlib.Path):
             assert not res.ok
             return
 
-    assert False, "Should have blocked upsert but didn't"
+    raise AssertionError("Should have blocked upsert but didn't")
+
 
 
 def test_payload_strict_mode_upsert(tmp_path: pathlib.Path):
@@ -153,7 +141,8 @@ def test_payload_strict_mode_upsert(tmp_path: pathlib.Path):
                 assert "Max payload storage size" in res.json()['status']['error']
                 return
 
-    assert False, "Should have blocked upsert but didn't"
+    raise AssertionError("Should have blocked upsert but didn't")
+
 
 
 def test_payload_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
@@ -198,7 +187,8 @@ def test_payload_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
             assert not res.ok
             return
 
-    assert False, "Should have blocked upsert but didn't"
+    raise AssertionError("Should have blocked upsert but didn't")
+
 
 
 def test_write_rate_limiting_across_node(tmp_path: pathlib.Path):
@@ -249,4 +239,4 @@ def test_write_rate_limiting_across_node(tmp_path: pathlib.Path):
             assert 1 <= int(response.headers['Retry-After']) <= 5
             return
 
-    assert False, "rate limiter was never triggered"
+    raise AssertionError("rate limiter was never triggered")

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -1,8 +1,21 @@
 import logging
 import pathlib
 
-from .fixtures import create_collection, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode
-from .utils import *
+from .fixtures import (
+    create_collection,
+    random_dense_vector,
+    set_strict_mode,
+    upsert_points,
+    upsert_random_points,
+)
+from .utils import (
+    create_shard_key,
+    get_cluster_info,
+    get_collection_local_shards_count,
+    start_cluster,
+    wait_collection_exists_and_active_on_all_peers,
+    wait_for_strict_mode_enabled,
+)
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -7,7 +7,7 @@ from .utils import *
 N_PEERS = 3
 N_SHARDS = 1
 N_REPLICA = 3
-
+COLLECTION_NAME = "test_triple_replication"
 
 def update_points_in_loop(peer_url, collection_name):
     offset = 0
@@ -29,13 +29,13 @@ def test_triple_replication(tmp_path: pathlib.Path):
 
     peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
 
-    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA)
+    create_collection(peer_api_uris[0], collection=COLLECTION_NAME, shard_number=N_SHARDS, replication_factor=N_REPLICA)
     wait_collection_exists_and_active_on_all_peers(
-        collection_name="test_collection",
+        collection_name=COLLECTION_NAME,
         peer_api_uris=peer_api_uris
     )
 
-    upload_process = run_update_points_in_background(peer_api_uris[1], "test_collection")
+    upload_process = run_update_points_in_background(peer_api_uris[1], COLLECTION_NAME)
 
     time.sleep(0.3)
 
@@ -66,10 +66,10 @@ def test_triple_replication(tmp_path: pathlib.Path):
         all_active = True
         points_counts = set()
         for peer_api_uri in peer_api_uris:
-            count = get_collection_point_count(peer_api_uri, "test_collection", exact=True)
+            count = get_collection_point_count(peer_api_uri, COLLECTION_NAME, exact=True)
             points_counts.add(count)
 
-            res = check_collection_cluster(peer_api_uri, "test_collection")
+            res = check_collection_cluster(peer_api_uri, COLLECTION_NAME)
             if res['state'] != 'Active':
                 all_active = False
 
@@ -77,7 +77,7 @@ def test_triple_replication(tmp_path: pathlib.Path):
             if len(points_counts) != 1:
                 with open("test_triple_replication.log", "w") as f:
                     for peer_api_uri in peer_api_uris:
-                        collection_name = "test_collection"
+                        collection_name = COLLECTION_NAME
                         res = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster", timeout=10)
                         f.write(f"{peer_api_uri} {res.json()['result']}\n")
                     for peer_api_uri in peer_api_uris:
@@ -85,7 +85,7 @@ def test_triple_replication(tmp_path: pathlib.Path):
                         f.write(f"{peer_api_uri} {res.json()['result']}\n")
 
                 for peer_api_uri in peer_api_uris:
-                    count = get_collection_point_count(peer_api_uri, "test_collection", exact=True)
+                    count = get_collection_point_count(peer_api_uri, COLLECTION_NAME, exact=True)
                     print(count)
 
                 assert False, f"Points count is not equal on all peers: {points_counts}"
@@ -93,4 +93,3 @@ def test_triple_replication(tmp_path: pathlib.Path):
 
         time.sleep(1)
         timeout -= 1
-

--- a/tests/openapi/helpers/collection_setup.py
+++ b/tests/openapi/helpers/collection_setup.py
@@ -1,6 +1,7 @@
-from retry import retry
-from .helpers import request_with_validation
 from requests.exceptions import ConnectionError
+from retry import retry
+
+from .helpers import request_with_validation
 
 
 @retry(ConnectionError, delay=1, tries=5, backoff=2)

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -1,16 +1,22 @@
 import pytest
+from requests import Response
 
-from .conftest import collection_name
-from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .conftest import collection_name as test_collection_name
+from .helpers.collection_setup import basic_collection_setup, drop_collection, full_collection_setup
 from .helpers.helpers import request_with_validation
 
+@pytest.fixture()
+def collection_name(test_collection_name):
+    basic_collection_setup(collection_name=test_collection_name)
+    yield test_collection_name
+    drop_collection(collection_name=test_collection_name)
 
-@pytest.fixture(autouse=True)
-def setup(collection_name):
-    basic_collection_setup(collection_name=collection_name)
-    yield
-    drop_collection(collection_name=collection_name)
-
+@pytest.fixture()
+def full_collection_name(test_collection_name):
+    coll_name = f"{test_collection_name}_full"
+    full_collection_setup(coll_name)
+    yield coll_name
+    drop_collection(collection_name=coll_name)
 
 def set_strict_mode(collection_name, strict_mode_config):
     request_with_validation(
@@ -1631,100 +1637,76 @@ def test_scroll_filter_many_conditions(collection_name):
     assert response.status_code == 429
     assert "Read rate limit exceeded: Operation requires 7 tokens" in response.json()['status']['error']
 
+def test_read_rate_limiter_many_vectors(full_collection_name):
+    collection_name = full_collection_name
 
-def test_strict_mode_group_limits(collection_name):
-    response = request_with_validation(
-        api="/collections/{collection_name}/points/search/groups",
-        method="POST",
-        path_params={"collection_name": collection_name},
-        body={
-            "vector": [1.0, 0.0, 0.0, 0.0],
-            "limit": 10,
-            "with_payload": True,
-            "group_by": "docId",
-            "group_size": 3,
-        },
-    )
-    assert response.ok
+    def check_response(response: Response, should_succeed: bool):
+        if should_succeed:
+            assert response.ok, response.text
+        else:
+            assert response.status_code == 429
+            assert "request larger than rate limiter capacity" in response.json()['status']['error']
 
-    response = request_with_validation(
-        api="/collections/{collection_name}/points/query/groups",
-        method="POST",
-        path_params={"collection_name": collection_name},
-        body={
-            "query": [1.0, 0.0, 0.0, 0.0],
-            "limit": 10,
-            "with_payload": True,
-            "group_by": "docId",
-            "group_size": 3,
-        },
-    )
-    assert response.ok
+    def check_multivector_query_raw(should_succeed: bool):
+        # query api with vector
+        multivector = [[0.1, 0.2, 0.3, 0.4] for _ in range(3)]
+        search_response = request_with_validation(
+            api='/collections/{collection_name}/points/query',
+            method="POST",
+            path_params={'collection_name': collection_name},
+            body={
+                "query": multivector,
+                "using": "dense-multi",
+                "limit": 5
+            }
+        )
+        check_response(search_response, should_succeed)
 
+    def check_multivector_query_id(should_succeed: bool):
+        # query api with id
+        search_response = request_with_validation(
+            api='/collections/{collection_name}/points/query',
+            method="POST",
+            path_params={'collection_name': collection_name},
+            body={
+                "query": 2, # this point has a multivector of 3 vectors
+                "using": "dense-multi",
+                "limit": 5
+            }
+        )
+        check_response(search_response, should_succeed)
 
+    # check without strict mode
+    check_multivector_query_raw(should_succeed=True)
+    check_multivector_query_id(should_succeed=True)
+
+    ##### Set strict mode with very low read_rate_limit, it should not succeed
     set_strict_mode(collection_name, {
         "enabled": True,
-        "max_query_limit": 15,
+        "read_rate_limit": 2 # multivector has 3 vectors
     })
+    check_multivector_query_raw(should_succeed=False)
 
-    # try again
-    response = request_with_validation(
-        api="/collections/{collection_name}/points/search/groups",
-        method="POST",
-        path_params={"collection_name": collection_name},
-        body={
-            "vector": [1.0, 0.0, 0.0, 0.0],
-            "limit": 10,
-            "with_payload": True,
-            "group_by": "docId",
-            "group_size": 3,
-        },
-    )
-
-    assert not response.ok
-    assert "Forbidden: Limit exceeded 30 > 15 for \"limit\"" in response.json()['status']['error']
-
-    response = request_with_validation(
-        api="/collections/{collection_name}/points/query/groups",
-        method="POST",
-        path_params={"collection_name": collection_name},
-        body={
-            "query": [1.0, 0.0, 0.0, 0.0],
-            "limit": 10,
-            "with_payload": True,
-            "group_by": "docId",
-            "group_size": 3,
-        },
-    )
-    assert not response.ok
-    assert "Forbidden: Limit exceeded 30 > 15 for \"limit\"" in response.json()['status']['error']
-
-def test_strict_mode_distance_matrix_limits(collection_name):
-    response = request_with_validation(
-        api="/collections/{collection_name}/points/search/matrix/pairs",
-        method="POST",
-        path_params={"collection_name": collection_name},
-        body={
-            "sample": 10,
-            "limit": 2,
-        },
-    )
-    assert response.ok
-
+    # reset rate limiter for next request
     set_strict_mode(collection_name, {
         "enabled": True,
-        "max_query_limit": 15,
+        "read_rate_limit": 2 # multivector has 3 vectors
     })
+    check_multivector_query_id(should_succeed=False)
 
-    # try again
-    response = request_with_validation(
-        api="/collections/{collection_name}/points/search/matrix/pairs",
-        method="POST",
-        path_params={"collection_name": collection_name},
-        body={
-            "sample": 10,
-            "limit": 2,
-        },
-    )
-    assert not response.ok
-    assert "Forbidden: Limit exceeded 20 > 15 for \"limit\"" in response.json()['status']['error']
+
+    #### Set strict mode with just enough read_rate_limit, it should succeed
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "read_rate_limit": 3 # multivector has 3 vectors
+    })
+    check_multivector_query_raw(should_succeed=True)
+
+    # reset rate limiter for next request
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "read_rate_limit": 5 # multivector has 3 vectors
+                             # + 1 of fetching the id
+                             # + 1 of the filter for not including the id
+    })
+    check_multivector_query_id(should_succeed=True)

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -1637,6 +1637,105 @@ def test_scroll_filter_many_conditions(collection_name):
     assert response.status_code == 429
     assert "Read rate limit exceeded: Operation requires 7 tokens" in response.json()['status']['error']
 
+
+def test_strict_mode_group_limits(collection_name):
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/groups",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+        },
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query/groups",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+        },
+    )
+    assert response.ok
+
+
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "max_query_limit": 15,
+    })
+
+    # try again
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/groups",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+        },
+    )
+
+    assert not response.ok
+    assert "Forbidden: Limit exceeded 30 > 15 for \"limit\"" in response.json()['status']['error']
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query/groups",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+        },
+    )
+    assert not response.ok
+    assert "Forbidden: Limit exceeded 30 > 15 for \"limit\"" in response.json()['status']['error']
+
+def test_strict_mode_distance_matrix_limits(collection_name):
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/matrix/pairs",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "sample": 10,
+            "limit": 2,
+        },
+    )
+    assert response.ok
+
+    set_strict_mode(collection_name, {
+        "enabled": True,
+        "max_query_limit": 15,
+    })
+
+    # try again
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/matrix/pairs",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "sample": 10,
+            "limit": 2,
+        },
+    )
+    assert not response.ok
+    assert "Forbidden: Limit exceeded 20 > 15 for \"limit\"" in response.json()['status']['error']
+
+
 def test_read_rate_limiter_many_vectors(full_collection_name):
     collection_name = full_collection_name
 

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -1779,7 +1779,7 @@ def test_read_rate_limiter_many_vectors(full_collection_name):
     check_multivector_query_raw(should_succeed=True)
     check_multivector_query_id(should_succeed=True)
 
-    ##### Set strict mode with very low read_rate_limit, it should not succeed
+    # Set strict mode with very low read_rate_limit, it should not succeed
     set_strict_mode(collection_name, {
         "enabled": True,
         "read_rate_limit": 2 # multivector has 3 vectors
@@ -1794,7 +1794,7 @@ def test_read_rate_limiter_many_vectors(full_collection_name):
     check_multivector_query_id(should_succeed=False)
 
 
-    #### Set strict mode with just enough read_rate_limit, it should succeed
+    # Set strict mode with just enough read_rate_limit, it should succeed
     set_strict_mode(collection_name, {
         "enabled": True,
         "read_rate_limit": 3 # multivector has 3 vectors


### PR DESCRIPTION
Considers the size of multivectors and total amount of examples in special queries like recommend, discover, etc. in the cost of a single core_search. 

This effectively limits requests that would be too expensive according to the rate-limiter setting. 