### PR TITLE
Fix flaky test: prevent asymmetric utilization IO/CPU utilization

### DIFF
--- a/lib/common/common/src/budget.rs
+++ b/lib/common/common/src/budget.rs
@@ -59,7 +59,7 @@ impl ResourceBudget {
     }
 
     fn min_io_permits(&self, desired_io: usize) -> usize {
-        desired_io.min(self.io_budget) // Use as much IO as requested, not less
+        desired_io.min(self.io_budget).div_ceil(2)
     }
 
     fn try_acquire_cpu(


### PR DESCRIPTION
Our `test_cancel_optimization` test is flaky. It fails on high CPU systems.

```bash
$ QDRANT_NUM_CPUS=24 cargo test -p collection -- test_cancel_optimization

---- tests::test_cancel_optimization stdout ----
actual_optimization_duration = 114 ms

thread 'tests::test_cancel_optimization' panicked at lib/collection/src/tests/mod.rs:210:9:
assertion `left == right` failed
  left: 2
 right: 3
```

The reason is asymmetric utilization of IO and CPU budget (implemented in <https://github.com/qdrant/qdrant/pull/6015>). On 24 CPUs, the previous implementation allowed 2 concurrent IO tasks while it allowed 3 concurrent CPU tasks.

This adjusts the permit selection to make it symmetric.

If we don't like this, the alternative would be to adjust the test. Change [this](https://github.com/qdrant/qdrant/blob/750c2dc8543e9e4cb425a7b50c50baa1be53f559/lib/collection/src/tests/mod.rs#L201-L207) to:

```rust
// We skip optimizations that use less than half of the preferred CPU budget
let expected_optimization_count = {
    let cpus = common::cpu::get_cpu_budget(0);
    let hnsw_threads = num_rayon_threads(0);
    (cpus / hnsw_threads).clamp(1, 3)
};
```


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?