### PR TITLE
Attempt to speedup additional links construction by measuring sub-graph connectivity first

### DIFF
--- a/lib/common/common/src/ext.rs
+++ b/lib/common/common/src/ext.rs
@@ -1,7 +1,6 @@
 use bitvec::order::BitOrder;
 use bitvec::slice::BitSlice;
 use bitvec::store::BitStore;
-use bitvec::vec::BitVec;
 
 pub trait OptionExt {
     /// `replace` if the given `value` is `Some`
@@ -23,25 +22,9 @@ pub trait BitSliceExt {
     fn get_bit(&self, index: usize) -> Option<bool>;
 }
 
-pub trait BitVecExt {
-    fn set_all(&mut self, bit: bool);
-}
-
 impl<T: BitStore, O: BitOrder> BitSliceExt for BitSlice<T, O> {
     #[inline]
     fn get_bit(&self, index: usize) -> Option<bool> {
         self.get(index).as_deref().copied()
-    }
-}
-
-impl<T: BitStore, O: BitOrder> BitVecExt for BitVec<T, O> {
-    fn set_all(&mut self, bit: bool) {
-        self.as_raw_mut_slice().fill_with(|| {
-            BitStore::new(if bit {
-                !<<T as bitvec::store::BitStore>::Mem>::ZERO
-            } else {
-                <<T as bitvec::store::BitStore>::Mem>::ZERO
-            })
-        });
     }
 }

--- a/lib/common/common/src/ext.rs
+++ b/lib/common/common/src/ext.rs
@@ -1,6 +1,7 @@
 use bitvec::order::BitOrder;
 use bitvec::slice::BitSlice;
 use bitvec::store::BitStore;
+use bitvec::vec::BitVec;
 
 pub trait OptionExt {
     /// `replace` if the given `value` is `Some`
@@ -22,9 +23,25 @@ pub trait BitSliceExt {
     fn get_bit(&self, index: usize) -> Option<bool>;
 }
 
+pub trait BitVecExt {
+    fn set_all(&mut self, bit: bool);
+}
+
 impl<T: BitStore, O: BitOrder> BitSliceExt for BitSlice<T, O> {
     #[inline]
     fn get_bit(&self, index: usize) -> Option<bool> {
         self.get(index).as_deref().copied()
+    }
+}
+
+impl<T: BitStore, O: BitOrder> BitVecExt for BitVec<T, O> {
+    fn set_all(&mut self, bit: bool) {
+        self.as_raw_mut_slice().fill_with(|| {
+            BitStore::new(if bit {
+                !<<T as bitvec::store::BitStore>::Mem>::ZERO
+            } else {
+                <<T as bitvec::store::BitStore>::Mem>::ZERO
+            })
+        });
     }
 }

--- a/lib/segment/src/index/hnsw_index/entry_points.rs
+++ b/lib/segment/src/index/hnsw_index/entry_points.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::PointOffsetType;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -108,6 +109,41 @@ impl EntryPoints {
                     .cloned()
                     .max_by_key(|ep| ep.level)
             })
+    }
+
+    pub fn get_random_entry_point<F, R: Rng + ?Sized>(
+        &self,
+        rnd: &mut R,
+        checker: F,
+    ) -> Option<EntryPoint>
+    where
+        F: Fn(PointOffsetType) -> bool,
+    {
+        let filtered_entry_points: Vec<_> = self
+            .entry_points
+            .iter()
+            .filter(|entry| checker(entry.point_id))
+            .cloned()
+            .collect();
+
+        if !filtered_entry_points.is_empty() {
+            let random_index = rnd.random_range(0..filtered_entry_points.len());
+            return Some(filtered_entry_points[random_index].clone());
+        }
+
+        let filtered_extra_entry_points: Vec<_> = self
+            .extra_entry_points
+            .iter_unsorted()
+            .filter(|entry| checker(entry.point_id))
+            .cloned()
+            .collect();
+
+        if !filtered_extra_entry_points.is_empty() {
+            let random_index = rnd.random_range(0..filtered_extra_entry_points.len());
+            return Some(filtered_extra_entry_points[random_index].clone());
+        }
+
+        None
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 use bitvec::prelude::BitVec;
-use common::ext::{BitSliceExt, BitVecExt};
+use common::ext::BitSliceExt;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoredPointOffset};
 use io::file_operations::atomic_save_bin;
@@ -178,7 +178,7 @@ impl GraphLayersBuilder {
 
             queue.clear();
             reached_points = 1; // Reset reached points
-            visited.set_all(false);
+            visited.fill(false);
         }
 
         reached_points as f32 / points.len() as f32

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 use bitvec::prelude::BitVec;
-use common::ext::BitSliceExt;
+use common::ext::{BitSliceExt, BitVecExt};
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoredPointOffset};
 use io::file_operations::atomic_save_bin;
@@ -72,6 +72,9 @@ impl GraphLayersBase for GraphLayersBuilder {
     }
 }
 
+/// Budget of how many checks have to be done at minimum to consider subgraph-connectivity approximation correct.
+const SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET: usize = 64;
+
 impl GraphLayersBuilder {
     pub fn get_entry_points(&self) -> MutexGuard<EntryPoints> {
         self.entry_points.lock()
@@ -82,12 +85,11 @@ impl GraphLayersBuilder {
     ///  - Select entry point, it would be a point with the highest level. If there are several, pick first one.
     ///  - Start Breadth-First Search (BFS) from the entry point, on each edge flip a coin to decide if the edge is removed or not.
     ///  - Count number of nodes reachable from the entry point.
+    ///  - Use visited points as entry points for the next layer below and repeat until layer 0 has reached.
     ///  - Return the fraction of reachable nodes to the total number of nodes in the sub-graph.
     ///
     /// Coin probability `q` is a parameter of this function. By default, it is 0.5.
-    pub fn subgraph_connectivity(&self, points: &[PointOffsetType], layer: usize, q: f32) -> f32 {
-        let mut reached_points = 0;
-
+    pub fn subgraph_connectivity(&self, points: &[PointOffsetType], q: f32) -> f32 {
         if points.is_empty() {
             return 1.0;
         }
@@ -95,15 +97,13 @@ impl GraphLayersBuilder {
         let max_point_id = *points.iter().max().unwrap();
 
         let mut visited: BitVec = BitVec::repeat(false, max_point_id as usize + 1);
-        let mut bitmask: BitVec = BitVec::repeat(false, max_point_id as usize + 1);
+        let mut point_selection: BitVec = BitVec::repeat(false, max_point_id as usize + 1);
 
         for point_id in points {
-            bitmask.set(*point_id as usize, true);
+            point_selection.set(*point_id as usize, true);
         }
 
         let mut rnd = rand::rng();
-
-        let mut queue = Vec::new();
 
         // Try to get entry point from the entry points list
         // If not found, select the point with the highest level
@@ -111,56 +111,74 @@ impl GraphLayersBuilder {
             .entry_points
             .lock()
             .get_random_entry_point(&mut rnd, |point_id| {
-                bitmask.get_bit(point_id as usize).unwrap_or(false)
+                point_selection.get_bit(point_id as usize).unwrap_or(false)
             })
             .map(|ep| ep.point_id);
 
         // Select entry point by selecting the point with the highest level
-
-        let entry_point = if let Some(entry_point) = entry_point {
-            // Entry point is found
-            entry_point
-        } else {
+        let entry_point = entry_point.unwrap_or_else(|| {
             points
                 .iter()
                 .max_by_key(|point_id| self.links_layers[**point_id as usize].len())
                 .cloned()
                 .unwrap()
-        };
+        });
+        let entry_layer = self.get_point_level(entry_point);
 
-        // Start BFS from the entry point
+        let mut queue: Vec<u32> = vec![];
 
-        queue.push(entry_point);
+        // Amount of points reached when searching the graph.
+        let mut reached_points = 1;
 
-        let already_visited = visited.replace(entry_point as usize, true);
-        if !already_visited {
-            reached_points += 1;
-        }
+        // Total points visited (also across retries).
+        let mut spent_budget = 0;
 
-        // Do not skip edges on the first point links
-        // to avoid random noise
-        let mut first = true;
+        // Retry loop, in case some budget is left.
+        loop {
+            visited.set(entry_point as usize, true);
 
-        while let Some(current_point) = queue.pop() {
-            let links = self.links_layers[current_point as usize][layer].read();
+            // Points visited in the previous layer (Get used as entry point in the iteration over the next layer)
+            let mut previous_visited_points = vec![entry_point];
 
-            for link in links.iter() {
-                // Flip a coin to decide if the edge is removed or not
-                let coin_flip = rnd.random_range(0.0..1.0);
-                if coin_flip < q && !first {
-                    continue;
-                }
+            // For each layer in HNSW lower than the entry point layer
+            for current_layer in (0..=entry_layer).rev() {
+                // Set entry points to visited points of previous layer.
+                queue.extend_from_slice(&previous_visited_points);
 
-                let is_selected = bitmask.get_bit(link as usize).unwrap_or(false);
-                let is_visited = visited.get_bit(link as usize).unwrap_or(false);
+                // Do BFS through all points on the current layer.
+                while let Some(current_point) = queue.pop() {
+                    let links = self.links_layers[current_point as usize][current_layer].read();
 
-                if !is_visited && is_selected {
-                    visited.replace(link as usize, true);
-                    reached_points += 1;
-                    queue.push(link);
+                    for link in links.iter() {
+                        spent_budget += 1;
+
+                        // Flip a coin to decide if the edge is removed or not
+                        let coin_flip = rnd.random_range(0.0..1.0);
+                        if coin_flip < q {
+                            continue;
+                        }
+
+                        let is_selected = point_selection.get_bit(link as usize).unwrap_or(false);
+                        let is_visited = visited.get_bit(link as usize).unwrap_or(false);
+
+                        if !is_visited && is_selected {
+                            visited.set(link as usize, true);
+                            reached_points += 1;
+                            queue.push(link);
+                            previous_visited_points.push(link);
+                        }
+                    }
                 }
             }
-            first = false;
+
+            // Budget exhausted, don't retry.
+            if spent_budget > SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET {
+                break;
+            }
+
+            queue.clear();
+            reached_points = 1; // Reset reached points
+            visited.set_all(false);
         }
 
         reached_points as f32 / points.len() as f32

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 use bitvec::prelude::BitVec;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
-use common::types::{PointOffsetType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 use io::file_operations::atomic_save_bin;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use rand::Rng;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -378,7 +378,14 @@ impl StructPayloadIndex {
         &self.config
     }
 
-    // Iterates over points which satisfy the filter. Might include already deleted points.
+    pub fn is_tenant(&self, field: &PayloadKeyType) -> bool {
+        self.config
+            .indexed_fields
+            .get(field)
+            .map(|indexed_field| indexed_field.is_tenant())
+            .unwrap_or(false)
+    }
+
     pub fn iter_filtered_points<'a>(
         &'a self,
         filter: &'a Filter,


### PR DESCRIPTION
H&M benchmark: https://github.com/qdrant/vector-db-benchmark/actions/runs/14785548595


--- 

ToDo:

- [x] Check that this feature doesn't break multitenancy
- [x] Check speedup / accuracy on other datasets, ideally for each datatype
- [x] Estimate indexing overhead for cases, where no shortcuts were possible

More benchmarks in https://github.com/qdrant/qdrant/pull/6571
