### PR TITLE
Speed up pending changes lookups using ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
 name = "gridstore"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bitvec",
  "bustle",
  "common",

--- a/lib/gridstore/Cargo.toml
+++ b/lib/gridstore/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 bench_rocksdb = ["dep:rocksdb"]
 
 [dependencies]
+ahash = { workspace = true }
 memmap2 = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -196,6 +196,10 @@ name = "in_memory_id_tracker"
 harness = false
 
 [[bench]]
+name = "mmap_bitslice_buffered_update_wrapper"
+harness = false
+
+[[bench]]
 name = "scorer_mmap"
 harness = false
 

--- a/lib/segment/benches/mmap_bitslice_buffered_update_wrapper.rs
+++ b/lib/segment/benches/mmap_bitslice_buffered_update_wrapper.rs
@@ -1,0 +1,72 @@
+use std::fs::File;
+use std::iter;
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use memmap2::MmapMut;
+use memory::mmap_type::MmapBitSlice;
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use segment::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
+use tempfile::tempdir;
+
+const SIZE: usize = 4 * 1024 * 1024;
+const FLAG_COUNT: usize = 1_000_000;
+const LOOKUP_COUNT: usize = 1_000_000;
+
+fn mmap_bitslice_buffered_update_wrapper(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("bitslice.mmap");
+
+    let file = File::create_new(path).unwrap();
+    file.set_len(SIZE as u64).unwrap();
+    file.sync_all().unwrap();
+
+    let mmap_mut = unsafe { MmapMut::map_mut(&file).unwrap() };
+    let mmap_bitslice = MmapBitSlice::from(mmap_mut, 0);
+    let mmap_bitslice_buffered_update_wrapper =
+        MmapBitSliceBufferedUpdateWrapper::new(mmap_bitslice);
+
+    // Set random flags and persist
+    for _ in 0..FLAG_COUNT {
+        mmap_bitslice_buffered_update_wrapper
+            .set(rng.random::<u64>() as usize % SIZE, rng.random());
+    }
+    mmap_bitslice_buffered_update_wrapper.flusher()().unwrap();
+
+    let mut group = c.benchmark_group("mmap-bitslice-buffered-update-wrapper");
+
+    let lookups: Vec<_> = iter::repeat_with(|| rng.random::<u64>() as usize % SIZE)
+        .take(LOOKUP_COUNT)
+        .collect();
+
+    group.bench_function("lookup-without-pending-changes", |b| {
+        b.iter(|| {
+            for lookup in &lookups {
+                black_box(mmap_bitslice_buffered_update_wrapper.get(*lookup).unwrap());
+            }
+        });
+    });
+
+    // Set random flags and keep them in pending changes list
+    for _ in 0..FLAG_COUNT {
+        mmap_bitslice_buffered_update_wrapper
+            .set(rng.random::<u64>() as usize % SIZE, rng.random());
+    }
+
+    group.bench_function("lookup-with-pending-changes", |b| {
+        b.iter(|| {
+            for lookup in &lookups {
+                black_box(mmap_bitslice_buffered_update_wrapper.get(*lookup).unwrap());
+            }
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = mmap_bitslice_buffered_update_wrapper
+}
+
+criterion_main!(benches);

--- a/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use common::ext::BitSliceExt as _;
 use memory::mmap_type::MmapBitSlice;
 use parking_lot::{Mutex, RwLock};
@@ -14,7 +14,7 @@ use crate::common::Flusher;
 pub struct MmapBitSliceBufferedUpdateWrapper {
     bitslice: Arc<RwLock<MmapBitSlice>>,
     len: usize,
-    pending_updates: Arc<Mutex<HashMap<usize, bool>>>,
+    pending_updates: Arc<Mutex<AHashMap<usize, bool>>>,
 }
 
 impl MmapBitSliceBufferedUpdateWrapper {
@@ -23,7 +23,7 @@ impl MmapBitSliceBufferedUpdateWrapper {
         Self {
             bitslice: Arc::new(RwLock::new(bitslice)),
             len,
-            pending_updates: Arc::new(Mutex::new(HashMap::new())),
+            pending_updates: Arc::new(Mutex::new(AHashMap::new())),
         }
     }
 
@@ -58,8 +58,8 @@ impl MmapBitSliceBufferedUpdateWrapper {
     /// Removes from `pending_updates` all results that are flushed.
     /// If values in `pending_updates` are changed, do not remove them.
     fn clear_flushed_updates(
-        flushed: HashMap<usize, bool>,
-        pending_updates: Arc<Mutex<HashMap<usize, bool>>>,
+        flushed: AHashMap<usize, bool>,
+        pending_updates: Arc<Mutex<AHashMap<usize, bool>>>,
     ) {
         pending_updates
             .lock()

--- a/lib/segment/src/common/mmap_slice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_slice_buffered_update_wrapper.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::mem;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use memory::mmap_type::MmapSlice;
 use parking_lot::{Mutex, RwLock};
 
@@ -19,7 +19,7 @@ where
 {
     mmap_slice: Arc<RwLock<MmapSlice<T>>>,
     len: usize,
-    pending_updates: Mutex<HashMap<usize, T>>,
+    pending_updates: Mutex<AHashMap<usize, T>>,
 }
 
 impl<T> MmapSliceBufferedUpdateWrapper<T>
@@ -31,7 +31,7 @@ where
         Self {
             mmap_slice: Arc::new(RwLock::new(mmap_slice)),
             len,
-            pending_updates: Mutex::new(HashMap::new()),
+            pending_updates: Mutex::new(AHashMap::new()),
         }
     }
 

--- a/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_delete_wrapper.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
 use std::mem;
 use std::sync::Arc;
 
+use ahash::AHashSet;
 use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
 
@@ -21,7 +21,7 @@ use crate::common::rocksdb_wrapper::{DatabaseColumnWrapper, LockedDatabaseColumn
 #[derive(Debug)]
 pub struct DatabaseColumnScheduledDeleteWrapper {
     db: DatabaseColumnWrapper,
-    deleted_pending_persistence: Arc<Mutex<HashSet<Vec<u8>>>>,
+    deleted_pending_persistence: Arc<Mutex<AHashSet<Vec<u8>>>>,
 }
 
 impl Clone for DatabaseColumnScheduledDeleteWrapper {
@@ -37,7 +37,7 @@ impl DatabaseColumnScheduledDeleteWrapper {
     pub fn new(db: DatabaseColumnWrapper) -> Self {
         Self {
             db,
-            deleted_pending_persistence: Arc::new(Mutex::new(HashSet::new())),
+            deleted_pending_persistence: Arc::new(Mutex::new(AHashSet::new())),
         }
     }
 
@@ -124,7 +124,7 @@ impl DatabaseColumnScheduledDeleteWrapper {
 
 pub struct LockedDatabaseColumnScheduledDeleteWrapper<'a> {
     base: LockedDatabaseColumnWrapper<'a>,
-    deleted_pending_persistence: &'a Mutex<HashSet<Vec<u8>>>,
+    deleted_pending_persistence: &'a Mutex<AHashSet<Vec<u8>>>,
 }
 
 impl LockedDatabaseColumnScheduledDeleteWrapper<'_> {
@@ -138,7 +138,7 @@ impl LockedDatabaseColumnScheduledDeleteWrapper<'_> {
 
 pub struct DatabaseColumnScheduledDeleteIterator<'a> {
     base: DatabaseColumnIterator<'a>,
-    deleted_pending_persistence: &'a Mutex<HashSet<Vec<u8>>>,
+    deleted_pending_persistence: &'a Mutex<AHashSet<Vec<u8>>>,
 }
 
 impl Iterator for DatabaseColumnScheduledDeleteIterator<'_> {

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use ahash::{AHashMap, AHashSet};
 use parking_lot::Mutex;
 
 use crate::common::Flusher;
@@ -21,8 +21,8 @@ pub struct DatabaseColumnScheduledUpdateWrapper {
 
 #[derive(Debug, Default, Clone)]
 struct PendingOperations {
-    deleted: HashSet<Vec<u8>>,
-    inserted: HashMap<Vec<u8>, Vec<u8>>,
+    deleted: AHashSet<Vec<u8>>,
+    inserted: AHashMap<Vec<u8>, Vec<u8>>,
 }
 
 impl DatabaseColumnScheduledUpdateWrapper {

--- a/lib/segment/src/common/score_fusion.rs
+++ b/lib/segment/src/common/score_fusion.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::iter;
 
+use ahash::AHashMap;
 use common::types::ScoreType;
 use itertools::{Itertools, MinMaxResult};
 use ordered_float::OrderedFloat;
@@ -73,7 +73,7 @@ pub fn score_fusion(
         })
         // combine to deduplicate
         .fold(
-            HashMap::<PointIdType, ScoredPoint>::new(),
+            AHashMap::<PointIdType, ScoredPoint>::new(),
             |mut acc, point| {
                 acc.entry(point.id)
                     .and_modify(|entry| match method {

--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use common::types::PointOffsetType;
 
 use crate::types::Payload;
@@ -8,7 +7,7 @@ use crate::types::Payload;
 /// Warn: for tests only
 #[derive(Debug, Default)]
 pub struct InMemoryPayloadStorage {
-    pub(crate) payload: HashMap<PointOffsetType, Payload>,
+    pub(crate) payload: AHashMap<PointOffsetType, Payload>,
 }
 
 impl InMemoryPayloadStorage {

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -92,7 +91,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
     }
 
     fn wipe(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
-        self.payload = HashMap::new();
+        self.payload = ahash::AHashMap::new();
         Ok(())
     }
 
@@ -188,7 +187,7 @@ mod tests {
                 payload.borrow().as_ref().cloned().unwrap()
             }),
             Some(&id_tracker),
-            &HashMap::new(),
+            &std::collections::HashMap::new(),
             &query,
             0,
             &IndexesMap::new(),

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -90,6 +90,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
         Ok(res)
     }
 
+    #[cfg(test)]
     fn wipe(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
         self.payload = ahash::AHashMap::new();
         Ok(())

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -194,6 +194,7 @@ impl PayloadStorage for MmapPayloadStorage {
         Ok(res)
     }
 
+    #[cfg(test)]
     fn wipe(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
         self.storage.write().wipe();
         Ok(())

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -163,6 +163,7 @@ impl PayloadStorage for OnDiskPayloadStorage {
         Ok(payload)
     }
 
+    #[cfg(test)]
     fn wipe(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
         self.db_wrapper.recreate_column_family()
     }

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -57,7 +57,8 @@ pub trait PayloadStorage {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<Payload>>;
 
-    /// Completely delete payload storage. Pufff!
+    /// Completely delete payload storage, without keeping allocated memory. Pufff!
+    #[cfg(test)]
     fn wipe(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()>;
 
     /// Return function that forces persistence of current storage state.

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -153,6 +153,7 @@ impl PayloadStorage for PayloadStorageEnum {
         }
     }
 
+    #[cfg(test)]
     fn wipe(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
         match self {
             #[cfg(feature = "testing")]

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
@@ -15,13 +15,13 @@ use crate::types::Payload;
 /// Persists all changes to disk using `store`, but only uses this storage during the initial load
 #[derive(Debug)]
 pub struct SimplePayloadStorage {
-    pub(crate) payload: HashMap<PointOffsetType, Payload>,
+    pub(crate) payload: AHashMap<PointOffsetType, Payload>,
     pub(crate) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
 }
 
 impl SimplePayloadStorage {
     pub fn open(database: Arc<RwLock<DB>>) -> OperationResult<Self> {
-        let mut payload_map: HashMap<PointOffsetType, Payload> = Default::default();
+        let mut payload_map: AHashMap<PointOffsetType, Payload> = Default::default();
 
         let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
             database,

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -99,7 +98,7 @@ impl PayloadStorage for SimplePayloadStorage {
     }
 
     fn wipe(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
-        self.payload = HashMap::new();
+        self.payload = ahash::AHashMap::new();
         self.db_wrapper.recreate_column_family()
     }
 

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -97,6 +97,7 @@ impl PayloadStorage for SimplePayloadStorage {
         Ok(res)
     }
 
+    #[cfg(test)]
     fn wipe(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
         self.payload = ahash::AHashMap::new();
         self.db_wrapper.recreate_column_family()


### PR DESCRIPTION
A very simple change - replace the standard [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html) with [`AHashMap`](https://docs.rs/ahash/latest/ahash/struct.AHashMap.html). Or more specifically, hash using [`ahash`](https://docs.rs/ahash).

It changes the hashmap in the mmap/rocksdb update buffer types where it lists changes pending flush. Its also applied to some surrounding types/functions. There are more places we can benefit from this, but lets take it step by step.

Ahash is much faster, at least on small numeric keys like we're using in many places. Here's a generic benchmark of <ins>sip13</ins> (used by standard HashMap) versus <ins>ahash</ins>:

![image](https://github.com/user-attachments/assets/8f290057-63b1-406e-b1a2-d4c6b0f8b139)
<small>[source](https://github.com/tkaitchuck/aHash/blob/7d5c661a74b12d5bc5448b0b83fdb429190db1a3/README.md#comparison-with-other-hashers)</small>

I've added a criterion benchmark that tests the change in the buffered mmap bitslice. I expect the effect to be similar for the other types.

Here's a bench for 100 iterations on look ups with 1 million pending changes:

```bash
# Before PR
$ cargo bench --bench mmap_bitslice_buffered_update_wrapper
mmap-bitslice-buffered-update-wrapper/lookup-with-pending-changes
                        time:   [43.298 ms 43.611 ms 43.949 ms]

# After PR
$ cargo bench --bench mmap_bitslice_buffered_update_wrapper
mmap-bitslice-buffered-update-wrapper/lookup-with-pending-changes
                        time:   [30.691 ms 30.881 ms 31.113 ms]
                        change: [-29.886% -29.189% -28.441%] (p = 0.00 < 0.05)
                        Performance has improved.
```

![Graph for 100 criterion samples](https://github.com/user-attachments/assets/443f8417-bada-4c87-a0b6-dbfef9eda876)

Red shows the lookup timing distribution for the type before this PR. Blue shows the timings after this PR, being about 30% faster.

Note that in the case of the pending changes list, it may be empty a lot of the time. In that case there is no time difference. The improvement in lookup time will get more and more significant as the pending changes list grows.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
