### PR TITLE
Also use limit+offset with prefetches, we cut offset at collection level

### DIFF
--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -94,6 +94,7 @@ impl PlannedQuery {
             params,
         } = request;
 
+        // Adjust limit so that we have enough results when we cut off the offset at a higher level
         let limit = limit + offset;
 
         let merge_plan = if !prefetches.is_empty() {
@@ -144,13 +145,6 @@ impl PlannedQuery {
                 }
             }
         } else {
-            // Only increase the limit with the offset when there are no prefetches
-            //
-            // Reason for this is because there is no guarantee of stability of results when prefetches and main query are not
-            // strongly correlated.
-            // For example: if prefetch is a knn search, and main query is an `order_by`, propagating the offset for trying to
-            // get a second page will just increase the pool of candidates for `order_by`. The second page in this case will be
-            // invalid because it will cut the offset on a different total ordering.
             let sources = match query {
                 Some(ScoringQuery::Vector(query)) => {
                     // Everything should come from 1 core search

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -93,6 +93,9 @@ impl PlannedQuery {
             with_payload,
             params,
         } = request;
+
+        let limit = limit + offset;
+
         let merge_plan = if !prefetches.is_empty() {
             if depth > MAX_PREFETCH_DEPTH {
                 return Err(CollectionError::bad_request(format!(
@@ -148,7 +151,6 @@ impl PlannedQuery {
             // For example: if prefetch is a knn search, and main query is an `order_by`, propagating the offset for trying to
             // get a second page will just increase the pool of candidates for `order_by`. The second page in this case will be
             // invalid because it will cut the offset on a different total ordering.
-            let limit = limit + offset;
             let sources = match query {
                 Some(ScoringQuery::Vector(query)) => {
                     // Everything should come from 1 core search


### PR DESCRIPTION
In our queries, we cut the offset off results at collection level. At shard level we should still adjust the limit so that there's enough results left when we cut the offset.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
