### PR TITLE
[query api] don't propagate offset into prefetches

### DIFF
--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -762,7 +762,7 @@ mod tests {
                 ),),
                 filter: dummy_filter,
                 params: dummy_params,
-                limit: 37 + 49, // limit + offset
+                limit: 37,
                 offset: 0,
                 with_payload: Some(WithPayloadInterface::Bool(false)),
                 with_vector: Some(WithVector::Bool(false)),

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -93,9 +93,6 @@ impl PlannedQuery {
             with_payload,
             params,
         } = request;
-        // Final offset is handled at collection level
-        let limit = limit + offset;
-
         let merge_plan = if !prefetches.is_empty() {
             if depth > MAX_PREFETCH_DEPTH {
                 return Err(CollectionError::bad_request(format!(
@@ -108,13 +105,8 @@ impl PlannedQuery {
             })?;
 
             if rescore.needs_intermediate_results() {
-                let sources = recurse_prefetches(
-                    &mut self.searches,
-                    &mut self.scrolls,
-                    prefetches,
-                    offset,
-                    &filter,
-                )?;
+                let sources =
+                    recurse_prefetches(&mut self.searches, &mut self.scrolls, prefetches, &filter)?;
 
                 let merge_plan = MergePlan {
                     sources,
@@ -129,13 +121,8 @@ impl PlannedQuery {
                     with_payload,
                 }
             } else {
-                let sources = recurse_prefetches(
-                    &mut self.searches,
-                    &mut self.scrolls,
-                    prefetches,
-                    offset,
-                    &filter,
-                )?;
+                let sources =
+                    recurse_prefetches(&mut self.searches, &mut self.scrolls, prefetches, &filter)?;
 
                 let merge_plan = MergePlan {
                     sources,
@@ -154,6 +141,14 @@ impl PlannedQuery {
                 }
             }
         } else {
+            // Only increase the limit with the offset when there are no prefetches
+            //
+            // Reason for this is because there is no guarantee of stability of results when prefetches and main query are not
+            // strongly correlated.
+            // For example: if prefetch is a knn search, and main query is an `order_by`, propagating the offset for trying to
+            // get a second page will just increase the pool of candidates for `order_by`. The second page in this case will be
+            // invalid because it will cut the offset on a different total ordering.
+            let limit = limit + offset;
             let sources = match query {
                 Some(ScoringQuery::Vector(query)) => {
                     // Everything should come from 1 core search
@@ -254,7 +249,6 @@ fn recurse_prefetches(
     core_searches: &mut Vec<CoreSearchRequest>,
     scrolls: &mut Vec<QueryScrollRequestInternal>,
     prefetches: Vec<ShardPrefetch>,
-    root_offset: usize, // Offset is added to all prefetches, so we make sure we have enough
     propagate_filter: &Option<Filter>, // Global filter to apply to all prefetches
 ) -> CollectionResult<Vec<Source>> {
     let mut sources = Vec::with_capacity(prefetches.len());
@@ -266,22 +260,18 @@ fn recurse_prefetches(
         let ShardPrefetch {
             prefetches,
             query,
-            limit: prefetch_limit,
+            limit,
             params,
             filter,
             score_threshold,
         } = prefetch;
-
-        // Offset is replicated at each step from the root to the leaves
-        let limit = prefetch_limit + root_offset;
 
         // Filters are propagated into the leaves
         let filter = Filter::merge_opts(propagate_filter.clone(), filter);
 
         let source = if !prefetches.is_empty() {
             // This has nested prefetches. Recurse into them
-            let inner_sources =
-                recurse_prefetches(core_searches, scrolls, prefetches, root_offset, &filter)?;
+            let inner_sources = recurse_prefetches(core_searches, scrolls, prefetches, &filter)?;
 
             let rescore = query.ok_or_else(|| {
                 CollectionError::bad_request("cannot have prefetches without a query".to_string())

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -1,7 +1,6 @@
 //! Platform-independent abstractions over [`memmap2::Mmap::advise`]/[`memmap2::MmapMut::advise`]
 //! and [`memmap2::Advice`].
 
-use std::fs::File;
 use std::hint::black_box;
 use std::io;
 use std::num::Wrapping;
@@ -187,6 +186,7 @@ pub fn clear_disk_cache(file_path: &Path) -> io::Result<()> {
         target_env = "uclibc",
     ))]
     {
+        use std::fs::File;
         use std::os::fd::AsRawFd as _;
 
         use nix::fcntl;

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -1,7 +1,6 @@
 //! Platform-independent abstractions over [`memmap2::Mmap::advise`]/[`memmap2::MmapMut::advise`]
 //! and [`memmap2::Advice`].
 
-use std::fs::File;
 use std::hint::black_box;
 use std::io;
 use std::num::Wrapping;

--- a/lib/common/memory/src/madvise.rs
+++ b/lib/common/memory/src/madvise.rs
@@ -1,6 +1,7 @@
 //! Platform-independent abstractions over [`memmap2::Mmap::advise`]/[`memmap2::MmapMut::advise`]
 //! and [`memmap2::Advice`].
 
+use std::fs::File;
 use std::hint::black_box;
 use std::io;
 use std::num::Wrapping;

--- a/tests/openapi/test_query_full.py
+++ b/tests/openapi/test_query_full.py
@@ -1441,8 +1441,8 @@ def test_random_rescore_with_offset(collection_name):
     random_result = response.json()["result"]["points"]
     assert len(random_result) == 1
     assert random_result[0]["id"] == 1
-    
-    # assert offset is propagated to prefetch
+
+    # assert offset is NOT propagated to prefetch
     seen = set()
     for _ in range(100):
         response = request_with_validation(
@@ -1450,7 +1450,7 @@ def test_random_rescore_with_offset(collection_name):
             method="POST",
             path_params={"collection_name": collection_name},
             body={
-                "prefetch": { "limit": 1 },
+                "prefetch": { "limit": 2 },
                 "query": {"sample": "random"},
                 "offset": 1,
             },
@@ -1458,14 +1458,14 @@ def test_random_rescore_with_offset(collection_name):
         assert response.ok, response.json()
         random_result = response.json()["result"]["points"]
         assert len(random_result) == 1
-    
+
         seen.add(random_result[0]["id"])
         if seen == {1, 2}:
             return
-    
-    # Although prefetch limit is 1, offset should be propagated, so randomness is applied to points 1 and 2.
+
+    # Offset is not propagated to prefetch, since prefetch without a query is a scroll, random sampling is applied to points 1 and 2.
     # By this point we should've seen both points.
-    assert False, f"after 100 tries, `seen` is expected to be {{1, 2}}, but it was {seen}"
+    raise AssertionError(f"after 100 tries, `seen` is expected to be {{1, 2}}, but it was {seen}")
 
 
 @pytest.mark.parametrize("query_filter", [None, *get_uuid_index_filters()])


### PR DESCRIPTION
One overlooked quirk when developing prefetches is that we should not propagate the main query offset into them. 

In general terms, offsets are not compatible with prefetches. Let's look at one example:

Imagine we have a vector search prefetch (limit=5), and an order_by main query (limit=3). For simplicity, let's assume letters are point IDs, and numbers are the order_by values
```
with offset 0
prefetch candidates: [a: 5, b: 8, c: 3, d: 9, e: 2]

main query ordering: [e: 2, c: 3, a: 5, b: 8, d: 9]
main query results:  [e: 2, c: 3, a: 5]

----------------------------------------
with offset 3 (propagated)
prefetch candidates: [a: 5, b: 8, c: 3, d: 9, e: 2, f: 6, g: 1, h: 4]

main query ordering: [g: 1, e: 2, c: 3, h: 4, a: 5, f: 6, b: 8, d: 9]
main query results:  [h: 4, a: 5, f: 6] 
```

As you can see, the second query, with an offset is not consistent with the first one. Result `g` will never appear.


With this PR, offset is not propagated anymore, so the limit in the prefetch is the total amount of offsetting that can happen for the request. If the user keeps paginating with offset and a fixed limit, results will be stable, but will eventually lead to an empty result.
