### PR TITLE
Abort resharding if any Resharding replica is to be marked dead

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -334,7 +334,12 @@ async fn clean_task(
                 crate::operations::point_ops::PointOperations::DeletePoints { ids },
             ));
         if let Err(err) = shard
-            .update_local(delete_operation, last_batch, HwMeasurementAcc::disposable())
+            .update_local(
+                delete_operation,
+                last_batch,
+                HwMeasurementAcc::disposable(),
+                false,
+            )
             .await
         {
             return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -436,64 +436,49 @@ impl Collection {
             )));
         }
 
-        // Abort resharding, if resharding shard is marked as `Dead`.
-        //
-        // This branch should only be triggered, if resharding is currently at `MigratingPoints`
-        // stage, because target shard should be marked as `Active`, when all resharding transfers
-        // are successfully completed, and so the check *right above* this one would be triggered.
-        //
-        // So, if resharding reached `ReadHashRingCommitted`, this branch *won't* be triggered,
-        // and resharding *won't* be cancelled. The update request should *fail* with "failed to
-        // update all replicas of a shard" error.
-        //
-        // If resharding reached `ReadHashRingCommitted`, and this branch is triggered *somehow*,
-        // then `Collection::abort_resharding` call should return an error, so no special handling
-        // is needed.
-        let is_resharding = matches!(
-            current_state,
-            Some(ReplicaState::Resharding | ReplicaState::ReshardingScaleDown)
-        );
-
-        // If *any* of re-sharding replicas are dead, we need to abort re-sharding before marking them as Dead
-        if is_resharding && new_state == ReplicaState::Dead {
-            drop(shard_holder); // need to release lock so abort_resharding() can take write lock
-
-            if let Some(state) = self.resharding_state().await {
-                self.abort_resharding(state.key(), false).await?;
-            }
-
-            // Actually mark as Dead
-            {
-                let shard_holder = self.shards_holder.read().await;
-                let replica_set = shard_holder
-                    .get_shard(shard_id)
-                    .ok_or_else(|| shard_not_found_error(shard_id))?;
-
-                replica_set
-                    .ensure_replica_with_state(peer_id, ReplicaState::Dead)
-                    .await?;
-            }
-
-            return Ok(());
-        }
-
         // Update replica status
         replica_set
             .ensure_replica_with_state(peer_id, new_state)
             .await?;
 
         if new_state == ReplicaState::Dead {
-            // TODO(resharding): Abort all resharding transfers!?
-
-            // Terminate transfer if source or target replicas are now dead
+            let resharding_state = shard_holder.resharding_state.read().clone();
             let related_transfers = shard_holder.get_related_transfers(shard_id, peer_id);
 
-            // `abort_shard_transfer` locks `shard_holder`!
+            // Functions below lock `shard_holder`!
             drop(shard_holder);
 
+            let mut abort_resharding_result = CollectionResult::Ok(());
+
+            // Abort resharding, if resharding shard is marked as `Dead`.
+            //
+            // This branch should only be triggered, if resharding is currently at `MigratingPoints`
+            // stage, because target shard should be marked as `Active`, when all resharding transfers
+            // are successfully completed, and so the check *right above* this one would be triggered.
+            //
+            // So, if resharding reached `ReadHashRingCommitted`, this branch *won't* be triggered,
+            // and resharding *won't* be cancelled. The update request should *fail* with "failed to
+            // update all replicas of a shard" error.
+            //
+            // If resharding reached `ReadHashRingCommitted`, and this branch is triggered *somehow*,
+            // then `Collection::abort_resharding` call should return an error, so no special handling
+            // is needed.
+            let is_resharding = current_state
+                .as_ref()
+                .is_some_and(ReplicaState::is_resharding);
+            if is_resharding {
+                if let Some(state) = resharding_state {
+                    abort_resharding_result = self.abort_resharding(state.key(), false).await;
+                }
+            }
+
+            // Terminate transfer if source or target replicas are now dead
             for transfer in related_transfers {
                 self.abort_shard_transfer(transfer.key(), None).await?;
             }
+
+            // Propagate resharding errors now
+            abort_resharding_result?;
         }
 
         // If not initialized yet, we need to check if it was initialized by this call

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -54,6 +54,7 @@ impl Collection {
                         OperationWithClockTag::from(operation.clone()),
                         wait,
                         hw_measurement_acc.clone(),
+                        false,
                     )
                 })
                 .collect();
@@ -103,7 +104,7 @@ impl Collection {
             };
 
             match ordering {
-                WriteOrdering::Weak => shard.update_local(operation, wait, hw_measurement_acc.clone()).await,
+                WriteOrdering::Weak => shard.update_local(operation, wait, hw_measurement_acc.clone(), false).await,
                 WriteOrdering::Medium | WriteOrdering::Strong => {
                     if let Some(clock_tag) = operation.clock_tag {
                         log::warn!(

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -128,6 +128,7 @@ impl Collection {
                         OperationWithClockTag::from(create_index_op),
                         true,
                         hw_counter.clone(),
+                        false,
                     ) // TODO: Assign clock tag!? 🤔
                     .await?;
             }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -894,6 +894,7 @@ impl ShardReplicaSet {
         &self,
         filter: Filter,
         hw_measurement_acc: HwMeasurementAcc,
+        force: bool,
     ) -> CollectionResult<UpdateResult> {
         let local_shard_guard = self.local.read().await;
 
@@ -950,7 +951,7 @@ impl ShardReplicaSet {
 
         // TODO(resharding): Assign clock tag to the operation!? 🤔
         let result = self
-            .update_local(op.into(), true, hw_measurement_acc)
+            .update_local(op.into(), true, hw_measurement_acc, force)
             .await?
             .ok_or_else(|| {
                 CollectionError::bad_request(format!(

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -134,7 +134,7 @@ async fn fixture() -> Collection {
             ])),
         ));
         shard
-            .update_local(op, true, HwMeasurementAcc::new())
+            .update_local(op, true, HwMeasurementAcc::new(), false)
             .await
             .expect("failed to insert points");
     }


### PR DESCRIPTION
Nodes can go down while resharding and we found an edge case where it can cause problems. 

Whenever a node goes down, the leader detects this (on next update request) because of `sync_local_state()`, and it notifies other peers by appending 
```
CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: "benchmark", shard_id: 0, peer_id: XYZ, state: Dead, from_state: None }))
```
to the consensus WAL. Now all online nodes are expected to apply this operation locally and **try** to mark the resharding replica as `Dead`. 

However, this logic to mark `Resharding/ReshardingScaleDown` state replicas as `Dead` behaves like this:
- If node that went down was the main resharding replica (`resharding_state.peer_id =  peer_that_went_down`), we abort resharding (this [also](https://github.com/qdrant/qdrant/blob/master/lib/collection/src/shards/shard_holder/resharding.rs#L317-L323) marks the shard as `Active`) 
- If other nodes with `Resharding/ReshardingScaleDown` replica goes down, we ignore the error and hence the leader keeps on trying forever to mark the `Resharding/ReshardingScaleDown` replica as `Dead` (bloats the consensus)

After this PR this logic change to:
- ~If **any** node containing `Resharding/ReshardingScaleDown` replica goes down, we first mark it as `Dead`, and then we abort resharding (doesn't mark the shard as `Active` anymore since it's `Dead` instead of `Resharding/ReshardingScaleDown`)~ 
- If **any** node containing `Resharding/ReshardingScaleDown` replica goes down, we first abort resharding and then mark it as `Dead`.

Reason for this is the following edge case:
- Imagine a node with `Resharding/ReshardingScaleDown` replica goes down
- An update X comes in and the replica down so it's not applied by this node.
- However, we currently mark the replica as `Active` after aborting resharding and `return Ok()`. `Active` replica state means it's expected to be in sync (won't ask for updates after it comes back online).
- Hence, it's better to mark it as `Dead` after aborting resharding so we don't miss any updates. 

Also, it's better to trigger abort if **any** node with resharding replica goes down . Imagine if node is marked as `Dead` then on recovery, it will ask take updates from other replicas hence revert all the work done by resharding. But CM will simply ignore this problem since it relies on `replicas_migrated` (which already includes this node) and doesn't retry resharding for such replicas leaving the replicas out of sync.

TODO:
- [ ] Add tests