### PR TITLE
Abort resharding after marking as dead

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -334,7 +334,12 @@ async fn clean_task(
                 crate::operations::point_ops::PointOperations::DeletePoints { ids },
             ));
         if let Err(err) = shard
-            .update_local(delete_operation, last_batch, HwMeasurementAcc::disposable())
+            .update_local(
+                delete_operation,
+                last_batch,
+                HwMeasurementAcc::disposable(),
+                false,
+            )
             .await
         {
             return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -34,7 +34,6 @@ use crate::common::collection_size_stats::{
 };
 use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfigInternal;
-use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::config_diff::{DiffConfig, OptimizersConfigDiff};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult, NodeType};
@@ -452,32 +451,26 @@ impl Collection {
             let mut abort_resharding_result = CollectionResult::Ok(());
             let mut abort_transfers_result = CollectionResult::Ok(());
 
-            // Terminate resharding if we kill a related shard
-            let has_resharding_state = current_state
+            // Abort resharding, if resharding shard is marked as `Dead`.
+            //
+            // This branch should only be triggered, if resharding is currently at `MigratingPoints`
+            // stage, because target shard should be marked as `Active`, when all resharding transfers
+            // are successfully completed, and so the check *right above* this one would be triggered.
+            //
+            // So, if resharding reached `ReadHashRingCommitted`, this branch *won't* be triggered,
+            // and resharding *won't* be cancelled. The update request should *fail* with "failed to
+            // update all replicas of a shard" error.
+            //
+            // If resharding reached `ReadHashRingCommitted`, and this branch is triggered *somehow*,
+            // then `Collection::abort_resharding` call should return an error, so no special handling
+            // is needed.
+            let is_resharding = current_state
                 .as_ref()
                 .is_some_and(ReplicaState::is_resharding);
-            match (has_resharding_state, resharding_state) {
-                // Not resharding, nothing to abort
-                (_, None) => {}
-                // If resharding up, abort if replica is in resharding state
-                (true, Some(state)) if state.direction == ReshardingDirection::Up => {
+            if is_resharding {
+                if let Some(state) = resharding_state {
                     abort_resharding_result = self.abort_resharding(state.key(), false).await;
                 }
-                // If resharding up, abort if we kill target shard
-                (_, Some(state))
-                    if state.direction == ReshardingDirection::Up
-                        && state.peer_id == peer_id
-                        && state.shard_id == shard_id =>
-                {
-                    abort_resharding_result = self.abort_resharding(state.key(), false).await;
-                }
-                // If resharding down, abort if replica is in resharding state
-                (true, Some(state)) if state.direction == ReshardingDirection::Down => {
-                    abort_resharding_result = self.abort_resharding(state.key(), false).await;
-                }
-                // Keep resharding running in other cases
-                // Might still be aborted by terminating related transfers below
-                (_, Some(_)) => {}
             }
 
             // Terminate transfer if source or target replicas are now dead

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -449,7 +449,6 @@ impl Collection {
             drop(shard_holder);
 
             let mut abort_resharding_result = CollectionResult::Ok(());
-            let mut abort_transfers_result = CollectionResult::Ok(());
 
             // Abort resharding, if resharding shard is marked as `Dead`.
             //
@@ -475,12 +474,11 @@ impl Collection {
 
             // Terminate transfer if source or target replicas are now dead
             for transfer in related_transfers {
-                abort_transfers_result = self.abort_shard_transfer(transfer.key(), None).await;
+                self.abort_shard_transfer(transfer.key(), None).await?;
             }
 
-            // Propagate resharding and shard transfer errors now
+            // Propagate resharding errors now
             abort_resharding_result?;
-            abort_transfers_result?;
         }
 
         // If not initialized yet, we need to check if it was initialized by this call

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -54,6 +54,7 @@ impl Collection {
                         OperationWithClockTag::from(operation.clone()),
                         wait,
                         hw_measurement_acc.clone(),
+                        false,
                     )
                 })
                 .collect();
@@ -103,7 +104,7 @@ impl Collection {
             };
 
             match ordering {
-                WriteOrdering::Weak => shard.update_local(operation, wait, hw_measurement_acc.clone()).await,
+                WriteOrdering::Weak => shard.update_local(operation, wait, hw_measurement_acc.clone(), false).await,
                 WriteOrdering::Medium | WriteOrdering::Strong => {
                     if let Some(clock_tag) = operation.clock_tag {
                         log::warn!(

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -128,6 +128,7 @@ impl Collection {
                         OperationWithClockTag::from(create_index_op),
                         true,
                         hw_counter.clone(),
+                        false,
                     ) // TODO: Assign clock tag!? 🤔
                     .await?;
             }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -894,6 +894,7 @@ impl ShardReplicaSet {
         &self,
         filter: Filter,
         hw_measurement_acc: HwMeasurementAcc,
+        force: bool,
     ) -> CollectionResult<UpdateResult> {
         let local_shard_guard = self.local.read().await;
 
@@ -950,7 +951,7 @@ impl ShardReplicaSet {
 
         // TODO(resharding): Assign clock tag to the operation!? 🤔
         let result = self
-            .update_local(op.into(), true, hw_measurement_acc)
+            .update_local(op.into(), true, hw_measurement_acc, force)
             .await?
             .ok_or_else(|| {
                 CollectionError::bad_request(format!(

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -134,7 +134,7 @@ async fn fixture() -> Collection {
             ])),
         ));
         shard
-            .update_local(op, true, HwMeasurementAcc::new())
+            .update_local(op, true, HwMeasurementAcc::new(), false)
             .await
             .expect("failed to insert points");
     }


### PR DESCRIPTION
Fixes on top of <https://github.com/qdrant/qdrant/pull/6364>

The main things this solves is:
- if resharding abort fails, don't forget to mark replica as dead
- if aborting resharding, don't forget to also cancel related shard transfers
- first mark replica as dead, then abort resharding
- no more replica state blinking, don't mark as active first and then dead
- actually delete points in replica even if in dead state

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?