### PR TITLE
Fix dev branch coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -87,8 +87,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # If scheduled by cron, run for dev branch, Otherwise specified branch (for workflow dispatch & push)
           ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref_name }}
-          fetch-depth: 0
+          fetch-depth: 0 # Fetch all history for all tags and branches
       - name: Install lcov
         run: sudo apt install -y lcov
       - name: Download unit test coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref_name }}
+          fetch-depth: 0
       - name: Install lcov
         run: sudo apt install -y lcov
       - name: Download unit test coverage


### PR DESCRIPTION
Coverage reports seems to be getting uploaded for `master` instead of `dev`

Logs don't have warnings or errors so the root cause is not 100% clear. But I suspect the problem is that we don't do enough commit info in `upload-and-merge` stage.  My hypothesis is that it's attaching the commit to the wrong branch because default fetch depth is 1 and hence it doesn't have full context and falls back to registering it as master branch. So this is similar to https://github.com/qdrant/qdrant/pull/6345

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
