### PR TITLE
Fix immutable mmap index files not included in snapshot

### DIFF
--- a/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mmap_bool_index.rs
@@ -447,7 +447,6 @@ impl PayloadFieldIndex for MmapBoolIndex {
     fn files(&self) -> Vec<std::path::PathBuf> {
         let mut files = self.trues_slice.files();
         files.extend(self.falses_slice.files());
-
         files
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use common::types::PointOffsetType;
 
 use super::immutable_inverted_index::ImmutableInvertedIndex;
@@ -127,6 +129,13 @@ impl ImmutableFullTextIndex {
         match self.storage {
             Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
             Storage::Mmap(index) => index.clear(),
+        }
+    }
+
+    pub fn files(&self) -> Vec<PathBuf> {
+        match self.storage {
+            Storage::RocksDb(_) => vec![],
+            Storage::Mmap(ref index) => index.files(),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -403,7 +403,7 @@ impl PayloadFieldIndex for FullTextIndex {
     fn files(&self) -> Vec<PathBuf> {
         match self {
             Self::Mutable(_) => vec![],
-            Self::Immutable(_) => vec![],
+            Self::Immutable(index) => index.files(),
             Self::Mmap(index) => index.files(),
         }
     }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -575,7 +575,7 @@ impl PayloadFieldIndex for GeoMapIndex {
 
     fn files(&self) -> Vec<PathBuf> {
         match &self {
-            GeoMapIndex::Mutable(index) => index.files(),
+            GeoMapIndex::Mutable(_) => vec![],
             GeoMapIndex::Immutable(index) => index.files(),
             GeoMapIndex::Mmap(index) => index.files(),
         }

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -1,6 +1,5 @@
 use std::cmp::max;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use ahash::AHashSet;

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -65,10 +65,6 @@ impl MutableGeoMapIndex {
         &self.db_wrapper
     }
 
-    pub fn files(&self) -> Vec<PathBuf> {
-        Default::default()
-    }
-
     pub fn load(&mut self) -> OperationResult<bool> {
         if !self.db_wrapper.has_column_family()? {
             return Ok(false);

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -312,7 +312,7 @@ impl<N: MapIndexKey + ?Sized> MapIndex<N> {
 
     fn files(&self) -> Vec<PathBuf> {
         match self {
-            MapIndex::Mutable(_) => Vec::new(),
+            MapIndex::Mutable(_) => vec![],
             MapIndex::Immutable(index) => index.files(),
             MapIndex::Mmap(index) => index.files(),
         }


### PR DESCRIPTION
Fix regression in <https://github.com/qdrant/qdrant/pull/6495>

When having an immutable full text index based on mmap storage, its files were not included when creating a snapshot. I missed to properly list them. This fixes the problem.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?