### PR TITLE
Strict mode allows fullscan for multitenant payload index

### DIFF
--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -118,7 +118,7 @@ impl Query {
                     // HNSW disabled AND no filters
                     return Err(CollectionError::strict_mode(
                         format!(
-                            "Fullscan forbidden{vector_error_label} – vector indexing is disabled (hnsw_config.m = 0)"
+                            "Fullscan forbidden{vector_error_label} because vector indexing is disabled (hnsw_config.m = 0)"
                         ),
                         "Enable vector indexing or use a prefetch query before rescoring",
                     ));

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -90,10 +90,17 @@ impl Query {
                         if uses_multitenant_filter {
                             // no need for HNSW
                             return Ok(());
+                        } else {
+                            return Err(CollectionError::strict_mode(
+                                format!(
+                                    "Fullscan forbidden on '{using}' while filtering on non multitenant key"
+                                ),
+                                "Filter by multitenant indexed payload key or enable vector indexing",
+                            ));
                         }
                     };
 
-                    // HNSW disabled AND no multitenant filter to leverage
+                    // HNSW disabled AND no filters
                     return Err(CollectionError::strict_mode(
                         format!(
                             "Fullscan forbidden on '{using}' – vector indexing is disabled (hnsw_config.m = 0)"

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -69,12 +69,12 @@ impl Query {
                         .get_params(using)
                         .and_then(|param| param.hnsw_config.as_ref());
 
-                    let vector_hnsw_m = vector_hnsw_config.and_then(|hnsw| hnsw.m);
+                    let vector_hnsw_m = vector_hnsw_config.and_then(|hnsw| hnsw.m).unwrap_or(0);
                     let vector_hnsw_payload_m = vector_hnsw_config
                         .and_then(|hnsw| hnsw.payload_m)
                         .unwrap_or(0);
 
-                    let is_hnsw_disabled = vector_hnsw_m == Some(0) && vector_hnsw_payload_m == 0;
+                    let is_hnsw_disabled = vector_hnsw_m == 0 && vector_hnsw_payload_m == 0;
                     if !is_hnsw_disabled {
                         // fast path when no additional checks required
                         return Ok(());

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2786,6 +2786,17 @@ impl Condition {
             | Condition::HasVector(_) => 0,
         }
     }
+
+    pub fn targeted_key(&self) -> Option<PayloadKeyType> {
+        match self {
+            Condition::Field(field_condition) => Some(field_condition.key.clone()),
+            Condition::IsEmpty(is_empty_condition) => Some(is_empty_condition.is_empty.key.clone()),
+            Condition::IsNull(is_null_condition) => Some(is_null_condition.is_null.key.clone()),
+            Condition::Nested(nested_condition) => Some(nested_condition.array_key()),
+            Condition::Filter(filter) => filter.iter_conditions().find_map(|c| c.targeted_key()),
+            Condition::HasId(_) | Condition::HasVector(_) | Condition::CustomIdChecker(_) => None,
+        }
+    }
 }
 
 // The validator crate does not support deriving for enums.

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -300,7 +300,7 @@ def test_strict_mode_unindexed_filter_integer_read_validation(collection_name):
     search_fail = search_request_with_filter()
     assert "count" in search_fail.json()['status']['error']
     assert not search_fail.ok
- 
+
 
 def test_strict_mode_unindexed_filter_write_validation(collection_name):
     def update_request_with_filter():
@@ -2118,7 +2118,7 @@ def test_strict_mode_full_scan(full_collection_name):
         }
     )
     assert not response.ok
-    assert "Fullscan forbidden on 'dense-multi' – vector indexing is disabled (hnsw_config.m = 0). Help: Enable vector indexing or use a prefetch query before rescoring" in response.json()['status']['error']
+    assert "Fullscan forbidden on 'dense-multi' because vector indexing is disabled (hnsw_config.m = 0). Help: Enable vector indexing or use a prefetch query before rescoring" in response.json()['status']['error']
 
     # sparse vector still works
     response = request_with_validation(
@@ -2172,7 +2172,7 @@ def test_strict_mode_full_scan(full_collection_name):
         }
     )
     assert not response.ok
-    assert "Fullscan forbidden on 'dense-multi' – vector indexing is disabled (hnsw_config.m = 0). Help: Enable vector indexing or use a prefetch query before rescoring" in response.json()['status']['error']
+    assert "Fullscan forbidden on 'dense-multi' because vector indexing is disabled (hnsw_config.m = 0). Help: Enable vector indexing or use a prefetch query before rescoring" in response.json()['status']['error']
 
 
 def test_strict_mode_full_scan_simple(full_collection_name):

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -2118,7 +2118,7 @@ def test_strict_mode_full_scan(full_collection_name):
         }
     )
     assert not response.ok
-    assert "Fullscan forbidden on 'dense-multi' because vector indexing is disabled (hnsw_config.m = 0). Help: Enable vector indexing or use a prefetch query before rescoring" in response.json()['status']['error']
+    assert "Request is forbidden on 'dense-multi' because global vector indexing is disabled (hnsw_config.m = 0). Help: Use tenant-specific filter, enable global vector indexing or enable strict mode `search_allow_exact` option" in response.json()['status']['error']
 
     # sparse vector still works
     response = request_with_validation(
@@ -2172,7 +2172,7 @@ def test_strict_mode_full_scan(full_collection_name):
         }
     )
     assert not response.ok
-    assert "Fullscan forbidden on 'dense-multi' because vector indexing is disabled (hnsw_config.m = 0). Help: Enable vector indexing or use a prefetch query before rescoring" in response.json()['status']['error']
+    assert "Request is forbidden on 'dense-multi' because global vector indexing is disabled (hnsw_config.m = 0). Help: Use tenant-specific filter, enable global vector indexing or enable strict mode `search_allow_exact` option" in response.json()['status']['error']
 
 
 def test_strict_mode_full_scan_simple(full_collection_name):
@@ -2288,7 +2288,7 @@ def test_strict_mode_multitenant_full_scan(full_collection_name):
     # filtered search not allowed anymore because no HNSW index
     response = filtered_query()
     assert not response.ok
-    assert "Filtered scan forbidden on 'dense-multi'" in response.json()['status']['error']
+    assert "Request is forbidden on 'dense-multi'" in response.json()['status']['error']
 
     # add payload index
     request_with_validation(
@@ -2305,7 +2305,7 @@ def test_strict_mode_multitenant_full_scan(full_collection_name):
     # still not allowed although we have payload index for the filter
     response = filtered_query()
     assert not response.ok
-    assert "Filtered scan forbidden on 'dense-multi'" in response.json()['status']['error']
+    assert "Request is forbidden on 'dense-multi'" in response.json()['status']['error']
 
     # add multitenant payload index
     request_with_validation(
@@ -2325,7 +2325,7 @@ def test_strict_mode_multitenant_full_scan(full_collection_name):
     # still not allowed although we have a multitenant payload index for the filter
     response = filtered_query()
     assert not response.ok
-    assert "Filtered scan forbidden on 'dense-multi'" in response.json()['status']['error']
+    assert "Request is forbidden on 'dense-multi'" in response.json()['status']['error']
 
     # enabled HNSW payload based index
     response = request_with_validation(

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -2178,6 +2178,19 @@ def test_strict_mode_full_scan(full_collection_name):
 def test_strict_mode_full_scan_simple(full_collection_name):
     collection_name = full_collection_name
 
+    # full scan allowed
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/query',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "query": 2,
+            "using": "dense-text",
+            "limit": 5
+        }
+    )
+    assert response.ok
+
     # disable HNSW index
     response = request_with_validation(
         api='/collections/{collection_name}',

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -2230,7 +2230,7 @@ def test_strict_mode_full_scan_simple(full_collection_name):
         }
     )
     assert not response.ok
-    assert response.status_code == 403
+    assert response.status_code == 400
 
 
 def test_strict_mode_multitenant_full_scan(full_collection_name):

--- a/tests/openapi/test_strictmode.py
+++ b/tests/openapi/test_strictmode.py
@@ -2178,6 +2178,20 @@ def test_strict_mode_full_scan(full_collection_name):
 def test_strict_mode_full_scan_simple(full_collection_name):
     collection_name = full_collection_name
 
+    # Enable strict mode with search_allow_exact
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PATCH",
+        path_params={'collection_name': collection_name},
+        body={
+            "strict_mode_config": {
+                "enabled": True,
+                "search_allow_exact": False
+            },
+        }
+    )
+    assert response.ok
+
     # full scan allowed
     response = request_with_validation(
         api='/collections/{collection_name}/points/query',
@@ -2197,10 +2211,6 @@ def test_strict_mode_full_scan_simple(full_collection_name):
         method="PATCH",
         path_params={'collection_name': collection_name},
         body={
-            "strict_mode_config": {
-                "enabled": True,
-                "search_allow_exact": False
-            },
             "hnsw_config": {
                 "m": 0
             }


### PR DESCRIPTION
In a previous [PR](https://github.com/qdrant/qdrant/pull/6473), fullscan was prohibited in strict mode when using `search_allow_exact=false`.

However we want to allow querying when no global HNSW is present if the query leverage a multitenant HNSW based payload index.