### PR TITLE
Use smol string as shard key - review suggestions

### DIFF
--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -4330,7 +4330,7 @@ pub enum ShardKey {
 
 impl From<String> for ShardKey {
     fn from(s: String) -> Self {
-        ShardKey::Keyword(s.into())
+        ShardKey::Keyword(SmolStr::from(s))
     }
 }
 
@@ -4342,7 +4342,7 @@ impl From<SmolStr> for ShardKey {
 
 impl From<&str> for ShardKey {
     fn from(s: &str) -> Self {
-        ShardKey::Keyword(s.into())
+        ShardKey::Keyword(SmolStr::from(s))
     }
 }
 


### PR DESCRIPTION
Applies <https://github.com/qdrant/qdrant/pull/6420#discussion_r2056145876>, which I forgot in <https://github.com/qdrant/qdrant/pull/6420>.

Thought I had applied the review suggestions before merging, but I now discovered I didn't properly push.