### PR TITLE
Add RocksDB feature flag to vector storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ chaos-testing = []
 data-consistency-check = ["collection/data-consistency-check"]
 gpu = ["gpu/gpu", "segment/gpu"]
 deb = []
+
+# Disabling RocksDB feature only partially disables RocksDB usage
+# More work is still required to eventually completely disable and remove it
 rocksdb = ["segment/rocksdb"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "qdrant"
 workspace = true
 
 [features]
-default = ["web", "parking_lot"]
+default = ["web", "parking_lot", "rocksdb"]
 web = ["actix-web"]
 multiling-chinese = ["segment/multiling-chinese"]
 multiling-japanese = ["segment/multiling-japanese"]
@@ -40,6 +40,7 @@ chaos-testing = []
 data-consistency-check = ["collection/data-consistency-check"]
 gpu = ["gpu/gpu", "segment/gpu"]
 deb = []
+rocksdb = ["segment/rocksdb"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"
@@ -104,7 +105,7 @@ common = { path = "lib/common/common" }
 cancel = { path = "lib/common/cancel" }
 memory = { path = "lib/common/memory" }
 issues = { path = "lib/common/issues" }
-segment = { path = "lib/segment" }
+segment = { path = "lib/segment", default-features = false }
 collection = { path = "lib/collection" }
 storage = { path = "lib/storage" }
 api = { path = "lib/api" }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -21,6 +21,7 @@ multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
 testing = ["common/testing", "sparse/testing", "gpu/testing"]
 gpu = ["gpu/gpu"]
+no-rocksdb = []
 
 [build-dependencies]
 cc = "1.2"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -22,6 +22,9 @@ multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
 testing = ["common/testing", "sparse/testing", "gpu/testing"]
 gpu = ["gpu/gpu"]
+
+# Disabling RocksDB feature only partially disables RocksDB usage
+# More work is still required to eventually completely disable and remove it
 rocksdb = []
 
 [build-dependencies]

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -132,6 +132,7 @@ io-uring = "0.7.7"
 [[bench]]
 name = "vector_search"
 harness = false
+required-features = ["rocksdb"]
 
 [[bench]]
 name = "hnsw_build_graph"
@@ -180,10 +181,12 @@ harness = false
 [[bench]]
 name = "sparse_index_build"
 harness = false
+required-features = ["rocksdb"]
 
 [[bench]]
 name = "sparse_vector_storage"
 harness = false
+required-features = ["rocksdb"]
 
 [[bench]]
 name = "multi_vector_search"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2024"
 workspace = true
 
 [features]
+default = ["rocksdb"]
 multiling-chinese = [
     "charabia/chinese-segmentation",
     "charabia/chinese-normalization",
@@ -21,7 +22,7 @@ multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
 testing = ["common/testing", "sparse/testing", "gpu/testing"]
 gpu = ["gpu/gpu"]
-no-rocksdb = []
+rocksdb = []
 
 [build-dependencies]
 cc = "1.2"

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -333,15 +333,15 @@ impl GpuVectorStorage {
         stopped: &AtomicBool,
     ) -> OperationResult<Self> {
         match vector_storage {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(vector_storage) => {
                 Self::new_dense_f32(device, vector_storage, force_half_precision, stopped)
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(vector_storage) => {
                 Self::new_dense(device, vector_storage, stopped)
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(vector_storage) => {
                 Self::new_dense_f16(device, vector_storage, stopped)
             }
@@ -403,18 +403,18 @@ impl GpuVectorStorage {
             VectorStorageEnum::SparseMmap(_) => Err(OperationError::from(
                 gpu::GpuError::NotSupported("Sparse vectors are not supported on GPU".to_string()),
             )),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(vector_storage) => Self::new_multi_f32(
                 device.clone(),
                 vector_storage,
                 force_half_precision,
                 stopped,
             ),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(vector_storage) => {
                 Self::new_multi(device, vector_storage, stopped)
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(vector_storage) => {
                 Self::new_multi_f16(device, vector_storage, stopped)
             }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -403,15 +403,18 @@ impl GpuVectorStorage {
             VectorStorageEnum::SparseMmap(_) => Err(OperationError::from(
                 gpu::GpuError::NotSupported("Sparse vectors are not supported on GPU".to_string()),
             )),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(vector_storage) => Self::new_multi_f32(
                 device.clone(),
                 vector_storage,
                 force_half_precision,
                 stopped,
             ),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(vector_storage) => {
                 Self::new_multi(device, vector_storage, stopped)
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(vector_storage) => {
                 Self::new_multi_f16(device, vector_storage, stopped)
             }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -333,12 +333,15 @@ impl GpuVectorStorage {
         stopped: &AtomicBool,
     ) -> OperationResult<Self> {
         match vector_storage {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(vector_storage) => {
                 Self::new_dense_f32(device, vector_storage, force_half_precision, stopped)
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(vector_storage) => {
                 Self::new_dense(device, vector_storage, stopped)
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(vector_storage) => {
                 Self::new_dense_f16(device, vector_storage, stopped)
             }

--- a/lib/segment/src/segment_constructor/rocksdb_builder.rs
+++ b/lib/segment/src/segment_constructor/rocksdb_builder.rs
@@ -6,7 +6,7 @@ use parking_lot::{RwLock, RwLockReadGuard};
 use super::segment_constructor_base::get_vector_name_with_prefix;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_wrapper;
-use crate::types::{SegmentConfig, SparseVectorStorageType};
+use crate::types::SegmentConfig;
 /// Struct to optionally create and open a RocksDB instance in a lazy way.
 /// Used as helper to eventually completely remove RocksDB.
 #[derive(Debug)]
@@ -30,14 +30,18 @@ impl RocksDbBuilder {
                 .sparse_vector_data
                 .iter()
                 .filter_map(|(vector_name, config)| {
-                    if matches!(config.storage_type, SparseVectorStorageType::OnDisk) {
-                        Some(get_vector_name_with_prefix(
+                    #[cfg(feature = "rocksdb")]
+                    if matches!(
+                        config.storage_type,
+                        crate::types::SparseVectorStorageType::OnDisk
+                    ) {
+                        return Some(get_vector_name_with_prefix(
                             rocksdb_wrapper::DB_VECTOR_CF,
                             vector_name,
-                        ))
-                    } else {
-                        None
+                        ));
                     }
+                    let (_, _) = (vector_name, config);
+                    None
                 });
 
         let column_families: Vec<_> = vector_cfs.chain(sparse_vector_cfs).collect();

--- a/lib/segment/src/segment_constructor/rocksdb_builder.rs
+++ b/lib/segment/src/segment_constructor/rocksdb_builder.rs
@@ -7,6 +7,7 @@ use super::segment_constructor_base::get_vector_name_with_prefix;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_wrapper;
 use crate::types::SegmentConfig;
+
 /// Struct to optionally create and open a RocksDB instance in a lazy way.
 /// Used as helper to eventually completely remove RocksDB.
 #[derive(Debug)]

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -80,10 +80,6 @@ impl SegmentBuilder {
         temp_dir: &Path,
         segment_config: &SegmentConfig,
     ) -> OperationResult<Self> {
-        // When we build a new segment, it is empty at first,
-        // so we can ignore the `stopped` flag
-        let stopped = AtomicBool::new(false);
-
         let temp_dir = create_temp_dir(temp_dir)?;
 
         let id_tracker = if segment_config.is_appendable() {
@@ -106,7 +102,7 @@ impl SegmentBuilder {
                 &mut db_builder,
                 vector_config,
                 #[cfg(feature = "rocksdb")]
-                &stopped,
+                &Default::default(),
                 &vector_storage_path,
                 #[cfg(feature = "rocksdb")]
                 vector_name,
@@ -125,11 +121,14 @@ impl SegmentBuilder {
             let vector_storage_path = get_vector_storage_path(temp_dir.path(), vector_name);
 
             let vector_storage = create_sparse_vector_storage(
+                #[cfg(feature = "rocksdb")]
                 &mut db_builder,
                 &vector_storage_path,
+                #[cfg(feature = "rocksdb")]
                 vector_name,
                 &sparse_vector_config.storage_type,
-                &stopped,
+                #[cfg(feature = "rocksdb")]
+                &Default::default(),
             )?;
 
             vector_data.insert(

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -102,10 +102,13 @@ impl SegmentBuilder {
         for (vector_name, vector_config) in &segment_config.vector_data {
             let vector_storage_path = get_vector_storage_path(temp_dir.path(), vector_name);
             let vector_storage = open_vector_storage(
+                #[cfg(not(feature = "no-rocksdb"))]
                 &mut db_builder,
                 vector_config,
+                #[cfg(not(feature = "no-rocksdb"))]
                 &stopped,
                 &vector_storage_path,
+                #[cfg(not(feature = "no-rocksdb"))]
                 vector_name,
             )?;
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -102,13 +102,13 @@ impl SegmentBuilder {
         for (vector_name, vector_config) in &segment_config.vector_data {
             let vector_storage_path = get_vector_storage_path(temp_dir.path(), vector_name);
             let vector_storage = open_vector_storage(
-                #[cfg(not(feature = "no-rocksdb"))]
+                #[cfg(feature = "rocksdb")]
                 &mut db_builder,
                 vector_config,
-                #[cfg(not(feature = "no-rocksdb"))]
+                #[cfg(feature = "rocksdb")]
                 &stopped,
                 &vector_storage_path,
-                #[cfg(not(feature = "no-rocksdb"))]
+                #[cfg(feature = "rocksdb")]
                 vector_name,
             )?;
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -99,13 +99,12 @@ pub fn get_vector_index_path(segment_path: &Path, vector_name: &VectorName) -> P
     segment_path.join(get_vector_name_with_prefix(VECTOR_INDEX_PATH, vector_name))
 }
 
-#[allow(unused_variables, clippy::needless_pass_by_ref_mut)]
 pub(crate) fn open_vector_storage(
-    db_builder: &mut RocksDbBuilder,
+    #[cfg(not(feature = "no-rocksdb"))] db_builder: &mut RocksDbBuilder,
     vector_config: &VectorDataConfig,
-    stopped: &AtomicBool,
+    #[cfg(not(feature = "no-rocksdb"))] stopped: &AtomicBool,
     vector_storage_path: &Path,
-    vector_name: &VectorName,
+    #[cfg(not(feature = "no-rocksdb"))] vector_name: &VectorName,
 ) -> OperationResult<VectorStorageEnum> {
     let storage_element_type = vector_config.datatype.unwrap_or_default();
 
@@ -579,10 +578,13 @@ fn create_segment(
 
         // Select suitable vector storage type based on configuration
         let vector_storage = sp(open_vector_storage(
+            #[cfg(not(feature = "no-rocksdb"))]
             &mut db_builder,
             vector_config,
+            #[cfg(not(feature = "no-rocksdb"))]
             stopped,
             &vector_storage_path,
+            #[cfg(not(feature = "no-rocksdb"))]
             vector_name,
         )?);
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -51,6 +51,7 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::{
 use crate::vector_storage::dense::memmap_dense_vector_storage::{
     open_memmap_vector_storage, open_memmap_vector_storage_byte, open_memmap_vector_storage_half,
 };
+#[cfg(not(feature = "no-rocksdb"))]
 use crate::vector_storage::dense::simple_dense_vector_storage::{
     open_simple_dense_byte_vector_storage, open_simple_dense_half_vector_storage,
     open_simple_dense_vector_storage,
@@ -139,6 +140,12 @@ pub(crate) fn open_vector_storage(
                     ),
                 }
             } else {
+                #[cfg(feature = "no-rocksdb")]
+                return Err(OperationError::service_error(
+                    "Failed to load 'Memory' storage type, RocksDB disabled in this Qdrant version",
+                ));
+
+                #[cfg(not(feature = "no-rocksdb"))]
                 match storage_element_type {
                     VectorStorageDatatype::Float32 => open_simple_dense_vector_storage(
                         db_builder.require()?,

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -51,7 +51,7 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::{
 use crate::vector_storage::dense::memmap_dense_vector_storage::{
     open_memmap_vector_storage, open_memmap_vector_storage_byte, open_memmap_vector_storage_half,
 };
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 use crate::vector_storage::dense::simple_dense_vector_storage::{
     open_simple_dense_byte_vector_storage, open_simple_dense_half_vector_storage,
     open_simple_dense_vector_storage,
@@ -62,7 +62,7 @@ use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_stora
     open_appendable_memmap_multi_vector_storage_byte,
     open_appendable_memmap_multi_vector_storage_half,
 };
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::{
     open_simple_multi_dense_vector_storage, open_simple_multi_dense_vector_storage_byte,
     open_simple_multi_dense_vector_storage_half,
@@ -100,23 +100,23 @@ pub fn get_vector_index_path(segment_path: &Path, vector_name: &VectorName) -> P
 }
 
 pub(crate) fn open_vector_storage(
-    #[cfg(not(feature = "no-rocksdb"))] db_builder: &mut RocksDbBuilder,
+    #[cfg(feature = "rocksdb")] db_builder: &mut RocksDbBuilder,
     vector_config: &VectorDataConfig,
-    #[cfg(not(feature = "no-rocksdb"))] stopped: &AtomicBool,
+    #[cfg(feature = "rocksdb")] stopped: &AtomicBool,
     vector_storage_path: &Path,
-    #[cfg(not(feature = "no-rocksdb"))] vector_name: &VectorName,
+    #[cfg(feature = "rocksdb")] vector_name: &VectorName,
 ) -> OperationResult<VectorStorageEnum> {
     let storage_element_type = vector_config.datatype.unwrap_or_default();
 
     match vector_config.storage_type {
         // In memory - RocksDB disabled
-        #[cfg(feature = "no-rocksdb")]
+        #[cfg(not(feature = "rocksdb"))]
         VectorStorageType::Memory => Err(OperationError::service_error(
             "Failed to load 'Memory' storage type, RocksDB disabled in this Qdrant version",
         )),
 
         // In memory - RocksDB enabled
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         VectorStorageType::Memory => {
             let db_column_name = get_vector_name_with_prefix(DB_VECTOR_CF, vector_name);
 
@@ -578,13 +578,13 @@ fn create_segment(
 
         // Select suitable vector storage type based on configuration
         let vector_storage = sp(open_vector_storage(
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             &mut db_builder,
             vector_config,
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             stopped,
             &vector_storage_path,
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             vector_name,
         )?);
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1382,6 +1382,7 @@ impl VectorDataConfig {
 #[serde(rename_all = "snake_case")]
 pub enum SparseVectorStorageType {
     /// Storage on disk (rocksdb storage)
+    #[cfg(feature = "rocksdb")]
     OnDisk,
     /// Storage in memory maps (gridstore storage)
     #[default]
@@ -1394,6 +1395,7 @@ impl SparseVectorStorageType {
         match self {
             // Both options are on disk, but we keep it explicit for the case if someone adds a new
             // storage type in the future
+            #[cfg(feature = "rocksdb")]
             Self::OnDisk => true,
             Self::Mmap => true,
         }
@@ -1413,8 +1415,15 @@ pub struct SparseVectorDataConfig {
 }
 
 /// If the storage type is not in config, it means it is the OnDisk variant
-const fn default_sparse_vector_storage_type_when_not_in_config() -> SparseVectorStorageType {
-    SparseVectorStorageType::OnDisk
+fn default_sparse_vector_storage_type_when_not_in_config() -> SparseVectorStorageType {
+    #[cfg(feature = "rocksdb")]
+    {
+        SparseVectorStorageType::OnDisk
+    }
+    #[cfg(not(feature = "rocksdb"))]
+    {
+        SparseVectorStorageType::default()
+    }
 }
 
 impl SparseVectorDataConfig {

--- a/lib/segment/src/vector_storage/common.rs
+++ b/lib/segment/src/vector_storage/common.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(feature = "rocksdb")]
 use serde::{Deserialize, Serialize};
 
 static ASYNC_SCORER: AtomicBool = AtomicBool::new(false);
@@ -14,6 +15,7 @@ pub fn get_async_scorer() -> bool {
 
 /// Storage type for RocksDB based storage
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[cfg(feature = "rocksdb")]
 pub struct StoredRecord<T> {
     pub deleted: bool,
     pub vector: T,

--- a/lib/segment/src/vector_storage/dense/mod.rs
+++ b/lib/segment/src/vector_storage/dense/mod.rs
@@ -2,7 +2,7 @@ pub mod appendable_dense_vector_storage;
 pub mod dynamic_mmap_flags;
 pub mod memmap_dense_vector_storage;
 pub mod mmap_dense_vectors;
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 pub mod simple_dense_vector_storage;
 #[cfg(test)]
 pub mod volatile_dense_vector_storage;

--- a/lib/segment/src/vector_storage/dense/mod.rs
+++ b/lib/segment/src/vector_storage/dense/mod.rs
@@ -2,6 +2,7 @@ pub mod appendable_dense_vector_storage;
 pub mod dynamic_mmap_flags;
 pub mod memmap_dense_vector_storage;
 pub mod mmap_dense_vectors;
+#[cfg(not(feature = "no-rocksdb"))]
 pub mod simple_dense_vector_storage;
 #[cfg(test)]
 pub mod volatile_dense_vector_storage;

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -12,6 +12,7 @@ mod tests;
 #[cfg(target_os = "linux")]
 mod async_io;
 mod async_io_mock;
+#[cfg(any(test, feature = "rocksdb"))]
 mod bitvec;
 pub mod chunked_vector_storage;
 pub mod common;

--- a/lib/segment/src/vector_storage/multi_dense/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/mod.rs
@@ -1,5 +1,5 @@
 pub mod appendable_mmap_multi_dense_vector_storage;
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 pub mod simple_multi_dense_vector_storage;
 #[cfg(test)]
 pub mod volatile_multi_dense_vector_storage;

--- a/lib/segment/src/vector_storage/multi_dense/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/mod.rs
@@ -1,4 +1,5 @@
 pub mod appendable_mmap_multi_dense_vector_storage;
+#[cfg(not(feature = "no-rocksdb"))]
 pub mod simple_multi_dense_vector_storage;
 #[cfg(test)]
 pub mod volatile_multi_dense_vector_storage;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -239,12 +239,15 @@ impl QuantizedVectors {
         stopped: &AtomicBool,
     ) -> OperationResult<Self> {
         match vector_storage {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -290,6 +290,7 @@ impl QuantizedVectors {
             VectorStorageEnum::DenseAppendableInRamHalf(v) => {
                 Self::create_impl(v.as_ref(), quantization_config, path, max_threads, stopped)
             }
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(_) => Err(OperationError::WrongSparse),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => Err(OperationError::WrongSparse),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -239,15 +239,15 @@ impl QuantizedVectors {
         stopped: &AtomicBool,
     ) -> OperationResult<Self> {
         match vector_storage {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }
@@ -294,15 +294,15 @@ impl QuantizedVectors {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => Err(OperationError::WrongSparse),
             VectorStorageEnum::SparseMmap(_) => Err(OperationError::WrongSparse),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => {
                 Self::create_multi_impl(v, quantization_config, path, max_threads, stopped)
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => {
                 Self::create_multi_impl(v, quantization_config, path, max_threads, stopped)
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => {
                 Self::create_multi_impl(v, quantization_config, path, max_threads, stopped)
             }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -294,12 +294,15 @@ impl QuantizedVectors {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => Err(OperationError::WrongSparse),
             VectorStorageEnum::SparseMmap(_) => Err(OperationError::WrongSparse),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => {
                 Self::create_multi_impl(v, quantization_config, path, max_threads, stopped)
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => {
                 Self::create_multi_impl(v, quantization_config, path, max_threads, stopped)
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => {
                 Self::create_multi_impl(v, quantization_config, path, max_threads, stopped)
             }

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -54,11 +54,11 @@ pub fn new_raw_scorer<'a>(
     hc: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage {
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         VectorStorageEnum::DenseSimple(vs) => raw_scorer_impl(query, vs, hc),
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         VectorStorageEnum::DenseSimpleByte(vs) => raw_scorer_byte_impl(query, vs, hc),
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         VectorStorageEnum::DenseSimpleHalf(vs) => raw_scorer_half_impl(query, vs, hc),
         #[cfg(test)]
         VectorStorageEnum::DenseVolatile(vs) => raw_scorer_impl(query, vs, hc),
@@ -107,11 +107,11 @@ pub fn new_raw_scorer<'a>(
         #[cfg(test)]
         VectorStorageEnum::SparseVolatile(vs) => raw_sparse_scorer_impl(query, vs, hc),
         VectorStorageEnum::SparseMmap(vs) => raw_sparse_scorer_impl(query, vs, hc),
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         VectorStorageEnum::MultiDenseSimple(vs) => raw_multi_scorer_impl(query, vs, hc),
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         VectorStorageEnum::MultiDenseSimpleByte(vs) => raw_multi_scorer_byte_impl(query, vs, hc),
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         VectorStorageEnum::MultiDenseSimpleHalf(vs) => raw_multi_scorer_half_impl(query, vs, hc),
         #[cfg(test)]
         VectorStorageEnum::MultiDenseVolatile(vs) => raw_multi_scorer_impl(query, vs, hc),

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -103,6 +103,7 @@ pub fn new_raw_scorer<'a>(
         VectorStorageEnum::DenseAppendableInRamHalf(vs) => {
             raw_scorer_half_impl(query, vs.as_ref(), hc)
         }
+        #[cfg(feature = "rocksdb")]
         VectorStorageEnum::SparseSimple(vs) => raw_sparse_scorer_impl(query, vs, hc),
         #[cfg(test)]
         VectorStorageEnum::SparseVolatile(vs) => raw_sparse_scorer_impl(query, vs, hc),

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -107,8 +107,11 @@ pub fn new_raw_scorer<'a>(
         #[cfg(test)]
         VectorStorageEnum::SparseVolatile(vs) => raw_sparse_scorer_impl(query, vs, hc),
         VectorStorageEnum::SparseMmap(vs) => raw_sparse_scorer_impl(query, vs, hc),
+        #[cfg(not(feature = "no-rocksdb"))]
         VectorStorageEnum::MultiDenseSimple(vs) => raw_multi_scorer_impl(query, vs, hc),
+        #[cfg(not(feature = "no-rocksdb"))]
         VectorStorageEnum::MultiDenseSimpleByte(vs) => raw_multi_scorer_byte_impl(query, vs, hc),
+        #[cfg(not(feature = "no-rocksdb"))]
         VectorStorageEnum::MultiDenseSimpleHalf(vs) => raw_multi_scorer_half_impl(query, vs, hc),
         #[cfg(test)]
         VectorStorageEnum::MultiDenseVolatile(vs) => raw_multi_scorer_impl(query, vs, hc),

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -54,8 +54,11 @@ pub fn new_raw_scorer<'a>(
     hc: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage {
+        #[cfg(not(feature = "no-rocksdb"))]
         VectorStorageEnum::DenseSimple(vs) => raw_scorer_impl(query, vs, hc),
+        #[cfg(not(feature = "no-rocksdb"))]
         VectorStorageEnum::DenseSimpleByte(vs) => raw_scorer_byte_impl(query, vs, hc),
+        #[cfg(not(feature = "no-rocksdb"))]
         VectorStorageEnum::DenseSimpleHalf(vs) => raw_scorer_half_impl(query, vs, hc),
         #[cfg(test)]
         VectorStorageEnum::DenseVolatile(vs) => raw_scorer_impl(query, vs, hc),

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -12,7 +12,6 @@ use gridstore::config::{Compression, StorageOptions};
 use parking_lot::RwLock;
 use sparse::common::sparse_vector::SparseVector;
 
-use super::simple_sparse_vector_storage::SPARSE_VECTOR_DISTANCE;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
@@ -217,7 +216,7 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
 
 impl VectorStorage for MmapSparseVectorStorage {
     fn distance(&self) -> crate::types::Distance {
-        SPARSE_VECTOR_DISTANCE
+        super::SPARSE_VECTOR_DISTANCE
     }
 
     fn datatype(&self) -> crate::types::VectorStorageDatatype {

--- a/lib/segment/src/vector_storage/sparse/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/mod.rs
@@ -1,5 +1,10 @@
 pub mod mmap_sparse_vector_storage;
+#[cfg(feature = "rocksdb")]
 pub mod simple_sparse_vector_storage;
 mod stored_sparse_vectors;
 #[cfg(test)]
 pub mod volatile_sparse_vector_storage;
+
+use crate::types::Distance;
+
+pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -22,8 +22,6 @@ use crate::vector_storage::bitvec::bitvec_set_deleted;
 use crate::vector_storage::common::StoredRecord;
 use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageEnum};
 
-pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;
-
 type StoredSparseVector = StoredRecord<SparseVector>;
 
 /// In-memory vector storage with on-update persistence using `store`
@@ -176,7 +174,7 @@ impl SparseVectorStorage for SimpleSparseVectorStorage {
 
 impl VectorStorage for SimpleSparseVectorStorage {
     fn distance(&self) -> Distance {
-        SPARSE_VECTOR_DISTANCE
+        super::SPARSE_VECTOR_DISTANCE
     }
 
     fn datatype(&self) -> VectorStorageDatatype {

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -13,7 +13,7 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantizationConfig};
 use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage;
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -330,7 +330,7 @@ fn test_score_quantized_points(storage: &mut VectorStorageEnum) {
 }
 
 #[test]
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 fn test_delete_points_in_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
@@ -360,7 +360,7 @@ fn test_delete_points_in_simple_vector_storages() {
 }
 
 #[test]
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 fn test_update_from_delete_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
@@ -389,7 +389,7 @@ fn test_update_from_delete_points_simple_vector_storages() {
 }
 
 #[test]
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 fn test_score_points_in_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
@@ -418,7 +418,7 @@ fn test_score_points_in_simple_vector_storages() {
 }
 
 #[test]
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 fn test_score_quantized_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -13,6 +13,7 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantizationConfig};
 use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage;
+#[cfg(not(feature = "no-rocksdb"))]
 use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -329,6 +330,7 @@ fn test_score_quantized_points(storage: &mut VectorStorageEnum) {
 }
 
 #[test]
+#[cfg(not(feature = "no-rocksdb"))]
 fn test_delete_points_in_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
@@ -358,6 +360,7 @@ fn test_delete_points_in_simple_vector_storages() {
 }
 
 #[test]
+#[cfg(not(feature = "no-rocksdb"))]
 fn test_update_from_delete_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
@@ -386,6 +389,7 @@ fn test_update_from_delete_points_simple_vector_storages() {
 }
 
 #[test]
+#[cfg(not(feature = "no-rocksdb"))]
 fn test_score_points_in_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
@@ -414,6 +418,7 @@ fn test_score_points_in_simple_vector_storages() {
 }
 
 #[test]
+#[cfg(not(feature = "no-rocksdb"))]
 fn test_score_quantized_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -77,6 +77,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     {
         let orig_iter = points.iter().flat_map(|multivec| multivec.multi_vectors());
         match storage as &VectorStorageEnum {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(_)
             | VectorStorageEnum::DenseSimpleByte(_)
             | VectorStorageEnum::DenseSimpleHalf(_) => unreachable!(),

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -24,7 +24,7 @@ use crate::vector_storage::{
 
 #[derive(Clone, Copy)]
 enum MultiDenseStorageType {
-    #[cfg(not(feature = "no-rocksdb"))]
+    #[cfg(feature = "rocksdb")]
     RocksDbFloat,
     AppendableMmapFloat,
 }
@@ -75,7 +75,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     {
         let orig_iter = points.iter().flat_map(|multivec| multivec.multi_vectors());
         match storage as &VectorStorageEnum {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(_)
             | VectorStorageEnum::DenseSimpleByte(_)
             | VectorStorageEnum::DenseSimpleHalf(_) => unreachable!(),
@@ -92,13 +92,13 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
             VectorStorageEnum::SparseSimple(_) | VectorStorageEnum::SparseMmap(_) => unreachable!(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => unreachable!(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => {
                 for (orig, vec) in orig_iter.zip(v.iterate_inner_vectors()) {
                     assert_eq!(orig, vec);
                 }
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(_)
             | VectorStorageEnum::MultiDenseSimpleHalf(_) => unreachable!(),
             VectorStorageEnum::MultiDenseVolatile(v) => {
@@ -266,7 +266,7 @@ fn create_vector_storage(
     path: &Path,
 ) -> VectorStorageEnum {
     match storage_type {
-        #[cfg(not(feature = "no-rocksdb"))]
+        #[cfg(feature = "rocksdb")]
         MultiDenseStorageType::RocksDbFloat => {
             use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
             use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
@@ -293,7 +293,7 @@ fn create_vector_storage(
 }
 
 #[rstest]
-#[cfg_attr(not(feature = "no-rocksdb"), case(MultiDenseStorageType::RocksDbFloat))]
+#[cfg_attr(feature = "rocksdb", case(MultiDenseStorageType::RocksDbFloat))]
 #[case(MultiDenseStorageType::AppendableMmapFloat)]
 fn test_delete_points_in_multi_dense_vector_storage(#[case] storage_type: MultiDenseStorageType) {
     let vec_dim = 1024;
@@ -319,7 +319,7 @@ fn test_delete_points_in_multi_dense_vector_storage(#[case] storage_type: MultiD
 }
 
 #[rstest]
-#[cfg_attr(not(feature = "no-rocksdb"), case(MultiDenseStorageType::RocksDbFloat))]
+#[cfg_attr(feature = "rocksdb", case(MultiDenseStorageType::RocksDbFloat))]
 #[case(MultiDenseStorageType::AppendableMmapFloat)]
 fn test_update_from_delete_points_multi_dense_vector_storage(
     #[case] storage_type: MultiDenseStorageType,
@@ -347,7 +347,7 @@ fn test_update_from_delete_points_multi_dense_vector_storage(
 }
 
 #[rstest]
-#[cfg_attr(not(feature = "no-rocksdb"), case(MultiDenseStorageType::RocksDbFloat))]
+#[cfg_attr(feature = "rocksdb", case(MultiDenseStorageType::RocksDbFloat))]
 #[case(MultiDenseStorageType::AppendableMmapFloat)]
 fn test_large_multi_dense_vector_storage(#[case] storage_type: MultiDenseStorageType) {
     assert!(MAX_MULTIVECTOR_FLATTENED_LEN * std::mem::size_of::<VectorElementType>() < CHUNK_SIZE);

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -37,6 +37,7 @@ use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::dense::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage;
 use crate::vector_storage::in_ram_persisted_vectors::InRamPersistedVectors;
+#[cfg(feature = "rocksdb")]
 use crate::vector_storage::sparse::simple_sparse_vector_storage::SimpleSparseVectorStorage;
 
 /// Trait for vector storage
@@ -245,6 +246,7 @@ pub enum VectorStorageEnum {
             >,
         >,
     ),
+    #[cfg(feature = "rocksdb")]
     SparseSimple(SimpleSparseVectorStorage),
     #[cfg(test)]
     SparseVolatile(VolatileSparseVectorStorage),
@@ -341,6 +343,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(_) => None,
             VectorStorageEnum::DenseAppendableInRamByte(_) => None,
             VectorStorageEnum::DenseAppendableInRamHalf(_) => None,
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(_) => None,
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => None,
@@ -413,6 +416,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamHalf(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(_) => VectorInternal::from(SparseVector::default()),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => VectorInternal::from(SparseVector::default()),
@@ -493,6 +497,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamHalf(v) => {
                 v.size_of_available_vectors_in_bytes()
             }
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.size_of_available_vectors_in_bytes(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.size_of_available_vectors_in_bytes(),
@@ -557,6 +562,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(vs) => vs.populate()?,
             VectorStorageEnum::DenseAppendableInRamByte(vs) => vs.populate()?,
             VectorStorageEnum::DenseAppendableInRamHalf(vs) => vs.populate()?,
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
@@ -606,6 +612,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseAppendableInRamByte(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseAppendableInRamHalf(vs) => vs.clear_cache()?,
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
@@ -657,6 +664,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.distance(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.distance(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.distance(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.distance(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.distance(),
@@ -705,6 +713,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.datatype(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.datatype(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.datatype(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.datatype(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.datatype(),
@@ -755,6 +764,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.is_on_disk(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.is_on_disk(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.is_on_disk(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.is_on_disk(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.is_on_disk(),
@@ -803,6 +813,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.total_vector_count(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.total_vector_count(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.total_vector_count(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.total_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.total_vector_count(),
@@ -851,6 +862,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.get_vector(key),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.get_vector(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.get_vector(key),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.get_vector(key),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector(key),
@@ -899,6 +911,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.get_vector_sequential(key),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.get_vector_sequential(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.get_vector_sequential(key),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.get_vector_sequential(key),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector_sequential(key),
@@ -947,6 +960,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.get_vector_opt(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.get_vector_opt(key),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.get_vector_opt(key),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector_opt(key),
@@ -1008,6 +1022,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRamHalf(v) => {
                 v.insert_vector(key, vector, hw_counter)
             }
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.insert_vector(key, vector, hw_counter),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.insert_vector(key, vector, hw_counter),
@@ -1080,6 +1095,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.update_from(other_vectors, stopped),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.update_from(other_vectors, stopped),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.update_from(other_vectors, stopped),
@@ -1140,6 +1156,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.flusher(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.flusher(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.flusher(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.flusher(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.flusher(),
@@ -1188,6 +1205,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.files(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.files(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.files(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.files(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.files(),
@@ -1236,6 +1254,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.delete_vector(key),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.delete_vector(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.delete_vector(key),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.delete_vector(key),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.delete_vector(key),
@@ -1284,6 +1303,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.is_deleted_vector(key),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.is_deleted_vector(key),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.is_deleted_vector(key),
@@ -1332,6 +1352,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.deleted_vector_count(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_count(),
@@ -1380,6 +1401,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableInRam(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseAppendableInRamByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseAppendableInRamHalf(v) => v.deleted_vector_bitslice(),
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_bitslice(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_bitslice(),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -10,14 +10,14 @@ use common::types::PointOffsetType;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::memmap_dense_vector_storage::MemmapDenseVectorStorage;
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 use super::dense::simple_dense_vector_storage::SimpleDenseVectorStorage;
 #[cfg(test)]
 use super::dense::volatile_dense_vector_storage::VolatileDenseVectorStorage;
 use super::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, MultivectorMmapOffset,
 };
-#[cfg(not(feature = "no-rocksdb"))]
+#[cfg(feature = "rocksdb")]
 use super::multi_dense::simple_multi_dense_vector_storage::SimpleMultiDenseVectorStorage;
 #[cfg(test)]
 use super::multi_dense::volatile_multi_dense_vector_storage::VolatileMultiDenseVectorStorage;
@@ -182,11 +182,11 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
 
 #[derive(Debug)]
 pub enum VectorStorageEnum {
-    #[cfg(not(feature = "no-rocksdb"))]
+    #[cfg(feature = "rocksdb")]
     DenseSimple(SimpleDenseVectorStorage<VectorElementType>),
-    #[cfg(not(feature = "no-rocksdb"))]
+    #[cfg(feature = "rocksdb")]
     DenseSimpleByte(SimpleDenseVectorStorage<VectorElementTypeByte>),
-    #[cfg(not(feature = "no-rocksdb"))]
+    #[cfg(feature = "rocksdb")]
     DenseSimpleHalf(SimpleDenseVectorStorage<VectorElementTypeHalf>),
     #[cfg(test)]
     DenseVolatile(VolatileDenseVectorStorage<VectorElementType>),
@@ -249,11 +249,11 @@ pub enum VectorStorageEnum {
     #[cfg(test)]
     SparseVolatile(VolatileSparseVectorStorage),
     SparseMmap(MmapSparseVectorStorage),
-    #[cfg(not(feature = "no-rocksdb"))]
+    #[cfg(feature = "rocksdb")]
     MultiDenseSimple(SimpleMultiDenseVectorStorage<VectorElementType>),
-    #[cfg(not(feature = "no-rocksdb"))]
+    #[cfg(feature = "rocksdb")]
     MultiDenseSimpleByte(SimpleMultiDenseVectorStorage<VectorElementTypeByte>),
-    #[cfg(not(feature = "no-rocksdb"))]
+    #[cfg(feature = "rocksdb")]
     MultiDenseSimpleHalf(SimpleMultiDenseVectorStorage<VectorElementTypeHalf>),
     #[cfg(test)]
     MultiDenseVolatile(VolatileMultiDenseVectorStorage<VectorElementType>),
@@ -320,11 +320,11 @@ pub enum VectorStorageEnum {
 impl VectorStorageEnum {
     pub fn try_multi_vector_config(&self) -> Option<&MultiVectorConfig> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(_) => None,
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(_) => None,
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(_) => None,
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(_) => None,
@@ -345,11 +345,11 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => None,
             VectorStorageEnum::SparseMmap(_) => None,
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(s) => Some(s.multi_vector_config()),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(s) => Some(s.multi_vector_config()),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(s) => Some(s.multi_vector_config()),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(s) => Some(s.multi_vector_config()),
@@ -368,13 +368,13 @@ impl VectorStorageEnum {
 
     pub(crate) fn default_vector(&self) -> VectorInternal {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => VectorInternal::from(vec![1.0; v.vector_dim()]),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
@@ -417,15 +417,15 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => VectorInternal::from(SparseVector::default()),
             VectorStorageEnum::SparseMmap(_) => VectorInternal::from(SparseVector::default()),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => {
                 VectorInternal::from(MultiDenseVectorInternal::placeholder(v.vector_dim()))
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => {
                 VectorInternal::from(MultiDenseVectorInternal::placeholder(v.vector_dim()))
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => {
                 VectorInternal::from(MultiDenseVectorInternal::placeholder(v.vector_dim()))
             }
@@ -464,11 +464,11 @@ impl VectorStorageEnum {
 
     pub fn size_of_available_vectors_in_bytes(&self) -> usize {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
@@ -501,11 +501,11 @@ impl VectorStorageEnum {
                     "Mmap sparse storage does not know its total size, get from index instead"
                 )
             }
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
@@ -536,11 +536,11 @@ impl VectorStorageEnum {
 
     pub fn populate(&self) -> OperationResult<()> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -561,11 +561,11 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::SparseMmap(vs) => vs.populate()?,
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -585,11 +585,11 @@ impl VectorStorageEnum {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -610,11 +610,11 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::SparseMmap(vs) => vs.clear_cache()?,
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(_) => {} // Can't populate as it is not mmap
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -636,11 +636,11 @@ impl VectorStorageEnum {
 impl VectorStorage for VectorStorageEnum {
     fn distance(&self) -> Distance {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.distance(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.distance(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.distance(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.distance(),
@@ -661,11 +661,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.distance(),
             VectorStorageEnum::SparseMmap(v) => v.distance(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.distance(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.distance(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.distance(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.distance(),
@@ -684,11 +684,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn datatype(&self) -> VectorStorageDatatype {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.datatype(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.datatype(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.datatype(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.datatype(),
@@ -709,11 +709,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.datatype(),
             VectorStorageEnum::SparseMmap(v) => v.datatype(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.datatype(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.datatype(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.datatype(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.datatype(),
@@ -734,11 +734,11 @@ impl VectorStorage for VectorStorageEnum {
     /// If true - data is stored on disk, and is not forced to be in RAM
     fn is_on_disk(&self) -> bool {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.is_on_disk(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.is_on_disk(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.is_on_disk(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.is_on_disk(),
@@ -759,11 +759,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.is_on_disk(),
             VectorStorageEnum::SparseMmap(v) => v.is_on_disk(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.is_on_disk(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_on_disk(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.is_on_disk(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.is_on_disk(),
@@ -782,11 +782,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn total_vector_count(&self) -> usize {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.total_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.total_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.total_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.total_vector_count(),
@@ -807,11 +807,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.total_vector_count(),
             VectorStorageEnum::SparseMmap(v) => v.total_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.total_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.total_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.total_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.total_vector_count(),
@@ -830,11 +830,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.get_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.get_vector(key),
@@ -855,11 +855,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector(key),
@@ -878,11 +878,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.get_vector_sequential(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector_sequential(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector_sequential(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.get_vector_sequential(key),
@@ -903,11 +903,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector_sequential(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector_sequential(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector_sequential(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector_sequential(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector_sequential(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector_sequential(key),
@@ -926,11 +926,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.get_vector_opt(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector_opt(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector_opt(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.get_vector_opt(key),
@@ -951,11 +951,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector_opt(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector_opt(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector_opt(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector_opt(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector_opt(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector_opt(key),
@@ -979,11 +979,11 @@ impl VectorStorage for VectorStorageEnum {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.insert_vector(key, vector, hw_counter),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.insert_vector(key, vector, hw_counter),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.insert_vector(key, vector, hw_counter),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.insert_vector(key, vector, hw_counter),
@@ -1012,11 +1012,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::SparseMmap(v) => v.insert_vector(key, vector, hw_counter),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.insert_vector(key, vector, hw_counter),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.insert_vector(key, vector, hw_counter),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.insert_vector(key, vector, hw_counter),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.insert_vector(key, vector, hw_counter),
@@ -1055,11 +1055,11 @@ impl VectorStorage for VectorStorageEnum {
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.update_from(other_vectors, stopped),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.update_from(other_vectors, stopped),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.update_from(other_vectors, stopped),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.update_from(other_vectors, stopped),
@@ -1084,11 +1084,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::SparseMmap(v) => v.update_from(other_vectors, stopped),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.update_from(other_vectors, stopped),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.update_from(other_vectors, stopped),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.update_from(other_vectors, stopped),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.update_from(other_vectors, stopped),
@@ -1119,11 +1119,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn flusher(&self) -> Flusher {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.flusher(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.flusher(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.flusher(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.flusher(),
@@ -1144,11 +1144,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.flusher(),
             VectorStorageEnum::SparseMmap(v) => v.flusher(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.flusher(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.flusher(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.flusher(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.flusher(),
@@ -1167,11 +1167,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn files(&self) -> Vec<PathBuf> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.files(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.files(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.files(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.files(),
@@ -1192,11 +1192,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.files(),
             VectorStorageEnum::SparseMmap(v) => v.files(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.files(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.files(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.files(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.files(),
@@ -1215,11 +1215,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.delete_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.delete_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.delete_vector(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.delete_vector(key),
@@ -1240,11 +1240,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.delete_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.delete_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.delete_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.delete_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.delete_vector(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.delete_vector(key),
@@ -1263,11 +1263,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.is_deleted_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.is_deleted_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.is_deleted_vector(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.is_deleted_vector(key),
@@ -1288,11 +1288,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.is_deleted_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.is_deleted_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.is_deleted_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_deleted_vector(key),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.is_deleted_vector(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.is_deleted_vector(key),
@@ -1311,11 +1311,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn deleted_vector_count(&self) -> usize {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.deleted_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.deleted_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.deleted_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_count(),
@@ -1336,11 +1336,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_count(),
             VectorStorageEnum::SparseMmap(v) => v.deleted_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_count(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.deleted_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_count(),
@@ -1359,11 +1359,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         match self {
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.deleted_vector_bitslice(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleByte(v) => v.deleted_vector_bitslice(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimpleHalf(v) => v.deleted_vector_bitslice(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_bitslice(),
@@ -1384,11 +1384,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::SparseMmap(v) => v.deleted_vector_bitslice(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_bitslice(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_bitslice(),
-            #[cfg(not(feature = "no-rocksdb"))]
+            #[cfg(feature = "rocksdb")]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.deleted_vector_bitslice(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_bitslice(),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -17,6 +17,7 @@ use super::dense::volatile_dense_vector_storage::VolatileDenseVectorStorage;
 use super::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, MultivectorMmapOffset,
 };
+#[cfg(not(feature = "no-rocksdb"))]
 use super::multi_dense::simple_multi_dense_vector_storage::SimpleMultiDenseVectorStorage;
 #[cfg(test)]
 use super::multi_dense::volatile_multi_dense_vector_storage::VolatileMultiDenseVectorStorage;
@@ -248,8 +249,11 @@ pub enum VectorStorageEnum {
     #[cfg(test)]
     SparseVolatile(VolatileSparseVectorStorage),
     SparseMmap(MmapSparseVectorStorage),
+    #[cfg(not(feature = "no-rocksdb"))]
     MultiDenseSimple(SimpleMultiDenseVectorStorage<VectorElementType>),
+    #[cfg(not(feature = "no-rocksdb"))]
     MultiDenseSimpleByte(SimpleMultiDenseVectorStorage<VectorElementTypeByte>),
+    #[cfg(not(feature = "no-rocksdb"))]
     MultiDenseSimpleHalf(SimpleMultiDenseVectorStorage<VectorElementTypeHalf>),
     #[cfg(test)]
     MultiDenseVolatile(VolatileMultiDenseVectorStorage<VectorElementType>),
@@ -341,8 +345,11 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => None,
             VectorStorageEnum::SparseMmap(_) => None,
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(s) => Some(s.multi_vector_config()),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(s) => Some(s.multi_vector_config()),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(s) => Some(s.multi_vector_config()),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(s) => Some(s.multi_vector_config()),
@@ -410,12 +417,15 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => VectorInternal::from(SparseVector::default()),
             VectorStorageEnum::SparseMmap(_) => VectorInternal::from(SparseVector::default()),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => {
                 VectorInternal::from(MultiDenseVectorInternal::placeholder(v.vector_dim()))
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => {
                 VectorInternal::from(MultiDenseVectorInternal::placeholder(v.vector_dim()))
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => {
                 VectorInternal::from(MultiDenseVectorInternal::placeholder(v.vector_dim()))
             }
@@ -491,8 +501,11 @@ impl VectorStorageEnum {
                     "Mmap sparse storage does not know its total size, get from index instead"
                 )
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
@@ -548,8 +561,11 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::SparseMmap(vs) => vs.populate()?,
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -594,8 +610,11 @@ impl VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::SparseMmap(vs) => vs.clear_cache()?,
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -642,8 +661,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.distance(),
             VectorStorageEnum::SparseMmap(v) => v.distance(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.distance(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.distance(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.distance(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.distance(),
@@ -687,8 +709,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.datatype(),
             VectorStorageEnum::SparseMmap(v) => v.datatype(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.datatype(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.datatype(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.datatype(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.datatype(),
@@ -734,8 +759,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.is_on_disk(),
             VectorStorageEnum::SparseMmap(v) => v.is_on_disk(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.is_on_disk(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_on_disk(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.is_on_disk(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.is_on_disk(),
@@ -779,8 +807,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.total_vector_count(),
             VectorStorageEnum::SparseMmap(v) => v.total_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.total_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.total_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.total_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.total_vector_count(),
@@ -824,8 +855,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector(key),
@@ -869,8 +903,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector_sequential(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector_sequential(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector_sequential(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector_sequential(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector_sequential(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector_sequential(key),
@@ -914,8 +951,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.get_vector_opt(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector_opt(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector_opt(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector_opt(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.get_vector_opt(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector_opt(key),
@@ -972,8 +1012,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::SparseMmap(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.insert_vector(key, vector, hw_counter),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.insert_vector(key, vector, hw_counter),
@@ -1041,8 +1084,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.update_from(other_vectors, stopped),
             VectorStorageEnum::SparseMmap(v) => v.update_from(other_vectors, stopped),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.update_from(other_vectors, stopped),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.update_from(other_vectors, stopped),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.update_from(other_vectors, stopped),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.update_from(other_vectors, stopped),
@@ -1098,8 +1144,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.flusher(),
             VectorStorageEnum::SparseMmap(v) => v.flusher(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.flusher(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.flusher(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.flusher(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.flusher(),
@@ -1143,8 +1192,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.files(),
             VectorStorageEnum::SparseMmap(v) => v.files(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.files(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.files(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.files(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.files(),
@@ -1188,8 +1240,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.delete_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.delete_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.delete_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.delete_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.delete_vector(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.delete_vector(key),
@@ -1233,8 +1288,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.is_deleted_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.is_deleted_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.is_deleted_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_deleted_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.is_deleted_vector(key),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.is_deleted_vector(key),
@@ -1278,8 +1336,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_count(),
             VectorStorageEnum::SparseMmap(v) => v.deleted_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.deleted_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_count(),
@@ -1323,8 +1384,11 @@ impl VectorStorage for VectorStorageEnum {
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::SparseMmap(v) => v.deleted_vector_bitslice(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_bitslice(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_bitslice(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::MultiDenseSimpleHalf(v) => v.deleted_vector_bitslice(),
             #[cfg(test)]
             VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_bitslice(),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -10,6 +10,7 @@ use common::types::PointOffsetType;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::memmap_dense_vector_storage::MemmapDenseVectorStorage;
+#[cfg(not(feature = "no-rocksdb"))]
 use super::dense::simple_dense_vector_storage::SimpleDenseVectorStorage;
 #[cfg(test)]
 use super::dense::volatile_dense_vector_storage::VolatileDenseVectorStorage;
@@ -180,8 +181,11 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
 
 #[derive(Debug)]
 pub enum VectorStorageEnum {
+    #[cfg(not(feature = "no-rocksdb"))]
     DenseSimple(SimpleDenseVectorStorage<VectorElementType>),
+    #[cfg(not(feature = "no-rocksdb"))]
     DenseSimpleByte(SimpleDenseVectorStorage<VectorElementTypeByte>),
+    #[cfg(not(feature = "no-rocksdb"))]
     DenseSimpleHalf(SimpleDenseVectorStorage<VectorElementTypeHalf>),
     #[cfg(test)]
     DenseVolatile(VolatileDenseVectorStorage<VectorElementType>),
@@ -312,8 +316,11 @@ pub enum VectorStorageEnum {
 impl VectorStorageEnum {
     pub fn try_multi_vector_config(&self) -> Option<&MultiVectorConfig> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(_) => None,
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(_) => None,
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(_) => None,
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(_) => None,
@@ -354,10 +361,13 @@ impl VectorStorageEnum {
 
     pub(crate) fn default_vector(&self) -> VectorInternal {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => VectorInternal::from(vec![1.0; v.vector_dim()]),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
@@ -444,8 +454,11 @@ impl VectorStorageEnum {
 
     pub fn size_of_available_vectors_in_bytes(&self) -> usize {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.size_of_available_vectors_in_bytes(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
@@ -510,8 +523,11 @@ impl VectorStorageEnum {
 
     pub fn populate(&self) -> OperationResult<()> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -553,8 +569,11 @@ impl VectorStorageEnum {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(_) => {} // Can't populate as it is not mmap
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(_) => {} // Can't populate as it is not mmap
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -598,8 +617,11 @@ impl VectorStorageEnum {
 impl VectorStorage for VectorStorageEnum {
     fn distance(&self) -> Distance {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.distance(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.distance(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.distance(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.distance(),
@@ -640,8 +662,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn datatype(&self) -> VectorStorageDatatype {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.datatype(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.datatype(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.datatype(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.datatype(),
@@ -684,8 +709,11 @@ impl VectorStorage for VectorStorageEnum {
     /// If true - data is stored on disk, and is not forced to be in RAM
     fn is_on_disk(&self) -> bool {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.is_on_disk(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.is_on_disk(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.is_on_disk(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.is_on_disk(),
@@ -726,8 +754,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn total_vector_count(&self) -> usize {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.total_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.total_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.total_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.total_vector_count(),
@@ -768,8 +799,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.get_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.get_vector(key),
@@ -810,8 +844,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.get_vector_sequential(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector_sequential(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector_sequential(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.get_vector_sequential(key),
@@ -852,8 +889,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.get_vector_opt(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.get_vector_opt(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.get_vector_opt(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.get_vector_opt(key),
@@ -899,8 +939,11 @@ impl VectorStorage for VectorStorageEnum {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.insert_vector(key, vector, hw_counter),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.insert_vector(key, vector, hw_counter),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.insert_vector(key, vector, hw_counter),
@@ -969,8 +1012,11 @@ impl VectorStorage for VectorStorageEnum {
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.update_from(other_vectors, stopped),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.update_from(other_vectors, stopped),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.update_from(other_vectors, stopped),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.update_from(other_vectors, stopped),
@@ -1027,8 +1073,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn flusher(&self) -> Flusher {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.flusher(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.flusher(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.flusher(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.flusher(),
@@ -1069,8 +1118,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn files(&self) -> Vec<PathBuf> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.files(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.files(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.files(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.files(),
@@ -1111,8 +1163,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.delete_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.delete_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.delete_vector(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.delete_vector(key),
@@ -1153,8 +1208,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.is_deleted_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.is_deleted_vector(key),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.is_deleted_vector(key),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.is_deleted_vector(key),
@@ -1195,8 +1253,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn deleted_vector_count(&self) -> usize {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.deleted_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.deleted_vector_count(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.deleted_vector_count(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_count(),
@@ -1237,8 +1298,11 @@ impl VectorStorage for VectorStorageEnum {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         match self {
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimple(v) => v.deleted_vector_bitslice(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleByte(v) => v.deleted_vector_bitslice(),
+            #[cfg(not(feature = "no-rocksdb"))]
             VectorStorageEnum::DenseSimpleHalf(v) => v.deleted_vector_bitslice(),
             #[cfg(test)]
             VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_bitslice(),


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6569>

Feature flag usage of RocksDB in our vector storage (dense, multi dense and sparse). For now, the flag will remain enabled by default.

```bash
# Build with RocksDB in vector storage (default)
cargo build

# Build without RocksDB in vector storage
cargo build --no-default-features --features parking_lot,web
```

Note that disabling the feature flag does not remove the dependency at compile time yet. It is still being used in a few other places, which will be feature flagged separately. This is just one of the necessary steps forward towards completely removing RocksDB at a future point in time.

### Tasks
- [x] Propagate flag to main crate
- [x] Merge <https://github.com/qdrant/qdrant/pull/6569>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?