### PR TITLE
Always run cancellation handle for interrupted optimizations

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -675,10 +675,7 @@ pub trait SegmentOptimizer {
         ) {
             Ok(segment) => segment,
             Err(error) => {
-                if matches!(error, CollectionError::Cancelled { .. }) {
-                    self.handle_cancellation(&segments, &proxy_ids, tmp_segment)?;
-                    return Err(error);
-                }
+                self.handle_cancellation(&segments, &proxy_ids, tmp_segment)?;
                 return Err(error);
             }
         };

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -2,15 +2,16 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 
 use common::budget::{ResourceBudget, ResourcePermit};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::disk::dir_size;
 use io::storage_version::StorageVersion;
 use itertools::Itertools;
+use parking_lot::lock_api::RwLockWriteGuard;
 use parking_lot::{Mutex, RwLockUpgradableReadGuard};
-use segment::common::operation_error::OperationResult;
+use segment::common::operation_error::{OperationResult, check_process_stopped};
 use segment::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
@@ -23,7 +24,7 @@ use segment::types::{HnswConfig, Indexes, QuantizationConfig, SegmentConfig, Vec
 
 use crate::collection_manager::holders::proxy_segment::{self, ProxyIndexChange, ProxySegment};
 use crate::collection_manager::holders::segment_holder::{
-    LockedSegment, LockedSegmentHolder, SegmentId,
+    LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
 };
 use crate::config::CollectionParams;
 use crate::operations::config_diff::DiffConfig;
@@ -341,17 +342,7 @@ pub trait SegmentOptimizer {
         restored_segment_ids
     }
 
-    /// Checks if optimization cancellation is requested.
-    fn check_cancellation(&self, stopped: &AtomicBool) -> CollectionResult<()> {
-        if stopped.load(Ordering::Relaxed) {
-            return Err(CollectionError::Cancelled {
-                description: "optimization cancelled by service".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    /// Unwraps proxy, adds temp segment into collection and returns a `Cancelled` error.
+    /// Unwraps proxy, adds temp segment into collection
     ///
     /// # Arguments
     ///
@@ -408,7 +399,7 @@ pub trait SegmentOptimizer {
     ) -> CollectionResult<Segment> {
         let mut segment_builder = self.optimized_segment_builder(optimizing_segments)?;
 
-        self.check_cancellation(stopped)?;
+        check_process_stopped(stopped)?;
 
         let segments: Vec<_> = optimizing_segments
             .iter()
@@ -543,7 +534,7 @@ pub trait SegmentOptimizer {
                         .delete_field_index_if_incompatible(*version, field_name, schema)?;
                 }
             }
-            self.check_cancellation(stopped)?;
+            check_process_stopped(stopped)?;
         }
 
         for (point_id, versions) in deleted_points_snapshot {
@@ -555,9 +546,11 @@ pub trait SegmentOptimizer {
         Ok(optimized_segment)
     }
 
-    /// Performs optimization of collections's segments, including:
-    ///     - Segment rebuilding
-    ///     - Segment joining
+    /// Performs optimization of collections's segments
+    ///
+    /// Including:
+    /// * Segment rebuilding
+    /// * Segment joining
     ///
     /// # Arguments
     ///
@@ -579,7 +572,7 @@ pub trait SegmentOptimizer {
         resource_budget: ResourceBudget,
         stopped: &AtomicBool,
     ) -> CollectionResult<usize> {
-        self.check_cancellation(stopped)?;
+        check_process_stopped(stopped)?;
 
         let mut timer = ScopeDurationMeasurer::new(self.get_telemetry_counter());
         timer.set_success(false);
@@ -610,7 +603,7 @@ pub trait SegmentOptimizer {
             return Ok(0);
         }
 
-        self.check_cancellation(stopped)?;
+        check_process_stopped(stopped)?;
 
         let hw_counter = HardwareCounterCell::disposable(); // Internal operation, no measurement needed!
 
@@ -657,14 +650,9 @@ pub trait SegmentOptimizer {
             proxy_ids
         };
 
-        if let Err(e) = self.check_cancellation(stopped) {
-            self.handle_cancellation(&segments, &proxy_ids, tmp_segment)?;
-            return Err(e);
-        }
-
-        // ---- SLOW PART -----
-
-        let mut optimized_segment = match self.build_new_segment(
+        // SLOW PART: create single optimized segment and propagate all new changes to it
+        let result = self.optimize_segment_propagate_changes(
+            &segments,
             &optimizing_segments,
             Arc::clone(&proxy_deleted_points),
             Arc::clone(&proxy_index_changes),
@@ -672,13 +660,101 @@ pub trait SegmentOptimizer {
             resource_budget,
             stopped,
             &hw_counter,
-        ) {
+        );
+        let (optimized_segment, mut write_segments_guard) = match result {
             Ok(segment) => segment,
-            Err(error) => {
+            Err(err) => {
+                // Properly cancel optimization on all error kinds
+                // Unwrap proxies and add temp segment to holder
                 self.handle_cancellation(&segments, &proxy_ids, tmp_segment)?;
-                return Err(error);
+                return Err(err);
             }
         };
+
+        // Replace proxy segments with new optimized segment
+        let point_count = optimized_segment.available_point_count();
+        let (_, proxies) = write_segments_guard.swap_new(optimized_segment, &proxy_ids);
+        debug_assert_eq!(
+            proxies.len(),
+            proxy_ids.len(),
+            "swapped different number of proxies on unwrap, missing or incorrect segment IDs?",
+        );
+
+        let has_appendable_segments = write_segments_guard.has_appendable_segment();
+
+        // Release reference counter for each optimized segment
+        drop(optimizing_segments);
+
+        // Append a temp segment to collection if it is not empty or there is no other appendable segment
+        if !has_appendable_segments || !tmp_segment.get().read().is_empty() {
+            write_segments_guard.add_new_locked(tmp_segment);
+
+            // Unlock collection for search and updates
+            // After the collection is unlocked - we can remove data as slow as we want
+            drop(write_segments_guard);
+
+            // Only remove data after we ensure the consistency of the collection.
+            // If remove fails - we will still have operational collection with reported error.
+            for proxy in proxies {
+                proxy.drop_data()?;
+            }
+        } else {
+            // Unlock collection for search and updates
+            // After the collection is unlocked - we can remove data as slow as we want
+            drop(write_segments_guard);
+
+            // Proxy contains pointer to the `tmp_segment`, so they should be removed first
+            for proxy in proxies {
+                proxy.drop_data()?;
+            }
+            tmp_segment.drop_data()?;
+        }
+
+        timer.set_success(true);
+
+        Ok(point_count)
+    }
+
+    /// Create a single optimized segment from the given segments.
+    ///
+    /// All point deletes or payload index changes made during optimization are propagated to the
+    /// optimized segment at the very end.
+    ///
+    /// This internally takes a write lock on the segments holder to block new updates when
+    /// finalizing optimization. It is returned so that the optimized segment can be inserted and
+    /// proxy segments can be dissolved before releasing the lock.
+    ///
+    /// # Warning
+    ///
+    /// This function is slow and must only be used on an optimization worker.
+    #[allow(clippy::too_many_arguments)]
+    fn optimize_segment_propagate_changes<'a>(
+        &self,
+        segments: &'a LockedSegmentHolder,
+        optimizing_segments: &[LockedSegment],
+        proxy_deleted_points: proxy_segment::LockedRmSet,
+        proxy_index_changes: proxy_segment::LockedIndexChanges,
+        permit: ResourcePermit, // IO resources for copying data
+        resource_budget: ResourceBudget,
+        stopped: &AtomicBool,
+        hw_counter: &HardwareCounterCell,
+    ) -> CollectionResult<(
+        Segment,
+        RwLockWriteGuard<'a, parking_lot::RawRwLock, SegmentHolder>,
+    )> {
+        check_process_stopped(stopped)?;
+
+        // ---- SLOW PART -----
+
+        let mut optimized_segment = self.build_new_segment(
+            optimizing_segments,
+            Arc::clone(&proxy_deleted_points),
+            Arc::clone(&proxy_index_changes),
+            permit,
+            resource_budget,
+            stopped,
+            hw_counter,
+        )?;
 
         // Avoid unnecessary point removing in the critical section:
         // - save already removed points while avoiding long read locks
@@ -694,100 +770,55 @@ pub trait SegmentOptimizer {
 
         // ---- SLOW PART ENDS HERE -----
 
-        if let Err(e) = self.check_cancellation(stopped) {
-            self.handle_cancellation(&segments, &proxy_ids, tmp_segment)?;
-            return Err(e);
+        check_process_stopped(stopped)?;
+
+        // This block locks all operations with collection. It should be fast
+        let write_segments_guard = segments.write();
+
+        // Apply index changes before point deletions
+        // Point deletions bump the segment version, can cause index changes to be ignored
+        for (field_name, change) in proxy_index_changes.read().iter_ordered() {
+            // Warn: change version might be lower than the segment version,
+            // because we might already applied the change earlier in optimization.
+            // Applied optimizations are not removed from `proxy_index_changes`.
+            match change {
+                ProxyIndexChange::Create(schema, version) => {
+                    optimized_segment.create_field_index(
+                        *version,
+                        field_name,
+                        Some(schema),
+                        hw_counter,
+                    )?;
+                }
+                ProxyIndexChange::Delete(version) => {
+                    optimized_segment.delete_field_index(*version, field_name)?;
+                }
+                ProxyIndexChange::DeleteIfIncompatible(version, schema) => {
+                    optimized_segment
+                        .delete_field_index_if_incompatible(*version, field_name, schema)?;
+                }
+            }
+
+            check_process_stopped(stopped)?;
         }
 
-        {
-            // This block locks all operations with collection. It should be fast
-            let mut write_segments_guard = segments.write();
-
-            // Apply index changes before point deletions
-            // Point deletions bump the segment version, can cause index changes to be ignored
-            for (field_name, change) in proxy_index_changes.read().iter_ordered() {
-                // Warn: change version might be lower than the segment version,
-                // because we might already applied the change earlier in optimization.
-                // Applied optimizations are not removed from `proxy_index_changes`.
-                match change {
-                    ProxyIndexChange::Create(schema, version) => {
-                        optimized_segment.create_field_index(
-                            *version,
-                            field_name,
-                            Some(schema),
-                            &hw_counter,
-                        )?;
-                    }
-                    ProxyIndexChange::Delete(version) => {
-                        optimized_segment.delete_field_index(*version, field_name)?;
-                    }
-                    ProxyIndexChange::DeleteIfIncompatible(version, schema) => {
-                        optimized_segment
-                            .delete_field_index_if_incompatible(*version, field_name, schema)?;
-                    }
-                }
-                self.check_cancellation(stopped)?;
-            }
-
-            let deleted_points = proxy_deleted_points.read();
-            let points_diff = deleted_points
-                .iter()
-                .filter(|&(point_id, _version)| !already_remove_points.contains(point_id));
-            for (&point_id, &versions) in points_diff {
-                // Delete points here with their operation version, that'll bump the optimized
-                // segment version and will ensure we flush the new changes
-                debug_assert!(
-                    versions.operation_version
-                        >= optimized_segment.point_version(point_id).unwrap_or(0),
-                    "proxied point deletes should have newer version than point in segment",
-                );
-                optimized_segment
-                    .delete_point(versions.operation_version, point_id, &hw_counter)
-                    .unwrap();
-            }
-
-            let point_count = optimized_segment.available_point_count();
-
-            let (_, proxies) = write_segments_guard.swap_new(optimized_segment, &proxy_ids);
-            debug_assert_eq!(
-                proxies.len(),
-                proxy_ids.len(),
-                "swapped different number of proxies on unwrap, missing or incorrect segment IDs?",
+        let deleted_points = proxy_deleted_points.read();
+        let points_diff = deleted_points
+            .iter()
+            .filter(|&(point_id, _version)| !already_remove_points.contains(point_id));
+        for (&point_id, &versions) in points_diff {
+            // Delete points here with their operation version, that'll bump the optimized
+            // segment version and will ensure we flush the new changes
+            debug_assert!(
+                versions.operation_version
+                    >= optimized_segment.point_version(point_id).unwrap_or(0),
+                "proxied point deletes should have newer version than point in segment",
             );
-
-            let has_appendable_segments = write_segments_guard.has_appendable_segment();
-
-            // Release reference counter of the optimized segments
-            drop(optimizing_segments);
-
-            // Append a temp segment to collection if it is not empty or there is no other appendable segment
-            if !has_appendable_segments || !tmp_segment.get().read().is_empty() {
-                write_segments_guard.add_new_locked(tmp_segment);
-
-                // unlock collection for search and updates
-                drop(write_segments_guard);
-                // After the collection is unlocked - we can remove data as slow as we want.
-
-                // Only remove data after we ensure the consistency of the collection.
-                // If remove fails - we will still have operational collection with reported error.
-                for proxy in proxies {
-                    proxy.drop_data()?;
-                }
-            } else {
-                // unlock collection for search and updates
-                drop(write_segments_guard);
-                // After the collection is unlocked - we can remove data as slow as we want.
-
-                // Proxy contains pointer to the `tmp_segment`, so they should be removed first
-                for proxy in proxies {
-                    proxy.drop_data()?;
-                }
-                tmp_segment.drop_data()?;
-            }
-
-            timer.set_success(true);
-
-            Ok(point_count)
+            optimized_segment
+                .delete_point(versions.operation_version, point_id, hw_counter)
+                .unwrap();
         }
+
+        Ok((optimized_segment, write_segments_guard))
     }
 }


### PR DESCRIPTION
Seems to fix Crasher, will let CI chew on it.

This PR makes sure we handle the on going proxy segments when failing with any error to build a new optimized segment.