### PR TITLE
Abort transfer on force peer delete

### DIFF
--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -461,6 +461,26 @@ impl TableOfContent {
         false
     }
 
+    pub async fn abort_peer_transfers(&self, peer_id: PeerId) -> CollectionResult<()> {
+        for collection in self.collections.read().await.values() {
+            let related_transfers = collection
+                .shards_holder()
+                .read()
+                .await
+                .get_transfers(|transfer| transfer.from == peer_id);
+
+            for transfer in related_transfers {
+                collection
+                    .shards_holder()
+                    .write()
+                    .await
+                    .register_abort_transfer(&transfer.key())?;
+            }
+        }
+
+        Ok(())
+    }
+
     pub async fn get_telemetry_data(
         &self,
         detail: TelemetryDetail,

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -79,6 +79,12 @@ fn remove_peer(
             });
         }
 
+        // If we reach here, either there are no shards or force removal is requested
+        if has_shards {
+            log::warn!("Aborting peer transfers for peer {peer_id} before force removal");
+            toc.abort_peer_transfers(peer_id).await?;
+        }
+
         match dispatcher.consensus_state() {
             Some(consensus_state) => {
                 consensus_state


### PR DESCRIPTION
Force deletes to a peer should also abort all shards transfers from this peer. Otherwise, they can remain stuck there forever.

TODO:
- [ ] Think we should abort `to` transfers for this force deleted peer

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

