### PR TITLE
Fix flaky test_hw_counter_for_plain_sparse_search

### DIFF
--- a/lib/sparse/src/index/tests/hw_counter_test.rs
+++ b/lib/sparse/src/index/tests/hw_counter_test.rs
@@ -24,8 +24,9 @@ fn do_search<I: InvertedIndex>(index: &I, query: RemappedSparseVector) -> HwMeas
     );
 
     let result = search_context.search(&match_all);
-
-    assert_eq!(result.len(), top);
+    // there might be less than `top` result
+    // happens if index contains less than `top` sparse vectors with indices overlapping the query indices
+    assert!(result.len() <= top);
 
     accumulator
 }
@@ -50,7 +51,9 @@ fn do_plain_search<I: InvertedIndex>(
 
     let result = search_context.plain_search(docs);
 
-    assert_eq!(result.len(), top);
+    // there might be less than `top` result
+    // happens if index contains less than `top` sparse vectors with indices overlapping the query indices
+    assert!(result.len() <= top);
 
     accumulator
 }


### PR DESCRIPTION
Tackling https://github.com/qdrant/qdrant/issues/6231

There is a common issue when testing sparse vector search with:
- randomly generated data
- randomly generated query vector

There is no guarantee that there will be at least `top` stored vectors with overlapping indices with the query.

