### PR TITLE
Add in-memory payload index on mmap storage (full text)

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_chunks_reader.rs
+++ b/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_chunks_reader.rs
@@ -38,10 +38,14 @@ impl<'a> ChunkReader<'a> {
         let chunks = self.chunks;
         let remainder_postings = self.remainder_postings;
 
+        // Check if in any chunk
         let in_chunks_range = !chunks.is_empty() && val >= chunks[0].initial && val <= last_doc_id;
-        let in_noncompressed_range =
-            !remainder_postings.is_empty() && val >= remainder_postings[0] && val <= last_doc_id;
-        in_chunks_range || in_noncompressed_range
+        if in_chunks_range {
+            return true;
+        }
+
+        // Check if in uncompressed range
+        !remainder_postings.is_empty() && val >= remainder_postings[0] && val <= last_doc_id
     }
 
     pub fn contains(&self, val: PointOffsetType) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_chunks_reader.rs
+++ b/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_chunks_reader.rs
@@ -208,9 +208,9 @@ impl<'a> ChunkReaderIter<'a> {
         if self.pending_remainder {
             self.pending_remainder = false;
             self.buffer
-                .copy_from_slice(self.chunk_reader.remainder_postings);
-            self.buffer
                 .truncate(self.chunk_reader.remainder_postings.len());
+            self.buffer
+                .copy_from_slice(self.chunk_reader.remainder_postings);
             self.buffer_position = 0;
             return Some(());
         }

--- a/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_chunks_reader.rs
+++ b/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_chunks_reader.rs
@@ -132,6 +132,10 @@ impl<'a> ChunkReader<'a> {
         self.chunks.len() * BitPackerImpl::BLOCK_LEN + self.remainder_postings.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.chunks.is_empty() && self.remainder_postings.is_empty()
+    }
+
     pub fn chunks_len(&self) -> usize {
         self.chunks.len()
     }

--- a/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/compressed_posting/compressed_posting_list.rs
@@ -102,4 +102,31 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_chunk_reader_iter_len() {
+        for step in 0..3 {
+            let (compressed_posting_list, _set) =
+                CompressedPostingList::generate_compressed_posting_list_fixture(step);
+
+            let reader = compressed_posting_list.reader();
+            let len = reader.len();
+
+            // Ensure chunk reader iterator length correctness
+            let mut iter = reader.iter();
+            assert_eq!(iter.len(), len);
+            assert_eq!(iter.size_hint(), (len, Some(len)));
+            assert_eq!(iter.clone().count(), len);
+
+            // Consume two iterator items
+            let _ = iter.next();
+            let _ = iter.next();
+
+            // Assert adjusted size
+            let len = len - 2;
+            assert_eq!(iter.len(), len);
+            assert_eq!(iter.size_hint(), (len, Some(len)));
+            assert_eq!(iter.count(), len);
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -61,7 +61,7 @@ impl InvertedIndex for ImmutableInvertedIndex {
         let postings = match postings_opt {
             // All tokens must have postings and query must not be empty
             Some(postings) if !postings.is_empty() => postings,
-            _ => return Box::new(vec![].into_iter()),
+            _ => return Box::new(std::iter::empty()),
         };
 
         let posting_readers: Vec<_> = postings

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -222,7 +222,7 @@ impl From<&MmapInvertedIndex> for ImmutableInvertedIndex {
         let point_to_tokens_count = index
             .point_to_tokens_count
             .iter()
-            .map(|&n| Some(n))
+            .map(|&n| if n > 0 { Some(n) } else { None })
             .collect();
 
         ImmutableInvertedIndex {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -190,7 +190,9 @@ impl From<&MmapInvertedIndex> for ImmutableInvertedIndex {
             .iter_postings(&hw_counter)
             .enumerate()
             .filter_map(|(orig_token, posting)| {
-                (!posting.is_empty()).then_some((orig_token, posting))
+                posting
+                    .filter(|posting| !posting.is_empty())
+                    .map(|posting| (orig_token, posting))
             })
             .enumerate()
             .map(|(new_token, (orig_token, posting))| {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -222,7 +222,14 @@ impl From<&MmapInvertedIndex> for ImmutableInvertedIndex {
         let point_to_tokens_count = index
             .point_to_tokens_count
             .iter()
-            .map(|&n| if n > 0 { Some(n) } else { None })
+            .enumerate()
+            .map(|(i, &n)| {
+                debug_assert!(
+                    index.is_active(i as u32) || n == 0,
+                    "deleted point index {i} has {n} tokens, expected zero",
+                );
+                (n > 0).then_some(n)
+            })
             .collect();
 
         ImmutableInvertedIndex {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -1,6 +1,7 @@
 use common::types::PointOffsetType;
 
 use super::immutable_inverted_index::ImmutableInvertedIndex;
+use super::inverted_index::InvertedIndex;
 use super::mmap_text_index::MmapFullTextIndex;
 use super::mutable_inverted_index::MutableInvertedIndex;
 use super::text_index::FullTextIndex;

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -48,13 +48,6 @@ impl ImmutableFullTextIndex {
         }
     }
 
-    pub fn init(&mut self) -> OperationResult<()> {
-        match self.storage {
-            Storage::RocksDb(ref db_wrapper) => db_wrapper.recreate_column_family(),
-            Storage::Mmap(ref mut index) => index.init(),
-        }
-    }
-
     /// Load storage
     ///
     /// Loads in-memory index from backing RocksDB or mmap storage.

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -85,16 +85,17 @@ impl ImmutableFullTextIndex {
     }
 
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        match self.storage {
-            Storage::RocksDb(ref db_wrapper) => {
-                let db_doc_id = FullTextIndex::store_key(id);
-                db_wrapper.remove(db_doc_id)?;
-            }
-            Storage::Mmap(ref mut index) => {
-                index.remove_point(id)?;
+        if self.inverted_index.remove_document(id) {
+            match self.storage {
+                Storage::RocksDb(ref db_wrapper) => {
+                    let db_doc_id = FullTextIndex::store_key(id);
+                    db_wrapper.remove(db_doc_id)?;
+                }
+                Storage::Mmap(ref mut index) => {
+                    index.remove_point(id)?;
+                }
             }
         }
-
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -22,11 +22,23 @@ enum Storage {
 }
 
 impl ImmutableFullTextIndex {
-    pub fn new(db_wrapper: DatabaseColumnScheduledDeleteWrapper, config: TextIndexParams) -> Self {
+    pub fn new_rocksdb(
+        db_wrapper: DatabaseColumnScheduledDeleteWrapper,
+        config: TextIndexParams,
+    ) -> Self {
         Self {
             inverted_index: Default::default(),
             config,
             storage: Storage::RocksDb(db_wrapper),
+        }
+    }
+
+    pub fn new_mmap(index: MmapFullTextIndex) -> Self {
+        let inverted_index = ImmutableInvertedIndex::from(&index.inverted_index);
+        Self {
+            inverted_index,
+            config: index.config.clone(),
+            storage: Storage::Mmap(Box::new(index)),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -1,38 +1,56 @@
 use common::types::PointOffsetType;
 
 use super::immutable_inverted_index::ImmutableInvertedIndex;
-use super::inverted_index::InvertedIndex;
+use super::mmap_text_index::MmapFullTextIndex;
 use super::mutable_inverted_index::MutableInvertedIndex;
 use super::text_index::FullTextIndex;
+use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::data_types::index::TextIndexParams;
 
 pub struct ImmutableFullTextIndex {
     pub(super) inverted_index: ImmutableInvertedIndex,
-    pub(super) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
     pub(super) config: TextIndexParams,
+    // Backing storage, source of state, persists deletions
+    storage: Storage,
+}
+
+enum Storage {
+    RocksDb(DatabaseColumnScheduledDeleteWrapper),
+    Mmap(Box<MmapFullTextIndex>),
 }
 
 impl ImmutableFullTextIndex {
     pub fn new(db_wrapper: DatabaseColumnScheduledDeleteWrapper, config: TextIndexParams) -> Self {
         Self {
             inverted_index: Default::default(),
-            db_wrapper,
             config,
+            storage: Storage::RocksDb(db_wrapper),
         }
     }
 
-    pub fn init(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
+    pub fn init(&mut self) -> OperationResult<()> {
+        match self.storage {
+            Storage::RocksDb(ref db_wrapper) => db_wrapper.recreate_column_family(),
+            Storage::Mmap(ref mut index) => index.init(),
+        }
     }
 
     pub fn load_from_db(&mut self) -> OperationResult<bool> {
-        if !self.db_wrapper.has_column_family()? {
+        let db_wrapper = match &self.storage {
+            Storage::RocksDb(db_wrapper) => Some(db_wrapper.clone()),
+            Storage::Mmap(_) => None,
+        };
+        let Some(db_wrapper) = db_wrapper else {
+            return Ok(true);
+        };
+
+        if !db_wrapper.has_column_family()? {
             return Ok(false);
         };
 
-        let db = self.db_wrapper.lock_db();
+        let db = db_wrapper.lock_db();
         let iter = db.iter()?.map(|(key, value)| {
             let idx = FullTextIndex::restore_key(&key);
             let tokens = FullTextIndex::deserialize_document(&value)?;
@@ -46,16 +64,39 @@ impl ImmutableFullTextIndex {
         Ok(true)
     }
 
+    #[cfg(test)]
+    pub fn get_db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
+        match self.storage {
+            Storage::RocksDb(ref db_wrapper) => Some(db_wrapper),
+            Storage::Mmap(_) => None,
+        }
+    }
+
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        if self.inverted_index.remove_document(id) {
-            let db_doc_id = FullTextIndex::store_key(id);
-            self.db_wrapper.remove(db_doc_id)?;
+        match self.storage {
+            Storage::RocksDb(ref db_wrapper) => {
+                let db_doc_id = FullTextIndex::store_key(id);
+                db_wrapper.remove(db_doc_id)?;
+            }
+            Storage::Mmap(ref mut index) => {
+                index.remove_point(id)?;
+            }
         }
 
         Ok(())
     }
 
     pub fn clear(self) -> OperationResult<()> {
-        self.db_wrapper.remove_column_family()
+        match self.storage {
+            Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
+            Storage::Mmap(index) => index.clear(),
+        }
+    }
+
+    pub fn flusher(&self) -> Flusher {
+        match self.storage {
+            Storage::RocksDb(ref db_wrapper) => db_wrapper.flusher(),
+            Storage::Mmap(ref index) => index.flusher(),
+        }
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -98,6 +98,12 @@ impl ImmutableFullTextIndex {
             return false;
         };
         self.inverted_index = ImmutableInvertedIndex::from(&index.inverted_index);
+
+        // Index is now loaded into memory, clear cache of backing mmap storage
+        if let Err(err) = index.clear_cache() {
+            log::warn!("Failed to clear mmap cache of ram mmap full text index: {err}");
+        }
+
         true
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -353,74 +353,96 @@ mod tests {
         let indexed_count = 10000;
         let deleted_count = 500;
 
-        let mut mutable = mutable_inverted_index(indexed_count, deleted_count);
-        let immutable = ImmutableInvertedIndex::from(mutable.clone());
+        let hw_counter = HardwareCounterCell::new();
+        let mmap_dir = tempfile::tempdir().unwrap();
+        let imm_mmap_dir = tempfile::tempdir().unwrap();
 
-        let path = tempfile::tempdir().unwrap().into_path();
+        let mut mut_index = mutable_inverted_index(indexed_count, deleted_count);
 
-        MmapInvertedIndex::create(path.clone(), immutable).unwrap();
+        let mut mmap_index = {
+            let immutable = ImmutableInvertedIndex::from(mut_index.clone());
+            MmapInvertedIndex::create(mmap_dir.path().into(), immutable).unwrap();
+            MmapInvertedIndex::open(mmap_dir.path().into(), false).unwrap()
+        };
 
-        let mut mmap_index = MmapInvertedIndex::open(path, false).unwrap();
+        let mut imm_mmap_index = {
+            let immutable = ImmutableInvertedIndex::from(mut_index.clone());
+            MmapInvertedIndex::create(imm_mmap_dir.path().into(), immutable).unwrap();
+            let mmap_index = MmapInvertedIndex::open(imm_mmap_dir.path().into(), false).unwrap();
+            ImmutableInvertedIndex::from(&mmap_index)
+        };
 
         let queries: Vec<_> = (0..100).map(|_| generate_query()).collect();
 
         let mut_parsed_queries: Vec<_> = queries
-            .clone()
-            .into_iter()
-            .map(|query| to_parsed_query(query, |token| mutable.vocab.get(&token).copied()))
+            .iter()
+            .cloned()
+            .map(|query| to_parsed_query(query, |token| mut_index.vocab.get(&token).copied()))
             .collect();
-
-        let hw_counter = HardwareCounterCell::new();
-
-        let imm_parsed_queries: Vec<_> = queries
-            .into_iter()
+        let mmap_parsed_queries: Vec<_> = queries
+            .iter()
+            .cloned()
             .map(|query| {
                 to_parsed_query(query, |token| mmap_index.get_token_id(&token, &hw_counter))
+            })
+            .collect();
+        let imm_mmap_parsed_queries: Vec<_> = queries
+            .into_iter()
+            .map(|query| {
+                to_parsed_query(query, |token| {
+                    imm_mmap_index.get_token_id(&token, &hw_counter)
+                })
             })
             .collect();
 
         check_query_congruence(
             &mut_parsed_queries,
-            &imm_parsed_queries,
-            &mutable,
+            &mmap_parsed_queries,
+            &imm_mmap_parsed_queries,
+            &mut_index,
             &mmap_index,
+            &imm_mmap_index,
             &hw_counter,
         );
 
         // Delete random documents from both indexes
-
         let points_to_delete: Vec<_> = (0..deleted_count)
             .map(|_| rand::rng().random_range(0..indexed_count))
             .collect();
-
         for point_id in &points_to_delete {
-            mutable.remove_document(*point_id);
+            mut_index.remove_document(*point_id);
             mmap_index.remove_document(*point_id);
+            imm_mmap_index.remove_document(*point_id);
         }
 
         // Check congruence after deletion
         check_query_congruence(
             &mut_parsed_queries,
-            &imm_parsed_queries,
-            &mutable,
+            &mmap_parsed_queries,
+            &imm_mmap_parsed_queries,
+            &mut_index,
             &mmap_index,
+            &imm_mmap_index,
             &hw_counter,
         );
     }
 
     fn check_query_congruence(
         mut_parsed_queries: &[Option<ParsedQuery>],
-        imm_parsed_queries: &[Option<ParsedQuery>],
-        mutable: &MutableInvertedIndex,
+        mmap_parsed_queries: &[Option<ParsedQuery>],
+        imm_mmap_parsed_queries: &[Option<ParsedQuery>],
+        mut_index: &MutableInvertedIndex,
         mmap_index: &MmapInvertedIndex,
+        imm_mmap_index: &ImmutableInvertedIndex,
         hw_counter: &HardwareCounterCell,
     ) {
-        for queries in mut_parsed_queries
-            .iter()
-            .cloned()
-            .zip(imm_parsed_queries.iter().cloned())
-        {
-            let (Some(mut_query), Some(imm_query)) = queries else {
+        for queries in mut_parsed_queries.iter().cloned().zip(
+            mmap_parsed_queries
+                .iter()
+                .cloned()
+                .zip(imm_mmap_parsed_queries.iter().cloned()),
+        ) {
+            let (Some(mut_query), (Some(imm_query), Some(imm_mmap_query))) = queries else {
                 // Immutable index can have a smaller vocabulary, since it only contains tokens that have
                 // non-empty posting lists.
                 // Since we removed some documents from the mutable index, it can happen that the immutable
@@ -429,10 +451,14 @@ mod tests {
                 // In this case both queries would filter to an empty set of documents.
                 continue;
             };
-            let mut_filtered = mutable.filter(mut_query, hw_counter).collect::<Vec<_>>();
+            let mut_filtered = mut_index.filter(mut_query, hw_counter).collect::<Vec<_>>();
             let imm_filtered = mmap_index.filter(imm_query, hw_counter).collect::<Vec<_>>();
+            let imm_mmap_filtered = imm_mmap_index
+                .filter(imm_mmap_query, hw_counter)
+                .collect::<Vec<_>>();
 
             assert_eq!(mut_filtered, imm_filtered);
+            assert_eq!(imm_filtered, imm_mmap_filtered);
         }
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -245,8 +245,7 @@ impl MmapPostings {
     pub fn iter_postings<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
-    ) -> impl Iterator<Item = ChunkReader<'a>> {
-        (0..self.header.posting_count as u32)
-            .map(|posting_idx| self.get(posting_idx, hw_counter).unwrap())
+    ) -> impl Iterator<Item = Option<ChunkReader<'a>>> {
+        (0..self.header.posting_count as u32).map(|posting_idx| self.get(posting_idx, hw_counter))
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -240,4 +240,13 @@ impl MmapPostings {
     pub fn populate(&self) {
         self.mmap.populate();
     }
+
+    /// Iterate over posting lists, returning chunk reader for each
+    pub fn iter_postings<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> impl Iterator<Item = ChunkReader<'a>> {
+        (0..self.header.posting_count as u32)
+            .map(|posting_idx| self.get(posting_idx, hw_counter).unwrap())
+    }
 }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -128,7 +128,7 @@ impl MmapInvertedIndex {
     pub(super) fn iter_postings<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
-    ) -> impl Iterator<Item = ChunkReader<'a>> {
+    ) -> impl Iterator<Item = Option<ChunkReader<'a>>> {
         self.postings.iter_postings(hw_counter)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -133,7 +133,7 @@ impl MmapInvertedIndex {
     }
 
     /// Returns whether the point id is valid and active.
-    fn is_active(&self, point_id: PointOffsetType) -> bool {
+    pub fn is_active(&self, point_id: PointOffsetType) -> bool {
         let is_deleted = self.deleted_points.get(point_id as usize).unwrap_or(true);
 
         !is_deleted

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -210,12 +210,12 @@ impl InvertedIndex for MmapInvertedIndex {
             .collect();
         let Some(posting_readers) = postings_opt else {
             // There are unseen tokens -> no matches
-            return Box::new(vec![].into_iter());
+            return Box::new(std::iter::empty());
         };
 
         if posting_readers.is_empty() {
             // Empty request -> no matches
-            return Box::new(vec![].into_iter());
+            return Box::new(std::iter::empty());
         }
 
         // in case of mmap immutable index, deleted points are still in the postings

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -41,18 +41,6 @@ impl MmapFullTextIndex {
         &self.inverted_index.path
     }
 
-    pub fn init(&mut self) -> OperationResult<()> {
-        self.inverted_index.deleted_points.forget_pending_updates();
-
-        let files = self.files();
-        let path = self.path();
-        for file in files {
-            std::fs::remove_file(file)?;
-        }
-        let _ = remove_dir(path);
-        Ok(())
-    }
-
     pub fn clear(self) -> OperationResult<()> {
         let files = self.files();
         let path = self.path();

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -65,7 +65,6 @@ impl MmapFullTextIndex {
 
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         self.inverted_index.remove_document(id);
-
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -41,6 +41,18 @@ impl MmapFullTextIndex {
         &self.inverted_index.path
     }
 
+    pub fn init(&mut self) -> OperationResult<()> {
+        self.inverted_index.deleted_points.forget_pending_updates();
+
+        let files = self.files();
+        let path = self.path();
+        for file in files {
+            std::fs::remove_file(file)?;
+        }
+        let _ = remove_dir(path);
+        Ok(())
+    }
+
     pub fn clear(self) -> OperationResult<()> {
         let files = self.files();
         let path = self.path();

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -150,11 +150,11 @@ impl InvertedIndex for MutableInvertedIndex {
             .collect();
         let Some(postings) = postings_opt else {
             // There are unseen tokens -> no matches
-            return Box::new(vec![].into_iter());
+            return Box::new(std::iter::empty());
         };
         if postings.is_empty() {
             // Empty request -> no matches
-            return Box::new(vec![].into_iter());
+            return Box::new(std::iter::empty());
         }
         intersect_postings_iterator(postings)
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -30,7 +30,7 @@ impl MutableFullTextIndex {
         self.db_wrapper.recreate_column_family()
     }
 
-    pub fn load_from_db(&mut self) -> OperationResult<bool> {
+    pub fn load(&mut self) -> OperationResult<bool> {
         if !self.db_wrapper.has_column_family()? {
             return Ok(false);
         };

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -146,7 +146,7 @@ mod tests {
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
-            let mut index = FullTextIndex::builder(db, config.clone(), "text")
+            let mut index = FullTextIndex::builder_rocksdb(db, config.clone(), "text")
                 .make_empty()
                 .unwrap();
 
@@ -216,7 +216,7 @@ mod tests {
 
         {
             let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-            let mut index = FullTextIndex::new_memory(db, config, "text", immutable);
+            let mut index = FullTextIndex::new_rocksdb(db, config, "text", immutable);
             let loaded = index.load().unwrap();
             assert!(loaded);
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -167,7 +167,7 @@ fn test_prefix_search(#[case] immutable: bool) {
     };
 
     let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
-    let mut index = FullTextIndex::builder(db.clone(), config.clone(), "text")
+    let mut index = FullTextIndex::builder_rocksdb(db.clone(), config.clone(), "text")
         .make_empty()
         .unwrap();
 
@@ -182,7 +182,7 @@ fn test_prefix_search(#[case] immutable: bool) {
     }
 
     if immutable {
-        index = FullTextIndex::new_memory(db, config, "text", false);
+        index = FullTextIndex::new_rocksdb(db, config, "text", false);
         index.load().unwrap();
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -34,7 +34,7 @@ pub enum FullTextIndex {
 }
 
 impl FullTextIndex {
-    pub fn new_memory(
+    pub fn new_rocksdb(
         db: Arc<RwLock<DB>>,
         config: TextIndexParams,
         field: &str,
@@ -77,12 +77,12 @@ impl FullTextIndex {
         }
     }
 
-    pub fn builder(
+    pub fn builder_rocksdb(
         db: Arc<RwLock<DB>>,
         config: TextIndexParams,
         field: &str,
     ) -> FullTextIndexBuilder {
-        FullTextIndexBuilder(Self::new_memory(db, config, field, true))
+        FullTextIndexBuilder(Self::new_rocksdb(db, config, field, true))
     }
 
     pub fn builder_mmap(

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -72,8 +72,14 @@ impl FullTextIndex {
     pub fn init(&mut self) -> OperationResult<()> {
         match self {
             Self::Mutable(index) => index.init(),
-            Self::Immutable(_) => unreachable!("not applicable for immutable index"),
-            Self::Mmap(_) => unreachable!("not applicable for mmap immutable index"),
+            Self::Immutable(_) => {
+                debug_assert!(false, "Immutable index should be initialized before use");
+                Ok(())
+            }
+            Self::Mmap(_) => {
+                debug_assert!(false, "Mmap index should be initialized before use");
+                Ok(())
+            }
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -382,7 +382,7 @@ impl PayloadFieldIndex for FullTextIndex {
     fn flusher(&self) -> Flusher {
         match self {
             Self::Mutable(index) => index.db_wrapper.flusher(),
-            Self::Immutable(index) => index.db_wrapper.flusher(),
+            Self::Immutable(index) => index.flusher(),
             Self::Mmap(index) => index.flusher(),
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -72,7 +72,7 @@ impl FullTextIndex {
     pub fn init(&mut self) -> OperationResult<()> {
         match self {
             Self::Mutable(index) => index.init(),
-            Self::Immutable(index) => index.init(),
+            Self::Immutable(_) => unreachable!("not applicable for immutable index"),
             Self::Mmap(_) => unreachable!("not applicable for mmap immutable index"),
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -48,7 +48,7 @@ impl FullTextIndex {
         if is_appendable {
             Self::Mutable(MutableFullTextIndex::new(db_wrapper, config))
         } else {
-            Self::Immutable(ImmutableFullTextIndex::new(db_wrapper, config))
+            Self::Immutable(ImmutableFullTextIndex::new_rocksdb(db_wrapper, config))
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -48,7 +48,7 @@ impl FullTextIndex {
         if is_appendable {
             Self::Mutable(MutableFullTextIndex::new(db_wrapper, config))
         } else {
-            Self::Immutable(ImmutableFullTextIndex::new_rocksdb(db_wrapper, config))
+            Self::Immutable(ImmutableFullTextIndex::open_rocksdb(db_wrapper, config))
         }
     }
 
@@ -63,7 +63,7 @@ impl FullTextIndex {
             Ok(Self::Mmap(Box::new(mmap_index)))
         } else {
             // Load into RAM, use mmap as backing storage
-            Ok(Self::Immutable(ImmutableFullTextIndex::new_mmap(
+            Ok(Self::Immutable(ImmutableFullTextIndex::open_mmap(
                 mmap_index,
             )))
         }
@@ -372,8 +372,8 @@ impl PayloadFieldIndex for FullTextIndex {
 
     fn load(&mut self) -> OperationResult<bool> {
         match self {
-            Self::Mutable(index) => index.load_from_db(),
-            Self::Immutable(index) => index.load_from_db(),
+            Self::Mutable(index) => index.load(),
+            Self::Immutable(index) => index.load(),
             Self::Mmap(_index) => Ok(true), // mmap index is always loaded
         }
     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -283,7 +283,7 @@ impl IndexSelector<'_> {
     ) -> OperationResult<FullTextIndex> {
         Ok(match self {
             IndexSelector::RocksDb(IndexSelectorRocksDb { db, is_appendable }) => {
-                FullTextIndex::new_memory(
+                FullTextIndex::new_rocksdb(
                     Arc::clone(db),
                     config,
                     &field.to_string(),
@@ -301,7 +301,7 @@ impl IndexSelector<'_> {
             IndexSelector::RocksDb(IndexSelectorRocksDb {
                 db,
                 is_appendable: _,
-            }) => FieldIndexBuilder::FullTextIndex(FullTextIndex::builder(
+            }) => FieldIndexBuilder::FullTextIndex(FullTextIndex::builder_rocksdb(
                 Arc::clone(db),
                 config,
                 &field.to_string(),

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -20,9 +20,9 @@ use memory::mmap_type::MmapBitSlice;
 use serde::{Deserialize, Serialize};
 
 use super::{IdIter, MapIndexKey};
-use crate::common::Flusher;
 use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
 use crate::common::operation_error::OperationResult;
+use crate::common::Flusher;
 use crate::index::field_index::mmap_point_to_values::MmapPointToValues;
 
 const DELETED_PATH: &str = "deleted.bin";

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -20,9 +20,9 @@ use memory::mmap_type::MmapBitSlice;
 use serde::{Deserialize, Serialize};
 
 use super::{IdIter, MapIndexKey};
+use crate::common::Flusher;
 use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
 use crate::common::operation_error::OperationResult;
-use crate::common::Flusher;
 use crate::index::field_index::mmap_point_to_values::MmapPointToValues;
 
 const DELETED_PATH: &str = "deleted.bin";

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -953,7 +953,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
             Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
                 AnyVariants::Strings(keywords) => {
                     if keywords.is_empty() {
-                        Some(Box::new(vec![].into_iter()))
+                        Some(Box::new(std::iter::empty()))
                     } else {
                         None
                     }
@@ -1343,7 +1343,7 @@ mod tests {
         // Ensure cardinality is non-zero
         assert!(
             !index
-                .except_cardinality(vec![].into_iter(), &hw_counter)
+                .except_cardinality(std::iter::empty(), &hw_counter)
                 .equals_min_exp_max(&CardinalityEstimation::exact(0))
         );
     }
@@ -1409,7 +1409,7 @@ mod tests {
         // Ensure cardinality is zero
         assert!(
             index
-                .except_cardinality(vec![].into_iter(), &hw_counter)
+                .except_cardinality(std::iter::empty(), &hw_counter)
                 .equals_min_exp_max(&CardinalityEstimation::exact(0))
         );
     }

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -186,7 +186,7 @@ impl PayloadIndex for PlainPayloadIndex {
         _threshold: usize,
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
         // No blocks for un-indexed payload
-        Box::new(vec![].into_iter())
+        Box::new(std::iter::empty())
     }
 
     fn overwrite_payload(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -634,7 +634,7 @@ impl PayloadIndex for StructPayloadIndex {
         threshold: usize,
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
         match self.field_indexes.get(field) {
-            None => Box::new(vec![].into_iter()),
+            None => Box::new(std::iter::empty()),
             Some(indexes) => {
                 let field_clone = field.to_owned();
                 Box::new(indexes.iter().flat_map(move |field_index| {


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6444>.

Add in-memory payload index for full text using mmap as storage.

Loading the in-memory full text payload index from mmap is **33x faster** than from RocksDB, as shown in this simple benchmark:

- `bfb --text-payloads --text-payload-length 40 -n 500000 -d1 --indexing-threshold 100`:
    - Old RocksDB based index: 2.4s, 2.5s, 2.5s, 2.6s = avg 2.5s
    - New mmap based index: 77.2ms, 75.1ms, 77.2ms, 74.7ms = avg 0.076s (33x faster!)

- `bfb --text-payloads --text-payload-length 100 --text-payload-vocabulary 50000 -n 500000 -d1 --indexing-threshold 100`:
    - Old RocksDB based index: 6.6s, 6.6s, 6.7s, 6.6s = avg 6.6s
    - New mmap based index: 202.8ms, 200.6ms, 211.2ms, 201.8ms = avg 0.2s (33x faster!)

### Tasks

- [x] ~Switch `point_to_tokens_count` key from option to number~ (will be done separately)
- [x] Add test
- [x] Do load benchmark
- [x] Drop mmap caches after load
- [x] Merge <https://github.com/qdrant/qdrant/pull/6444>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
