### PR TITLE
Use more write buffers, and flush them

### DIFF
--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -157,7 +157,9 @@ impl<K: Key + ?Sized, V: Sized + FromBytes + Immutable + IntoBytes + KnownLayout
             }
         }
 
+        bufw.flush()?;
         drop(bufw);
+
         file.as_file().sync_all()?;
         file.persist(path)?;
 

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -157,6 +157,7 @@ impl<K: Key + ?Sized, V: Sized + FromBytes + Immutable + IntoBytes + KnownLayout
             }
         }
 
+        // Explicitly flush write buffer so we can catch IO errors
         bufw.flush()?;
         drop(bufw);
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -198,7 +198,6 @@ impl ImmutableIdTracker {
             Self::write_entry(&mut writer, internal_id, external_id)?;
         }
 
-        writer.flush()?;
         Ok(())
     }
 
@@ -321,7 +320,6 @@ impl ImmutableIdTracker {
         let file = File::create(Self::mappings_file_path(path))?;
         let mut writer = BufWriter::new(&file);
         Self::store_mapping(&mappings, &mut writer)?;
-        writer.flush()?;
         file.sync_all()?;
 
         deleted_wrapper.flusher()()?;

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -319,8 +319,9 @@ impl ImmutableIdTracker {
 
         // Write mappings to disk.
         let file = File::create(Self::mappings_file_path(path))?;
-        let writer = BufWriter::new(&file);
-        Self::store_mapping(&mappings, writer)?;
+        let mut writer = BufWriter::new(&file);
+        Self::store_mapping(&mappings, &mut writer)?;
+        writer.flush()?;
         file.sync_all()?;
 
         deleted_wrapper.flusher()()?;

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -725,7 +725,7 @@ fn store_version_changes(
             "Failed to flush ID tracker point versions write buffer: {err}",
         ))
     })?;
-    let file = writer.into_inner().unwrap();
+    let file = writer.into_inner().map_err(|err| err.into_error())?;
     file.sync_all().map_err(|err| {
         OperationError::service_error(format!("Failed to fsync ID tracker point versions: {err}"))
     })?;

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -372,6 +372,7 @@ fn store_mapping_changes(mappings_path: &Path, changes: Vec<MappingChange>) -> O
     })?;
 
     // Explicitly fsync file contents to ensure durability
+    writer.flush()?;
     let file = writer.into_inner().unwrap();
     file.sync_all().map_err(|err| {
         OperationError::service_error(format!("Failed to fsync ID tracker point mappings: {err}"))
@@ -719,12 +720,12 @@ fn store_version_changes(
     })?;
 
     // Explicitly fsync file contents to ensure durability
-    let file = writer.into_inner().map_err(|err| {
+    writer.flush().map_err(|err| {
         OperationError::service_error(format!(
-            "Failed to close ID tracker point versions write buffer: {}",
-            err.into_error()
+            "Failed to close ID tracker point versions write buffer: {err}",
         ))
     })?;
+    let file = writer.into_inner().unwrap();
     file.sync_all().map_err(|err| {
         OperationError::service_error(format!("Failed to fsync ID tracker point versions: {err}"))
     })?;

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -722,7 +722,7 @@ fn store_version_changes(
     // Explicitly fsync file contents to ensure durability
     writer.flush().map_err(|err| {
         OperationError::service_error(format!(
-            "Failed to close ID tracker point versions write buffer: {err}",
+            "Failed to flush ID tracker point versions write buffer: {err}",
         ))
     })?;
     let file = writer.into_inner().unwrap();

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -208,7 +208,7 @@ impl MmapPostings {
             }
         }
 
-        // Dropping will flush the buffer to the file
+        // Explicitly flush write buffer so we can catch IO errors
         bufw.flush()?;
         drop(bufw);
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -209,7 +209,9 @@ impl MmapPostings {
         }
 
         // Dropping will flush the buffer to the file
+        bufw.flush()?;
         drop(bufw);
+
         file.as_file().sync_all()?;
         file.persist(path)?;
 

--- a/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
@@ -218,8 +218,11 @@ impl GraphLinksSerializer {
         let file = File::create(temp_path.as_path())?;
         let mut buf = std::io::BufWriter::new(&file);
         self.serialize_to_writer(&mut buf)?;
+
+        // Explicitly flush write buffer so we can catch IO errors
         buf.flush()?;
         file.sync_all()?;
+
         std::fs::rename(temp_path, path)?;
         Ok(())
     }

--- a/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
@@ -218,6 +218,7 @@ impl GraphLinksSerializer {
         let file = File::create(temp_path.as_path())?;
         let mut buf = std::io::BufWriter::new(&file);
         self.serialize_to_writer(&mut buf)?;
+        buf.flush()?;
         file.sync_all()?;
         std::fs::rename(temp_path, path)?;
         Ok(())

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -223,7 +223,7 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
 
         // Explicitly flush write buffer so we can catch IO errors
         buffer.flush()?;
-        buffer.into_inner().unwrap().sync_all()?;
+        buffer.into_inner()?.sync_all()?;
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -220,9 +220,10 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
         for i in 0..self.len() {
             buffer.write_all(self.get(i))?;
         }
+
+        // Explicitly flush write buffer so we can catch IO errors
         buffer.flush()?;
-        let file = buffer.into_inner().unwrap();
-        file.sync_all()?;
+        buffer.into_inner().unwrap().sync_all()?;
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 use std::collections::TryReserveError;
 use std::fs::File;
-use std::io::{BufReader, Read, Write};
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::mem;
 use std::path::Path;
 
@@ -216,11 +216,13 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
     }
 
     fn save_to_file(&self, path: &Path) -> std::io::Result<()> {
-        let mut buffer = File::create(path)?;
+        let mut buffer = BufWriter::new(File::create(path)?);
         for i in 0..self.len() {
             buffer.write_all(self.get(i))?;
         }
-        buffer.sync_all()?;
+        buffer.flush()?;
+        let file = buffer.into_inner().unwrap();
+        file.sync_all()?;
         Ok(())
     }
 

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -199,10 +199,12 @@ async fn _do_create_full_snapshot(
             builder.append_path_with_name(&temp_file, &snapshot_name)?;
         }
         builder.append_path_with_name(&config_path_clone, "config.json")?;
-
         builder.finish()?;
+
+        // Explicitly flush write buffer so we can catch IO errors
         drop(builder);
         file.flush()?;
+
         Ok::<(), StorageError>(())
     });
     archiving.await??;

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -2,6 +2,7 @@ pub mod download;
 pub mod recover;
 
 use std::collections::HashMap;
+use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use collection::operations::snapshot_ops::SnapshotDescription;
@@ -191,8 +192,8 @@ async fn _do_create_full_snapshot(
     let full_snapshot_path_clone = temp_full_snapshot_path.clone();
     let archiving = tokio::task::spawn_blocking(move || {
         // have to use std here, cause TarBuilder is not async
-        let file = std::fs::File::create(&full_snapshot_path_clone)?;
-        let mut builder = TarBuilder::new(file);
+        let mut file = BufWriter::new(std::fs::File::create(&full_snapshot_path_clone)?);
+        let mut builder = TarBuilder::new(&mut file);
         builder.sparse(true);
         for (temp_file, snapshot_name) in temp_collection_snapshots {
             builder.append_path_with_name(&temp_file, &snapshot_name)?;
@@ -200,6 +201,8 @@ async fn _do_create_full_snapshot(
         builder.append_path_with_name(&config_path_clone, "config.json")?;
 
         builder.finish()?;
+        drop(builder);
+        file.flush()?;
         Ok::<(), StorageError>(())
     });
     archiving.await??;


### PR DESCRIPTION
Does two things in places where it makes sense:
- buffer writes
- explicitly flush write buffers to catch IO errors in our own error handling

Continuation of <https://github.com/qdrant/qdrant/pull/6513>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?