### PR TITLE
[mutable text index] No need to wrap vec in option

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -141,9 +141,8 @@ impl From<MutableInvertedIndex> for ImmutableInvertedIndex {
             .postings
             .into_iter()
             .enumerate()
-            .filter_map(|(orig_token, posting)| match posting {
-                Some(posting) if posting.len() > 0 => Some((orig_token, posting)),
-                _ => None,
+            .filter_map(|(orig_token, posting)| {
+                (!posting.is_empty()).then_some((orig_token, posting))
             })
             .enumerate()
             .map(|(new_token, (orig_token, posting))| {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -280,12 +280,7 @@ mod tests {
 
                 let orig_token = mutable.vocab.get(key).unwrap();
 
-                let orig_posting = mutable
-                    .postings
-                    .get(*orig_token as usize)
-                    .cloned()
-                    .unwrap()
-                    .unwrap();
+                let orig_posting = mutable.postings.get(*orig_token as usize).cloned().unwrap();
 
                 let new_contains_orig = orig_posting
                     .iter()

--- a/lib/segment/src/index/field_index/full_text_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/posting_list.rs
@@ -6,10 +6,6 @@ pub struct PostingList {
 }
 
 impl PostingList {
-    pub fn new(idx: PointOffsetType) -> Self {
-        Self { list: vec![idx] }
-    }
-
     pub fn insert(&mut self, idx: PointOffsetType) {
         if self.list.is_empty() || idx > *self.list.last().unwrap() {
             self.list.push(idx);
@@ -29,19 +25,28 @@ impl PostingList {
         }
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.list.len()
     }
 
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    #[inline]
     pub fn contains(&self, val: PointOffsetType) -> bool {
         self.list.binary_search(&val).is_ok()
     }
 
+    #[inline]
     pub fn iter(&self) -> impl Iterator<Item = PointOffsetType> + '_ {
         self.list.iter().copied()
     }
 
-    pub(crate) fn into_vec(self) -> Vec<PointOffsetType> {
+    #[inline]
+    pub fn into_vec(self) -> Vec<PointOffsetType> {
         self.list
     }
 }


### PR DESCRIPTION
Builds on top of #6264 

I think this is an unnecessary wrapping into `Option`, if a posting list is empty, let it just be an empty `PostingList`.
`Option<PostingList>` and `PostingList` both use 24 bytes, even when the option is `None`.

Main change is this:
```diff
pub struct MutableInvertedIndex {
-    pub(in crate::index::field_index::full_text_index) postings: Vec<Option<PostingList>>,
+    pub(in crate::index::field_index::full_text_index) postings: Vec<PostingList>,
    pub(in crate::index::field_index::full_text_index) vocab: HashMap<String, TokenId>,
    pub(in crate::index::field_index::full_text_index) point_to_docs: Vec<Option<Document>>,
    pub(in crate::index::field_index::full_text_index) points_count: usize,
}
```