### PR TITLE
Fix unecessary unsafe in Clippy 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.85"
 default-run = "qdrant"
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.86"
 default-run = "qdrant"
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.87"
 default-run = "qdrant"
 
 [lints]

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -8,11 +8,14 @@ use crate::data_types::vectors::{DenseVector, VectorElementType};
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "fma")]
 #[allow(clippy::missing_safety_doc)]
-pub fn hsum256_ps_avx(x: __m256) -> f32 {
-    let x128: __m128 = _mm_add_ps(_mm256_extractf128_ps(x, 1), _mm256_castps256_ps128(x));
-    let x64: __m128 = _mm_add_ps(x128, _mm_movehl_ps(x128, x128));
-    let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
-    _mm_cvtss_f32(x32)
+#[allow(unused_unsafe)] // remove once we can bump the MSRV to 1.87 (cargo-chef)
+pub unsafe fn hsum256_ps_avx(x: __m256) -> f32 {
+    unsafe {
+        let x128: __m128 = _mm_add_ps(_mm256_extractf128_ps(x, 1), _mm256_castps256_ps128(x));
+        let x64: __m128 = _mm_add_ps(x128, _mm_movehl_ps(x128, x128));
+        let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
+        _mm_cvtss_f32(x32)
+    }
 }
 
 #[target_feature(enable = "avx")]

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -8,13 +8,11 @@ use crate::data_types::vectors::{DenseVector, VectorElementType};
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "fma")]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe fn hsum256_ps_avx(x: __m256) -> f32 {
-    unsafe {
-        let x128: __m128 = _mm_add_ps(_mm256_extractf128_ps(x, 1), _mm256_castps256_ps128(x));
-        let x64: __m128 = _mm_add_ps(x128, _mm_movehl_ps(x128, x128));
-        let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
-        _mm_cvtss_f32(x32)
-    }
+pub fn hsum256_ps_avx(x: __m256) -> f32 {
+    let x128: __m128 = _mm_add_ps(_mm256_extractf128_ps(x, 1), _mm256_castps256_ps128(x));
+    let x64: __m128 = _mm_add_ps(x128, _mm_movehl_ps(x128, x128));
+    let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
+    _mm_cvtss_f32(x32)
 }
 
 #[target_feature(enable = "avx")]

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -8,7 +8,7 @@ use crate::data_types::vectors::{DenseVector, VectorElementType};
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "fma")]
 #[allow(clippy::missing_safety_doc)]
-#[allow(unused_unsafe)] // remove once we can bump the MSRV to 1.87 (cargo-chef)
+#[allow(unused_unsafe)] // TODO remove once we can bump the MSRV to 1.87 (cargo-chef)
 pub unsafe fn hsum256_ps_avx(x: __m256) -> f32 {
     unsafe {
         let x128: __m128 = _mm_add_ps(_mm256_extractf128_ps(x, 1), _mm256_castps256_ps128(x));

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -10,10 +10,13 @@ use crate::data_types::vectors::{DenseVector, VectorElementType};
 
 #[target_feature(enable = "sse")]
 #[allow(clippy::missing_safety_doc)]
-pub fn hsum128_ps_sse(x: __m128) -> f32 {
-    let x64: __m128 = _mm_add_ps(x, _mm_movehl_ps(x, x));
-    let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
-    _mm_cvtss_f32(x32)
+#[allow(unused_unsafe)] // remove once we can bump the MSRV to 1.87 (cargo-chef)
+pub unsafe fn hsum128_ps_sse(x: __m128) -> f32 {
+    unsafe {
+        let x64: __m128 = _mm_add_ps(x, _mm_movehl_ps(x, x));
+        let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
+        _mm_cvtss_f32(x32)
+    }
 }
 
 #[target_feature(enable = "sse")]

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -10,12 +10,10 @@ use crate::data_types::vectors::{DenseVector, VectorElementType};
 
 #[target_feature(enable = "sse")]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe fn hsum128_ps_sse(x: __m128) -> f32 {
-    unsafe {
-        let x64: __m128 = _mm_add_ps(x, _mm_movehl_ps(x, x));
-        let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
-        _mm_cvtss_f32(x32)
-    }
+pub fn hsum128_ps_sse(x: __m128) -> f32 {
+    let x64: __m128 = _mm_add_ps(x, _mm_movehl_ps(x, x));
+    let x32: __m128 = _mm_add_ss(x64, _mm_shuffle_ps(x64, x64, 0x55));
+    _mm_cvtss_f32(x32)
 }
 
 #[target_feature(enable = "sse")]

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -10,7 +10,7 @@ use crate::data_types::vectors::{DenseVector, VectorElementType};
 
 #[target_feature(enable = "sse")]
 #[allow(clippy::missing_safety_doc)]
-#[allow(unused_unsafe)] // remove once we can bump the MSRV to 1.87 (cargo-chef)
+#[allow(unused_unsafe)] // TODO remove once we can bump the MSRV to 1.87 (cargo-chef)
 pub unsafe fn hsum128_ps_sse(x: __m128) -> f32 {
     unsafe {
         let x64: __m128 = _mm_add_ps(x, _mm_movehl_ps(x, x));


### PR DESCRIPTION
Rust [v1.87](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/) has hit our CI.

There is one tiny thing left to fix.
 
```
error: unnecessary `unsafe` block
  --> lib/segment/src/spaces/simple_sse.rs:14:5
   |
14 |     unsafe {
   |     ^^^^^^ unnecessary `unsafe` block
   |
   = note: `-D unused-unsafe` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_unsafe)]`

error: unnecessary `unsafe` block
  --> lib/segment/src/spaces/simple_avx.rs:12:5
   |
12 |     unsafe {
   |     ^^^^^^ unnecessary `unsafe` block

error: could not compile `segment` (lib) due to 2 previous errors
```

https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/#safe-architecture-intrinsics

```
Most std::arch intrinsics that are unsafe only due to requiring target features to be enabled are now callable in safe code that has those features enabled. 
```

We cannot fix the lint because it would force us to bump the MSRV to 1.87 which we cannot do until the new version of the Rust docker image is released with `cargo-chef`.