### PR TITLE
Make reads sequential in BatchedVectorReader

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -62,6 +62,10 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
         self.get_vector_opt(key).expect("vector not found")
     }
 
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        self.get_vector(key)
+    }
+
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
         self.vectors.get_opt(key as _).map(|v| v.into())
     }

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -407,6 +407,11 @@ impl<T: Sized + Copy + 'static> ChunkedVectorStorage<T> for ChunkedMmapVectors<T
     }
 
     #[inline]
+    fn get_many_sequential(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
+        ChunkedMmapVectors::get_many(self, key, count, true)
+    }
+
+    #[inline]
     fn get_batch<'a>(
         &'a self,
         keys: &[VectorOffsetType],

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -357,6 +357,10 @@ impl<T: Sized + Copy + 'static> ChunkedVectorStorage<T> for ChunkedMmapVectors<T
         ChunkedMmapVectors::get(self, key, false)
     }
 
+    fn get_sequential(&self, key: VectorOffsetType) -> Option<&[T]> {
+        ChunkedMmapVectors::get(self, key, true)
+    }
+
     #[inline]
     fn files(&self) -> Vec<PathBuf> {
         ChunkedMmapVectors::files(self)

--- a/lib/segment/src/vector_storage/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/chunked_vector_storage.rs
@@ -18,6 +18,8 @@ pub trait ChunkedVectorStorage<T> {
 
     fn get(&self, key: VectorOffsetType) -> Option<&[T]>;
 
+    fn get_sequential(&self, key: VectorOffsetType) -> Option<&[T]>;
+
     fn files(&self) -> Vec<PathBuf>;
 
     fn flusher(&self) -> Flusher;

--- a/lib/segment/src/vector_storage/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/chunked_vector_storage.rs
@@ -48,6 +48,9 @@ pub trait ChunkedVectorStorage<T> {
     /// Returns `count` flattened vectors starting from key. if chunk boundary is crossed, returns None
     fn get_many(&self, key: VectorOffsetType, count: usize) -> Option<&[T]>;
 
+    /// Returns `count` flattened vectors starting from key. if chunk boundary is crossed, returns None
+    fn get_many_sequential(&self, key: VectorOffsetType, count: usize) -> Option<&[T]>;
+
     /// Returns batch of vectors by keys.
     /// Underlying storage might apply some optimizations to prefetch vectors.
     fn get_batch<'a>(

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -123,6 +123,13 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
         self.get_vector_opt(key).expect("vector not found")
     }
 
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        self.vectors
+            .get_sequential(key as VectorOffsetType)
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
+            .expect("Vector not found")
+    }
+
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
         self.vectors
             .get(key as VectorOffsetType)

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -183,6 +183,15 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        self.mmap_store
+            .as_ref()
+            .unwrap()
+            .get_vector_opt_sequential(key)
+            .map(|vector| T::slice_to_float_cow(vector.into()).into())
+            .expect("Vector not found")
+    }
+
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
         self.mmap_store
             .as_ref()

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -220,6 +220,11 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        // In memory so no optimization to be done here.
+        self.get_vector(key)
+    }
+
     /// Get vector by key, if it exists.
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
         self.vectors

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -96,6 +96,12 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
     }
 
     #[inline]
+    fn get_many_sequential(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
+        // No optimization for sequential access
+        self.mmap_storage.get_many(key, count)
+    }
+
+    #[inline]
     fn get_batch<'a>(
         &'a self,
         keys: &[VectorOffsetType],

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -45,6 +45,10 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
         self.mmap_storage.get(key)
     }
 
+    fn get_sequential(&self, key: VectorOffsetType) -> Option<&[T]> {
+        self.mmap_storage.get_sequential(key)
+    }
+
     #[inline]
     fn files(&self) -> Vec<PathBuf> {
         self.mmap_storage.files()

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -119,6 +119,26 @@ impl<
             })
     }
 
+    /// Returns None if key is not found
+    fn get_multi_opt_sequential(
+        &self,
+        key: PointOffsetType,
+    ) -> Option<TypedMultiDenseVectorRef<T>> {
+        self.offsets
+            .get_sequential(key as VectorOffsetType)
+            .and_then(|mmap_offset| {
+                let mmap_offset = mmap_offset.first().expect("mmap_offset must not be empty");
+                self.vectors.get_many(
+                    mmap_offset.offset as VectorOffsetType,
+                    mmap_offset.count as usize,
+                )
+            })
+            .map(|flattened_vectors| TypedMultiDenseVectorRef {
+                flattened_vectors,
+                dim: self.vectors.dim(),
+            })
+    }
+
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {
         (0..self.total_vector_count()).flat_map(|key| {
             let mmap_offset = self
@@ -174,6 +194,16 @@ impl<
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         self.get_vector_opt(key).expect("vector not found")
+    }
+
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        self.get_multi_opt_sequential(key)
+            .map(|multi_dense_vector| {
+                CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
+                    multi_dense_vector,
+                )))
+            })
+            .expect("vector not found")
     }
 
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -128,7 +128,7 @@ impl<
             .get_sequential(key as VectorOffsetType)
             .and_then(|mmap_offset| {
                 let mmap_offset = mmap_offset.first().expect("mmap_offset must not be empty");
-                self.vectors.get_many(
+                self.vectors.get_many_sequential(
                     mmap_offset.offset as VectorOffsetType,
                     mmap_offset.count as usize,
                 )

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -310,6 +310,14 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
         })
     }
 
+    fn get_multi_opt_sequential(
+        &self,
+        key: PointOffsetType,
+    ) -> Option<TypedMultiDenseVectorRef<T>> {
+        // No sequential optimizations available for in memory storage.
+        self.get_multi_opt(key)
+    }
+
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {
         (0..self.total_vector_count()).flat_map(|key| {
             let metadata = &self.vectors_metadata[key];
@@ -351,6 +359,10 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         self.get_vector_opt(key).expect("vector not found")
+    }
+
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        self.get_vector(key)
     }
 
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -228,6 +228,11 @@ impl VectorStorage for MmapSparseVectorStorage {
         vector.unwrap_or_else(CowVector::default_sparse)
     }
 
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        // No optimizations available for gridstore (yet).
+        self.get_vector(key)
+    }
+
     /// Get vector by key, if it exists.
     ///
     /// Ignore any error

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -191,6 +191,11 @@ impl VectorStorage for SimpleSparseVectorStorage {
         vector.unwrap_or_else(CowVector::default_sparse)
     }
 
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        // In memory, so no sequential read optimization.
+        self.get_vector(key)
+    }
+
     /// Get vector by key, if it exists.
     ///
     /// ignore any error

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -61,6 +61,9 @@ pub trait VectorStorage {
     /// Get the vector by the given key
     fn get_vector(&self, key: PointOffsetType) -> CowVector;
 
+    /// Get the vector by the given key with potential optimizations for sequential reads.
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector;
+
     /// Get the vector by the given key if it exists
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector>;
 
@@ -151,6 +154,8 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     fn vector_dim(&self) -> usize;
     fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T>;
     fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<T>>;
+    fn get_multi_opt_sequential(&self, key: PointOffsetType)
+    -> Option<TypedMultiDenseVectorRef<T>>;
     fn get_batch_multi<'a>(
         &'a self,
         keys: &[PointOffsetType],
@@ -629,6 +634,34 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::MultiDenseAppendableInRam(v) => v.get_vector(key),
             VectorStorageEnum::MultiDenseAppendableInRamByte(v) => v.get_vector(key),
             VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => v.get_vector(key),
+        }
+    }
+
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        match self {
+            VectorStorageEnum::DenseSimple(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseSimpleByte(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseMemmap(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseMemmapByte(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseAppendableInRam(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseAppendableInRamByte(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::DenseAppendableInRamHalf(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::SparseSimple(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::SparseMmap(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseSimple(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseAppendableInRam(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => v.get_vector_sequential(key),
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => v.get_vector_sequential(key),
         }
     }
 


### PR DESCRIPTION
Depends on #6487

Improves optimization when copying points from different segments into a new one.


Benchmark:

**On the same machine** with storage on a Hetzner Network Disk (5M points, 20=>10 segments, vectors on disk)
Dev: 200s
PR: 3s

**SSH-FS mounted** Hetzner Network Disk (100k points, 10=>5 segments, vectors on disk)
Dev: ~450s
PR: 240s