### PR TITLE
HardwareCounterCell::disposable() Performance Improvement

### DIFF
--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -61,3 +61,7 @@ harness = false
 [[bench]]
 name = "mmap_hashmap"
 harness = false
+
+[[bench]]
+name = "hw_counter"
+harness = false

--- a/lib/common/common/benches/hw_counter.rs
+++ b/lib/common/common/benches/hw_counter.rs
@@ -1,0 +1,20 @@
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+fn bench_hw_counter(c: &mut Criterion) {
+    c.bench_function("Disposable Hw Cell", |b| {
+        b.iter(|| {
+            let _ = HardwareCounterCell::disposable();
+        });
+    });
+
+    c.bench_function("Disposable Hw Acc", |b| {
+        b.iter(|| {
+            let _ = HwMeasurementAcc::disposable();
+        });
+    });
+}
+
+criterion_group!(hw_counter, bench_hw_counter);
+criterion_main!(hw_counter);

--- a/lib/common/common/src/counter/conditioned_counter.rs
+++ b/lib/common/common/src/counter/conditioned_counter.rs
@@ -97,7 +97,7 @@ mod test {
         }
 
         assert_eq!(parent.cpu_counter().get(), 0);
-        assert_eq!(parent.accumulator.get_cpu(), 0);
+        assert_eq!(parent.accumulator.as_ref().unwrap().get_cpu(), 0);
     }
 
     #[test]
@@ -111,7 +111,7 @@ mod test {
 
         assert_eq!(parent.cpu_counter().get(), 5);
 
-        let parent_acc = parent.accumulator.clone();
+        let parent_acc = parent.new_accumulator();
         drop(parent); // Parents accumulator gets written after `parent` drops.
         assert_eq!(parent_acc.get_cpu(), 5);
     }
@@ -131,7 +131,7 @@ mod test {
         }
 
         assert_eq!(parent.cpu_counter().get(), 0); // Parents accumulator gets written, not the counter cell!
-        assert_eq!(parent.accumulator.get_cpu(), 5);
+        assert_eq!(parent.accumulator.as_ref().unwrap().get_cpu(), 5);
     }
 
     #[test]

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -88,7 +88,9 @@ impl HardwareCounterCell {
     }
 
     pub fn new_accumulator(&self) -> HwMeasurementAcc {
-        self.accumulator.clone().unwrap_or_default()
+        self.accumulator
+            .clone()
+            .unwrap_or_else(HwMeasurementAcc::disposable)
     }
 
     /// Create a copy of the current counter cell with the same accumulator and config,

--- a/lib/common/common/src/counter/hardware_counter.rs
+++ b/lib/common/common/src/counter/hardware_counter.rs
@@ -18,7 +18,7 @@ pub struct HardwareCounterCell {
     pub(super) payload_index_io_write_counter: CounterCell,
     pub(super) vector_io_read_counter: CounterCell,
     pub(super) vector_io_write_counter: CounterCell,
-    pub(super) accumulator: HwMeasurementAcc,
+    pub(super) accumulator: Option<HwMeasurementAcc>,
 }
 
 #[cfg(feature = "testing")]
@@ -50,7 +50,7 @@ impl HardwareCounterCell {
             payload_index_io_write_counter: CounterCell::new(),
             vector_io_read_counter: CounterCell::new(),
             vector_io_write_counter: CounterCell::new(),
-            accumulator: HwMeasurementAcc::new(),
+            accumulator: Some(HwMeasurementAcc::new()),
         }
     }
 
@@ -68,7 +68,7 @@ impl HardwareCounterCell {
             payload_index_io_write_counter: CounterCell::new(),
             vector_io_read_counter: CounterCell::new(),
             vector_io_write_counter: CounterCell::new(),
-            accumulator: HwMeasurementAcc::disposable(),
+            accumulator: None,
         }
     }
 
@@ -83,12 +83,12 @@ impl HardwareCounterCell {
             payload_index_io_write_counter: CounterCell::new(),
             vector_io_read_counter: CounterCell::new(),
             vector_io_write_counter: CounterCell::new(),
-            accumulator,
+            accumulator: Some(accumulator),
         }
     }
 
     pub fn new_accumulator(&self) -> HwMeasurementAcc {
-        self.accumulator.clone()
+        self.accumulator.clone().unwrap_or_default()
     }
 
     /// Create a copy of the current counter cell with the same accumulator and config,
@@ -181,7 +181,9 @@ impl HardwareCounterCell {
     }
 
     fn merge_to_accumulator(&self) {
-        self.accumulator.accumulate(self.get_hw_data());
+        if let Some(accumulator) = &self.accumulator {
+            accumulator.accumulate(self.get_hw_data());
+        }
     }
 }
 
@@ -201,7 +203,11 @@ impl Drop for HardwareCounterCell {
 impl From<&HardwareCounterCell> for HardwareData {
     fn from(value: &HardwareCounterCell) -> Self {
         let counter_values = value.get_hw_data();
-        let acc_values = value.accumulator.hw_data();
+        let acc_values = value
+            .accumulator
+            .as_ref()
+            .map(|i| i.hw_data())
+            .unwrap_or_default();
         counter_values + acc_values
     }
 }

--- a/lib/common/common/src/counter/hardware_data.rs
+++ b/lib/common/common/src/counter/hardware_data.rs
@@ -1,7 +1,7 @@
 use std::ops::Add;
 
 /// Contains all hardware metrics. Only serves as value holding structure without any semantics.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct HardwareData {
     pub cpu: usize,
     pub payload_io_read: usize,


### PR DESCRIPTION
Improve performance of `HardwareCounterCell::disposable()` by 72x.
Since disposable HwCounterCells have to be passed to unmeasured functions, even in hot-paths, performance
is critical.

Dev:
```
Disposable Hw Cell      time:   [170.26 ns 170.48 ns 170.77 ns]
```

This PR:
```
Disposable Hw Cell      time:   [2.3429 ns 2.3600 ns 2.3769 ns]
                        change: [-98.609% -98.601% -98.594%] (p = 0.00 < 0.05)
                        Performance has improved.
```