### PR TITLE
Generate less debug symbols in `dev` profile

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,9 +79,9 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: consensus-test-logs
-          retention-days: 90 # default max value
           path: consensus_test_logs
+          name: consensus-test-logs
+          retention-days: 10
 
   test-consensus-compose:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,6 +285,9 @@ lto = false
 opt-level = 3
 codegen-units = 256 # restore default value for faster compilation
 
+[profile.dev]
+debug = "line-tables-only"
+
 # Override for fast sha256 hashing in dev builds
 [profile.dev.package.sha2]
 opt-level = 3


### PR DESCRIPTION
Another go at reducing debug symbols size in `dev` profile. No noticeable improvement to compilation speeds, but `target` dir is 25-30% smaller on my machine (~7 GB with `line-tables-only` vs ~9.5 GB with `full`). Panics should work properly this time (tested on macOS and Docker, cause that's all I have available).

Also reduce retention time for integration test logs.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
