### PR TITLE
Strict mode detects full scan on query

### DIFF
--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -8,7 +8,7 @@ use crate::operations::universal_query::collection_query::{
 };
 
 impl Query {
-    fn check_strict_mode(
+    async fn check_strict_mode(
         &self,
         collection: &Collection,
         strict_mode_config: &StrictModeConfig,
@@ -35,6 +35,54 @@ impl Query {
         }
         Ok(())
     }
+
+    /// Check that the query does not perform a fullscan based on the collection configuration.
+    async fn check_fullscan(
+        &self,
+        using: &str,
+        collection: &Collection,
+        strict_mode_config: &StrictModeConfig,
+    ) -> CollectionResult<()> {
+        // Check only applies on `search_allow_exact`
+        if strict_mode_config.search_allow_exact == Some(false) {
+            match &self {
+                Query::Fusion(_) | Query::OrderBy(_) | Query::Formula(_) | Query::Sample(_) => (),
+                Query::Vector(_) => {
+                    let config = collection.collection_config.read().await;
+
+                    // ignore sparse vectors
+                    let query_targets_sparse = config
+                        .params
+                        .sparse_vectors
+                        .as_ref()
+                        .is_some_and(|sparse| sparse.contains_key(using));
+                    if query_targets_sparse {
+                        // sparse vectors are always indexed
+                        return Ok(());
+                    }
+
+                    // check HNSW configuration for vector
+                    let vector_hnsw_config = &config
+                        .params
+                        .vectors
+                        .get_params(using)
+                        .and_then(|param| param.hnsw_config.as_ref());
+
+                    let vector_hnsw_m = vector_hnsw_config.and_then(|hnsw| hnsw.m);
+                    // TODO(strict-mode) check also payload_m if if there is a filter by tenant/principal
+                    if vector_hnsw_m == Some(0) {
+                        return Err(CollectionError::strict_mode(
+                            format!(
+                                "Fullscan forbidden on '{using}' – vector indexing is disabled (hnsw_config.m = 0)"
+                            ),
+                            "Enable vector indexing or use a prefetch query before rescoring",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 impl StrictModeVerification for CollectionQueryRequest {
@@ -45,12 +93,22 @@ impl StrictModeVerification for CollectionQueryRequest {
     ) -> CollectionResult<()> {
         // CollectionPrefetch.prefetch is of type CollectionPrefetch (recursive type)
         for prefetch in &self.prefetch {
-            Box::pin(prefetch.check_strict_mode(collection, strict_mode_config)).await?;
+            prefetch
+                .check_strict_mode(collection, strict_mode_config)
+                .await?;
         }
 
         if let Some(query) = self.query.as_ref() {
+            // check query can perform fullscan when not rescoring
+            if self.prefetch.is_empty() {
+                query
+                    .check_fullscan(&self.using, collection, strict_mode_config)
+                    .await?;
+            }
             // check for unindexed fields in formula
-            query.check_strict_mode(collection, strict_mode_config)?
+            query
+                .check_strict_mode(collection, strict_mode_config)
+                .await?
         }
 
         Ok(())
@@ -89,8 +147,14 @@ impl StrictModeVerification for CollectionPrefetch {
         }
 
         if let Some(query) = self.query.as_ref() {
+            // check if prefetch can perform a fullscan
+            query
+                .check_fullscan(&self.using, collection, strict_mode_config)
+                .await?;
             // check for unindexed fields in formula
-            query.check_strict_mode(collection, strict_mode_config)?
+            query
+                .check_strict_mode(collection, strict_mode_config)
+                .await?
         }
 
         Ok(())
@@ -124,8 +188,16 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
         strict_mode_config: &StrictModeConfig,
     ) -> CollectionResult<()> {
         if let Some(query) = self.query.as_ref() {
+            // check query can perform fullscan when not rescoring
+            if self.prefetch.is_empty() {
+                query
+                    .check_fullscan(&self.using, collection, strict_mode_config)
+                    .await?;
+            }
             // check for unindexed fields in formula
-            query.check_strict_mode(collection, strict_mode_config)?
+            query
+                .check_strict_mode(collection, strict_mode_config)
+                .await?
         }
         // check for unindexed fields targeted by group_by
         check_grouping_field(&self.group_by, collection, strict_mode_config)?;


### PR DESCRIPTION
This PR implements fully the strict mode for `search_allow_exact` to make sure no search query can be issued against a disabled HNSW index.

The check takes into account the presence of prefetches to still allow the rescoring use case anyway. 