### PR TITLE
Switch to ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,4 +217,4 @@ LABEL org.opencontainers.image.documentation="https://qdrant.com/docs"
 LABEL org.opencontainers.image.source="https://github.com/qdrant/qdrant"
 LABEL org.opencontainers.image.vendor="Qdrant"
 
-CMD ["./entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
This way all the flags and arguments can be passed to entrypoint.sh#L21 just by docker run qdrant --example-flag arg
