### PR TITLE
Add partial snapshot recovery and read operation locks

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -337,6 +337,17 @@ impl Collection {
             .assert_shard_exists(shard_id)
     }
 
+    pub async fn take_partial_snapshot_lock(
+        &self,
+        shard_id: ShardId,
+        recovery_type: RecoveryType,
+    ) -> CollectionResult<Option<tokio::sync::OwnedMutexGuard<()>>> {
+        self.shards_holder
+            .read()
+            .await
+            .take_partial_snapshot_recovery_lock(shard_id, recovery_type)
+    }
+
     pub async fn get_partial_snapshot_manifest(
         &self,
         shard_id: ShardId,

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -337,7 +337,7 @@ impl Collection {
             .assert_shard_exists(shard_id)
     }
 
-    pub async fn take_partial_snapshot_lock(
+    pub async fn try_take_partial_snapshot_recovery_lock(
         &self,
         shard_id: ShardId,
         recovery_type: RecoveryType,
@@ -345,7 +345,7 @@ impl Collection {
         self.shards_holder
             .read()
             .await
-            .take_partial_snapshot_recovery_lock(shard_id, recovery_type)
+            .try_take_partial_snapshot_recovery_lock(shard_id, recovery_type)
     }
 
     pub async fn get_partial_snapshot_manifest(

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1043,6 +1043,8 @@ pub enum CollectionError {
         description: String,
         retry_after: Option<Duration>,
     },
+    #[error("Shard temporarily unavailable: {description}")]
+    ShardUnavailable { description: String },
 }
 
 impl CollectionError {
@@ -1152,6 +1154,12 @@ impl CollectionError {
         }
     }
 
+    pub fn shard_unavailable(description: impl Into<String>) -> Self {
+        Self::ShardUnavailable {
+            description: description.into(),
+        }
+    }
+
     /// Returns true if the error is transient and the operation can be retried.
     /// Returns false if the error is not transient and the operation should fail on all replicas.
     pub fn is_transient(&self) -> bool {
@@ -1162,6 +1170,7 @@ impl CollectionError {
             Self::Cancelled { .. } => true,
             Self::OutOfMemory { .. } => true,
             Self::PreConditionFailed { .. } => true,
+            Self::ShardUnavailable { .. } => true,
             // Not transient
             Self::BadInput { .. } => false,
             Self::NotFound { .. } => false,

--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -122,7 +122,7 @@ impl ShardReplicaSet {
             )));
         };
 
-        self.check_partial_snapshot_read_lock()?;
+        let _partial_snapshot_search_lock = self.try_take_search_read_lock()?;
 
         read_operation(local.get()).await
     }
@@ -157,7 +157,7 @@ impl ShardReplicaSet {
 
         let local_operation = if local_is_active {
             let local_operation = async {
-                self.check_partial_snapshot_read_lock()?;
+                let _partial_snapshot_search_lock = self.try_take_search_read_lock()?;
 
                 let Some(local) = local else {
                     return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -122,6 +122,8 @@ impl ShardReplicaSet {
             )));
         };
 
+        self.check_partial_snapshot_read_lock()?;
+
         read_operation(local.get()).await
     }
 
@@ -155,6 +157,8 @@ impl ShardReplicaSet {
 
         let local_operation = if local_is_active {
             let local_operation = async {
+                self.check_partial_snapshot_read_lock()?;
+
                 let Some(local) = local else {
                     return Err(CollectionError::service_error(format!(
                         "Local shard {} not found",

--- a/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
+++ b/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use crate::operations::types::{CollectionError, CollectionResult};
+
+#[derive(Debug)]
+pub struct PartialSnapshotMeta {
+    recovery_lock: Arc<tokio::sync::Mutex<()>>,
+    read_lock: Arc<tokio::sync::Semaphore>,
+}
+
+impl PartialSnapshotMeta {
+    pub fn new() -> Self {
+        Self {
+            recovery_lock: Arc::new(tokio::sync::Mutex::new(())),
+            read_lock: Arc::new(tokio::sync::Semaphore::new(1)),
+        }
+    }
+
+    pub fn take_recovery_lock(&self) -> CollectionResult<tokio::sync::OwnedMutexGuard<()>> {
+        self.recovery_lock.clone().try_lock_owned().map_err(|_| {
+            CollectionError::bad_request("partial snapshot recovery is already in progress")
+        })
+    }
+
+    pub fn take_read_lock(&self) -> CollectionResult<tokio::sync::OwnedSemaphorePermit> {
+        self.read_lock.clone().try_acquire_owned().map_err(|_| {
+            CollectionError::bad_request("partial snapshot recovery is already in progress")
+        })
+    }
+
+    pub fn check_read_lock(&self) -> CollectionResult<()> {
+        let read_operation_permits = self.read_lock.available_permits();
+
+        if read_operation_permits > 0 {
+            Ok(())
+        } else {
+            Err(CollectionError::ServiceError {
+                error: "shard unavailable, partial snapshot recovery is in progress".into(),
+                backtrace: None,
+            })
+        }
+    }
+}

--- a/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
+++ b/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
@@ -16,13 +16,13 @@ impl PartialSnapshotMeta {
         }
     }
 
-    pub fn take_recovery_lock(&self) -> CollectionResult<tokio::sync::OwnedMutexGuard<()>> {
+    pub fn try_take_recovery_lock(&self) -> CollectionResult<tokio::sync::OwnedMutexGuard<()>> {
         self.recovery_lock.clone().try_lock_owned().map_err(|_| {
             CollectionError::bad_request("partial snapshot recovery is already in progress")
         })
     }
 
-    pub fn take_read_lock(&self) -> CollectionResult<tokio::sync::OwnedSemaphorePermit> {
+    pub fn try_take_read_lock(&self) -> CollectionResult<tokio::sync::OwnedSemaphorePermit> {
         self.read_lock.clone().try_acquire_owned().map_err(|_| {
             CollectionError::bad_request("partial snapshot recovery is already in progress")
         })

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -60,16 +60,16 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub fn take_partial_snapshot_recovery_lock(
+    pub fn try_take_partial_snapshot_recovery_lock(
         &self,
     ) -> CollectionResult<tokio::sync::OwnedMutexGuard<()>> {
-        self.partial_snapshot_meta.take_recovery_lock()
+        self.partial_snapshot_meta.try_take_recovery_lock()
     }
 
-    pub fn take_partial_snapshot_read_lock(
+    pub fn try_take_partial_snapshot_read_lock(
         &self,
     ) -> CollectionResult<tokio::sync::OwnedSemaphorePermit> {
-        self.partial_snapshot_meta.take_read_lock()
+        self.partial_snapshot_meta.try_take_read_lock()
     }
 
     pub fn check_partial_snapshot_read_lock(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -60,6 +60,22 @@ impl ShardReplicaSet {
         Ok(())
     }
 
+    pub fn take_partial_snapshot_recovery_lock(
+        &self,
+    ) -> CollectionResult<tokio::sync::OwnedMutexGuard<()>> {
+        self.partial_snapshot_meta.take_recovery_lock()
+    }
+
+    pub fn take_partial_snapshot_read_lock(
+        &self,
+    ) -> CollectionResult<tokio::sync::OwnedSemaphorePermit> {
+        self.partial_snapshot_meta.take_read_lock()
+    }
+
+    pub fn check_partial_snapshot_read_lock(&self) -> CollectionResult<()> {
+        self.partial_snapshot_meta.check_read_lock()
+    }
+
     pub fn restore_snapshot(
         snapshot_path: &Path,
         this_peer_id: PeerId,

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -66,14 +66,14 @@ impl ShardReplicaSet {
         self.partial_snapshot_meta.try_take_recovery_lock()
     }
 
-    pub fn try_take_partial_snapshot_read_lock(
-        &self,
-    ) -> CollectionResult<tokio::sync::OwnedSemaphorePermit> {
-        self.partial_snapshot_meta.try_take_read_lock()
+    pub async fn take_search_write_lock(&self) -> tokio::sync::OwnedRwLockWriteGuard<()> {
+        self.partial_snapshot_meta.take_search_write_lock().await
     }
 
-    pub fn check_partial_snapshot_read_lock(&self) -> CollectionResult<()> {
-        self.partial_snapshot_meta.check_read_lock()
+    pub fn try_take_search_read_lock(
+        &self,
+    ) -> CollectionResult<tokio::sync::OwnedRwLockReadGuard<()>> {
+        self.partial_snapshot_meta.try_take_search_read_lock()
     }
 
     pub fn restore_snapshot(

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1017,8 +1017,8 @@ impl ShardHolder {
 
         task.await??;
 
-        let _partial_snapshot_read_operation_lock =
-            self.take_partial_snapshot_read_operation_lock(shard_id, recovery_type)?;
+        let _partial_snapshot_read_lock =
+            self.try_take_partial_snapshot_read_lock(shard_id, recovery_type)?;
 
         // `ShardHolder::recover_local_shard_from` is *not* cancel safe
         // (see `ShardReplicaSet::restore_local_replica_from`)
@@ -1068,7 +1068,7 @@ impl ShardHolder {
         Ok(res)
     }
 
-    pub fn take_partial_snapshot_recovery_lock(
+    pub fn try_take_partial_snapshot_recovery_lock(
         &self,
         shard_id: ShardId,
         recovery_type: RecoveryType,
@@ -1079,14 +1079,14 @@ impl ShardHolder {
                 let lock = self
                     .get_shard(shard_id)
                     .ok_or_else(|| shard_not_found_error(shard_id))?
-                    .take_partial_snapshot_recovery_lock()?;
+                    .try_take_partial_snapshot_recovery_lock()?;
 
                 Ok(Some(lock))
             }
         }
     }
 
-    fn take_partial_snapshot_read_operation_lock(
+    fn try_take_partial_snapshot_read_lock(
         &self,
         shard_id: ShardId,
         recovery_type: RecoveryType,
@@ -1097,7 +1097,7 @@ impl ShardHolder {
                 let lock = self
                     .get_shard(shard_id)
                     .ok_or_else(|| shard_not_found_error(shard_id))?
-                    .take_partial_snapshot_read_lock()?;
+                    .try_take_partial_snapshot_read_lock()?;
 
                 Ok(Some(lock))
             }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1017,6 +1017,9 @@ impl ShardHolder {
 
         task.await??;
 
+        let _partial_snapshot_read_operation_lock =
+            self.take_partial_snapshot_read_operation_lock(shard_id, recovery_type)?;
+
         // `ShardHolder::recover_local_shard_from` is *not* cancel safe
         // (see `ShardReplicaSet::restore_local_replica_from`)
         let recovered = self
@@ -1063,6 +1066,42 @@ impl ShardHolder {
             .await?;
 
         Ok(res)
+    }
+
+    pub fn take_partial_snapshot_recovery_lock(
+        &self,
+        shard_id: ShardId,
+        recovery_type: RecoveryType,
+    ) -> CollectionResult<Option<tokio::sync::OwnedMutexGuard<()>>> {
+        match recovery_type {
+            RecoveryType::Full => Ok(None),
+            RecoveryType::Partial => {
+                let lock = self
+                    .get_shard(shard_id)
+                    .ok_or_else(|| shard_not_found_error(shard_id))?
+                    .take_partial_snapshot_recovery_lock()?;
+
+                Ok(Some(lock))
+            }
+        }
+    }
+
+    fn take_partial_snapshot_read_operation_lock(
+        &self,
+        shard_id: ShardId,
+        recovery_type: RecoveryType,
+    ) -> CollectionResult<Option<tokio::sync::OwnedSemaphorePermit>> {
+        match recovery_type {
+            RecoveryType::Full => Ok(None),
+            RecoveryType::Partial => {
+                let lock = self
+                    .get_shard(shard_id)
+                    .ok_or_else(|| shard_not_found_error(shard_id))?
+                    .take_partial_snapshot_read_lock()?;
+
+                Ok(Some(lock))
+            }
+        }
     }
 
     /// # Cancel safety

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -45,6 +45,7 @@ impl From<StorageError> for Status {
                 }
                 tonic::Code::ResourceExhausted
             }
+            StorageError::ShardUnavailable { .. } => tonic::Code::Unavailable,
         };
         let mut status = Status::new(error_code, format!("{error}"));
         // add metadata headers

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -42,6 +42,8 @@ pub enum StorageError {
         description: String,
         retry_after: Option<Duration>,
     },
+    #[error("Shard temporarily unavailable: {description}")]
+    ShardUnavailable { description: String },
 }
 
 impl StorageError {
@@ -158,6 +160,9 @@ impl StorageError {
                 description,
                 retry_after,
             },
+            CollectionError::ShardUnavailable { .. } => StorageError::ShardUnavailable {
+                description: overriding_description,
+            },
         }
     }
 }
@@ -217,6 +222,9 @@ impl From<CollectionError> for StorageError {
                 description,
                 retry_after,
             },
+            CollectionError::ShardUnavailable { description } => {
+                StorageError::ShardUnavailable { description }
+            }
         }
     }
 }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -37,6 +37,7 @@ use crate::actix::helpers::{self, HttpError};
 use crate::common;
 use crate::common::collections::*;
 use crate::common::http_client::HttpClient;
+use crate::common::snapshots::try_take_partial_snapshot_recovery_lock;
 
 #[derive(Deserialize, Serialize, JsonSchema, Validate)]
 pub struct SnapshotUploadingParam {
@@ -609,7 +610,19 @@ async fn recover_partial_snapshot(
     // nothing to verify.
     let pass = new_unchecked_verification_pass();
 
+    let try_take_recovery_lock_future =
+        try_take_partial_snapshot_recovery_lock(&dispatcher, &collection, shard, &access, &pass);
+
+    let recovery_lock = match try_take_recovery_lock_future.await {
+        Ok(recovery_lock) => recovery_lock,
+        Err(err) => {
+            return helpers::process_response_error(err, tokio::time::Instant::now(), None);
+        }
+    };
+
     let future = cancel::future::spawn_cancel_on_drop(async move |cancel| {
+        let _recovery_lock = recovery_lock;
+
         // TODO: Run this check before the multipart blob is uploaded
         let collection_pass = access
             .check_global_access(AccessRequirements::new().manage())?
@@ -675,20 +688,13 @@ async fn recover_partial_snapshot_from(
     // nothing to verify
     let pass = new_unchecked_verification_pass();
 
-    let try_take_recovery_lock_future = async {
-        let collection_pass = access
-            .check_global_access(AccessRequirements::new().manage())?
-            .issue_pass(&collection_name);
-
-        let recovery_lock = dispatcher
-            .toc(&access, &pass)
-            .get_collection(&collection_pass)
-            .await?
-            .try_take_partial_snapshot_recovery_lock(shard_id, RecoveryType::Partial)
-            .await?;
-
-        Ok(recovery_lock)
-    };
+    let try_take_recovery_lock_future = try_take_partial_snapshot_recovery_lock(
+        &dispatcher,
+        &collection_name,
+        shard_id,
+        &access,
+        &pass,
+    );
 
     let recovery_lock = match try_take_recovery_lock_future.await {
         Ok(recovery_lock) => recovery_lock,

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -675,7 +675,7 @@ async fn recover_partial_snapshot_from(
     // nothing to verify
     let pass = new_unchecked_verification_pass();
 
-    let take_recovery_lock_future = async {
+    let try_take_recovery_lock_future = async {
         let collection_pass = access
             .check_global_access(AccessRequirements::new().manage())?
             .issue_pass(&collection_name);
@@ -684,13 +684,13 @@ async fn recover_partial_snapshot_from(
             .toc(&access, &pass)
             .get_collection(&collection_pass)
             .await?
-            .take_partial_snapshot_lock(shard_id, RecoveryType::Partial)
+            .try_take_partial_snapshot_recovery_lock(shard_id, RecoveryType::Partial)
             .await?;
 
         Ok(recovery_lock)
     };
 
-    let recovery_lock = match take_recovery_lock_future.await {
+    let recovery_lock = match try_take_recovery_lock_future.await {
         Ok(recovery_lock) => recovery_lock,
         Err(err) => {
             return helpers::process_response_error(err, tokio::time::Instant::now(), None);

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -187,6 +187,7 @@ impl HttpError {
             StorageError::Forbidden { .. } => {}
             StorageError::PreconditionFailed { .. } => {}
             StorageError::InferenceError { .. } => {}
+            StorageError::ShardUnavailable { .. } => {}
         }
         headers
     }
@@ -207,6 +208,7 @@ impl ResponseError for HttpError {
             StorageError::PreconditionFailed { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
             StorageError::InferenceError { .. } => http::StatusCode::BAD_REQUEST,
             StorageError::RateLimitExceeded { .. } => http::StatusCode::TOO_MANY_REQUESTS,
+            StorageError::ShardUnavailable { .. } => http::StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 }


### PR DESCRIPTION
This PR adds
- `partial_snapshot_recovery_lock`
  - which only allows recovering a single partial snapshot request at a time
- and `partial_snapshot_read_lock`
  - which explicitly rejects read operations while partial snapshot recovery is in progress

__TODO:__
- [x] check partial snapshot recovery lock with `?wait=false`
- [x] add tests
- [ ] ~~report status of the last recovered partial snapshot~~
  - _will be implemented in a separate PR_

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
