### PR TITLE
Deterministic HNSW builder

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -505,8 +505,9 @@ pub trait SegmentOptimizer {
                 description: "optimization cancelled while waiting for budget".to_string(),
             })?;
 
+        let mut rng = rand::rng();
         let mut optimized_segment: Segment =
-            segment_builder.build(indexing_permit, stopped, hw_counter)?;
+            segment_builder.build(indexing_permit, stopped, &mut rng, hw_counter)?;
 
         // Delete points
         let deleted_points_snapshot = proxy_deleted_points

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -66,7 +66,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-fn make_segment_index<R: Rng + ?Sized>(rnd: &mut R, distance: Distance) -> HNSWIndex {
+fn make_segment_index<R: Rng + ?Sized>(rng: &mut R, distance: Distance) -> HNSWIndex {
     let stopped = AtomicBool::new(false);
     let segment_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -93,7 +93,7 @@ fn make_segment_index<R: Rng + ?Sized>(rnd: &mut R, distance: Distance) -> HNSWI
     let mut segment = build_segment(segment_dir.path(), &segment_config, true).unwrap();
     for n in 0..NUM_POINTS {
         let idx = (n as u64).into();
-        let multi_vec = random_multi_vector(rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT);
+        let multi_vec = random_multi_vector(rng, VECTOR_DIM, NUM_VECTORS_PER_POINT);
         let named_vectors = only_default_multi_vector(&multi_vec);
         segment
             .upsert_point(n as SeqNumberType, idx, named_vectors, &hw_counter)
@@ -127,6 +127,7 @@ fn make_segment_index<R: Rng + ?Sized>(rnd: &mut R, distance: Distance) -> HNSWI
             old_indices: &[],
             gpu_device: None,
             stopped: &stopped,
+            rng,
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -118,8 +118,8 @@ pub fn random_bool_payload<R: Rng + ?Sized>(
         .collect_vec()
 }
 
-pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> DenseVector {
-    (0..size).map(|_| rnd_gen.random()).collect()
+pub fn random_vector<R: Rng + ?Sized>(rng: &mut R, size: usize) -> DenseVector {
+    (0..size).map(|_| rng.random()).collect()
 }
 
 pub fn random_dense_byte_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> DenseVector {
@@ -133,13 +133,13 @@ pub fn random_dense_byte_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -
 }
 
 pub fn random_multi_vector<R: Rng + ?Sized>(
-    rnd_gen: &mut R,
+    rng: &mut R,
     vector_size: usize,
     num_vector_per_points: usize,
 ) -> MultiDenseVectorInternal {
     let mut vectors = vec![];
     for _ in 0..num_vector_per_points {
-        let vec = random_vector(rnd_gen, vector_size);
+        let vec = random_vector(rng, vector_size);
         vectors.extend(vec);
     }
     MultiDenseVectorInternal::new(vectors, vector_size)

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -28,7 +28,7 @@ fn test_graph_connectivity() {
     let distance = Distance::Cosine;
     let full_scan_threshold = 10_000;
 
-    let mut rnd = rng();
+    let mut rng = rng();
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -38,7 +38,7 @@ fn test_graph_connectivity() {
     let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
         segment
             .upsert_point(
@@ -79,6 +79,7 @@ fn test_graph_connectivity() {
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -16,6 +16,7 @@ use common::small_uint::U24;
 use common::types::PointOffsetType;
 use io::storage_version::StorageVersion;
 use itertools::Itertools;
+use rand::Rng;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -455,10 +456,11 @@ impl SegmentBuilder {
         Ok(true)
     }
 
-    pub fn build(
+    pub fn build<R: Rng + ?Sized>(
         self,
         permit: ResourcePermit,
         stopped: &AtomicBool,
+        rng: &mut R,
         hw_counter: &HardwareCounterCell,
     ) -> Result<Segment, OperationError> {
         let (temp_dir, destination_path) = {
@@ -590,6 +592,7 @@ impl SegmentBuilder {
                         old_indices: &old_indices.remove(vector_name).unwrap(),
                         gpu_device: gpu_device.as_ref(),
                         stopped,
+                        rng,
                         feature_flags: feature_flags(),
                     },
                 )?;

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -31,7 +31,7 @@ fn test_batch_and_single_request_equivalency() {
     let num_payload_values = 2;
     let dim = 8;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
@@ -52,9 +52,9 @@ fn test_batch_and_single_request_equivalency() {
 
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         segment
@@ -71,10 +71,10 @@ fn test_batch_and_single_request_equivalency() {
     }
 
     for _ in 0..10 {
-        let query_vector_1 = random_vector(&mut rnd, dim).into();
-        let query_vector_2 = random_vector(&mut rnd, dim).into();
+        let query_vector_1 = random_vector(&mut rng, dim).into();
+        let query_vector_2 = random_vector(&mut rng, dim).into();
 
-        let payload_value = random_int_payload(&mut rnd, 1..=1).pop().unwrap();
+        let payload_value = random_int_payload(&mut rng, 1..=1).pop().unwrap();
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
             JsonPath::new(int_key),
@@ -162,6 +162,7 @@ fn test_batch_and_single_request_equivalency() {
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -169,10 +170,10 @@ fn test_batch_and_single_request_equivalency() {
     .unwrap();
 
     for _ in 0..10 {
-        let query_vector_1 = random_vector(&mut rnd, dim).into();
-        let query_vector_2 = random_vector(&mut rnd, dim).into();
+        let query_vector_1 = random_vector(&mut rng, dim).into();
+        let query_vector_2 = random_vector(&mut rng, dim).into();
 
-        let payload_value = random_int_payload(&mut rnd, 1..=1).pop().unwrap();
+        let payload_value = random_int_payload(&mut rng, 1..=1).pop().unwrap();
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
             JsonPath::new(int_key),

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -69,7 +69,7 @@ fn test_byte_storage_hnsw(
     let full_scan_threshold = 0;
     let num_payload_values = 2;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir_float = Builder::new()
         .prefix("segment_dir_float")
@@ -113,9 +113,9 @@ fn test_byte_storage_hnsw(
 
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_dense_byte_vector(&mut rnd, dim);
+        let vector = random_dense_byte_vector(&mut rng, dim);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         let hw_counter = HardwareCounterCell::new();
@@ -193,6 +193,7 @@ fn test_byte_storage_hnsw(
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -203,10 +204,10 @@ fn test_byte_storage_hnsw(
     let mut hits = 0;
     let attempts = 100;
     for i in 0..attempts {
-        let query = random_query(&query_variant, &mut rnd, dim);
+        let query = random_query(&query_variant, &mut rng, dim);
 
         let range_size = 40;
-        let left_range = rnd.random_range(0..400);
+        let left_range = rng.random_range(0..400);
         let right_range = left_range + range_size;
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -209,7 +209,7 @@ fn test_byte_storage_binary_quantization_hnsw(
     let full_scan_threshold = 16; // KB
     let num_payload_values = 2;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir_byte = Builder::new().prefix("segment_dir_byte").tempdir().unwrap();
     let quantized_data_path = dir_byte.path();
@@ -251,9 +251,9 @@ fn test_byte_storage_binary_quantization_hnsw(
 
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim, storage_data_type);
+        let vector = random_vector(&mut rng, dim, storage_data_type);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         segment_byte
@@ -338,6 +338,7 @@ fn test_byte_storage_binary_quantization_hnsw(
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -348,10 +349,10 @@ fn test_byte_storage_binary_quantization_hnsw(
     let mut sames = 0;
     let attempts = 100;
     for _ in 0..attempts {
-        let query = random_query(&query_variant, &mut rnd, dim, storage_data_type);
+        let query = random_query(&query_variant, &mut rng, dim, storage_data_type);
 
         let range_size = 40;
-        let left_range = rnd.random_range(0..400);
+        let left_range = rng.random_range(0..400);
         let right_range = left_range + range_size;
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -99,7 +99,11 @@ fn test_rebuild_with_removed_vectors() {
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let merged_segment: Segment = builder.build(permit, &stopped, &hw_counter).unwrap();
+    let mut rng = rand::rng();
+
+    let merged_segment: Segment = builder
+        .build(permit, &stopped, &mut rng, &hw_counter)
+        .unwrap();
 
     let merged_points_count = merged_segment.available_point_count();
 

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -7,7 +7,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::flags::FeatureFlags;
 use common::types::PointOffsetType;
 use itertools::Itertools;
-use rand::{Rng, rng};
+use rand::Rng;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
@@ -38,7 +38,7 @@ fn exact_search_test() {
     let indexing_threshold = 500; // num vectors
     let num_payload_values = 2;
 
-    let mut rnd = rng();
+    let mut rng = rand::rng();
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -50,9 +50,9 @@ fn exact_search_test() {
     let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         segment
@@ -141,6 +141,7 @@ fn exact_search_test() {
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -150,7 +151,7 @@ fn exact_search_test() {
     let top = 3;
     let attempts = 50;
     for _i in 0..attempts {
-        let query = random_vector(&mut rnd, dim).into();
+        let query = random_vector(&mut rng, dim).into();
 
         let index_result = hnsw_index
             .search(
@@ -177,7 +178,7 @@ fn exact_search_test() {
         );
 
         let range_size = 40;
-        let left_range = rnd.random_range(0..400);
+        let left_range = rng.random_range(0..400);
         let right_range = left_range + range_size;
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -62,7 +62,7 @@ fn _test_filterable_hnsw(
     let indexing_threshold = 500; // num vectors
     let num_payload_values = 2;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -73,9 +73,9 @@ fn _test_filterable_hnsw(
     let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         segment
@@ -162,6 +162,7 @@ fn _test_filterable_hnsw(
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -172,10 +173,10 @@ fn _test_filterable_hnsw(
     let mut hits = 0;
     let attempts = 100;
     for i in 0..attempts {
-        let query = random_query(&query_variant, &mut rnd, dim);
+        let query = random_query(&query_variant, &mut rng, dim);
 
         let range_size = 40;
-        let left_range = rnd.random_range(0..400);
+        let left_range = rng.random_range(0..400);
         let right_range = left_range + range_size;
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -67,7 +67,7 @@ fn test_gpu_filterable_hnsw() {
     let full_scan_threshold = 32; // KB
     let num_payload_values = 2;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -79,9 +79,9 @@ fn test_gpu_filterable_hnsw() {
     let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         segment
@@ -141,6 +141,7 @@ fn test_gpu_filterable_hnsw() {
             permit,
             old_indices: &[],
             gpu_device: Some(&locked_device), // enable GPU
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -151,10 +152,10 @@ fn test_gpu_filterable_hnsw() {
     let mut hits = 0;
     let attempts = 100;
     for i in 0..attempts {
-        let query = random_vector(&mut rnd, dim).into();
+        let query = random_vector(&mut rng, dim).into();
 
         let range_size = 40;
-        let left_range = rnd.random_range(0..400);
+        let left_range = rng.random_range(0..400);
         let right_range = left_range + range_size;
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -26,15 +26,15 @@ use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 3;
 
-fn random_discovery_query<R: Rng + ?Sized>(rnd: &mut R, dim: usize) -> QueryVector {
-    let num_pairs: usize = rnd.random_range(1..MAX_EXAMPLE_PAIRS);
+fn random_discovery_query<R: Rng + ?Sized>(rng: &mut R, dim: usize) -> QueryVector {
+    let num_pairs: usize = rng.random_range(1..MAX_EXAMPLE_PAIRS);
 
-    let target = random_vector(rnd, dim).into();
+    let target = random_vector(rng, dim).into();
 
     let pairs = (0..num_pairs)
         .map(|_| {
-            let positive = random_vector(rnd, dim).into();
-            let negative = random_vector(rnd, dim).into();
+            let positive = random_vector(rng, dim).into();
+            let negative = random_vector(rng, dim).into();
             ContextPair { positive, negative }
         })
         .collect_vec();
@@ -42,8 +42,8 @@ fn random_discovery_query<R: Rng + ?Sized>(rnd: &mut R, dim: usize) -> QueryVect
     DiscoveryQuery::new(target, pairs).into()
 }
 
-fn get_random_keyword_of<R: Rng + ?Sized>(num_options: usize, rnd: &mut R) -> String {
-    let random_number = rnd.random_range(0..num_options);
+fn get_random_keyword_of<R: Rng + ?Sized>(num_options: usize, rng: &mut R) -> String {
+    let random_number = rng.random_range(0..num_options);
     format!("keyword_{random_number}")
 }
 
@@ -62,7 +62,7 @@ fn hnsw_discover_precision() {
     let distance = Distance::Cosine;
     let full_scan_threshold = 16; // KB
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -73,7 +73,7 @@ fn hnsw_discover_precision() {
 
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
         segment
             .upsert_point(
@@ -114,6 +114,7 @@ fn hnsw_discover_precision() {
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -124,7 +125,7 @@ fn hnsw_discover_precision() {
     let mut discovery_hits = 0;
     let attempts = 100;
     for _i in 0..attempts {
-        let query: QueryVector = random_discovery_query(&mut rnd, dim);
+        let query: QueryVector = random_discovery_query(&mut rng, dim);
 
         let index_discovery_result = hnsw_index
             .search(
@@ -171,7 +172,7 @@ fn filtered_hnsw_discover_precision() {
     let full_scan_threshold = 16; // KB
     let num_payload_values = 4;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -183,9 +184,9 @@ fn filtered_hnsw_discover_precision() {
     let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
-        let keyword_payload = get_random_keyword_of(num_payload_values, &mut rnd);
+        let keyword_payload = get_random_keyword_of(num_payload_values, &mut rng);
         let payload = payload_json! {keyword_key: keyword_payload};
 
         segment
@@ -238,6 +239,7 @@ fn filtered_hnsw_discover_precision() {
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -250,12 +252,12 @@ fn filtered_hnsw_discover_precision() {
     for _i in 0..attempts {
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
             JsonPath::new(keyword_key),
-            get_random_keyword_of(num_payload_values, &mut rnd).into(),
+            get_random_keyword_of(num_payload_values, &mut rng).into(),
         )));
 
         let filter_query = Some(&filter);
 
-        let query: QueryVector = random_discovery_query(&mut rnd, dim);
+        let query: QueryVector = random_discovery_query(&mut rng, dim);
 
         let index_discovery_result = hnsw_index
             .search(

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -55,7 +55,7 @@ fn test_multi_filterable_hnsw(
     let full_scan_threshold = 8; // KB
     let num_payload_values = 2;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -85,10 +85,10 @@ fn test_multi_filterable_hnsw(
     for n in 0..num_points {
         let idx = n.into();
         // Random number of vectors per multivec point
-        let num_vector_for_point = rnd.random_range(1..=max_num_vector_per_points);
-        let multi_vec = random_multi_vector(&mut rnd, vector_dim, num_vector_for_point);
+        let num_vector_for_point = rng.random_range(1..=max_num_vector_per_points);
+        let multi_vec = random_multi_vector(&mut rng, vector_dim, num_vector_for_point);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         let named_vectors = only_default_multi_vector(&multi_vec);
@@ -144,6 +144,7 @@ fn test_multi_filterable_hnsw(
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -155,12 +156,12 @@ fn test_multi_filterable_hnsw(
     let attempts = 100;
     for i in 0..attempts {
         // Random number of vectors per multivec query
-        let num_vector_for_query = rnd.random_range(1..=max_num_vector_per_points);
+        let num_vector_for_query = rng.random_range(1..=max_num_vector_per_points);
         let query =
-            random_multi_vec_query(&query_variant, &mut rnd, vector_dim, num_vector_for_query);
+            random_multi_vec_query(&query_variant, &mut rng, vector_dim, num_vector_for_query);
 
         let range_size = 40;
-        let left_range = rnd.random_range(0..400);
+        let left_range = rng.random_range(0..400);
         let right_range = left_range + range_size;
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -38,7 +38,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
     let num_payload_values = 2;
     let dim = 8;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
@@ -71,7 +71,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
 
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
         let preprocessed_vector = match distance {
             Distance::Cosine => {
                 <CosineMetric as Metric<VectorElementType>>::preprocess(vector.clone())
@@ -88,7 +88,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         };
         let vector_multi = MultiDenseVectorInternal::new(preprocessed_vector, vector.len());
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         segment
@@ -148,6 +148,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
             permit: permit.clone(),
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -167,11 +168,11 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
     .unwrap();
 
     for _ in 0..10 {
-        let random_vector = random_vector(&mut rnd, dim);
+        let random_vector = random_vector(&mut rng, dim);
         let query_vector = random_vector.clone().into();
         let query_vector_multi = QueryVector::Nearest(vec![random_vector].try_into().unwrap());
 
-        let payload_value = random_int_payload(&mut rnd, 1..=1).pop().unwrap();
+        let payload_value = random_int_payload(&mut rng, 1..=1).pop().unwrap();
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
             JsonPath::new(int_key),

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -38,9 +38,9 @@ enum QuantizationVariant {
     Binary,
 }
 
-fn random_vector<R: Rng + ?Sized>(rnd: &mut R, dim: usize) -> MultiDenseVectorInternal {
-    let count = rnd.random_range(1..=MAX_VECTORS_COUNT);
-    let mut vector = random_multi_vector(rnd, dim, count);
+fn random_vector<R: Rng + ?Sized>(rng: &mut R, dim: usize) -> MultiDenseVectorInternal {
+    let count = rng.random_range(1..=MAX_VECTORS_COUNT);
+    let mut vector = random_multi_vector(rng, dim, count);
     // for BQ change range to [-0.5; 0.5]
     vector.flattened_vectors.iter_mut().for_each(|x| *x -= 0.5);
     vector
@@ -189,7 +189,7 @@ fn test_multivector_quantization_hnsw(
     let full_scan_threshold = 16; // KB
     let num_payload_values = 2;
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let quantized_data_path = dir.path();
@@ -225,9 +225,9 @@ fn test_multivector_quantization_hnsw(
 
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rnd, dim);
+        let vector = random_vector(&mut rng, dim);
 
-        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);
         let payload = payload_json! {int_key: int_payload};
 
         segment
@@ -318,6 +318,7 @@ fn test_multivector_quantization_hnsw(
             permit,
             old_indices: &[],
             gpu_device: None,
+            rng: &mut rng,
             stopped: &stopped,
             feature_flags: FeatureFlags::default(),
         },
@@ -328,10 +329,10 @@ fn test_multivector_quantization_hnsw(
     let mut sames = 0;
     let attempts = 100;
     for _ in 0..attempts {
-        let query = random_query(&query_variant, &mut rnd, dim);
+        let query = random_query(&query_variant, &mut rng, dim);
 
         let range_size = 40;
-        let left_range = rnd.random_range(0..400);
+        let left_range = rng.random_range(0..400);
         let right_range = left_range + range_size;
 
         let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -34,6 +34,7 @@ fn test_building_new_segment() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
+    let mut rng = rand::rng();
     let stopped = AtomicBool::new(false);
 
     let segment1 = build_segment_1(dir.path());
@@ -74,7 +75,9 @@ fn test_building_new_segment() {
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let merged_segment: Segment = builder.build(permit, &stopped, &hw_counter).unwrap();
+    let merged_segment: Segment = builder
+        .build(permit, &stopped, &mut rng, &hw_counter)
+        .unwrap();
 
     let new_segment_count = dir.path().read_dir().unwrap().count();
 
@@ -101,6 +104,7 @@ fn test_building_new_defragmented_segment() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
+    let mut rng = rand::rng();
     let stopped = AtomicBool::new(false);
 
     let defragment_key = JsonPath::from_str(PAYLOAD_KEY).unwrap();
@@ -152,7 +156,9 @@ fn test_building_new_defragmented_segment() {
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let merged_segment: Segment = builder.build(permit, &stopped, &hw_counter).unwrap();
+    let merged_segment: Segment = builder
+        .build(permit, &stopped, &mut rng, &hw_counter)
+        .unwrap();
 
     let new_segment_count = dir.path().read_dir().unwrap().count();
 
@@ -236,6 +242,7 @@ fn test_building_new_sparse_segment() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
+    let mut rng = rand::rng();
     let stopped = AtomicBool::new(false);
 
     let hw_counter = HardwareCounterCell::new();
@@ -277,7 +284,9 @@ fn test_building_new_sparse_segment() {
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let merged_segment: Segment = builder.build(permit, &stopped, &hw_counter).unwrap();
+    let merged_segment: Segment = builder
+        .build(permit, &stopped, &mut rng, &hw_counter)
+        .unwrap();
 
     let new_segment_count = dir.path().read_dir().unwrap().count();
 
@@ -300,6 +309,7 @@ fn test_building_new_sparse_segment() {
 }
 
 fn estimate_build_time(segment: &Segment, stop_delay_millis: Option<u64>) -> (u64, bool) {
+    let mut rng = rand::rng();
     let stopped = Arc::new(AtomicBool::new(false));
 
     let dir = Builder::new().prefix("segment_dir1").tempdir().unwrap();
@@ -344,7 +354,7 @@ fn estimate_build_time(segment: &Segment, stop_delay_millis: Option<u64>) -> (u6
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let res = builder.build(permit, &stopped, &hw_counter);
+    let res = builder.build(permit, &stopped, &mut rng, &hw_counter);
 
     let is_cancelled = match res {
         Ok(_) => false,
@@ -366,6 +376,7 @@ fn test_building_new_segment_bug_5614() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
+    let mut rng = rand::rng();
     let stopped = AtomicBool::new(false);
 
     let mut segment1 = build_segment_1(dir.path());
@@ -405,7 +416,9 @@ fn test_building_new_segment_bug_5614() {
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let merged_segment: Segment = builder.build(permit, &stopped, &hw_counter).unwrap();
+    let merged_segment: Segment = builder
+        .build(permit, &stopped, &mut rng, &hw_counter)
+        .unwrap();
 
     // Assert correct point versions - must have latest
     assert_eq!(merged_segment.point_version(100.into()), Some(124));
@@ -501,6 +514,7 @@ fn test_building_new_segment_with_mmap_payload() {
     let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
+    let mut rng = rand::rng();
     let stopped = AtomicBool::new(false);
 
     let mut segment1 = build_simple_segment_with_payload_storage(
@@ -544,7 +558,9 @@ fn test_building_new_segment_with_mmap_payload() {
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let new_segment: Segment = builder.build(permit, &stopped, &hw_counter).unwrap();
+    let new_segment: Segment = builder
+        .build(permit, &stopped, &mut rng, &hw_counter)
+        .unwrap();
     assert_eq!(
         new_segment.segment_config.payload_storage_type,
         PayloadStorageType::Mmap

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -134,10 +134,12 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
     )
     .unwrap();
     segment_builder.update(&[&segment], &false.into()).unwrap();
+    let mut rng = rand::rng();
     let segment = segment_builder
         .build(
             ResourcePermit::dummy(num_rayon_threads(0) as u32),
             &false.into(),
+            &mut rng,
             &HardwareCounterCell::new(),
         )
         .unwrap();


### PR DESCRIPTION
One source of variation during tests is the creation of hnsw, this PR allows a random number generator to be passed to the builder.

Locally, after running some of the flaky tests a few hundred times, they stopped failing. Let's see if CI agrees over time