### PR TITLE
Fix force delete peer flaky test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,6 +36,11 @@ jobs:
 
           poetry -C tests check --lock
           poetry -C tests install --no-root
+      - name: Build
+        run: cargo build --features "service_debug data-consistency-check" --locked
+      - name: Run integration tests
+        run: poetry -C tests run ./tests/integration-tests.sh
+        shell: bash
 
   integration-tests-consensus:
 
@@ -64,8 +69,11 @@ jobs:
           poetry -C tests install --no-root
       - name: Build
         run: cargo build --features "service_debug data-consistency-check" --locked
+      - name: Run integration tests - 1 peer
+        run: poetry -C tests run ./tests/integration-tests.sh distributed
+        shell: bash
       - name: Run integration tests - multiple peers - pytest
-        run: poetry -C tests run pytest tests/consensus_tests --durations=10 -k test_force_delete_peer
+        run: poetry -C tests run pytest tests/consensus_tests --durations=10
         timeout-minutes: 60
       - name: upload logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,11 +36,6 @@ jobs:
 
           poetry -C tests check --lock
           poetry -C tests install --no-root
-      - name: Build
-        run: cargo build --features "service_debug data-consistency-check" --locked
-      - name: Run integration tests
-        run: poetry -C tests run ./tests/integration-tests.sh
-        shell: bash
 
   integration-tests-consensus:
 
@@ -69,11 +64,8 @@ jobs:
           poetry -C tests install --no-root
       - name: Build
         run: cargo build --features "service_debug data-consistency-check" --locked
-      - name: Run integration tests - 1 peer
-        run: poetry -C tests run ./tests/integration-tests.sh distributed
-        shell: bash
       - name: Run integration tests - multiple peers - pytest
-        run: poetry -C tests run pytest tests/consensus_tests --durations=10
+        run: poetry -C tests run pytest tests/consensus_tests --durations=10 -k test_force_delete_peer
         timeout-minutes: 60
       - name: upload logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,15 @@ jobs:
       - name: Build
         run: cargo build --features "service_debug data-consistency-check" --locked
       - name: Run integration tests - multiple peers - pytest
-        run: poetry -C tests run pytest tests/consensus_tests --durations=10 -k test_force_delete_peer
+        run: |
+          # Run pytest in a loop until it fails
+          counter=0
+          while poetry -C tests run pytest tests/consensus_tests --durations=10 -k test_force_delete_peer -x -vv; do
+              counter=$((counter + 1))
+              echo "==========Test passed $counter times. Running again...========="
+              rm -rf consensus_test_logs
+          done
+          echo "Test failed. Exiting."
         timeout-minutes: 60
       - name: upload logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,15 +65,7 @@ jobs:
       - name: Build
         run: cargo build --features "service_debug data-consistency-check" --locked
       - name: Run integration tests - multiple peers - pytest
-        run: |
-          # Run pytest in a loop until it fails
-          counter=0
-          while poetry -C tests run pytest tests/consensus_tests --durations=10 -k test_force_delete_peer -x -vv; do
-              counter=$((counter + 1))
-              echo "==========Test passed $counter times. Running again...========="
-              rm -rf consensus_test_logs
-          done
-          echo "Test failed. Exiting."
+        run: poetry -C tests run pytest tests/consensus_tests --durations=10 -k test_force_delete_peer
         timeout-minutes: 60
       - name: upload logs
         uses: actions/upload-artifact@v4

--- a/tests/consensus_tests/test_force_delete_peer.py
+++ b/tests/consensus_tests/test_force_delete_peer.py
@@ -52,11 +52,7 @@ def test_force_delete_source_peer_during_transfers(tmp_path: pathlib.Path):
     )
 
     # Wait for start of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 1)
-
-    transfers = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)[
-        "shard_transfers"
-    ]
+    transfers = wait_for_collection_shard_transfers_count_and_return_transfers(peer_api_uris[0], COLLECTION_NAME, 1)
     assert len(transfers) == 1
     assert transfers[0]["to"] == list(peer_id_to_url.keys())[-1] # last peer was restarted
     from_peer_id = transfers[0]["from"]

--- a/tests/consensus_tests/test_force_delete_peer.py
+++ b/tests/consensus_tests/test_force_delete_peer.py
@@ -52,7 +52,7 @@ def test_force_delete_source_peer_during_transfers(tmp_path: pathlib.Path):
     )
 
     # Wait for start of shard transfer
-    transfers = wait_for_collection_shard_transfers_count_and_return_transfers(peer_api_uris[0], COLLECTION_NAME, 1)
+    transfers = wait_for_collection_shard_transfers_count_and_return(peer_api_uris[0], COLLECTION_NAME, 1)
     assert len(transfers) == 1
     assert transfers[0]["to"] == list(peer_id_to_url.keys())[-1] # last peer was restarted
     from_peer_id = transfers[0]["from"]

--- a/tests/consensus_tests/test_force_delete_peer.py
+++ b/tests/consensus_tests/test_force_delete_peer.py
@@ -34,7 +34,7 @@ def test_force_delete_source_peer_during_transfers(tmp_path: pathlib.Path):
         peer_id_to_url[peer_id] = peer_api_uri
 
     # Insert some initial number of points
-    upsert_random_points(peer_api_uris[0], 3000)
+    upsert_random_points(peer_api_uris[0], 100)
 
     # Kill last peer
     p = processes.pop()
@@ -42,7 +42,7 @@ def test_force_delete_source_peer_during_transfers(tmp_path: pathlib.Path):
     sleep(1)  # Give killed peer time to release WAL lock
 
     # Upsert points to mark dummy replica as dead, that will trigger recovery transfer
-    upsert_random_points(peer_api_uris[0], 100)
+    upsert_random_points(peer_api_uris[0], 3000)
 
     # Restart same peer
     peer_api_uris[-1] = start_peer(

--- a/tests/consensus_tests/test_force_delete_peer.py
+++ b/tests/consensus_tests/test_force_delete_peer.py
@@ -28,44 +28,23 @@ def test_force_delete_source_peer_during_transfers(tmp_path: pathlib.Path):
         collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris
     )
 
-    peer_id_to_url = {}
+    peer_url_to_id = {}
     for peer_api_uri in peer_api_uris:
         peer_id = get_peer_id(peer_api_uri)
-        peer_id_to_url[peer_id] = peer_api_uri
+        peer_url_to_id[peer_api_uri] = peer_id
 
     # Insert some initial number of points
-    upsert_random_points(peer_api_uris[0], 100)
-
-    # Kill last peer
-    p = processes.pop()
-    p.kill()
-    sleep(1)  # Give killed peer time to release WAL lock
-
-    # Upsert points to mark dummy replica as dead, that will trigger recovery transfer
     upsert_random_points(peer_api_uris[0], 3000)
 
-    # Restart same peer
-    peer_api_uris[-1] = start_peer(
-        peer_dirs[-1],
-        f"peer_{N_PEERS}_restarted.log",
-        bootstrap_uri,
-    )
-
-    # Wait for start of shard transfer
-    transfers = wait_for_collection_shard_transfers_count_and_return(peer_api_uris[0], COLLECTION_NAME, 1)
-    assert len(transfers) == 1
-    assert transfers[0]["to"] == list(peer_id_to_url.keys())[-1] # last peer was restarted
-    from_peer_id = transfers[0]["from"]
-
-    # Stop the 'source' node to simulate an unreachable node which needs to be deleted
-    source_peer_url = peer_id_to_url[from_peer_id]
-    peer_idx = peer_api_uris.index(source_peer_url)
-    peer_api_uris.pop(peer_idx) # Remove from urls so we don't try to call it
+    # Start a transfer from first peer to last peer ID
+    from_peer_id = peer_url_to_id[peer_api_uris[-1]]
+    to_peer_id = peer_url_to_id[peer_api_uris[0]]
+    replicate_shard(peer_api_uris[-1], COLLECTION_NAME, 0, from_peer_id, to_peer_id)
 
     # Force delete 'from' peer ID by requesting remaining peers to do so
     force_delete_peer(peer_api_uris[0], from_peer_id)
 
-    # We expect transfers to be aborted
+    # We expect all transfers to be aborted (peer was force deleted before transfer finished) or finished
     wait_for_collection_shard_transfers_count(
         peer_api_uris[0], COLLECTION_NAME, 0
     )

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -439,13 +439,19 @@ def check_collection_local_shards_point_count(peer_api_uri: str, collection_name
 
     return is_correct
 
-
 def check_collection_shard_transfers_count(peer_api_uri: str, collection_name: str,
                                            expected_shard_transfers_count: int, headers={}) -> bool:
     collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
-    local_shard_count = len(collection_cluster_info["shard_transfers"])
-    return local_shard_count == expected_shard_transfers_count
+    shard_transfers = collection_cluster_info["shard_transfers"]
+    return len(shard_transfers) == expected_shard_transfers_count
 
+def check_collection_shard_transfers_count_and_return(peer_api_uri: str, collection_name: str,
+                                           expected_shard_transfers_count: int, headers={}) -> Tuple[bool, List[dict]]:
+    collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
+    shard_transfers = collection_cluster_info["shard_transfers"]
+    if len(shard_transfers) == expected_shard_transfers_count:
+        return (True, shard_transfers)
+    return (False, [])
 
 def check_collection_resharding_operations_count(peer_api_uri: str, collection_name: str,
                                            expected_resharding_operations_count: int, headers={}) -> bool:
@@ -622,6 +628,14 @@ def wait_for_collection_shard_transfers_count(peer_api_uri: str, collection_name
         raise e
 
 
+def wait_for_collection_shard_transfers_count_and_return(peer_api_uri: str, collection_name: str,
+                                              expected_shard_transfer_count: int, headers={}) -> List[dict]:
+    try:
+        return wait_with_return(check_collection_shard_transfers_count_and_return, peer_api_uri, collection_name, expected_shard_transfer_count, headers=headers)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name, headers=headers)
+        raise e
+
 def wait_for_collection_shard_transfer_method(peer_api_uri: str, collection_name: str,
                                               expected_method: str):
     try:
@@ -694,6 +708,19 @@ def wait_for(condition: Callable[..., bool], *args, wait_for_timeout=WAIT_TIME_S
         else:
             time.sleep(wait_for_interval)
 
+def wait_with_return(condition: Callable[..., Tuple[bool, any]], *args, wait_for_timeout=WAIT_TIME_SEC, wait_for_interval=RETRY_INTERVAL_SEC, **kwargs):
+    start = time.time()
+    while True:
+        success, return_value = condition(*args, **kwargs)
+        if success:
+            return return_value
+
+        elapsed = time.time() - start
+        if elapsed > wait_for_timeout:
+            raise Exception(
+                f"Timeout waiting for condition {condition.__name__} to be satisfied in {wait_for_timeout} seconds")
+        else:
+            time.sleep(wait_for_interval)
 
 def peer_is_online(peer_api_uri: str, path: str = "/readyz") -> bool:
     try:


### PR DESCRIPTION
~I did these these~:
- ~Flipped the initial vs later upsert count to avoid extending test duration. Upserting more points in the 2nd upsert ensures that we catch the transfer while it's still ongoing~ 
- ~Solving [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) by returning last transfers after the wait fn~

Simplified the test so we don't need `get_collection_cluster_info` or `wait_for_collection_shard_transfers_count` which depend on transient states and lead to flaky behaviour. Original intention was to ensure that if peer is force deleted while transfers are ongoing, any ongoing transfers from/to the peer must be aborted.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
