### PR TITLE
Fix update wrapper

### DIFF
--- a/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
@@ -61,14 +61,9 @@ impl MmapBitSliceBufferedUpdateWrapper {
         flushed: HashMap<usize, bool>,
         pending_updates: Arc<Mutex<HashMap<usize, bool>>>,
     ) {
-        let mut pending_updates = pending_updates.lock();
-        for (index, value) in flushed {
-            if let Some(pending_value) = pending_updates.get(&index) {
-                if *pending_value == value {
-                    pending_updates.remove(&index);
-                }
-            }
-        }
+        pending_updates
+            .lock()
+            .retain(|point_id, a| flushed.get(point_id).is_none_or(|b| a != b));
     }
 
     pub fn flusher(&self) -> Flusher {

--- a/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::mem;
 use std::sync::Arc;
 
 use common::ext::BitSliceExt as _;
@@ -15,7 +14,7 @@ use crate::common::Flusher;
 pub struct MmapBitSliceBufferedUpdateWrapper {
     bitslice: Arc<RwLock<MmapBitSlice>>,
     len: usize,
-    pending_updates: Mutex<HashMap<usize, bool>>,
+    pending_updates: Arc<Mutex<HashMap<usize, bool>>>,
 }
 
 impl MmapBitSliceBufferedUpdateWrapper {
@@ -24,7 +23,7 @@ impl MmapBitSliceBufferedUpdateWrapper {
         Self {
             bitslice: Arc::new(RwLock::new(bitslice)),
             len,
-            pending_updates: Mutex::new(HashMap::new()),
+            pending_updates: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -56,15 +55,35 @@ impl MmapBitSliceBufferedUpdateWrapper {
         self.len == 0
     }
 
+    /// Removes from `pending_updates` all results that are flushed.
+    /// If values in `pending_updates` are changed, do not remove them.
+    fn clear_flushed_updated(
+        flushed: HashMap<usize, bool>,
+        pending_updates: Arc<Mutex<HashMap<usize, bool>>>,
+    ) {
+        let mut pending_updates = pending_updates.lock();
+        for (index, value) in flushed {
+            if let Some(pending_value) = pending_updates.get(&index) {
+                if *pending_value == value {
+                    pending_updates.remove(&index);
+                }
+            }
+        }
+    }
+
     pub fn flusher(&self) -> Flusher {
-        let pending_updates = mem::take(&mut *self.pending_updates.lock());
+        let pending_updates = self.pending_updates.lock().clone();
         let bitslice = self.bitslice.clone();
+        let pending_updates_arc = self.pending_updates.clone();
+
         Box::new(move || {
             let mut mmap_slice_write = bitslice.write();
-            for (index, value) in pending_updates {
-                mmap_slice_write.set(index, value);
+            for (index, value) in pending_updates.iter() {
+                mmap_slice_write.set(*index, *value);
             }
-            Ok(mmap_slice_write.flusher()()?)
+            mmap_slice_write.flusher()()?;
+            Self::clear_flushed_updated(pending_updates, pending_updates_arc);
+            Ok(())
         })
     }
 }

--- a/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
@@ -57,7 +57,7 @@ impl MmapBitSliceBufferedUpdateWrapper {
 
     /// Removes from `pending_updates` all results that are flushed.
     /// If values in `pending_updates` are changed, do not remove them.
-    fn clear_flushed_updated(
+    fn clear_flushed_updates(
         flushed: HashMap<usize, bool>,
         pending_updates: Arc<Mutex<HashMap<usize, bool>>>,
     ) {
@@ -77,7 +77,7 @@ impl MmapBitSliceBufferedUpdateWrapper {
                 mmap_slice_write.set(*index, *value);
             }
             mmap_slice_write.flusher()()?;
-            Self::clear_flushed_updated(pending_updates, pending_updates_arc);
+            Self::clear_flushed_updates(pending_updates, pending_updates_arc);
             Ok(())
         })
     }

--- a/lib/segment/src/common/mmap_slice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_slice_buffered_update_wrapper.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::mem;
 use std::sync::Arc;
 
 use memory::mmap_type::MmapSlice;
@@ -17,19 +16,35 @@ where
 {
     mmap_slice: Arc<RwLock<MmapSlice<T>>>,
     len: usize,
-    pending_updates: Mutex<HashMap<usize, T>>,
+    pending_updates: Arc<Mutex<HashMap<usize, T>>>,
 }
 
 impl<T> MmapSliceBufferedUpdateWrapper<T>
 where
-    T: 'static,
+    T: 'static + PartialEq,
 {
     pub fn new(mmap_slice: MmapSlice<T>) -> Self {
         let len = mmap_slice.len();
         Self {
             mmap_slice: Arc::new(RwLock::new(mmap_slice)),
             len,
-            pending_updates: Mutex::new(HashMap::new()),
+            pending_updates: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Removes from `pending_updates` all results that are flushed.
+    /// If values in `pending_updates` are changed, do not remove them.
+    fn clear_flushed_updated(
+        flushed: HashMap<usize, T>,
+        pending_updates: Arc<Mutex<HashMap<usize, T>>>,
+    ) {
+        let mut pending_updates = pending_updates.lock();
+        for (index, value) in flushed {
+            if let Some(pending_value) = pending_updates.get(&index) {
+                if *pending_value == value {
+                    pending_updates.remove(&index);
+                }
+            }
         }
     }
 
@@ -45,17 +60,21 @@ where
 
 impl<T> MmapSliceBufferedUpdateWrapper<T>
 where
-    T: 'static + Sync + Send,
+    T: 'static + Sync + Send + Clone + PartialEq,
 {
     pub fn flusher(&self) -> Flusher {
-        let pending_updates = mem::take(&mut *self.pending_updates.lock());
+        let pending_updates = self.pending_updates.lock().clone();
         let slice = self.mmap_slice.clone();
+        let pending_updates_arc = self.pending_updates.clone();
+
         Box::new(move || {
             let mut mmap_slice_write = slice.write();
-            for (index, value) in pending_updates {
-                mmap_slice_write[index] = value;
+            for (index, value) in pending_updates.iter() {
+                mmap_slice_write[*index] = value.clone();
             }
-            Ok(mmap_slice_write.flusher()()?)
+            mmap_slice_write.flusher()()?;
+            Self::clear_flushed_updated(pending_updates, pending_updates_arc);
+            Ok(())
         })
     }
 }

--- a/lib/segment/src/common/mmap_slice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_slice_buffered_update_wrapper.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::mem;
 use std::sync::Arc;
 
 use memory::mmap_type::MmapSlice;
@@ -9,6 +10,8 @@ use crate::common::Flusher;
 /// A wrapper around `MmapSlice` that delays writing changes to the underlying file until they get
 /// flushed manually.
 /// This expects the underlying MmapSlice not to grow in size.
+///
+/// WARN: this structure is expected to be write-only.
 #[derive(Debug)]
 pub struct MmapSliceBufferedUpdateWrapper<T>
 where
@@ -16,35 +19,19 @@ where
 {
     mmap_slice: Arc<RwLock<MmapSlice<T>>>,
     len: usize,
-    pending_updates: Arc<Mutex<HashMap<usize, T>>>,
+    pending_updates: Mutex<HashMap<usize, T>>,
 }
 
 impl<T> MmapSliceBufferedUpdateWrapper<T>
 where
-    T: 'static + PartialEq,
+    T: 'static,
 {
     pub fn new(mmap_slice: MmapSlice<T>) -> Self {
         let len = mmap_slice.len();
         Self {
             mmap_slice: Arc::new(RwLock::new(mmap_slice)),
             len,
-            pending_updates: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
-
-    /// Removes from `pending_updates` all results that are flushed.
-    /// If values in `pending_updates` are changed, do not remove them.
-    fn clear_flushed_updated(
-        flushed: HashMap<usize, T>,
-        pending_updates: Arc<Mutex<HashMap<usize, T>>>,
-    ) {
-        let mut pending_updates = pending_updates.lock();
-        for (index, value) in flushed {
-            if let Some(pending_value) = pending_updates.get(&index) {
-                if *pending_value == value {
-                    pending_updates.remove(&index);
-                }
-            }
+            pending_updates: Mutex::new(HashMap::new()),
         }
     }
 
@@ -60,21 +47,17 @@ where
 
 impl<T> MmapSliceBufferedUpdateWrapper<T>
 where
-    T: 'static + Sync + Send + Clone + PartialEq,
+    T: 'static + Sync + Send,
 {
     pub fn flusher(&self) -> Flusher {
-        let pending_updates = self.pending_updates.lock().clone();
+        let pending_updates = mem::take(&mut *self.pending_updates.lock());
         let slice = self.mmap_slice.clone();
-        let pending_updates_arc = self.pending_updates.clone();
-
         Box::new(move || {
             let mut mmap_slice_write = slice.write();
-            for (index, value) in pending_updates.iter() {
-                mmap_slice_write[*index] = value.clone();
+            for (index, value) in pending_updates {
+                mmap_slice_write[index] = value;
             }
-            mmap_slice_write.flusher()()?;
-            Self::clear_flushed_updated(pending_updates, pending_updates_arc);
-            Ok(())
+            Ok(mmap_slice_write.flusher()()?)
         })
     }
 }

--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -5,9 +5,9 @@ use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
 
 use super::rocksdb_wrapper::DatabaseColumnIterator;
+use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_wrapper::{DatabaseColumnWrapper, LockedDatabaseColumnWrapper};
-use crate::common::Flusher;
 
 /// Wrapper around `DatabaseColumnWrapper` that ensures, that keys that were removed from the
 /// database are only persisted on flush explicitly.

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -1,7 +1,6 @@
-use std::collections::{HashMap, HashSet};
-use std::mem;
-
 use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -16,10 +15,10 @@ use crate::common::rocksdb_wrapper::{DatabaseColumnWrapper, LockedDatabaseColumn
 #[derive(Debug)]
 pub struct DatabaseColumnScheduledUpdateWrapper {
     db: DatabaseColumnWrapper,
-    pending_operations: Mutex<PendingOperations>, // in-flight operations persisted on flush
+    pending_operations: Arc<Mutex<PendingOperations>>, // in-flight operations persisted on flush
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct PendingOperations {
     deleted: HashSet<Vec<u8>>,
     inserted: HashMap<Vec<u8>, Vec<u8>>,
@@ -29,7 +28,7 @@ impl DatabaseColumnScheduledUpdateWrapper {
     pub fn new(db: DatabaseColumnWrapper) -> Self {
         Self {
             db,
-            pending_operations: Mutex::new(PendingOperations::default()),
+            pending_operations: Arc::new(Mutex::new(PendingOperations::default())),
         }
     }
 
@@ -57,22 +56,50 @@ impl DatabaseColumnScheduledUpdateWrapper {
         Ok(())
     }
 
+    /// Removes from `pending_updates` all results that are flushed.
+    /// If values in `pending_updates` are changed, do not remove them.
+    fn clear_flushed_updated(
+        flushed: PendingOperations,
+        pending_operations: Arc<Mutex<PendingOperations>>,
+    ) {
+        let mut pending_guard = pending_operations.lock();
+        for id in flushed.deleted {
+            pending_guard.deleted.remove(&id);
+        }
+        for (id, value) in flushed.inserted {
+            if let Some(pending_value) = pending_guard.inserted.get(&id) {
+                if *pending_value == value {
+                    pending_guard.inserted.remove(&id);
+                }
+            }
+        }
+    }
+
     pub fn flusher(&self) -> Flusher {
-        let PendingOperations { deleted, inserted } =
-            mem::take(&mut *self.pending_operations.lock());
+        let PendingOperations { deleted, inserted } = self.pending_operations.lock().clone();
+
         debug_assert!(
             inserted.keys().all(|key| !deleted.contains(key)),
             "Key to marked for insertion is also marked for deletion!"
         );
         let wrapper = self.db.clone();
+        let pending_operations_arc = self.pending_operations.clone();
+
         Box::new(move || {
-            for id in deleted {
+            for id in deleted.iter() {
                 wrapper.remove(id)?;
             }
-            for (id, value) in inserted {
+            for (id, value) in inserted.iter() {
                 wrapper.put(id, value)?;
             }
-            wrapper.flusher()()
+            wrapper.flusher()()?;
+
+            Self::clear_flushed_updated(
+                PendingOperations { deleted, inserted },
+                pending_operations_arc,
+            );
+
+            Ok(())
         })
     }
 

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -1,6 +1,7 @@
-use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -67,13 +67,9 @@ impl DatabaseColumnScheduledUpdateWrapper {
         for id in flushed.deleted {
             pending_guard.deleted.remove(&id);
         }
-        for (id, value) in flushed.inserted {
-            if let Some(pending_value) = pending_guard.inserted.get(&id) {
-                if *pending_value == value {
-                    pending_guard.inserted.remove(&id);
-                }
-            }
-        }
+        pending_guard
+            .inserted
+            .retain(|point_id, a| flushed.inserted.get(point_id).is_none_or(|b| a != b));
     }
 
     pub fn flusher(&self) -> Flusher {

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -59,7 +59,7 @@ impl DatabaseColumnScheduledUpdateWrapper {
 
     /// Removes from `pending_updates` all results that are flushed.
     /// If values in `pending_updates` are changed, do not remove them.
-    fn clear_flushed_updated(
+    fn clear_flushed_updates(
         flushed: PendingOperations,
         pending_operations: Arc<Mutex<PendingOperations>>,
     ) {
@@ -91,7 +91,7 @@ impl DatabaseColumnScheduledUpdateWrapper {
             }
             wrapper.flusher()()?;
 
-            Self::clear_flushed_updated(
+            Self::clear_flushed_updates(
                 PendingOperations { deleted, inserted },
                 pending_operations_arc,
             );


### PR DESCRIPTION
It looks like we had a broken flush procedure in all db wrappers.

Old logic does the following:

- accumulate updates in tmp structure in ram
- On flush - move tmp structure in flush thread
- Write changes from tmp structure to disk

But, what if we read from the structure in the moment after flush thread created, but before it is actually written - we can have inconsistent results.


This PR: makes a copy of changes for the thread and only removes pending updates if they are persisted.

