### PR TITLE
Use null index more

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
@@ -240,11 +239,11 @@ impl IndexSelector<'_> {
     pub fn new_null_index(
         dir: &Path,
         field: &JsonPath,
-        max_point_offset: PointOffsetType,
+        total_point_count: usize,
     ) -> OperationResult<Option<FieldIndex>> {
         // null index is always on disk and is appendable
         Ok(
-            MmapNullIndex::open_if_exists(&null_dir(dir, field), max_point_offset)?
+            MmapNullIndex::open_if_exists(&null_dir(dir, field), total_point_count)?
                 .map(FieldIndex::NullIndex),
         )
     }

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -30,6 +30,12 @@ pub enum PrimaryCondition {
     HasVector(VectorNameBuf),
 }
 
+impl From<FieldCondition> for PrimaryCondition {
+    fn from(condition: FieldCondition) -> Self {
+        PrimaryCondition::Condition(Box::new(condition))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PayloadBlockCondition {
     pub condition: FieldCondition,

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -209,7 +209,7 @@ impl MmapNullIndex {
 
 impl PayloadFieldIndex for MmapNullIndex {
     fn count_indexed_points(&self) -> usize {
-        self.has_values_slice.count_flags()
+        self.has_values_slice.len()
     }
 
     fn load(&mut self) -> OperationResult<bool> {

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -79,7 +79,10 @@ impl MmapNullIndex {
         })
     }
 
-    pub fn open_if_exists(path: &Path, max_point_offset: PointOffsetType) -> OperationResult<Option<Self>> {
+    pub fn open_if_exists(
+        path: &Path,
+        max_point_offset: PointOffsetType,
+    ) -> OperationResult<Option<Self>> {
         if !path.is_dir() {
             return Ok(None);
         }

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -248,9 +248,9 @@ pub fn invert_estimation(
 ) -> CardinalityEstimation {
     CardinalityEstimation {
         primary_clauses: vec![],
-        min: total - estimation.max,
-        exp: total - estimation.exp,
-        max: total - estimation.min,
+        min: total.saturating_sub(estimation.max),
+        exp: total.saturating_sub(estimation.exp),
+        max: total.saturating_sub(estimation.min),
     }
 }
 

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -329,7 +329,7 @@ mod tests {
             },
             Condition::IsEmpty(condition) => CardinalityEstimation {
                 primary_clauses: vec![PrimaryCondition::Condition(Box::new(
-                    FieldCondition::new_is_empty(condition.is_empty.key.clone()),
+                    FieldCondition::new_is_empty(condition.is_empty.key.clone(), true),
                 ))],
                 min: 0,
                 exp: TOTAL / 2,
@@ -337,7 +337,7 @@ mod tests {
             },
             Condition::IsNull(condition) => CardinalityEstimation {
                 primary_clauses: vec![PrimaryCondition::Condition(Box::new(
-                    FieldCondition::new_is_null(condition.is_null.key.clone()),
+                    FieldCondition::new_is_null(condition.is_null.key.clone(), true),
                 ))],
                 min: 0,
                 exp: TOTAL / 2,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -143,7 +143,9 @@ impl StructPayloadIndex {
             .saturating_sub(1) as PointOffsetType;
 
         // Special null index complements every index.
-        if let Some(null_index) = IndexSelector::new_null_index(&self.path, field, max_point_offset)? {
+        if let Some(null_index) =
+            IndexSelector::new_null_index(&self.path, field, max_point_offset)?
+        {
             // todo: This means that null index will not be built if it is not loaded here.
             //       Maybe we should set `is_loaded` to false to trigger index building.
             indexes.push(null_index);

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -414,9 +414,7 @@ impl StructPayloadIndex {
                     })
                 })
                 .filter(move |&id| {
-                    !visited_list.check_and_update_visited(id)
-                        && struct_filtered_context.check(id)
-                        && !id_tracker.is_deleted_point(id)
+                    !visited_list.check_and_update_visited(id) && struct_filtered_context.check(id)
                 });
 
             Either::Right(iter)

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -132,9 +132,11 @@ impl StructPayloadIndex {
         field: PayloadKeyTypeRef,
         payload_schema: &PayloadFieldSchema,
     ) -> OperationResult<Vec<FieldIndex>> {
+        let max_point_offset = self.id_tracker.borrow().total_point_count().saturating_sub(1) as PointOffsetType;
+
         let mut indexes = self
             .selector(payload_schema)
-            .new_index(field, payload_schema)?;
+            .new_index(field, payload_schema, max_point_offset)?;
 
         let mut is_loaded = true;
         for ref mut index in indexes.iter_mut() {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -136,10 +136,7 @@ impl StructPayloadIndex {
             .selector(payload_schema)
             .new_index(field, payload_schema)?;
 
-        let total_point_count = self
-            .id_tracker
-            .borrow()
-            .total_point_count();
+        let total_point_count = self.id_tracker.borrow().total_point_count();
 
         // Special null index complements every index.
         if let Some(null_index) =
@@ -302,14 +299,14 @@ impl StructPayloadIndex {
             }
             Condition::IsEmpty(IsEmptyCondition { is_empty: field }) => {
                 let available_points = self.available_point_count();
-                let condition = FieldCondition::new_is_empty(field.key.clone());
+                let condition = FieldCondition::new_is_empty(field.key.clone(), true);
 
                 self.estimate_field_condition(&condition, nested_path, hw_counter)
                     .unwrap_or_else(|| CardinalityEstimation::unknown(available_points))
             }
             Condition::IsNull(IsNullCondition { is_null: field }) => {
                 let available_points = self.available_point_count();
-                let condition = FieldCondition::new_is_null(field.key.clone());
+                let condition = FieldCondition::new_is_null(field.key.clone(), true);
 
                 self.estimate_field_condition(&condition, nested_path, hw_counter)
                     .unwrap_or_else(|| CardinalityEstimation::unknown(available_points))

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -378,7 +378,7 @@ impl StructPayloadIndex {
         &self.config
     }
 
-    // Iterates over points which satisfy the filter and are not deleted.
+    // Iterates over points which satisfy the filter. Might include already deleted points.
     pub fn iter_filtered_points<'a>(
         &'a self,
         filter: &'a Filter,

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -54,7 +54,6 @@ impl Segment {
                 let iter = payload_index
                     .iter_filtered_points(filter, &*id_tracker, &filter_cardinality, hw_counter)
                     .check_stop_every(STOP_CHECK_INTERVAL, || is_stopped.load(Ordering::Relaxed))
-                    .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                     .fold(HashMap::new(), |mut map, point_id| {
                         facet_index
                             .get_point_values(point_id)
@@ -129,7 +128,6 @@ impl Segment {
             payload_index
                 .iter_filtered_points(filter, &*id_tracker, &filter_cardinality, hw_counter)
                 .check_stop(|| is_stopped.load(Ordering::Relaxed))
-                .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                 .fold(BTreeSet::new(), |mut set, point_id| {
                     set.extend(facet_index.get_point_values(point_id));
                     set

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -53,8 +53,8 @@ impl Segment {
                 // aka. read from other indexes
                 let iter = payload_index
                     .iter_filtered_points(filter, &*id_tracker, &filter_cardinality, hw_counter)
-                    .filter(|internal_id| !id_tracker.is_deleted_point(*internal_id))
                     .check_stop_every(STOP_CHECK_INTERVAL, || is_stopped.load(Ordering::Relaxed))
+                    .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                     .fold(HashMap::new(), |mut map, point_id| {
                         facet_index
                             .get_point_values(point_id)
@@ -128,8 +128,8 @@ impl Segment {
 
             payload_index
                 .iter_filtered_points(filter, &*id_tracker, &filter_cardinality, hw_counter)
-                .filter(|internal_id| !id_tracker.is_deleted_point(*internal_id))
                 .check_stop(|| is_stopped.load(Ordering::Relaxed))
+                .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                 .fold(BTreeSet::new(), |mut set, point_id| {
                     set.extend(facet_index.get_point_values(point_id));
                     set

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -53,6 +53,7 @@ impl Segment {
                 // aka. read from other indexes
                 let iter = payload_index
                     .iter_filtered_points(filter, &*id_tracker, &filter_cardinality, hw_counter)
+                    .filter(|internal_id| !id_tracker.is_deleted_point(*internal_id))
                     .check_stop_every(STOP_CHECK_INTERVAL, || is_stopped.load(Ordering::Relaxed))
                     .fold(HashMap::new(), |mut map, point_id| {
                         facet_index
@@ -127,6 +128,7 @@ impl Segment {
 
             payload_index
                 .iter_filtered_points(filter, &*id_tracker, &filter_cardinality, hw_counter)
+                .filter(|internal_id| !id_tracker.is_deleted_point(*internal_id))
                 .check_stop(|| is_stopped.load(Ordering::Relaxed))
                 .fold(BTreeSet::new(), |mut set, point_id| {
                     set.extend(facet_index.get_point_values(point_id));

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2508,7 +2508,7 @@ impl FieldCondition {
         }
     }
 
-    pub fn new_is_empty(key: PayloadKeyType) -> Self {
+    pub fn new_is_empty(key: PayloadKeyType, is_empty: bool) -> Self {
         Self {
             key,
             r#match: None,
@@ -2517,12 +2517,12 @@ impl FieldCondition {
             geo_radius: None,
             geo_polygon: None,
             values_count: None,
-            is_empty: Some(true),
+            is_empty: Some(is_empty),
             is_null: None,
         }
     }
 
-    pub fn new_is_null(key: PayloadKeyType) -> Self {
+    pub fn new_is_null(key: PayloadKeyType, is_null: bool) -> Self {
         Self {
             key,
             r#match: None,
@@ -2532,7 +2532,7 @@ impl FieldCondition {
             geo_polygon: None,
             values_count: None,
             is_empty: None,
-            is_null: Some(true),
+            is_null: Some(is_null),
         }
     }
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -477,7 +477,7 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
 
     for (_field, indexes) in struct_segment.payload_index.borrow().field_indexes.iter() {
         for index in indexes {
-            assert!(index.count_indexed_points() < num_points as usize);
+            assert!(index.count_indexed_points() <= num_points as usize);
             assert!(
                 index.count_indexed_points()
                     > (num_points as usize - points_to_delete - points_to_clear)

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -626,11 +626,17 @@ fn test_is_empty_conditions(test_segments: &TestSegments) -> Result<()> {
 
     let real_number = plain_result.len();
 
+    let id_tracker = test_segments.struct_segment.id_tracker.borrow();
     let struct_result = test_segments
         .struct_segment
         .payload_index
         .borrow()
-        .query_points(&filter, &hw_counter);
+        .query_points(&filter, &hw_counter)
+        .into_iter()
+        // null index does not track deleted points, so we need to filter them out here. In callsites,
+        // the deleted check is done externally anyway
+        .filter(|id| !id_tracker.is_deleted_point(*id))
+        .collect::<Vec<_>>();
 
     ensure!(plain_result == struct_result);
 


### PR DESCRIPTION
Currently null index was only working for `is_empty=false` and `is_null=true` cases.

By making the index aware of the `max_point_offset` available, we can also make it work for `is_empty=true` and `is_null=false`.

This PR also builds the index even if the `IndexSelector` chooses RocksDB-based index. Now the null index is chosen regardless of appendable and on-disk parameters.

### Perf gains
In some local manual tests, I can see about 1.8x difference between dev and branch. It is quite small (**~2.5ms vs ~1.4ms**) but noticeable
```shell
# upload 1M points without payload
bfb -n 1000000 --dim 64

# this will apply int payloads to ~10% of points, randomly
bfb -n 100000 --dim 64 --skip-create --int-payloads 1000 --max-id 1000000
```
then created the index through dashboard
```http
PUT /collections/benchmark/index
{
  "field_name": "c",
  "field_schema": {
    "type": "integer",
    "on_disk": true
  }
}
```

then did this for each build, watching the server timings in the logs, not the wall time registered by hyperfine
```shell
hyperfine "curl -X POST -H \"Content-Type: application/json\" -d '{\"query\": 3, \"filter\": {\"must\": {\"key\": \"c\", \"is_empty\": true}}}' localhost:6333/collections/benchmark/points/query" --warmup 200
```