### PR TITLE
Validate IntegerIndexParams

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -206,6 +206,8 @@ fn configure_validation(builder: Builder) -> Builder {
             ("UpdateBatchPoints.operations", "length(min = 1)"),
             ("CreateFieldIndexCollection.collection_name", "length(min = 1, max = 255)"),
             ("CreateFieldIndexCollection.field_name", "length(min = 1)"),
+            ("CreateFieldIndexCollection.field_index_params", ""),
+            ("PayloadIndexParams.index_params", ""),
             ("DeleteFieldIndexCollection.collection_name", "length(min = 1, max = 255)"),
             ("DeleteFieldIndexCollection.field_name", "length(min = 1)"),
             ("SearchPoints.collection_name", "length(min = 1, max = 255)"),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -865,6 +865,7 @@ pub struct UuidIndexParams {
     #[prost(bool, optional, tag = "2")]
     pub on_disk: ::core::option::Option<bool>,
 }
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -873,6 +874,7 @@ pub struct PayloadIndexParams {
         oneof = "payload_index_params::IndexParams",
         tags = "3, 2, 4, 5, 1, 6, 7, 8"
     )]
+    #[validate(nested)]
     pub index_params: ::core::option::Option<payload_index_params::IndexParams>,
 }
 /// Nested message and enum types in `PayloadIndexParams`.
@@ -4389,6 +4391,7 @@ pub struct CreateFieldIndexCollection {
     pub field_type: ::core::option::Option<i32>,
     /// Payload index params.
     #[prost(message, optional, tag = "5")]
+    #[validate(nested)]
     pub field_index_params: ::core::option::Option<PayloadIndexParams>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use common::validation::{validate_range_generic, validate_shard_different_peers};
+use segment::data_types::index::validate_integer_index_params;
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::qdrant as grpc;
@@ -381,6 +382,35 @@ pub fn validate_timestamp(ts: &prost_wkt_types::Timestamp) -> Result<(), Validat
     )?;
     validate_range_generic(ts.nanos, Some(0), Some(999_999_999))?;
     Ok(())
+}
+
+impl Validate for super::qdrant::payload_index_params::IndexParams {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        match self {
+            grpc::payload_index_params::IndexParams::KeywordIndexParams(_) => Ok(()),
+            grpc::payload_index_params::IndexParams::IntegerIndexParams(integer_index_params) => {
+                integer_index_params.validate()
+            }
+            grpc::payload_index_params::IndexParams::FloatIndexParams(_) => Ok(()),
+            grpc::payload_index_params::IndexParams::GeoIndexParams(_) => Ok(()),
+            grpc::payload_index_params::IndexParams::TextIndexParams(_) => Ok(()),
+            grpc::payload_index_params::IndexParams::BoolIndexParams(_) => Ok(()),
+            grpc::payload_index_params::IndexParams::DatetimeIndexParams(_) => Ok(()),
+            grpc::payload_index_params::IndexParams::UuidIndexParams(_) => Ok(()),
+        }
+    }
+}
+
+impl Validate for super::qdrant::IntegerIndexParams {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let super::qdrant::IntegerIndexParams {
+            lookup,
+            range,
+            is_principal: _,
+            on_disk: _,
+        } = &self;
+        validate_integer_index_params(lookup, range)
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use validator::{Validate, ValidationError, ValidationErrors};
 
 // Keyword
 
@@ -10,7 +11,9 @@ pub enum KeywordIndexType {
     Keyword,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct KeywordIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -55,6 +58,33 @@ pub struct IntegerIndexParams {
     pub on_disk: Option<bool>,
 }
 
+impl Validate for IntegerIndexParams {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let IntegerIndexParams {
+            r#type: _,
+            lookup,
+            range,
+            is_principal: _,
+            on_disk: _,
+        } = &self;
+        validate_integer_index_params(lookup, range)
+    }
+}
+
+pub fn validate_integer_index_params(
+    lookup: &Option<bool>,
+    range: &Option<bool>,
+) -> Result<(), ValidationErrors> {
+    if lookup == &Some(false) && range == &Some(false) {
+        let mut errors = ValidationErrors::new();
+        let error =
+            ValidationError::new("the 'lookup' and 'range' capabilities can't be both disabled");
+        errors.add("lookup", error);
+        return Err(errors);
+    }
+    Ok(())
+}
+
 // UUID
 
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Hash, Eq)]
@@ -64,7 +94,9 @@ pub enum UuidIndexType {
     Uuid,
 }
 
-#[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
+#[derive(
+    Default, Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct UuidIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -88,7 +120,9 @@ pub enum FloatIndexType {
     Float,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct FloatIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -112,7 +146,9 @@ pub enum GeoIndexType {
     Geo,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct GeoIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -142,7 +178,9 @@ pub enum TokenizerType {
     Multilingual,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct TextIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -177,7 +215,9 @@ pub enum BoolIndexType {
     Bool,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct BoolIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -197,7 +237,9 @@ pub enum DatetimeIndexType {
     Datetime,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct DatetimeIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -11,9 +11,7 @@ pub enum KeywordIndexType {
     Keyword,
 }
 
-#[derive(
-    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
-)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct KeywordIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -94,9 +92,7 @@ pub enum UuidIndexType {
     Uuid,
 }
 
-#[derive(
-    Default, Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
-)]
+#[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct UuidIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -120,9 +116,7 @@ pub enum FloatIndexType {
     Float,
 }
 
-#[derive(
-    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
-)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct FloatIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -146,9 +140,7 @@ pub enum GeoIndexType {
     Geo,
 }
 
-#[derive(
-    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
-)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct GeoIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -178,9 +170,7 @@ pub enum TokenizerType {
     Multilingual,
 }
 
-#[derive(
-    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
-)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct TextIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -215,9 +205,7 @@ pub enum BoolIndexType {
     Bool,
 }
 
-#[derive(
-    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
-)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct BoolIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
@@ -237,9 +225,7 @@ pub enum DatetimeIndexType {
     Datetime,
 }
 
-#[derive(
-    Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq, Validate,
-)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct DatetimeIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1774,11 +1774,39 @@ impl PayloadSchemaParams {
     }
 }
 
+impl Validate for PayloadSchemaParams {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        match self {
+            PayloadSchemaParams::Keyword(keyword_index_params) => keyword_index_params.validate(),
+            PayloadSchemaParams::Integer(integer_index_params) => integer_index_params.validate(),
+            PayloadSchemaParams::Float(float_index_params) => float_index_params.validate(),
+            PayloadSchemaParams::Geo(geo_index_params) => geo_index_params.validate(),
+            PayloadSchemaParams::Text(text_index_params) => text_index_params.validate(),
+            PayloadSchemaParams::Bool(bool_index_params) => bool_index_params.validate(),
+            PayloadSchemaParams::Datetime(datetime_index_params) => {
+                datetime_index_params.validate()
+            }
+            PayloadSchemaParams::Uuid(uuid_index_params) => uuid_index_params.validate(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum PayloadFieldSchema {
     FieldType(PayloadSchemaType),
     FieldParams(PayloadSchemaParams),
+}
+
+impl Validate for PayloadFieldSchema {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        match self {
+            PayloadFieldSchema::FieldType(_) => Ok(()), // nothing to validate
+            PayloadFieldSchema::FieldParams(payload_schema_params) => {
+                payload_schema_params.validate()
+            }
+        }
+    }
 }
 
 impl Display for PayloadFieldSchema {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1777,16 +1777,14 @@ impl PayloadSchemaParams {
 impl Validate for PayloadSchemaParams {
     fn validate(&self) -> Result<(), ValidationErrors> {
         match self {
-            PayloadSchemaParams::Keyword(keyword_index_params) => keyword_index_params.validate(),
+            PayloadSchemaParams::Keyword(_) => Ok(()),
             PayloadSchemaParams::Integer(integer_index_params) => integer_index_params.validate(),
-            PayloadSchemaParams::Float(float_index_params) => float_index_params.validate(),
-            PayloadSchemaParams::Geo(geo_index_params) => geo_index_params.validate(),
-            PayloadSchemaParams::Text(text_index_params) => text_index_params.validate(),
-            PayloadSchemaParams::Bool(bool_index_params) => bool_index_params.validate(),
-            PayloadSchemaParams::Datetime(datetime_index_params) => {
-                datetime_index_params.validate()
-            }
-            PayloadSchemaParams::Uuid(uuid_index_params) => uuid_index_params.validate(),
+            PayloadSchemaParams::Float(_) => Ok(()),
+            PayloadSchemaParams::Geo(_) => Ok(()),
+            PayloadSchemaParams::Text(_) => Ok(()),
+            PayloadSchemaParams::Bool(_) => Ok(()),
+            PayloadSchemaParams::Datetime(_) => Ok(()),
+            PayloadSchemaParams::Uuid(_) => Ok(()),
         }
     }
 }

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -224,6 +224,7 @@ pub struct DeleteVectorsOperation {
 pub struct CreateFieldIndex {
     pub field_name: PayloadKeyType,
     #[serde(alias = "field_type")]
+    #[validate(nested)]
     pub field_schema: Option<PayloadFieldSchema>,
 }
 

--- a/tests/openapi/test_payload_indexing.py
+++ b/tests/openapi/test_payload_indexing.py
@@ -10,6 +10,23 @@ def setup(collection_name):
     yield
     drop_collection(collection_name=collection_name)
 
+def test_payload_indexing_validation(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}/index',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "field_name": "test_payload",
+            "field_schema": {
+              "type": "integer",
+              "lookup": False,
+              "range": False,
+            }
+        }
+    )
+    assert response.status_code == 422
+    assert "Validation error: the 'lookup' and 'range' capabilities can't be both disabled" in response.json()["status"]["error"]
 
 def test_payload_indexing_operations(collection_name):
     # create payload


### PR DESCRIPTION
Add API validation for `IntegerIndexParams` to prevent users from creating integer indexes which do not support `lookup` nor `range` to avoid bad performance.
