### PR TITLE
Mutable ID tracker: only persist mappings or versions if changed

### DIFF
--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -198,7 +198,7 @@ impl IdTracker for MutableIdTracker {
         }
 
         // Set version and persist if changed
-        let changed = self.internal_to_version[internal_id as usize] != version;
+        let changed = self.internal_to_version[internal_id as usize] != version || version == 0;
         if changed {
             self.internal_to_version[internal_id as usize] = version;
             self.pending_versions.lock().insert(internal_id, version);


### PR DESCRIPTION
A simple optimization idea for the mutable ID tracker. Only persist point mappings and versions if they change.

This way we can potentially skip a flush - skipping file/IO operations - if mappings or versions don't change.

I did not benchmark this change, nor am I sure on how likely this is to happen in practice. It may not be beneficial at all.

Any thoughts on a change like this? Please feel free to discuss below.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?