### PR TITLE
[phrase matching] populate `point_to_doc` structures

### DIFF
--- a/lib/posting_list/src/lib.rs
+++ b/lib/posting_list/src/lib.rs
@@ -22,10 +22,13 @@ impl SizedValue for u32 {}
 impl SizedValue for u64 {}
 
 pub trait UnsizedValue {
+    /// Returns the length of the serialized value in bytes.
     fn write_len(&self) -> usize;
 
+    /// Writes the value to the given buffer.
     fn write_to(&self, dst: &mut [u8]);
 
+    /// Creates a value from the given bytes.
     fn from_bytes(data: &[u8]) -> Self;
 }
 

--- a/lib/posting_list/src/value_handler.rs
+++ b/lib/posting_list/src/value_handler.rs
@@ -109,11 +109,7 @@ impl<V: UnsizedValue> ValueHandler for UnsizedHandler<V> {
             .windows(2)
             .map(|w| w[0].get() as usize..w[1].get() as usize)
             // the last one is not included in windows, but goes until the end
-            .chain(
-                last_offset
-                    .iter()
-                    .map(|&last| last.get() as usize..current_offset as usize),
-            );
+            .chain(last_offset.map(|&last| last.get() as usize..current_offset as usize));
 
         let mut var_sized_data = vec![0; current_offset as usize];
         for (value, range) in values.iter().zip(ranges) {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use common::types::PointOffsetType;
-use itertools::Either;
 
 use super::immutable_inverted_index::ImmutableInvertedIndex;
 use super::inverted_index::InvertedIndex;
@@ -84,13 +83,7 @@ impl ImmutableFullTextIndex {
         let phrase_matching = self.config.phrase_matching.unwrap_or_default();
         let iter = db.iter()?.map(|(key, value)| {
             let idx = FullTextIndex::restore_key(&key);
-
-            let tokens = if phrase_matching {
-                Either::Left(FullTextIndex::deserialize_document(&value)?.into_iter())
-            } else {
-                Either::Right(FullTextIndex::deserialize_token_set(&value)?.into_iter())
-            };
-
+            let tokens = FullTextIndex::deserialize_document(&value)?;
             Ok((idx, tokens))
         });
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -30,6 +30,10 @@ impl TokenSet {
         &self.0
     }
 
+    pub fn inner(self) -> Vec<TokenId> {
+        self.0
+    }
+
     pub fn contains(&self, token: &TokenId) -> bool {
         self.0.binary_search(token).is_ok()
     }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -124,19 +124,19 @@ pub trait InvertedIndex {
     ) -> Vec<TokenId> {
         str_tokens
             .into_iter()
-            .map(|token| self.register_token(token.as_ref()))
+            .map(|token| self.register_token(token))
             .collect()
     }
 
     /// Translate the string tokens into token ids.
     /// If it is an unseen token, it is added to the vocabulary and a new token id is generated.
-    fn register_token(&mut self, token_str: &str) -> TokenId {
+    fn register_token<S: AsRef<str>>(&mut self, token_str: S) -> TokenId {
         let vocab = self.get_vocab_mut();
-        match vocab.get(token_str) {
+        match vocab.get(token_str.as_ref()) {
             Some(&idx) => idx,
             None => {
                 let next_token_id = vocab.len() as TokenId;
-                vocab.insert(token_str.to_string(), next_token_id);
+                vocab.insert(token_str.as_ref().to_string(), next_token_id);
                 next_token_id
             }
         }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -275,14 +275,13 @@ pub trait InvertedIndex {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
 
     use common::counter::hardware_counter::HardwareCounterCell;
     use rand::Rng;
     use rand::seq::SliceRandom;
     use rstest::rstest;
 
-    use super::{InvertedIndex, ParsedQuery, TokenId, TokenSet};
+    use super::{Document, InvertedIndex, ParsedQuery, TokenId, TokenSet};
     use crate::index::field_index::full_text_index::immutable_inverted_index::ImmutableInvertedIndex;
     use crate::index::field_index::full_text_index::mmap_inverted_index::MmapInvertedIndex;
     use crate::index::field_index::full_text_index::mutable_inverted_index::MutableInvertedIndex;
@@ -316,16 +315,25 @@ mod tests {
         Some(ParsedQuery::Tokens(tokens))
     }
 
-    fn mutable_inverted_index(indexed_count: u32, deleted_count: u32) -> MutableInvertedIndex {
-        let mut index = MutableInvertedIndex::default();
+    fn mutable_inverted_index(
+        indexed_count: u32,
+        deleted_count: u32,
+        with_positions: bool,
+    ) -> MutableInvertedIndex {
+        let mut index = MutableInvertedIndex::new(with_positions);
 
         let hw_counter = HardwareCounterCell::new();
 
         for idx in 0..indexed_count {
             // Generate 10 to 30-word documents
             let doc_len = rand::rng().random_range(10..=30);
-            let tokens: BTreeSet<String> = (0..doc_len).map(|_| generate_word()).collect();
+            let tokens: Vec<String> = (0..doc_len).map(|_| generate_word()).collect();
             let token_ids = index.register_tokens(&tokens);
+            if with_positions {
+                index
+                    .index_document(idx, Document(token_ids.clone()), &hw_counter)
+                    .unwrap();
+            }
             let token_set = TokenSet::from_iter(token_ids);
             index.index_tokens(idx, token_set, &hw_counter).unwrap();
         }
@@ -340,9 +348,9 @@ mod tests {
         index
     }
 
-    #[test]
-    fn test_mutable_to_immutable() {
-        let mutable = mutable_inverted_index(2000, 400);
+    #[rstest]
+    fn test_mutable_to_immutable(#[values(false, true)] phrase_matching: bool) {
+        let mutable = mutable_inverted_index(2000, 400, phrase_matching);
 
         // todo: test with phrase-enabled
         let immutable = ImmutableInvertedIndex::from(mutable.clone());
@@ -380,11 +388,14 @@ mod tests {
     #[case(10, 2)]
     #[case(0, 0)]
     #[test]
-    fn test_immutable_to_mmap_to_immutable(#[case] indexed_count: u32, #[case] deleted_count: u32) {
+    fn test_immutable_to_mmap_to_immutable(
+        #[case] indexed_count: u32,
+        #[case] deleted_count: u32,
+        #[values(false, true)] phrase_matching: bool,
+    ) {
         use std::collections::HashSet;
 
-        let mutable = mutable_inverted_index(indexed_count, deleted_count);
-        // todo: test with phrase-enabled
+        let mutable = mutable_inverted_index(indexed_count, deleted_count, phrase_matching);
         let immutable = ImmutableInvertedIndex::from(mutable);
 
         let mmap_dir = tempfile::tempdir().unwrap();
@@ -392,7 +403,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         MmapInvertedIndex::create(mmap_dir.path().into(), immutable.clone()).unwrap();
-        let mmap = MmapInvertedIndex::open(mmap_dir.path().into(), false, false).unwrap();
+        let mmap = MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching).unwrap();
 
         let imm_mmap = ImmutableInvertedIndex::from(&mmap);
 
@@ -445,20 +456,20 @@ mod tests {
         assert_eq!(immutable.points_count, imm_mmap.points_count);
     }
 
-    #[test]
-    fn test_mmap_index_congruence() {
+    #[rstest]
+    fn test_mmap_index_congruence(#[values(false, true)] phrase_matching: bool) {
         let indexed_count = 10000;
         let deleted_count = 500;
 
         let hw_counter = HardwareCounterCell::new();
         let mmap_dir = tempfile::tempdir().unwrap();
 
-        let mut mut_index = mutable_inverted_index(indexed_count, deleted_count);
+        let mut mut_index = mutable_inverted_index(indexed_count, deleted_count, phrase_matching);
 
-        // todo: test with phrase-enabled
         let immutable = ImmutableInvertedIndex::from(mut_index.clone());
         MmapInvertedIndex::create(mmap_dir.path().into(), immutable).unwrap();
-        let mut mmap_index = MmapInvertedIndex::open(mmap_dir.path().into(), false, false).unwrap();
+        let mut mmap_index =
+            MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching).unwrap();
 
         let mut imm_mmap_index = ImmutableInvertedIndex::from(&mmap_index);
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -100,13 +100,12 @@ impl MmapInvertedIndex {
         let point_to_tokens_count_path = path.join(POINT_TO_TOKENS_COUNT_FILE);
         let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
-        let postings = if !has_positions {
-            MmapPostingsEnum::Ids(MmapPostings::<()>::open(&postings_path, populate)?)
-        } else {
-            MmapPostingsEnum::WithPositions(MmapPostings::<Positions>::open(
+        let postings = match has_positions {
+            false => MmapPostingsEnum::Ids(MmapPostings::<()>::open(&postings_path, populate)?),
+            true => MmapPostingsEnum::WithPositions(MmapPostings::<Positions>::open(
                 &postings_path,
                 populate,
-            )?)
+            )?),
         };
         let vocab = MmapHashMap::<str, TokenId>::open(&vocab_path, false)?;
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -125,9 +125,7 @@ impl ValueIndexer for FullTextMmapIndexBuilder {
             });
         }
 
-        let tokens = self
-            .mutable_index
-            .register_tokens(str_tokens.iter().map(String::as_str));
+        let tokens = self.mutable_index.register_tokens(&str_tokens);
 
         if self.mutable_index.point_to_doc.is_some() {
             let document = Document::new(tokens.clone());

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -88,9 +88,10 @@ pub struct FullTextMmapIndexBuilder {
 
 impl FullTextMmapIndexBuilder {
     pub fn new(path: PathBuf, config: TextIndexParams, is_on_disk: bool) -> Self {
+        let with_positions = config.phrase_matching == Some(true);
         Self {
             path,
-            mutable_index: MutableInvertedIndex::default(),
+            mutable_index: MutableInvertedIndex::new(with_positions),
             config,
             is_on_disk,
         }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -25,10 +25,10 @@ pub struct MutableInvertedIndex {
 
 impl MutableInvertedIndex {
     pub fn build_index(
-        iter: impl Iterator<Item = OperationResult<(PointOffsetType, BTreeSet<String>)>>,
-        // TODO(phrase-index): add param for including phrase field
+        iter: impl Iterator<Item = OperationResult<(PointOffsetType, impl Iterator<Item = String>)>>,
+        phrase_matching: bool,
     ) -> OperationResult<Self> {
-        let mut builder = MutableInvertedIndexBuilder::default();
+        let mut builder = MutableInvertedIndexBuilder::new(phrase_matching);
         builder.add_iter(iter)?;
         Ok(builder.build())
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -10,7 +10,6 @@ use super::postings_iterator::intersect_postings_iterator;
 use crate::common::operation_error::OperationResult;
 
 #[cfg_attr(test, derive(Clone))]
-#[derive(Default)]
 pub struct MutableInvertedIndex {
     pub(super) postings: Vec<PostingList>,
     pub(super) vocab: HashMap<String, TokenId>,
@@ -24,6 +23,17 @@ pub struct MutableInvertedIndex {
 }
 
 impl MutableInvertedIndex {
+    /// Create a new inverted index with or without positional information.
+    pub fn new(with_positions: bool) -> Self {
+        Self {
+            postings: Vec::new(),
+            vocab: HashMap::new(),
+            point_to_tokens: Vec::new(),
+            point_to_doc: with_positions.then_some(Vec::new()),
+            points_count: 0,
+        }
+    }
+
     pub fn build_index(
         iter: impl Iterator<Item = OperationResult<(PointOffsetType, impl Iterator<Item = String>)>>,
         phrase_matching: bool,
@@ -128,7 +138,7 @@ impl InvertedIndex for MutableInvertedIndex {
             .write_back_counter();
 
         // Ensure container has enough capacity
-        if point_to_doc.len() <= point_id as usize {
+        if point_id as usize >= point_to_doc.len() {
             let new_len = point_id as usize + 1;
 
             hw_cell_wb.incr_delta((new_len - point_to_doc.len()) * size_of::<Option<Document>>());
@@ -143,7 +153,7 @@ impl InvertedIndex for MutableInvertedIndex {
     }
 
     fn remove(&mut self, idx: PointOffsetType) -> bool {
-        if self.point_to_tokens.len() <= idx as usize {
+        if idx as usize >= self.point_to_tokens.len() {
             return false; // Already removed or never actually existed
         }
 
@@ -151,16 +161,16 @@ impl InvertedIndex for MutableInvertedIndex {
             return false;
         };
 
+        if let Some(point_to_doc) = &mut self.point_to_doc {
+            point_to_doc[idx as usize] = None;
+        }
+
         self.points_count -= 1;
 
         for removed_token in removed_token_set.tokens() {
             // unwrap safety: posting list exists and contains the point idx
             let posting = self.postings.get_mut(*removed_token as usize).unwrap();
             posting.remove(idx);
-        }
-
-        if let Some(point_to_doc) = &mut self.point_to_doc {
-            point_to_doc[idx as usize] = None;
         }
 
         true

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -35,7 +35,7 @@ impl MutableInvertedIndex {
     }
 
     pub fn build_index(
-        iter: impl Iterator<Item = OperationResult<(PointOffsetType, impl Iterator<Item = String>)>>,
+        iter: impl Iterator<Item = OperationResult<(PointOffsetType, Vec<String>)>>,
         phrase_matching: bool,
     ) -> OperationResult<Self> {
         let mut builder = MutableInvertedIndexBuilder::new(phrase_matching);

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index_builder.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index_builder.rs
@@ -1,42 +1,49 @@
-use std::collections::BTreeSet;
-
 use common::types::PointOffsetType;
 
-use super::inverted_index::{InvertedIndex, TokenSet};
+use super::inverted_index::InvertedIndex;
 use super::mutable_inverted_index::MutableInvertedIndex;
 use crate::common::operation_error::OperationResult;
+use crate::index::field_index::full_text_index::inverted_index::Document;
 
-#[derive(Default)]
 pub struct MutableInvertedIndexBuilder {
     index: MutableInvertedIndex,
 }
 
 impl MutableInvertedIndexBuilder {
+    pub fn new(phrase_matching: bool) -> Self {
+        let mut index = MutableInvertedIndex::default();
+
+        // choose whether to register positions of tokens
+        if phrase_matching {
+            index.point_to_doc = Some(Default::default());
+        }
+
+        Self { index }
+    }
+
     /// Add a vector to the inverted index builder
-    pub fn add(
-        &mut self,
-        idx: PointOffsetType,
-        str_tokens: BTreeSet<String>,
-        // TODO(phrase-index): add param for including phrase field
-    ) {
+    pub fn add(&mut self, idx: PointOffsetType, str_tokens: impl IntoIterator<Item = String>) {
         self.index.points_count += 1;
 
         if self.index.point_to_tokens.len() <= idx as usize {
             self.index
                 .point_to_tokens
                 .resize_with(idx as usize + 1, Default::default);
+            if let Some(point_to_doc) = self.index.point_to_doc.as_mut() {
+                point_to_doc.resize_with(idx as usize + 1, Default::default);
+            }
         }
 
-        let tokens = self
-            .index
-            .register_tokens(str_tokens.iter().map(String::as_str));
-        let tokens_set = TokenSet::from_iter(tokens);
-        self.index.point_to_tokens[idx as usize] = Some(tokens_set);
+        let tokens = self.index.register_tokens(str_tokens);
+
+        if let Some(point_to_doc) = self.index.point_to_doc.as_mut() {
+            point_to_doc[idx as usize] = Some(Document::new(tokens.clone()));
+        }
     }
 
     pub fn add_iter(
         &mut self,
-        iter: impl Iterator<Item = OperationResult<(PointOffsetType, BTreeSet<String>)>>,
+        iter: impl Iterator<Item = OperationResult<(PointOffsetType, impl Iterator<Item = String>)>>,
         // TODO(phrase-index): add param for including phrase field
     ) -> OperationResult<()> {
         for item in iter {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index_builder.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index_builder.rs
@@ -44,7 +44,7 @@ impl MutableInvertedIndexBuilder {
 
     pub fn add_iter(
         &mut self,
-        iter: impl Iterator<Item = OperationResult<(PointOffsetType, impl Iterator<Item = String>)>>,
+        iter: impl Iterator<Item = OperationResult<(PointOffsetType, Vec<String>)>>,
         // TODO(phrase-index): add param for including phrase field
     ) -> OperationResult<()> {
         for item in iter {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -6,6 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use gridstore::Gridstore;
 use gridstore::config::StorageOptions;
+use itertools::Itertools;
 use parking_lot::RwLock;
 
 use super::inverted_index::{Document, InvertedIndex, TokenSet};
@@ -246,8 +246,8 @@ impl MutableFullTextIndex {
             // store ordered tokens
             str_tokens
         } else {
-            // store unique tokens
-            BTreeSet::from_iter(str_tokens).into_iter().collect()
+            // store sorted, unique tokens
+            str_tokens.into_iter().sorted().dedup().collect()
         };
 
         let db_document = FullTextIndex::serialize_document(tokens_to_store)?;

--- a/lib/segment/src/index/field_index/full_text_index/positions.rs
+++ b/lib/segment/src/index/field_index/full_text_index/positions.rs
@@ -17,7 +17,7 @@ impl PostingValue for Positions {
 
 impl UnsizedValue for Positions {
     fn write_len(&self) -> usize {
-        self.0.len() * std::mem::size_of::<u32>()
+        self.0.as_bytes().len()
     }
 
     fn write_to(&self, dst: &mut [u8]) {


### PR DESCRIPTION
Builds on top of #6602 

Adds a `phrase_matching` bool param in the text index parameterization which controls how to store the tokens of each text.