### PR TITLE
[phrase match] Introduce ordered document

### DIFF
--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -415,6 +415,28 @@ impl Key for str {
     }
 }
 
+impl Key for u32 {
+    const ALIGN: usize = align_of::<u32>();
+
+    const NAME: [u8; 8] = *b"u32\0\0\0\0\0";
+
+    fn write_bytes(&self) -> usize {
+        size_of::<u32>()
+    }
+
+    fn write(&self, buf: &mut impl Write) -> io::Result<()> {
+        buf.write_all(self.as_bytes())
+    }
+
+    fn matches(&self, buf: &[u8]) -> bool {
+        buf.get(..size_of::<u32>()) == Some(self.as_bytes())
+    }
+
+    fn from_bytes(buf: &[u8]) -> Option<&Self> {
+        Some(u32::ref_from_prefix(buf).ok()?.0)
+    }
+}
+
 impl Key for i64 {
     const ALIGN: usize = align_of::<i64>();
 

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -24,10 +24,10 @@ impl InvertedIndex for ImmutableInvertedIndex {
         &mut self.vocab
     }
 
-    fn index_document(
+    fn index_tokens(
         &mut self,
         _idx: PointOffsetType,
-        _document: super::inverted_index::Document,
+        _tokens: super::inverted_index::TokenSet,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         Err(OperationError::service_error(
@@ -171,7 +171,7 @@ impl From<MutableInvertedIndex> for ImmutableInvertedIndex {
             postings,
             vocab,
             point_to_tokens_count: index
-                .point_to_docs
+                .point_to_tokens
                 .iter()
                 .map(|doc| doc.as_ref().map(|doc| doc.len()))
                 .collect(),

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -35,6 +35,17 @@ impl InvertedIndex for ImmutableInvertedIndex {
         ))
     }
 
+    fn index_document(
+        &mut self,
+        _idx: PointOffsetType,
+        _document: super::inverted_index::Document,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        Err(OperationError::service_error(
+            "Can't add values to immutable text index",
+        ))
+    }
+
     fn remove_document(&mut self, idx: PointOffsetType) -> bool {
         if self.values_is_empty(idx) {
             return false; // Already removed or never actually existed

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -55,12 +55,21 @@ impl FromIterator<TokenId> for TokenSet {
 }
 
 /// Contains the token ids that make up a document, in the same order that appear in the document.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Document(Vec<TokenId>);
 
 impl Document {
     pub fn new(tokens: Vec<TokenId>) -> Self {
         Self(tokens)
+    }
+}
+
+impl IntoIterator for Document {
+    type Item = TokenId;
+    type IntoIter = std::vec::IntoIter<TokenId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -178,6 +178,17 @@ impl InvertedIndex for MmapInvertedIndex {
         ))
     }
 
+    fn index_document(
+        &mut self,
+        _idx: PointOffsetType,
+        _document: super::inverted_index::Document,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        Err(OperationError::service_error(
+            "Can't add values to mmap immutable text index",
+        ))
+    }
+
     fn remove_document(&mut self, idx: PointOffsetType) -> bool {
         let Some(is_deleted) = self.deleted_points.get(idx as usize) else {
             return false; // Never existed

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -167,10 +167,10 @@ impl InvertedIndex for MmapInvertedIndex {
         unreachable!("MmapInvertedIndex does not support mutable operations")
     }
 
-    fn index_document(
+    fn index_tokens(
         &mut self,
         _idx: PointOffsetType,
-        _document: super::inverted_index::Document,
+        _tokens: super::inverted_index::TokenSet,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         Err(OperationError::service_error(

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -117,17 +117,17 @@ impl ValueIndexer for FullTextMmapIndexBuilder {
             return Ok(());
         }
 
-        let mut tokens: BTreeSet<String> = BTreeSet::new();
+        let mut str_tokens: BTreeSet<String> = BTreeSet::new();
 
         for value in values {
             Tokenizer::tokenize_doc(&value, &self.config, |token| {
-                tokens.insert(token.to_owned());
+                str_tokens.insert(token.to_owned());
             });
         }
 
-        let document = self.mutable_index.document_from_tokens(&tokens);
+        let tokens = self.mutable_index.token_ids(&str_tokens);
         self.mutable_index
-            .index_document(id, document, hw_counter)?;
+            .index_tokens(id, tokens, hw_counter)?;
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::fs::{create_dir_all, remove_dir};
 use std::path::PathBuf;
 
@@ -7,7 +6,7 @@ use common::types::PointOffsetType;
 use serde_json::Value;
 
 use super::immutable_inverted_index::ImmutableInvertedIndex;
-use super::inverted_index::InvertedIndex;
+use super::inverted_index::{Document, InvertedIndex, TokenSet};
 use super::mmap_inverted_index::MmapInvertedIndex;
 use super::mutable_inverted_index::MutableInvertedIndex;
 use super::text_index::FullTextIndex;
@@ -117,17 +116,24 @@ impl ValueIndexer for FullTextMmapIndexBuilder {
             return Ok(());
         }
 
-        let mut str_tokens: BTreeSet<String> = BTreeSet::new();
+        let mut str_tokens = Vec::new();
 
         for value in values {
             Tokenizer::tokenize_doc(&value, &self.config, |token| {
-                str_tokens.insert(token.to_owned());
+                str_tokens.push(token.to_owned());
             });
         }
 
         let tokens = self.mutable_index.token_ids(&str_tokens);
-        self.mutable_index
-            .index_tokens(id, tokens, hw_counter)?;
+
+        if self.mutable_index.point_to_doc.is_some() {
+            let document = Document::new(tokens.clone());
+            self.mutable_index
+                .index_document(id, document, hw_counter)?;
+        }
+
+        let token_set = TokenSet::from_iter(tokens);
+        self.mutable_index.index_tokens(id, token_set, hw_counter)?;
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -5,7 +5,9 @@ use common::types::PointOffsetType;
 
 use super::inverted_index::InvertedIndex;
 use crate::common::operation_error::OperationResult;
-use crate::index::field_index::full_text_index::inverted_index::{Document, ParsedQuery, TokenId};
+use crate::index::field_index::full_text_index::inverted_index::{
+    TokenSet, ParsedQuery, TokenId,
+};
 use crate::index::field_index::full_text_index::posting_list::PostingList;
 use crate::index::field_index::full_text_index::postings_iterator::intersect_postings_iterator;
 
@@ -14,7 +16,7 @@ use crate::index::field_index::full_text_index::postings_iterator::intersect_pos
 pub struct MutableInvertedIndex {
     pub(in crate::index::field_index::full_text_index) postings: Vec<PostingList>,
     pub(in crate::index::field_index::full_text_index) vocab: HashMap<String, TokenId>,
-    pub(in crate::index::field_index::full_text_index) point_to_docs: Vec<Option<Document>>,
+    pub(in crate::index::field_index::full_text_index) point_to_tokens: Vec<Option<TokenSet>>,
     pub(in crate::index::field_index::full_text_index) points_count: usize,
 }
 
@@ -25,23 +27,23 @@ impl MutableInvertedIndex {
         let mut index = Self::default();
 
         // update point_to_docs
-        for i in iter {
+        for item in iter {
             index.points_count += 1;
-            let (idx, tokens) = i?;
+            let (idx, str_tokens) = item?;
 
-            if index.point_to_docs.len() <= idx as usize {
+            if index.point_to_tokens.len() <= idx as usize {
                 index
-                    .point_to_docs
+                    .point_to_tokens
                     .resize_with(idx as usize + 1, Default::default);
             }
 
-            let document = index.document_from_tokens(&tokens);
-            index.point_to_docs[idx as usize] = Some(document);
+            let tokens = index.token_ids(&str_tokens);
+            index.point_to_tokens[idx as usize] = Some(tokens);
         }
 
         // build postings from point_to_docs
         // build in order to increase document id
-        for (idx, doc) in index.point_to_docs.iter().enumerate() {
+        for (idx, doc) in index.point_to_tokens.iter().enumerate() {
             if let Some(doc) = doc {
                 for token_idx in doc.tokens() {
                     if index.postings.len() <= *token_idx as usize {
@@ -61,8 +63,8 @@ impl MutableInvertedIndex {
         Ok(index)
     }
 
-    fn get_doc(&self, idx: PointOffsetType) -> Option<&Document> {
-        self.point_to_docs.get(idx as usize)?.as_ref()
+    fn get_tokens(&self, idx: PointOffsetType) -> Option<&TokenSet> {
+        self.point_to_tokens.get(idx as usize)?.as_ref()
     }
 }
 
@@ -71,10 +73,10 @@ impl InvertedIndex for MutableInvertedIndex {
         &mut self.vocab
     }
 
-    fn index_document(
+    fn index_tokens(
         &mut self,
         point_id: PointOffsetType,
-        document: Document,
+        tokens: TokenSet,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.points_count += 1;
@@ -83,18 +85,28 @@ impl InvertedIndex for MutableInvertedIndex {
             .payload_index_io_write_counter()
             .write_back_counter();
 
-        if self.point_to_docs.len() <= point_id as usize {
+        if self.point_to_tokens.len() <= point_id as usize {
             let new_len = point_id as usize + 1;
 
             // Only measure the overhead of `Document` here since we account for the tokens a few lines below.
-            hw_cell_wb
-                .incr_delta((new_len - self.point_to_docs.len()) * size_of::<Option<Document>>());
+            hw_cell_wb.incr_delta(
+                (new_len - self.point_to_tokens.len()) * size_of::<Option<TokenSet>>(),
+            );
 
-            self.point_to_docs.resize_with(new_len, Default::default);
+            self.point_to_tokens.resize_with(new_len, Default::default);
+
+            // Resize the ordered documents vector as well
+            if self.point_to_ordered_docs.len() <= point_id as usize {
+                hw_cell_wb.incr_delta(
+                    (new_len - self.point_to_ordered_docs.len()) * size_of::<Option<OrderedDocument>>(),
+                );
+
+                self.point_to_ordered_docs.resize_with(new_len, Default::default);
+            }
         }
 
-        for token_idx in document.tokens() {
-            let token_idx_usize = *token_idx as usize;
+        for token_id in tokens.tokens() {
+            let token_idx_usize = *token_id as usize;
 
             if self.postings.len() <= token_idx_usize {
                 let new_len = token_idx_usize + 1;
@@ -109,17 +121,44 @@ impl InvertedIndex for MutableInvertedIndex {
 
             hw_cell_wb.incr_delta(size_of_val(&point_id));
         }
-        self.point_to_docs[point_id as usize] = Some(document);
+        self.point_to_tokens[point_id as usize] = Some(tokens);
+
+        Ok(())
+    }
+
+    fn index_ordered_document(
+        &mut self,
+        point_id: PointOffsetType,
+        ordered_document: OrderedDocument,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let mut hw_cell_wb = hw_counter
+            .payload_index_io_write_counter()
+            .write_back_counter();
+
+        // Ensure the point_to_ordered_docs has enough capacity
+        if self.point_to_ordered_docs.len() <= point_id as usize {
+            let new_len = point_id as usize + 1;
+
+            hw_cell_wb.incr_delta(
+                (new_len - self.point_to_ordered_docs.len()) * size_of::<Option<OrderedDocument>>(),
+            );
+
+            self.point_to_ordered_docs.resize_with(new_len, Default::default);
+        }
+
+        // Store the ordered document
+        self.point_to_ordered_docs[point_id as usize] = Some(ordered_document);
 
         Ok(())
     }
 
     fn remove_document(&mut self, idx: PointOffsetType) -> bool {
-        if self.point_to_docs.len() <= idx as usize {
+        if self.point_to_tokens.len() <= idx as usize {
             return false; // Already removed or never actually existed
         }
 
-        let Some(removed_doc) = std::mem::take(&mut self.point_to_docs[idx as usize]) else {
+        let Some(removed_doc) = std::mem::take(&mut self.point_to_tokens[idx as usize]) else {
             return false;
         };
 
@@ -177,7 +216,7 @@ impl InvertedIndex for MutableInvertedIndex {
         point_id: PointOffsetType,
         _: &HardwareCounterCell,
     ) -> bool {
-        if let Some(doc) = self.get_doc(point_id) {
+        if let Some(doc) = self.get_tokens(point_id) {
             parsed_query.check_match(doc)
         } else {
             false
@@ -185,12 +224,12 @@ impl InvertedIndex for MutableInvertedIndex {
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        self.get_doc(point_id).map(|x| x.is_empty()).unwrap_or(true)
+        self.get_tokens(point_id).map(|x| x.is_empty()).unwrap_or(true)
     }
 
     fn values_count(&self, point_id: PointOffsetType) -> usize {
         // Maybe we want number of documents in the future?
-        self.get_doc(point_id).map(|x| x.len()).unwrap_or(0)
+        self.get_tokens(point_id).map(|x| x.len()).unwrap_or(0)
     }
 
     fn points_count(&self) -> usize {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -25,6 +25,7 @@ pub struct MutableInvertedIndex {
 impl MutableInvertedIndex {
     pub fn build_index(
         iter: impl Iterator<Item = OperationResult<(PointOffsetType, BTreeSet<String>)>>,
+        // TODO: add param for including phrase field.
     ) -> OperationResult<Self> {
         let mut index = Self::default();
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -220,7 +220,7 @@ impl InvertedIndex for MutableInvertedIndex {
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        self.get_tokens(point_id).map_or(true, |x| x.is_empty())
+        self.get_tokens(point_id).is_none_or(|x| x.is_empty())
     }
 
     fn values_count(&self, point_id: PointOffsetType) -> usize {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -1,9 +1,7 @@
-use std::collections::BTreeSet;
-
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
-use super::inverted_index::InvertedIndex;
+use super::inverted_index::{Document, InvertedIndex, TokenSet};
 use super::mutable_inverted_index::MutableInvertedIndex;
 use super::text_index::FullTextIndex;
 use super::tokenizers::Tokenizer;
@@ -57,20 +55,30 @@ impl MutableFullTextIndex {
             return Ok(());
         }
 
-        let mut str_tokens: BTreeSet<String> = BTreeSet::new();
+        let mut str_tokens = Vec::new();
 
         for value in values {
             Tokenizer::tokenize_doc(&value, &self.config, |token| {
-                str_tokens.insert(token.to_owned());
+                str_tokens.push(token.to_owned());
             });
         }
 
         let tokens = self.inverted_index.token_ids(&str_tokens);
+
+        if self.inverted_index.point_to_doc.is_some() {
+            let document = Document::new(tokens.clone());
+            self.inverted_index
+                .index_document(idx, document, hw_counter)?;
+        }
+
+        let token_set = TokenSet::from_iter(tokens);
         self.inverted_index
-            .index_tokens(idx, tokens, hw_counter)?;
+            .index_tokens(idx, token_set, hw_counter)?;
 
         let db_idx = FullTextIndex::store_key(idx);
-        let db_document = FullTextIndex::serialize_document_tokens(str_tokens)?;
+
+        let db_document =
+            FullTextIndex::serialize_document_tokens(str_tokens.into_iter().collect())?;
 
         self.db_wrapper.put(db_idx, db_document)?;
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::immutable_text_index::ImmutableFullTextIndex;
-use super::inverted_index::{InvertedIndex, TokenSet, ParsedQuery, TokenId};
+use super::inverted_index::{InvertedIndex, ParsedQuery, TokenId, TokenSet};
 use super::mmap_text_index::{FullTextMmapIndexBuilder, MmapFullTextIndex};
 use super::mutable_text_index::MutableFullTextIndex;
 use super::tokenizers::Tokenizer;
@@ -248,10 +248,10 @@ impl FullTextIndex {
     }
 
     pub fn parse_document(&self, text: &str, hw_counter: &HardwareCounterCell) -> TokenSet {
-        let mut document_tokens = vec![];
+        let mut document_tokens = AHashSet::new();
         Tokenizer::tokenize_doc(text, self.config(), |token| {
             if let Some(token_id) = self.get_token(token, hw_counter) {
-                document_tokens.push(token_id);
+                document_tokens.insert(token_id);
             }
         });
         TokenSet::new(document_tokens)

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::immutable_text_index::ImmutableFullTextIndex;
-use super::inverted_index::{Document, InvertedIndex, ParsedQuery, TokenId};
+use super::inverted_index::{InvertedIndex, TokenSet, ParsedQuery, TokenId};
 use super::mmap_text_index::{FullTextMmapIndexBuilder, MmapFullTextIndex};
 use super::mutable_text_index::MutableFullTextIndex;
 use super::tokenizers::Tokenizer;
@@ -247,14 +247,14 @@ impl FullTextIndex {
         Some(ParsedQuery { tokens })
     }
 
-    pub fn parse_document(&self, text: &str, hw_counter: &HardwareCounterCell) -> Document {
+    pub fn parse_document(&self, text: &str, hw_counter: &HardwareCounterCell) -> TokenSet {
         let mut document_tokens = vec![];
         Tokenizer::tokenize_doc(text, self.config(), |token| {
             if let Some(token_id) = self.get_token(token, hw_counter) {
                 document_tokens.push(token_id);
             }
         });
-        Document::new(document_tokens)
+        TokenSet::new(document_tokens)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Introduces a new optional field to full-text inverted indices, where the entire document is stored in the form of token ids.

Up to now, a `Document` meant the unique tokens that exist in the document, but now, we need to rethink the concept.

In this PR:
- `Document` is the list of tokens, in the order they appear in the text
- `TokenSet` is the unique tokens in the text.

The new field is not yet populated, it will be done in a later PR