### PR TITLE
criterion hnsw filtered search

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -168,6 +168,10 @@ name = "boolean_filtering"
 harness = false
 
 [[bench]]
+name = "hnsw_filtered_search_asymptotic"
+harness = false
+
+[[bench]]
 name = "numeric_index_check_values"
 harness = false
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -168,7 +168,7 @@ name = "boolean_filtering"
 harness = false
 
 [[bench]]
-name = "hnsw_filtered_search_asymptotic"
+name = "segment_filtered_search_asymptotic"
 harness = false
 
 [[bench]]

--- a/lib/segment/benches/boolean_filtering.rs
+++ b/lib/segment/benches/boolean_filtering.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -89,6 +90,7 @@ pub fn keyword_index_boolean_query_points(c: &mut Criterion) {
     let seed = 42;
 
     let mut rng = StdRng::seed_from_u64(seed);
+    let feature_flags = feature_flags();
 
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let payload_storage = Arc::new(AtomicRefCell::new(
@@ -103,6 +105,7 @@ pub fn keyword_index_boolean_query_points(c: &mut Criterion) {
         id_tracker,
         std::collections::HashMap::new(),
         dir.path(),
+        &feature_flags,
         true,
     )
     .unwrap();

--- a/lib/segment/benches/hnsw_filtered_search_asymptotic.rs
+++ b/lib/segment/benches/hnsw_filtered_search_asymptotic.rs
@@ -1,0 +1,193 @@
+#[cfg(not(target_os = "windows"))]
+mod prof;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use common::budget::ResourcePermit;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::{FeatureFlags, init_feature_flags};
+use common::types::PointOffsetType;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use itertools::Itertools;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng, rng};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
+use segment::entry::entry_point::SegmentEntry;
+use segment::fixtures::index_fixtures::{FakeFilterContext, random_vector};
+use segment::fixtures::payload_fixtures::random_int_payload;
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
+use segment::index::hnsw_index::num_rayon_threads;
+use segment::index::hnsw_index::point_scorer::FilteredScorer;
+use segment::index::{PayloadIndex, VectorIndex};
+use segment::json_path::JsonPath;
+use segment::payload_json;
+use segment::segment_constructor::VectorIndexBuildArgs;
+use segment::segment_constructor::segment_builder::SegmentBuilder;
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::spaces::simple::CosineMetric;
+use segment::types::{
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType,
+    PayloadStorageType, Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
+    VectorStorageType,
+};
+use segment::vector_storage::DEFAULT_STOPPED;
+use tempfile::Builder;
+
+mod fixture;
+
+type Metric = CosineMetric;
+
+fn hnsw_benchmark(c: &mut Criterion) {
+    let mut feature_flags = FeatureFlags::default();
+    feature_flags.payload_index_skip_rocksdb = true;
+    init_feature_flags(feature_flags.clone());
+
+    let mut group = c.benchmark_group("hnsw-small-cardinality");
+
+    let stopped = AtomicBool::new(false);
+
+    let dim = 8;
+    let m = 8;
+    let num_vectors: u64 = 50_000;
+    let ef = 32;
+    let ef_construct = 16;
+    let distance = Distance::Cosine;
+    let full_scan_threshold = 16; // KB
+    let indexing_threshold = 500; // num vectors
+    let num_payload_values = 5;
+
+    let mut rnd = rng();
+
+    let segment_fill_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let tmp_dir = Builder::new().prefix("tmp_dir").tempdir().unwrap();
+
+    let int_key = "int";
+
+    let hw_counter = HardwareCounterCell::new();
+    let permit_cpu_count = num_rayon_threads(1);
+    let permit = ResourcePermit::dummy(permit_cpu_count as u32);
+
+    let mut segment = build_simple_segment(segment_fill_dir.path(), dim, distance).unwrap();
+    for n in 0..num_vectors {
+        let idx = n.into();
+        let vector = random_vector(&mut rnd, dim);
+
+        let int_payload = random_int_payload(&mut rnd, 0..=num_payload_values);
+        let payload = payload_json! {int_key: int_payload};
+
+        segment
+            .upsert_point(
+                n as SeqNumberType,
+                idx,
+                only_default_vector(&vector),
+                &hw_counter,
+            )
+            .unwrap();
+        segment
+            .set_full_payload(n as SeqNumberType, idx, &payload, &hw_counter)
+            .unwrap();
+    }
+    let opnum = num_vectors + 1;
+    segment
+        .create_field_index(
+            opnum,
+            &JsonPath::new(int_key),
+            Some(&PayloadSchemaType::Integer.into()),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let mut segment_builder = SegmentBuilder::new(
+        segment_dir.path(),
+        tmp_dir.path(),
+        &SegmentConfig {
+            vector_data: HashMap::from([(
+                DEFAULT_VECTOR_NAME.to_owned(),
+                VectorDataConfig {
+                    size: dim,
+                    distance,
+                    storage_type: VectorStorageType::Memory,
+                    index: Indexes::Hnsw(HnswConfig {
+                        m,
+                        ef_construct,
+                        full_scan_threshold: 100,
+                        max_indexing_threads: 1,
+                        on_disk: Some(false),
+                        payload_m: None,
+                    }),
+                    quantization_config: None,
+                    multivector_config: None,
+                    datatype: None,
+                },
+            )]),
+            sparse_vector_data: Default::default(),
+            payload_storage_type: PayloadStorageType::InMemory,
+        },
+    )
+    .unwrap();
+
+    // segment_builder.add_indexed_field(JsonPath::new(int_key), PayloadSchemaType::Integer.into());
+    segment_builder.update(&[&segment], &stopped).unwrap();
+
+    let segment = segment_builder
+        .build(permit, &stopped, &hw_counter)
+        .unwrap();
+
+    let left_range = 1;
+    let right_range = num_payload_values;
+    let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
+        JsonPath::new(int_key),
+        Range {
+            lt: None,
+            gt: None,
+            gte: Some(f64::from(left_range)),
+            lte: Some(f64::from(right_range as i32)),
+        },
+    )));
+
+    let top = 5;
+    group.bench_function("hnsw-exact-search", |b| {
+        b.iter(|| {
+            let query = random_vector(&mut rnd, dim).into();
+
+            let plain_result = segment
+                .search(
+                    DEFAULT_VECTOR_NAME,
+                    &query,
+                    &Default::default(),
+                    &Default::default(),
+                    Some(&filter),
+                    top,
+                    Some(&SearchParams {
+                        hnsw_ef: Some(ef),
+                        exact: true,
+                        ..Default::default()
+                    }),
+                )
+                .unwrap();
+
+            black_box(plain_result)
+        })
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
+    targets = hnsw_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = hnsw_benchmark
+}
+
+criterion_main!(benches);

--- a/lib/segment/benches/hnsw_filtered_search_asymptotic.rs
+++ b/lib/segment/benches/hnsw_filtered_search_asymptotic.rs
@@ -2,50 +2,37 @@
 mod prof;
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::flags::{FeatureFlags, init_feature_flags};
-use common::types::PointOffsetType;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use itertools::Itertools;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng, rng};
+use common::flags::{FeatureFlags, feature_flags};
+use criterion::measurement::WallTime;
+use criterion::{BenchmarkGroup, Criterion, black_box, criterion_group, criterion_main};
+use rand::rng;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
 use segment::entry::entry_point::SegmentEntry;
-use segment::fixtures::index_fixtures::{FakeFilterContext, random_vector};
+use segment::fixtures::index_fixtures::random_vector;
 use segment::fixtures::payload_fixtures::random_int_payload;
-use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
-use segment::index::hnsw_index::point_scorer::FilteredScorer;
-use segment::index::{PayloadIndex, VectorIndex};
 use segment::json_path::JsonPath;
 use segment::payload_json;
-use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
-use segment::spaces::simple::CosineMetric;
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, PayloadSchemaType,
     PayloadStorageType, Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
     VectorStorageType,
 };
-use segment::vector_storage::DEFAULT_STOPPED;
 use tempfile::Builder;
 
 mod fixture;
 
-type Metric = CosineMetric;
-
-fn hnsw_benchmark(c: &mut Criterion) {
-    let mut feature_flags = FeatureFlags::default();
-    feature_flags.payload_index_skip_rocksdb = true;
-    init_feature_flags(feature_flags.clone());
-
-    let mut group = c.benchmark_group("hnsw-small-cardinality");
-
+fn filtered_hnsw_benchmark_with_flags(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    test_prefix: &str,
+    feature_flags: FeatureFlags,
+) {
     let stopped = AtomicBool::new(false);
 
     let dim = 8;
@@ -54,8 +41,6 @@ fn hnsw_benchmark(c: &mut Criterion) {
     let ef = 32;
     let ef_construct = 16;
     let distance = Distance::Cosine;
-    let full_scan_threshold = 16; // KB
-    let indexing_threshold = 500; // num vectors
     let num_payload_values = 5;
 
     let mut rnd = rng();
@@ -128,6 +113,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
         },
     )
     .unwrap();
+    segment_builder.set_feature_flags(feature_flags);
 
     // segment_builder.add_indexed_field(JsonPath::new(int_key), PayloadSchemaType::Integer.into());
     segment_builder.update(&[&segment], &stopped).unwrap();
@@ -149,7 +135,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
     )));
 
     let top = 5;
-    group.bench_function("hnsw-exact-search", |b| {
+    group.bench_function(format!("{}-exact-search", test_prefix), |b| {
         b.iter(|| {
             let query = random_vector(&mut rnd, dim).into();
 
@@ -173,6 +159,44 @@ fn hnsw_benchmark(c: &mut Criterion) {
         })
     });
 
+    group.bench_function(format!("{}-hnsw-search", test_prefix), |b| {
+        b.iter(|| {
+            let query = random_vector(&mut rnd, dim).into();
+
+            let plain_result = segment
+                .search(
+                    DEFAULT_VECTOR_NAME,
+                    &query,
+                    &Default::default(),
+                    &Default::default(),
+                    Some(&filter),
+                    top,
+                    Some(&SearchParams {
+                        hnsw_ef: Some(ef),
+                        ..Default::default()
+                    }),
+                )
+                .unwrap();
+
+            black_box(plain_result)
+        })
+    });
+}
+
+fn filtered_hnsw_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("filtered-hnsw-segment");
+
+    let mut feature_flags = feature_flags();
+    feature_flags.payload_index_skip_rocksdb = true;
+    filtered_hnsw_benchmark_with_flags(&mut group, "filtered-hnsw-mmap", feature_flags.clone());
+
+    feature_flags.payload_index_skip_rocksdb = false;
+    filtered_hnsw_benchmark_with_flags(
+        &mut group,
+        "filtered-hnsw-immutable",
+        feature_flags.clone(),
+    );
+
     group.finish();
 }
 
@@ -180,7 +204,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
-    targets = hnsw_benchmark
+    targets = filtered_hnsw_benchmark
 }
 
 #[cfg(target_os = "windows")]

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use common::types::PointOffsetType;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::prelude::StdRng;
@@ -46,6 +47,7 @@ fn range_filtering(c: &mut Criterion) {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
     let hw_counter = HardwareCounterCell::new();
+    let feature_flags = feature_flags();
 
     // generate points with payload
     let mut payload_storage = InMemoryPayloadStorage::default();
@@ -67,6 +69,7 @@ fn range_filtering(c: &mut Criterion) {
         id_tracker.clone(),
         std::collections::HashMap::new(),
         dir.path(),
+        &feature_flags,
         true,
     )
     .unwrap();
@@ -128,6 +131,7 @@ fn range_filtering(c: &mut Criterion) {
         id_tracker,
         std::collections::HashMap::new(),
         dir.path(),
+        &feature_flags,
         false,
     )
     .unwrap();

--- a/lib/segment/benches/segment_filtered_search_asymptotic.rs
+++ b/lib/segment/benches/segment_filtered_search_asymptotic.rs
@@ -26,8 +26,6 @@ use segment::types::{
 };
 use tempfile::Builder;
 
-mod fixture;
-
 fn segment_filtered_search_benchmark_with_flags(
     group: &mut BenchmarkGroup<'_, WallTime>,
     test_prefix: &str,

--- a/lib/segment/benches/segment_filtered_search_asymptotic.rs
+++ b/lib/segment/benches/segment_filtered_search_asymptotic.rs
@@ -135,7 +135,7 @@ fn segment_filtered_search_benchmark_with_flags(
     )));
 
     let top = 5;
-    group.bench_function(format!("{}-plain", test_prefix), |b| {
+    group.bench_function(format!("{test_prefix}-plain"), |b| {
         b.iter(|| {
             let query = random_vector(&mut rnd, dim).into();
 
@@ -159,7 +159,7 @@ fn segment_filtered_search_benchmark_with_flags(
         })
     });
 
-    group.bench_function(format!("{}-hnsw", test_prefix), |b| {
+    group.bench_function(format!("{test_prefix}-hnsw"), |b| {
         b.iter(|| {
             let query = random_vector(&mut rnd, dim).into();
 
@@ -188,14 +188,14 @@ fn segment_filtered_search_benchmark(c: &mut Criterion) {
     segment_filtered_search_benchmark_with_flags(
         &mut group,
         "segment-filtered-search-prefetched-mmap",
-        feature_flags.clone(),
+        feature_flags,
     );
 
     feature_flags.payload_index_skip_rocksdb = false;
     segment_filtered_search_benchmark_with_flags(
         &mut group,
         "segment-filtered-search-prefetched-immutable-ram",
-        feature_flags.clone(),
+        feature_flags,
     );
 
     group.finish();

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use half::f16;
@@ -38,6 +39,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("sparse-vector-build-group");
 
     let stopped = AtomicBool::new(false);
+    let feature_flags = feature_flags();
     let mut rnd = StdRng::seed_from_u64(42);
 
     let payload_dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
@@ -53,6 +55,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
         id_tracker.clone(),
         std::collections::HashMap::new(),
         payload_dir.path(),
+        &feature_flags,
         true,
     )
     .unwrap();

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use bitvec::prelude::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use common::types::PointOffsetType;
 use rand::SeedableRng;
 use rand::prelude::StdRng;
@@ -262,6 +263,7 @@ pub fn create_struct_payload_index(
         id_tracker,
         std::collections::HashMap::new(),
         path,
+        &feature_flags(),
         true,
     )
     .unwrap();

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use common::types::PointOffsetType;
 use rand::Rng;
 use sparse::common::sparse_vector::SparseVector;
@@ -47,6 +48,7 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
         id_tracker.clone(),
         std::collections::HashMap::new(),
         payload_dir,
+        &feature_flags(),
         true,
     )?;
     let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -7,7 +7,7 @@ use ahash::AHashSet;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
-use common::flags::feature_flags;
+use common::flags::FeatureFlags;
 use common::types::PointOffsetType;
 use itertools::Either;
 use log::debug;
@@ -162,6 +162,7 @@ impl StructPayloadIndex {
         id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
         vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
         path: &Path,
+        feature_flags: &FeatureFlags,
         is_appendable: bool,
     ) -> OperationResult<Self> {
         create_dir_all(path)?;
@@ -170,7 +171,7 @@ impl StructPayloadIndex {
             PayloadConfig::load(&config_path)?
         } else {
             let mut new_config = PayloadConfig::default();
-            if feature_flags().payload_index_skip_rocksdb && !is_appendable {
+            if feature_flags.payload_index_skip_rocksdb && !is_appendable {
                 new_config.skip_rocksdb = Some(true);
             }
             new_config

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -598,7 +598,7 @@ impl SegmentBuilder {
                         old_indices: &old_indices.remove(vector_name).unwrap(),
                         gpu_device: gpu_device.as_ref(),
                         stopped,
-                        feature_flags: feature_flags,
+                        feature_flags,
                     },
                 )?;
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -11,7 +11,7 @@ use atomic_refcell::AtomicRefCell;
 use bitvec::macros::internal::funty::Integral;
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::flags::feature_flags;
+use common::flags::{FeatureFlags, feature_flags};
 use common::small_uint::U24;
 use common::types::PointOffsetType;
 use io::storage_version::StorageVersion;
@@ -56,6 +56,7 @@ pub struct SegmentBuilder {
     payload_storage: PayloadStorageEnum,
     vector_data: HashMap<VectorNameBuf, VectorData>,
     segment_config: SegmentConfig,
+    feature_flags: FeatureFlags,
 
     // The path, where fully created segment will be moved
     destination_path: PathBuf,
@@ -144,12 +145,17 @@ impl SegmentBuilder {
             payload_storage,
             vector_data,
             segment_config: segment_config.clone(),
+            feature_flags: feature_flags(),
 
             destination_path,
             temp_dir,
             indexed_fields: Default::default(),
             defragment_keys: vec![],
         })
+    }
+
+    pub fn set_feature_flags(&mut self, feature_flags: FeatureFlags) {
+        self.feature_flags = feature_flags;
     }
 
     pub fn set_defragment_keys(&mut self, keys: Vec<PayloadKeyType>) {
@@ -468,6 +474,7 @@ impl SegmentBuilder {
                 payload_storage,
                 mut vector_data,
                 segment_config,
+                feature_flags,
                 destination_path,
                 temp_dir,
                 indexed_fields,
@@ -546,6 +553,7 @@ impl SegmentBuilder {
                 id_tracker_arc.clone(),
                 vector_storages_arc.clone(),
                 &payload_index_path,
+                &feature_flags,
                 appendable_flag,
             )?;
             for (field, payload_schema) in indexed_fields {
@@ -590,7 +598,7 @@ impl SegmentBuilder {
                         old_indices: &old_indices.remove(vector_name).unwrap(),
                         gpu_device: gpu_device.as_ref(),
                         stopped,
-                        feature_flags: feature_flags(),
+                        feature_flags: feature_flags,
                     },
                 )?;
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
-use common::flags::FeatureFlags;
+use common::flags::{FeatureFlags, feature_flags};
 use io::storage_version::StorageVersion;
 use log::info;
 use parking_lot::{Mutex, RwLock};

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -598,6 +598,7 @@ fn create_segment(
         id_tracker.clone(),
         vector_storages.clone(),
         &payload_index_path,
+        &feature_flags(),
         appendable_flag,
     )?);
 

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use common::types::PointOffsetType;
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::index::PayloadIndex;
@@ -76,6 +77,7 @@ fn test_filtering_context_consistency() {
         id_tracker,
         HashMap::new(),
         dir.path(),
+        &feature_flags(),
         true,
     )
     .unwrap();

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use common::types::PointOffsetType;
 use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
@@ -1188,6 +1189,7 @@ fn test_update_payload_index_type() {
         id_tracker,
         HashMap::new(),
         dir.path(),
+        &feature_flags(),
         true,
     )
     .unwrap();


### PR DESCRIPTION
Adding a criterion benchmark for HNSW filtered search.

It covers HNSW and plain search with a numeric payload index with immutable and mmap options.