### PR TITLE
Invert feature_flags.hnsw_healing

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1437,7 +1437,7 @@ impl<'a> OldIndexCandidate<'a> {
 
         if old_id_tracker.deleted_point_count() != 0 {
             // Old index has deleted points.
-            if feature_flags.hnsw_healing {
+            if !feature_flags.hnsw_healing {
                 return None;
             }
         }
@@ -1485,7 +1485,7 @@ impl<'a> OldIndexCandidate<'a> {
                 (None, Some(_)) => {
                     // Vector was in the old index, but not in the new one.
                     missing_points += 1;
-                    if feature_flags.hnsw_healing {
+                    if !feature_flags.hnsw_healing {
                         return None;
                     }
                 }
@@ -1498,7 +1498,7 @@ impl<'a> OldIndexCandidate<'a> {
                     } else {
                         // Vector is changed.
                         missing_points += 1;
-                        if feature_flags.hnsw_healing {
+                        if !feature_flags.hnsw_healing {
                             return None;
                         }
                     }
@@ -1513,7 +1513,7 @@ impl<'a> OldIndexCandidate<'a> {
             let old_offset = old_offset as PointOffsetType;
             if old_id_tracker.is_deleted_point(old_offset) && old_graph_has_point(old_offset) {
                 missing_points += 1;
-                if feature_flags.hnsw_healing {
+                if !feature_flags.hnsw_healing {
                     return None;
                 }
             }


### PR DESCRIPTION
The PR #6543 (commit https://github.com/qdrant/qdrant/pull/6543/commits/1481fd086ec1e3a128d0f4a61446212fd587e806) introduced a blunder typo: the healing is *enabled* by default, and `QDRANT__FEATURE_FLAGS__HNSW_HEALING=true` *disables* it. The expected behavior is other way around.

This PR fixes it.

