### PR TITLE
Fix strict mode unindexed group_by path

### DIFF
--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -97,6 +97,10 @@ impl Collection {
         Ok(result)
     }
 
+    pub fn payload_key_is_indexed(&self, key: &JsonPath) -> bool {
+        self.payload_index_schema.read().schema.contains_key(key)
+    }
+
     /// Returns an arbitrary payload key along with acceptable
     /// schemas used by `filter` which can be indexed but currently is not.
     /// If this function returns `None` all indexable keys in `filter` are indexed.

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -97,8 +97,8 @@ impl Collection {
         Ok(result)
     }
 
-    pub fn payload_key_is_indexed(&self, key: &JsonPath) -> bool {
-        self.payload_index_schema.read().schema.contains_key(key)
+    pub fn payload_key_index_schema(&self, key: &JsonPath) -> Option<PayloadFieldSchema> {
+        self.payload_index_schema.read().schema.get(key).cloned()
     }
 
     /// Returns an arbitrary payload key along with acceptable

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -11,6 +11,7 @@ mod update;
 
 use std::fmt::Display;
 
+use segment::json_path::JsonPath;
 use segment::types::{Filter, SearchParams, StrictModeConfig};
 
 use super::types::{CollectionError, CollectionResult};
@@ -293,6 +294,32 @@ impl StrictModeVerification for SearchParams {
     fn request_search_params(&self) -> Option<&SearchParams> {
         None
     }
+}
+
+pub fn check_grouping_field(
+    group_by: &JsonPath,
+    collection: &Collection,
+    strict_mode_config: &StrictModeConfig,
+) -> CollectionResult<()> {
+    // check for unindexed fields targeted by group_by
+    if strict_mode_config.unindexed_filtering_retrieve == Some(false) {
+        // check the group_by field is indexed and support `match` statement
+        if let Some(schema) = collection.payload_key_index_schema(group_by) {
+            let schema_kind = schema.kind();
+            if !schema_kind.support_match() {
+                return Err(CollectionError::strict_mode(
+                    format!("Index of type \"{schema_kind:?}\" found for \"{group_by}\""),
+                    "Create an index supporting `match` for this key.",
+                ));
+            }
+        } else {
+            return Err(CollectionError::strict_mode(
+                format!("Index required but not found for \"{group_by}\""),
+                "Create an index supporting `match` for this key.",
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -305,8 +305,8 @@ pub fn check_grouping_field(
     if strict_mode_config.unindexed_filtering_retrieve == Some(false) {
         // check the group_by field is indexed and support `match` statement
         if let Some(schema) = collection.payload_key_index_schema(group_by) {
-            let schema_kind = schema.kind();
-            if !schema_kind.support_match() {
+            if !schema.supports_match() {
+                let schema_kind = schema.kind();
                 return Err(CollectionError::strict_mode(
                     format!("Index of type \"{schema_kind:?}\" found for \"{group_by}\""),
                     "Create an index supporting `match` for this key.",

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -127,6 +127,15 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
             // check for unindexed fields in formula
             query.check_strict_mode(collection, strict_mode_config)?
         }
+        // check for unindexed fields targeted by group_by
+        if strict_mode_config.unindexed_filtering_retrieve == Some(false)
+            && !collection.payload_key_is_indexed(&self.group_by)
+        {
+            return Err(CollectionError::strict_mode(
+                format!("Index required but not found for \"{}\"", self.group_by,),
+                "Create an index for this key.",
+            ));
+        }
         Ok(())
     }
 

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -1,6 +1,6 @@
 use segment::types::StrictModeConfig;
 
-use super::StrictModeVerification;
+use super::{StrictModeVerification, check_grouping_field};
 use crate::collection::Collection;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::collection_query::{
@@ -128,14 +128,7 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
             query.check_strict_mode(collection, strict_mode_config)?
         }
         // check for unindexed fields targeted by group_by
-        if strict_mode_config.unindexed_filtering_retrieve == Some(false)
-            && !collection.payload_key_is_indexed(&self.group_by)
-        {
-            return Err(CollectionError::strict_mode(
-                format!("Index required but not found for \"{}\"", self.group_by,),
-                "Create an index for this key.",
-            ));
-        }
+        check_grouping_field(&self.group_by, collection, strict_mode_config)?;
         Ok(())
     }
 

--- a/lib/collection/src/operations/verification/search.rs
+++ b/lib/collection/src/operations/verification/search.rs
@@ -1,9 +1,11 @@
 use api::rest::{SearchGroupsRequestInternal, SearchRequestInternal};
 use segment::types::{Filter, SearchParams, StrictModeConfig};
 
-use super::StrictModeVerification;
+use super::{StrictModeVerification, check_grouping_field};
 use crate::collection::Collection;
-use crate::operations::types::{CollectionError, CollectionResult, CoreSearchRequest, SearchRequestBatch};
+use crate::operations::types::{
+    CollectionError, CollectionResult, CoreSearchRequest, SearchRequestBatch,
+};
 
 impl StrictModeVerification for SearchRequestInternal {
     fn indexed_filter_read(&self) -> Option<&Filter> {
@@ -92,17 +94,7 @@ impl StrictModeVerification for SearchGroupsRequestInternal {
         strict_mode_config: &StrictModeConfig,
     ) -> CollectionResult<()> {
         // check for unindexed fields targeted by group_by
-        if strict_mode_config.unindexed_filtering_retrieve == Some(false)
-            && !collection.payload_key_is_indexed(&self.group_request.group_by)
-        {
-            return Err(CollectionError::strict_mode(
-                format!(
-                    "Index required but not found for \"{}\"",
-                    self.group_request.group_by
-                ),
-                "Create an index for this key.",
-            ));
-        }
+        check_grouping_field(&self.group_request.group_by, collection, strict_mode_config)?;
         Ok(())
     }
 

--- a/lib/collection/src/operations/verification/search.rs
+++ b/lib/collection/src/operations/verification/search.rs
@@ -3,9 +3,7 @@ use segment::types::{Filter, SearchParams, StrictModeConfig};
 
 use super::{StrictModeVerification, check_grouping_field};
 use crate::collection::Collection;
-use crate::operations::types::{
-    CollectionError, CollectionResult, CoreSearchRequest, SearchRequestBatch,
-};
+use crate::operations::types::{CollectionResult, CoreSearchRequest, SearchRequestBatch};
 
 impl StrictModeVerification for SearchRequestInternal {
     fn indexed_filter_read(&self) -> Option<&Filter> {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1711,6 +1711,20 @@ impl PayloadSchemaType {
             Self::Uuid => PayloadSchemaParams::Uuid(UuidIndexParams::default()),
         }
     }
+
+    /// Check if this type supports a `match` condition
+    pub fn support_match(&self) -> bool {
+        match self {
+            Self::Keyword => true,
+            Self::Integer => true,
+            Self::Bool => true,
+            Self::Uuid => true,
+            Self::Float => false,
+            Self::Geo => false,
+            Self::Text => false,
+            Self::Datetime => false,
+        }
+    }
 }
 
 /// Payload type with parameters

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1711,20 +1711,6 @@ impl PayloadSchemaType {
             Self::Uuid => PayloadSchemaParams::Uuid(UuidIndexParams::default()),
         }
     }
-
-    /// Check if this type supports a `match` condition
-    pub fn support_match(&self) -> bool {
-        match self {
-            Self::Keyword => true,
-            Self::Integer => true,
-            Self::Bool => true,
-            Self::Uuid => true,
-            Self::Float => false,
-            Self::Geo => false,
-            Self::Text => false,
-            Self::Datetime => false,
-        }
-    }
 }
 
 /// Payload type with parameters
@@ -1838,6 +1824,34 @@ impl PayloadFieldSchema {
         match self {
             PayloadFieldSchema::FieldType(t) => *t,
             PayloadFieldSchema::FieldParams(p) => p.kind(),
+        }
+    }
+
+    /// Check if this type supports a `match` condition
+    pub fn supports_match(&self) -> bool {
+        match self {
+            PayloadFieldSchema::FieldType(payload_schema_type) => match payload_schema_type {
+                PayloadSchemaType::Keyword => true,
+                PayloadSchemaType::Integer => true,
+                PayloadSchemaType::Uuid => true,
+                PayloadSchemaType::Bool => true,
+                PayloadSchemaType::Float => false,
+                PayloadSchemaType::Geo => false,
+                PayloadSchemaType::Text => false,
+                PayloadSchemaType::Datetime => false,
+            },
+            PayloadFieldSchema::FieldParams(payload_schema_params) => match payload_schema_params {
+                PayloadSchemaParams::Keyword(_) => true,
+                PayloadSchemaParams::Integer(integer_index_params) => {
+                    integer_index_params.lookup == Some(true)
+                }
+                PayloadSchemaParams::Uuid(_) => true,
+                PayloadSchemaParams::Bool(_) => true,
+                PayloadSchemaParams::Float(_) => false,
+                PayloadSchemaParams::Geo(_) => false,
+                PayloadSchemaParams::Text(_) => false,
+                PayloadSchemaParams::Datetime(_) => false,
+            },
         }
     }
 }


### PR DESCRIPTION
Fix strict mode for grouping APIs to make sure `unindexed_filtering_retrieve` applies to the field grouped on.