### PR TITLE
Measure hardware in generic posting list

### DIFF
--- a/lib/posting_list/src/posting_list.rs
+++ b/lib/posting_list/src/posting_list.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use common::counter::conditioned_counter::ConditionedCounter;
 use common::types::PointOffsetType;
 use zerocopy::little_endian::U32;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -87,14 +88,14 @@ impl<H: ValueHandler> PostingList<H> {
             _phantom,
         } = self;
 
-        PostingListView {
+        PostingListView::from_components(
             id_data,
             chunks,
             var_size_data,
             remainders,
-            last_id: *last_id,
-            _phantom: PhantomData,
-        }
+            *last_id,
+            ConditionedCounter::never(),
+        )
     }
 
     pub fn visitor(&self) -> PostingVisitor<'_, H> {

--- a/lib/posting_list/src/view.rs
+++ b/lib/posting_list/src/view.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use bitpacking::BitPacker;
+use common::counter::conditioned_counter::ConditionedCounter;
 use common::types::PointOffsetType;
 use zerocopy::little_endian::U32;
 
@@ -11,13 +12,13 @@ use crate::visitor::PostingVisitor;
 use crate::{BitPackerImpl, CHUNK_LEN, IdsPostingListView, PostingChunk, PostingList, SizedValue};
 
 /// A non-owning view of [`PostingList`].
-#[derive(Debug)]
 pub struct PostingListView<'a, H: ValueHandler> {
     pub(crate) id_data: &'a [u8],
-    pub(crate) chunks: &'a [PostingChunk<H::Sized>],
+    chunks: &'a [PostingChunk<H::Sized>],
     pub(crate) var_size_data: &'a [u8],
-    pub(crate) remainders: &'a [RemainderPosting<H::Sized>],
+    remainders: &'a [RemainderPosting<H::Sized>],
     pub(crate) last_id: Option<PointOffsetType>,
+    pub(crate) hw_counter: ConditionedCounter<'a>,
     pub(crate) _phantom: PhantomData<H>,
 }
 
@@ -35,6 +36,7 @@ impl<'a> IdsPostingListView<'a> {
         chunks: &'a [PostingChunk<()>],
         remainders: &'a [RemainderPosting<()>],
         last_id: Option<PointOffsetType>,
+        hw_counter: ConditionedCounter<'a>,
     ) -> Self {
         Self {
             id_data,
@@ -42,6 +44,7 @@ impl<'a> IdsPostingListView<'a> {
             var_size_data: &[],
             remainders,
             last_id,
+            hw_counter,
             _phantom: PhantomData,
         }
     }
@@ -53,6 +56,7 @@ impl<'a, V: SizedValue> PostingListView<'a, SizedHandler<V>> {
         chunks: &'a [PostingChunk<V>],
         remainders: &'a [RemainderPosting<V>],
         last_id: Option<PointOffsetType>,
+        hw_counter: ConditionedCounter<'a>,
     ) -> Self {
         Self {
             id_data,
@@ -60,6 +64,7 @@ impl<'a, V: SizedValue> PostingListView<'a, SizedHandler<V>> {
             var_size_data: &[],
             remainders,
             last_id,
+            hw_counter,
             _phantom: PhantomData,
         }
     }
@@ -102,6 +107,7 @@ impl<'a, H: ValueHandler> PostingListView<'a, H> {
             var_size_data,
             remainders,
             last_id,
+            hw_counter: _,
             _phantom,
         } = self;
 
@@ -120,6 +126,7 @@ impl<'a, H: ValueHandler> PostingListView<'a, H> {
         var_size_data: &'a [u8],
         remainders: &'a [RemainderPosting<H::Sized>],
         last_id: Option<PointOffsetType>,
+        hw_counter: ConditionedCounter<'a>,
     ) -> Self {
         Self {
             id_data,
@@ -127,6 +134,7 @@ impl<'a, H: ValueHandler> PostingListView<'a, H> {
             var_size_data,
             remainders,
             last_id,
+            hw_counter,
             _phantom: PhantomData,
         }
     }
@@ -140,6 +148,12 @@ impl<'a, H: ValueHandler> PostingListView<'a, H> {
         let compressed_size =
             PostingChunk::get_compressed_size(self.chunks, self.id_data, chunk_index);
         let chunk_bits = compressed_size * u8::BITS as usize / CHUNK_LEN;
+
+        // Measure the compressed size
+        self.hw_counter
+            .payload_index_io_read_counter()
+            .incr_delta(compressed_size);
+
         BitPackerImpl::new().decompress_sorted(
             chunk.initial_id.get(),
             &self.id_data
@@ -148,12 +162,37 @@ impl<'a, H: ValueHandler> PostingListView<'a, H> {
             chunk_bits as u8,
         );
     }
-    pub(crate) fn sized_values_unchecked(&self, chunk_idx: usize) -> &[H::Sized] {
-        &self.chunks[chunk_idx].sized_values
+
+    pub(crate) fn get_chunk_unchecked(&self, chunk_idx: usize) -> &PostingChunk<H::Sized> {
+        self.hw_counter
+            .payload_index_io_read_counter()
+            .incr_delta(size_of::<PostingChunk<H::Sized>>());
+
+        &self.chunks[chunk_idx]
     }
 
-    pub(crate) fn sized_values(&self, chunk_idx: usize) -> Option<&[H::Sized; CHUNK_LEN]> {
-        self.chunks.get(chunk_idx).map(|chunk| &chunk.sized_values)
+    pub(crate) fn get_chunk(&self, chunk_idx: usize) -> Option<&PostingChunk<H::Sized>> {
+        self.chunks.get(chunk_idx).inspect(|_| {
+            self.hw_counter
+                .payload_index_io_read_counter()
+                .incr_delta(size_of::<PostingChunk<H::Sized>>());
+        })
+    }
+
+    pub(crate) fn chunks_len(&self) -> usize {
+        self.chunks.len()
+    }
+
+    pub(crate) fn remainders_len(&self) -> usize {
+        self.remainders.len()
+    }
+
+    pub(crate) fn get_remainder(&self, idx: usize) -> Option<&RemainderPosting<H::Sized>> {
+        self.remainders.get(idx).inspect(|_| {
+            self.hw_counter
+                .payload_index_io_read_counter()
+                .incr_delta(size_of::<RemainderPosting<H::Sized>>());
+        })
     }
 
     pub(crate) fn is_in_range(&self, id: PointOffsetType) -> bool {
@@ -166,7 +205,7 @@ impl<'a, H: ValueHandler> PostingListView<'a, H> {
             .chunks
             .first()
             .map(|chunk| chunk.initial_id.get())
-            .or_else(|| self.remainders.first().map(|elem| elem.id.get()))
+            .or_else(|| self.get_remainder(0).map(|elem| elem.id.get()))
         else {
             return false;
         };
@@ -199,6 +238,11 @@ impl<'a, H: ValueHandler> PostingListView<'a, H> {
         // this function assumes it is within the range
         debug_assert!(id >= chunks_slice[0].initial_id.get());
         debug_assert!(self.last_id.is_some_and(|last_id| id <= last_id));
+
+        // Measure with complexity of the binary search
+        self.hw_counter
+            .payload_index_io_read_counter()
+            .incr_delta(chunks_slice.len().ilog2() as usize * size_of::<PostingChunk<H::Sized>>());
 
         match chunks_slice.binary_search_by(|chunk| chunk.initial_id.get().cmp(&id)) {
             // id is the initial value of the chunk with index idx

--- a/lib/posting_list/src/visitor.rs
+++ b/lib/posting_list/src/visitor.rs
@@ -85,7 +85,7 @@ impl<'a, H: ValueHandler> PostingVisitor<'a, H> {
         let remainder_offset = match self.list.search_in_remainders(id) {
             Ok(found_remainder_offset) => found_remainder_offset,
             Err(closest_remainder_offset) => {
-                if closest_remainder_offset >= self.list.remainders.len() {
+                if closest_remainder_offset >= self.list.remainders_len() {
                     // There is no greater or equal id in the posting list
                     return None;
                 }
@@ -94,7 +94,7 @@ impl<'a, H: ValueHandler> PostingVisitor<'a, H> {
             }
         };
 
-        Some(remainder_offset + self.list.chunks.len() * CHUNK_LEN)
+        Some(remainder_offset + self.list.chunks_len() * CHUNK_LEN)
     }
 
     pub fn contains(&mut self, id: PointOffsetType) -> bool {
@@ -104,12 +104,12 @@ impl<'a, H: ValueHandler> PostingVisitor<'a, H> {
 
         // Find the chunk that may contain the id and check if the id is in the chunk
         let chunk_index = self.list.find_chunk(id, None);
-        if let Some(chunk_index) = chunk_index {
-            if self.list.chunks[chunk_index].initial_id == id {
+        if let Some(chunk_idx) = chunk_index {
+            if self.list.get_chunk_unchecked(chunk_idx).initial_id == id {
                 return true;
             }
 
-            self.decompressed_chunk(chunk_index)
+            self.decompressed_chunk(chunk_idx)
                 .binary_search(&id)
                 .is_ok()
         } else {
@@ -127,9 +127,9 @@ impl<'a, H: ValueHandler> PostingVisitor<'a, H> {
         }
 
         // get from chunk
-        if chunk_idx < self.list.chunks.len() {
+        if chunk_idx < self.list.chunks_len() {
             let id = self.decompressed_chunk(chunk_idx)[local_offset];
-            let chunk_sized_values = self.list.sized_values_unchecked(chunk_idx);
+            let chunk_sized_values = self.list.get_chunk_unchecked(chunk_idx).sized_values;
             let sized_value = chunk_sized_values[local_offset];
             let next_sized_value = || {
                 chunk_sized_values
@@ -138,23 +138,33 @@ impl<'a, H: ValueHandler> PostingVisitor<'a, H> {
                     // or check first of the next chunk
                     .or_else(|| {
                         self.list
-                            .sized_values(chunk_idx + 1)
-                            .map(|sized_values| sized_values[0])
+                            .get_chunk(chunk_idx + 1)
+                            .map(|chunk| chunk.sized_values[0])
                     })
                     // or, if it is the last one, check first from remainders
-                    .or_else(|| self.list.remainders.first().map(|e| e.value))
+                    .or_else(|| self.list.get_remainder(0).map(|e| e.value))
             };
 
-            let value = H::get_value(sized_value, next_sized_value, self.list.var_size_data);
+            let value = H::get_value(
+                sized_value,
+                next_sized_value,
+                self.list.var_size_data,
+                &self.list.hw_counter,
+            );
 
             return Some(PostingElement { id, value });
         }
 
         // else, get from remainder
-        self.list.remainders.get(local_offset).map(|e| {
+        self.list.get_remainder(local_offset).map(|e| {
             let id = e.id;
-            let next_sized_value = || self.list.remainders.get(local_offset + 1).map(|r| r.value);
-            let value = H::get_value(e.value, next_sized_value, self.list.var_size_data);
+            let next_sized_value = || self.list.get_remainder(local_offset + 1).map(|r| r.value);
+            let value = H::get_value(
+                e.value,
+                next_sized_value,
+                self.list.var_size_data,
+                &self.list.hw_counter,
+            );
 
             PostingElement {
                 id: id.get(),

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mmap_postings.rs
@@ -124,6 +124,7 @@ impl MmapPostings {
             chunks,
             remainder_postings,
             Some(last_doc_id),
+            hw_counter,
         ))
     }
 


### PR DESCRIPTION
Builds on top of #6565.

Adds a `ConditionedCounter` to the generic posting list view, and takes measurements whenever the `PostingListView`'s slices are read