### PR TITLE
Fix point comparison in test

### DIFF
--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -5,7 +5,7 @@ import shutil
 import requests
 from time import sleep
 
-from .fixtures import create_collection, upsert_random_points, random_dense_vector, search, scroll
+from .fixtures import create_collection, upsert_random_points, scroll
 from .utils import *
 
 N_PEERS = 3

--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -115,9 +115,8 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
 
     query_city = "London"
 
-    query_vector = random_dense_vector()
-    initial_search_result = search(peer_api_uris[0], query_vector, query_city)
-    assert len(initial_search_result) > 0
+    initial_scroll_result = scroll(peer_api_uris[0], query_city)
+    assert len(initial_scroll_result) > 0
 
     snapshot_name = create_snapshot(peer_api_uris[-1])
     assert snapshot_name is not None
@@ -208,11 +207,11 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
     for shard in remote_shards:
         assert shard["state"] == "Active"
 
-    # Check that 'search' returns the same results after recovery
-    new_search_result = search(peer_api_uris[-1], query_vector, query_city)
-    assert len(new_search_result) == len(initial_search_result)
-    new_ids = [r["id"] for r in new_search_result]
-    initial_ids = [r["id"] for r in initial_search_result]
+    # Check that 'scroll' returns the same results after recovery
+    new_scroll_result = scroll(peer_api_uris[-1], query_city)
+    assert len(new_scroll_result) == len(initial_scroll_result)
+    new_ids = [r["id"] for r in new_scroll_result]
+    initial_ids = [r["id"] for r in initial_scroll_result]
     assert new_ids == initial_ids, (new_ids, initial_ids)
 
 
@@ -243,11 +242,8 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     upsert_random_points(peer_api_uris[0], n_points)
 
     query_city = "London"
-    query_vector = random_dense_vector()
-    initial_search_result = search(
-        peer_api_uris[0], query_vector, query_city
-    )
-    assert len(initial_search_result) > 0
+    initial_scroll_result = scroll(peer_api_uris[0], query_city)
+    assert len(initial_scroll_result) > 0
 
     # Simulate killing on snapshot recovery (corrupting shard dir and adding a shard initializing flag)
     # this can happen in practice when a node is killed while shard directory was being moved from /qdrant/snapshots to /qdrant/storage
@@ -346,9 +342,9 @@ def test_dirty_shard_handling_with_active_replicas(tmp_path: pathlib.Path, trans
     for shard in remote_shards:
         assert shard["state"] == "Active"
 
-    # Check that 'search' returns the same results after recovery
-    new_search_result = search(peer_api_uris[-1], query_vector, query_city)
-    assert len(new_search_result) == len(initial_search_result)
-    new_ids = [r["id"] for r in new_search_result]
-    initial_ids = [r["id"] for r in initial_search_result]
+    # Check that 'scroll' returns the same results after recovery
+    new_scroll_result = scroll(peer_api_uris[-1], query_city)
+    assert len(new_scroll_result) == len(initial_scroll_result)
+    new_ids = [r["id"] for r in new_scroll_result]
+    initial_ids = [r["id"] for r in initial_scroll_result]
     assert new_ids == initial_ids, (new_ids, initial_ids)


### PR DESCRIPTION
Resolve https://github.com/qdrant/qdrant/issues/6467

We basically changed 1 one of the points and hence final results often changed. Now we upsert that with `offset=10000` so it doesn't affect the existing results (scroll returns 10 points by default, it's almost impossible that it will get point ID = 10k in those first 10 results). 