### PR TITLE
Use ahash for all maps/sets holding point IDs, offsets or similar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 name = "api"
 version = "1.13.7-dev"
 dependencies = [
+ "ahash",
  "chrono",
  "common",
  "itertools 0.14.0",
@@ -3824,6 +3825,7 @@ dependencies = [
 name = "memory"
 version = "0.0.0"
 dependencies = [
+ "ahash",
  "bitvec",
  "delegate",
  "log",
@@ -6281,6 +6283,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "storage"
 version = "0.2.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "api",
  "async-trait",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 tracing = ["dep:tracing", "segment/tracing"]
 
 [dependencies]
+ahash = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
 prost-wkt-types = { workspace = true }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1,7 +1,8 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr as _;
 use std::time::Instant;
 
+use ahash::AHashSet;
 use chrono::{NaiveDateTime, Timelike};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_data::HardwareData;
@@ -1348,7 +1349,7 @@ impl TryFrom<HasIdCondition> for segment::types::HasIdCondition {
 
     fn try_from(value: HasIdCondition) -> Result<Self, Self::Error> {
         let HasIdCondition { has_id } = value;
-        let set: HashSet<segment::types::PointIdType> = has_id
+        let set: AHashSet<segment::types::PointIdType> = has_id
             .into_iter()
             .map(|p| p.try_into())
             .collect::<Result<_, _>>()?;

--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
 use std::time::Duration;
 
+use ahash::AHashSet;
 use api::rest::{
     SearchMatrixOffsetsResponse, SearchMatrixPair, SearchMatrixPairsResponse,
     SearchMatrixRequestInternal,
@@ -204,7 +204,7 @@ impl Collection {
         // filter to only include the sampled points in the search
         // use the same filter for all requests to leverage batch search
         let filter = Filter::new_must(Condition::HasId(HasIdCondition::from(
-            sampled_point_ids.iter().copied().collect::<HashSet<_>>(),
+            sampled_point_ids.iter().copied().collect::<AHashSet<_>>(),
         )));
 
         // Perform nearest neighbor search for each sampled point

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
 use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ahash::AHashSet;
+use ahash::{AHashMap, AHashSet};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::{TryFutureExt, future};
 use itertools::{Either, Itertools};
@@ -238,7 +237,7 @@ impl Collection {
             )
             .await?;
 
-        let mut records_map: HashMap<ExtendedPointId, RecordInternal> = retrieved_records
+        let mut records_map: AHashMap<ExtendedPointId, RecordInternal> = retrieved_records
             .into_iter()
             .map(|rec| (rec.id, rec))
             .collect();

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use ahash::AHashMap;
 use bitvec::prelude::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
@@ -30,7 +31,7 @@ use segment::types::{
 
 use crate::collection_manager::holders::segment_holder::LockedSegment;
 
-pub type LockedRmSet = Arc<RwLock<HashMap<PointIdType, ProxyDeletedPoint>>>;
+pub type LockedRmSet = Arc<RwLock<AHashMap<PointIdType, ProxyDeletedPoint>>>;
 pub type LockedIndexChanges = Arc<RwLock<ProxyIndexChanges>>;
 
 /// This object is a wrapper around read-only segment.

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -1,8 +1,9 @@
+use std::collections::BTreeSet;
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use ahash::AHashMap;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::ScoreType;
 use futures::stream::FuturesUnordered;
@@ -89,7 +90,7 @@ impl SegmentsSearcher {
         further_results: &[Vec<bool>],
     ) -> (
         BatchResultAggregator,
-        HashMap<SegmentOffset, Vec<BatchOffset>>,
+        AHashMap<SegmentOffset, Vec<BatchOffset>>,
     ) {
         let number_segments = search_result.len();
         let batch_size = limits.len();
@@ -132,7 +133,7 @@ impl SegmentsSearcher {
         }
 
         // segment id -> list of batch ids
-        let mut searches_to_rerun: HashMap<SegmentOffset, Vec<BatchOffset>> = HashMap::new();
+        let mut searches_to_rerun: AHashMap<SegmentOffset, Vec<BatchOffset>> = AHashMap::new();
 
         // Check if we want to re-run the search without sampling on some segments
         for (batch_id, required_limit) in limits.into_iter().enumerate() {
@@ -380,7 +381,7 @@ impl SegmentsSearcher {
         with_vector: &WithVector,
         runtime_handle: &Handle,
         hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<HashMap<PointIdType, RecordInternal>> {
+    ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
         let stopping_guard = StoppingGuard::new();
         runtime_handle
             .spawn_blocking({
@@ -411,9 +412,9 @@ impl SegmentsSearcher {
         with_vector: &WithVector,
         is_stopped: &AtomicBool,
         hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<HashMap<PointIdType, RecordInternal>> {
-        let mut point_version: HashMap<PointIdType, SeqNumberType> = Default::default();
-        let mut point_records: HashMap<PointIdType, RecordInternal> = Default::default();
+    ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
+        let mut point_version: AHashMap<PointIdType, SeqNumberType> = Default::default();
+        let mut point_records: AHashMap<PointIdType, RecordInternal> = Default::default();
 
         let hw_counter = hw_measurement_acc.get_counter_cell();
 
@@ -771,8 +772,7 @@ fn get_hnsw_ef_construct(config: &SegmentConfig, vector_name: &VectorName) -> Op
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
+    use ahash::AHashSet;
     use api::rest::SearchRequestInternal;
     use common::counter::hardware_counter::HardwareCounterCell;
     use parking_lot::RwLock;
@@ -814,7 +814,7 @@ mod tests {
                     plain_index.is_small_enough_for_unindexed_search(225, None, &hw_counter);
                 assert!(res_2);
 
-                let ids: HashSet<_> = vec![1, 2].into_iter().map(PointIdType::from).collect();
+                let ids: AHashSet<_> = vec![1, 2].into_iter().map(PointIdType::from).collect();
 
                 let ids_filter = Filter::new_must(Condition::HasId(HasIdCondition::from(ids)));
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -1,8 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use ahash::AHashMap;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use itertools::Itertools;
@@ -303,7 +304,7 @@ fn test_delete_all_point_versions() {
     .unwrap();
     assert_eq!(
         retrieved,
-        HashMap::from([(
+        AHashMap::from([(
             point_id,
             RecordInternal {
                 id: point_id,

--- a/lib/collection/src/common/fetch_vectors.rs
+++ b/lib/collection/src/common/fetch_vectors.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::time::Duration;
 
+use ahash::{AHashMap, AHashSet};
 use api::rest::ShardKeySelector;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::Future;
@@ -114,8 +114,8 @@ pub type CollectionName = String;
 ///
 #[derive(Default, Debug)]
 pub struct ReferencedVectors {
-    collection_mapping: HashMap<CollectionName, HashMap<PointIdType, RecordInternal>>,
-    default_mapping: HashMap<PointIdType, RecordInternal>,
+    collection_mapping: AHashMap<CollectionName, AHashMap<PointIdType, RecordInternal>>,
+    default_mapping: AHashMap<PointIdType, RecordInternal>,
 }
 
 impl ReferencedVectors {
@@ -128,7 +128,7 @@ impl ReferencedVectors {
             None => self.default_mapping.extend(mapping),
             Some(collection) => {
                 let entry = self.collection_mapping.entry(collection);
-                let entry_internal: &mut HashMap<_, _> = entry.or_default();
+                let entry_internal: &mut AHashMap<_, _> = entry.or_default();
                 entry_internal.extend(mapping);
             }
         }
@@ -138,7 +138,7 @@ impl ReferencedVectors {
         self.default_mapping.extend(other.default_mapping);
         for (collection_name, points) in other.collection_mapping {
             let entry = self.collection_mapping.entry(collection_name);
-            let entry_internal: &mut HashMap<_, _> = entry.or_default();
+            let entry_internal: &mut AHashMap<_, _> = entry.or_default();
             entry_internal.extend(points);
         }
     }
@@ -177,8 +177,8 @@ impl ReferencedVectors {
 
 #[derive(Default, Debug)]
 pub struct ReferencedPoints<'coll_name> {
-    ids_per_collection: HashMap<Option<&'coll_name String>, HashSet<PointIdType>>,
-    vector_names_per_collection: HashMap<Option<&'coll_name String>, HashSet<VectorNameBuf>>,
+    ids_per_collection: AHashMap<Option<&'coll_name String>, AHashSet<PointIdType>>,
+    vector_names_per_collection: AHashMap<Option<&'coll_name String>, AHashSet<VectorNameBuf>>,
 }
 
 impl<'coll_name> ReferencedPoints<'coll_name> {

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
 
+use ahash::{AHashMap, AHashSet};
 use itertools::Itertools;
 use segment::data_types::groups::GroupId;
 use segment::json_path::JsonPath;
@@ -11,15 +11,15 @@ use serde_json::Value;
 
 use super::types::{AggregatorError, Group};
 
-type Hits = HashMap<PointIdType, ScoredPoint>;
+type Hits = AHashMap<PointIdType, ScoredPoint>;
 pub(super) struct GroupsAggregator {
-    groups: HashMap<GroupId, Hits>,
+    groups: AHashMap<GroupId, Hits>,
     max_group_size: usize,
     grouped_by: JsonPath,
     max_groups: usize,
-    full_groups: HashSet<GroupId>,
-    group_best_scores: HashMap<GroupId, ScoredPoint>,
-    all_ids: HashSet<ExtendedPointId>,
+    full_groups: AHashSet<GroupId>,
+    group_best_scores: AHashMap<GroupId, ScoredPoint>,
+    all_ids: AHashSet<ExtendedPointId>,
     order: Option<Order>,
 }
 
@@ -31,13 +31,13 @@ impl GroupsAggregator {
         order: Option<Order>,
     ) -> Self {
         Self {
-            groups: HashMap::with_capacity(groups),
+            groups: AHashMap::with_capacity(groups),
             max_group_size: group_size,
             grouped_by,
             max_groups: groups,
-            full_groups: HashSet::with_capacity(groups),
-            group_best_scores: HashMap::with_capacity(groups),
-            all_ids: HashSet::with_capacity(groups * group_size),
+            full_groups: AHashSet::with_capacity(groups),
+            group_best_scores: AHashMap::with_capacity(groups),
+            all_ids: AHashSet::with_capacity(groups * group_size),
             order,
         }
     }
@@ -71,7 +71,7 @@ impl GroupsAggregator {
             let group = self
                 .groups
                 .entry(group_key.clone())
-                .or_insert_with(|| HashMap::with_capacity(self.max_group_size));
+                .or_insert_with(|| AHashMap::with_capacity(self.max_group_size));
 
             let entry = group.entry(point.id);
 
@@ -145,7 +145,7 @@ impl GroupsAggregator {
 
     /// Gets the keys of the groups that have less than the max group size
     pub(super) fn keys_of_unfilled_best_groups(&self) -> Vec<Value> {
-        let best_group_keys: HashSet<_> = self.best_group_keys().into_iter().collect();
+        let best_group_keys: AHashSet<_> = self.best_group_keys().into_iter().collect();
         best_group_keys
             .difference(&self.full_groups)
             .cloned()
@@ -160,12 +160,12 @@ impl GroupsAggregator {
 
     /// Gets the amount of best groups that have reached the max group size
     pub(super) fn len_of_filled_best_groups(&self) -> usize {
-        let best_group_keys: HashSet<_> = self.best_group_keys().into_iter().collect();
+        let best_group_keys: AHashSet<_> = self.best_group_keys().into_iter().collect();
         best_group_keys.intersection(&self.full_groups).count()
     }
 
     /// Gets the ids of the already present points across all the groups
-    pub(super) fn ids(&self) -> &HashSet<ExtendedPointId> {
+    pub(super) fn ids(&self) -> &AHashSet<ExtendedPointId> {
         &self.all_ids
     }
 

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::future::Future;
 use std::time::Duration;
 
+use ahash::AHashMap;
 use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use fnv::FnvBuildHasher;
@@ -470,7 +470,7 @@ pub async fn group_by(
     let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
 
     // enrich with payload and vector
-    let enriched_points: HashMap<_, _> = collection
+    let enriched_points: AHashMap<_, _> = collection
         .fill_search_result_with_payload(
             bare_points,
             Some(request.source.with_payload),
@@ -554,8 +554,7 @@ fn increase_limit_for_group(shard_prefetch: &mut ShardPrefetch, group_size: usiz
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
+    use ahash::AHashMap;
     use segment::data_types::groups::GroupId;
     use segment::payload_json;
     use segment::types::{Payload, ScoredPoint};
@@ -613,7 +612,7 @@ mod tests {
             make_scored_point(4, 1.0, Some(payload_b.clone())),
         ];
 
-        let set: HashMap<_, _> = hydrated.into_iter().map(|p| (p.id, p)).collect();
+        let set: AHashMap<_, _> = hydrated.into_iter().map(|p| (p.id, p)).collect();
 
         // act
         groups.iter_mut().for_each(|group| group.hydrate_from(&set));

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use segment::data_types::groups::GroupId;
 use segment::json_path::JsonPath;
 use segment::types::{PointIdType, ScoredPoint};
@@ -20,7 +19,7 @@ pub(super) struct Group {
 }
 
 impl Group {
-    pub(super) fn hydrate_from(&mut self, map: &HashMap<PointIdType, ScoredPoint>) {
+    pub(super) fn hydrate_from(&mut self, map: &AHashMap<PointIdType, ScoredPoint>) {
         self.hits.iter_mut().for_each(|hit| {
             if let Some(point) = map.get(&hit.id) {
                 hit.payload.clone_from(&point.payload);

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -1,5 +1,4 @@
-use std::collections::HashSet;
-
+use ahash::AHashSet;
 use api::rest::LookupLocation;
 use common::types::ScoreType;
 use itertools::Itertools;
@@ -361,7 +360,7 @@ pub struct CollectionPrefetch {
 
 /// Exclude the referenced ids by editing the filter.
 fn exclude_referenced_ids(ids: Vec<ExtendedPointId>, filter: Option<Filter>) -> Option<Filter> {
-    let ids: HashSet<_> = ids.into_iter().collect();
+    let ids: AHashSet<_> = ids.into_iter().collect();
 
     if ids.is_empty() {
         return filter;

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -382,9 +382,7 @@ impl TryFrom<Vec<ShardQueryRequest>> for PlannedQuery {
 
 #[cfg(test)]
 mod tests {
-
-    use std::collections::HashSet;
-
+    use ahash::AHashSet;
     use segment::data_types::vectors::{MultiDenseVectorInternal, NamedQuery, VectorInternal};
     use segment::json_path::JsonPath;
     use segment::types::{
@@ -406,8 +404,9 @@ mod tests {
             "has_oranges".try_into().unwrap(),
             true.into(),
         )));
-        let filter_outer =
-            Filter::new_must(Condition::HasId(HashSet::from([1.into(), 2.into()]).into()));
+        let filter_outer = Filter::new_must(Condition::HasId(
+            AHashSet::from([1.into(), 2.into()]).into(),
+        ));
 
         let request = ShardQueryRequest {
             prefetches: vec![ShardPrefetch {

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
 use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ahash::AHashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -414,7 +414,7 @@ impl LocalShard {
 
 /// Extracts point ids from sources, and creates a filter to only include those ids.
 fn filter_with_sources_ids(sources: impl Iterator<Item = Vec<ScoredPoint>>) -> Filter {
-    let mut point_ids = HashSet::new();
+    let mut point_ids = AHashSet::new();
 
     for source in sources {
         for point in source.iter() {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -1,9 +1,9 @@
-use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
+use ahash::AHashSet;
 use async_trait::async_trait;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -36,7 +36,7 @@ use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
 use crate::update_handler::UpdateSignal;
 
-type ChangedPointsSet = Arc<RwLock<HashSet<PointIdType>>>;
+type ChangedPointsSet = Arc<RwLock<AHashSet<PointIdType>>>;
 
 /// ProxyShard
 ///

--- a/lib/collection/src/tests/fixtures.rs
+++ b/lib/collection/src/tests/fixtures.rs
@@ -1,5 +1,4 @@
-use std::collections::HashSet;
-
+use ahash::AHashSet;
 use segment::data_types::vectors::VectorStructInternal;
 use segment::types::{
     Condition, Distance, Filter, PayloadFieldSchema, PayloadSchemaType, PointIdType,
@@ -116,5 +115,5 @@ pub fn delete_point_operation(idx: u64) -> CollectionUpdateOperations {
 }
 
 pub fn filter_single_id(id: impl Into<PointIdType>) -> Filter {
-    Filter::new_must(Condition::HasId(HashSet::from([id.into()]).into()))
+    Filter::new_must(Condition::HasId(AHashSet::from([id.into()]).into()))
 }

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
+use ahash::AHashSet;
 use api::rest::{OrderByInterface, SearchRequestInternal};
 use collection::operations::CollectionUpdateOperations;
 use collection::operations::payload_ops::{PayloadOps, SetPayloadOp};
@@ -650,7 +651,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
             result_desc.points
         );
 
-        let asc_already_seen: HashSet<_> = result_asc.points.iter().map(|x| x.id).collect();
+        let asc_already_seen: AHashSet<_> = result_asc.points.iter().map(|x| x.id).collect();
 
         dbg!(&asc_already_seen);
         let asc_second_page = collection
@@ -689,7 +690,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
         assert_eq!(asc_second_page.points.len(), 5);
         assert!(asc_second_page_points.is_subset(&valid_asc_second_page_points));
 
-        let desc_already_seen: HashSet<_> = result_desc.points.iter().map(|x| x.id).collect();
+        let desc_already_seen: AHashSet<_> = result_desc.points.iter().map(|x| x.id).collect();
 
         dbg!(&desc_already_seen);
 
@@ -819,7 +820,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
     }
 
     // delete points with id (0, 3)
-    let to_be_deleted: HashSet<PointIdType> = vec![0.into(), 3.into()].into_iter().collect();
+    let to_be_deleted: AHashSet<PointIdType> = vec![0.into(), 3.into()].into_iter().collect();
     let delete_filter =
         segment::types::Filter::new_must(Condition::HasId(HasIdCondition::from(to_be_deleted)));
 

--- a/lib/common/memory/Cargo.toml
+++ b/lib/common/memory/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 workspace = true
 
 [dependencies]
+ahash = { workspace = true }
 delegate = { workspace = true }
 memmap2 = { workspace = true }
 log = { workspace = true }

--- a/lib/common/memory/src/chunked_utils.rs
+++ b/lib/common/memory/src/chunked_utils.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
+
+use ahash::AHashMap;
 
 use crate::madvise::{Advice, AdviceSetting};
 use crate::mmap_ops::{create_and_ensure_length, open_read_mmap, open_write_mmap};
@@ -62,7 +63,7 @@ pub fn read_mmaps<T: Sized>(
     populate: bool,
     advice: AdviceSetting,
 ) -> Result<Vec<UniversalMmapChunk<T>>, MmapError> {
-    let mut mmap_files: HashMap<usize, _> = HashMap::new();
+    let mut mmap_files: AHashMap<usize, _> = AHashMap::new();
     for entry in directory.read_dir()? {
         let entry = entry?;
         let path = entry.path();

--- a/lib/segment/src/common/reciprocal_rank_fusion.rs
+++ b/lib/segment/src/common/reciprocal_rank_fusion.rs
@@ -3,7 +3,7 @@
 
 use std::collections::hash_map::Entry;
 
-use ahash::{HashMap, HashMapExt};
+use ahash::AHashMap;
 use ordered_float::OrderedFloat;
 
 use crate::types::{ExtendedPointId, ScoredPoint};
@@ -24,7 +24,7 @@ fn position_score(position: usize) -> f32 {
 /// Does not break ties.
 pub fn rrf_scoring(responses: impl IntoIterator<Item = Vec<ScoredPoint>>) -> Vec<ScoredPoint> {
     // track scored points by id
-    let mut points_by_id: HashMap<ExtendedPointId, ScoredPoint> = HashMap::new();
+    let mut points_by_id: AHashMap<ExtendedPointId, ScoredPoint> = AHashMap::new();
 
     for response in responses {
         for (pos, mut point) in response.into_iter().enumerate() {

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -1,7 +1,8 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use ahash::AHashSet;
 use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -25,7 +26,7 @@ struct Counts {
 
 pub struct ImmutableGeoMapIndex {
     counts_per_hash: Vec<Counts>,
-    points_map: Vec<(GeoHash, HashSet<PointOffsetType>)>,
+    points_map: Vec<(GeoHash, AHashSet<PointOffsetType>)>,
     point_to_values: ImmutablePointToValues<GeoPoint>,
     points_count: usize,
     points_values_count: usize,
@@ -247,7 +248,7 @@ impl ImmutableGeoMapIndex {
     }
 
     fn decrement_hash_point_counts(&mut self, geo_hashes: &[GeoHash]) {
-        let mut seen_hashes: HashSet<GeoHash> = Default::default();
+        let mut seen_hashes: AHashSet<GeoHash> = Default::default();
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
                 let sub_geo_hash = geo_hash.truncate(i);

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -1,8 +1,9 @@
 use std::cmp::max;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use delegate::delegate;
@@ -43,7 +44,7 @@ pub struct InMemoryGeoMapIndex {
         ...
     }
      */
-    pub points_map: BTreeMap<GeoHash, HashSet<PointOffsetType>>,
+    pub points_map: BTreeMap<GeoHash, AHashSet<PointOffsetType>>,
     pub point_to_values: Vec<Vec<GeoPoint>>,
     pub points_count: usize,
     pub points_values_count: usize,
@@ -362,7 +363,7 @@ impl InMemoryGeoMapIndex {
     }
 
     fn increment_hash_point_counts(&mut self, geo_hashes: &[GeoHash]) {
-        let mut seen_hashes: HashSet<GeoHash> = Default::default();
+        let mut seen_hashes: AHashSet<GeoHash> = Default::default();
 
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
@@ -403,7 +404,7 @@ impl InMemoryGeoMapIndex {
     }
 
     fn decrement_hash_point_counts(&mut self, geo_hashes: &[GeoHash]) {
-        let mut seen_hashes: HashSet<GeoHash> = Default::default();
+        let mut seen_hashes: AHashSet<GeoHash> = Default::default();
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
                 let sub_geo_hash = geo_hash.truncate(i);

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -1,5 +1,4 @@
-use std::collections::HashSet;
-
+use ahash::AHashSet;
 use common::types::PointOffsetType;
 
 use crate::types::{FieldCondition, VectorNameBuf};
@@ -27,7 +26,7 @@ pub use field_index_base::*;
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimaryCondition {
     Condition(Box<FieldCondition>),
-    Ids(HashSet<PointOffsetType>),
+    Ids(AHashSet<PointOffsetType>),
     HasVector(VectorNameBuf),
 }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -1,8 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use ahash::AHashSet;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
@@ -297,7 +298,7 @@ impl StructPayloadIndex {
             }
             Condition::HasId(has_id) => {
                 let id_tracker_ref = self.id_tracker.borrow();
-                let mapped_ids: HashSet<PointOffsetType> = has_id
+                let mapped_ids: AHashSet<PointOffsetType> = has_id
                     .has_id
                     .iter()
                     .filter_map(|external_id| id_tracker_ref.internal_id(*external_id))

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -323,9 +323,9 @@ impl ConditionChecker for SimpleConditionChecker {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use std::str::FromStr;
 
+    use ahash::AHashSet;
     use tempfile::Builder;
 
     use super::*;
@@ -648,17 +648,17 @@ mod tests {
         assert!(!payload_checker.check(0, &query));
 
         // id Filter
-        let ids: HashSet<_> = vec![1, 2, 3].into_iter().map(|x| x.into()).collect();
+        let ids: AHashSet<_> = vec![1, 2, 3].into_iter().map(|x| x.into()).collect();
 
         let query = Filter::new_must_not(Condition::HasId(ids.into()));
         assert!(!payload_checker.check(2, &query));
 
-        let ids: HashSet<_> = vec![1, 2, 3].into_iter().map(|x| x.into()).collect();
+        let ids: AHashSet<_> = vec![1, 2, 3].into_iter().map(|x| x.into()).collect();
 
         let query = Filter::new_must_not(Condition::HasId(ids.into()));
         assert!(payload_checker.check(10, &query));
 
-        let ids: HashSet<_> = vec![1, 2, 3].into_iter().map(|x| x.into()).collect();
+        let ids: AHashSet<_> = vec![1, 2, 3].into_iter().map(|x| x.into()).collect();
 
         let query = Filter::new_must(Condition::HasId(ids.into()));
         assert!(payload_checker.check(2, &query));

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use ahash::AHashSet;
 use common::types::ScoreType;
 use fnv::FnvBuildHasher;
 use geo::{Contains, Coord, Distance as GeoDistance, Haversine, LineString, Point, Polygon};
@@ -2572,7 +2573,8 @@ impl From<JsonPath> for IsEmptyCondition {
 /// ID-based filtering condition
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct HasIdCondition {
-    pub has_id: HashSet<PointIdType>,
+    #[schemars(schema_with = "HashSet::<PointIdType>::json_schema")]
+    pub has_id: AHashSet<PointIdType>,
 }
 
 /// Filter points which have specific vector assigned
@@ -2587,9 +2589,9 @@ impl From<VectorNameBuf> for HasVectorCondition {
     }
 }
 
-impl From<HashSet<PointIdType>> for HasIdCondition {
-    fn from(set: HashSet<PointIdType>) -> Self {
-        HasIdCondition { has_id: set }
+impl From<AHashSet<PointIdType>> for HasIdCondition {
+    fn from(has_id: AHashSet<PointIdType>) -> Self {
+        HasIdCondition { has_id }
     }
 }
 

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::sync::atomic::AtomicBool;
 
+use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use itertools::Itertools;
 use segment::common::operation_error::OperationError;
@@ -43,7 +43,7 @@ fn test_point_exclusion() {
     let best_match = res.first().expect("Non-empty result");
     assert_eq!(best_match.id, 3.into());
 
-    let ids: HashSet<_> = HashSet::from_iter([3.into()]);
+    let ids: AHashSet<_> = AHashSet::from_iter([3.into()]);
 
     let frt = Filter::new_must_not(Condition::HasId(ids.into()));
 
@@ -96,7 +96,7 @@ fn test_named_vector_search() {
     let best_match = res.first().expect("Non-empty result");
     assert_eq!(best_match.id, 3.into());
 
-    let ids: HashSet<_> = HashSet::from_iter([3.into()]);
+    let ids: AHashSet<_> = AHashSet::from_iter([3.into()]);
 
     let frt = Filter {
         should: None,

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -1,6 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 
+use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::TelemetryDetail;
 use itertools::Itertools;
@@ -313,7 +314,7 @@ fn sparse_index_hardware_measurement_test() {
     assert_eq!(cpu_usage, 0);
 
     // Some filter so we do plain sparse search
-    let ids: HashSet<PointIdType> = (0..3).map(ExtendedPointId::NumId).collect();
+    let ids: AHashSet<PointIdType> = (0..3).map(ExtendedPointId::NumId).collect();
     let filter = Filter::new_must(Condition::HasId(HasIdCondition::from(ids)));
 
     sparse_index

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -19,6 +19,7 @@ proptest = { workspace = true }
 env_logger = "0.11"
 
 [dependencies]
+ahash = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
 wal = { workspace = true }

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::mem::take;
 
+use ahash::AHashSet;
 use api::rest::LookupLocation;
 use collection::collection::distance_matrix::CollectionSearchMatrixRequest;
 use collection::grouping::group_by::{GroupRequest, SourceRequest};
@@ -564,7 +564,7 @@ impl CheckableCollectionOperation for CollectionUpdateOperations {
 
 /// Create a `must` filter from a list of point IDs.
 fn make_filter_from_ids(ids: Vec<ExtendedPointId>) -> Filter {
-    let cond = ids.into_iter().collect::<HashSet<_>>().into();
+    let cond = ids.into_iter().collect::<AHashSet<_>>().into();
     Filter {
         must: Some(vec![Condition::HasId(cond)]),
         ..Default::default()


### PR DESCRIPTION
Follow up of <https://github.com/qdrant/qdrant/pull/6385>, using the same change and argument, but applied on much more types.

Migrates to [`ahash`](https://docs.rs/) on all maps and sets holding simple numbers, like point IDs, point offsets and other.

The change is quite aggressive, but contains no logic changes as the hash map types are interchangeable. We can discuss here whether we like the change or not.

I did not add a benchmark for this, nor did I extensively test its performance. But I think the results presented in <https://github.com/qdrant/qdrant/pull/6385> are good enough to deem this an improvement.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
