### PR TITLE
Add volatile dense vector storage, use in tests

### DIFF
--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -310,13 +310,12 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
-    use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
     use crate::data_types::vectors::{DenseVector, QueryVector};
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
     use crate::id_tracker::id_tracker_base::IdTracker;
     use crate::index::hnsw_index::point_scorer::FilteredScorer;
     use crate::types::{PointIdType, QuantizationConfig, ScalarQuantizationConfig};
-    use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
+    use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
     use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
     use crate::vector_storage::{DEFAULT_STOPPED, new_raw_scorer};
 
@@ -347,16 +346,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         {
-            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
-            let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let mut storage2 = open_simple_dense_vector_storage(
-                db,
-                DB_VECTOR_CF,
-                4,
-                Distance::Dot,
-                &AtomicBool::new(false),
-            )
-            .unwrap();
+            let mut storage2 = new_volatile_dense_vector_storage(4, Distance::Dot);
             {
                 storage2
                     .insert_vector(0, points[0].as_slice().into(), &hw_counter)
@@ -387,16 +377,7 @@ mod tests {
         borrowed_id_tracker.drop(PointIdType::NumId(2)).unwrap();
 
         {
-            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
-            let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let mut storage2 = open_simple_dense_vector_storage(
-                db,
-                DB_VECTOR_CF,
-                4,
-                Distance::Dot,
-                &AtomicBool::new(false),
-            )
-            .unwrap();
+            let mut storage2 = new_volatile_dense_vector_storage(4, Distance::Dot);
             {
                 storage2
                     .insert_vector(3, points[3].as_slice().into(), &hw_counter)
@@ -458,16 +439,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         {
-            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
-            let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let mut storage2 = open_simple_dense_vector_storage(
-                db,
-                DB_VECTOR_CF,
-                4,
-                Distance::Dot,
-                &AtomicBool::new(false),
-            )
-            .unwrap();
+            let mut storage2 = new_volatile_dense_vector_storage(4, Distance::Dot);
             {
                 points.iter().enumerate().for_each(|(i, vec)| {
                     storage2
@@ -583,16 +555,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         {
-            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
-            let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let mut storage2 = open_simple_dense_vector_storage(
-                db,
-                DB_VECTOR_CF,
-                4,
-                Distance::Dot,
-                &AtomicBool::new(false),
-            )
-            .unwrap();
+            let mut storage2 = new_volatile_dense_vector_storage(4, Distance::Dot);
             {
                 points.iter().enumerate().for_each(|(i, vec)| {
                     storage2
@@ -665,16 +628,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         {
-            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
-            let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let mut storage2 = open_simple_dense_vector_storage(
-                db,
-                DB_VECTOR_CF,
-                4,
-                Distance::Dot,
-                &AtomicBool::new(false),
-            )
-            .unwrap();
+            let mut storage2 = new_volatile_dense_vector_storage(4, Distance::Dot);
             {
                 for (i, vec) in points.iter().enumerate() {
                     storage2
@@ -748,16 +702,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         {
-            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
-            let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let mut storage2 = open_simple_dense_vector_storage(
-                db,
-                DB_VECTOR_CF,
-                4,
-                Distance::Dot,
-                &AtomicBool::new(false),
-            )
-            .unwrap();
+            let mut storage2 = new_volatile_dense_vector_storage(4, Distance::Dot);
             {
                 for (i, vec) in points.iter().enumerate() {
                     storage2

--- a/lib/segment/src/vector_storage/dense/mod.rs
+++ b/lib/segment/src/vector_storage/dense/mod.rs
@@ -3,3 +3,5 @@ pub mod dynamic_mmap_flags;
 pub mod memmap_dense_vector_storage;
 pub mod mmap_dense_vectors;
 pub mod simple_dense_vector_storage;
+#[cfg(test)]
+pub mod volatile_dense_vector_storage;

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -1,0 +1,177 @@
+use std::borrow::Cow;
+use std::ops::Range;
+use std::sync::atomic::AtomicBool;
+
+use bitvec::prelude::{BitSlice, BitVec};
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::ext::BitSliceExt as _;
+use common::types::PointOffsetType;
+
+use crate::common::Flusher;
+use crate::common::operation_error::{OperationResult, check_process_stopped};
+use crate::data_types::named_vectors::CowVector;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::types::{Distance, VectorStorageDatatype};
+use crate::vector_storage::bitvec::bitvec_set_deleted;
+use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
+use crate::vector_storage::chunked_vectors::ChunkedVectors;
+use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum};
+
+/// In-memory vector storage that is volatile
+///
+/// This storage is not persisted and intended for temporary use in tests.
+#[derive(Debug)]
+pub struct VolatileDenseVectorStorage<T: PrimitiveVectorElement> {
+    dim: usize,
+    distance: Distance,
+    vectors: ChunkedVectors<T>,
+    /// BitVec for deleted flags. Grows dynamically upto last set flag.
+    deleted: BitVec,
+    /// Current number of deleted vectors.
+    deleted_count: usize,
+}
+
+pub fn new_volatile_dense_vector_storage(dim: usize, distance: Distance) -> VectorStorageEnum {
+    VectorStorageEnum::DenseVolatile(VolatileDenseVectorStorage::new(dim, distance))
+}
+
+pub fn new_volatile_dense_byte_vector_storage(dim: usize, distance: Distance) -> VectorStorageEnum {
+    VectorStorageEnum::DenseVolatileByte(VolatileDenseVectorStorage::new(dim, distance))
+}
+
+pub fn new_volatile_dense_half_vector_storage(dim: usize, distance: Distance) -> VectorStorageEnum {
+    VectorStorageEnum::DenseVolatileHalf(VolatileDenseVectorStorage::new(dim, distance))
+}
+
+impl<T: PrimitiveVectorElement> VolatileDenseVectorStorage<T> {
+    pub fn new(dim: usize, distance: Distance) -> Self {
+        let vectors = ChunkedVectors::new(dim);
+        let (deleted, deleted_count) = (BitVec::new(), 0);
+
+        VolatileDenseVectorStorage {
+            dim,
+            distance,
+            vectors,
+            deleted,
+            deleted_count,
+        }
+    }
+
+    /// Set deleted flag for given key. Returns previous deleted state.
+    #[inline]
+    fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
+        if !deleted && key as usize >= self.vectors.len() {
+            return false;
+        }
+        let was_deleted = bitvec_set_deleted(&mut self.deleted, key, deleted);
+        if was_deleted != deleted {
+            if !was_deleted {
+                self.deleted_count += 1;
+            } else {
+                self.deleted_count = self.deleted_count.saturating_sub(1);
+            }
+        }
+        was_deleted
+    }
+}
+
+impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorStorage<T> {
+    fn vector_dim(&self) -> usize {
+        self.dim
+    }
+
+    fn get_dense(&self, key: PointOffsetType) -> &[T] {
+        self.vectors.get(key as VectorOffsetType)
+    }
+}
+
+impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> {
+    fn distance(&self) -> Distance {
+        self.distance
+    }
+
+    fn datatype(&self) -> VectorStorageDatatype {
+        T::datatype()
+    }
+
+    fn is_on_disk(&self) -> bool {
+        false
+    }
+
+    fn total_vector_count(&self) -> usize {
+        self.vectors.len()
+    }
+
+    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+        self.get_vector_opt(key).expect("vector not found")
+    }
+
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+        // In memory so no optimization to be done here.
+        self.get_vector(key)
+    }
+
+    /// Get vector by key, if it exists.
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        self.vectors
+            .get_opt(key as VectorOffsetType)
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
+    }
+
+    fn insert_vector(
+        &mut self,
+        key: PointOffsetType,
+        vector: VectorRef,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let vector: &[VectorElementType] = vector.try_into()?;
+        let vector = T::slice_from_float_cow(Cow::from(vector));
+        self.vectors
+            .insert(key as VectorOffsetType, vector.as_ref())?;
+        self.set_deleted(key, false);
+        Ok(())
+    }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let start_index = self.vectors.len() as PointOffsetType;
+        for (other_vector, other_deleted) in other_vectors {
+            check_process_stopped(stopped)?;
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
+            let new_id = self.vectors.push(other_vector.as_ref())? as PointOffsetType;
+            self.set_deleted(new_id, other_deleted);
+        }
+        let end_index = self.vectors.len() as PointOffsetType;
+        Ok(start_index..end_index)
+    }
+
+    fn flusher(&self) -> Flusher {
+        Box::new(|| Ok(()))
+    }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        vec![]
+    }
+
+    fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
+        let is_deleted = !self.set_deleted(key, true);
+        Ok(is_deleted)
+    }
+
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get_bit(key as usize).unwrap_or(false)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -248,6 +248,18 @@ impl QuantizedVectors {
             VectorStorageEnum::DenseSimpleHalf(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => {
+                Self::create_impl(v, quantization_config, path, max_threads, stopped)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => {
+                Self::create_impl(v, quantization_config, path, max_threads, stopped)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => {
+                Self::create_impl(v, quantization_config, path, max_threads, stopped)
+            }
             VectorStorageEnum::DenseMemmap(v) => {
                 Self::create_impl(v.as_ref(), quantization_config, path, max_threads, stopped)
             }

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -57,6 +57,12 @@ pub fn new_raw_scorer<'a>(
         VectorStorageEnum::DenseSimple(vs) => raw_scorer_impl(query, vs, hc),
         VectorStorageEnum::DenseSimpleByte(vs) => raw_scorer_byte_impl(query, vs, hc),
         VectorStorageEnum::DenseSimpleHalf(vs) => raw_scorer_half_impl(query, vs, hc),
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatile(vs) => raw_scorer_impl(query, vs, hc),
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(vs) => raw_scorer_byte_impl(query, vs, hc),
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileHalf(vs) => raw_scorer_half_impl(query, vs, hc),
 
         VectorStorageEnum::DenseMemmap(vs) => {
             if vs.has_async_reader() {

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -76,37 +76,40 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     {
         let orig_iter = points.iter().flat_map(|multivec| multivec.multi_vectors());
         match storage as &VectorStorageEnum {
-            VectorStorageEnum::DenseSimple(_) => unreachable!(),
-            VectorStorageEnum::DenseSimpleByte(_) => unreachable!(),
-            VectorStorageEnum::DenseSimpleHalf(_) => unreachable!(),
-            VectorStorageEnum::DenseMemmap(_) => unreachable!(),
-            VectorStorageEnum::DenseMemmapByte(_) => unreachable!(),
-            VectorStorageEnum::DenseMemmapHalf(_) => unreachable!(),
-            VectorStorageEnum::DenseAppendableMemmap(_) => unreachable!(),
-            VectorStorageEnum::DenseAppendableMemmapByte(_) => unreachable!(),
-            VectorStorageEnum::DenseAppendableMemmapHalf(_) => unreachable!(),
-            VectorStorageEnum::SparseSimple(_) => unreachable!(),
-            VectorStorageEnum::SparseMmap(_) => unreachable!(),
+            VectorStorageEnum::DenseSimple(_)
+            | VectorStorageEnum::DenseSimpleByte(_)
+            | VectorStorageEnum::DenseSimpleHalf(_) => unreachable!(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(_)
+            | VectorStorageEnum::DenseVolatileByte(_)
+            | VectorStorageEnum::DenseVolatileHalf(_) => unreachable!(),
+            VectorStorageEnum::DenseMemmap(_)
+            | VectorStorageEnum::DenseMemmapByte(_)
+            | VectorStorageEnum::DenseMemmapHalf(_) => unreachable!(),
+            VectorStorageEnum::DenseAppendableMemmap(_)
+            | VectorStorageEnum::DenseAppendableMemmapByte(_)
+            | VectorStorageEnum::DenseAppendableMemmapHalf(_) => unreachable!(),
+            VectorStorageEnum::SparseSimple(_) | VectorStorageEnum::SparseMmap(_) => unreachable!(),
             VectorStorageEnum::MultiDenseSimple(v) => {
                 for (orig, vec) in orig_iter.zip(v.iterate_inner_vectors()) {
                     assert_eq!(orig, vec);
                 }
             }
-            VectorStorageEnum::MultiDenseSimpleByte(_) => unreachable!(),
-            VectorStorageEnum::MultiDenseSimpleHalf(_) => unreachable!(),
+            VectorStorageEnum::MultiDenseSimpleByte(_)
+            | VectorStorageEnum::MultiDenseSimpleHalf(_) => unreachable!(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
                 for (orig, vec) in orig_iter.zip(v.iterate_inner_vectors()) {
                     assert_eq!(orig, vec);
                 }
             }
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(_) => unreachable!(),
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(_) => unreachable!(),
-            VectorStorageEnum::DenseAppendableInRam(_) => unreachable!(),
-            VectorStorageEnum::DenseAppendableInRamByte(_) => unreachable!(),
-            VectorStorageEnum::DenseAppendableInRamHalf(_) => unreachable!(),
-            VectorStorageEnum::MultiDenseAppendableInRam(_) => unreachable!(),
-            VectorStorageEnum::MultiDenseAppendableInRamByte(_) => unreachable!(),
-            VectorStorageEnum::MultiDenseAppendableInRamHalf(_) => unreachable!(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+            | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_) => unreachable!(),
+            VectorStorageEnum::DenseAppendableInRam(_)
+            | VectorStorageEnum::DenseAppendableInRamByte(_)
+            | VectorStorageEnum::DenseAppendableInRamHalf(_) => unreachable!(),
+            VectorStorageEnum::MultiDenseAppendableInRam(_)
+            | VectorStorageEnum::MultiDenseAppendableInRamByte(_)
+            | VectorStorageEnum::MultiDenseAppendableInRamHalf(_) => unreachable!(),
         };
     }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -11,6 +11,8 @@ use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::memmap_dense_vector_storage::MemmapDenseVectorStorage;
 use super::dense::simple_dense_vector_storage::SimpleDenseVectorStorage;
+#[cfg(test)]
+use super::dense::volatile_dense_vector_storage::VolatileDenseVectorStorage;
 use super::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, MultivectorMmapOffset,
 };
@@ -177,6 +179,12 @@ pub enum VectorStorageEnum {
     DenseSimple(SimpleDenseVectorStorage<VectorElementType>),
     DenseSimpleByte(SimpleDenseVectorStorage<VectorElementTypeByte>),
     DenseSimpleHalf(SimpleDenseVectorStorage<VectorElementTypeHalf>),
+    #[cfg(test)]
+    DenseVolatile(VolatileDenseVectorStorage<VectorElementType>),
+    #[cfg(test)]
+    DenseVolatileByte(VolatileDenseVectorStorage<VectorElementTypeByte>),
+    #[cfg(test)]
+    DenseVolatileHalf(VolatileDenseVectorStorage<VectorElementTypeHalf>),
     DenseMemmap(Box<MemmapDenseVectorStorage<VectorElementType>>),
     DenseMemmapByte(Box<MemmapDenseVectorStorage<VectorElementTypeByte>>),
     DenseMemmapHalf(Box<MemmapDenseVectorStorage<VectorElementTypeHalf>>),
@@ -295,6 +303,12 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseSimple(_) => None,
             VectorStorageEnum::DenseSimpleByte(_) => None,
             VectorStorageEnum::DenseSimpleHalf(_) => None,
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(_) => None,
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(_) => None,
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(_) => None,
             VectorStorageEnum::DenseMemmap(_) => None,
             VectorStorageEnum::DenseMemmapByte(_) => None,
             VectorStorageEnum::DenseMemmapHalf(_) => None,
@@ -325,6 +339,16 @@ impl VectorStorageEnum {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
             VectorStorageEnum::DenseSimpleHalf(v) => {
+                VectorInternal::from(vec![1.0; v.vector_dim()])
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => VectorInternal::from(vec![1.0; v.vector_dim()]),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => {
+                VectorInternal::from(vec![1.0; v.vector_dim()])
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
             VectorStorageEnum::DenseMemmap(v) => VectorInternal::from(vec![1.0; v.vector_dim()]),
@@ -389,6 +413,12 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseMemmap(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseMemmapByte(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.size_of_available_vectors_in_bytes(),
@@ -441,6 +471,12 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(_) => {} // Can't populate as it is not mmap
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(_) => {} // Can't populate as it is not mmap
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::DenseMemmap(vs) => vs.populate()?,
             VectorStorageEnum::DenseMemmapByte(vs) => vs.populate()?,
             VectorStorageEnum::DenseMemmapHalf(vs) => vs.populate()?,
@@ -470,6 +506,12 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(_) => {} // Can't populate as it is not mmap
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(_) => {} // Can't populate as it is not mmap
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::DenseMemmap(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseMemmapByte(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseMemmapHalf(vs) => vs.clear_cache()?,
@@ -501,6 +543,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.distance(),
             VectorStorageEnum::DenseSimpleByte(v) => v.distance(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.distance(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.distance(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.distance(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.distance(),
             VectorStorageEnum::DenseMemmap(v) => v.distance(),
             VectorStorageEnum::DenseMemmapByte(v) => v.distance(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.distance(),
@@ -529,6 +577,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.datatype(),
             VectorStorageEnum::DenseSimpleByte(v) => v.datatype(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.datatype(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.datatype(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.datatype(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.datatype(),
             VectorStorageEnum::DenseMemmap(v) => v.datatype(),
             VectorStorageEnum::DenseMemmapByte(v) => v.datatype(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.datatype(),
@@ -559,6 +613,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.is_on_disk(),
             VectorStorageEnum::DenseSimpleByte(v) => v.is_on_disk(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.is_on_disk(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.is_on_disk(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.is_on_disk(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.is_on_disk(),
             VectorStorageEnum::DenseMemmap(v) => v.is_on_disk(),
             VectorStorageEnum::DenseMemmapByte(v) => v.is_on_disk(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.is_on_disk(),
@@ -587,6 +647,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.total_vector_count(),
             VectorStorageEnum::DenseSimpleByte(v) => v.total_vector_count(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.total_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.total_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.total_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.total_vector_count(),
             VectorStorageEnum::DenseMemmap(v) => v.total_vector_count(),
             VectorStorageEnum::DenseMemmapByte(v) => v.total_vector_count(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.total_vector_count(),
@@ -615,6 +681,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.get_vector(key),
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector(key),
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.get_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.get_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.get_vector(key),
             VectorStorageEnum::DenseMemmap(v) => v.get_vector(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.get_vector(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.get_vector(key),
@@ -643,6 +715,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.get_vector_sequential(key),
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector_sequential(key),
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector_sequential(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.get_vector_sequential(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.get_vector_sequential(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.get_vector_sequential(key),
             VectorStorageEnum::DenseMemmap(v) => v.get_vector_sequential(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.get_vector_sequential(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.get_vector_sequential(key),
@@ -671,6 +749,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector_opt(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.get_vector_opt(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.get_vector_opt(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseMemmap(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.get_vector_opt(key),
@@ -704,6 +788,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseSimpleByte(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseSimpleHalf(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseMemmap(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseMemmapByte(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseMemmapHalf(v) => v.insert_vector(key, vector, hw_counter),
@@ -756,6 +846,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::DenseSimpleByte(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::DenseSimpleHalf(v) => v.update_from(other_vectors, stopped),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.update_from(other_vectors, stopped),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.update_from(other_vectors, stopped),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::DenseMemmap(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::DenseMemmapByte(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::DenseMemmapHalf(v) => v.update_from(other_vectors, stopped),
@@ -800,6 +896,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.flusher(),
             VectorStorageEnum::DenseSimpleByte(v) => v.flusher(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.flusher(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.flusher(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.flusher(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.flusher(),
             VectorStorageEnum::DenseMemmap(v) => v.flusher(),
             VectorStorageEnum::DenseMemmapByte(v) => v.flusher(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.flusher(),
@@ -828,6 +930,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.files(),
             VectorStorageEnum::DenseSimpleByte(v) => v.files(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.files(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.files(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.files(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.files(),
             VectorStorageEnum::DenseMemmap(v) => v.files(),
             VectorStorageEnum::DenseMemmapByte(v) => v.files(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.files(),
@@ -856,6 +964,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.delete_vector(key),
             VectorStorageEnum::DenseSimpleByte(v) => v.delete_vector(key),
             VectorStorageEnum::DenseSimpleHalf(v) => v.delete_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.delete_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.delete_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.delete_vector(key),
             VectorStorageEnum::DenseMemmap(v) => v.delete_vector(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.delete_vector(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.delete_vector(key),
@@ -884,6 +998,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseSimpleByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseSimpleHalf(v) => v.is_deleted_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.is_deleted_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.is_deleted_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseMemmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.is_deleted_vector(key),
@@ -912,6 +1032,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseSimpleByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.deleted_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.deleted_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_count(),
@@ -940,6 +1066,12 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseSimple(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseSimpleByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseSimpleHalf(v) => v.deleted_vector_bitslice(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_bitslice(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.deleted_vector_bitslice(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_bitslice(),


### PR DESCRIPTION
Add a new dense vector storage type. The storage is volatile, purely in memory, and is intended for use in testing.

This brings us a tiny step closer to fully removing RocksDB from our code base.

We were using the RocksDB based dense vector storage as baseline in many of our tests. It must be replaced so that RocksDB can be removed at some point.

It is possible to replace them with the appendable mmap storage. However, I prefer this volatile storage because it is much simpler and doesn't require any IO.

If we deem this acceptable, I'll also implement this for other storage types if necessary.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?