### PR TITLE
Add comment for why we set custom large-error-threshold

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
+# For Rust 1.87 until fixed: <https://github.com/hyperium/tonic/issues/2253>
 large-error-threshold = 256


### PR DESCRIPTION
Extension on <https://github.com/qdrant/qdrant/pull/6529>

May be good to keep track of this. If it ever gets resolved, we can drop the config.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?