### PR TITLE
Add RocksDB feature flag to ID trackers

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -12,6 +12,7 @@ use super::mutable_id_tracker::MutableIdTracker;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
+#[cfg(feature = "rocksdb")]
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::types::{PointIdType, SeqNumberType};
 
@@ -177,6 +178,7 @@ pub enum IdTrackerEnum {
     InMemoryIdTracker(InMemoryIdTracker),
 
     // Deprecated since Qdrant 1.14
+    #[cfg(feature = "rocksdb")]
     RocksDbIdTracker(SimpleIdTracker),
 }
 
@@ -190,6 +192,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.internal_version(internal_id)
             }
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.internal_version(internal_id),
         }
     }
@@ -209,6 +212,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.set_internal_version(internal_id, version)
             }
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
                 id_tracker.set_internal_version(internal_id, version)
             }
@@ -220,6 +224,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.internal_id(external_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.internal_id(external_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.internal_id(external_id),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.internal_id(external_id),
         }
     }
@@ -229,6 +234,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.external_id(internal_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.external_id(internal_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.external_id(internal_id),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.external_id(internal_id),
         }
     }
@@ -248,6 +254,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.set_link(external_id, internal_id)
             }
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
                 id_tracker.set_link(external_id, internal_id)
             }
@@ -259,6 +266,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.drop(external_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.drop(external_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.drop(external_id),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.drop(external_id),
         }
     }
@@ -268,6 +276,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_external(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_external(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_external(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_external(),
         }
     }
@@ -277,6 +286,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_internal(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_internal(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_internal(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_internal(),
         }
     }
@@ -289,6 +299,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_from(external_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_from(external_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_from(external_id),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_from(external_id),
         }
     }
@@ -298,6 +309,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_ids(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_ids(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_ids(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_ids(),
         }
     }
@@ -307,6 +319,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_random(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_random(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_random(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.iter_random(),
         }
     }
@@ -316,6 +329,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.mapping_flusher(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.mapping_flusher(),
         }
     }
@@ -325,6 +339,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.versions_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.versions_flusher(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.versions_flusher(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.versions_flusher(),
         }
     }
@@ -334,6 +349,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.total_point_count(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.total_point_count(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.total_point_count(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.total_point_count(),
         }
     }
@@ -343,6 +359,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deleted_point_count(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deleted_point_count(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deleted_point_count(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.deleted_point_count(),
         }
     }
@@ -352,6 +369,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
         }
     }
@@ -365,6 +383,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.is_deleted_point(internal_id)
             }
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.is_deleted_point(internal_id),
         }
     }
@@ -374,6 +393,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.name(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.name(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.name(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.name(),
         }
     }
@@ -383,6 +403,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.cleanup_versions(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.cleanup_versions(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.cleanup_versions(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.cleanup_versions(),
         }
     }
@@ -392,6 +413,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.files(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.files(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.files(),
+            #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.files(),
         }
     }

--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -4,6 +4,7 @@ pub mod immutable_id_tracker;
 pub mod in_memory_id_tracker;
 pub mod mutable_id_tracker;
 pub mod point_mappings;
+#[cfg(feature = "rocksdb")]
 pub mod simple_id_tracker;
 
 use common::types::PointOffsetType;

--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -10,7 +10,7 @@ use common::types::PointOffsetType;
 pub use id_tracker_base::*;
 use itertools::Itertools as _;
 
-use crate::types::ExtendedPointId;
+use crate::types::{ExtendedPointId, PointIdType};
 
 /// Calling [`for_each_unique_point`] will yield this struct for each unique
 /// point.
@@ -68,6 +68,15 @@ pub fn for_each_unique_point<'a>(
         }
     }
     f(best_item);
+}
+
+impl From<&ExtendedPointId> for PointIdType {
+    fn from(point_id: &ExtendedPointId) -> Self {
+        match point_id {
+            ExtendedPointId::NumId(idx) => PointIdType::NumId(*idx),
+            ExtendedPointId::Uuid(uuid) => PointIdType::Uuid(*uuid),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -27,64 +27,6 @@ enum StoredPointId {
     String(String),
 }
 
-impl From<&ExtendedPointId> for PointIdType {
-    fn from(point_id: &ExtendedPointId) -> Self {
-        match point_id {
-            ExtendedPointId::NumId(idx) => PointIdType::NumId(*idx),
-            ExtendedPointId::Uuid(uuid) => PointIdType::Uuid(*uuid),
-        }
-    }
-}
-
-impl From<&ExtendedPointId> for StoredPointId {
-    fn from(point_id: &ExtendedPointId) -> Self {
-        match point_id {
-            ExtendedPointId::NumId(idx) => StoredPointId::NumId(*idx),
-            ExtendedPointId::Uuid(uuid) => StoredPointId::Uuid(*uuid),
-        }
-    }
-}
-
-impl From<ExtendedPointId> for StoredPointId {
-    fn from(point_id: ExtendedPointId) -> Self {
-        Self::from(&point_id)
-    }
-}
-
-impl From<&StoredPointId> for ExtendedPointId {
-    fn from(point_id: &StoredPointId) -> Self {
-        match point_id {
-            StoredPointId::NumId(idx) => ExtendedPointId::NumId(*idx),
-            StoredPointId::Uuid(uuid) => ExtendedPointId::Uuid(*uuid),
-            StoredPointId::String(str) => {
-                unimplemented!("cannot convert internal string id '{str}' to external id")
-            }
-        }
-    }
-}
-
-impl From<StoredPointId> for ExtendedPointId {
-    fn from(point_id: StoredPointId) -> Self {
-        match point_id {
-            StoredPointId::NumId(idx) => ExtendedPointId::NumId(idx),
-            StoredPointId::Uuid(uuid) => ExtendedPointId::Uuid(uuid),
-            StoredPointId::String(str) => {
-                unimplemented!("cannot convert internal string id '{str}' to external id")
-            }
-        }
-    }
-}
-
-#[inline]
-fn stored_to_external_id(point_id: StoredPointId) -> PointIdType {
-    point_id.into()
-}
-
-#[inline]
-fn external_to_stored_id(point_id: &PointIdType) -> StoredPointId {
-    point_id.into()
-}
-
 #[derive(Debug)]
 pub struct SimpleIdTracker {
     internal_to_version: Vec<SeqNumberType>,
@@ -187,12 +129,12 @@ impl SimpleIdTracker {
     }
 
     fn store_key(external_id: &PointIdType) -> Vec<u8> {
-        bincode::serialize(&external_to_stored_id(external_id)).unwrap()
+        bincode::serialize(&StoredPointId::from(external_id)).unwrap()
     }
 
     fn restore_key(data: &[u8]) -> PointIdType {
         let stored_external_id: StoredPointId = bincode::deserialize(data).unwrap();
-        stored_to_external_id(stored_external_id)
+        PointIdType::from(stored_external_id)
     }
 
     fn delete_key(&self, external_id: &PointIdType) -> OperationResult<()> {
@@ -356,6 +298,45 @@ impl IdTracker for SimpleIdTracker {
 
     fn files(&self) -> Vec<PathBuf> {
         vec![]
+    }
+}
+
+impl From<&ExtendedPointId> for StoredPointId {
+    fn from(point_id: &ExtendedPointId) -> Self {
+        match point_id {
+            ExtendedPointId::NumId(idx) => StoredPointId::NumId(*idx),
+            ExtendedPointId::Uuid(uuid) => StoredPointId::Uuid(*uuid),
+        }
+    }
+}
+
+impl From<ExtendedPointId> for StoredPointId {
+    fn from(point_id: ExtendedPointId) -> Self {
+        Self::from(&point_id)
+    }
+}
+
+impl From<&StoredPointId> for ExtendedPointId {
+    fn from(point_id: &StoredPointId) -> Self {
+        match point_id {
+            StoredPointId::NumId(idx) => ExtendedPointId::NumId(*idx),
+            StoredPointId::Uuid(uuid) => ExtendedPointId::Uuid(*uuid),
+            StoredPointId::String(str) => {
+                unimplemented!("cannot convert internal string id '{str}' to external id")
+            }
+        }
+    }
+}
+
+impl From<StoredPointId> for ExtendedPointId {
+    fn from(point_id: StoredPointId) -> Self {
+        match point_id {
+            StoredPointId::NumId(idx) => ExtendedPointId::NumId(idx),
+            StoredPointId::Uuid(uuid) => ExtendedPointId::Uuid(uuid),
+            StoredPointId::String(str) => {
+                unimplemented!("cannot convert internal string id '{str}' to external id")
+            }
+        }
     }
 }
 

--- a/lib/segment/src/segment_constructor/rocksdb_builder.rs
+++ b/lib/segment/src/segment_constructor/rocksdb_builder.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use parking_lot::{RwLock, RwLockReadGuard};
+use parking_lot::RwLock;
 
 use super::segment_constructor_base::get_vector_name_with_prefix;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -61,7 +61,8 @@ impl RocksDbBuilder {
         })
     }
 
-    pub fn read(&self) -> Option<RwLockReadGuard<'_, rocksdb::DB>> {
+    #[cfg(feature = "rocksdb")]
+    pub fn read(&self) -> Option<parking_lot::RwLockReadGuard<'_, rocksdb::DB>> {
         self.rocksdb.as_ref().map(|db| db.read())
     }
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -483,6 +483,7 @@ impl SegmentBuilder {
                 IdTrackerEnum::ImmutableIdTracker(_) => {
                     unreachable!("ImmutableIdTracker should not be used for building segment")
                 }
+                #[cfg(feature = "rocksdb")]
                 IdTrackerEnum::RocksDbIdTracker(_) => id_tracker,
             };
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -532,49 +532,13 @@ fn create_segment(
 
     let appendable_flag = config.is_appendable();
 
-    let mutable_id_tracker =
+    let use_mutable_id_tracker =
         appendable_flag || !ImmutableIdTracker::mappings_file_path(segment_path).is_file();
-
-    let id_tracker = if mutable_id_tracker {
-        // Determine whether we use the new (file based) or old (RocksDB) mutable ID tracker
-        // Decide based on the feature flag and state on disk
-        let use_new_mutable_tracker = if let Some(db) = db_builder.read() {
-            // New ID tracker is enabled by default, but we still use the old tracker if we have
-            // any mappings stored in RocksDB
-            //
-            // TODO(1.15 or later): remove this check and use new mutable ID tracker unconditionally
-            if let Some(cf) = db.cf_handle(DB_MAPPING_CF) {
-                let count = db
-                    .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
-                    .map_err(|err| {
-                        OperationError::service_error(format!(
-                            "Failed to get estimated number of keys from RocksDB: {err}"
-                        ))
-                    })?
-                    .unwrap_or_default();
-
-                count == 0
-            } else {
-                true
-            }
-        } else {
-            true
-        };
-
-        if use_new_mutable_tracker {
-            sp(IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
-                segment_path,
-            )?))
-        } else {
-            sp(IdTrackerEnum::RocksDbIdTracker(create_rocksdb_id_tracker(
-                db_builder.require()?,
-            )?))
-        }
-    } else {
-        sp(IdTrackerEnum::ImmutableIdTracker(
-            create_immutable_id_tracker(segment_path)?,
-        ))
-    };
+    let id_tracker = create_segment_id_tracker(
+        use_mutable_id_tracker,
+        segment_path,
+        &mut db_builder,
+    )?;
 
     let mut vector_storages = HashMap::new();
 
@@ -733,6 +697,53 @@ fn create_segment(
         database: db_builder.build(),
         flush_thread: Mutex::new(None),
     })
+}
+
+fn create_segment_id_tracker(
+    mutable_id_tracker: bool,
+    segment_path: &Path,
+    db_builder: &mut RocksDbBuilder,
+) -> OperationResult<Arc<AtomicRefCell<IdTrackerEnum>>> {
+    if !mutable_id_tracker {
+        return Ok(sp(IdTrackerEnum::ImmutableIdTracker(
+            create_immutable_id_tracker(segment_path)?,
+        )));
+    }
+
+    // Determine whether we use the new (file based) or old (RocksDB) mutable ID tracker
+    // Decide based on the feature flag and state on disk
+    let use_rocksdb_mutable_tracker = if let Some(db) = db_builder.read() {
+        // New ID tracker is enabled by default, but we still use the old tracker if we have
+        // any mappings stored in RocksDB
+        //
+        // TODO(1.15 or later): remove this check and use new mutable ID tracker unconditionally
+        if let Some(cf) = db.cf_handle(DB_MAPPING_CF) {
+            let count = db
+                .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
+                .map_err(|err| {
+                    OperationError::service_error(format!(
+                        "Failed to get estimated number of keys from RocksDB: {err}"
+                    ))
+                })?
+                .unwrap_or_default();
+
+            count > 0
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    if use_rocksdb_mutable_tracker {
+        return Ok(sp(IdTrackerEnum::RocksDbIdTracker(
+            create_rocksdb_id_tracker(db_builder.require()?)?,
+        )));
+    }
+
+    Ok(sp(IdTrackerEnum::MutableIdTracker(
+        create_mutable_id_tracker(segment_path)?,
+    )))
 }
 
 pub fn load_segment(path: &Path, stopped: &AtomicBool) -> OperationResult<Option<Segment>> {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -10,18 +10,21 @@ use common::budget::ResourcePermit;
 use common::flags::FeatureFlags;
 use io::storage_version::StorageVersion;
 use log::info;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
+#[cfg(feature = "rocksdb")]
+use parking_lot::RwLock;
 use rand::Rng;
+#[cfg(feature = "rocksdb")]
 use rocksdb::DB;
 use serde::Deserialize;
 use uuid::Uuid;
 
 use super::rocksdb_builder::RocksDbBuilder;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
-use crate::common::rocksdb_wrapper::DB_MAPPING_CF;
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
+#[cfg(feature = "rocksdb")]
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerSS};
 use crate::index::VectorIndexEnum;
@@ -341,6 +344,7 @@ pub(crate) fn create_mutable_id_tracker(segment_path: &Path) -> OperationResult<
     MutableIdTracker::open(segment_path)
 }
 
+#[cfg(feature = "rocksdb")]
 pub(crate) fn create_rocksdb_id_tracker(
     database: Arc<RwLock<DB>>,
 ) -> OperationResult<SimpleIdTracker> {
@@ -537,6 +541,7 @@ fn create_segment(
     let id_tracker = create_segment_id_tracker(
         use_mutable_id_tracker,
         segment_path,
+        #[cfg(feature = "rocksdb")]
         &mut db_builder,
     )?;
 
@@ -702,7 +707,7 @@ fn create_segment(
 fn create_segment_id_tracker(
     mutable_id_tracker: bool,
     segment_path: &Path,
-    db_builder: &mut RocksDbBuilder,
+    #[cfg(feature = "rocksdb")] db_builder: &mut RocksDbBuilder,
 ) -> OperationResult<Arc<AtomicRefCell<IdTrackerEnum>>> {
     if !mutable_id_tracker {
         return Ok(sp(IdTrackerEnum::ImmutableIdTracker(
@@ -712,33 +717,38 @@ fn create_segment_id_tracker(
 
     // Determine whether we use the new (file based) or old (RocksDB) mutable ID tracker
     // Decide based on the feature flag and state on disk
-    let use_rocksdb_mutable_tracker = if let Some(db) = db_builder.read() {
-        // New ID tracker is enabled by default, but we still use the old tracker if we have
-        // any mappings stored in RocksDB
-        //
-        // TODO(1.15 or later): remove this check and use new mutable ID tracker unconditionally
-        if let Some(cf) = db.cf_handle(DB_MAPPING_CF) {
-            let count = db
-                .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
-                .map_err(|err| {
-                    OperationError::service_error(format!(
-                        "Failed to get estimated number of keys from RocksDB: {err}"
-                    ))
-                })?
-                .unwrap_or_default();
+    #[cfg(feature = "rocksdb")]
+    {
+        use crate::common::rocksdb_wrapper::DB_MAPPING_CF;
 
-            count > 0
+        let use_rocksdb_mutable_tracker = if let Some(db) = db_builder.read() {
+            // New ID tracker is enabled by default, but we still use the old tracker if we have
+            // any mappings stored in RocksDB
+            //
+            // TODO(1.15 or later): remove this check and use new mutable ID tracker unconditionally
+            if let Some(cf) = db.cf_handle(DB_MAPPING_CF) {
+                let count = db
+                    .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
+                    .map_err(|err| {
+                        OperationError::service_error(format!(
+                            "Failed to get estimated number of keys from RocksDB: {err}"
+                        ))
+                    })?
+                    .unwrap_or_default();
+
+                count > 0
+            } else {
+                false
+            }
         } else {
             false
-        }
-    } else {
-        false
-    };
+        };
 
-    if use_rocksdb_mutable_tracker {
-        return Ok(sp(IdTrackerEnum::RocksDbIdTracker(
-            create_rocksdb_id_tracker(db_builder.require()?)?,
-        )));
+        if use_rocksdb_mutable_tracker {
+            return Ok(sp(IdTrackerEnum::RocksDbIdTracker(
+                create_rocksdb_id_tracker(db_builder.require()?)?,
+            )));
+        }
     }
 
     Ok(sp(IdTrackerEnum::MutableIdTracker(


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6566>

Feature flag usage of RocksDB in our ID trackers.

```bash
# Build with RocksDB in ID trackers (default)
cargo build

# Build without RocksDB in ID trackers
cargo build --no-default-features --features parking_lot,web
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?