### PR TITLE
Snapshot multipart form fields should have names

### DIFF
--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -54,6 +54,7 @@ pub struct SnapshottingParam {
 }
 
 #[derive(MultipartForm)]
+#[multipart(deny_unknown_fields)]
 pub struct SnapshottingForm {
     snapshot: TempFile,
 }

--- a/tests/openapi/test_snapshot.py
+++ b/tests/openapi/test_snapshot.py
@@ -131,6 +131,28 @@ def test_collection_snapshot_operations(http_server, collection_name):
     )
     assert response.status_code == 400
 
+    # try to upload the snapshot with malformed multipart
+    boundary = '----WebKitFormBoundary7MA4YWxkTrZu0gW'
+    headers = {
+        'Content-Type': f'multipart/form-data; boundary={boundary}',
+    }
+
+    # Manually build the multipart body
+    with open(srv_dir / "snapshot.tar", 'rb') as f:
+        snapshot_content = f.read()
+
+    # empty name
+    body = (
+       f'--{boundary}\r\n'
+       f'Content-Disposition: form-data; name=""\r\n\r\n'
+    ).encode('utf-8') + snapshot_content + f'\r\n--{boundary}--\r\n'.encode('utf-8')
+
+    response = requests.post(
+        f"{QDRANT_HOST}/collections/{collection_name}/snapshots/upload",
+        headers=headers,
+        data=body)
+    assert response.status_code == 400
+
     # validate that the collection is not recovered
     response = request_with_validation(
         api='/collections/{collection_name}/points/scroll',


### PR DESCRIPTION
Uploading multipart form snapshot without a file name triggers a debug_assert in `actix-multipart`.

File without names are conflict with each other internally.

```rust
// ensure limits are shared for all fields with this name
let mut field_limits = HashMap::<String, Option<usize>>::new();

while let Some(field) = multipart.try_next().await? {
    debug_assert!(
        !field.form_field_name.is_empty(),
        "multipart form fields should have names",
    );

    // Retrieve the limit for this field
    let entry = field_limits
        .entry(field.form_field_name.clone())
        .or_insert_with(|| T::limit(&field.form_field_name));

    limits.field_limit_remaining.clone_from(entry);

    T::handle_field(&req, field, &mut limits, &mut state).await?;

    // Update the stored limit
    *entry = limits.field_limit_remaining;
}
```

This PR adds a validation from the crate to avoid the crash in debug mode and misuse in release mode.

```
2025-04-25T11:41:08.116048Z ERROR qdrant::startup: Panic backtrace:
   0: qdrant::startup::setup_panic_hook::{{closure}}
             at ./src/startup.rs:19:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/alloc/src/boxed.rs:1990:9
   2: std::panicking::rust_panic_with_hook
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:839:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:697:13
   4: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/sys/backtrace.rs:168:18
   5: rust_begin_unwind
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:695:5
   6: core::panicking::panic_fmt
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/panicking.rs:75:14
   7: <actix_multipart::form::MultipartForm<T> as actix_web::extract::FromRequest>::from_request::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-multipart-0.7.2/src/form/mod.rs:332:21
   8: <F as futures_core::future::TryFuture>::try_poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-core-0.3.31/src/future.rs:92:9
   9: <futures_util::future::try_future::into_future::IntoFuture<Fut> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/future/try_future/into_future.rs:34:9
  10: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/future/future/map.rs:55:37
  11: <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/lib.rs:86:13
  12: <futures_util::future::try_future::MapErr<Fut,F> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/lib.rs:86:13
  13: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  14: <actix_web::extract::tuple_from_req::TupleFromRequest5<A,B,C,D,E> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-web-4.10.2/src/extract.rs:354:66
  15: actix_web::handler::handler_service::{{closure}}::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-web-4.10.2/src/handler.rs:108:68
  16: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  17: <actix_web::resource::Resource<T> as actix_web::service::HttpServiceFactory>::register::{{closure}}::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-web-4.10.2/src/resource.rs:451:28
  18: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  19: <actix_web::middleware::compress::CompressResponse<S,B> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-web-4.10.2/src/middleware/compress.rs:177:22
  20: <actix_utils::future::either::Either<L,R> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-utils-3.0.1/src/future/either.rs:76:43
  21: <actix_web_extras::middleware::condition::ConditionMiddlewareFuture<E,D> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-web-extras-0.1.0/src/middleware/condition.rs:139:55
  22: <actix_cors::middleware::CorsMiddleware<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-cors-0.7.1/src/middleware.rs:239:27
  23: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  24: <actix_web::middleware::condition::ConditionMiddlewareFuture<E,D> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-web-4.10.2/src/middleware/condition.rs:123:54
  25: <actix_web::middleware::logger::LoggerResponse<S,B> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-web-4.10.2/src/middleware/logger.rs:361:32
  26: <qdrant::actix::actix_telemetry::ActixTelemetryService<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::{{closure}}
             at ./src/actix/actix_telemetry.rs:47:35
  27: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  28: <actix_service::map_err::MapErrFuture<A,Req,F,E> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-service-2.0.2/src/map_err.rs:99:9
  29: actix_http::h1::dispatcher::InnerDispatcher<T,S,B,X,U>::poll_response
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-http-3.10.0/src/h1/dispatcher.rs:466:27
  30: <actix_http::h1::dispatcher::Dispatcher<T,S,B,X,U> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-http-3.10.0/src/h1/dispatcher.rs:1128:43
  31: <actix_http::service::HttpServiceHandlerResponse<T,S,B,X,U> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-http-3.10.0/src/service.rs:1052:45
  32: <actix_service::and_then::AndThenServiceResponse<A,B,Req> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-service-2.0.2/src/and_then.rs:114:37
  33: <actix_server::service::StreamService<S,I> as actix_service::Service<(actix_server::worker::WorkerCounterGuard,actix_server::socket::MioStream)>>::call::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-server-2.1.1/src/service.rs:75:31
  34: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  35: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/core.rs:331:17
  36: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/loom/std/unsafe_cell.rs:16:9
  37: tokio::runtime::task::core::Core<T,S>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/core.rs:320:13
  38: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/harness.rs:532:19
  39: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
  40: std::panicking::try::do_call
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:587:40
  41: __rust_try
  42: std::panicking::try
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:550:19
  43: std::panic::catch_unwind
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:358:14
  44: tokio::runtime::task::harness::poll_future
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/harness.rs:520:18
  45: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/harness.rs:209:27
  46: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/harness.rs:154:15
  47: tokio::runtime::task::raw::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/raw.rs:271:5
  48: tokio::runtime::task::raw::RawTask::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/raw.rs:201:18
  49: tokio::runtime::task::LocalNotified<S>::run
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/task/mod.rs:463:9
  50: tokio::task::local::LocalSet::tick::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:739:60
  51: tokio::task::coop::with_budget
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:167:5
  52: tokio::task::coop::budget
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:133:5
  53: tokio::task::local::LocalSet::tick
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:739:31
  54: <tokio::task::local::RunUntil<T> as core::future::future::Future>::poll::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:1045:16
  55: tokio::task::local::LocalSet::with::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:793:13
  56: std::thread::local::LocalKey<T>::try_with
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:310:12
  57: std::thread::local::LocalKey<T>::with
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:274:15
  58: tokio::task::local::LocalSet::with
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:791:9
  59: <tokio::task::local::RunUntil<T> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:1031:9
  60: tokio::task::local::LocalSet::run_until::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:689:19
  61: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  62: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:733:54
  63: tokio::task::coop::with_budget
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:167:5
  64: tokio::task::coop::budget
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:133:5
  65: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:733:25
  66: tokio::runtime::scheduler::current_thread::Context::enter
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:432:19
  67: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:732:36
  68: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:820:68
  69: tokio::runtime::context::scoped::Scoped<T>::set
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context/scoped.rs:40:9
  70: tokio::runtime::context::set_scheduler::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context.rs:180:26
  71: std::thread::local::LocalKey<T>::try_with
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:310:12
  72: std::thread::local::LocalKey<T>::with
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:274:15
  73: tokio::runtime::context::set_scheduler
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context.rs:180:9
  74: tokio::runtime::scheduler::current_thread::CoreGuard::enter
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:820:27
  75: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:720:19
  76: tokio::runtime::scheduler::current_thread::CurrentThread::block_on::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:200:28
  77: tokio::runtime::context::runtime::enter_runtime
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context/runtime.rs:65:16
  78: tokio::runtime::scheduler::current_thread::CurrentThread::block_on
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/current_thread/mod.rs:188:9
  79: tokio::runtime::runtime::Runtime::block_on_inner
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/runtime.rs:368:47
  80: tokio::runtime::runtime::Runtime::block_on
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/runtime.rs:342:13
  81: tokio::task::local::LocalSet::block_on
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/local.rs:646:9
  82: actix_rt::runtime::Runtime::block_on
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-rt-2.7.0/src/runtime.rs:80:9
  83: actix_rt::arbiter::Arbiter::with_tokio_rt::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-rt-2.7.0/src/arbiter.rs:144:21
  84: std::sys::backtrace::__rust_begin_short_backtrace
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
  85: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:559:17
  86: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
  87: std::panicking::try::do_call
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:587:40
  88: __rust_try
  89: std::panicking::try
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:550:19
  90: std::panic::catch_unwind
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:358:14
  91: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:557:30
  92: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  93: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/alloc/src/boxed.rs:1976:9
  94: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/alloc/src/boxed.rs:1976:9
  95: std::sys::pal::unix::thread::Thread::new::thread_start
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/sys/pal/unix/thread.rs:106:17
  96: start_thread
             at ./nptl/pthread_create.c:447:8
  97: __GI___clone3
             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78:0

2025-04-25T11:41:08.116814Z ERROR qdrant::startup: Panic occurred in file /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-multipart-0.7.2/src/form/mod.rs at line 332: multipart form fields should have names
```