### PR TITLE
Use mold for building tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,17 @@ jobs:
       uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install mold
+      uses: rui314/setup-mold@v1
+    - name: Enable mold on Linux
+      run: |
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          mkdir .cargo
+          echo "[target.x86_64-unknown-linux-gnu]" >> .cargo/config.toml
+          echo "linker = \"clang\"" >> .cargo/config.toml
+          echo "rustflags = [\"-C\", \"link-arg=-fuse-ld=/usr/local/bin/mold\"]" >> .cargo/config.toml
+        fi
+      shell: bash
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Build


### PR DESCRIPTION
This step often fails for Linux with

```
Run cargo build --tests --workspace --locked
  cargo build --tests --workspace --locked
  shell: /usr/bin/bash -e {0}
  env:
    CARGO_TERM_COLOR: always
    CARGO_HOME: /home/runner/.cargo
    CARGO_INCREMENTAL: 0
    CACHE_ON_FAILURE: false
    Updating crates.io index
   Compiling memory v0.0.0 (/home/runner/work/qdrant/qdrant/lib/common/memory)
   Compiling common v0.0.0 (/home/runner/work/qdrant/qdrant/lib/common/common)
   Compiling io v0.0.0 (/home/runner/work/qdrant/qdrant/lib/common/io)
   Compiling dataset v0.0.0 (/home/runner/work/qdrant/qdrant/lib/common/dataset)
   Compiling quantization v0.1.0 (/home/runner/work/qdrant/qdrant/lib/quantization)
   Compiling segment v0.6.0 (/home/runner/work/qdrant/qdrant/lib/segment)
   Compiling gpu v0.1.0 (/home/runner/work/qdrant/qdrant/lib/gpu)
   Compiling macros v0.1.0 (/home/runner/work/qdrant/qdrant/lib/macros)
   Compiling issues v0.0.0 (/home/runner/work/qdrant/qdrant/lib/common/issues)
   Compiling cancel v0.0.0 (/home/runner/work/qdrant/qdrant/lib/common/cancel)
   Compiling gridstore v0.1.0 (/home/runner/work/qdrant/qdrant/lib/gridstore)
   Compiling api v1.14.0 (/home/runner/work/qdrant/qdrant/lib/api)
   Compiling sparse v0.1.0 (/home/runner/work/qdrant/qdrant/lib/sparse)
   Compiling collection v0.4.2 (/home/runner/work/qdrant/qdrant/lib/collection)
   Compiling storage v0.2.0 (/home/runner/work/qdrant/qdrant/lib/storage)
   Compiling qdrant v1.14.0 (/home/runner/work/qdrant/qdrant)
Error: Process completed with exit code 143.
```

This PR uses `mold` for linking as it fixed the same issue on Crasher https://github.com/qdrant/crasher/pull/17