### PR TITLE
Fix inconsistent point deduplication in search/query

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ahash::AHashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::{TryFutureExt, future};
 use itertools::{Either, Itertools};
@@ -631,6 +632,7 @@ impl Collection {
 
         // Shape: [num_internal_queries, num_shards, num_scored_points]
         let all_shards_result_by_transposed = transposed_iter(all_shards_results);
+        let mut seen = AHashSet::new();
 
         for (query_info, shards_results) in
             query_infos.into_iter().zip(all_shards_result_by_transposed)
@@ -668,6 +670,8 @@ impl Collection {
                     ),
                 }
                 .dedup()
+                // Deduplicate non-consecutive points by specific scored point fields
+                .filter(|point| seen.insert(point.key()))
                 .take(query_info.take)
                 .collect();
 
@@ -697,6 +701,8 @@ impl Collection {
             };
 
             results.push(intermediate_result);
+
+            seen.clear();
         }
 
         Ok(results)

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -671,7 +671,7 @@ impl Collection {
                 }
                 .dedup()
                 // Deduplicate non-consecutive points by specific scored point fields
-                .filter(|point| seen.insert(point.key()))
+                .filter(|point| seen.insert(point.dedup_key()))
                 .take(query_info.take)
                 .collect();
 

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -293,7 +293,7 @@ impl Collection {
                 Order::SmallBetter => Either::Right(results_from_shards.kmerge_by(|a, b| a < b)),
             }
             // Deduplicate non-consecutive points by specific scored point fields
-            .filter(|point| seen.insert(point.key()));
+            .filter(|point| seen.insert(point.dedup_key()));
 
             // Skip `offset` only for client requests
             // to avoid applying `offset` twice in distributed mode.

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -271,7 +271,7 @@ impl Collection {
 
         // Merge results from shards in order and deduplicate based on point ID
         let mut top_results: Vec<Vec<ScoredPoint>> = Vec::with_capacity(batch_size);
-        let mut seen_ids = AHashSet::new();
+        let mut seen = AHashSet::new();
 
         for (batch_index, request) in request.searches.iter().enumerate() {
             let order = if request.query.is_distance_scored() {
@@ -292,7 +292,8 @@ impl Collection {
                 Order::LargeBetter => Either::Left(results_from_shards.kmerge_by(|a, b| a > b)),
                 Order::SmallBetter => Either::Right(results_from_shards.kmerge_by(|a, b| a < b)),
             }
-            .filter(|point| seen_ids.insert(point.id));
+            // Deduplicate non-consecutive points by specific scored point fields
+            .filter(|point| seen.insert(point.key()));
 
             // Skip `offset` only for client requests
             // to avoid applying `offset` twice in distributed mode.
@@ -307,7 +308,7 @@ impl Collection {
 
             top_results.push(top_res);
 
-            seen_ids.clear();
+            seen.clear();
         }
 
         Ok(top_results)

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -218,6 +218,76 @@ async fn test_scroll_dedup() {
         );
         assert!(record.order_value.is_some());
     }
+
+    // Scroll all points using query API
+    let points = collection
+        .query(
+            ShardQueryRequest {
+                query: None,
+                prefetches: vec![],
+                filter: None,
+                params: Some(SearchParams {
+                    exact: true,
+                    ..Default::default()
+                }),
+                limit: 100,
+                offset: 0,
+                with_payload: WithPayloadInterface::Bool(false),
+                with_vector: WithVector::Bool(false),
+                score_threshold: None,
+            },
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::disposable(),
+        )
+        .await
+        .expect("failed to scroll");
+    assert!(!points.is_empty(), "expected some points");
+
+    let mut seen = HashSet::new();
+    for point_id in points.iter().map(|point| point.id) {
+        assert!(
+            seen.insert(point_id),
+            "got point id {point_id} more than once, they should be deduplicated",
+        );
+    }
+
+    // Scroll all points with ordering using query API
+    let points = collection
+        .query(
+            ShardQueryRequest {
+                query: Some(ScoringQuery::OrderBy(
+                    OrderByInterface::Key("num".parse().unwrap()).into(),
+                )),
+                prefetches: vec![],
+                filter: None,
+                params: Some(SearchParams {
+                    exact: true,
+                    ..Default::default()
+                }),
+                limit: 100,
+                offset: 0,
+                with_payload: WithPayloadInterface::Bool(false),
+                with_vector: WithVector::Bool(false),
+                score_threshold: None,
+            },
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::disposable(),
+        )
+        .await
+        .expect("failed to scroll");
+    assert!(!points.is_empty(), "expected some points");
+
+    let mut seen = HashSet::new();
+    for point_id in points.iter().map(|point| point.id) {
+        assert!(
+            seen.insert(point_id),
+            "got point id {point_id} more than once, they should be deduplicated",
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -252,12 +322,11 @@ async fn test_retrieve_dedup() {
     }
 }
 
-/// Test should match behavior of [`test_query_dedup`]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_search_dedup() {
     let collection = fixture().await;
 
-    let hw_acc = HwMeasurementAcc::disposable();
+    // Search with search API
     let points = collection
         .search(
             CoreSearchRequest {
@@ -276,7 +345,7 @@ async fn test_search_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
-            hw_acc,
+            HwMeasurementAcc::disposable(),
         )
         .await
         .expect("failed to search");
@@ -289,13 +358,8 @@ async fn test_search_dedup() {
             "got point id {point_id} more than once, they should be deduplicated",
         );
     }
-}
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_query_dedup() {
-    let collection = fixture().await;
-
-    let hw_acc = HwMeasurementAcc::disposable();
+    // Search with query API
     let points = collection
         .query(
             ShardQueryRequest {
@@ -317,50 +381,10 @@ async fn test_query_dedup() {
             None,
             ShardSelectorInternal::All,
             None,
-            hw_acc,
+            HwMeasurementAcc::disposable(),
         )
         .await
         .expect("failed to query");
-    assert!(!points.is_empty(), "expected some points");
-
-    let mut seen = HashSet::new();
-    for point_id in points.iter().map(|point| point.id) {
-        assert!(
-            seen.insert(point_id),
-            "got point id {point_id} more than once, they should be deduplicated",
-        );
-    }
-}
-
-/// Test should match behavior of [`test_scroll_dedup`]
-#[tokio::test(flavor = "multi_thread")]
-async fn test_query_scroll_dedup() {
-    let collection = fixture().await;
-
-    let hw_acc = HwMeasurementAcc::disposable();
-    let points = collection
-        .query(
-            ShardQueryRequest {
-                query: None,
-                prefetches: vec![],
-                filter: None,
-                params: Some(SearchParams {
-                    exact: true,
-                    ..Default::default()
-                }),
-                limit: 100,
-                offset: 0,
-                with_payload: WithPayloadInterface::Bool(false),
-                with_vector: WithVector::Bool(false),
-                score_threshold: None,
-            },
-            None,
-            ShardSelectorInternal::All,
-            None,
-            hw_acc,
-        )
-        .await
-        .expect("failed to scroll");
     assert!(!points.is_empty(), "expected some points");
 
     let mut seen = HashSet::new();

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -105,7 +105,7 @@ async fn fixture() -> Collection {
         .create_payload_index(
             "num".parse().unwrap(),
             PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::disposable(),
         )
         .await
         .expect("failed to create payload index");
@@ -140,7 +140,7 @@ async fn fixture() -> Collection {
             ])),
         ));
         shard
-            .update_local(op, true, None, HwMeasurementAcc::new(), false)
+            .update_local(op, true, None, HwMeasurementAcc::disposable(), false)
             .await
             .expect("failed to insert points");
     }
@@ -174,7 +174,7 @@ async fn test_scroll_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::disposable(),
         )
         .await
         .expect("failed to search");
@@ -202,7 +202,7 @@ async fn test_scroll_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::disposable(),
         )
         .await
         .expect("failed to search");
@@ -237,7 +237,7 @@ async fn test_retrieve_dedup() {
             None,
             &ShardSelectorInternal::All,
             None,
-            HwMeasurementAcc::new(),
+            HwMeasurementAcc::disposable(),
         )
         .await
         .expect("failed to search");
@@ -257,7 +257,7 @@ async fn test_retrieve_dedup() {
 async fn test_search_dedup() {
     let collection = fixture().await;
 
-    let hw_acc = HwMeasurementAcc::new();
+    let hw_acc = HwMeasurementAcc::disposable();
     let points = collection
         .search(
             CoreSearchRequest {
@@ -295,7 +295,7 @@ async fn test_search_dedup() {
 async fn test_query_dedup() {
     let collection = fixture().await;
 
-    let hw_acc = HwMeasurementAcc::new();
+    let hw_acc = HwMeasurementAcc::disposable();
     let points = collection
         .query(
             ShardQueryRequest {
@@ -337,7 +337,7 @@ async fn test_query_dedup() {
 async fn test_query_scroll_dedup() {
     let collection = fixture().await;
 
-    let hw_acc = HwMeasurementAcc::new();
+    let hw_acc = HwMeasurementAcc::disposable();
     let points = collection
         .query(
             ShardQueryRequest {
@@ -372,14 +372,14 @@ async fn test_query_scroll_dedup() {
     }
 }
 
-pub fn dummy_on_replica_failure() -> ChangePeerFromState {
+fn dummy_on_replica_failure() -> ChangePeerFromState {
     Arc::new(move |_peer_id, _shard_id, _from_state| {})
 }
 
-pub fn dummy_request_shard_transfer() -> RequestShardTransfer {
+fn dummy_request_shard_transfer() -> RequestShardTransfer {
     Arc::new(move |_transfer| {})
 }
 
-pub fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+fn dummy_abort_shard_transfer() -> AbortShardTransfer {
     Arc::new(|_transfer, _reason| {})
 }

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -252,6 +252,7 @@ async fn test_retrieve_dedup() {
     }
 }
 
+/// Test should match behavior of [`test_query_dedup`]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_search_dedup() {
     let collection = fixture().await;

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -332,6 +332,46 @@ async fn test_query_dedup() {
     }
 }
 
+/// Test should match behavior of [`test_scroll_dedup`]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_query_scroll_dedup() {
+    let collection = fixture().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+    let points = collection
+        .query(
+            ShardQueryRequest {
+                query: None,
+                prefetches: vec![],
+                filter: None,
+                params: Some(SearchParams {
+                    exact: true,
+                    ..Default::default()
+                }),
+                limit: 100,
+                offset: 0,
+                with_payload: WithPayloadInterface::Bool(false),
+                with_vector: WithVector::Bool(false),
+                score_threshold: None,
+            },
+            None,
+            ShardSelectorInternal::All,
+            None,
+            hw_acc,
+        )
+        .await
+        .expect("failed to scroll");
+    assert!(!points.is_empty(), "expected some points");
+
+    let mut seen = HashSet::new();
+    for point_id in points.iter().map(|point| point.id) {
+        assert!(
+            seen.insert(point_id),
+            "got point id {point_id} more than once, they should be deduplicated",
+        );
+    }
+}
+
 pub fn dummy_on_replica_failure() -> ChangePeerFromState {
     Arc::new(move |_peer_id, _shard_id, _from_state| {})
 }

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -10,6 +10,7 @@ use rand::{RngExt, rng};
 use segment::data_types::vectors::NamedQuery;
 use segment::types::{
     Distance, ExtendedPointId, Payload, PayloadFieldSchema, PayloadSchemaType, SearchParams,
+    WithPayloadInterface, WithVector,
 };
 use serde_json::{Map, Value};
 use shard::query::query_enum::QueryEnum;
@@ -25,6 +26,7 @@ use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{
     CoreSearchRequest, PointRequestInternal, ScrollRequestInternal, VectorsConfig,
 };
+use crate::operations::universal_query::shard_query::{ScoringQuery, ShardQueryRequest};
 use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use crate::optimizers_builder::OptimizersConfig;
@@ -277,6 +279,47 @@ async fn test_search_dedup() {
         )
         .await
         .expect("failed to search");
+    assert!(!points.is_empty(), "expected some points");
+
+    let mut seen = HashSet::new();
+    for point_id in points.iter().map(|point| point.id) {
+        assert!(
+            seen.insert(point_id),
+            "got point id {point_id} more than once, they should be deduplicated",
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_query_dedup() {
+    let collection = fixture().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+    let points = collection
+        .query(
+            ShardQueryRequest {
+                query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
+                    NamedQuery::default_dense(vec![0.1, 0.2, 0.3, 0.4]),
+                ))),
+                prefetches: vec![],
+                filter: None,
+                params: Some(SearchParams {
+                    exact: true,
+                    ..Default::default()
+                }),
+                limit: 100,
+                offset: 0,
+                with_payload: WithPayloadInterface::Bool(false),
+                with_vector: WithVector::Bool(false),
+                score_threshold: None,
+            },
+            None,
+            ShardSelectorInternal::All,
+            None,
+            hw_acc,
+        )
+        .await
+        .expect("failed to query");
     assert!(!points.is_empty(), "expected some points");
 
     let mut seen = HashSet::new();

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -137,7 +137,6 @@ pub enum OrderValue {
     Float(FloatPayloadType),
 }
 
-#[cfg(any(test, feature = "testing"))]
 impl std::hash::Hash for OrderValue {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -412,7 +412,6 @@ impl ScoredPoint {
             vector: _,
         } = self;
 
-        // TODO: this is NOT efficient due to clone and may have a significant performance impact
         (*id, shard_key.clone(), *order_value)
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -401,7 +401,7 @@ impl ScoredPoint {
     ///
     /// Docs: https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding
     #[inline]
-    pub fn key(&self) -> (PointIdType, Option<ShardKey>, Option<OrderValue>) {
+    pub fn dedup_key(&self) -> (PointIdType, Option<ShardKey>, Option<OrderValue>) {
         let Self {
             id,
             shard_key,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -389,6 +389,34 @@ pub struct ScoredPoint {
     pub order_value: Option<OrderValue>,
 }
 
+impl ScoredPoint {
+    /// Get scored point key, used for collection level point deduplication
+    ///
+    /// This key is a unique value per point to deduplicate.
+    ///
+    /// To match our documentation, we explicitly compare the following fields:
+    /// - point ID
+    /// - shard key - collect points multiple times if placed in different shard keys
+    /// - order value - collect points multiple times if having a different order value, appear multiple times if a payload key has multiple values (array)
+    ///
+    /// Docs: https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding
+    #[inline]
+    pub fn key(&self) -> (PointIdType, Option<ShardKey>, Option<OrderValue>) {
+        let Self {
+            id,
+            shard_key,
+            order_value,
+            version: _,
+            score: _,
+            payload: _,
+            vector: _,
+        } = self;
+
+        // TODO: this is NOT efficient due to clone and may have a significant performance impact
+        (*id, shard_key.clone(), *order_value)
+    }
+}
+
 impl Eq for ScoredPoint {}
 
 impl Ord for ScoredPoint {


### PR DESCRIPTION
Point deduplication was inconsistent in the search and query API.

This changes our deduplication logic in both the search and query API to match our documentation.

It now deduplicates (non-sequential) points by:
- point ID
- shard key - we expect to see the same point more than once if in different shard keys
- order value - we expect to see the same point more than once if it matched multiple payload values (array) on the same payload key

The added tests now confirm consistency.

### Tasks
- [ ] There's a `clone` in the `key()` function which may be expensive, ideally we replace this with just a reference but it's not obvious to do
      (<https://github.com/qdrant/qdrant/pull/6420> and https://github.com/qdrant/qdrant/pull/6426 makes cloning the shard key significantly cheaper, that may be good enough)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
