### PR TITLE
Bump version to v1.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "api"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.14.0"
+version = "1.14.1"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.14.0"
+version = "1.14.1"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.14.0";
+pub const QDRANT_VERSION_STRING: &str = "1.14.1";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=1d286412fe47c54c1c225bdea133185c2a81fc0f
+IGNORE_UPTO=a9e83f665f3e7b77f24d8cc52220b00f715586c7
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
```
# Changelog

## Improvements

* https://github.com/qdrant/qdrant/pull/6458 - Speed up WAL-delta shard transfer significantly via batching and more careful synchronization
* https://github.com/qdrant/qdrant/pull/6462 - Improve GPU indexing speed for payload-related HNSW links, reuse GPU resources
* https://github.com/qdrant/qdrant/pull/6444, https://github.com/qdrant/qdrant/pull/6495, https://github.com/qdrant/qdrant/pull/6503, https://github.com/qdrant/qdrant/pull/6587 - Greatly improve payload index load time by replacing RocksDB with mmaps as persistence layer
* https://github.com/qdrant/qdrant/pull/6446 - Make GridStore flush slightly faster, update gaps in batch
* https://github.com/qdrant/qdrant/pull/6510 - Optimize GridStore reads, tell the kernel we use random reads
* https://github.com/qdrant/qdrant/pull/6502 - Better IO/CPU resource scheduling for optimizers
* https://github.com/qdrant/qdrant/pull/6487 - Batch IO when merging segments in optimizer, improve indexing speed
* https://github.com/qdrant/qdrant/pull/6513 - Buffer IO while reading files
* https://github.com/qdrant/qdrant/pull/6501 - Speed up HNSW construction by improving heuristics computation
* https://github.com/qdrant/qdrant/pull/6504 - Improve performance of `isEmpty` and `!isNull` conditions with a specialized index
* https://github.com/qdrant/qdrant/pull/6536 - Limit S3 upload parallelism, prevent network errors on high CPU machines
* https://github.com/qdrant/qdrant/pull/6548 - Add config option to limit number of collections

## Bug fixes

* https://github.com/qdrant/qdrant/pull/6403 - Fix potential inconsistency during index creation, make it atomic
* https://github.com/qdrant/qdrant/pull/6478 - Address performance degradation for large batch queries with a lot of segments
* https://github.com/qdrant/qdrant/pull/6445 - Fix not freeing all GridStore blocks if there are many updates
* https://github.com/qdrant/qdrant/pull/6363 - Fix strict mode `unindexed_filtering_retrieve` not being enforced in `group_by` queries
* https://github.com/qdrant/qdrant/pull/6498 - Fix strict mode `search_allow_exact` preventing full-scan in segments without main HNSW graph
* https://github.com/qdrant/qdrant/pull/6505 - Abort shard transfers related to peer being force removed
* https://github.com/qdrant/qdrant/pull/6533 - Always overwrite existing payload on upsert, fix REST vs gRPC discrepancy
* https://github.com/qdrant/qdrant/pull/6549 - Correctly cancel on optimization failure, keep collection consistent on red status error
* https://github.com/qdrant/qdrant/pull/6560 - Use HTTP 400 instead of 403 for strict mode errors, prevent web-ui from constantly asking new API key
* https://github.com/qdrant/qdrant/pull/6582 - Register payload indices in consensus on snapshot recovery
```