### PR TITLE
Don't batch queries if having more segments than search threads

### DIFF
--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -31,6 +31,7 @@ pub struct SharedStorageConfig {
     pub outgoing_shard_transfers_limit: Option<usize>,
     pub snapshots_path: String,
     pub snapshots_config: SnapshotsConfig,
+    pub search_thread_count: usize,
 }
 
 impl Default for SharedStorageConfig {
@@ -48,6 +49,7 @@ impl Default for SharedStorageConfig {
             outgoing_shard_transfers_limit: DEFAULT_IO_SHARD_TRANSFER_LIMIT,
             snapshots_path: DEFAULT_SNAPSHOTS_PATH.to_string(),
             snapshots_config: default::Default::default(),
+            search_thread_count: common::defaults::search_thread_count(common::cpu::get_num_cpus()),
         }
     }
 }
@@ -67,6 +69,7 @@ impl SharedStorageConfig {
         outgoing_shard_transfers_limit: Option<usize>,
         snapshots_path: String,
         snapshots_config: SnapshotsConfig,
+        search_thread_count: usize,
     ) -> Self {
         let update_queue_size = update_queue_size.unwrap_or(match node_type {
             NodeType::Normal => DEFAULT_UPDATE_QUEUE_SIZE,
@@ -85,6 +88,7 @@ impl SharedStorageConfig {
             outgoing_shard_transfers_limit,
             snapshots_path,
             snapshots_config,
+            search_thread_count,
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -40,8 +40,10 @@ impl LocalShard {
         let skip_batching = if core_request.searches.len() <= CHUNK_SIZE {
             // Don't batch if we have few searches, prevents cloning request
             true
-        } else if self.segments.read().len() > common::cpu::get_num_cpus() {
-            // Don't batch if we have more segments than CPUs to prevent overhead of many threads
+        } else if self.segments.read().len() > self.shared_storage_config.search_thread_count {
+            // Don't batch if we have more segments than search threads
+            // Not a perfect condition, but it helps to prevent consuming a lot of search threads
+            // if the number of segments is large
             true
         } else {
             false

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -44,6 +44,9 @@ impl LocalShard {
             // Don't batch if we have more segments than search threads
             // Not a perfect condition, but it helps to prevent consuming a lot of search threads
             // if the number of segments is large
+            // Note: search threads are shared with all other search threads on this Qdrant
+            // instance, and other shards also have segments. For simplicity this only considers
+            // the global search thread count and local segment count.
             // See: <https://github.com/qdrant/qdrant/pull/6478>
             true
         } else {

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -44,6 +44,7 @@ impl LocalShard {
             // Don't batch if we have more segments than search threads
             // Not a perfect condition, but it helps to prevent consuming a lot of search threads
             // if the number of segments is large
+            // See: <https://github.com/qdrant/qdrant/pull/6478>
             true
         } else {
             false

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -59,3 +59,26 @@ pub fn thread_count_for_hnsw(num_cpu: usize) -> usize {
         65.. => 16,
     }
 }
+
+/// Number of search threads to use in the search runtime.
+///
+/// Dynamic based on CPU size.
+#[inline(always)]
+pub fn search_thread_count(max_search_threads: usize) -> usize {
+    if max_search_threads != 0 {
+        return max_search_threads;
+    }
+
+    // At least one thread, but not more than number of CPUs - 1 if there are more than 2 CPU
+    // Example:
+    // Num CPU = 1 -> 1 thread
+    // Num CPU = 2 -> 2 thread - if we use one thread with 2 cpus, its too much un-utilized resources
+    // Num CPU = 3 -> 2 thread
+    // Num CPU = 4 -> 3 thread
+    // Num CPU = 5 -> 4 thread
+    match cpu::get_num_cpus() {
+        0..=1 => 1,
+        2 => 2,
+        num_cpu @ 3.. => num_cpu - 1,
+    }
+}

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -123,6 +123,7 @@ impl StorageConfig {
             self.performance.outgoing_shard_transfers_limit,
             self.snapshots_path.clone(),
             self.snapshots_config.clone(),
+            common::defaults::search_thread_count(self.performance.max_search_threads),
         )
     }
 }

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -18,28 +18,10 @@ pub struct LocksOption {
 }
 
 pub fn create_search_runtime(max_search_threads: usize) -> io::Result<Runtime> {
-    let mut search_threads = max_search_threads;
-
-    if search_threads == 0 {
-        let num_cpu = common::cpu::get_num_cpus();
-        // At least one thread, but not more than number of CPUs - 1 if there are more than 2 CPU
-        // Example:
-        // Num CPU = 1 -> 1 thread
-        // Num CPU = 2 -> 2 thread - if we use one thread with 2 cpus, its too much un-utilized resources
-        // Num CPU = 3 -> 2 thread
-        // Num CPU = 4 -> 3 thread
-        // Num CPU = 5 -> 4 thread
-        search_threads = match num_cpu {
-            0 => 1,
-            1 => 1,
-            2 => 2,
-            _ => num_cpu - 1,
-        };
-    }
-
+    let num_threads = common::defaults::search_thread_count(max_search_threads);
     runtime::Builder::new_multi_thread()
-        .worker_threads(search_threads)
-        .max_blocking_threads(search_threads)
+        .worker_threads(num_threads)
+        .max_blocking_threads(num_threads)
         .enable_all()
         .thread_name_fn(|| {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/6423> regression
Extension of <https://github.com/qdrant/qdrant/pull/6326>

While the condition change is not perfect, it does help significantly with the issue as described above.

This just prevents batching for a specific case that is known to perform bad: when having a high number of segments versus search threads.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?