### PR TITLE
Fix Clippy 1.87 large error

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+large-error-threshold = 256


### PR DESCRIPTION
Follow up to https://github.com/qdrant/qdrant/pull/6518

There is a large amount of warning with:

```
error: the `Err`-variant returned from this function is very large
    --> lib/api/src/grpc/conversions.rs:2210:6
     |
2210 | ) -> Result<segment_vectors::NamedVectorStruct, Status> {
     |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 176 bytes
     |
     = help: try reducing the size of `tonic::Status`, for example by boxing large elements or replacing it with `Box<tonic::Status>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
```

Given that we use the Tonic's `Status` a lot as error type, I decided to simply raise the the threshold for the time being.

We can decide later if we want to Box all the call sites.