### PR TITLE
Fix flaky test with dirty shards

### DIFF
--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -297,11 +297,13 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
         extra_env=extra_env
     )
 
+    wait_for_same_commit(peer_api_uris=peer_api_uris)
+
     # We expect transfer to be started again if stopped in between because of node crash
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 1)
+    wait_for_collection_shard_transfers_count(peer_api_uris[-1], COLLECTION_NAME, 1)
 
     # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+    wait_for_collection_shard_transfers_count(peer_api_uris[-1], COLLECTION_NAME, 0)
 
     # Wait for all replicas to be active on the receiving peer
     wait_for_all_replicas_active(peer_api_uris[-1], COLLECTION_NAME)


### PR DESCRIPTION
Try fixing the flakiness in test introduced by https://github.com/qdrant/qdrant/pull/6364. 

Somehow the bug didn't reproduce for me except once. It happened at [this](https://github.com/qdrant/qdrant/pull/6397/files#diff-c03f565135518d69bd66fe24214e6005ba3c6102155d72790d6ba8bfe25a7c02R312) line where it returns 0 shards. 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
