### PR TITLE
Incremental HNSW: merge join by vector values

### DIFF
--- a/lib/common/common/src/cmp.rs
+++ b/lib/common/common/src/cmp.rs
@@ -1,0 +1,19 @@
+use std::cmp::Ordering;
+
+/// Returns the ordering between two slices of `f32` values.
+///
+/// The order is arbitrary but consistent.
+pub fn total_cmp_f32_slices(a: &[f32], b: &[f32]) -> Ordering {
+    if a.len() != b.len() {
+        return a.len().cmp(&b.len());
+    }
+
+    for (a, b) in a.iter().zip(b.iter()) {
+        match Ord::cmp(&a.to_bits(), &b.to_bits()) {
+            Ordering::Equal => (),
+            cmp => return cmp,
+        }
+    }
+
+    Ordering::Equal
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bitpacking;
 pub mod bitpacking_links;
 pub mod bitpacking_ordered;
 pub mod budget;
+pub mod cmp;
 pub mod counter;
 pub mod cpu;
 pub mod defaults;

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -1,6 +1,8 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::slice::ChunksExactMut;
 
+use common::cmp::total_cmp_f32_slices;
 use half::f16;
 use itertools::Itertools;
 use schemars::JsonSchema;
@@ -367,6 +369,16 @@ impl<'a, T: PrimitiveVectorElement> TypedMultiDenseVectorRef<'a, T> {
             flattened_vectors: self.flattened_vectors.to_owned(),
             dim: self.dim,
         }
+    }
+}
+
+impl TypedMultiDenseVectorRef<'_, f32> {
+    /// Returns the ordering between this vector and another vector.
+    ///
+    /// The order is arbitrary but consistent.
+    pub fn total_cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&self.dim, &other.dim)
+            .then_with(|| total_cmp_f32_slices(self.flattened_vectors, other.flattened_vectors))
     }
 }
 

--- a/lib/segment/tests/integration/hnsw_incremental_build.rs
+++ b/lib/segment/tests/integration/hnsw_incremental_build.rs
@@ -2,45 +2,54 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use ahash::{HashSet, HashSetExt as _};
 use atomic_refcell::AtomicRefCell;
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::flags::FeatureFlags;
-use itertools::Itertools as _;
 use rand::rngs::StdRng;
-use rand::seq::SliceRandom as _;
+use rand::seq::{IndexedRandom, SliceRandom as _};
 use rand::{Rng as _, SeedableRng as _};
+use rstest::rstest;
+use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{
     DEFAULT_VECTOR_NAME, QueryVector, VectorElementType, only_default_vector,
 };
 use segment::entry::SegmentEntry as _;
 use segment::fixtures::index_fixtures::random_vector;
 use segment::index::VectorIndexEnum;
-use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
+use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexBuildStats, HnswIndexOpenArgs};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::segment::Segment;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
-use segment::types::{Distance, ExtendedPointId, HnswConfig, SeqNumberType};
+use segment::types::{Distance, HnswConfig};
 use tap::Tap as _;
 use tempfile::Builder;
 
 use crate::hnsw_quantized_search_test::check_matches;
-
-const NUM_POINTS: usize = 5_000;
-const ITERATIONS: usize = 10;
 
 const DIM: usize = 8;
 const M: usize = 16;
 const EF_CONSTRUCT: usize = 64;
 const DISTANCE: Distance = Distance::Cosine;
 
-#[test]
-fn hnsw_incremental_build() {
+struct Point {
+    id: u64,
+    vector: Option<Vec<VectorElementType>>,
+}
+
+#[rstest]
+#[case::default(false, 10)]
+#[case::with_hard_deletions(true, 3)]
+fn hnsw_incremental_build(#[case] do_deletions: bool, #[case] iterations: usize) {
+    use rand::seq::IndexedMutRandom as _;
+
     let _ = env_logger::builder()
         .is_test(true)
         .filter_level(log::LevelFilter::Trace)
         .try_init();
+    let hw_counter = HardwareCounterCell::new();
 
     let mut rnd = StdRng::seed_from_u64(42);
 
@@ -49,78 +58,151 @@ fn hnsw_incremental_build() {
         .tempdir()
         .unwrap();
 
-    let ids = std::iter::repeat_with(|| ExtendedPointId::NumId(rnd.random()))
-        .unique()
-        .take(NUM_POINTS)
-        .collect_vec();
-    let vectors = std::iter::repeat_with(|| random_vector(&mut rnd, DIM))
-        .take(NUM_POINTS)
-        .collect_vec();
+    let mut unique_ids = HashSet::<u64>::new();
 
-    let vector_refs = vectors.iter().map(|v| v.as_slice()).collect_vec();
+    let mut points = Vec::<Point>::new();
 
     let num_queries = 10;
     let query_vectors: Vec<QueryVector> = (0..num_queries)
         .map(|_| random_vector(&mut rnd, DIM).into())
         .collect();
 
+    let mut op_id = 0;
     let mut last_index = None;
-    for i in 1..=ITERATIONS {
-        log::info!(
-            "Building segment with {:.0}% of data",
-            i as f64 / ITERATIONS as f64 * 100.0
-        );
+    let mut last_indexed_points = 0;
+    for i in 0..iterations {
+        log::info!("Iteration {i}/{iterations}");
 
-        let num_points = i * NUM_POINTS / ITERATIONS;
-        let segment = make_segment(
-            &mut rnd,
-            &dir.path().join(format!("segment_{i}")),
-            &ids[0..num_points],
-            &vector_refs[0..num_points],
-        );
+        //
+        // Phase 1.
+        // Decide what points/vectors a new segment will have.
+        //
+
+        if i > 0 {
+            if do_deletions {
+                for _ in 0..10 {
+                    // Hard-delete a point.
+                    loop {
+                        let idx = rnd.random_range(0..points.len());
+                        if points[idx].vector.is_some() {
+                            points.swap_remove(idx);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            for _ in 0..20 {
+                // Add a vector to a point.
+                loop {
+                    let point = points.choose_mut(&mut rnd).unwrap();
+                    if point.vector.is_none() {
+                        point.vector = Some(random_vector(&mut rnd, DIM));
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Add points with vectors.
+        for _ in 0..500 {
+            points.push(Point {
+                id: unique_id(&mut rnd, &mut unique_ids),
+                vector: Some(random_vector(&mut rnd, DIM)),
+            });
+        }
+
+        // Add points without vectors.
+        for _ in 0..50 {
+            points.push(Point {
+                id: unique_id(&mut rnd, &mut unique_ids),
+                vector: None,
+            });
+        }
+
+        // Shuffle to stress-test old_to_new/new_to_old mappings.
+        points.shuffle(&mut rnd);
+
+        //
+        // Phase 2:
+        // Build segment and index.
+        //
+
+        let segment_path = dir.path().join(format!("segment_{i}"));
+        let mut segment = build_simple_segment(&segment_path, DIM, DISTANCE).unwrap();
+
+        let mut indexed_points = 0;
+        for point in &points {
+            let vectors = match point.vector.as_ref() {
+                Some(vector) => {
+                    indexed_points += 1;
+                    only_default_vector(vector)
+                }
+                None => NamedVectors::default(),
+            };
+            segment
+                .upsert_point(op_id, point.id.into(), vectors, &hw_counter)
+                .unwrap();
+            op_id += 1;
+        }
 
         let index_path = dir.path().join(format!("hnsw_{i}"));
         let old_indices = last_index
             .as_ref()
             .map_or(vec![], |idx| vec![Arc::clone(idx)]);
 
-        let index = build_hnsw_index(&index_path, &segment, &old_indices);
+        let (index, stats) = build_hnsw_index(&index_path, &segment, &old_indices);
+        if do_deletions {
+            // Not supported yet, so should be 0.
+            assert_eq!(stats.reused_points, 0);
+        } else {
+            assert_eq!(stats.reused_points, last_indexed_points);
+        }
+        last_indexed_points = indexed_points;
 
-        let ef = 64;
+        let ef = 32;
         let top = 10;
         check_matches(&query_vectors, &segment, &index, None, ef, top);
+
+        //
+        // Phase 3.
+        //
+        // Soft-delete vectors and points from the indexed segment.
+        // They will re-appear in the new segment on the next iteration.
+        //
+
+        points.choose_multiple(&mut rnd, 100).for_each(|point| {
+            segment
+                .delete_vector(op_id, point.id.into(), DEFAULT_VECTOR_NAME)
+                .unwrap();
+            op_id += 1;
+        });
+
+        points.choose_multiple(&mut rnd, 100).for_each(|point| {
+            segment
+                .delete_point(op_id, point.id.into(), &hw_counter)
+                .unwrap();
+            op_id += 1;
+        });
 
         last_index = Some(Arc::new(AtomicRefCell::new(VectorIndexEnum::Hnsw(index))));
     }
 }
 
-fn make_segment(
-    rnd: &mut StdRng,
-    path: &Path,
-    ids: &[ExtendedPointId],
-    vectors: &[&[VectorElementType]],
-) -> Segment {
-    let mut sequence = (0..ids.len()).collect_vec();
-    sequence.shuffle(rnd);
-
-    let hw_counter = HardwareCounterCell::new();
-
-    let mut segment = build_simple_segment(path, DIM, DISTANCE).unwrap();
-    for n in sequence {
-        let vector = only_default_vector(vectors[n]);
-        segment
-            .upsert_point(n as SeqNumberType, ids[n], vector, &hw_counter)
-            .unwrap();
+fn unique_id(rnd: &mut StdRng, unique_ids: &mut HashSet<u64>) -> u64 {
+    loop {
+        let id = rnd.random_range(0..u64::MAX);
+        if unique_ids.insert(id) {
+            return id;
+        }
     }
-
-    segment
 }
 
 fn build_hnsw_index(
     path: &Path,
     segment: &Segment,
     old_indices: &[Arc<AtomicRefCell<VectorIndexEnum>>],
-) -> HNSWIndex {
+) -> (HNSWIndex, HnswIndexBuildStats) {
     log::info!("Building HNSW index for {:?}", path.file_name().unwrap());
 
     let hnsw_config = HnswConfig {
@@ -135,7 +217,7 @@ fn build_hnsw_index(
     let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
     let permit = Arc::new(ResourcePermit::dummy(permit_cpu_count as u32));
 
-    HNSWIndex::build(
+    HNSWIndex::build_with_stats(
         HnswIndexOpenArgs {
             path,
             id_tracker: segment.id_tracker.clone(),


### PR DESCRIPTION
The change in this PR is summarized by this comment:

https://github.com/qdrant/qdrant/blob/44952f8feb50333ff6d01f51def10b5dc3941c1a/lib/segment/src/index/hnsw_index/hnsw.rs#L1378-L1388

I.e. compare vector values instead of looking into an id tracker. Vector comparisons for sorting are done bit-wise.