### PR TITLE
Decrease retry count on flaky test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.ci]
 # Retry tests before failing them.
-retries = { backoff = "exponential", count = 2, delay = "2s" }
+retries = { backoff = "exponential", count = 1, delay = "2s" }
 # Do not cancel the test run on the first failure.
 fail-fast = false
 # Print out output for failing tests as soon as they fail, and also at the end


### PR DESCRIPTION
Having up to 2 retries makes a total of 3 runs for a flaky test.
This is too generous.

This PR gives only one additional chance to a flaky test to succeed.