### PR TITLE
Fix CI clippy lint for flush_bench

### DIFF
--- a/lib/gridstore/benches/flush_bench.rs
+++ b/lib/gridstore/benches/flush_bench.rs
@@ -10,7 +10,7 @@ pub fn flush_bench(c: &mut Criterion) {
 
     // Test sequential updates' flushing performance
     for unflushed_updates in [100, 1_000, prepopulation_size].iter() {
-        let bench_name = format!("flush after {} sequential writes", unflushed_updates);
+        let bench_name = format!("flush after {unflushed_updates} sequential writes");
 
         c.bench_function(&bench_name, |b| {
             // Setup: Create a storage with a specified number of records
@@ -48,7 +48,7 @@ pub fn flush_bench(c: &mut Criterion) {
 
     // Test random updates' flushing performance
     for unflushed_updates in [100, 1_000, prepopulation_size].iter() {
-        let bench_name = format!("flush after {} random writes", unflushed_updates);
+        let bench_name = format!("flush after {unflushed_updates} random writes");
 
         c.bench_function(&bench_name, |b| {
             // Setup: Create a storage with a specified number of records


### PR DESCRIPTION
CI is currently broken with

```
error: variables can be used directly in the `format!` string
  --> lib/gridstore/benches/flush_bench.rs:13:26
   |
13 |         let bench_name = format!("flush after {} sequential writes", unflushed_updates);
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
   |
13 -         let bench_name = format!("flush after {} sequential writes", unflushed_updates);
13 +         let bench_name = format!("flush after {unflushed_updates} sequential writes");
   |

error: variables can be used directly in the `format!` string
  --> lib/gridstore/benches/flush_bench.rs:51:26
   |
51 |         let bench_name = format!("flush after {} random writes", unflushed_updates);
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
   |
51 -         let bench_name = format!("flush after {} random writes", unflushed_updates);
51 +         let bench_name = format!("flush after {unflushed_updates} random writes");
   |

error: could not compile `gridstore` (bench "flush_bench") due to 2 previous errors
```