### PR TITLE
Telemetry improvements

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12093,8 +12093,7 @@
       "OperationDurationStatistics": {
         "type": "object",
         "required": [
-          "count",
-          "total_duration_micros"
+          "count"
         ],
         "properties": {
           "count": {
@@ -12129,7 +12128,8 @@
             "description": "The total duration of all operations in microseconds.",
             "type": "integer",
             "format": "uint64",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "last_responded": {
             "type": "string",
@@ -12176,7 +12176,6 @@
       "OptimizerTelemetry": {
         "type": "object",
         "required": [
-          "log",
           "optimizations",
           "status"
         ],
@@ -12191,7 +12190,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/TrackerTelemetry"
-            }
+            },
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11403,7 +11403,6 @@
           "id",
           "init_time_ms",
           "resharding",
-          "shard_clean_tasks",
           "shards",
           "transfers"
         ],
@@ -11441,7 +11440,8 @@
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ShardCleanStatusTelemetry"
-            }
+            },
+            "nullable": true
           }
         }
       },
@@ -12132,7 +12132,8 @@
           "fail_count": {
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "avg_duration_micros": {
             "description": "The average time taken by 128 latest operations, calculated as a weighted mean.",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11570,6 +11570,34 @@
             "format": "uint",
             "minimum": 0
           },
+          "vectors_size_bytes": {
+            "description": "An ESTIMATION of effective amount of bytes used for vectors Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "payloads_size_bytes": {
+            "description": "An estimation of the effective amount of bytes used for payloads Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_points": {
+            "description": "Sum of segment points This is an approximate number Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "num_vectors": {
+            "description": "Sum of number of vectors in all segments This is an approximate number Do NOT rely on this number unless you know what you are doing",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
           "segments": {
             "type": "array",
             "items": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11401,10 +11401,7 @@
         "required": [
           "config",
           "id",
-          "init_time_ms",
-          "resharding",
-          "shards",
-          "transfers"
+          "init_time_ms"
         ],
         "properties": {
           "id": {
@@ -11422,19 +11419,22 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReplicaSetTelemetry"
-            }
+            },
+            "nullable": true
           },
           "transfers": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ShardTransferInfo"
-            }
+            },
+            "nullable": true
           },
           "resharding": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReshardingInfo"
-            }
+            },
+            "nullable": true
           },
           "shard_clean_tasks": {
             "type": "object",

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -794,6 +794,8 @@ impl Collection {
             )
         };
 
+        let shard_clean_tasks = self.clean_local_shards_statuses();
+
         CollectionTelemetry {
             id: self.name(),
             init_time_ms: self.init_time.as_millis() as u64,
@@ -801,7 +803,7 @@ impl Collection {
             shards: shards_telemetry,
             transfers,
             resharding,
-            shard_clean_tasks: self.clean_local_shards_statuses(),
+            shard_clean_tasks: (!shard_clean_tasks.is_empty()).then_some(shard_clean_tasks),
         }
     }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use clean::ShardCleanTasks;
 use common::budget::ResourceBudget;
-use common::types::TelemetryDetail;
+use common::types::{DetailsLevel, TelemetryDetail};
 use io::storage_version::StorageVersion;
 use segment::types::ShardKey;
 use semver::Version;
@@ -36,7 +36,7 @@ use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfigInternal;
 use crate::operations::config_diff::{DiffConfig, OptimizersConfigDiff};
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::{CollectionError, CollectionResult, NodeType};
+use crate::operations::types::{CollectionError, CollectionResult, NodeType, OptimizersStatus};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
@@ -53,7 +53,9 @@ use crate::shards::transfer::helpers::check_transfer_conflicts_strict;
 use crate::shards::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
 use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
 use crate::shards::{CollectionId, replica_set};
-use crate::telemetry::{CollectionConfigTelemetry, CollectionTelemetry};
+use crate::telemetry::{
+    CollectionConfigTelemetry, CollectionTelemetry, CollectionsAggregatedTelemetry,
+};
 
 /// Collection's data is split into several shards.
 pub struct Collection {
@@ -773,11 +775,16 @@ impl Collection {
 
     pub async fn get_telemetry_data(&self, detail: TelemetryDetail) -> CollectionTelemetry {
         let (shards_telemetry, transfers, resharding) = {
-            let mut shards_telemetry = Vec::new();
             let shards_holder = self.shards_holder.read().await;
-            for shard in shards_holder.all_shards() {
-                shards_telemetry.push(shard.get_telemetry_data(detail).await)
-            }
+            let shards_telemetry = if detail.level >= DetailsLevel::Level3 {
+                let mut shards_telemetry = Vec::new();
+                for shard in shards_holder.all_shards() {
+                    shards_telemetry.push(shard.get_telemetry_data(detail).await)
+                }
+                shards_telemetry
+            } else {
+                vec![]
+            };
             (
                 shards_telemetry,
                 shards_holder.get_shard_transfer_info(&*self.transfer_tasks.lock().await),
@@ -795,6 +802,35 @@ impl Collection {
             transfers,
             resharding,
             shard_clean_tasks: self.clean_local_shards_statuses(),
+        }
+    }
+
+    pub async fn get_aggregated_telemetry_data(&self) -> CollectionsAggregatedTelemetry {
+        let shards_holder = self.shards_holder.read().await;
+
+        let mut shard_optimization_statuses = Vec::new();
+        let mut vectors = 0;
+
+        for shard in shards_holder.all_shards() {
+            let shard_optimization_status = shard
+                .get_optimization_status()
+                .await
+                .unwrap_or(OptimizersStatus::Ok);
+
+            shard_optimization_statuses.push(shard_optimization_status);
+
+            vectors += shard.count_vectors().await;
+        }
+
+        let optimizers_status = shard_optimization_statuses
+            .into_iter()
+            .max()
+            .unwrap_or(OptimizersStatus::Ok);
+
+        CollectionsAggregatedTelemetry {
+            vectors,
+            optimizers_status,
+            params: self.collection_config.read().await.params.clone(),
         }
     }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -819,7 +819,7 @@ impl Collection {
 
             shard_optimization_statuses.push(shard_optimization_status);
 
-            vectors += shard.count_vectors().await;
+            vectors += shard.get_size_stats().await.num_vectors;
         }
 
         let optimizers_status = shard_optimization_statuses

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -10,8 +10,8 @@ use segment::data_types::order_by::OrderBy;
 use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, SnapshotFormat, WithPayload, WithPayloadInterface,
-    WithVector,
+    ExtendedPointId, Filter, ScoredPoint, SizeStats, SnapshotFormat, WithPayload,
+    WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
 
@@ -62,6 +62,10 @@ impl DummyShard {
             variant_name: Some("dummy shard".into()),
             status: Some(ShardStatus::Green),
             total_optimized_points: 0,
+            vectors_size_bytes: None,
+            payloads_size_bytes: None,
+            num_points: None,
+            num_vectors: None,
             segments: vec![],
             optimizations: Default::default(),
             async_scorer: None,
@@ -72,8 +76,8 @@ impl DummyShard {
         OptimizersStatus::Ok
     }
 
-    pub fn count_vectors(&self) -> usize {
-        0
+    pub fn get_size_stats(&self) -> SizeStats {
+        SizeStats::default()
     }
 
     pub fn estimate_cardinality(

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -18,8 +18,8 @@ use tokio::runtime::Handle;
 use crate::operations::OperationWithClockTag;
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
-    CountRequestInternal, CountResult, PointRequestInternal, RecordInternal, ShardStatus,
-    UpdateResult,
+    CountRequestInternal, CountResult, OptimizersStatus, PointRequestInternal, RecordInternal,
+    ShardStatus, UpdateResult,
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::shards::shard_trait::ShardOperation;
@@ -66,6 +66,14 @@ impl DummyShard {
             optimizations: Default::default(),
             async_scorer: None,
         }
+    }
+
+    pub fn get_optimization_status(&self) -> OptimizersStatus {
+        OptimizersStatus::Ok
+    }
+
+    pub fn count_vectors(&self) -> usize {
+        0
     }
 
     pub fn estimate_cardinality(

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -12,7 +12,7 @@ use segment::data_types::order_by::OrderBy;
 use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, PointIdType, ScoredPoint, SnapshotFormat, WithPayload,
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, WithPayload,
     WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
@@ -349,8 +349,8 @@ impl ForwardProxyShard {
         self.wrapped_shard.get_optimization_status()
     }
 
-    pub fn count_vectors(&self) -> usize {
-        self.wrapped_shard.count_vectors()
+    pub fn get_size_stats(&self) -> SizeStats {
+        self.wrapped_shard.get_size_stats()
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -26,8 +26,8 @@ use crate::operations::point_ops::{
 };
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
-    CountRequestInternal, CountResult, PointRequestInternal, RecordInternal, UpdateResult,
-    UpdateStatus,
+    CountRequestInternal, CountResult, OptimizersStatus, PointRequestInternal, RecordInternal,
+    UpdateResult, UpdateStatus,
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::{
@@ -343,6 +343,14 @@ impl ForwardProxyShard {
 
     pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
         self.wrapped_shard.get_telemetry_data(detail)
+    }
+
+    pub fn get_optimization_status(&self) -> OptimizersStatus {
+        self.wrapped_shard.get_optimization_status()
+    }
+
+    pub fn count_vectors(&self) -> usize {
+        self.wrapped_shard.count_vectors()
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -1,0 +1,74 @@
+use std::sync::atomic::Ordering;
+
+use common::types::{DetailsLevel, TelemetryDetail};
+use segment::vector_storage::common::get_async_scorer;
+
+use crate::operations::types::OptimizersStatus;
+use crate::shards::local_shard::LocalShard;
+use crate::shards::telemetry::{LocalShardTelemetry, OptimizerTelemetry};
+
+impl LocalShard {
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
+        let segments_read_guard = self.segments.read();
+
+        let segments: Vec<_> = if detail.level >= DetailsLevel::Level4 {
+            segments_read_guard
+                .iter()
+                .map(|(_id, segment)| segment.get().read().get_telemetry_data(detail))
+                .collect()
+        } else {
+            vec![]
+        };
+
+        let optimizer_status = match &segments_read_guard.optimizer_errors {
+            None => OptimizersStatus::Ok,
+            Some(error) => OptimizersStatus::Error(error.to_string()),
+        };
+        drop(segments_read_guard);
+        let optimizations = self
+            .optimizers
+            .iter()
+            .map(|optimizer| {
+                optimizer
+                    .get_telemetry_counter()
+                    .lock()
+                    .get_statistics(detail)
+            })
+            .fold(Default::default(), |acc, x| acc + x);
+
+        let total_optimized_points = self.total_optimized_points.load(Ordering::Relaxed);
+
+        LocalShardTelemetry {
+            variant_name: None,
+            status: None,
+            total_optimized_points,
+            segments,
+            optimizations: OptimizerTelemetry {
+                status: optimizer_status,
+                optimizations,
+                log: (detail.level >= DetailsLevel::Level4)
+                    .then(|| self.optimizers_log.lock().to_telemetry()),
+            },
+            async_scorer: Some(get_async_scorer()),
+        }
+    }
+
+    pub fn get_optimization_status(&self) -> OptimizersStatus {
+        let segments_read_guard = self.segments.read();
+        let optimizer_status = match &segments_read_guard.optimizer_errors {
+            None => OptimizersStatus::Ok,
+            Some(error) => OptimizersStatus::Error(error.to_string()),
+        };
+        drop(segments_read_guard);
+        optimizer_status
+    }
+
+    pub fn count_vectors(&self) -> usize {
+        let mut vectors = 0;
+        let segments_read_guard = self.segments.read();
+        for (_segment_id, segment) in segments_read_guard.iter() {
+            vectors += segment.get().read().info().num_vectors
+        }
+        vectors
+    }
+}

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -14,7 +14,7 @@ use segment::data_types::order_by::OrderBy;
 use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, PointIdType, ScoredPoint, SnapshotFormat, WithPayload,
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, WithPayload,
     WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
@@ -152,8 +152,8 @@ impl ProxyShard {
         self.wrapped_shard.get_optimization_status()
     }
 
-    pub fn count_vectors(&self) -> usize {
-        self.wrapped_shard.count_vectors()
+    pub fn get_size_stats(&self) -> SizeStats {
+        self.wrapped_shard.get_size_stats()
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -28,7 +28,8 @@ use crate::operations::operation_effect::{
 };
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
-    CountRequestInternal, CountResult, PointRequestInternal, RecordInternal, UpdateResult,
+    CountRequestInternal, CountResult, OptimizersStatus, PointRequestInternal, RecordInternal,
+    UpdateResult,
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::shards::local_shard::LocalShard;
@@ -145,6 +146,14 @@ impl ProxyShard {
 
     pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
         self.wrapped_shard.get_telemetry_data(detail)
+    }
+
+    pub fn get_optimization_status(&self) -> OptimizersStatus {
+        self.wrapped_shard.get_optimization_status()
+    }
+
+    pub fn count_vectors(&self) -> usize {
+        self.wrapped_shard.count_vectors()
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -14,8 +14,8 @@ use segment::data_types::order_by::OrderBy;
 use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, SnapshotFormat, WithPayload, WithPayloadInterface,
-    WithVector,
+    ExtendedPointId, Filter, ScoredPoint, SizeStats, SnapshotFormat, WithPayload,
+    WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
@@ -194,8 +194,8 @@ impl QueueProxyShard {
             .get_optimization_status()
     }
 
-    pub fn count_vectors(&self) -> usize {
-        self.inner_unchecked().wrapped_shard.count_vectors()
+    pub fn get_size_stats(&self) -> SizeStats {
+        self.inner_unchecked().wrapped_shard.get_size_stats()
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -28,7 +28,8 @@ use crate::operations::OperationWithClockTag;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
-    CountRequestInternal, CountResult, PointRequestInternal, RecordInternal, UpdateResult,
+    CountRequestInternal, CountResult, OptimizersStatus, PointRequestInternal, RecordInternal,
+    UpdateResult,
 };
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::shards::local_shard::LocalShard;
@@ -185,6 +186,16 @@ impl QueueProxyShard {
         self.inner_unchecked()
             .wrapped_shard
             .get_telemetry_data(detail)
+    }
+
+    pub fn get_optimization_status(&self) -> OptimizersStatus {
+        self.inner_unchecked()
+            .wrapped_shard
+            .get_optimization_status()
+    }
+
+    pub fn count_vectors(&self) -> usize {
+        self.inner_unchecked().wrapped_shard.count_vectors()
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -17,6 +17,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::rate_limiting::RateLimiter;
 use common::types::TelemetryDetail;
 use schemars::JsonSchema;
+use segment::common::anonymize::Anonymize;
 use segment::types::{ExtendedPointId, Filter, ShardKey};
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
@@ -1212,7 +1213,9 @@ impl ReplicaSetState {
 }
 
 /// State of the single shard within a replica set.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(
+    Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq, Eq, Hash, Clone, Copy, Anonymize,
+)]
 pub enum ReplicaState {
     // Active and sound
     #[default]

--- a/lib/collection/src/shards/replica_set/telemetry.rs
+++ b/lib/collection/src/shards/replica_set/telemetry.rs
@@ -41,9 +41,8 @@ impl ShardReplicaSet {
         let local_shard = self.local.read().await;
         let local = local_shard.as_ref();
 
-        match local {
-            Some(local_shard) => local_shard.get_size_stats(),
-            None => SizeStats::default(),
-        }
+        local
+            .map(|local_shard| local_shard.get_size_stats())
+            .unwrap_or_default()
     }
 }

--- a/lib/collection/src/shards/replica_set/telemetry.rs
+++ b/lib/collection/src/shards/replica_set/telemetry.rs
@@ -1,0 +1,48 @@
+use common::types::TelemetryDetail;
+
+use crate::operations::types::OptimizersStatus;
+use crate::shards::replica_set::ShardReplicaSet;
+use crate::shards::telemetry::ReplicaSetTelemetry;
+
+impl ShardReplicaSet {
+    pub(crate) async fn get_telemetry_data(&self, detail: TelemetryDetail) -> ReplicaSetTelemetry {
+        let local_shard = self.local.read().await;
+        let local = local_shard.as_ref();
+
+        let local_telemetry = match local {
+            Some(local_shard) => Some(local_shard.get_telemetry_data(detail).await),
+            None => None,
+        };
+
+        ReplicaSetTelemetry {
+            id: self.shard_id,
+            key: self.shard_key.clone(),
+            local: local_telemetry,
+            remote: self
+                .remotes
+                .read()
+                .await
+                .iter()
+                .map(|remote| remote.get_telemetry_data(detail))
+                .collect(),
+            replicate_states: self.replica_state.read().peers(),
+        }
+    }
+
+    pub(crate) async fn get_optimization_status(&self) -> Option<OptimizersStatus> {
+        let local_shard = self.local.read().await;
+        let local = local_shard.as_ref();
+
+        local.map(|local_shard| local_shard.get_optimization_status())
+    }
+
+    pub(crate) async fn count_vectors(&self) -> usize {
+        let local_shard = self.local.read().await;
+        let local = local_shard.as_ref();
+
+        match local {
+            Some(local_shard) => local_shard.count_vectors(),
+            None => 0,
+        }
+    }
+}

--- a/lib/collection/src/shards/replica_set/telemetry.rs
+++ b/lib/collection/src/shards/replica_set/telemetry.rs
@@ -1,4 +1,5 @@
 use common::types::TelemetryDetail;
+use segment::types::SizeStats;
 
 use crate::operations::types::OptimizersStatus;
 use crate::shards::replica_set::ShardReplicaSet;
@@ -36,13 +37,13 @@ impl ShardReplicaSet {
         local.map(|local_shard| local_shard.get_optimization_status())
     }
 
-    pub(crate) async fn count_vectors(&self) -> usize {
+    pub(crate) async fn get_size_stats(&self) -> SizeStats {
         let local_shard = self.local.read().await;
         let local = local_shard.as_ref();
 
         match local {
-            Some(local_shard) => local_shard.count_vectors(),
-            None => 0,
+            Some(local_shard) => local_shard.get_size_stats(),
+            None => SizeStats::default(),
         }
     }
 }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -7,7 +7,7 @@ use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::segment_manifest::SegmentManifests;
 use segment::index::field_index::CardinalityEstimation;
-use segment::types::{Filter, SnapshotFormat};
+use segment::types::{Filter, SizeStats, SnapshotFormat};
 
 use super::local_shard::clock_map::RecoveryPoint;
 use super::update_tracker::UpdateTracker;
@@ -98,13 +98,13 @@ impl Shard {
         }
     }
 
-    pub fn count_vectors(&self) -> usize {
+    pub fn get_size_stats(&self) -> SizeStats {
         match self {
-            Shard::Local(local_shard) => local_shard.count_vectors(),
-            Shard::Proxy(proxy_shard) => proxy_shard.count_vectors(),
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.count_vectors(),
-            Shard::QueueProxy(queue_proxy_shard) => queue_proxy_shard.count_vectors(),
-            Shard::Dummy(dummy_shard) => dummy_shard.count_vectors(),
+            Shard::Local(local_shard) => local_shard.get_size_stats(),
+            Shard::Proxy(proxy_shard) => proxy_shard.get_size_stats(),
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.get_size_stats(),
+            Shard::QueueProxy(queue_proxy_shard) => queue_proxy_shard.get_size_stats(),
+            Shard::Dummy(dummy_shard) => dummy_shard.get_size_stats(),
         }
     }
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -12,7 +12,7 @@ use segment::types::{Filter, SnapshotFormat};
 use super::local_shard::clock_map::RecoveryPoint;
 use super::update_tracker::UpdateTracker;
 use crate::operations::operation_effect::{EstimateOperationEffectArea, OperationEffectArea};
-use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::types::{CollectionError, CollectionResult, OptimizersStatus};
 use crate::shards::dummy_shard::DummyShard;
 use crate::shards::forward_proxy_shard::ForwardProxyShard;
 use crate::shards::local_shard::LocalShard;
@@ -86,6 +86,26 @@ impl Shard {
         };
         telemetry.variant_name = Some(self.variant_name().to_string());
         telemetry
+    }
+
+    pub fn get_optimization_status(&self) -> OptimizersStatus {
+        match self {
+            Shard::Local(local_shard) => local_shard.get_optimization_status(),
+            Shard::Proxy(proxy_shard) => proxy_shard.get_optimization_status(),
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.get_optimization_status(),
+            Shard::QueueProxy(queue_proxy_shard) => queue_proxy_shard.get_optimization_status(),
+            Shard::Dummy(dummy_shard) => dummy_shard.get_optimization_status(),
+        }
+    }
+
+    pub fn count_vectors(&self) -> usize {
+        match self {
+            Shard::Local(local_shard) => local_shard.count_vectors(),
+            Shard::Proxy(proxy_shard) => proxy_shard.count_vectors(),
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.count_vectors(),
+            Shard::QueueProxy(queue_proxy_shard) => queue_proxy_shard.count_vectors(),
+            Shard::Dummy(dummy_shard) => dummy_shard.count_vectors(),
+        }
     }
 
     pub async fn create_snapshot(

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -53,7 +53,7 @@ pub struct LocalShardTelemetry {
     /// Do NOT rely on this number unless you know what you are doing
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_points: Option<usize>,
-    /// Sum of numer of vectors in all segments
+    /// Sum of number of vectors in all segments
     /// This is an approximate number
     /// Do NOT rely on this number unless you know what you are doing
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
-use segment::common::anonymize::Anonymize;
+use segment::common::anonymize::{Anonymize, anonymize_collection_with_u64_hashable_key};
 use segment::common::operation_time_statistics::OperationDurationStatistics;
 use segment::telemetry::SegmentTelemetry;
 use segment::types::ShardKey;
@@ -19,7 +19,7 @@ pub struct ReplicaSetTelemetry {
     pub key: Option<ShardKey>,
     pub local: Option<LocalShardTelemetry>,
     pub remote: Vec<RemoteShardTelemetry>,
-    #[anonymize(value = HashMap::new())]
+    #[anonymize(with = anonymize_collection_with_u64_hashable_key)]
     pub replicate_states: HashMap<PeerId, ReplicaState>,
 }
 

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -50,5 +50,6 @@ pub struct LocalShardTelemetry {
 pub struct OptimizerTelemetry {
     pub status: OptimizersStatus,
     pub optimizations: OperationDurationStatistics,
-    pub log: Vec<TrackerTelemetry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log: Option<Vec<TrackerTelemetry>>,
 }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -40,6 +40,24 @@ pub struct LocalShardTelemetry {
     pub status: Option<ShardStatus>,
     /// Total number of optimized points since the last start.
     pub total_optimized_points: usize,
+    /// An ESTIMATION of effective amount of bytes used for vectors
+    /// Do NOT rely on this number unless you know what you are doing
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vectors_size_bytes: Option<usize>,
+    /// An estimation of the effective amount of bytes used for payloads
+    /// Do NOT rely on this number unless you know what you are doing
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payloads_size_bytes: Option<usize>,
+    /// Sum of segment points
+    /// This is an approximate number
+    /// Do NOT rely on this number unless you know what you are doing
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_points: Option<usize>,
+    /// Sum of numer of vectors in all segments
+    /// This is an approximate number
+    /// Do NOT rely on this number unless you know what you are doing
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_vectors: Option<usize>,
     pub segments: Vec<SegmentTelemetry>,
     pub optimizations: OptimizerTelemetry,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -21,9 +21,9 @@ pub struct CollectionTelemetry {
     pub shards: Vec<ReplicaSetTelemetry>,
     pub transfers: Vec<ShardTransferInfo>,
     pub resharding: Vec<ReshardingInfo>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
-    pub shard_clean_tasks: HashMap<ShardId, ShardCleanStatusTelemetry>,
+    pub shard_clean_tasks: Option<HashMap<ShardId, ShardCleanStatusTelemetry>>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -22,7 +22,7 @@ pub struct CollectionTelemetry {
     pub transfers: Vec<ShardTransferInfo>,
     pub resharding: Vec<ReshardingInfo>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[anonymize(value = HashMap::new())]
+    #[anonymize(false)]
     pub shard_clean_tasks: HashMap<ShardId, ShardCleanStatusTelemetry>,
 }
 

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
-use crate::operations::types::{ReshardingInfo, ShardTransferInfo};
+use crate::operations::types::{OptimizersStatus, ReshardingInfo, ShardTransferInfo};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::shard::ShardId;
 use crate::shards::telemetry::ReplicaSetTelemetry;
@@ -24,6 +24,13 @@ pub struct CollectionTelemetry {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[anonymize(false)]
     pub shard_clean_tasks: HashMap<ShardId, ShardCleanStatusTelemetry>,
+}
+
+#[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
+pub struct CollectionsAggregatedTelemetry {
+    pub vectors: usize,
+    pub optimizers_status: OptimizersStatus,
+    pub params: CollectionParams,
 }
 
 impl CollectionTelemetry {

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -15,12 +15,21 @@ use crate::shards::telemetry::ReplicaSetTelemetry;
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
 pub struct CollectionTelemetry {
     pub id: String,
+
     #[anonymize(false)]
     pub init_time_ms: u64,
+
     pub config: CollectionConfigTelemetry,
-    pub shards: Vec<ReplicaSetTelemetry>,
-    pub transfers: Vec<ShardTransferInfo>,
-    pub resharding: Vec<ReshardingInfo>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shards: Option<Vec<ReplicaSetTelemetry>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transfers: Option<Vec<ShardTransferInfo>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resharding: Option<Vec<ReshardingInfo>>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
     pub shard_clean_tasks: Option<HashMap<ShardId, ShardCleanStatusTelemetry>>,
@@ -37,6 +46,7 @@ impl CollectionTelemetry {
     pub fn count_vectors(&self) -> usize {
         self.shards
             .iter()
+            .flatten()
             .filter_map(|shard| shard.local.as_ref())
             .flat_map(|x| x.segments.iter())
             .map(|s| s.info.num_vectors)

--- a/lib/common/common/src/types.rs
+++ b/lib/common/common/src/types.rs
@@ -37,9 +37,31 @@ pub struct TelemetryDetail {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DetailsLevel {
+    /// Minimal information level
+    /// - app info
+    /// - minimal telemetry by endpoint
+    /// - cluster status
     Level0,
+    /// Detailed common info level
+    /// - app info details
+    /// - system info
+    ///   - hardware flags
+    ///   - hardware usage per collection
+    ///   - RAM usage
+    /// - cluster basic details
+    /// - collections basic info
     Level1,
+    /// Detailed consensus info - peers info
+    /// Collections:
+    ///  - detailed config
+    ///  - Shards - basic config
     Level2,
+    /// Shards:
+    ///  - detailed config
+    ///  - Optimizers info
+    Level3,
+    /// Segment level telemetry
+    Level4,
 }
 
 impl Default for TelemetryDetail {
@@ -56,7 +78,10 @@ impl From<usize> for DetailsLevel {
         match value {
             0 => DetailsLevel::Level0,
             1 => DetailsLevel::Level1,
-            _ => DetailsLevel::Level2,
+            2 => DetailsLevel::Level2,
+            3 => DetailsLevel::Level3,
+            4 => DetailsLevel::Level4,
+            _ => DetailsLevel::Level4,
         }
     }
 }

--- a/lib/segment/src/common/anonymize.rs
+++ b/lib/segment/src/common/anonymize.rs
@@ -92,6 +92,24 @@ where
         .collect()
 }
 
+pub fn hash_u64(value: u64) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+pub fn anonymize_collection_with_u64_hashable_key<C, V>(collection: &C) -> C
+where
+    for<'a> &'a C: IntoIterator<Item = (&'a u64, &'a V)>,
+    C: FromIterator<(u64, V)>,
+    V: Anonymize,
+{
+    collection
+        .into_iter()
+        .map(|(k, v)| (hash_u64(*k), v.anonymize()))
+        .collect()
+}
+
 impl Anonymize for String {
     fn anonymize(&self) -> Self {
         let mut hasher = DefaultHasher::new();

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -418,6 +418,14 @@ pub struct SegmentInfo {
     pub vector_data: HashMap<String, VectorDataInfo>,
 }
 
+#[derive(Debug, Default)]
+pub struct SizeStats {
+    pub num_vectors: usize,
+    pub vectors_size_bytes: usize,
+    pub payloads_size_bytes: usize,
+    pub num_points: usize,
+}
+
 /// Additional parameters of the search
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, Copy, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -26,7 +26,7 @@ use collection::shards::channel_service::ChannelService;
 use collection::shards::replica_set::{AbortShardTransfer, ReplicaState};
 use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::{CollectionId, replica_set};
-use collection::telemetry::CollectionTelemetry;
+use collection::telemetry::{CollectionTelemetry, CollectionsAggregatedTelemetry};
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwSharedDrain;
 use common::cpu::get_num_cpus;
@@ -471,6 +471,20 @@ impl TableOfContent {
         for collection_pass in &all_collections {
             if let Ok(collection) = self.get_collection(collection_pass).await {
                 result.push(collection.get_telemetry_data(detail).await);
+            }
+        }
+        result
+    }
+
+    pub async fn get_aggregated_telemetry_data(
+        &self,
+        access: &Access,
+    ) -> Vec<CollectionsAggregatedTelemetry> {
+        let mut result = Vec::new();
+        let all_collections = self.all_collections_whole_access(access).await;
+        for collection_pass in &all_collections {
+            if let Ok(collection) = self.get_collection(collection_pass).await {
+                result.push(collection.get_aggregated_telemetry_data().await);
             }
         }
         result

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -79,7 +79,7 @@ async fn metrics(
         .prepare_data(
             &access,
             TelemetryDetail {
-                level: DetailsLevel::Level1,
+                level: DetailsLevel::Level3,
                 histograms: true,
             },
         )

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -438,7 +438,7 @@ impl OperationDurationMetricsBuilder {
         ));
         self.duration_histogram_secs.push(histogram(
             stat.count as u64,
-            stat.total_duration_micros as f64 / 1_000_000.0,
+            stat.total_duration_micros.unwrap_or(0) as f64 / 1_000_000.0,
             &stat
                 .duration_micros_histogram
                 .iter()

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -418,7 +418,7 @@ impl OperationDurationMetricsBuilder {
     ) {
         self.total.push(counter(stat.count as f64, labels));
         self.fail_total
-            .push(counter(stat.fail_count as f64, labels));
+            .push(counter(stat.fail_count.unwrap_or_default() as f64, labels));
 
         if !add_timings {
             return;

--- a/src/common/telemetry_ops/collections_telemetry.rs
+++ b/src/common/telemetry_ops/collections_telemetry.rs
@@ -1,19 +1,10 @@
-use collection::config::CollectionParams;
-use collection::operations::types::OptimizersStatus;
-use collection::telemetry::CollectionTelemetry;
+use collection::telemetry::{CollectionTelemetry, CollectionsAggregatedTelemetry};
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::Serialize;
 use storage::content_manager::toc::TableOfContent;
 use storage::rbac::Access;
-
-#[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
-pub struct CollectionsAggregatedTelemetry {
-    pub vectors: usize,
-    pub optimizers_status: OptimizersStatus,
-    pub params: CollectionParams,
-}
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
 #[serde(untagged)]
@@ -30,39 +21,23 @@ pub struct CollectionsTelemetry {
     pub collections: Option<Vec<CollectionTelemetryEnum>>,
 }
 
-impl From<CollectionTelemetry> for CollectionsAggregatedTelemetry {
-    fn from(telemetry: CollectionTelemetry) -> Self {
-        let optimizers_status = telemetry
-            .shards
-            .iter()
-            .filter_map(|shard| shard.local.as_ref().map(|x| x.optimizations.status.clone()))
-            .max()
-            .unwrap_or(OptimizersStatus::Ok);
-
-        CollectionsAggregatedTelemetry {
-            vectors: telemetry.count_vectors(),
-            optimizers_status,
-            params: telemetry.config.params,
-        }
-    }
-}
-
 impl CollectionsTelemetry {
     pub async fn collect(detail: TelemetryDetail, access: &Access, toc: &TableOfContent) -> Self {
         let number_of_collections = toc.all_collections(access).await.len();
         let collections = if detail.level >= DetailsLevel::Level1 {
-            let telemetry_data = toc
-                .get_telemetry_data(detail, access)
-                .await
-                .into_iter()
-                .map(|telemetry| {
-                    if detail.level >= DetailsLevel::Level2 {
-                        CollectionTelemetryEnum::Full(telemetry)
-                    } else {
-                        CollectionTelemetryEnum::Aggregated(telemetry.into())
-                    }
-                })
-                .collect();
+            let telemetry_data = if detail.level >= DetailsLevel::Level2 {
+                toc.get_telemetry_data(detail, access)
+                    .await
+                    .into_iter()
+                    .map(CollectionTelemetryEnum::Full)
+                    .collect()
+            } else {
+                toc.get_aggregated_telemetry_data(access)
+                    .await
+                    .into_iter()
+                    .map(CollectionTelemetryEnum::Aggregated)
+                    .collect()
+            };
 
             Some(telemetry_data)
         } else {

--- a/tests/openapi/test_service.py
+++ b/tests/openapi/test_service.py
@@ -41,6 +41,24 @@ def test_telemetry():
     endpoint = result['requests']['rest']['responses']['PUT /collections/{name}/points']
     assert endpoint['200']['count'] > 0
 
+    assert 'avg_duration_micros' in endpoint['200']
+
+def test_telemetry_detailed():
+    response = request_with_validation(
+        api='/telemetry',
+        method="GET",
+        query_params={'details_level': '10'},
+    )
+
+    assert response.ok
+
+    result = response.json()['result']
+
+    assert result['collections']['number_of_collections'] >= 1
+
+    endpoint = result['requests']['rest']['responses']['PUT /collections/{name}/points']
+    assert endpoint['200']['count'] > 0
+
     last_queried = endpoint['200']['last_responded']
     last_queried = datetime.fromisoformat(last_queried)
     # Assert today


### PR DESCRIPTION
Main idea: for automated tools like Cluster Manager it should be enough to work with level-3. Level-4 is quite expensive in terms of request size and should only be required for in-depth performance debug 


- allow shard states in anonymize telemetry (with hashed peer ids)
- split shard and segments detail levels

--- 

- Make sure cluster manager can use Level3 of telemetry