### PR TITLE
Enable `payload_index_skip_rocksdb` flag by default

### DIFF
--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -16,7 +16,7 @@ pub struct FeatureFlags {
     /// Whether to skip usage of RocksDB in immutable payload indices.
     ///
     /// First implemented in Qdrant 1.13.5.
-    // TODO(1.15): enable by default
+    /// Enabled by default in Qdrant 1.14.1
     pub payload_index_skip_rocksdb: bool,
 
     /// Whether to use incremental HNSW building.
@@ -30,7 +30,7 @@ impl Default for FeatureFlags {
     fn default() -> FeatureFlags {
         FeatureFlags {
             all: false,
-            payload_index_skip_rocksdb: false,
+            payload_index_skip_rocksdb: true,
             incremental_hnsw_building: true,
             hnsw_healing: false,
         }


### PR DESCRIPTION
Enable `payload_index_skip_rocksdb` feature flag by default.

I'd like to include this in the 1.14 release.

Motivation:
- faster index loading on start:
  - https://github.com/qdrant/qdrant/pull/6444
  - https://github.com/qdrant/qdrant/pull/6495
  - https://github.com/qdrant/qdrant/pull/6503)
- we're satisfied with the results in our CI benchmarks
- backwards compatible, older versions will just load it as mmap index

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?