### PR TITLE
Fix flaky test formula

### DIFF
--- a/tests/openapi/test_query_formula.py
+++ b/tests/openapi/test_query_formula.py
@@ -15,6 +15,7 @@ def setup(on_disk_vectors, collection_name):
         api="/collections/{collection_name}/index",
         method="PUT",
         path_params={"collection_name": collection_name},
+        query_params={"wait": 'true'},
         body={"field_name": "price", "field_schema": "float"},
     )
     assert response.ok


### PR DESCRIPTION
The test is flaky on slow machines.

```
FAILED tests/openapi/test_query_formula.py::test_formula[True-formula0-<lambda>] - AssertionError: {'status': {'error': 'Wrong input: Expected number value for price in the payload and/or in the formula defaults. Error: Value is not a number'}, 'time': 0.002502803}
```

We need to make sure the payload index has been built.