### PR TITLE
Heuristic optimization

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -474,6 +474,7 @@ mod tests {
     use crate::fixtures::index_fixtures::TestRawScorerProducer;
     use crate::index::hnsw_index::graph_layers::GraphLayersBase;
     use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
+    use crate::index::hnsw_index::links_container::LinksContainer;
     use crate::spaces::simple::DotProductMetric;
     use crate::types::Distance;
     use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
@@ -973,10 +974,14 @@ mod tests {
 
             let scorer_fn = |a, b| scorer.score_internal(a, b);
 
-            let heuristic =
-                GraphLayersBuilder::select_candidates_with_heuristic(search_result, m, scorer_fn);
+            let mut heuristic = LinksContainer::with_capacity(m);
+            heuristic.fill_from_sorted_with_heuristic(
+                search_result.into_iter_sorted(),
+                m,
+                scorer_fn,
+            );
 
-            for (&cpu, gpu) in heuristic.iter().zip(gpu_group_result.iter()) {
+            for (cpu, gpu) in heuristic.iter().zip(gpu_group_result.iter()) {
                 assert_eq!(cpu, gpu.idx);
             }
         }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_links.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_links.rs
@@ -187,6 +187,7 @@ impl GpuLinks {
             .filter(|&point_id| {
                 !graph_layers_builder.links_layers()[point_id][level]
                     .read()
+                    .links()
                     .is_empty()
             })
             .collect();
@@ -196,7 +197,7 @@ impl GpuLinks {
 
             for &point_id in points_slice {
                 let links = graph_layers_builder.links_layers()[point_id][level].read();
-                self.set_links(point_id as PointOffsetType, &links)?;
+                self.set_links(point_id as PointOffsetType, links.links())?;
             }
             self.apply_gpu_patches(gpu_context)?;
             gpu_context.run()?;
@@ -259,8 +260,7 @@ impl GpuLinks {
                 let links_count = chunk[0] as usize;
                 let links = &chunk[1..=links_count];
                 let mut dst = graph_layers_builder.links_layers()[point_id][level].write();
-                dst.clear();
-                dst.extend(links.iter().copied().filter(|&other_point_id| {
+                dst.fill_from(links.iter().copied().filter(|&other_point_id| {
                     let is_correct_link =
                         level < graph_layers_builder.links_layers()[other_point_id as usize].len();
                     if !is_correct_link {

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -201,10 +201,12 @@ mod tests {
             for level in (0..levels_a + 1).rev() {
                 let links_a = graph_a.links_layers()[point_id as usize][level]
                     .read()
-                    .clone();
+                    .links()
+                    .to_vec();
                 let links_b = graph_b.links_layers()[point_id as usize][level]
                     .read()
-                    .clone();
+                    .links()
+                    .to_vec();
                 if links_a != links_b {
                     log::error!("Wrong links point_id={point_id} at level {level}");
                 }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -1,12 +1,10 @@
 use std::borrow::Cow;
 use std::cmp::{max, min};
-use std::collections::BinaryHeap;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 use bitvec::prelude::BitVec;
-use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
-use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoredPointOffset};
 use io::file_operations::atomic_save_bin;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use rand::Rng;
@@ -14,15 +12,16 @@ use rand::distr::Uniform;
 
 use super::graph_layers::GraphLayerData;
 use super::graph_links::{GraphLinks, GraphLinksFormat};
+use super::links_container::LinksContainer;
 use crate::common::operation_error::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
-use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase, LinkContainer};
+use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase};
 use crate::index::hnsw_index::graph_links::GraphLinksSerializer;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::search_context::SearchContext;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 
-pub type LockedLinkContainer = RwLock<LinkContainer>;
+pub type LockedLinkContainer = RwLock<LinksContainer>;
 pub type LockedLayersContainer = Vec<LockedLinkContainer>;
 
 /// Same as `GraphLayers`,  but allows to build in parallel
@@ -58,8 +57,8 @@ impl GraphLayersBase for GraphLayersBuilder {
         let links = self.links_layers[point_id as usize][level].read();
         let ready_list = self.ready_list.read();
         for link in links.iter() {
-            if ready_list[*link as usize] {
-                f(*link);
+            if ready_list[link as usize] {
+                f(link);
             }
         }
     }
@@ -131,7 +130,7 @@ impl GraphLayersBuilder {
     ) -> GraphLinksSerializer {
         let edges = link_layers
             .into_iter()
-            .map(|l| l.into_iter().map(|l| l.into_inner()).collect())
+            .map(|l| l.into_iter().map(|l| l.into_inner().into_vec()).collect())
             .collect();
         GraphLinksSerializer::new(edges, format, m, m0)
     }
@@ -177,11 +176,11 @@ impl GraphLayersBuilder {
         reserve: bool,
     ) -> Self {
         let links_layers = std::iter::repeat_with(|| {
-            vec![RwLock::new(if reserve {
-                Vec::with_capacity(m0)
+            vec![RwLock::new(LinksContainer::with_capacity(if reserve {
+                m0
             } else {
-                vec![]
-            })]
+                0
+            }))]
         })
         .take(num_vectors)
         .collect();
@@ -240,10 +239,11 @@ impl GraphLayersBuilder {
                     let other_links = other_links.into_inner();
                     visited_list.next_iteration();
                     let mut current_links = current_layers[level].write();
-                    current_links.iter().copied().for_each(|x| {
+                    current_links.iter().for_each(|x| {
                         visited_list.check_and_update_visited(x);
                     });
                     for other_link in other_links
+                        .into_vec()
                         .into_iter()
                         .filter(|x| !visited_list.check_and_update_visited(*x))
                     {
@@ -284,84 +284,11 @@ impl GraphLayersBuilder {
         }
         let point_layers = &mut self.links_layers[point_id as usize];
         while point_layers.len() <= level {
-            let links = Vec::with_capacity(self.m);
+            let links = LinksContainer::with_capacity(self.m);
             point_layers.push(RwLock::new(links));
         }
         self.max_level
             .fetch_max(level, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    /// Connect new point to links, so that links contains only closest points
-    fn connect_new_point<F>(
-        links: &mut LinkContainer,
-        new_point_id: PointOffsetType,
-        target_point_id: PointOffsetType,
-        level_m: usize,
-        mut score_internal: F,
-    ) where
-        F: FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
-    {
-        // ToDo: binary search here ? (most likely does not worth it)
-        let new_to_target = score_internal(target_point_id, new_point_id);
-
-        let mut id_to_insert = links.len();
-        for (i, &item) in links.iter().enumerate() {
-            let target_to_link = score_internal(target_point_id, item);
-            if target_to_link < new_to_target {
-                id_to_insert = i;
-                break;
-            }
-        }
-
-        if links.len() < level_m {
-            links.insert(id_to_insert, new_point_id);
-        } else if id_to_insert != links.len() {
-            links.pop();
-            links.insert(id_to_insert, new_point_id);
-        }
-    }
-
-    /// <https://github.com/nmslib/hnswlib/issues/99>
-    fn select_candidate_with_heuristic_from_sorted<F>(
-        candidates: impl Iterator<Item = ScoredPointOffset>,
-        m: usize,
-        mut score_internal: F,
-    ) -> Vec<PointOffsetType>
-    where
-        F: FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
-    {
-        let mut result_list = Vec::with_capacity(m);
-        for current_closest in candidates {
-            if result_list.len() >= m {
-                break;
-            }
-            let mut is_good = true;
-            for &selected_point in &result_list {
-                let dist_to_already_selected = score_internal(current_closest.idx, selected_point);
-                if dist_to_already_selected > current_closest.score {
-                    is_good = false;
-                    break;
-                }
-            }
-            if is_good {
-                result_list.push(current_closest.idx);
-            }
-        }
-
-        result_list
-    }
-
-    /// <https://github.com/nmslib/hnswlib/issues/99>
-    pub(crate) fn select_candidates_with_heuristic<F>(
-        candidates: FixedLengthPriorityQueue<ScoredPointOffset>,
-        m: usize,
-        score_internal: F,
-    ) -> Vec<PointOffsetType>
-    where
-        F: FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
-    {
-        let closest_iter = candidates.into_iter_sorted();
-        Self::select_candidate_with_heuristic_from_sorted(closest_iter, m, score_internal)
     }
 
     pub fn link_new_point(&self, point_id: PointOffsetType, mut points_scorer: FilteredScorer) {
@@ -427,8 +354,7 @@ impl GraphLayersBuilder {
 
         for (level, neighbours) in levels.iter().enumerate() {
             let mut links = self.links_layers[point_id as usize][level].write();
-            links.clear();
-            links.extend_from_slice(neighbours);
+            links.fill_from(neighbours.iter().copied());
         }
 
         let was_ready = self.ready_list.write().replace(point_id as usize, true);
@@ -496,7 +422,7 @@ impl GraphLayersBuilder {
             let mut existing_links = self.links_layers[point_id as usize][curr_level].write();
             {
                 let ready_list = self.ready_list.read();
-                for &existing_link in existing_links.iter() {
+                for existing_link in existing_links.iter() {
                     if !visited_list.check(existing_link) && ready_list[existing_link as usize] {
                         search_context.process_candidate(ScoredPointOffset {
                             idx: existing_link,
@@ -506,39 +432,15 @@ impl GraphLayersBuilder {
                 }
             }
 
-            let selected_nearest =
-                Self::select_candidates_with_heuristic(search_context.nearest, level_m, scorer);
-            existing_links.clone_from(&selected_nearest);
-            selected_nearest
+            let iter = search_context.nearest.into_iter_sorted();
+            existing_links.fill_from_sorted_with_heuristic(iter, level_m, scorer);
+            existing_links.links().to_vec()
         };
 
         for &other_point in &selected_nearest {
-            let mut other_point_links = self.links_layers[other_point as usize][curr_level].write();
-            if other_point_links.len() < level_m {
-                // If linked point is lack of neighbours
-                other_point_links.push(point_id);
-            } else {
-                let mut candidates = BinaryHeap::with_capacity(level_m + 1);
-                candidates.push(ScoredPointOffset {
-                    idx: point_id,
-                    score: points_scorer.score_internal(point_id, other_point),
-                });
-                for other_point_link in other_point_links.iter().take(level_m).copied() {
-                    candidates.push(ScoredPointOffset {
-                        idx: other_point_link,
-                        score: points_scorer.score_internal(other_point_link, other_point),
-                    });
-                }
-                let selected_candidates = Self::select_candidate_with_heuristic_from_sorted(
-                    candidates.into_sorted_vec().into_iter().rev(),
-                    level_m,
-                    scorer,
-                );
-                other_point_links.clear(); // this do not free memory, which is good
-                for selected in selected_candidates.iter().copied() {
-                    other_point_links.push(selected);
-                }
-            }
+            self.links_layers[other_point as usize][curr_level]
+                .write()
+                .connect_with_heuristic(point_id, other_point, level_m, scorer);
         }
     }
 
@@ -554,12 +456,12 @@ impl GraphLayersBuilder {
         for nearest_point in search_context.nearest.iter_unsorted() {
             {
                 let mut links = self.links_layers[point_id as usize][curr_level].write();
-                Self::connect_new_point(&mut links, nearest_point.idx, point_id, level_m, scorer);
+                links.connect(nearest_point.idx, point_id, level_m, scorer);
             }
 
             {
                 let mut links = self.links_layers[nearest_point.idx as usize][curr_level].write();
-                Self::connect_new_point(&mut links, point_id, nearest_point.idx, level_m, scorer);
+                links.connect(point_id, nearest_point.idx, level_m, scorer);
             }
         }
     }
@@ -576,7 +478,7 @@ impl GraphLayersBuilder {
         let mut count = 0;
         for links in self.links_layers.iter() {
             if links.len() > level {
-                sum += links[level].read().len();
+                sum += links[level].read().links().len();
                 count += 1;
             }
         }
@@ -590,19 +492,19 @@ impl GraphLayersBuilder {
 
 #[cfg(test)]
 mod tests {
+    use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
     use itertools::Itertools;
     use rand::SeedableRng;
     use rand::prelude::StdRng;
-    use rand::seq::SliceRandom;
     use rstest::rstest;
 
     use super::*;
-    use crate::data_types::vectors::{DenseVector, VectorElementType};
+    use crate::data_types::vectors::VectorElementType;
     use crate::fixtures::index_fixtures::{TestRawScorerProducer, random_vector};
     use crate::index::hnsw_index::graph_links::normalize_links;
     use crate::index::hnsw_index::tests::create_graph_layer_fixture;
     use crate::spaces::metric::Metric;
-    use crate::spaces::simple::{CosineMetric, EuclidMetric};
+    use crate::spaces::simple::CosineMetric;
     use crate::vector_storage::DEFAULT_STOPPED;
     use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
 
@@ -730,7 +632,7 @@ mod tests {
         let total_links_0: usize = graph_layers_builder
             .links_layers
             .iter()
-            .map(|x| x[0].read().len())
+            .map(|x| x[0].read().links().len())
             .sum();
 
         assert!(total_links_0 > 0);
@@ -793,7 +695,7 @@ mod tests {
                 .links(idx as PointOffsetType, 0)
                 .collect_vec();
             let links_builder = graph_layers_builder.links_layers[idx][0].read();
-            let link_container_from_builder = links_builder.iter().copied().collect::<Vec<_>>();
+            let link_container_from_builder = links_builder.links().to_vec();
             let m = match format {
                 GraphLinksFormat::Plain => 0,
                 GraphLinksFormat::Compressed => M * 2,
@@ -823,7 +725,7 @@ mod tests {
         let total_links_0: usize = graph_layers_builder
             .links_layers
             .iter()
-            .map(|x| x[0].read().len())
+            .map(|x| x[0].read().links().len())
             .sum();
 
         assert!(total_links_0 > 0);
@@ -899,105 +801,5 @@ mod tests {
             .sum();
         let avg_connectivity = total_edges as f64 / NUM_VECTORS as f64;
         eprintln!("avg_connectivity = {avg_connectivity:#?}");
-    }
-
-    #[test]
-    #[ignore]
-    fn test_candidate_selection_heuristics() {
-        const NUM_VECTORS: usize = 100;
-        const DIM: usize = 16;
-        const M: usize = 16;
-
-        let mut rng = StdRng::seed_from_u64(42);
-
-        let vector_holder = TestRawScorerProducer::<EuclidMetric>::new(DIM, NUM_VECTORS, &mut rng);
-
-        let mut candidates: FixedLengthPriorityQueue<ScoredPointOffset> =
-            FixedLengthPriorityQueue::new(NUM_VECTORS);
-
-        let new_vector_to_insert = random_vector(&mut rng, DIM);
-
-        let scorer = vector_holder.get_scorer(new_vector_to_insert);
-
-        for i in 0..NUM_VECTORS {
-            candidates.push(ScoredPointOffset {
-                idx: i as PointOffsetType,
-                score: scorer.score_point(i as PointOffsetType),
-            });
-        }
-
-        let sorted_candidates = candidates.into_sorted_vec();
-
-        for x in sorted_candidates.iter().take(M) {
-            eprintln!("sorted_candidates = ({}, {})", x.idx, x.score);
-        }
-
-        let selected_candidates = GraphLayersBuilder::select_candidate_with_heuristic_from_sorted(
-            sorted_candidates.into_iter(),
-            M,
-            |a, b| scorer.score_internal(a, b),
-        );
-
-        for x in selected_candidates.iter() {
-            eprintln!("selected_candidates = {x}");
-        }
-    }
-
-    #[test]
-    fn test_connect_new_point() {
-        let num_points = 10;
-        let m = 6;
-        let ef_construct = 32;
-
-        // See illustration in docs
-        let points: Vec<DenseVector> = vec![
-            vec![21.79, 7.18],  // Target
-            vec![20.58, 5.46],  // 1  B - yes
-            vec![21.19, 4.51],  // 2  C
-            vec![24.73, 8.24],  // 3  D - yes
-            vec![24.55, 9.98],  // 4  E
-            vec![26.11, 6.85],  // 5  F
-            vec![17.64, 11.14], // 6  G - yes
-            vec![14.97, 11.52], // 7  I
-            vec![14.97, 9.60],  // 8  J
-            vec![16.23, 14.32], // 9  H
-            vec![12.69, 19.13], // 10 K
-        ];
-
-        let scorer = |a: PointOffsetType, b: PointOffsetType| {
-            -((points[a as usize][0] - points[b as usize][0]).powi(2)
-                + (points[a as usize][1] - points[b as usize][1]).powi(2))
-            .sqrt()
-        };
-
-        let mut insert_ids = (1..points.len() as PointOffsetType).collect_vec();
-
-        let mut candidates = FixedLengthPriorityQueue::new(insert_ids.len());
-        for &id in &insert_ids {
-            candidates.push(ScoredPointOffset {
-                idx: id,
-                score: scorer(0, id),
-            });
-        }
-
-        let res = GraphLayersBuilder::select_candidates_with_heuristic(candidates, m, scorer);
-
-        assert_eq!(&res, &vec![1, 3, 6]);
-
-        let mut rng = StdRng::seed_from_u64(42);
-
-        let graph_layers_builder = GraphLayersBuilder::new(num_points, m, m, ef_construct, 1, true);
-        insert_ids.shuffle(&mut rng);
-        for &id in &insert_ids {
-            let level_m = graph_layers_builder.get_m(0);
-            let mut links = graph_layers_builder.links_layers[0][0].write();
-            GraphLayersBuilder::connect_new_point(&mut links, id, 0, level_m, scorer)
-        }
-        let mut result = Vec::new();
-        graph_layers_builder.links_layers[0][0]
-            .read()
-            .iter()
-            .for_each(|x| result.push(*x));
-        assert_eq!(&result, &vec![1, 2, 3, 4, 5, 6]);
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -12,7 +12,7 @@ use rand::distr::Uniform;
 
 use super::graph_layers::GraphLayerData;
 use super::graph_links::{GraphLinks, GraphLinksFormat};
-use super::links_container::LinksContainer;
+use super::links_container::{ItemsBuffer, LinksContainer};
 use crate::common::operation_error::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
 use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase};
@@ -437,10 +437,11 @@ impl GraphLayersBuilder {
             existing_links.links().to_vec()
         };
 
+        let mut items = ItemsBuffer::default();
         for &other_point in &selected_nearest {
             self.links_layers[other_point as usize][curr_level]
                 .write()
-                .connect_with_heuristic(point_id, other_point, level_m, scorer);
+                .connect_with_heuristic(point_id, other_point, level_m, scorer, &mut items);
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/links_container.rs
+++ b/lib/segment/src/index/hnsw_index/links_container.rs
@@ -1,0 +1,243 @@
+use std::collections::BinaryHeap;
+use std::iter::Copied;
+
+use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+
+pub struct LinksContainer {
+    links: Vec<PointOffsetType>,
+}
+
+impl LinksContainer {
+    pub fn with_capacity(m: usize) -> Self {
+        Self {
+            links: Vec::with_capacity(m),
+        }
+    }
+
+    pub fn push(&mut self, link: PointOffsetType) {
+        self.links.push(link);
+    }
+
+    pub fn links(&self) -> &[PointOffsetType] {
+        &self.links
+    }
+
+    pub fn iter(&self) -> Copied<std::slice::Iter<'_, u32>> {
+        self.links.iter().copied()
+    }
+
+    pub fn into_vec(self) -> Vec<PointOffsetType> {
+        self.links
+    }
+
+    pub fn fill_from(&mut self, points: impl Iterator<Item = PointOffsetType>) {
+        self.links.clear();
+        self.links.extend(points);
+    }
+
+    pub fn fill_from_sorted_with_heuristic(
+        &mut self,
+        candidates: impl Iterator<Item = ScoredPointOffset>,
+        level_m: usize,
+        score: impl FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
+    ) {
+        self.links.clear();
+        let selected = select_candidate_with_heuristic_from_sorted(candidates, level_m, score);
+        self.links.clone_from(&selected);
+    }
+
+    /// Connect new point to links, so that links contains only closest points
+    pub fn connect(
+        &mut self,
+        new_point_id: PointOffsetType,
+        target_point_id: PointOffsetType,
+        level_m: usize,
+        mut score: impl FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
+    ) {
+        // ToDo: binary search here ? (most likely does not worth it)
+        let new_to_target = score(target_point_id, new_point_id);
+
+        let mut id_to_insert = self.links.len();
+        for (i, &item) in self.links.iter().enumerate() {
+            let target_to_link = score(target_point_id, item);
+            if target_to_link < new_to_target {
+                id_to_insert = i;
+                break;
+            }
+        }
+
+        if self.links.len() < level_m {
+            self.links.insert(id_to_insert, new_point_id);
+        } else if id_to_insert != self.links.len() {
+            self.links.pop();
+            self.links.insert(id_to_insert, new_point_id);
+        }
+    }
+
+    pub fn connect_with_heuristic(
+        &mut self,
+        point_id: PointOffsetType,
+        other_point: PointOffsetType,
+        level_m: usize,
+        mut score: impl FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
+    ) {
+        if self.links.len() < level_m {
+            // If linked point is lack of neighbours
+            self.links.push(point_id);
+        } else {
+            let mut candidates = BinaryHeap::with_capacity(level_m + 1);
+            candidates.push(ScoredPointOffset {
+                idx: point_id,
+                score: score(point_id, other_point),
+            });
+            for other_point_link in self.links.iter().take(level_m).copied() {
+                candidates.push(ScoredPointOffset {
+                    idx: other_point_link,
+                    score: score(other_point_link, other_point),
+                });
+            }
+            let selected_candidates = select_candidate_with_heuristic_from_sorted(
+                candidates.into_sorted_vec().into_iter().rev(),
+                level_m,
+                score,
+            );
+            self.links.clear(); // this do not free memory, which is good
+            for selected in selected_candidates.iter().copied() {
+                self.links.push(selected);
+            }
+        }
+    }
+}
+
+/// <https://github.com/nmslib/hnswlib/issues/99>
+fn select_candidate_with_heuristic_from_sorted(
+    candidates: impl Iterator<Item = ScoredPointOffset>,
+    m: usize,
+    mut score: impl FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
+) -> Vec<PointOffsetType> {
+    let mut result_list = Vec::with_capacity(m);
+    for current_closest in candidates {
+        if result_list.len() >= m {
+            break;
+        }
+        let mut is_good = true;
+        for &selected_point in &result_list {
+            let dist_to_already_selected = score(current_closest.idx, selected_point);
+            if dist_to_already_selected > current_closest.score {
+                is_good = false;
+                break;
+            }
+        }
+        if is_good {
+            result_list.push(current_closest.idx);
+        }
+    }
+
+    result_list
+}
+
+#[cfg(test)]
+mod tests {
+    use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
+    use itertools::Itertools as _;
+    use rand::SeedableRng as _;
+    use rand::rngs::StdRng;
+    use rand::seq::SliceRandom as _;
+
+    use super::*;
+    use crate::data_types::vectors::DenseVector;
+    use crate::fixtures::index_fixtures::{TestRawScorerProducer, random_vector};
+    use crate::spaces::simple::EuclidMetric;
+
+    #[test]
+    #[ignore]
+    fn test_candidate_selection_heuristics() {
+        const NUM_VECTORS: usize = 100;
+        const DIM: usize = 16;
+        const M: usize = 16;
+
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let vector_holder = TestRawScorerProducer::<EuclidMetric>::new(DIM, NUM_VECTORS, &mut rng);
+
+        let mut candidates: FixedLengthPriorityQueue<ScoredPointOffset> =
+            FixedLengthPriorityQueue::new(NUM_VECTORS);
+
+        let new_vector_to_insert = random_vector(&mut rng, DIM);
+
+        let scorer = vector_holder.get_scorer(new_vector_to_insert);
+
+        for i in 0..NUM_VECTORS {
+            candidates.push(ScoredPointOffset {
+                idx: i as PointOffsetType,
+                score: scorer.score_point(i as PointOffsetType),
+            });
+        }
+
+        let sorted_candidates_vec = candidates.clone().into_sorted_vec();
+
+        for x in sorted_candidates_vec.iter().take(M) {
+            eprintln!("sorted_candidates = ({}, {})", x.idx, x.score);
+        }
+
+        let mut container = LinksContainer::with_capacity(M);
+        container.fill_from_sorted_with_heuristic(candidates.into_iter_sorted(), M, |a, b| {
+            scorer.score_internal(a, b)
+        });
+        let selected_candidates = container.links().to_vec();
+
+        for x in selected_candidates.iter() {
+            eprintln!("selected_candidates = {x}");
+        }
+    }
+
+    #[test]
+    fn test_connect_new_point() {
+        let m = 6;
+
+        // See illustration in docs
+        let points: Vec<DenseVector> = vec![
+            vec![21.79, 7.18],  // Target
+            vec![20.58, 5.46],  // 1  B - yes
+            vec![21.19, 4.51],  // 2  C
+            vec![24.73, 8.24],  // 3  D - yes
+            vec![24.55, 9.98],  // 4  E
+            vec![26.11, 6.85],  // 5  F
+            vec![17.64, 11.14], // 6  G - yes
+            vec![14.97, 11.52], // 7  I
+            vec![14.97, 9.60],  // 8  J
+            vec![16.23, 14.32], // 9  H
+            vec![12.69, 19.13], // 10 K
+        ];
+
+        let scorer = |a: PointOffsetType, b: PointOffsetType| {
+            -((points[a as usize][0] - points[b as usize][0]).powi(2)
+                + (points[a as usize][1] - points[b as usize][1]).powi(2))
+            .sqrt()
+        };
+
+        let mut insert_ids = (1..points.len() as PointOffsetType).collect_vec();
+
+        let mut candidates = FixedLengthPriorityQueue::new(insert_ids.len());
+        for &id in &insert_ids {
+            candidates.push(ScoredPointOffset {
+                idx: id,
+                score: scorer(0, id),
+            });
+        }
+
+        let mut res = LinksContainer::with_capacity(m);
+        res.fill_from_sorted_with_heuristic(candidates.into_iter_sorted(), m, scorer);
+
+        assert_eq!(&res.links(), &[1, 3, 6]);
+
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let mut links_container = LinksContainer::with_capacity(m);
+        insert_ids.shuffle(&mut rng);
+        for &id in &insert_ids {
+            links_container.connect(id, 0, m, scorer);
+        }
+        assert_eq!(links_container.links(), &vec![1, 2, 3, 4, 5, 6]);
+    }
+}

--- a/lib/segment/src/index/hnsw_index/links_container.rs
+++ b/lib/segment/src/index/hnsw_index/links_container.rs
@@ -293,19 +293,51 @@ mod tests {
     fn test_connect_new_point() {
         let m = 6;
 
-        // See illustration in docs
+        // ○ 10 K
+        //
+        //
+        //
+        //
+        //
+        //
+        //
+        //
+        //
+        //
+        //                 ○ 9 H
+        //
+        //
+        //
+        //
+        //
+        //           ○ 7 I
+        //                        ● 6 G
+        //
+        //
+        //           ○ 8 J                                         ○ 4 E
+        //
+        //
+        //                                                          ● 3 D
+        //
+        //
+        //                                            ◉ Target             ○ 5 F
+        //   Y
+        //   ▲
+        //   │                                  ● 1 B
+        //   └──▶ X
+        //                                         ○ 2 C
         let points: Vec<DenseVector> = vec![
-            vec![21.79, 7.18],  // Target
-            vec![20.58, 5.46],  // 1  B - yes
-            vec![21.19, 4.51],  // 2  C
-            vec![24.73, 8.24],  // 3  D - yes
-            vec![24.55, 9.98],  // 4  E
-            vec![26.11, 6.85],  // 5  F
-            vec![17.64, 11.14], // 6  G - yes
-            vec![14.97, 11.52], // 7  I
-            vec![14.97, 9.60],  // 8  J
-            vec![16.23, 14.32], // 9  H
-            vec![12.69, 19.13], // 10 K
+            vec![21.79, 07.18], //   Target
+            vec![20.58, 05.46], // + 1 B
+            vec![21.19, 04.51], //   2 C   closer to B than to the target
+            vec![24.73, 08.24], // + 3 D
+            vec![24.55, 09.98], //   4 E   closer to D than to the target
+            vec![26.11, 06.85], //   5 F   closer to D than to the target
+            vec![17.64, 11.14], // + 6 G
+            vec![14.97, 11.52], //   7 I   closer to G than to the target
+            vec![14.97, 09.60], //   8 J   closer to B and G than to the target
+            vec![16.23, 14.32], //   9 H   closer to G than to the target
+            vec![12.69, 19.13], //  10 K   closer to G than to the target
         ];
 
         let scorer = |a: PointOffsetType, b: PointOffsetType| {

--- a/lib/segment/src/index/hnsw_index/links_container.rs
+++ b/lib/segment/src/index/hnsw_index/links_container.rs
@@ -8,7 +8,7 @@ use crate::common::vector_utils::TrySetCapacityExact as _;
 
 pub struct LinksContainer {
     links: Vec<PointOffsetType>,
-    /// Amount of links that processed by the heuristic.
+    /// Number of links that have been processed by the heuristic.
     processed_by_heuristic: u32,
 }
 
@@ -64,7 +64,7 @@ impl LinksContainer {
             }
             self.links.push(candidate.idx);
             if self.links.len() >= level_m {
-                return;
+                break;
             }
         }
         self.processed_by_heuristic = self.links.len() as u32;
@@ -173,8 +173,8 @@ impl LinksContainer {
             order: None,
         });
         items.0.sort_unstable_by(|a, b| {
-            if a.order.is_some() && b.order.is_some() {
-                return a.order.unwrap().cmp(&b.order.unwrap());
+            if let (Some(a_order), Some(b_order)) = (a.order, b.order) {
+                return a_order.cmp(&b_order);
             }
             b.score(target_point_id, &mut score)
                 .total_cmp(&a.score(target_point_id, &mut score))

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -8,6 +8,7 @@ pub mod graph_layers;
 pub mod graph_layers_builder;
 pub mod graph_links;
 pub mod hnsw;
+mod links_container;
 pub mod point_scorer;
 mod search_context;
 


### PR DESCRIPTION
This PR optimizes heuristic computation.

When building the HNSW graph (particularly when adding incoming links), the following loop pattern happen:
A few links are added to the container, then this container is pruned using the heuristic and the loop starts again.
Illustrated by pseudo code:
```
links += new_points
links = heuristic(links)
links += new_points
links = heuristic(links)
…
```

Running the heuristic requires `O(n*n)` vector comparisons, thus this part of the code could take a significant percentage of the graph building time.

However, some vector comparisons could be avoided if part of the input has already been processed by the heuristic.
This PR implements this optimization by introducing a new struct `LinksContainer` that tracks the number of points that are processed by the heuristic and uses this information to speed up the next heuristic call.

A similar change was proposed two years ago in #1965 and #1968, and described in a [notion page](https://www.notion.so/qdrant/Heuristic-optimization-ee4ff1ee35cc4ce2828ef87d09dd300b).

## Performance

Graph building time measured for a single segment (not the full dataset). Times in seconds.

| Dataset    | Quantization   | Points |   `dev` | This PR |  Change |
| ---------- | -------------- | -----: | ------: | ------: | ------: |
| dbpedia    |                |  25.6k |    7.49 |    7.38 |  -1.5 % |
| dbpedia    |                | 243.8k |  120.00 |  110.93 |  -7.6 % |
| dbpedia    | Binary         | 243.8k |   39.71 |   34.82 | -12.3 % |
| dbpedia    | Scalar u8 0.99 | 243.8k |   66.14 |   60.51 |  -8.5 % |
| dbpedia    | Product x16    | 243.8k | 1289.36 |  789.30 | -38.8 % |
| glove 100  |                |   300k |   57.40 |   50.84 | -11.4 % |
| random 128 |                |   100k |   39.16 |   24.68 | -37.0 % |


## Further improvements

Some ideas (not implemented in this PR):

1. Cache scores, i.e. add `scores: Vec<ScoreType>` into `LinksContainer`. I expect it to cut the number of comparisons by 33% at the cost of using 2x RAM.

   Not implemented in this PR as it imposes a different trade-off. (as opposed to current implementation which I believe is strictly better)

2. Use smarter way to merge old and new scores. In this PR, I use regular sort with comparison function that could skip scores calculation when comparing two old links ([src](https://github.com/qdrant/qdrant/blob/f1a5b5e18e5bbb8a170479ab62b647bb20bb52c4/lib/segment/src/index/hnsw_index/links_container.rs#L175-L181)). This slightly reduces amount of comparisons, but still not ideal. A better approach would be to use merging/sorting algorithm that minimizes number of comparisons. E.g. adding exactly one link should result in a binary search. Check the description of [`binary-merge`](https://docs.rs/binary-merge/0.1.2/binary_merge/index.html) crate. (I'm not proposing to use this particular crate, but their problem statement perfectly describes what I mean).

   Not implemented in this PR as I think it would be an overkill at this moment.