### PR TITLE
Fix flaky test rate limiter

### DIFF
--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(limiter.tokens, 599.0);
 
         assert_eq!(limiter.try_consume(10.0), Ok(()));
-        assert_eq_floats(limiter.tokens, 589.0, 0.001);
+        assert_eq_floats(limiter.tokens, 589.0, 0.01);
     }
 
     #[test]


### PR DESCRIPTION
Fixing https://github.com/qdrant/qdrant/issues/5850

There is no need for a high precision comparison here.