### PR TITLE
Always overwrite existing payload on upsert

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -399,6 +399,8 @@ pub(crate) fn delete_field_index(
 
 /// Upsert to a point ID with the specified vectors and payload in the given segment.
 ///
+/// If the payload is None, the existing payload will be cleared.
+///
 /// Returns
 /// - Ok(true) if the operation was successful and point replaced existing value
 /// - Ok(false) if the operation was successful and point was inserted
@@ -414,6 +416,8 @@ fn upsert_with_payload(
     let mut res = segment.upsert_point(op_num, point_id, vectors, hw_counter)?;
     if let Some(full_payload) = payload {
         res &= segment.set_full_payload(op_num, point_id, full_payload, hw_counter)?;
+    } else {
+        res &= segment.clear_payload(op_num, point_id, hw_counter)?;
     }
     Ok(res)
 }

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -65,6 +65,33 @@ fi
   ]
 }' $QDRANT_HOST qdrant.Points/Upsert
 
+# Upsert point with empty payload
+"${docker_grpcurl[@]}" -d '{
+  "collection_name": "test_collection",
+  "points": [
+    {
+      "id": { "num": 1 },
+      "vectors": { "vector": { "data": [0.05, 0.61, 0.76, 0.74] }},
+      "payload": {}
+    }
+  ]
+}' $QDRANT_HOST qdrant.Points/Upsert
+
+# Retrieve point by ID
+response=$("${docker_grpcurl[@]}" -d '{
+  "collection_name": "test_collection",
+  "with_payload": {"enable": true},
+  "with_vectors": {"enable": true},
+  "ids": [{ "num": 1 }]
+}' $QDRANT_HOST qdrant.Points/Get)
+
+payload_exists=$(echo "$response" | jq '(.result[0].payload != null)')
+
+if [[ "$payload_exists" == true ]]; then
+  echo "Payload should be empty."
+  exit 1
+fi
+
 # Insert invalid sparse vector, check that validation error is returned
 "${docker_grpcurl[@]}" -d '{
   "collection_name": "test_collection",

--- a/tests/openapi/test_payload_operations.py
+++ b/tests/openapi/test_payload_operations.py
@@ -588,3 +588,96 @@ def test_payload_index_overwrite(collection_name):
     )
     assert response.ok
     assert len(response.json()["result"]["points"]) == 1
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    assert len(response.json()['result']['payload']) == 3
+
+    # check point payload upsert cleared if empty
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [1, 2, 3, 4],
+                    "payload": { },
+                },
+            ]
+        },
+    )
+    assert response.ok
+
+    # payload cleared
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    assert len(response.json()['result']['payload']) == 0
+
+    # check point payload upsert overwrite
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [1, 2, 3, 4],
+                    "payload": {
+                        "key": {
+                            "nested": 1
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    assert response.ok
+
+    # payload overwritten
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    assert len(response.json()['result']['payload']) == 1
+    assert response.json()['result']['payload']["key"] == {"nested": 1}
+
+    # check point payload upsert cleared if missing
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [1, 2, 3, 4]
+                },
+            ]
+        },
+    )
+    assert response.ok
+
+    # payload cleared
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    assert len(response.json()['result']['payload']) == 0


### PR DESCRIPTION
This PR changes the behavior of the point upsert API so that is always overwrite the existing payload value.

Previously, passing a None payload left the existing payload unchanged.

The main motivation for this change is the bug https://github.com/qdrant/qdrant/issues/6449 where gRPC and REST would behave differently due to different handling of empty vs optional values.

Now passing an empty value or no value at all will always result in clearing the existing payload.

This changed passed the `qdrant-client` congruence tests.