### PR TITLE
Wait when putting collection metadata

### DIFF
--- a/tests/consensus_tests/test_consensus_compaction.py
+++ b/tests/consensus_tests/test_consensus_compaction.py
@@ -129,7 +129,7 @@ def test_consensus_compaction_shard_keys(tmp_path: pathlib.Path):
 
 
 def put_metadata_key(peer_uris: list[str], key: str, value: Any):
-    resp = requests.put(f"{peer_uris[0]}/cluster/metadata/keys/{key}", json=value)
+    resp = requests.put(f"{peer_uris[0]}/cluster/metadata/keys/{key}?wait=true", json=value)
     assert_http_ok(resp)
     sleep(CONSENSUS_WAIT_SECONDS)
     get_metadata_key(peer_uris, key, value)


### PR DESCRIPTION
Related to <https://github.com/qdrant/qdrant/issues/6531>

Potentially improves reliability with `wait=true` when setting cluster metadata.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?