### PR TITLE
Fix warning regarding missing wait param in openapi tests

### DIFF
--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -120,6 +120,7 @@ def test_multi_vector_float_persisted(collection_name):
         api='/collections/{collection_name}/points/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [2]
         }

--- a/tests/openapi/test_multi_vector_uint8.py
+++ b/tests/openapi/test_multi_vector_uint8.py
@@ -121,6 +121,7 @@ def test_multi_vector_uint8_persisted(collection_name):
         api='/collections/{collection_name}/points/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [2]
         }

--- a/tests/openapi/test_multi_vector_unnamed.py
+++ b/tests/openapi/test_multi_vector_unnamed.py
@@ -115,6 +115,7 @@ def test_multi_vector_float_persisted(collection_name):
         api='/collections/{collection_name}/points/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [2]
         }

--- a/tests/openapi/test_optional_vectors.py
+++ b/tests/openapi/test_optional_vectors.py
@@ -25,6 +25,7 @@ def test_delete_and_search(collection_name):
         api='/collections/{collection_name}/points/vectors/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [2, 3],
             "vector": ["text"]
@@ -56,6 +57,7 @@ def test_retrieve_deleted_vector(collection_name):
         api='/collections/{collection_name}/points/vectors/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [1, 3],
             "vector": ["text"]
@@ -300,6 +302,7 @@ def test_update_empty_vectors(collection_name):
         api='/collections/{collection_name}/points/vectors/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [1],
             "vector": ["image", "text"]
@@ -581,6 +584,7 @@ def delete_vectors(collection_name):
         api='/collections/{collection_name}/points/vectors/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [1, 2],
             "vector": ["image"]
@@ -592,6 +596,7 @@ def delete_vectors(collection_name):
         api='/collections/{collection_name}/points/vectors/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "points": [2, 3],
             "vector": ["text"]
@@ -635,6 +640,7 @@ def test_delete_all_vectors(collection_name):
         api='/collections/{collection_name}/points/vectors/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "filter": {},
             "vector": ["image", "text"]

--- a/tests/openapi/test_payload_operations.py
+++ b/tests/openapi/test_payload_operations.py
@@ -428,6 +428,7 @@ def test_payload_operations(collection_name):
         api='/collections/{collection_name}/points/payload/delete',
         method="POST",
         path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
         body={
             "keys": ["key5"],
             "filter": {


### PR DESCRIPTION
Fix the following type of warning.

```
 qdrant/tests/openapi/helpers/helpers.py:81: UserWarning: Delete call for /collections/{collection_name}/points/delete missing wait=true param, adding it
```