### PR TITLE
Only initialize segment RocksDB if it's used by the segment

### DIFF
--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -77,7 +77,7 @@ pub struct Segment {
     /// Last unhandled error
     /// If not None, all update operations will be aborted until original operation is performed properly
     pub error_status: Option<SegmentFailedState>,
-    pub database: Arc<RwLock<DB>>,
+    pub database: Option<Arc<RwLock<DB>>>,
     pub flush_thread: Mutex<Option<JoinHandle<OperationResult<SeqNumberType>>>>,
 }
 

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -277,15 +277,17 @@ pub fn snapshot_files(
     // TODO: Version RocksDB!? 🤯
 
     if include_if(ROCKS_DB_VIRT_FILE.as_ref()) {
-        let db_backup_path = temp_path.join(DB_BACKUP_PATH);
+        if let Some(db) = &segment.database {
+            let db_backup_path = temp_path.join(DB_BACKUP_PATH);
 
-        let db = segment.database.read();
-        crate::rocksdb_backup::create(&db, &db_backup_path).map_err(|err| {
-            OperationError::service_error(format!(
-                "failed to create RocksDB backup at {}: {err}",
-                db_backup_path.display()
-            ))
-        })?;
+            let db = db.read();
+            crate::rocksdb_backup::create(&db, &db_backup_path).map_err(|err| {
+                OperationError::service_error(format!(
+                    "failed to create RocksDB backup at {}: {err}",
+                    db_backup_path.display()
+                ))
+            })?;
+        }
     }
 
     if include_if(PAYLOAD_INDEX_ROCKS_DB_VIRT_FILE.as_ref()) {

--- a/lib/segment/src/segment_constructor/mod.rs
+++ b/lib/segment/src/segment_constructor/mod.rs
@@ -1,3 +1,4 @@
+mod rocksdb_builder;
 pub mod segment_builder;
 mod segment_constructor_base;
 pub mod simple_segment_constructor;

--- a/lib/segment/src/segment_constructor/rocksdb_builder.rs
+++ b/lib/segment/src/segment_constructor/rocksdb_builder.rs
@@ -1,0 +1,87 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::{RwLock, RwLockReadGuard};
+
+use super::segment_constructor_base::get_vector_name_with_prefix;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::rocksdb_wrapper;
+use crate::types::{SegmentConfig, SparseVectorStorageType};
+
+#[derive(Debug)]
+pub struct RocksDbBuilder {
+    path: PathBuf,
+    column_families: Vec<String>,
+    rocksdb: Option<Arc<RwLock<rocksdb::DB>>>,
+    is_required: bool,
+}
+
+impl RocksDbBuilder {
+    pub fn new(path: impl Into<PathBuf>, config: &SegmentConfig) -> OperationResult<Self> {
+        let path = path.into();
+
+        let vector_cfs = config.vector_data.keys().map(|vector_name| {
+            get_vector_name_with_prefix(rocksdb_wrapper::DB_VECTOR_CF, vector_name)
+        });
+
+        let sparse_vector_cfs =
+            config
+                .sparse_vector_data
+                .iter()
+                .filter_map(|(vector_name, config)| {
+                    if matches!(config.storage_type, SparseVectorStorageType::OnDisk) {
+                        Some(get_vector_name_with_prefix(
+                            rocksdb_wrapper::DB_VECTOR_CF,
+                            vector_name,
+                        ))
+                    } else {
+                        None
+                    }
+                });
+
+        let column_families: Vec<_> = vector_cfs.chain(sparse_vector_cfs).collect();
+
+        let rocksdb = if rocksdb_wrapper::check_db_exists(&path) {
+            Some(open_db(&path, &column_families)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            path,
+            column_families,
+            rocksdb,
+            is_required: false,
+        })
+    }
+
+    pub fn read(&self) -> Option<RwLockReadGuard<'_, rocksdb::DB>> {
+        self.rocksdb.as_ref().map(|db| db.read())
+    }
+
+    pub fn require(&mut self) -> OperationResult<Arc<RwLock<rocksdb::DB>>> {
+        let db = match &self.rocksdb {
+            Some(db) => db,
+            None => self
+                .rocksdb
+                .insert(open_db(&self.path, &self.column_families)?),
+        };
+
+        self.is_required = true;
+
+        Ok(db.clone())
+    }
+
+    pub fn build(self) -> Option<Arc<RwLock<rocksdb::DB>>> {
+        self.rocksdb.filter(|_| self.is_required)
+    }
+}
+
+fn open_db(path: &Path, cfs: &[impl AsRef<str>]) -> OperationResult<Arc<RwLock<rocksdb::DB>>> {
+    rocksdb_wrapper::open_db(path, cfs).map_err(|err| {
+        OperationError::service_error(format!(
+            "failed to open RocksDB at {}: {err}",
+            path.display(),
+        ))
+    })
+}

--- a/lib/segment/src/segment_constructor/rocksdb_builder.rs
+++ b/lib/segment/src/segment_constructor/rocksdb_builder.rs
@@ -7,7 +7,8 @@ use super::segment_constructor_base::get_vector_name_with_prefix;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_wrapper;
 use crate::types::{SegmentConfig, SparseVectorStorageType};
-
+/// Struct to optionally create and open a RocksDB instance in a lazy way.
+/// Used as helper to eventually completely remove RocksDB.
 #[derive(Debug)]
 pub struct RocksDbBuilder {
     path: PathBuf,

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -19,8 +19,9 @@ use itertools::Itertools;
 use tempfile::TempDir;
 use uuid::Uuid;
 
+use super::rocksdb_builder::RocksDbBuilder;
 use super::{
-    RocksDbBuilder, create_mutable_id_tracker, create_payload_storage, create_sparse_vector_index,
+    create_mutable_id_tracker, create_payload_storage, create_sparse_vector_index,
     create_sparse_vector_storage, get_payload_index_path, get_vector_index_path,
     get_vector_storage_path, new_segment_path, open_vector_storage,
 };

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -20,9 +20,9 @@ use tempfile::TempDir;
 use uuid::Uuid;
 
 use super::{
-    create_mutable_id_tracker, create_payload_storage, create_sparse_vector_index,
+    RocksDbBuilder, create_mutable_id_tracker, create_payload_storage, create_sparse_vector_index,
     create_sparse_vector_storage, get_payload_index_path, get_vector_index_path,
-    get_vector_storage_path, new_segment_path, open_segment_db, open_vector_storage,
+    get_vector_storage_path, new_segment_path, open_vector_storage,
 };
 use crate::common::error_logging::LogError;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
@@ -83,23 +83,23 @@ impl SegmentBuilder {
 
         let temp_dir = create_temp_dir(temp_dir)?;
 
-        let database = open_segment_db(temp_dir.path(), segment_config)?;
-
         let id_tracker = if segment_config.is_appendable() {
             IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(temp_dir.path())?)
         } else {
             IdTrackerEnum::InMemoryIdTracker(InMemoryIdTracker::new())
         };
 
+        let mut db_builder = RocksDbBuilder::new(temp_dir.path(), segment_config)?;
+
         let payload_storage =
-            create_payload_storage(database.clone(), segment_config, temp_dir.path())?;
+            create_payload_storage(&mut db_builder, temp_dir.path(), segment_config)?;
 
         let mut vector_data = HashMap::new();
 
         for (vector_name, vector_config) in &segment_config.vector_data {
             let vector_storage_path = get_vector_storage_path(temp_dir.path(), vector_name);
             let vector_storage = open_vector_storage(
-                &database,
+                &mut db_builder,
                 vector_config,
                 &stopped,
                 &vector_storage_path,
@@ -119,7 +119,7 @@ impl SegmentBuilder {
             let vector_storage_path = get_vector_storage_path(temp_dir.path(), vector_name);
 
             let vector_storage = create_sparse_vector_storage(
-                database.clone(),
+                &mut db_builder,
                 &vector_storage_path,
                 vector_name,
                 &sparse_vector_config.storage_type,


### PR DESCRIPTION
Basically, subject. Currently, we always initialize RocksDB when creating a segment, even if it's later completely unused by any structure in the segment. This PR makes the field optional and tweaks segment initialization, so that we only open it if it's required.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
