### PR TITLE
Cap max number of concurrent S3 upload

### DIFF
--- a/lib/collection/src/operations/snapshot_storage_ops.rs
+++ b/lib/collection/src/operations/snapshot_storage_ops.rs
@@ -116,7 +116,8 @@ pub async fn multipart_upload(
 
     // Initialize CpuBudget to manage concurrency
     let cpu_budget = ResourceBudget::default();
-    let max_concurrency = cpu_budget.available_cpu_budget();
+    // Cap max concurrency to avoid saturating the network on high core count
+    let max_concurrency = std::cmp::min(cpu_budget.available_cpu_budget(), 8);
 
     // Note:
     //  1. write.write() is sync but a worker thread is spawned internally.


### PR DESCRIPTION
Possible fix for https://github.com/qdrant/qdrant/issues/6515

The rational is that very high core count machine could saturate the network IO or even trigger the S3 bucket throttling mechanism.

For those reasons it makes sense to cap the max number of concurrent S3 upload.

Change not tested.