### PR TITLE
Update merge 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3849,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "merge"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+checksum = "56e520ba58faea3487f75df198b1d079644ec226ea3b0507d002c6fa4b8cf93a"
 dependencies = [
  "merge_derive",
  "num-traits",
@@ -3859,14 +3859,14 @@ dependencies = [
 
 [[package]]
 name = "merge_derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+checksum = "5c8f8ce6efff81cbc83caf4af0905c46e58cb46892f63ad3835e81b47eaf7968"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4517,6 +4517,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ thiserror = "2.0.12"
 libc = "0.2"
 bitvec = "1.0.1"
 smallvec = { version = "1.15.0", features = ["write"] }
-merge = "0.1.0"
+merge = "0.2.0"
 dashmap = "6.1"
 
 [[bin]]

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -482,4 +482,30 @@ mod tests {
         let new_config = update.update(&base_config).unwrap();
         assert_eq!(new_config.wal_segments_ahead, 2)
     }
+
+    #[test]
+    fn test_none_value_does_not_overwrite() {
+        let base_config = HnswConfig {
+            m: 16,
+            ef_construct: 100,
+            ..HnswConfig::default()
+        };
+
+        let diff = HnswConfigDiff {
+            m: None,                 // This should not overwrite the existing value
+            ef_construct: Some(200), // This should overwrite
+            full_scan_threshold: None,
+            max_indexing_threads: None,
+            on_disk: None,
+            payload_m: None,
+        };
+
+        // Merge the diff into the base config
+        let merged = diff.update(&base_config).unwrap();
+
+        // The m value should not be changed
+        assert_eq!(merged.m, 16);
+        // The ef_construct value should be updated
+        assert_eq!(merged.ef_construct, 200);
+    }
 }

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -58,9 +58,11 @@ pub trait DiffConfig<T: DeserializeOwned + Serialize> {
 pub struct HnswConfigDiff {
     /// Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub m: Option<usize>,
     /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index.
     #[validate(range(min = 4))]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ef_construct: Option<usize>,
     /// Minimal size (in kilobytes) of vectors for additional payload-based indexing.
@@ -72,6 +74,7 @@ pub struct HnswConfigDiff {
         default,
         skip_serializing_if = "Option::is_none"
     )]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 10))]
     pub full_scan_threshold: Option<usize>,
     /// Number of parallel threads used for background index building.
@@ -79,12 +82,15 @@ pub struct HnswConfigDiff {
     /// Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
     /// On small CPUs, less threads are used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub max_indexing_threads: Option<usize>,
     /// Store HNSW index on disk. If set to false, the index will be stored in RAM. Default: false
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub on_disk: Option<bool>,
     /// Custom M param for additional payload-aware HNSW links. If not set, default M will be used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub payload_m: Option<usize>,
 }
 
@@ -94,32 +100,40 @@ pub struct HnswConfigDiff {
 pub struct WalConfigDiff {
     /// Size of a single WAL segment in MB
     #[validate(range(min = 1))]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub wal_capacity_mb: Option<usize>,
     /// Number of WAL segments to create ahead of actually used ones
+    #[merge(strategy = merge::option::overwrite_none)]
     pub wal_segments_ahead: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Merge, PartialEq, Eq, Hash)]
 pub struct CollectionParamsDiff {
     /// Number of replicas for each shard
+    #[merge(strategy = merge::option::overwrite_none)]
     pub replication_factor: Option<NonZeroU32>,
     /// Minimal number successful responses from replicas to consider operation successful
+    #[merge(strategy = merge::option::overwrite_none)]
     pub write_consistency_factor: Option<NonZeroU32>,
     /// Fan-out every read request to these many additional remote nodes (and return first available response)
+    #[merge(strategy = merge::option::overwrite_none)]
     pub read_fan_out_factor: Option<u32>,
     /// If true - point's payload will not be stored in memory.
     /// It will be read from the disk every time it is requested.
     /// This setting saves RAM by (slightly) increasing the response time.
     /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
     #[serde(default)]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub on_disk_payload: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, Merge)]
 pub struct OptimizersConfigDiff {
     /// The minimal fraction of deleted vectors in a segment, required to perform segment optimization
+    #[merge(strategy = merge::option::overwrite_none)]
     pub deleted_threshold: Option<f64>,
     /// The minimal number of vectors in a segment, required to perform segment optimization
+    #[merge(strategy = merge::option::overwrite_none)]
     pub vacuum_min_vector_number: Option<usize>,
     /// Target amount of segments optimizer will try to keep.
     /// Real amount of segments may vary depending on multiple parameters:
@@ -129,6 +143,7 @@ pub struct OptimizersConfigDiff {
     /// It is recommended to select default number of segments as a factor of the number of search threads,
     /// so that each segment would be handled evenly by one of the threads
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
+    #[merge(strategy = merge::option::overwrite_none)]
     pub default_segment_number: Option<usize>,
     /// Do not create segments larger this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
@@ -138,6 +153,7 @@ pub struct OptimizersConfigDiff {
     /// If search speed is more important - make this parameter higher.
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "max_segment_size_kb")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub max_segment_size: Option<usize>,
     /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
@@ -149,6 +165,7 @@ pub struct OptimizersConfigDiff {
     ///
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "memmap_threshold_kb")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub memmap_threshold: Option<usize>,
     /// Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
     ///
@@ -158,13 +175,16 @@ pub struct OptimizersConfigDiff {
     ///
     /// Note: 1kB = 1 vector of size 256.
     #[serde(alias = "indexing_threshold_kb")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub indexing_threshold: Option<usize>,
     /// Minimum interval between forced flushes.
+    #[merge(strategy = merge::option::overwrite_none)]
     pub flush_interval_sec: Option<u64>,
     /// Max number of threads (jobs) for running optimizations per shard.
     /// Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
     /// If "auto" - have no limit and choose dynamically to saturate CPU.
     /// If 0 - no optimization threads, optimizations will be disabled.
+    #[merge(strategy = merge::option::overwrite_none)]
     pub max_optimization_threads: Option<MaxOptimizationThreads>,
 }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1908,6 +1908,7 @@ impl From<&segment::types::VectorDataConfig> for VectorParamsBase {
 pub struct VectorParamsDiff {
     /// Update params for HNSW index. If empty object - it will be unset.
     #[serde(default, skip_serializing_if = "is_hnsw_diff_empty")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(nested)]
     pub hnsw_config: Option<HnswConfigDiff>,
     /// Update params for quantization. If none - it is left unchanged.
@@ -1916,10 +1917,12 @@ pub struct VectorParamsDiff {
         alias = "quantization",
         skip_serializing_if = "Option::is_none"
     )]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(nested)]
     pub quantization_config: Option<QuantizationConfigDiff>,
     /// If true, vectors are served from disk, improving RAM usage at the cost of latency
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub on_disk: Option<bool>,
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -961,7 +961,6 @@ pub struct StrictModeConfig {
     /// Max size of a collections payload storage in bytes
     #[serde(skip_serializing_if = "Option::is_none")]
     #[merge(strategy = merge::option::overwrite_none)]
-    #[merge(strategy = merge::option::overwrite_none)]
     pub max_collection_payload_size_bytes: Option<usize>,
 
     /// Max number of points estimated in a collection

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -771,6 +771,7 @@ impl From<BinaryQuantizationConfig> for QuantizationConfig {
 pub struct StrictModeSparse {
     /// Max length of sparse vector
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub max_length: Option<usize>,
 }
@@ -832,6 +833,7 @@ impl From<StrictModeSparse> for StrictModeSparseOutput {
 pub struct StrictModeMultivector {
     /// Max number of vectors in a multivector
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub max_vectors: Option<usize>,
 }
@@ -893,81 +895,100 @@ pub struct StrictModeConfig {
     // Global
     /// Whether strict mode is enabled for a collection or not.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub enabled: Option<bool>,
 
     /// Max allowed `limit` parameter for all APIs that don't have their own max limit.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub max_query_limit: Option<usize>,
 
     /// Max allowed `timeout` parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub max_timeout: Option<usize>,
 
     /// Allow usage of unindexed fields in retrieval based (e.g. search) filters.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub unindexed_filtering_retrieve: Option<bool>,
 
     /// Allow usage of unindexed fields in filtered updates (e.g. delete by payload).
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub unindexed_filtering_update: Option<bool>,
 
     // Search
     /// Max HNSW value allowed in search parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub search_max_hnsw_ef: Option<usize>,
 
     /// Whether exact search is allowed or not.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub search_allow_exact: Option<bool>,
 
     /// Max oversampling value allowed in search.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub search_max_oversampling: Option<f64>,
 
     /// Max batchsize when upserting
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub upsert_max_batchsize: Option<usize>,
 
     /// Max size of a collections vector storage in bytes, ignoring replicas.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub max_collection_vector_size_bytes: Option<usize>,
 
     /// Max number of read operations per minute per replica
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub read_rate_limit: Option<usize>,
 
     /// Max number of write operations per minute per replica
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub write_rate_limit: Option<usize>,
 
     /// Max size of a collections payload storage in bytes
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub max_collection_payload_size_bytes: Option<usize>,
 
     /// Max number of points estimated in a collection
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(range(min = 1))]
     pub max_points_count: Option<usize>,
 
     /// Max conditions a filter can have.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub filter_max_conditions: Option<usize>,
 
     /// Max size of a condition, eg. items in `MatchAny`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     pub condition_max_size: Option<usize>,
 
     /// Multivector configuration
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(nested)]
     pub multivector_config: Option<StrictModeMultivectorConfig>,
 
     /// Sparse vector configuration
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
     #[validate(nested)]
     pub sparse_config: Option<StrictModeSparseConfig>,
 }


### PR DESCRIPTION
Dependabot does not see the update for some reason.

Here is the changelog https://git.sr.ht/~ireas/merge-rs/tree/master/item/CHANGELOG.md

The `Option` breaking change is explained here https://git.sr.ht/~ireas/merge-rs/commit/d9cabc50505f520e630b5c4d1557f6126e5c9bb8

`option::overwrite_none` is equivalent to the previous behavior.

I am not sure yet if we want to migrate to `option::recurse` later.

Another interesting point is that it removes one dependency on

```
Crate:     proc-macro-error
Version:   1.0.4
Warning:   unmaintained
Title:     proc-macro-error is unmaintained
Date:      2024-09-01
ID:        RUSTSEC-2024-0370
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0370
```