### PR TITLE
Fix compilation of bench

### DIFF
--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -270,6 +270,7 @@ impl BitmaskGaps {
 }
 
 #[cfg(test)]
+#[cfg(debug_assertions)]
 mod tests {
     use proptest::prelude::*;
     use tempfile::tempdir;


### PR DESCRIPTION
Running `cargo bench --all` fails with

```
error[E0308]: mismatched types
   --> lib/gridstore/src/bitmask/gaps.rs:285:25
    |
285 |           ) -> RegionGaps {
    |  _________________________^
286 | |             if leading + trailing >= region_size_blocks {
287 | |                 return RegionGaps::all_free(region_size_blocks);
...   |
298 | |         }
    | |_________^ expected `RegionGaps`, found `()`

error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> lib/gridstore/src/bitmask/gaps.rs:606:13
    |
606 |             RegionGaps::new(1, 2, 3, region_size_blocks),
    |             ^^^^^^^^^^^^^^^          ------------------ unexpected argument #4 of type `u16`
    |
note: associated function defined here
   --> lib/gridstore/src/bitmask/gaps.rs:21:12
    |
21  |     pub fn new(
    |            ^^^
help: remove the extra argument
    |
606 -             RegionGaps::new(1, 2, 3, region_size_blocks),
606 +             RegionGaps::new(1, 2, 3),
    |

error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> lib/gridstore/src/bitmask/gaps.rs:607:13
    |
607 |             RegionGaps::new(4, 5, 6, region_size_blocks),
    |             ^^^^^^^^^^^^^^^          ------------------ unexpected argument #4 of type `u16`
    |
note: associated function defined here
   --> lib/gridstore/src/bitmask/gaps.rs:21:12
    |
21  |     pub fn new(
    |            ^^^
help: remove the extra argument
    |
607 -             RegionGaps::new(4, 5, 6, region_size_blocks),
607 +             RegionGaps::new(4, 5, 6),
    |

error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> lib/gridstore/src/bitmask/gaps.rs:608:13
    |
608 |             RegionGaps::new(7, 8, 9, region_size_blocks),
    |             ^^^^^^^^^^^^^^^          ------------------ unexpected argument #4 of type `u16`
    |
note: associated function defined here
   --> lib/gridstore/src/bitmask/gaps.rs:21:12
    |
21  |     pub fn new(
    |            ^^^
help: remove the extra argument
    |
608 -             RegionGaps::new(7, 8, 9, region_size_blocks),
608 +             RegionGaps::new(7, 8, 9),
    |

error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> lib/gridstore/src/bitmask/gaps.rs:633:13
    |
633 |             RegionGaps::new(10, 11, 12, region_size_blocks),
    |             ^^^^^^^^^^^^^^^             ------------------ unexpected argument #4 of type `u16`
    |
note: associated function defined here
   --> lib/gridstore/src/bitmask/gaps.rs:21:12
    |
21  |     pub fn new(
    |            ^^^
help: remove the extra argument
    |
633 -             RegionGaps::new(10, 11, 12, region_size_blocks),
633 +             RegionGaps::new(10, 11, 12),
...
```

The fix is to annotated the test block to enforce debug assertions. 