### PR TITLE
rollback disabling of debug symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,9 +285,6 @@ lto = false
 opt-level = 3
 codegen-units = 256 # restore default value for faster compilation
 
-[profile.dev]
-debug = false
-
 # Override for fast sha256 hashing in dev builds
 [profile.dev.package.sha2]
 opt-level = 3


### PR DESCRIPTION
With removed likes panic backtrace looks like this:


```
2025-04-20T09:59:04.898821Z ERROR qdrant::startup: Panic backtrace: 
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: <unknown>
  17: <unknown>
  18: <unknown>
  19: <unknown>
  20: <unknown>
  21: <unknown>
  22: <unknown>
  23: <unknown>
  24: <unknown>
  25: <unknown>
  26: <unknown>
  27: <unknown>
  28: <unknown>
  29: <unknown>
  30: <unknown>
  31: <unknown>
  32: <unknown>
  33: <unknown>
  34: <unknown>
  35: <unknown>
  36: <unknown>
  37: <unknown>
  38: <unknown>
  39: <unknown>
  40: <unknown>
```