### PR TITLE
Disable nextest retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,4 @@
 [profile.ci]
-# Retry tests before failing them.
-retries = { backoff = "exponential", count = 2, delay = "2s" }
 # Do not cancel the test run on the first failure.
 fail-fast = false
 # Print out output for failing tests as soon as they fail, and also at the end


### PR DESCRIPTION
The current retry setup for failed tests is too comfortable.

It allowed us to not think too much about the problem of flaky tests and have issues piling on to the side 

Exhibit A: https://github.com/qdrant/qdrant/issues?q=is%3Aissue%20state%3Aopen%20Flaky

I propose to remove the retry mechanism to force us to fix our tests for real.