### PR TITLE
careful index creation

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -454,6 +454,9 @@ pub trait SegmentOptimizer {
                 ProxyIndexChange::Delete(_) => {
                     segment_builder.remove_indexed_field(field_name);
                 }
+                ProxyIndexChange::DeleteIfIncompatible(_, schema) => {
+                    segment_builder.remove_index_field_if_incompatible(field_name, schema);
+                }
             }
         }
 
@@ -531,6 +534,10 @@ pub trait SegmentOptimizer {
                 }
                 ProxyIndexChange::Delete(version) => {
                     optimized_segment.delete_field_index(*version, field_name)?;
+                }
+                ProxyIndexChange::DeleteIfIncompatible(version, schema) => {
+                    optimized_segment
+                        .delete_field_index_if_incompatible(*version, field_name, schema)?;
                 }
             }
             self.check_cancellation(stopped)?;
@@ -713,6 +720,10 @@ pub trait SegmentOptimizer {
                     }
                     ProxyIndexChange::Delete(version) => {
                         optimized_segment.delete_field_index(*version, field_name)?;
+                    }
+                    ProxyIndexChange::DeleteIfIncompatible(version, schema) => {
+                        optimized_segment
+                            .delete_field_index_if_incompatible(*version, field_name, schema)?;
                     }
                 }
                 self.check_cancellation(stopped)?;

--- a/lib/segment/src/data_types/build_index_result.rs
+++ b/lib/segment/src/data_types/build_index_result.rs
@@ -1,0 +1,16 @@
+use crate::index::field_index::FieldIndex;
+use crate::types::PayloadFieldSchema;
+
+pub enum BuildFieldIndexResult {
+    /// Index was not built, as operation version is lower than segment version
+    SkippedByVersion,
+    /// Index was already built
+    AlreadyExists,
+    /// Incompatible schema
+    IncompatibleSchema,
+    /// Index was built
+    Built {
+        indexes: Vec<FieldIndex>,
+        schema: PayloadFieldSchema,
+    },
+}

--- a/lib/segment/src/data_types/mod.rs
+++ b/lib/segment/src/data_types/mod.rs
@@ -8,3 +8,4 @@ pub mod query_context;
 pub mod segment_manifest;
 pub mod tiny_map;
 pub mod vectors;
+pub mod build_index_result;

--- a/lib/segment/src/data_types/mod.rs
+++ b/lib/segment/src/data_types/mod.rs
@@ -1,3 +1,4 @@
+pub mod build_index_result;
 pub mod facets;
 pub mod groups;
 pub mod index;
@@ -8,4 +9,3 @@ pub mod query_context;
 pub mod segment_manifest;
 pub mod tiny_map;
 pub mod vectors;
-pub mod build_index_result;

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -6,15 +6,25 @@ use common::types::PointOffsetType;
 use serde_json::Value;
 
 use super::field_index::FieldIndex;
-use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::common::Flusher;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::json_path::JsonPath;
 use crate::payload_storage::FilterContext;
 use crate::types::{
-    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
+    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
     SeqNumberType,
 };
+
+pub enum BuildIndexResult {
+    /// Index was built
+    Built(Vec<FieldIndex>),
+    /// Index was already built
+    AlreadyBuilt,
+    /// Field Index already exists, but incompatible schema
+    /// Requires extra actions to remove the old index.
+    IncompatibleSchema,
+}
 
 pub trait PayloadIndex {
     /// Get indexed fields
@@ -26,7 +36,7 @@ pub trait PayloadIndex {
         field: PayloadKeyTypeRef,
         payload_schema: &PayloadFieldSchema,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Option<Vec<FieldIndex>>>;
+    ) -> OperationResult<BuildIndexResult>;
 
     /// Apply already built indexes
     fn apply_index(
@@ -42,20 +52,17 @@ pub trait PayloadIndex {
         field: PayloadKeyTypeRef,
         payload_schema: impl Into<PayloadFieldSchema>,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        let payload_schema = payload_schema.into();
-
-        let Some(field_index) = self.build_index(field, &payload_schema, hw_counter)? else {
-            return Ok(());
-        };
-
-        self.apply_index(field.to_owned(), payload_schema, field_index)?;
-
-        Ok(())
-    }
+    ) -> OperationResult<()>;
 
     /// Remove index
     fn drop_index(&mut self, field: PayloadKeyTypeRef) -> OperationResult<()>;
+
+    /// Remove index if incompatible with new payload schema
+    fn drop_index_if_incompatible(
+        &mut self,
+        field: PayloadKeyTypeRef,
+        new_payload_schema: &PayloadFieldSchema,
+    ) -> OperationResult<()>;
 
     /// Estimate amount of points (min, max) which satisfies filtering condition.
     ///
@@ -141,13 +148,6 @@ pub trait PayloadIndex {
 
     /// Return function that forces persistence of current storage state.
     fn flusher(&self) -> Flusher;
-
-    /// Infer payload type from existing payload data.
-    fn infer_payload_type(
-        &self,
-        key: PayloadKeyTypeRef,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Option<PayloadSchemaType>>;
 
     fn take_database_snapshot(&self, path: &Path) -> OperationResult<()>;
 

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -6,14 +6,13 @@ use common::types::PointOffsetType;
 use serde_json::Value;
 
 use super::field_index::FieldIndex;
-use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::json_path::JsonPath;
 use crate::payload_storage::FilterContext;
 use crate::types::{
-    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
-    SeqNumberType,
+    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, SeqNumberType,
 };
 
 pub enum BuildIndexResult {

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -9,17 +9,15 @@ use common::types::PointOffsetType;
 use schemars::_serde_json::Value;
 
 use super::field_index::FieldIndex;
-use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
 use crate::index::{BuildIndexResult, PayloadIndex};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
-use crate::types::{
-    Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
-};
+use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
 ///

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::{fs, thread};
 
 use common::counter::hardware_counter::HardwareCounterCell;

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -1,16 +1,16 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::{fs, thread};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::TelemetryDetail;
 
 use super::Segment;
-use crate::common::operation_error::OperationError::TypeInferenceError;
 use crate::common::operation_error::{OperationError, OperationResult, SegmentFailedState};
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
+use crate::data_types::build_index_result::BuildFieldIndexResult;
 use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
@@ -18,7 +18,7 @@ use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQuer
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::SegmentEntry;
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
-use crate::index::{PayloadIndex, VectorIndex};
+use crate::index::{BuildIndexResult, PayloadIndex, VectorIndex};
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorage;
 use crate::telemetry::SegmentTelemetry;
@@ -738,45 +738,52 @@ impl SegmentEntry for Segment {
         })
     }
 
+    fn delete_field_index_if_incompatible(
+        &mut self,
+        op_num: SeqNumberType,
+        key: PayloadKeyTypeRef,
+        field_schema: &PayloadFieldSchema,
+    ) -> OperationResult<bool> {
+        self.handle_segment_version_and_failure(op_num, |segment| {
+            segment
+                .payload_index
+                .borrow_mut()
+                .drop_index_if_incompatible(key, field_schema)?;
+            Ok(true)
+        })
+    }
+
     fn build_field_index(
         &self,
         op_num: SeqNumberType,
         key: PayloadKeyTypeRef,
-        field_type: Option<&PayloadFieldSchema>,
+        field_type: &PayloadFieldSchema,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Option<(PayloadFieldSchema, Vec<FieldIndex>)>> {
+    ) -> OperationResult<BuildFieldIndexResult> {
         // Check version without updating it
         if self.version.unwrap_or(0) > op_num {
-            return Ok(None);
+            return Ok(BuildFieldIndexResult::SkippedByVersion);
         }
 
-        match field_type {
-            Some(schema) => {
-                let res = self
-                    .payload_index
-                    .borrow()
-                    .build_index(key, schema, hw_counter)?
-                    .map(|field_index| (schema.to_owned(), field_index));
-
-                Ok(res)
+        let field_index = match self
+            .payload_index
+            .borrow()
+            .build_index(key, field_type, hw_counter)?
+        {
+            BuildIndexResult::Built(indexes) => indexes,
+            BuildIndexResult::AlreadyBuilt => {
+                return Ok(BuildFieldIndexResult::AlreadyExists);
             }
-            None => match self.infer_from_payload_data(key, hw_counter)? {
-                None => Err(TypeInferenceError {
-                    field_name: key.clone(),
-                }),
-                Some(schema_type) => {
-                    let schema = schema_type.into();
+            BuildIndexResult::IncompatibleSchema => {
+                // This function expects that incompatible schema is already removed
+                return Ok(BuildFieldIndexResult::IncompatibleSchema);
+            }
+        };
 
-                    let res = self
-                        .payload_index
-                        .borrow()
-                        .build_index(key, &schema, hw_counter)?
-                        .map(|field_index| (schema, field_index));
-
-                    Ok(res)
-                }
-            },
-        }
+        Ok(BuildFieldIndexResult::Built {
+            indexes: field_index,
+            schema: field_type.clone(),
+        })
     }
 
     fn apply_field_index(

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -24,8 +24,8 @@ use crate::entry::entry_point::SegmentEntry;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::types::{
-    Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointIdType,
-    SegmentState, SeqNumberType, SnapshotFormat, VectorName,
+    Payload, PayloadFieldSchema, PayloadKeyType, PointIdType, SegmentState, SeqNumberType,
+    SnapshotFormat, VectorName,
 };
 use crate::utils;
 use crate::vector_storage::VectorStorage;
@@ -419,15 +419,6 @@ impl Segment {
 
     pub fn save_current_state(&self) -> OperationResult<()> {
         Self::save_state(&self.get_state(), &self.current_path)
-    }
-
-    pub(super) fn infer_from_payload_data(
-        &self,
-        key: PayloadKeyTypeRef,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Option<PayloadSchemaType>> {
-        let payload_index = self.payload_index.borrow();
-        payload_index.infer_payload_type(key, hw_counter)
     }
 
     /// Unpacks and restores the segment snapshot in-place. The original

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -164,6 +164,18 @@ impl SegmentBuilder {
         self.indexed_fields.remove(field);
     }
 
+    pub fn remove_index_field_if_incompatible(
+        &mut self,
+        field: &PayloadKeyType,
+        schema: &PayloadFieldSchema,
+    ) {
+        if let Some(existing_schema) = self.indexed_fields.get(field) {
+            if existing_schema != schema {
+                self.indexed_fields.remove(field);
+            }
+        }
+    }
+
     pub fn add_indexed_field(&mut self, field: PayloadKeyType, schema: PayloadFieldSchema) {
         self.indexed_fields.insert(field, schema);
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -13,7 +13,6 @@ use common::types::ScoreType;
 use fnv::FnvBuildHasher;
 use geo::{Contains, Coord, Distance as GeoDistance, Haversine, LineString, Point, Polygon};
 use indexmap::IndexSet;
-use itertools::Itertools;
 use merge::Merge;
 use ordered_float::OrderedFloat;
 use schemars::JsonSchema;
@@ -1883,25 +1882,6 @@ pub fn value_type(value: &Value) -> Option<PayloadSchemaType> {
     }
 }
 
-pub fn infer_value_type(value: &Value) -> Option<PayloadSchemaType> {
-    match value {
-        Value::Array(array) => infer_collection_value_type(array),
-        _ => value_type(value),
-    }
-}
-
-pub fn infer_collection_value_type<'a, I>(values: I) -> Option<PayloadSchemaType>
-where
-    I: IntoIterator<Item = &'a Value>,
-{
-    let possible_types = values.into_iter().map(value_type).unique().collect_vec();
-    if possible_types.len() != 1 {
-        None // There is an ambiguity or empty array
-    } else {
-        possible_types.into_iter().next().unwrap()
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ValueVariants {
@@ -3200,6 +3180,7 @@ mod tests {
     use rstest::rstest;
     use serde::de::DeserializeOwned;
     use serde_json;
+    use itertools::Itertools;
 
     use super::test_utils::build_polygon_with_interiors;
     use super::*;

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3177,10 +3177,10 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use rstest::rstest;
     use serde::de::DeserializeOwned;
     use serde_json;
-    use itertools::Itertools;
 
     use super::test_utils::build_polygon_with_interiors;
     use super::*;


### PR DESCRIPTION
Current implementation of payload index building had a problem: if payload index already existed and we tried to overwrite it with a new one, and the service was stopped during the process, we could end up in the situation where one index was created in storage, while another index was configured. That caused panic on start:

```
2025-04-20T09:21:25.054723Z  INFO storage::content_manager::toc: Loading collection: hist_vector_100D_40
2025-04-20T09:21:25.439576Z ERROR qdrant::startup: Panic backtrace:
   0: std::backtrace::Backtrace::create
   1: qdrant::startup::setup_panic_hook::{{closure}}
   2: std::panicking::rust_panic_with_hook
   3: std::panicking::begin_panic_handler::{{closure}}
   4: std::sys::backtrace::__rust_end_short_backtrace
   5: rust_begin_unwind
   6: core::panicking::panic_fmt
   7: core::result::unwrap_failed
   8: segment::index::field_index::numeric_index::mutable_numeric_index::MutableNumericIndex<T>::load
   9: segment::index::field_index::numeric_index::NumericIndexInner<T>::load
  10: segment::index::struct_payload_index::StructPayloadIndex::open
  11: segment::segment_constructor::segment_constructor_base::create_segment
  12: segment::segment_constructor::segment_constructor_base::load_segment
  13: std::sys::backtrace::__rust_begin_short_backtrace
  14: core::ops::function::FnOnce::call_once{{vtable.shim}}
  15: std::sys::pal::unix::thread::Thread::new::thread_start
  16: <unknown>
  17: <unknown>
2025-04-20T09:21:25.439604Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/index/key_encoding.rs at line 120: called `Result::unwrap()` on an `Err` value: TryFromSliceError(())
```

To prevent this error, this PR changes index creation function in a way, that we always drop incompatible index before trying to build a new one.

Additionally, this PR removes obsolete auto-inference of the index type, which is not used anyway.

