### PR TITLE
Fully replace SmolStr with ecow string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "ecow"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5eeffa816451f3a6a4cce9cd796e3e5ba6018638d3ce5cc7f87b73bababf60"
+checksum = "b92b481eb5d59fd8e80e92ff11d057d1ca8d144b2cd8c66cc8d5bd177a3c0dc5"
 dependencies = [
  "serde",
 ]
@@ -5899,7 +5899,6 @@ dependencies = [
  "serde_variant",
  "sha2",
  "smallvec",
- "smol_str",
  "sparse",
  "strum",
  "sysinfo",
@@ -6204,15 +6203,6 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
-
-[[package]]
-name = "smol_str"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -85,8 +85,7 @@ fs_extra = "1.3.0"
 tinyvec = { version = "1.9.0", features = ["alloc", "latest_stable_rust"] }
 validator = { workspace = true }
 chrono = { workspace = true }
-smol_str = { version = "0.3.2", default-features = false, features = ["serde"] }
-ecow = { version = "0.2.4", features = ["serde"] }
+ecow = { version = "0.2.5", features = ["serde"] }
 fnv = { workspace = true }
 indexmap = { workspace = true }
 ahash = { workspace = true }

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -1,9 +1,9 @@
 use std::ops::{Index, Range};
 
+use ecow::EcoString;
 use geo::{Coord, Distance, Haversine, Intersects, LineString, Point, Polygon};
 use geohash::{Direction, GeohashError, decode, decode_bbox, encode};
 use itertools::Itertools;
-use smol_str::SmolStr;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::types::{GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius};
@@ -61,10 +61,10 @@ impl Index<usize> for GeoHash {
     }
 }
 
-impl TryFrom<SmolStr> for GeoHash {
+impl TryFrom<EcoString> for GeoHash {
     type Error = GeohashError;
 
-    fn try_from(hash: SmolStr) -> Result<Self, Self::Error> {
+    fn try_from(hash: EcoString) -> Result<Self, Self::Error> {
         Self::new(hash.as_str())
     }
 }
@@ -77,7 +77,7 @@ impl TryFrom<String> for GeoHash {
     }
 }
 
-impl From<GeoHash> for SmolStr {
+impl From<GeoHash> for EcoString {
     fn from(hash: GeoHash) -> Self {
         hash.iter().collect()
     }
@@ -232,7 +232,7 @@ fn sphere_lat(lat: f64) -> f64 {
 
 /// Get neighbour geohash even from the other side of coordinates
 fn sphere_neighbor(hash: GeoHash, direction: Direction) -> Result<GeoHash, GeohashError> {
-    let hash_str = SmolStr::from(hash);
+    let hash_str = EcoString::from(hash);
     let (coord, lon_err, lat_err) = decode(hash_str.as_str())?;
     let (dlat, dlng) = direction.to_tuple();
     let lon = sphere_lon(coord.x + 2f64 * lon_err.abs() * dlng);
@@ -249,7 +249,7 @@ pub fn encode_max_precision(lon: f64, lat: f64) -> Result<GeoHash, GeohashError>
 }
 
 pub fn geo_hash_to_box(geo_hash: GeoHash) -> GeoBoundingBox {
-    let rectangle = decode_bbox(SmolStr::from(geo_hash).as_str()).unwrap();
+    let rectangle = decode_bbox(EcoString::from(geo_hash).as_str()).unwrap();
     let top_left = GeoPoint {
         lon: rectangle.min().x,
         lat: rectangle.max().y,
@@ -414,7 +414,9 @@ pub fn circle_hashes(circle: &GeoRadius, max_regions: usize) -> OperationResult<
             .map(|hashes| {
                 hashes
                     .into_iter()
-                    .filter(|hash| check_circle_intersection(SmolStr::from(*hash).as_str(), circle))
+                    .filter(|hash| {
+                        check_circle_intersection(EcoString::from(*hash).as_str(), circle)
+                    })
                     .collect_vec()
             })
     };
@@ -452,7 +454,7 @@ fn boundary_hashes(boundary: &LineString, max_regions: usize) -> OperationResult
                 hashes
                     .into_iter()
                     .filter(|hash| {
-                        check_polygon_intersection(SmolStr::from(*hash).as_str(), &polygon)
+                        check_polygon_intersection(EcoString::from(*hash).as_str(), &polygon)
                     })
                     .collect_vec()
             })
@@ -501,7 +503,10 @@ pub fn polygon_hashes(polygon: &GeoPolygon, max_regions: usize) -> OperationResu
                 hashes
                     .into_iter()
                     .filter(|hash| {
-                        check_polygon_intersection(SmolStr::from(*hash).as_str(), &polygon_wrapper)
+                        check_polygon_intersection(
+                            EcoString::from(*hash).as_str(),
+                            &polygon_wrapper,
+                        )
                     })
                     .collect_vec()
             })
@@ -631,7 +636,7 @@ mod tests {
         let mut hashes = v.iter().map(|s| GeoHash::new(s).unwrap()).collect_vec();
         hashes.sort_unstable();
         v.sort_unstable();
-        assert_eq!(hashes.iter().map(|h| SmolStr::from(*h)).collect_vec(), v);
+        assert_eq!(hashes.iter().map(|h| EcoString::from(*h)).collect_vec(), v);
 
         // special case for hash which ends with 0
         // "uft56" and "uft560000000" have the same encoded chars, but different length
@@ -1245,44 +1250,44 @@ mod tests {
     #[test]
     fn sphere_neighbor_corner_cases() {
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("z").unwrap(), Direction::NE).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("z").unwrap(), Direction::NE).unwrap()),
             "b"
         );
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("zz").unwrap(), Direction::NE).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("zz").unwrap(), Direction::NE).unwrap()),
             "bp"
         );
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("0").unwrap(), Direction::SW).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("0").unwrap(), Direction::SW).unwrap()),
             "p"
         );
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("00").unwrap(), Direction::SW).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("00").unwrap(), Direction::SW).unwrap()),
             "pb"
         );
 
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("8").unwrap(), Direction::W).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("8").unwrap(), Direction::W).unwrap()),
             "x"
         );
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("8h").unwrap(), Direction::W).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("8h").unwrap(), Direction::W).unwrap()),
             "xu"
         );
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("r").unwrap(), Direction::E).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("r").unwrap(), Direction::E).unwrap()),
             "2"
         );
         assert_eq!(
-            &SmolStr::from(sphere_neighbor(GeoHash::new("ru").unwrap(), Direction::E).unwrap()),
+            &EcoString::from(sphere_neighbor(GeoHash::new("ru").unwrap(), Direction::E).unwrap()),
             "2h"
         );
 
         assert_eq!(
-            SmolStr::from(
+            EcoString::from(
                 sphere_neighbor(GeoHash::new("ww8p1r4t8").unwrap(), Direction::SE).unwrap()
             ),
-            SmolStr::from(&geohash::neighbor("ww8p1r4t8", Direction::SE).unwrap())
+            EcoString::from(&geohash::neighbor("ww8p1r4t8", Direction::SE).unwrap())
         );
     }
 
@@ -1315,7 +1320,7 @@ mod tests {
         ];
 
         let common_prefix = common_hash_prefix(&geo_hashes).unwrap();
-        println!("common_prefix = {:?}", SmolStr::from(common_prefix));
+        println!("common_prefix = {:?}", EcoString::from(common_prefix));
 
         //assert_eq!(common_prefix, GeoHash::new("zbcd").unwrap());
 
@@ -1327,7 +1332,7 @@ mod tests {
         ];
 
         let common_prefix = common_hash_prefix(&geo_hashes).unwrap();
-        println!("common_prefix = {:?}", SmolStr::from(common_prefix));
+        println!("common_prefix = {:?}", EcoString::from(common_prefix));
 
         assert_eq!(common_prefix, GeoHash::new("").unwrap());
     }

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::ops::{Index, Range};
 
 use ecow::EcoString;
@@ -80,6 +81,15 @@ impl TryFrom<String> for GeoHash {
 impl From<GeoHash> for EcoString {
     fn from(hash: GeoHash) -> Self {
         hash.iter().collect()
+    }
+}
+
+impl Display for GeoHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for c in self.iter() {
+            write!(f, "{c}")?;
+        }
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use ahash::AHashSet;
 use common::types::PointOffsetType;
+use ecow::EcoString;
 use parking_lot::RwLock;
 use rocksdb::DB;
-use smol_str::SmolStr;
 
 use super::GeoMapIndex;
 use super::mutable_geo_index::{InMemoryGeoMapIndex, MutableGeoMapIndex};
@@ -196,7 +196,7 @@ impl ImmutableGeoMapIndex {
             } else {
                 log::warn!(
                     "Geo index error: no points for hash {} was found",
-                    SmolStr::from(removed_geo_hash),
+                    EcoString::from(removed_geo_hash),
                 );
             };
 
@@ -234,14 +234,14 @@ impl ImmutableGeoMapIndex {
                     debug_assert!(
                         false,
                         "Hash value count is already empty: {}",
-                        SmolStr::from(sub_geo_hash),
+                        EcoString::from(sub_geo_hash),
                     );
                 }
             } else {
                 debug_assert!(
                     false,
                     "Hash value count is not found for hash: {}",
-                    SmolStr::from(sub_geo_hash),
+                    EcoString::from(sub_geo_hash),
                 );
             }
         }
@@ -267,14 +267,14 @@ impl ImmutableGeoMapIndex {
                         debug_assert!(
                             false,
                             "Hash point count is already empty: {}",
-                            SmolStr::from(sub_geo_hash),
+                            EcoString::from(sub_geo_hash),
                         );
                     }
                 } else {
                     debug_assert!(
                         false,
                         "Hash point count is not found for hash: {}",
-                        SmolStr::from(sub_geo_hash),
+                        EcoString::from(sub_geo_hash),
                     );
                 };
             }

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use ahash::AHashSet;
 use common::types::PointOffsetType;
-use ecow::EcoString;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
@@ -194,10 +193,7 @@ impl ImmutableGeoMapIndex {
             {
                 self.points_map[index].1.remove(&idx);
             } else {
-                log::warn!(
-                    "Geo index error: no points for hash {} was found",
-                    EcoString::from(removed_geo_hash),
-                );
+                log::warn!("Geo index error: no points for hash {removed_geo_hash} was found");
             };
 
             self.decrement_hash_value_counts(&removed_geo_hash);
@@ -231,17 +227,12 @@ impl ImmutableGeoMapIndex {
                 if values_count > 0 {
                     self.counts_per_hash[index].values = values_count - 1;
                 } else {
-                    debug_assert!(
-                        false,
-                        "Hash value count is already empty: {}",
-                        EcoString::from(sub_geo_hash),
-                    );
+                    debug_assert!(false, "Hash value count is already empty: {sub_geo_hash}");
                 }
             } else {
                 debug_assert!(
                     false,
-                    "Hash value count is not found for hash: {}",
-                    EcoString::from(sub_geo_hash),
+                    "Hash value count is not found for hash: {sub_geo_hash}",
                 );
             }
         }
@@ -264,17 +255,12 @@ impl ImmutableGeoMapIndex {
                     if points_count > 0 {
                         self.counts_per_hash[index].points = points_count - 1;
                     } else {
-                        debug_assert!(
-                            false,
-                            "Hash point count is already empty: {}",
-                            EcoString::from(sub_geo_hash),
-                        );
+                        debug_assert!(false, "Hash point count is already empty: {sub_geo_hash}");
                     }
                 } else {
                     debug_assert!(
                         false,
-                        "Hash point count is not found for hash: {}",
-                        EcoString::from(sub_geo_hash),
+                        "Hash point count is not found for hash: {sub_geo_hash}",
                     );
                 };
             }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use ecow::{EcoString, eco_format};
 use itertools::Itertools;
 use mutable_geo_index::InMemoryGeoMapIndex;
 use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
-use smol_str::{SmolStr, format_smolstr};
 
 use self::immutable_geo_index::ImmutableGeoMapIndex;
 use self::mmap_geo_index::MmapGeoMapIndex;
@@ -129,9 +129,9 @@ impl GeoMapIndex {
         format!("{field}_geo")
     }
 
-    fn encode_db_key(value: GeoHash, idx: PointOffsetType) -> SmolStr {
-        let value_str = SmolStr::from(value);
-        format_smolstr!("{value_str}/{idx}")
+    fn encode_db_key(value: GeoHash, idx: PointOffsetType) -> EcoString {
+        let value_str = EcoString::from(value);
+        eco_format!("{value_str}/{idx}")
     }
 
     fn decode_db_key(s: &str) -> OperationResult<(GeoHash, PointOffsetType)> {

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -130,8 +130,7 @@ impl GeoMapIndex {
     }
 
     fn encode_db_key(value: GeoHash, idx: PointOffsetType) -> EcoString {
-        let value_str = EcoString::from(value);
-        eco_format!("{value_str}/{idx}")
+        eco_format!("{value}/{idx}")
     }
 
     fn decode_db_key(s: &str) -> OperationResult<(GeoHash, PointOffsetType)> {

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -7,7 +7,6 @@ use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use delegate::delegate;
-use ecow::EcoString;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
@@ -270,10 +269,7 @@ impl InMemoryGeoMapIndex {
                 hash_ids.remove(&idx);
                 hash_ids.is_empty()
             } else {
-                log::warn!(
-                    "Geo index error: no points for hash {} was found",
-                    EcoString::from(removed_geo_hash),
-                );
+                log::warn!("Geo index error: no points for hash {removed_geo_hash} was found");
                 false
             };
 
@@ -391,8 +387,7 @@ impl InMemoryGeoMapIndex {
                 None => {
                     debug_assert!(
                         false,
-                        "Hash value count is not found for hash: {}",
-                        sub_geo_hash,
+                        "Hash value count is not found for hash: {sub_geo_hash}",
                     );
                     self.values_per_hash.insert(sub_geo_hash, 0);
                 }
@@ -416,8 +411,7 @@ impl InMemoryGeoMapIndex {
                     None => {
                         debug_assert!(
                             false,
-                            "Hash point count is not found for hash: {}",
-                            EcoString::from(sub_geo_hash),
+                            "Hash point count is not found for hash: {sub_geo_hash}",
                         );
                         self.points_per_hash.insert(sub_geo_hash, 0);
                     }

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -7,9 +7,9 @@ use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use delegate::delegate;
+use ecow::EcoString;
 use parking_lot::RwLock;
 use rocksdb::DB;
-use smol_str::SmolStr;
 
 use super::GeoMapIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -128,7 +128,7 @@ impl MutableGeoMapIndex {
                         |e| OperationError::service_error(format!("Malformed geo points: {e}")),
                     )?;
                 let key = GeoMapIndex::encode_db_key(geo_hash_to_remove, idx);
-                self.db_wrapper.remove(key)?;
+                self.db_wrapper.remove(key.as_bytes())?;
             }
             self.in_memory_index.remove_point(idx)
         } else {
@@ -149,7 +149,7 @@ impl MutableGeoMapIndex {
             let key = GeoMapIndex::encode_db_key(added_geo_hash, idx);
             let value = GeoMapIndex::encode_db_value(added_point);
 
-            self.db_wrapper.put(key, value)?;
+            self.db_wrapper.put(key.as_bytes(), value)?;
         }
         self.in_memory_index
             .add_many_geo_points(idx, values, hw_counter)
@@ -272,7 +272,7 @@ impl InMemoryGeoMapIndex {
             } else {
                 log::warn!(
                     "Geo index error: no points for hash {} was found",
-                    SmolStr::from(removed_geo_hash),
+                    EcoString::from(removed_geo_hash),
                 );
                 false
             };
@@ -392,7 +392,7 @@ impl InMemoryGeoMapIndex {
                     debug_assert!(
                         false,
                         "Hash value count is not found for hash: {}",
-                        SmolStr::from(sub_geo_hash),
+                        sub_geo_hash,
                     );
                     self.values_per_hash.insert(sub_geo_hash, 0);
                 }
@@ -417,7 +417,7 @@ impl InMemoryGeoMapIndex {
                         debug_assert!(
                             false,
                             "Hash point count is not found for hash: {}",
-                            SmolStr::from(sub_geo_hash),
+                            EcoString::from(sub_geo_hash),
                         );
                         self.points_per_hash.insert(sub_geo_hash, 0);
                     }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -11,13 +11,13 @@ use ahash::HashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap_hashmap::Key;
 use common::types::PointOffsetType;
+use ecow::EcoString;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use mmap_map_index::MmapMapIndex;
 use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
-use smol_str::SmolStr;
 use uuid::Uuid;
 
 use self::immutable_map_index::ImmutableMapIndex;
@@ -53,10 +53,10 @@ pub trait MapIndexKey: Key + MmapValue + Eq + Display + Debug {
 }
 
 impl MapIndexKey for str {
-    type Owned = SmolStr;
+    type Owned = EcoString;
 
     fn to_owned(&self) -> Self::Owned {
-        SmolStr::from(self)
+        EcoString::from(self)
     }
 }
 
@@ -1339,26 +1339,26 @@ mod tests {
     fn test_string_disk_map_index(#[case] index_type: IndexType) {
         let data = vec![
             vec![
-                SmolStr::from("AABB"),
-                SmolStr::from("UUFF"),
-                SmolStr::from("IIBB"),
+                EcoString::from("AABB"),
+                EcoString::from("UUFF"),
+                EcoString::from("IIBB"),
             ],
             vec![
-                SmolStr::from("PPMM"),
-                SmolStr::from("QQXX"),
-                SmolStr::from("YYBB"),
+                EcoString::from("PPMM"),
+                EcoString::from("QQXX"),
+                EcoString::from("YYBB"),
             ],
             vec![
-                SmolStr::from("FFMM"),
-                SmolStr::from("IICC"),
-                SmolStr::from("IIBB"),
+                EcoString::from("FFMM"),
+                EcoString::from("IICC"),
+                EcoString::from("IIBB"),
             ],
             vec![
-                SmolStr::from("AABB"),
-                SmolStr::from("UUFF"),
-                SmolStr::from("IIBB"),
+                EcoString::from("AABB"),
+                EcoString::from("UUFF"),
+                EcoString::from("IIBB"),
             ],
-            vec![SmolStr::from("PPGG")],
+            vec![EcoString::from("PPGG")],
         ];
 
         let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
@@ -1380,7 +1380,7 @@ mod tests {
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     fn test_empty_index(#[case] index_type: IndexType) {
-        let data: Vec<Vec<SmolStr>> = vec![];
+        let data: Vec<Vec<EcoString>> = vec![];
 
         let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
         save_map_index::<str>(&data, temp_dir.path(), index_type, |v| v.to_string().into());

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -19,7 +19,6 @@ use ordered_float::OrderedFloat;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
-use smol_str::SmolStr;
 use strum::EnumIter;
 use uuid::Uuid;
 use validator::{Validate, ValidationError, ValidationErrors};
@@ -2031,8 +2030,8 @@ impl From<String> for Match {
     }
 }
 
-impl From<SmolStr> for Match {
-    fn from(keyword: SmolStr) -> Self {
+impl From<EcoString> for Match {
+    fn from(keyword: EcoString) -> Self {
         Self::Value(MatchValue {
             value: ValueVariants::String(keyword.into()),
         })


### PR DESCRIPTION
Continuation after <https://github.com/qdrant/qdrant/pull/6426>, using the same benchmark as argument.

Required <https://github.com/typst/ecow/pull/48> to be merged and released.

As a bonus, this removes a bunch of intermediate strings by formatting directly.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?