### PR TITLE
Use ecow strings for shard keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecow"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5eeffa816451f3a6a4cce9cd796e3e5ba6018638d3ce5cc7f87b73bababf60"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5838,6 +5847,7 @@ dependencies = [
  "data-encoding",
  "dataset",
  "delegate",
+ "ecow",
  "env_logger",
  "fnv",
  "fs_extra",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -86,6 +86,7 @@ tinyvec = { version = "1.9.0", features = ["alloc", "latest_stable_rust"] }
 validator = { workspace = true }
 chrono = { workspace = true }
 smol_str = { version = "0.3.2", default-features = false, features = ["serde"] }
+ecow = { version = "0.2.4", features = ["serde"] }
 fnv = { workspace = true }
 indexmap = { workspace = true }
 ahash = { workspace = true }

--- a/lib/segment/src/common/anonymize.rs
+++ b/lib/segment/src/common/anonymize.rs
@@ -3,8 +3,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 
 use chrono::{DateTime, Utc};
+use ecow::{EcoString, eco_format};
 pub use macros::Anonymize;
-use smol_str::{SmolStr, format_smolstr};
 use uuid::Uuid;
 
 /// This trait provides a derive macro.
@@ -119,11 +119,11 @@ impl Anonymize for String {
     }
 }
 
-impl Anonymize for SmolStr {
+impl Anonymize for EcoString {
     fn anonymize(&self) -> Self {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
-        format_smolstr!("{}", hasher.finish())
+        eco_format!("{}", hasher.finish())
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use ahash::AHashSet;
 use common::types::ScoreType;
+use ecow::EcoString;
 use fnv::FnvBuildHasher;
 use geo::{Contains, Coord, Distance as GeoDistance, Haversine, LineString, Point, Polygon};
 use indexmap::IndexSet;
@@ -4322,7 +4323,7 @@ pub enum ShardKey {
         schema_with = "String::json_schema",
         example = "shard_key_string_example"
     )]
-    Keyword(SmolStr),
+    Keyword(EcoString),
     #[schemars(example = "shard_key_number_example")]
     #[anonymize(false)]
     Number(u64),
@@ -4330,19 +4331,19 @@ pub enum ShardKey {
 
 impl From<String> for ShardKey {
     fn from(s: String) -> Self {
-        ShardKey::Keyword(SmolStr::from(s))
+        ShardKey::Keyword(EcoString::from(s))
     }
 }
 
-impl From<SmolStr> for ShardKey {
-    fn from(s: SmolStr) -> Self {
+impl From<EcoString> for ShardKey {
+    fn from(s: EcoString) -> Self {
         ShardKey::Keyword(s)
     }
 }
 
 impl From<&str> for ShardKey {
     fn from(s: &str) -> Self {
-        ShardKey::Keyword(SmolStr::from(s))
+        ShardKey::Keyword(EcoString::from(s))
     }
 }
 


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/6420> I implemented usage of `SmolStr` for shard keys.

[Here](https://github.com/qdrant/qdrant/pull/6420#issuecomment-2824510509) a different string type is suggested: `ecow`'s `EcoString`

A fresh benchmark convinces me:

![image](https://github.com/user-attachments/assets/ac0edb80-3547-4f15-b418-56833679492a)

<small>([source](https://github.com/rosetta-rs/string-rosetta-rs))</small>

We probably want to fully replace SmolStr at some point, but there are some blockers for that. I'll put it on my list of tasks because it's not high priority.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?