### PR TITLE
Use smol string as shard key

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -71,28 +71,19 @@ pub fn convert_shard_key_to_grpc(value: segment::types::ShardKey) -> ShardKey {
 
 pub fn convert_shard_key_from_grpc(value: ShardKey) -> Option<segment::types::ShardKey> {
     let ShardKey { key } = value;
-    match key {
-        None => None,
-        Some(key) => match key {
-            shard_key::Key::Keyword(keyword) => Some(segment::types::ShardKey::from(keyword)),
-            shard_key::Key::Number(number) => Some(segment::types::ShardKey::Number(number)),
-        },
-    }
+    key.map(|key| match key {
+        shard_key::Key::Keyword(keyword) => segment::types::ShardKey::from(keyword),
+        shard_key::Key::Number(number) => segment::types::ShardKey::Number(number),
+    })
 }
 
 pub fn convert_shard_key_from_grpc_opt(
     value: Option<ShardKey>,
 ) -> Option<segment::types::ShardKey> {
-    match value {
-        None => None,
-        Some(key) => match key.key {
-            None => None,
-            Some(key) => match key {
-                shard_key::Key::Keyword(keyword) => Some(segment::types::ShardKey::from(keyword)),
-                shard_key::Key::Number(number) => Some(segment::types::ShardKey::Number(number)),
-            },
-        },
-    }
+    value.and_then(|value| value.key).map(|key| match key {
+        shard_key::Key::Keyword(keyword) => segment::types::ShardKey::from(keyword),
+        shard_key::Key::Number(number) => segment::types::ShardKey::Number(number),
+    })
 }
 impl From<ShardKeySelector> for rest::ShardKeySelector {
     fn from(value: ShardKeySelector) -> Self {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -61,7 +61,7 @@ use crate::rest::schema as rest;
 pub fn convert_shard_key_to_grpc(value: segment::types::ShardKey) -> ShardKey {
     match value {
         segment::types::ShardKey::Keyword(keyword) => ShardKey {
-            key: Some(shard_key::Key::Keyword(keyword)),
+            key: Some(shard_key::Key::Keyword(keyword.to_string())),
         },
         segment::types::ShardKey::Number(number) => ShardKey {
             key: Some(shard_key::Key::Number(number)),
@@ -74,7 +74,7 @@ pub fn convert_shard_key_from_grpc(value: ShardKey) -> Option<segment::types::Sh
     match key {
         None => None,
         Some(key) => match key {
-            shard_key::Key::Keyword(keyword) => Some(segment::types::ShardKey::Keyword(keyword)),
+            shard_key::Key::Keyword(keyword) => Some(segment::types::ShardKey::from(keyword)),
             shard_key::Key::Number(number) => Some(segment::types::ShardKey::Number(number)),
         },
     }
@@ -88,9 +88,7 @@ pub fn convert_shard_key_from_grpc_opt(
         Some(key) => match key.key {
             None => None,
             Some(key) => match key {
-                shard_key::Key::Keyword(keyword) => {
-                    Some(segment::types::ShardKey::Keyword(keyword))
-                }
+                shard_key::Key::Keyword(keyword) => Some(segment::types::ShardKey::from(keyword)),
                 shard_key::Key::Number(number) => Some(segment::types::ShardKey::Number(number)),
             },
         },

--- a/lib/segment/src/common/anonymize.rs
+++ b/lib/segment/src/common/anonymize.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use chrono::{DateTime, Utc};
 pub use macros::Anonymize;
+use smol_str::{SmolStr, format_smolstr};
 use uuid::Uuid;
 
 /// This trait provides a derive macro.
@@ -115,6 +116,14 @@ impl Anonymize for String {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
         hasher.finish().to_string()
+    }
+}
+
+impl Anonymize for SmolStr {
+    fn anonymize(&self) -> Self {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        format_smolstr!("{}", hasher.finish())
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -4337,8 +4337,11 @@ fn shard_key_number_example() -> u64 {
 #[derive(Deserialize, Serialize, JsonSchema, Anonymize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(untagged)]
 pub enum ShardKey {
-    #[schemars(example = "shard_key_string_example")]
-    Keyword(String),
+    #[schemars(
+        schema_with = "String::json_schema",
+        example = "shard_key_string_example"
+    )]
+    Keyword(SmolStr),
     #[schemars(example = "shard_key_number_example")]
     #[anonymize(false)]
     Number(u64),
@@ -4346,13 +4349,19 @@ pub enum ShardKey {
 
 impl From<String> for ShardKey {
     fn from(s: String) -> Self {
+        ShardKey::Keyword(s.into())
+    }
+}
+
+impl From<SmolStr> for ShardKey {
+    fn from(s: SmolStr) -> Self {
         ShardKey::Keyword(s)
     }
 }
 
 impl From<&str> for ShardKey {
     fn from(s: &str) -> Self {
-        ShardKey::Keyword(s.to_owned())
+        ShardKey::Keyword(s.into())
     }
 }
 


### PR DESCRIPTION
Replace the user-defined shard key `String` type to [`SmolStr`](https://docs.rs/smol_str/latest/smol_str/struct.SmolStr.html). It remains exactly the same size (24-bytes), but puts small strings on the stack to eliminate a heap allocation.

I feel like this is a great candidate for the type change because: shard keys can easily be 23-bytes or less, shard keys are cloned all over the place.

Specifically, this change is desired for <https://github.com/qdrant/qdrant/pull/6413> which also wants to extensively clone the shard key to allow point deduplication.

The type changes does not affect our OpenAPI schema.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?