### PR TITLE
Faster wal-delta transfer

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -300,6 +300,8 @@ fn configure_validation(builder: Builder) -> Builder {
             ("ClearPayloadPointsInternal.clear_payload_points", ""),
             ("CreateFieldIndexCollectionInternal.create_field_index_collection", ""),
             ("DeleteFieldIndexCollectionInternal.delete_field_index_collection", ""),
+            ("UpdateOperation.update", ""),
+            ("UpdateBatchInternal.operations", ""),
             ("SearchPointsInternal.search_points", ""),
             ("SearchBatchPointsInternal.collection_name", "length(min = 1, max = 255)"),
             ("SearchBatchPointsInternal.search_points", ""),

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -7,6 +7,7 @@ pub mod dynamic_pool;
 #[rustfmt::skip] // tonic uses `prettyplease` to format its output
 #[path = "grpc.health.v1.rs"]
 pub mod grpc_health_v1;
+pub mod ops;
 pub mod transport_channel_pool;
 pub mod validate;
 

--- a/lib/api/src/grpc/ops.rs
+++ b/lib/api/src/grpc/ops.rs
@@ -1,0 +1,23 @@
+use crate::grpc::HardwareUsage;
+
+impl HardwareUsage {
+    pub fn add(&mut self, other: Self) {
+        let Self {
+            cpu,
+            payload_io_read,
+            payload_io_write,
+            payload_index_io_read,
+            payload_index_io_write,
+            vector_io_read,
+            vector_io_write,
+        } = other;
+
+        self.cpu += cpu;
+        self.payload_io_read += payload_io_read;
+        self.payload_io_write += payload_io_write;
+        self.payload_index_io_read += payload_index_io_read;
+        self.payload_index_io_write += payload_index_io_write;
+        self.vector_io_read += vector_io_read;
+        self.vector_io_write += vector_io_write;
+    }
+}

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -17,6 +17,7 @@ service PointsInternal {
   rpc ClearPayload (ClearPayloadPointsInternal) returns (PointsOperationResponseInternal) {}
   rpc CreateFieldIndex (CreateFieldIndexCollectionInternal) returns (PointsOperationResponseInternal) {}
   rpc DeleteFieldIndex (DeleteFieldIndexCollectionInternal) returns (PointsOperationResponseInternal) {}
+  rpc UpdateBatch (UpdateBatchInternal) returns (PointsOperationResponseInternal) {}
   rpc CoreSearchBatch (CoreSearchBatchPointsInternal) returns (SearchBatchResponse) {}
   rpc Scroll (ScrollPointsInternal) returns (ScrollResponse) {}
   rpc Count (CountPointsInternal) returns (CountResponse) {}
@@ -95,6 +96,28 @@ message DeleteFieldIndexCollectionInternal {
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
 }
+
+message UpdateOperation {
+    oneof update {
+        SyncPointsInternal sync = 1;
+        UpsertPointsInternal upsert = 2;
+        DeletePointsInternal delete = 3;
+        UpdateVectorsInternal update_vectors = 4;
+        DeleteVectorsInternal delete_vectors = 5;
+        SetPayloadPointsInternal set_payload = 6;
+        SetPayloadPointsInternal overwrite_payload = 7;
+        DeletePayloadPointsInternal delete_payload = 8;
+        ClearPayloadPointsInternal clear_payload = 9;
+        CreateFieldIndexCollectionInternal create_field_index = 10;
+        DeleteFieldIndexCollectionInternal delete_field_index = 11;
+    }
+}
+
+
+message UpdateBatchInternal {
+    repeated UpdateOperation operations = 1;
+}
+
 
 // Has to be backward compatible with `PointsOperationResponse`!
 message PointsOperationResponseInternal {

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -195,6 +195,25 @@ impl Validate for grpc::condition::ConditionOneOf {
     }
 }
 
+impl Validate for grpc::update_operation::Update {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        use grpc::update_operation::Update;
+        match self {
+            Update::Sync(op) => op.validate(),
+            Update::Upsert(op) => op.validate(),
+            Update::Delete(op) => op.validate(),
+            Update::UpdateVectors(op) => op.validate(),
+            Update::DeleteVectors(op) => op.validate(),
+            Update::SetPayload(op) => op.validate(),
+            Update::OverwritePayload(op) => op.validate(),
+            Update::DeletePayload(op) => op.validate(),
+            Update::ClearPayload(op) => op.validate(),
+            Update::CreateFieldIndex(op) => op.validate(),
+            Update::DeleteFieldIndex(op) => op.validate(),
+        }
+    }
+}
+
 impl Validate for grpc::FieldCondition {
     fn validate(&self) -> Result<(), ValidationErrors> {
         let grpc::FieldCondition {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -716,6 +716,10 @@ async fn transfer_operations_batch(
     wait: bool,
     hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<()> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+
     let supports_update_batching =
         remote_shard.check_version(&MINIMAL_VERSION_FOR_BATCH_WAL_TRANSFER);
 


### PR DESCRIPTION
Speed-up wal-delta transfer.

---

ToDo:

- [x] use batch update API instead of independent requests
- [x] do not wait for updates except for the last one
- [ ] run experiment
- [ ] make batch size larger (optional) 