### PR TITLE
Reuse space more in gridstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,6 +2414,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "smallvec",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ serde_cbor = "0.11.2"
 serde_variant = "0.1.3"
 sha2 = "0.10.8"
 serde_json = { version = "~1.0", features = ["preserve_order"] }
+smallvec = "1.15.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tap = "1.0.1"
 tar = "0.4.41"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -43,7 +43,7 @@ hashring = "0.3.6"
 tinyvec = { version = "1.9.0", features = ["alloc", "latest_stable_rust"] }
 bitvec = { workspace = true }
 lazy_static = "1.5.0"
-smallvec = "1.15.0"
+smallvec = { workspace = true }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/lib/gridstore/Cargo.toml
+++ b/lib/gridstore/Cargo.toml
@@ -17,6 +17,7 @@ ahash = { workspace = true }
 memmap2 = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
+smallvec = { workspace = true }
 parking_lot = { workspace = true }
 tempfile = { workspace = true }
 lz4_flex = { version = "0.11.3", default-features = false }

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -68,7 +68,7 @@ impl PointerUpdates {
     /// Set is Some, Unset is None
     fn latest(&self) -> Option<ValuePointer> {
         if self.latest_is_set {
-            self.history.last().cloned()
+            self.history.last().copied()
         } else {
             None
         }

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -53,7 +53,10 @@ impl PointerUpdates {
 
     /// Mark this pointer as pending for freeing
     fn unset(&mut self, pointer: ValuePointer) {
-        self.history.push(pointer);
+        // Prevent duplicating pointers to free
+        if self.history.last() != Some(&pointer) {
+            self.history.push(pointer);
+        }
         self.latest_is_set = false;
     }
 
@@ -75,7 +78,7 @@ impl PointerUpdates {
     fn outdated_pointers(self) -> impl Iterator<Item = ValuePointer> {
         let take = if self.latest_is_set {
             // all but the latest one
-            self.history.len() - 1
+            self.history.len().saturating_sub(1)
         } else {
             // all of them
             self.history.len()

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -38,9 +38,10 @@ impl ValuePointer {
 
 #[derive(Debug, Default)]
 struct PointerUpdates {
-    /// Whether the latest pointer is set (true) or unset (false)
+    /// Whether the latest pointer is set (`true`) or unset (`false`).
+    /// If this is `true`, then history must have at least one element.
     latest_is_set: bool,
-    /// List of pointers where the value was written
+    /// List of pointers where the value has been written
     history: SmallVec<[ValuePointer; 1]>,
 }
 
@@ -75,7 +76,7 @@ impl PointerUpdates {
     }
 
     /// Returns pointers that need to be freed, i.e. They have been written, and are no longer needed
-    fn outdated_pointers(self) -> impl Iterator<Item = ValuePointer> {
+    fn into_outdated_pointers(self) -> impl Iterator<Item = ValuePointer> {
         let take = if self.latest_is_set {
             // all but the latest one
             self.history.len().saturating_sub(1)
@@ -189,7 +190,7 @@ impl Tracker {
                     self.persist_pointer(point_offset, None);
                 }
             }
-            old_pointers.extend(updates.outdated_pointers());
+            old_pointers.extend(updates.into_outdated_pointers());
         }
         // increment header count if necessary
         self.persist_pointer_count();

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -6,6 +6,7 @@ use memory::madvise::{Advice, AdviceSetting};
 use memory::mmap_ops::{
     create_and_ensure_length, open_write_mmap, transmute_from_u8, transmute_to_u8,
 };
+use smallvec::SmallVec;
 
 pub type PointOffset = u32;
 pub type BlockOffset = u32;
@@ -40,7 +41,7 @@ struct PointerUpdates {
     /// Whether the latest pointer is set (true) or unset (false)
     latest_is_set: bool,
     /// List of pointers where the value was written
-    history: Vec<ValuePointer>,
+    history: SmallVec<[ValuePointer; 1]>,
 }
 
 impl PointerUpdates {

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -35,27 +35,52 @@ impl ValuePointer {
     }
 }
 
-#[derive(Debug)]
-enum PointerUpdate {
-    Set(ValuePointer),
-    Unset(ValuePointer),
+#[derive(Debug, Default)]
+struct PointerUpdates {
+    /// Whether the latest pointer is set (true) or unset (false)
+    latest_is_set: bool,
+    /// List of pointers where the value was written
+    history: Vec<ValuePointer>,
 }
 
-impl PointerUpdate {
+impl PointerUpdates {
+    /// Set the current latest pointer
+    fn set(&mut self, pointer: ValuePointer) {
+        self.history.push(pointer);
+        self.latest_is_set = true;
+    }
+
+    /// Mark this pointer as pending for freeing
+    fn unset(&mut self, pointer: ValuePointer) {
+        self.history.push(pointer);
+        self.latest_is_set = false;
+    }
+
     #[cfg(test)]
     fn is_set(&self) -> bool {
-        match self {
-            PointerUpdate::Set(_) => true,
-            PointerUpdate::Unset(_) => false,
-        }
+        self.latest_is_set
     }
 
     /// Set is Some, Unset is None
-    fn to_option(&self) -> Option<ValuePointer> {
-        match self {
-            PointerUpdate::Set(pointer) => Some(*pointer),
-            PointerUpdate::Unset(_) => None,
+    fn latest(&self) -> Option<ValuePointer> {
+        if self.latest_is_set {
+            self.history.last().cloned()
+        } else {
+            None
         }
+    }
+
+    /// Returns pointers that need to be freed, i.e. They have been written, and are no longer needed
+    fn outdated_pointers(self) -> impl Iterator<Item = ValuePointer> {
+        let take = if self.latest_is_set {
+            // all but the latest one
+            self.history.len() - 1
+        } else {
+            // all of them
+            self.history.len()
+        };
+
+        self.history.into_iter().take(take)
     }
 }
 
@@ -75,7 +100,7 @@ pub struct Tracker {
     /// Updates that haven't been flushed
     ///
     /// When flushing, these updates get written into the mmap and flushed at once.
-    pending_updates: AHashMap<PointOffset, PointerUpdate>,
+    pending_updates: AHashMap<PointOffset, PointerUpdates>,
 
     /// The maximum pointer offset in the tracker (updated in memory).
     next_pointer_offset: PointOffset,
@@ -143,9 +168,9 @@ impl Tracker {
         // Write pending updates from memory
         let mut pending_updates = std::mem::take(&mut self.pending_updates);
         let mut old_pointers = Vec::new();
-        for (point_offset, update) in pending_updates.drain() {
-            match update {
-                PointerUpdate::Set(new_pointer) => {
+        for (point_offset, updates) in pending_updates.drain() {
+            match updates.latest() {
+                Some(new_pointer) => {
                     if let Some(old_pointer) =
                         self.get_raw(point_offset).and_then(|pointer| *pointer)
                     {
@@ -155,12 +180,12 @@ impl Tracker {
                     // write the new pointer
                     self.persist_pointer(point_offset, Some(new_pointer));
                 }
-                PointerUpdate::Unset(old_pointer) => {
-                    old_pointers.push(old_pointer);
-                    // write the new pointer
+                None => {
+                    // write the new None pointer
                     self.persist_pointer(point_offset, None);
                 }
             }
+            old_pointers.extend(updates.outdated_pointers());
         }
         // increment header count if necessary
         self.persist_pointer_count();
@@ -262,7 +287,7 @@ impl Tracker {
     pub fn get(&self, point_offset: PointOffset) -> Option<ValuePointer> {
         self.pending_updates
             .get(&point_offset)
-            .map(PointerUpdate::to_option)
+            .map(PointerUpdates::latest)
             // if the value is not in the pending updates, check the mmap
             .or_else(|| self.get_raw(point_offset).copied())
             .flatten()
@@ -280,7 +305,9 @@ impl Tracker {
 
     pub fn set(&mut self, point_offset: PointOffset, value_pointer: ValuePointer) {
         self.pending_updates
-            .insert(point_offset, PointerUpdate::Set(value_pointer));
+            .entry(point_offset)
+            .or_default()
+            .set(value_pointer);
         self.next_pointer_offset = self.next_pointer_offset.max(point_offset + 1);
     }
 
@@ -290,7 +317,9 @@ impl Tracker {
 
         if let Some(pointer) = pointer_opt {
             self.pending_updates
-                .insert(point_offset, PointerUpdate::Unset(pointer));
+                .entry(point_offset)
+                .or_default()
+                .unset(pointer);
         }
 
         pointer_opt

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -91,7 +91,7 @@ indexmap = { workspace = true }
 ahash = { workspace = true }
 self_cell = "1.2.0"
 sha2 = { workspace = true }
-smallvec = "1.15.0"
+smallvec = { workspace = true }
 is_sorted = "0.1.1"
 strum = { workspace = true }
 byteorder = { workspace = true }


### PR DESCRIPTION
This PR fixes one thing we overlooked in gridstore.

Pending updates only stored the last place where a value is. So, when flushing, we would only free the previous _stored_ value. If multiple updates happened in between flushes, we'd end up with storage that is never marked as free.

With these changes, now we keep track of *all* the places that values have been written in between flushes, so that we only keep the latest one, and are able to mark all the previous places as free.


### Testing

For testing, I modified one test, so that it failed without the changes, and also did manual validation by making sure that 
```bash
bfb -n 5000000 --max-id 10 -d 128 --float-payloads true --segments 1 --on-disk-payload --text-payloads --text-payload-length 100 --skip-field-indices
```
doesn't grow the size of payload storage forever. It now reduces in between flushes, and it is minimal after updates have finished.