### PR TITLE
Add in-memory payload index on mmap storage (geo)

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -101,7 +101,7 @@ impl ImmutableFullTextIndex {
     }
 
     #[cfg(test)]
-    pub fn get_db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
+    pub fn db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
         match self.storage {
             Storage::RocksDb(ref db_wrapper) => Some(db_wrapper),
             Storage::Mmap(_) => None,

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -212,6 +212,11 @@ impl ImmutableGeoMapIndex {
         self.points_values_count = index.points_values_count();
         self.max_values_per_point = index.max_values_per_point();
 
+        // Index is now loaded into memory, clear cache of backing mmap storage
+        if let Err(err) = index.clear_cache() {
+            log::warn!("Failed to clear mmap cache of ram mmap geo index: {err}");
+        }
+
         true
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -70,7 +70,7 @@ pub struct MmapGeoMapIndex {
     pub(super) point_to_values: MmapPointToValues<GeoPoint>,
     /// Deleted flags for each PointOffsetType
     pub(super) deleted: MmapBitSliceBufferedUpdateWrapper,
-    deleted_count: usize,
+    pub(super) deleted_count: usize,
     points_values_count: usize,
     max_values_per_point: usize,
     is_on_disk: bool,

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -27,24 +27,23 @@ const POINTS_MAP_IDS: &str = "points_map_ids.bin";
 const STATS_PATH: &str = "mmap_field_index_stats.json";
 
 #[repr(C)]
-#[derive(Clone, Debug)]
-struct Counts {
-    hash: GeoHash,
-    points: u32,
-    values: u32,
+#[derive(Copy, Clone, Debug)]
+pub(super) struct Counts {
+    pub hash: GeoHash,
+    pub points: u32,
+    pub values: u32,
 }
 
 #[repr(C)]
-#[derive(Clone, Debug)]
-struct PointKeyValue {
-    hash: GeoHash,
-    ids_start: u32,
-    ids_end: u32,
+#[derive(Copy, Clone, Debug)]
+pub(super) struct PointKeyValue {
+    pub hash: GeoHash,
+    pub ids_start: u32,
+    pub ids_end: u32,
 }
 
 ///
 ///   points_map
-///
 ///  ┌─────────────────────────────────────────┐
 ///  │ (ABC, 10, 20)|(ABD, 20, 40)             │
 ///  └────────┬──┬──────────┬───┬──────────────┘
@@ -61,16 +60,16 @@ pub struct MmapGeoMapIndex {
     path: PathBuf,
     /// Stores GeoHash, points count and values count.
     /// Sorted by geohash, so we binary search the region.
-    counts_per_hash: MmapSlice<Counts>,
+    pub(super) counts_per_hash: MmapSlice<Counts>,
     /// Stores GeoHash and associated range of offsets in the points_map_ids.
     /// Sorted by geohash, so we binary search the region.
-    points_map: MmapSlice<PointKeyValue>,
+    pub(super) points_map: MmapSlice<PointKeyValue>,
     /// A storage of associations between geo-hashes and point ids. (See the diagram above)
-    points_map_ids: MmapSlice<PointOffsetType>,
+    pub(super) points_map_ids: MmapSlice<PointOffsetType>,
     /// One-to-many mapping of the PointOffsetType to the GeoPoint.
-    point_to_values: MmapPointToValues<GeoPoint>,
+    pub(super) point_to_values: MmapPointToValues<GeoPoint>,
     /// Deleted flags for each PointOffsetType
-    deleted: MmapBitSliceBufferedUpdateWrapper,
+    pub(super) deleted: MmapBitSliceBufferedUpdateWrapper,
     deleted_count: usize,
     points_values_count: usize,
     max_values_per_point: usize,

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -187,7 +187,7 @@ impl GeoMapIndex {
     pub fn flusher(&self) -> Flusher {
         match self {
             GeoMapIndex::Mutable(index) => index.db_wrapper().flusher(),
-            GeoMapIndex::Immutable(index) => index.db_wrapper().flusher(),
+            GeoMapIndex::Immutable(index) => index.flusher(),
             GeoMapIndex::Mmap(index) => index.flusher(),
         }
     }
@@ -559,7 +559,7 @@ impl PayloadFieldIndex for GeoMapIndex {
     fn cleanup(self) -> OperationResult<()> {
         match self {
             GeoMapIndex::Mutable(index) => index.db_wrapper().remove_column_family(),
-            GeoMapIndex::Immutable(index) => index.db_wrapper().remove_column_family(),
+            GeoMapIndex::Immutable(index) => index.clear(),
             GeoMapIndex::Mmap(index) => index.clear(),
         }
     }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -1673,8 +1673,8 @@ mod tests {
                     .collect::<BTreeSet<_>>(),
             );
             assert_eq!(
-                indices[0].iterator(hashes.to_vec()).collect::<HashSet<_>>(),
-                index.iterator(hashes.to_vec()).collect::<HashSet<_>>(),
+                indices[0].iterator(hashes.clone()).collect::<HashSet<_>>(),
+                index.iterator(hashes.clone()).collect::<HashSet<_>>(),
             );
             for point_id in 0..POINT_COUNT {
                 assert_eq!(

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -50,7 +50,7 @@ impl GeoMapIndex {
         if is_appendable {
             GeoMapIndex::Mutable(MutableGeoMapIndex::new(db, &store_cf_name))
         } else {
-            GeoMapIndex::Immutable(ImmutableGeoMapIndex::new(db, &store_cf_name))
+            GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_rocksdb(db, &store_cf_name))
         }
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -55,9 +55,14 @@ impl GeoMapIndex {
     }
 
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
-        Ok(GeoMapIndex::Mmap(Box::new(MmapGeoMapIndex::load(
-            path, is_on_disk,
-        )?)))
+        let mmap_index = MmapGeoMapIndex::load(path, is_on_disk)?;
+        if is_on_disk {
+            Ok(GeoMapIndex::Mmap(Box::new(mmap_index)))
+        } else {
+            Ok(GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
+                mmap_index,
+            )))
+        }
     }
 
     pub fn builder(db: Arc<RwLock<DB>>, field: &str) -> GeoMapIndexBuilder {

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -747,9 +747,11 @@ mod tests {
                     let GeoMapIndex::Mmap(index) = builder.finalize()? else {
                         panic!("expected mmap index");
                     };
-                    Ok(GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
-                        *index,
-                    )))
+
+                    // Load index from mmap
+                    let mut index = GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(*index));
+                    index.load()?;
+                    Ok(index)
                 }
             }
         }

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -390,7 +390,7 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
     }
 
     #[cfg(test)]
-    pub fn get_db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
+    pub fn db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
         match self.storage {
             Storage::RocksDb(ref db_wrapper) => Some(db_wrapper),
             Storage::Mmap(_) => None,

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -236,7 +236,7 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
 
     fn flusher(&self) -> Flusher {
         match self {
-            MapIndex::Mutable(index) => index.get_db_wrapper().flusher(),
+            MapIndex::Mutable(index) => index.db_wrapper().flusher(),
             MapIndex::Immutable(index) => index.flusher(),
             MapIndex::Mmap(index) => index.flusher(),
         }
@@ -293,7 +293,7 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
 
     fn clear(self) -> OperationResult<()> {
         match self {
-            MapIndex::Mutable(index) => index.get_db_wrapper().remove_column_family(),
+            MapIndex::Mutable(index) => index.db_wrapper().remove_column_family(),
             MapIndex::Immutable(index) => index.clear(),
             MapIndex::Mmap(index) => index.clear(),
         }
@@ -489,7 +489,7 @@ where
 
     fn init(&mut self) -> OperationResult<()> {
         match &mut self.0 {
-            MapIndex::Mutable(index) => index.get_db_wrapper().recreate_column_family(),
+            MapIndex::Mutable(index) => index.db_wrapper().recreate_column_family(),
             MapIndex::Immutable(_) => unreachable!(),
             MapIndex::Mmap(_) => unreachable!(),
         }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -96,7 +96,7 @@ impl<N: MapIndexKey + ?Sized> MutableMapIndex<N> {
         Ok(())
     }
 
-    pub fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
+    pub fn db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         &self.db_wrapper
     }
 

--- a/lib/segment/src/index/field_index/mmap_point_to_values.rs
+++ b/lib/segment/src/index/field_index/mmap_point_to_values.rs
@@ -378,6 +378,17 @@ impl<T: MmapValue + ?Sized> MmapPointToValues<T> {
         clear_disk_cache(&self.file_name)?;
         Ok(())
     }
+
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            PointOffsetType,
+            Option<impl Iterator<Item = T::Referenced<'_>> + '_>,
+        ),
+    > + Clone {
+        (0..self.len() as PointOffsetType).map(|idx| (idx, self.get_values(idx)))
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -261,7 +261,7 @@ impl<T: Encodable + Numericable + MmapValue + Default> ImmutableNumericIndex<T> 
     }
 
     #[cfg(test)]
-    pub(super) fn get_db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
+    pub(super) fn db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
         match self.storage {
             Storage::RocksDb(ref db_wrapper) => Some(db_wrapper),
             Storage::Mmap(_) => None,

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -223,7 +223,7 @@ impl<T: Encodable + Numericable + MmapValue + Default> NumericIndexInner<T> {
 
     pub fn flusher(&self) -> Flusher {
         match self {
-            NumericIndexInner::Mutable(index) => index.get_db_wrapper().flusher(),
+            NumericIndexInner::Mutable(index) => index.db_wrapper().flusher(),
             NumericIndexInner::Immutable(index) => index.flusher(),
             NumericIndexInner::Mmap(index) => index.flusher(),
         }
@@ -562,7 +562,7 @@ where
 
     fn init(&mut self) -> OperationResult<()> {
         match &mut self.0.inner {
-            NumericIndexInner::Mutable(index) => index.get_db_wrapper().recreate_column_family(),
+            NumericIndexInner::Mutable(index) => index.db_wrapper().recreate_column_family(),
             NumericIndexInner::Immutable(_) => unreachable!(),
             NumericIndexInner::Mmap(_) => unreachable!(),
         }
@@ -603,7 +603,7 @@ where
 
     fn init(&mut self) -> OperationResult<()> {
         match &mut self.index.inner {
-            NumericIndexInner::Mutable(index) => index.get_db_wrapper().recreate_column_family(),
+            NumericIndexInner::Mutable(index) => index.db_wrapper().recreate_column_family(),
             NumericIndexInner::Immutable(_) => unreachable!(),
             NumericIndexInner::Mmap(_) => unreachable!(),
         }
@@ -698,7 +698,7 @@ impl<T: Encodable + Numericable + MmapValue + Default> PayloadFieldIndex for Num
 
     fn cleanup(self) -> OperationResult<()> {
         match self {
-            NumericIndexInner::Mutable(index) => index.get_db_wrapper().recreate_column_family(),
+            NumericIndexInner::Mutable(index) => index.db_wrapper().recreate_column_family(),
             NumericIndexInner::Immutable(index) => index.clear(),
             NumericIndexInner::Mmap(index) => index.clear(),
         }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -217,7 +217,7 @@ impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
         self.in_memory_index
     }
 
-    pub fn get_db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
+    pub fn db_wrapper(&self) -> &DatabaseColumnScheduledDeleteWrapper {
         &self.db_wrapper
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -347,8 +347,8 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
     let index = index_builder.finalize().unwrap();
 
     let db = match index.inner() {
-        NumericIndexInner::Mutable(index) => Some(index.get_db_wrapper().get_database()),
-        NumericIndexInner::Immutable(index) => index.get_db_wrapper().map(|db| db.get_database()),
+        NumericIndexInner::Mutable(index) => Some(index.db_wrapper().get_database()),
+        NumericIndexInner::Immutable(index) => index.db_wrapper().map(|db| db.get_database()),
         NumericIndexInner::Mmap(_) => None,
     };
     drop(index);

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1510,6 +1510,24 @@ impl From<GeoPoint> for geo::Point {
     }
 }
 
+/// Geo point that implements `PartialOrd`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
+#[cfg(test)]
+pub struct OrderedGeoPoint {
+    pub lon: OrderedFloat<f64>,
+    pub lat: OrderedFloat<f64>,
+}
+
+#[cfg(test)]
+impl From<GeoPoint> for OrderedGeoPoint {
+    fn from(geo_point: GeoPoint) -> Self {
+        OrderedGeoPoint {
+            lon: OrderedFloat(geo_point.lon),
+            lat: OrderedFloat(geo_point.lat),
+        }
+    }
+}
+
 pub trait PayloadContainer {
     /// Return value from payload by path.
     /// If value is not present in the payload, returns empty vector.


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6495>.

Add in-memory payload index for geo points using mmap as storage.

Loading the in-memory full text payload index from mmap is **24x faster** than from RocksDB, as shown in this simple benchmark:

- `bfb --geo-payloads -n 2000000 -d1 --indexing-threshold 100`:
    - Old RocksDB based index: 11.78s, 11.86s, 11.57s, 11.66s = avg 11.72s
    - New mmap based index: 0.489s, 0.476s, 0.476s, 0.477s = avg 0.480ms (24x faster)

### Tasks

- [x] Add test
- [x] Do load benchmark
- [x] Drop mmap caches after load
- [x] Merge <https://github.com/qdrant/qdrant/pull/6495>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
