### PR TITLE
[minor opt] update region gaps in batch when flushing

### DIFF
--- a/lib/gridstore/Cargo.toml
+++ b/lib/gridstore/Cargo.toml
@@ -55,3 +55,7 @@ harness = false
 [[bench]]
 name = "bustle_bench"
 harness = false
+
+[[bench]]
+name = "flush_bench"
+harness = false

--- a/lib/gridstore/benches/flush_bench.rs
+++ b/lib/gridstore/benches/flush_bench.rs
@@ -1,0 +1,90 @@
+use std::time::{Duration, Instant};
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use criterion::{Criterion, criterion_group, criterion_main};
+use gridstore::fixtures::{empty_storage, random_payload};
+use rand::Rng;
+
+pub fn flush_bench(c: &mut Criterion) {
+    let prepopulation_size = 10_000;
+
+    // Test sequential updates' flushing performance
+    for unflushed_updates in [100, 1_000, prepopulation_size].iter() {
+        let bench_name = format!("flush after {} sequential writes", unflushed_updates);
+
+        c.bench_function(&bench_name, |b| {
+            // Setup: Create a storage with a specified number of records
+            let (_dir, mut storage) = empty_storage();
+            let mut rng = rand::rng();
+            let hw_counter = HardwareCounterCell::new();
+            let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+            // Pre-populate storage with sequential random data
+            for i in 0..prepopulation_size {
+                let payload = random_payload(&mut rng, 1); // Small payload to speed up setup
+                storage.put_value(i, &payload, hw_counter_ref).unwrap();
+            }
+
+            b.iter_custom(|iters| {
+                let mut total_elapsed = Duration::ZERO;
+                for _ in 0..iters {
+                    // apply sequential ids
+                    for i in 0..*unflushed_updates {
+                        let payload = random_payload(&mut rng, 1);
+                        storage.put_value(i, &payload, hw_counter_ref).unwrap();
+                    }
+
+                    // Benchmark the flush operation after accumulating updates
+                    let instant = Instant::now();
+
+                    storage.flush().unwrap();
+
+                    total_elapsed += instant.elapsed();
+                }
+                total_elapsed
+            });
+        });
+    }
+
+    // Test random updates' flushing performance
+    for unflushed_updates in [100, 1_000, prepopulation_size].iter() {
+        let bench_name = format!("flush after {} random writes", unflushed_updates);
+
+        c.bench_function(&bench_name, |b| {
+            // Setup: Create a storage with a specified number of records
+            let (_dir, mut storage) = empty_storage();
+            let mut rng = rand::rng();
+            let hw_counter = HardwareCounterCell::new();
+            let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+            // Pre-populate storage with random data
+            for i in 0..prepopulation_size {
+                let payload = random_payload(&mut rng, 1); // Small payload to speed up setup
+                storage.put_value(i, &payload, hw_counter_ref).unwrap();
+            }
+
+            b.iter_custom(|iters| {
+                let mut total_elapsed = Duration::ZERO;
+                for _ in 0..iters {
+                    // Apply random updates
+                    for _ in 0..*unflushed_updates {
+                        let id = rng.random_range(0..prepopulation_size);
+                        let payload = random_payload(&mut rng, 1);
+                        storage.put_value(id, &payload, hw_counter_ref).unwrap();
+                    }
+
+                    // Benchmark the flush operation after accumulating updates
+                    let instant = Instant::now();
+
+                    storage.flush().unwrap();
+
+                    total_elapsed += instant.elapsed();
+                }
+                total_elapsed
+            });
+        });
+    }
+}
+
+criterion_group!(benches, flush_bench);
+criterion_main!(benches);

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -374,14 +374,14 @@ impl Bitmask {
     pub(crate) fn mark_blocks_batch(
         &mut self,
         page_id: PageId,
-        relative_block_ranges: impl Iterator<Item = Range<usize>>,
+        local_block_ranges: impl Iterator<Item = Range<usize>>,
         used: bool,
     ) {
         let page_start = self.range_of_page(page_id).start;
 
         let mut lowest_offset = usize::MAX;
         let mut highest_offset = page_start;
-        for range in relative_block_ranges {
+        for range in local_block_ranges {
             let bitmask_range = (range.start + page_start)..(range.end + page_start);
             self.bitslice[bitmask_range.clone()].fill(used);
 

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use io::file_operations::atomic_save_json;
+use itertools::Itertools;
 use lz4_flex::compress_prepend_size;
 use memory::mmap_type;
 use parking_lot::RwLock;
@@ -513,14 +514,19 @@ impl<V> Gridstore<V> {
 
         // update all free blocks in the bitmask
         bitmask_guard.with_upgraded(|guard| {
-            for pointer in old_pointers {
-                // TODO: mark in batch? so that we update the gaps less times.
-                guard.mark_blocks(
-                    pointer.page_id,
-                    pointer.block_offset,
-                    Self::blocks_for_value(pointer.length as usize, self.config.block_size_bytes),
-                    false,
-                );
+            for (page_id, pointer_group) in
+                &old_pointers.into_iter().chunk_by(|pointer| pointer.page_id)
+            {
+                let relative_ranges = pointer_group.map(|pointer| {
+                    let start = pointer.block_offset;
+                    let end = pointer.block_offset
+                        + Self::blocks_for_value(
+                            pointer.length as usize,
+                            self.config.block_size_bytes,
+                        );
+                    start as usize..end as usize
+                });
+                guard.mark_blocks_batch(page_id, relative_ranges, false);
             }
         });
         bitmask_guard.flush()?;

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -517,7 +517,7 @@ impl<V> Gridstore<V> {
             for (page_id, pointer_group) in
                 &old_pointers.into_iter().chunk_by(|pointer| pointer.page_id)
             {
-                let relative_ranges = pointer_group.map(|pointer| {
+                let local_ranges = pointer_group.map(|pointer| {
                     let start = pointer.block_offset;
                     let end = pointer.block_offset
                         + Self::blocks_for_value(
@@ -526,7 +526,7 @@ impl<V> Gridstore<V> {
                         );
                     start as usize..end as usize
                 });
-                guard.mark_blocks_batch(page_id, relative_ranges, false);
+                guard.mark_blocks_batch(page_id, local_ranges, false);
             }
         });
         bitmask_guard.flush()?;


### PR DESCRIPTION
Found this TODO while inspecting the code, I don't have great numbers to share, but when profiling the `bustle_bench`, the flamegraph proved that flushing takes less time when there are lots of updates.

Before:
<img width="654" alt="imagen" src="https://github.com/user-attachments/assets/55ff7036-eac9-411e-9294-051728bcb2c5" />


After:
<img width="580" alt="imagen" src="https://github.com/user-attachments/assets/3de18385-3b5f-488c-9192-558c20b26056" />
