### PR TITLE
Clippy 1.87 autofix

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -163,7 +163,6 @@ impl ConfigMismatchOptimizer {
                             let target_quantization = target_quantization_vector
                                 .as_ref()
                                 .or(target_quantization_collection);
-                            
 
                             vector_data
                                 .quantization_config

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -163,7 +163,9 @@ impl ConfigMismatchOptimizer {
                             let target_quantization = target_quantization_vector
                                 .as_ref()
                                 .or(target_quantization_collection);
-                            let quantization_mismatch = vector_data
+                            
+
+                            vector_data
                                 .quantization_config
                                 .as_ref()
                                 .zip(target_quantization)
@@ -174,9 +176,7 @@ impl ConfigMismatchOptimizer {
                                     vector_data.index.is_indexed()
                                         && (vector_data.quantization_config.is_some()
                                             != target_quantization.is_some())
-                                });
-
-                            quantization_mismatch
+                                })
                         });
 
                 // Determine whether dense data in segment has mismatch

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -63,8 +63,7 @@ impl<W: Write> Write for FusedWriteSeek<W> {
         if !self.enabled.load(Ordering::Acquire) {
             // This error shouldn't be observable. It might appear only in
             // `tar::Builder::drop`, and will be ignored there.
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 "Using WriteBox after it is disabled",
             ));
         }
@@ -214,8 +213,7 @@ impl<W: Write + Seek> BuilderExt<W> {
     pub fn blocking_finish(self) -> io::Result<()> {
         let mut bb: BlowFuseOnDrop<_> = Arc::try_unwrap(self.tar)
             .map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::Other,
+                io::Error::other(
                     "finish called with multiple references to the tar builder",
                 )
             })?
@@ -316,8 +314,7 @@ mod tests {
     impl Write for DummyBridgeWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
             if self.0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     "Forced error in write",
                 ));
             }
@@ -327,8 +324,7 @@ mod tests {
 
         fn flush(&mut self) -> io::Result<()> {
             if self.0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     "Forced error in flush",
                 ));
             }

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -63,9 +63,7 @@ impl<W: Write> Write for FusedWriteSeek<W> {
         if !self.enabled.load(Ordering::Acquire) {
             // This error shouldn't be observable. It might appear only in
             // `tar::Builder::drop`, and will be ignored there.
-            return Err(io::Error::other(
-                "Using WriteBox after it is disabled",
-            ));
+            return Err(io::Error::other("Using WriteBox after it is disabled"));
         }
         self.output.write(buf)
     }
@@ -213,9 +211,7 @@ impl<W: Write + Seek> BuilderExt<W> {
     pub fn blocking_finish(self) -> io::Result<()> {
         let mut bb: BlowFuseOnDrop<_> = Arc::try_unwrap(self.tar)
             .map_err(|_| {
-                io::Error::other(
-                    "finish called with multiple references to the tar builder",
-                )
+                io::Error::other("finish called with multiple references to the tar builder")
             })?
             .into_inner();
 
@@ -314,9 +310,7 @@ mod tests {
     impl Write for DummyBridgeWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
             if self.0 {
-                return Err(io::Error::other(
-                    "Forced error in write",
-                ));
+                return Err(io::Error::other("Forced error in write"));
             }
             self.1.blocking_lock().extend_from_slice(buf); // panics in async
             Ok(buf.len())
@@ -324,9 +318,7 @@ mod tests {
 
         fn flush(&mut self) -> io::Result<()> {
             if self.0 {
-                return Err(io::Error::other(
-                    "Forced error in flush",
-                ));
+                return Err(io::Error::other("Forced error in flush"));
             }
             let _ = self.1.blocking_lock(); // panics in async
             Ok(())

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -165,7 +165,7 @@ pub fn validate_multi_vector_by_length(multivec_length: &[usize]) -> Result<(), 
     }
 
     // check all individual vectors non-empty
-    if multivec_length.iter().any(|v| *v == 0) {
+    if multivec_length.contains(&0) {
         let mut errors = ValidationErrors::default();
         let mut err = ValidationError::new("empty_vector");
         err.add_param(Cow::from("message"), &"all vectors must be non-empty");

--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -44,12 +44,10 @@ impl EncodedStorage for Vec<u8> {
         if buffer.len() == expected_size {
             Ok(buffer)
         } else {
-            Err(std::io::Error::other(
-                format!(
-                    "Loaded storage size {} is not equal to expected size {expected_size}",
-                    buffer.len()
-                ),
-            ))
+            Err(std::io::Error::other(format!(
+                "Loaded storage size {} is not equal to expected size {expected_size}",
+                buffer.len()
+            )))
         }
     }
 

--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -44,8 +44,7 @@ impl EncodedStorage for Vec<u8> {
         if buffer.len() == expected_size {
             Ok(buffer)
         } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 format!(
                     "Loaded storage size {} is not equal to expected size {expected_size}",
                     buffer.len()

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -324,11 +324,7 @@ impl OperationDurationsAggregator {
 
         let mut sliding_window_avg = vec![0.; data.len()];
         for i in 0..data.len() {
-            let from = if i < SLIDING_WINDOW_LEN {
-                0
-            } else {
-                i - SLIDING_WINDOW_LEN
-            };
+            let from = i.saturating_sub(SLIDING_WINDOW_LEN);
             sliding_window_avg[i] = Self::simple_moving_average(&data[from..i + 1]);
         }
 

--- a/lib/segment/src/compat.rs
+++ b/lib/segment/src/compat.rs
@@ -49,7 +49,11 @@ impl From<SegmentConfigV5> for SegmentConfig {
                         .as_ref()
                         .and(old_data.quantization_config),
                     // Mmap if explicitly on disk, otherwise convert old storage type
-                    storage_type: if old_data.on_disk == Some(true) { VectorStorageType::Mmap } else { old_segment.storage_type.into() },
+                    storage_type: if old_data.on_disk == Some(true) {
+                        VectorStorageType::Mmap
+                    } else {
+                        old_segment.storage_type.into()
+                    },
                     multivector_config: None,
                     datatype: None,
                 };

--- a/lib/segment/src/compat.rs
+++ b/lib/segment/src/compat.rs
@@ -49,9 +49,7 @@ impl From<SegmentConfigV5> for SegmentConfig {
                         .as_ref()
                         .and(old_data.quantization_config),
                     // Mmap if explicitly on disk, otherwise convert old storage type
-                    storage_type: (old_data.on_disk == Some(true))
-                        .then_some(VectorStorageType::Mmap)
-                        .unwrap_or_else(|| old_segment.storage_type.into()),
+                    storage_type: if old_data.on_disk == Some(true) { VectorStorageType::Mmap } else { old_segment.storage_type.into() },
                     multivector_config: None,
                     datatype: None,
                 };

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -53,10 +53,7 @@ impl InvertedIndex for ImmutableInvertedIndex {
         let postings_opt: Option<Vec<_>> = query
             .tokens
             .iter()
-            .map(|&token_id| {
-                
-                self.postings.get(token_id as usize)
-            })
+            .map(|&token_id| self.postings.get(token_id as usize))
             .collect();
 
         let postings = match postings_opt {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -54,8 +54,8 @@ impl InvertedIndex for ImmutableInvertedIndex {
             .tokens
             .iter()
             .map(|&token_id| {
-                let postings = self.postings.get(token_id as usize);
-                postings
+                
+                self.postings.get(token_id as usize)
             })
             .collect();
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -144,8 +144,8 @@ impl InvertedIndex for MutableInvertedIndex {
             .map(|&vocab_idx| {
                 // if a ParsedQuery token was given an index, then it must exist in the vocabulary
                 // dictionary. Posting list entry can be None but it exists.
-                let postings = self.postings.get(vocab_idx as usize);
-                postings
+                
+                self.postings.get(vocab_idx as usize)
             })
             .collect();
         let Some(postings) = postings_opt else {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -144,7 +144,7 @@ impl InvertedIndex for MutableInvertedIndex {
             .map(|&vocab_idx| {
                 // if a ParsedQuery token was given an index, then it must exist in the vocabulary
                 // dictionary. Posting list entry can be None but it exists.
-                
+
                 self.postings.get(vocab_idx as usize)
             })
             .collect();

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -308,7 +308,9 @@ impl<T: Numericable + Serialize + DeserializeOwned> Histogram<T> {
             return (0, 0, 0);
         }
 
-        let estimation = left_border
+        
+
+        left_border
             .into_iter()
             .chain(self.borders.range((from_, to_)))
             .chain(right_border)
@@ -344,9 +346,7 @@ impl<T: Numericable + Serialize + DeserializeOwned> Histogram<T> {
                 },
             )
             .reduce(|a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2))
-            .unwrap_or((0, 0, 0));
-
-        estimation
+            .unwrap_or((0, 0, 0))
     }
 
     pub fn remove<F, G>(&mut self, val: &Point<T>, left_neighbour: F, right_neighbour: G)

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -308,8 +308,6 @@ impl<T: Numericable + Serialize + DeserializeOwned> Histogram<T> {
             return (0, 0, 0);
         }
 
-        
-
         left_border
             .into_iter()
             .chain(self.borders.range((from_, to_)))

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -435,13 +435,13 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
     pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&N) -> bool) -> bool {
         let mut hw_count_val = 0;
 
-        let res = self.point_to_values.check_values_any(idx, |v| {
+        
+
+        self.point_to_values.check_values_any(idx, |v| {
             let v = v.borrow();
             hw_count_val += <N as MmapValue>::mmapped_size(v.as_referenced());
             check_fn(v)
-        });
-
-        res
+        })
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -435,8 +435,6 @@ impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N> {
     pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&N) -> bool) -> bool {
         let mut hw_count_val = 0;
 
-        
-
         self.point_to_values.check_values_any(idx, |v| {
             let v = v.borrow();
             hw_count_val += <N as MmapValue>::mmapped_size(v.as_referenced());

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -220,8 +220,7 @@ impl PayloadStorage for MmapPayloadStorage {
             |point_id, payload| {
                 callback(point_id, payload).map_err(|e|
                     // TODO return proper error
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
+                    std::io::Error::other(
                         e.to_string(),
                     ))
             },

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -205,8 +205,7 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
         if vectors.len() == vectors_count {
             Ok(vectors)
         } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 format!(
                     "Loaded vectors count {} is not equal to expected count {vectors_count}",
                     vectors.len(),

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -205,12 +205,10 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
         if vectors.len() == vectors_count {
             Ok(vectors)
         } else {
-            Err(std::io::Error::other(
-                format!(
-                    "Loaded vectors count {} is not equal to expected count {vectors_count}",
-                    vectors.len(),
-                ),
-            ))
+            Err(std::io::Error::other(format!(
+                "Loaded vectors count {} is not equal to expected count {vectors_count}",
+                vectors.len(),
+            )))
         }
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -38,8 +38,7 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
         if mmap.len() == expected_size {
             Ok(Self { mmap })
         } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 format!(
                     "Loaded storage size {} is not equal to expected size {expected_size}",
                     mmap.len()

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -38,12 +38,10 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
         if mmap.len() == expected_size {
             Ok(Self { mmap })
         } else {
-            Err(std::io::Error::other(
-                format!(
-                    "Loaded storage size {} is not equal to expected size {expected_size}",
-                    mmap.len()
-                ),
-            ))
+            Err(std::io::Error::other(format!(
+                "Loaded storage size {} is not equal to expected size {expected_size}",
+                mmap.len()
+            )))
         }
     }
 

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -189,7 +189,7 @@ pub fn init(
             );
 
             let config = certificate_helpers::actix_tls_server_config(&settings)
-                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+                .map_err(io::Error::other)?;
             server.bind_rustls_0_23(bind_addr, config)?
         } else {
             log::info!("TLS disabled for REST API");

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -106,7 +106,7 @@ fn load_ca_certificate(tls_config: &TlsConfig) -> io::Result<Certificate> {
 }
 
 pub fn tonic_error_to_io_error(err: tonic::transport::Error) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, err)
+    io::Error::other(err)
 }
 
 #[cfg(test)]

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -171,6 +171,6 @@ impl From<Error> for StorageError {
 
 impl From<Error> for io::Error {
     fn from(err: Error) -> Self {
-        io::Error::new(io::ErrorKind::Other, err)
+        io::Error::other(err)
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -286,9 +286,7 @@ impl Settings {
     }
 
     pub fn tls_config_is_undefined_error() -> io::Error {
-        io::Error::other(
-            "TLS config is not defined in the Qdrant config file",
-        )
+        io::Error::other("TLS config is not defined in the Qdrant config file")
     }
 
     pub fn validate_and_warn(&self) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -286,8 +286,7 @@ impl Settings {
     }
 
     pub fn tls_config_is_undefined_error() -> io::Error {
-        io::Error::new(
-            io::ErrorKind::Other,
+        io::Error::other(
             "TLS config is not defined in the Qdrant config file",
         )
     }


### PR DESCRIPTION
Rust [1.87](https://releases.rs/docs/1.87.0/) is coming out soon.

A lot of Clippy lints are being triggered.

I propose to manage those in several PRs for better clarity.

This first PR is the result of `clippy --fix` to get get started.