### PR TITLE
Add `recover_partial_snapshot_from` endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ prometheus = { version = "0.14.0", default-features = false }
 validator = { workspace = true }
 jsonwebtoken = "9.3.1"
 
+tempfile = { workspace = true }
+
 # Consensus related crates
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -196,7 +196,7 @@ async fn upload_snapshot(
 
         if let Some(checksum) = &params.checksum {
             let snapshot_checksum = sha_256::hash_file(snapshot.file.path()).await?;
-            if !sha_256::hashes_equal(&snapshot_checksum, &checksum) {
+            if !sha_256::hashes_equal(&snapshot_checksum, checksum) {
                 return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
             }
         }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -5,7 +5,7 @@ use actix_multipart::form::tempfile::TempFile;
 use actix_web::{Responder, Result, delete, get, post, put, web};
 use actix_web_validator as valid;
 use collection::common::file_utils::move_file;
-use collection::common::sha_256::{hash_file, hashes_equal};
+use collection::common::sha_256;
 use collection::common::snapshot_stream::SnapshotStream;
 use collection::operations::snapshot_ops::{
     ShardSnapshotRecover, SnapshotPriority, SnapshotRecover,
@@ -195,8 +195,8 @@ async fn upload_snapshot(
         access.check_global_access(AccessRequirements::new().manage())?;
 
         if let Some(checksum) = &params.checksum {
-            let snapshot_checksum = hash_file(snapshot.file.path()).await?;
-            if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
+            let snapshot_checksum = sha_256::hash_file(snapshot.file.path()).await?;
+            if !sha_256::hashes_equal(&snapshot_checksum, &checksum) {
                 return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
             }
         }
@@ -476,8 +476,8 @@ async fn upload_shard_snapshot(
 
         let future = async {
             if let Some(checksum) = checksum {
-                let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
-                if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
+                let snapshot_checksum = sha_256::hash_file(form.snapshot.file.path()).await?;
+                if !sha_256::hashes_equal(&snapshot_checksum, &checksum) {
                     return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
                 }
             }
@@ -617,8 +617,8 @@ async fn recover_partial_snapshot(
 
         let future = async {
             if let Some(checksum) = checksum {
-                let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
-                if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
+                let snapshot_checksum = sha_256::hash_file(form.snapshot.file.path()).await?;
+                if !sha_256::hashes_equal(&snapshot_checksum, &checksum) {
                     return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
                 }
             }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -475,12 +475,12 @@ async fn upload_shard_snapshot(
             .issue_pass(&collection);
 
         let future = async {
-        if let Some(checksum) = checksum {
-            let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
-            if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
-                return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
+            if let Some(checksum) = checksum {
+                let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
+                if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
+                    return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
+                }
             }
-        }
 
             let collection = dispatcher
                 .toc(&access, &pass)
@@ -616,12 +616,12 @@ async fn recover_partial_snapshot(
             .issue_pass(&collection);
 
         let future = async {
-        if let Some(checksum) = checksum {
-            let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
-            if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
-                return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
+            if let Some(checksum) = checksum {
+                let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
+                if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
+                    return Err(StorageError::checksum_mismatch(snapshot_checksum, checksum));
+                }
             }
-        }
 
             let collection = dispatcher
                 .toc(&access, &pass)

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -13,12 +13,12 @@ use collection::operations::snapshot_ops::{
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::replica_set::snapshots::RecoveryType;
 use collection::shards::shard::ShardId;
-use futures::{FutureExt as _, TryFutureExt as _};
+use futures::{FutureExt as _, StreamExt as _, TryFutureExt as _};
 use reqwest::Url;
 use schemars::JsonSchema;
 use segment::data_types::segment_manifest::SegmentManifests;
 use serde::{Deserialize, Serialize};
-use storage::content_manager::errors::StorageError;
+use storage::content_manager::errors::{StorageError, StorageResult};
 use storage::content_manager::snapshots::recover::do_recover_from_snapshot;
 use storage::content_manager::snapshots::{
     do_create_full_snapshot, do_delete_collection_snapshot, do_delete_full_snapshot,
@@ -27,6 +27,7 @@ use storage::content_manager::snapshots::{
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::{Access, AccessRequirements};
+use tokio::io::AsyncWriteExt as _;
 use uuid::Uuid;
 use validator::Validate;
 
@@ -652,6 +653,99 @@ async fn recover_partial_snapshot(
     helpers::time_or_accept(future, wait.unwrap_or(true)).await
 }
 
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct PartialSnapshotRecoverFrom {
+    peer_url: Url,
+    api_key: Option<String>,
+}
+
+#[post("/collections/{collection}/shards/{shard}/snapshot/partial/recover_from")]
+async fn recover_partial_snapshot_from(
+    dispatcher: web::Data<Dispatcher>,
+    http_client: web::Data<HttpClient>,
+    path: web::Path<(String, ShardId)>,
+    query: web::Query<SnapshottingParam>,
+    web::Json(request): web::Json<PartialSnapshotRecoverFrom>,
+    ActixAccess(access): ActixAccess,
+) -> impl Responder {
+    let (collection_name, shard_id) = path.into_inner();
+    let PartialSnapshotRecoverFrom { peer_url, api_key } = request;
+    let SnapshottingParam { wait } = query.into_inner();
+
+    // nothing to verify
+    let pass = new_unchecked_verification_pass();
+
+    let future = cancel::future::spawn_cancel_on_drop(async move |cancel| {
+        let cancel_safe = async {
+            let toc = dispatcher.toc(&access, &pass);
+
+            let collection_pass = access
+                .check_global_access(AccessRequirements::new().manage())?
+                .issue_pass(&collection_name)
+                .into_static();
+
+            let collection = toc.get_collection(&collection_pass).await?;
+            collection.assert_shard_exists(shard_id).await?;
+
+            let http_client = http_client.client(api_key.as_deref())?;
+
+            let create_snapshot_url = format!(
+                "{peer_url}/collections/{collection_name}/shards/{shard_id}/snapshot/partial/create"
+            );
+
+            let snapshot_manifest = collection.get_partial_snapshot_manifest(shard_id).await?;
+
+            let download_dir = toc.optional_temp_or_snapshot_temp_path()?;
+            let (partial_snapshot_file, partial_snapshot_temp_path) = tempfile::Builder::new()
+                .prefix("partial-snapshot")
+                .suffix(".download")
+                .tempfile_in(&download_dir)?
+                .into_parts();
+
+            let response = http_client
+                .post(create_snapshot_url)
+                .json(&snapshot_manifest)
+                .send()
+                .await?
+                .error_for_status()?;
+
+            let mut partial_snapshot_file = tokio::fs::File::from_std(partial_snapshot_file);
+            let mut partial_snapshot_stream = response.bytes_stream();
+
+            while let Some(chunk) = partial_snapshot_stream.next().await {
+                partial_snapshot_file.write_all(&chunk?).await?;
+            }
+
+            partial_snapshot_file.flush().await?;
+
+            // TODO: Check partial snapshot checksum!?
+            //
+            // E.g., we can return snapshot checksum as HTTP header in `create_partial_snapshot` response
+
+            StorageResult::Ok((collection, partial_snapshot_temp_path))
+        };
+
+        let (collection, partial_snapshot_temp_path) =
+            cancel::future::cancel_on_token(cancel.clone(), cancel_safe).await??;
+
+        common::snapshots::recover_shard_snapshot_impl(
+            dispatcher.toc(&access, &pass),
+            &collection,
+            shard_id,
+            &partial_snapshot_temp_path,
+            SnapshotPriority::NoSync,
+            RecoveryType::Partial,
+            cancel,
+        )
+        .await?;
+
+        Ok(true)
+    })
+    .map(|res| res.map_err(Into::into).and_then(|res| res));
+
+    helpers::time_or_accept(future, wait.unwrap_or(true)).await
+}
+
 #[get("/collections/{collection}/shards/{shard}/snapshot/partial/manifest")]
 async fn get_partial_snapshot_manifest(
     dispatcher: web::Data<Dispatcher>,
@@ -699,5 +793,6 @@ pub fn config_snapshots_api(cfg: &mut web::ServiceConfig) {
         .service(delete_shard_snapshot)
         .service(create_partial_snapshot)
         .service(recover_partial_snapshot)
+        .service(recover_partial_snapshot_from)
         .service(get_partial_snapshot_manifest);
 }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -615,6 +615,7 @@ async fn recover_partial_snapshot(
             .check_global_access(AccessRequirements::new().manage())?
             .issue_pass(&collection);
 
+        let future = async {
         if let Some(checksum) = checksum {
             let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
             if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
@@ -622,7 +623,6 @@ async fn recover_partial_snapshot(
             }
         }
 
-        let future = async {
             let collection = dispatcher
                 .toc(&access, &pass)
                 .get_collection(&collection_pass)

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -474,6 +474,7 @@ async fn upload_shard_snapshot(
             .check_global_access(AccessRequirements::new().manage())?
             .issue_pass(&collection);
 
+        let future = async {
         if let Some(checksum) = checksum {
             let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
             if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
@@ -481,7 +482,6 @@ async fn upload_shard_snapshot(
             }
         }
 
-        let future = async {
             let collection = dispatcher
                 .toc(&access, &pass)
                 .get_collection(&collection_pass)

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -709,7 +709,9 @@ async fn recover_partial_snapshot_from(
                 .await?
                 .error_for_status()?;
 
-            let mut partial_snapshot_file = tokio::fs::File::from_std(partial_snapshot_file);
+            let mut partial_snapshot_file =
+                tokio::io::BufWriter::new(tokio::fs::File::from_std(partial_snapshot_file));
+
             let mut partial_snapshot_stream = response.bytes_stream();
 
             while let Some(chunk) = partial_snapshot_stream.next().await {

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use collection::collection::Collection;
-use collection::common::sha_256::{hash_file, hashes_equal};
+use collection::common::sha_256;
 use collection::common::snapshot_stream::SnapshotStream;
 use collection::operations::snapshot_ops::{
     ShardSnapshotLocation, SnapshotDescription, SnapshotPriority,
@@ -178,8 +178,8 @@ pub async fn recover_shard_snapshot(
             };
 
             if let Some(checksum) = checksum {
-                let snapshot_checksum = hash_file(&snapshot_path).await?;
-                if !hashes_equal(&snapshot_checksum, &checksum) {
+                let snapshot_checksum = sha_256::hash_file(&snapshot_path).await?;
+                if !sha_256::hashes_equal(&snapshot_checksum, &checksum) {
                     return Err(StorageError::bad_input(format!(
                         "Snapshot checksum mismatch: expected {checksum}, got {snapshot_checksum}"
                     )));

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use collection::collection::Collection;
-use collection::common::sha_256::hash_file;
+use collection::common::sha_256::{hash_file, hashes_equal};
 use collection::common::snapshot_stream::SnapshotStream;
 use collection::operations::snapshot_ops::{
     ShardSnapshotLocation, SnapshotDescription, SnapshotPriority,
@@ -179,7 +179,7 @@ pub async fn recover_shard_snapshot(
 
             if let Some(checksum) = checksum {
                 let snapshot_checksum = hash_file(&snapshot_path).await?;
-                if snapshot_checksum != checksum {
+                if !hashes_equal(&snapshot_checksum, &checksum) {
                     return Err(StorageError::bad_input(format!(
                         "Snapshot checksum mismatch: expected {checksum}, got {snapshot_checksum}"
                     )));

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -135,8 +135,8 @@ pub async fn recover_shard_snapshot(
     // - `recover_shard_snapshot_impl` is *not* cancel safe
     //   - but the task is *spawned* on the runtime and won't be cancelled, if request is cancelled
 
-    cancel::future::spawn_cancel_on_drop(move |cancel| async move {
-        let future = async {
+    cancel::future::spawn_cancel_on_drop(async move |cancel| {
+        let cancel_safe = async {
             let collection = toc.get_collection(&collection_pass).await?;
             collection.assert_shard_exists(shard_id).await?;
 
@@ -186,11 +186,11 @@ pub async fn recover_shard_snapshot(
                 }
             }
 
-            Result::<_, StorageError>::Ok((collection, snapshot_path))
+            Ok((collection, snapshot_path))
         };
 
         let (collection, snapshot_path) =
-            cancel::future::cancel_on_token(cancel.clone(), future).await??;
+            cancel::future::cancel_on_token(cancel.clone(), cancel_safe).await??;
 
         // `recover_shard_snapshot_impl` is *not* cancel safe
         let result = recover_shard_snapshot_impl(


### PR DESCRIPTION
This PR adds `recover_partial_snapshot_from` endpoint, that is required to allow cluster manager to use partial snapshot API.

__TODO:__
- [x] update integration tests

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
