### PR TITLE
Fix WAL delta transfer flakiness

### DIFF
--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -202,7 +202,7 @@ def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path):
     assert_http_ok(r)
 
     # Assert WAL delta transfer progress, and wait for it to finish
-    wait_for_collection_shard_transfer_progress(peer_api_uris[0], COLLECTION_NAME, None, 10)
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 1)
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 
     # All nodes must have one shard
@@ -301,7 +301,7 @@ def test_shard_wal_delta_transfer_manual_recovery_chain(tmp_path: pathlib.Path):
     assert_http_ok(r)
 
     # Assert WAL delta transfer progress, and wait for it to finish
-    wait_for_collection_shard_transfer_progress(peer_api_uris[0], COLLECTION_NAME, None, 10)
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 1)
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 
     # Start inserting into the fourth peer again
@@ -322,7 +322,7 @@ def test_shard_wal_delta_transfer_manual_recovery_chain(tmp_path: pathlib.Path):
     assert_http_ok(r)
 
     # Assert WAL delta transfer progress, and wait for it to finish
-    wait_for_collection_shard_transfer_progress(peer_api_uris[3], COLLECTION_NAME, None, 10)
+    wait_for_collection_shard_transfers_count(peer_api_uris[3], COLLECTION_NAME, 1)
     wait_for_collection_shard_transfers_count(peer_api_uris[3], COLLECTION_NAME, 0)
 
     upload_process_1.kill()
@@ -450,7 +450,7 @@ def test_shard_wal_delta_transfer_abort_and_retry(tmp_path: pathlib.Path):
     assert_http_ok(r)
 
     # Assert WAL delta transfer progress, and wait for it to finish
-    wait_for_collection_shard_transfer_progress(peer_api_uris[0], COLLECTION_NAME, None, 10)
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 1)
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 
     # All nodes must have one shard


### PR DESCRIPTION
Attempts to fix <https://github.com/qdrant/qdrant/issues/6539>

Fixes flakiness in the WAL delta transfer tests.

In the test, transfers are very short. The transfer may already be completed when we're waiting on a specific state to synchronize the test. This was causing flakiness.

Instead of waiting for specific shard transfer progress, just wait for any transfer to be active.

I can't be 100% this will fix flakiness in CI, but I've been seeing good results locally. Over 100 runs I now have 0 failures. If it still appears to be flaky, we can take further action.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?