### PR TITLE
Remove some generics from scorer

### DIFF
--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -113,7 +113,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             QueryVector::Nearest(vector) => {
                 match vector {
                     VectorInternal::Dense(dense_vector) => {
-                        let query_scorer = MetricQueryScorer::<VectorElementType, TMetric, _>::new(
+                        let query_scorer = MetricQueryScorer::<_, TMetric, _>::new(
                             dense_vector,
                             storage,
                             hardware_counter,
@@ -132,7 +132,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             }
             QueryVector::RecommendBestScore(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+                let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                     RecoBestScoreQuery::from(reco_query),
                     storage,
                     hardware_counter,
@@ -141,7 +141,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+                let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                     RecoSumScoresQuery::from(reco_query),
                     storage,
                     hardware_counter,
@@ -151,7 +151,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<DenseVector> =
                     discovery_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+                let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                     discovery_query,
                     storage,
                     hardware_counter,
@@ -160,7 +160,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+                let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                     context_query,
                     storage,
                     hardware_counter,

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -132,7 +132,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             }
             QueryVector::RecommendBestScore(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                     RecoBestScoreQuery::from(reco_query),
                     storage,
                     hardware_counter,
@@ -141,7 +141,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                     RecoSumScoresQuery::from(reco_query),
                     storage,
                     hardware_counter,
@@ -151,7 +151,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             QueryVector::Discovery(discovery_query) => {
                 let discovery_query: DiscoveryQuery<DenseVector> =
                     discovery_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                     discovery_query,
                     storage,
                     hardware_counter,
@@ -160,7 +160,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                     context_query,
                     storage,
                     hardware_counter,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -210,7 +210,7 @@ fn new_scorer_with_metric<
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {
         QueryVector::Nearest(vector) => {
-            let query_scorer = MetricQueryScorer::<VectorElementType, TMetric, _>::new(
+            let query_scorer = MetricQueryScorer::<_, TMetric, _>::new(
                 vector.try_into()?,
                 vector_storage,
                 hardware_counter,
@@ -219,7 +219,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -228,7 +228,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -237,7 +237,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -246,7 +246,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,
@@ -292,7 +292,7 @@ fn new_scorer_byte_with_metric<
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {
         QueryVector::Nearest(vector) => {
-            let query_scorer = MetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
+            let query_scorer = MetricQueryScorer::<_, TMetric, _>::new(
                 vector.try_into()?,
                 vector_storage,
                 hardware_counter,
@@ -301,7 +301,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -310,7 +310,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -319,7 +319,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -328,7 +328,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,
@@ -374,7 +374,7 @@ fn new_scorer_half_with_metric<
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {
         QueryVector::Nearest(vector) => {
-            let query_scorer = MetricQueryScorer::<VectorElementTypeHalf, TMetric, _>::new(
+            let query_scorer = MetricQueryScorer::<_, TMetric, _>::new(
                 vector.try_into()?,
                 vector_storage,
                 hardware_counter_cell,
@@ -383,7 +383,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter_cell,
@@ -392,7 +392,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter_cell,
@@ -401,7 +401,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter_cell,
@@ -410,7 +410,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = CustomQueryScorer::<_, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter_cell,
@@ -469,7 +469,7 @@ fn new_multi_scorer_with_metric<
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {
         QueryVector::Nearest(vector) => {
-            let query_scorer = MultiMetricQueryScorer::<VectorElementType, TMetric, _>::new(
+            let query_scorer = MultiMetricQueryScorer::<_, TMetric, _>::new(
                 &vector.try_into()?,
                 vector_storage,
                 hardware_counter,
@@ -478,7 +478,7 @@ fn new_multi_scorer_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let query_scorer: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(query_scorer),
                 vector_storage,
                 hardware_counter,
@@ -487,7 +487,7 @@ fn new_multi_scorer_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -497,7 +497,7 @@ fn new_multi_scorer_with_metric<
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -507,7 +507,7 @@ fn new_multi_scorer_with_metric<
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,
@@ -557,7 +557,7 @@ fn new_multi_scorer_byte_with_metric<
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {
         QueryVector::Nearest(vector) => {
-            let query_scorer = MultiMetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
+            let query_scorer = MultiMetricQueryScorer::<_, TMetric, _>::new(
                 &vector.try_into()?,
                 vector_storage,
                 hardware_counter,
@@ -566,7 +566,7 @@ fn new_multi_scorer_byte_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -575,7 +575,7 @@ fn new_multi_scorer_byte_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -585,7 +585,7 @@ fn new_multi_scorer_byte_with_metric<
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -595,7 +595,7 @@ fn new_multi_scorer_byte_with_metric<
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,
@@ -645,7 +645,7 @@ fn new_multi_scorer_half_with_metric<
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {
         QueryVector::Nearest(vector) => {
-            let query_scorer = MultiMetricQueryScorer::<VectorElementTypeHalf, TMetric, _>::new(
+            let query_scorer = MultiMetricQueryScorer::<_, TMetric, _>::new(
                 &vector.try_into()?,
                 vector_storage,
                 hardware_counter,
@@ -654,7 +654,7 @@ fn new_multi_scorer_half_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -663,7 +663,7 @@ fn new_multi_scorer_half_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -673,7 +673,7 @@ fn new_multi_scorer_half_with_metric<
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -683,7 +683,7 @@ fn new_multi_scorer_half_with_metric<
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<_, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -219,7 +219,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -228,7 +228,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -237,7 +237,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -246,7 +246,7 @@ fn new_scorer_with_metric<
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,
@@ -301,7 +301,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -310,7 +310,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -319,7 +319,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -328,7 +328,7 @@ fn new_scorer_byte_with_metric<
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,
@@ -383,7 +383,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(reco_query),
                 vector_storage,
                 hardware_counter_cell,
@@ -392,7 +392,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter_cell,
@@ -401,7 +401,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter_cell,
@@ -410,7 +410,7 @@ fn new_scorer_half_with_metric<
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
+            let query_scorer = CustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter_cell,
@@ -478,7 +478,7 @@ fn new_multi_scorer_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let query_scorer: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 RecoBestScoreQuery::from(query_scorer),
                 vector_storage,
                 hardware_counter,
@@ -487,7 +487,7 @@ fn new_multi_scorer_with_metric<
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 RecoSumScoresQuery::from(reco_query),
                 vector_storage,
                 hardware_counter,
@@ -497,7 +497,7 @@ fn new_multi_scorer_with_metric<
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 discovery_query,
                 vector_storage,
                 hardware_counter,
@@ -507,7 +507,7 @@ fn new_multi_scorer_with_metric<
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+            let query_scorer = MultiCustomQueryScorer::<VectorElementType, TMetric, _, _>::new(
                 context_query,
                 vector_storage,
                 hardware_counter,
@@ -566,44 +566,40 @@ fn new_multi_scorer_byte_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    RecoBestScoreQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+                RecoBestScoreQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    RecoSumScoresQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+                RecoSumScoresQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    discovery_query,
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+                discovery_query,
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
-                    context_query,
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _>::new(
+                context_query,
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
     }
@@ -658,44 +654,40 @@ fn new_multi_scorer_half_with_metric<
         }
         QueryVector::RecommendBestScore(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    RecoBestScoreQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+                RecoBestScoreQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::RecommendSumScores(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVectorInternal> = reco_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    RecoSumScoresQuery::from(reco_query),
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+                RecoSumScoresQuery::from(reco_query),
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Discovery(discovery_query) => {
             let discovery_query: DiscoveryQuery<MultiDenseVectorInternal> =
                 discovery_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    discovery_query,
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+                discovery_query,
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVectorInternal> =
                 context_query.transform_into()?;
-            let query_scorer =
-                MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _, _>::new(
-                    context_query,
-                    vector_storage,
-                    hardware_counter,
-                );
+            let query_scorer = MultiCustomQueryScorer::<VectorElementTypeHalf, TMetric, _, _>::new(
+                context_query,
+                vector_storage,
+                hardware_counter,
+            );
             raw_scorer_from_query_scorer(query_scorer)
         }
     }


### PR DESCRIPTION
In the following code, `TInputQuery` conceptually is not a type paramater of the scorer, but rather of its constructor.

```rust
pub struct CustomQueryScorer<
    TInputQuery: Query<DenseVector>, // <---
    TStoredQuery: Query<TypedDenseVector<TElement>>,
    // ...
> {
    query: TStoredQuery,
    _input_query: PhantomData<TInputQuery>,
    // ...
}

impl<
    TInputQuery: Query<DenseVector> + TransformInto</* ... */>, // <---
    TStoredQuery: Query<TypedDenseVector<TElement>>,
    // ...
> CustomQueryScorer<TInputQuery, TStoredQuery, /* ... */> {
    pub fn new(query: TInputQuery, /* ... */) -> Self {
        let query: TStoredQuery = query.transform(/* ... */).unwrap();
        // ...
```

The first commit in this PR moves `TInputQuery` from `struct CustomQueryScorer` into `CustomQueryScorer::new`, and the same for `MultiCustomQueryScorer`, reducing generics congestion a bit.
The second commit omits explicit generic parameters in places where the compiler is able to figure them by itself (e.g. `MetricQueryScorer::<VectorElementType, TMetric, _>::new` -> `MetricQueryScorer::<_, TMetric, _>::new`).