### PR TITLE
Add `partial_snapshot_create_requests` and `*_recovery_timestamp` to telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11546,17 +11546,15 @@
               "$ref": "#/components/schemas/ReplicaState"
             }
           },
-          "ongoing_create_partial_snapshot_requests": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "partial_snapshot_recovery_timestamp": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0,
-            "nullable": true
+          "partial_snapshot": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PartialSnapshotTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -12341,6 +12339,25 @@
           },
           "updates": {
             "$ref": "#/components/schemas/OperationDurationStatistics"
+          }
+        }
+      },
+      "PartialSnapshotTelemetry": {
+        "type": "object",
+        "required": [
+          "ongoing_create_snapshot_requests",
+          "recovery_timestamp"
+        ],
+        "properties": {
+          "ongoing_create_snapshot_requests": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "recovery_timestamp": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11545,6 +11545,18 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/ReplicaState"
             }
+          },
+          "ongoing_create_partial_snapshot_requests": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "partial_snapshot_recovery_timestamp": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -225,7 +225,7 @@ impl ShardReplicaSet {
             write_ordering_lock: Mutex::new(()),
             clock_set: Default::default(),
             write_rate_limiter,
-            partial_snapshot_meta: PartialSnapshotMeta::new(),
+            partial_snapshot_meta: PartialSnapshotMeta::default(),
         })
     }
 
@@ -366,7 +366,7 @@ impl ShardReplicaSet {
             write_ordering_lock: Mutex::new(()),
             clock_set: Default::default(),
             write_rate_limiter,
-            partial_snapshot_meta: PartialSnapshotMeta::new(),
+            partial_snapshot_meta: PartialSnapshotMeta::default(),
         };
 
         // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!

--- a/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
+++ b/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
@@ -84,7 +84,7 @@ impl PartialSnapshotMeta {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct RequestTracker {
     requests: Arc<AtomicUsize>,
 }

--- a/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
+++ b/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
@@ -1,4 +1,6 @@
 use std::sync::Arc;
+use std::sync::atomic::{self, AtomicU64, AtomicUsize};
+use std::time::{Duration, SystemTime};
 
 use crate::operations::types::{CollectionError, CollectionResult};
 
@@ -25,13 +27,20 @@ use crate::operations::types::{CollectionError, CollectionResult};
 ///
 #[derive(Debug, Default)]
 pub struct PartialSnapshotMeta {
+    ongoing_create_snapshot_requests_tracker: RequestTracker,
     recovery_lock: Arc<tokio::sync::Mutex<()>>,
     search_lock: Arc<tokio::sync::RwLock<()>>,
+    recovery_timestamp: AtomicU64,
 }
 
 impl PartialSnapshotMeta {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn ongoing_create_snapshot_requests(&self) -> usize {
+        self.ongoing_create_snapshot_requests_tracker.requests()
+    }
+
+    pub fn track_create_snapshot_request(&self) -> RequestGuard {
+        self.ongoing_create_snapshot_requests_tracker
+            .track_request()
     }
 
     pub fn try_take_recovery_lock(&self) -> CollectionResult<tokio::sync::OwnedMutexGuard<()>> {
@@ -54,5 +63,52 @@ impl PartialSnapshotMeta {
                 error: "shard unavailable, partial snapshot recovery is in progress".into(),
                 backtrace: None,
             })
+    }
+
+    pub fn recovery_timestamp(&self) -> u64 {
+        self.recovery_timestamp.load(atomic::Ordering::Relaxed)
+    }
+
+    pub fn snapshot_recovered(&self) {
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        self.recovery_timestamp
+            .store(timestamp, atomic::Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RequestTracker {
+    requests: Arc<AtomicUsize>,
+}
+
+impl RequestTracker {
+    pub fn requests(&self) -> usize {
+        self.requests.load(atomic::Ordering::Relaxed)
+    }
+
+    pub fn track_request(&self) -> RequestGuard {
+        RequestGuard::new(self.requests.clone())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestGuard {
+    requests: Arc<AtomicUsize>,
+}
+
+impl RequestGuard {
+    fn new(requests: Arc<AtomicUsize>) -> Self {
+        requests.fetch_add(1, atomic::Ordering::Relaxed);
+        Self { requests }
+    }
+}
+
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        self.requests.fetch_sub(1, atomic::Ordering::Relaxed);
     }
 }

--- a/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
+++ b/lib/collection/src/shards/replica_set/partial_snapshot_meta.rs
@@ -27,9 +27,13 @@ use crate::operations::types::{CollectionError, CollectionResult};
 ///
 #[derive(Debug, Default)]
 pub struct PartialSnapshotMeta {
+    /// Tracks ongoing operations of creation of partial snapshots.
+    /// There might be multiple parallel requests to create partial snapshots,
+    /// so we track them with a counter.
     ongoing_create_snapshot_requests_tracker: RequestTracker,
     recovery_lock: Arc<tokio::sync::Mutex<()>>,
     search_lock: Arc<tokio::sync::RwLock<()>>,
+    /// Timestamp of the last successful snapshot recovery.
     recovery_timestamp: AtomicU64,
 }
 

--- a/lib/collection/src/shards/replica_set/telemetry.rs
+++ b/lib/collection/src/shards/replica_set/telemetry.rs
@@ -3,7 +3,7 @@ use segment::types::SizeStats;
 
 use crate::operations::types::OptimizersStatus;
 use crate::shards::replica_set::ShardReplicaSet;
-use crate::shards::telemetry::ReplicaSetTelemetry;
+use crate::shards::telemetry::{PartialSnapshotTelemetry, ReplicaSetTelemetry};
 
 impl ShardReplicaSet {
     pub(crate) async fn get_telemetry_data(&self, detail: TelemetryDetail) -> ReplicaSetTelemetry {
@@ -27,13 +27,12 @@ impl ShardReplicaSet {
                 .map(|remote| remote.get_telemetry_data(detail))
                 .collect(),
             replicate_states: self.replica_state.read().peers(),
-            ongoing_create_partial_snapshot_requests: Some(
-                self.partial_snapshot_meta
+            partial_snapshot: Some(PartialSnapshotTelemetry {
+                ongoing_create_snapshot_requests: self
+                    .partial_snapshot_meta
                     .ongoing_create_snapshot_requests(),
-            ),
-            partial_snapshot_recovery_timestamp: Some(
-                self.partial_snapshot_meta.recovery_timestamp(),
-            ),
+                recovery_timestamp: self.partial_snapshot_meta.recovery_timestamp(),
+            }),
         }
     }
 

--- a/lib/collection/src/shards/replica_set/telemetry.rs
+++ b/lib/collection/src/shards/replica_set/telemetry.rs
@@ -27,6 +27,13 @@ impl ShardReplicaSet {
                 .map(|remote| remote.get_telemetry_data(detail))
                 .collect(),
             replicate_states: self.replica_state.read().peers(),
+            ongoing_create_partial_snapshot_requests: Some(
+                self.partial_snapshot_meta
+                    .ongoing_create_snapshot_requests(),
+            ),
+            partial_snapshot_recovery_timestamp: Some(
+                self.partial_snapshot_meta.recovery_timestamp(),
+            ),
         }
     }
 

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -21,6 +21,10 @@ pub struct ReplicaSetTelemetry {
     pub remote: Vec<RemoteShardTelemetry>,
     #[anonymize(with = anonymize_collection_with_u64_hashable_key)]
     pub replicate_states: HashMap<PeerId, ReplicaState>,
+    #[anonymize(false)]
+    pub ongoing_create_partial_snapshot_requests: Option<usize>,
+    #[anonymize(false)]
+    pub partial_snapshot_recovery_timestamp: Option<u64>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -21,10 +21,7 @@ pub struct ReplicaSetTelemetry {
     pub remote: Vec<RemoteShardTelemetry>,
     #[anonymize(with = anonymize_collection_with_u64_hashable_key)]
     pub replicate_states: HashMap<PeerId, ReplicaState>,
-    #[anonymize(false)]
-    pub ongoing_create_partial_snapshot_requests: Option<usize>,
-    #[anonymize(false)]
-    pub partial_snapshot_recovery_timestamp: Option<u64>,
+    pub partial_snapshot: Option<PartialSnapshotTelemetry>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
@@ -75,4 +72,12 @@ pub struct OptimizerTelemetry {
     pub optimizations: OperationDurationStatistics,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log: Option<Vec<TrackerTelemetry>>,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, JsonSchema, Anonymize)]
+pub struct PartialSnapshotTelemetry {
+    #[anonymize(false)]
+    pub ongoing_create_snapshot_requests: usize,
+    #[anonymize(false)]
+    pub recovery_timestamp: u64,
 }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -21,6 +21,7 @@ pub struct ReplicaSetTelemetry {
     pub remote: Vec<RemoteShardTelemetry>,
     #[anonymize(with = anonymize_collection_with_u64_hashable_key)]
     pub replicate_states: HashMap<PeerId, ReplicaState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub partial_snapshot: Option<PartialSnapshotTelemetry>,
 }
 

--- a/tests/openapi/test_service.py
+++ b/tests/openapi/test_service.py
@@ -84,7 +84,10 @@ def test_telemetry_detail(level: int):
         assert set(collection.keys()) == {'id', 'init_time_ms', 'config', 'shards', 'transfers', 'resharding'}
 
         shard = collection['shards'][0]
-        assert set(shard.keys()) == {'id', 'key', 'local', 'remote', 'replicate_states'}
+        assert set(shard.keys()) == {
+            'id', 'key', 'local', 'remote', 'replicate_states',
+            'ongoing_create_partial_snapshot_requests', 'partial_snapshot_recovery_timestamp'
+        }
 
         local_shard = shard['local']
 

--- a/tests/openapi/test_service.py
+++ b/tests/openapi/test_service.py
@@ -84,10 +84,7 @@ def test_telemetry_detail(level: int):
         assert set(collection.keys()) == {'id', 'init_time_ms', 'config', 'shards', 'transfers', 'resharding'}
 
         shard = collection['shards'][0]
-        assert set(shard.keys()) == {
-            'id', 'key', 'local', 'remote', 'replicate_states',
-            'ongoing_create_partial_snapshot_requests', 'partial_snapshot_recovery_timestamp'
-        }
+        assert set(shard.keys()) == {'id', 'key', 'local', 'remote', 'replicate_states', 'partial_snapshot'}
 
         local_shard = shard['local']
 


### PR DESCRIPTION
This PR adds two partial snapshot fields to replica set telemetry:
- `ongoing_create_snapshot_requests ` – counts concurrent create partial snapshot requests
- `recovery_timestamp ` – tracks UNIX timestamp of the last successfully recovered partial snapshot

These fields are needed so that cluster-manager can apply limits on partial snapshot creation/recovery.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
