### PR TITLE
Migrate away from RocksDB based dense vector storage

### DIFF
--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -28,6 +28,10 @@ pub struct FeatureFlags {
     /// Whether to actively migrate RocksDB based ID trackers into a new format.
     // TODO(1.15): enable by default
     pub migrate_rocksdb_id_tracker: bool,
+
+    /// Whether to actively migrate RocksDB based dense vector storage into a new format.
+    // TODO(1.15): enable by default
+    pub migrate_rocksdb_dense_vector_storage: bool,
 }
 
 impl Default for FeatureFlags {
@@ -38,6 +42,7 @@ impl Default for FeatureFlags {
             incremental_hnsw_building: true,
             hnsw_healing: false,
             migrate_rocksdb_id_tracker: false,
+            migrate_rocksdb_dense_vector_storage: false,
         }
     }
 }
@@ -58,6 +63,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         incremental_hnsw_building,
         hnsw_healing,
         migrate_rocksdb_id_tracker,
+        migrate_rocksdb_dense_vector_storage,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags
@@ -66,6 +72,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         *incremental_hnsw_building = true;
         *hnsw_healing = true;
         *migrate_rocksdb_id_tracker = true;
+        *migrate_rocksdb_dense_vector_storage = true;
     }
 
     let res = FEATURE_FLAGS.set(flags);

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -29,9 +29,9 @@ pub struct FeatureFlags {
     // TODO(1.15): enable by default
     pub migrate_rocksdb_id_tracker: bool,
 
-    /// Whether to actively migrate RocksDB based dense vector storage into a new format.
+    /// Whether to actively migrate RocksDB based vector storages into a new format.
     // TODO(1.15): enable by default
-    pub migrate_rocksdb_dense_vector_storage: bool,
+    pub migrate_rocksdb_vector_storage: bool,
 }
 
 impl Default for FeatureFlags {
@@ -42,7 +42,7 @@ impl Default for FeatureFlags {
             incremental_hnsw_building: true,
             hnsw_healing: false,
             migrate_rocksdb_id_tracker: false,
-            migrate_rocksdb_dense_vector_storage: false,
+            migrate_rocksdb_vector_storage: false,
         }
     }
 }
@@ -63,7 +63,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         incremental_hnsw_building,
         hnsw_healing,
         migrate_rocksdb_id_tracker,
-        migrate_rocksdb_dense_vector_storage,
+        migrate_rocksdb_vector_storage: migrate_rocksdb_dense_vector_storage,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -63,7 +63,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         incremental_hnsw_building,
         hnsw_healing,
         migrate_rocksdb_id_tracker,
-        migrate_rocksdb_vector_storage: migrate_rocksdb_dense_vector_storage,
+        migrate_rocksdb_vector_storage,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags
@@ -72,7 +72,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         *incremental_hnsw_building = true;
         *hnsw_healing = true;
         *migrate_rocksdb_id_tracker = true;
-        *migrate_rocksdb_dense_vector_storage = true;
+        *migrate_rocksdb_vector_storage = true;
     }
 
     let res = FEATURE_FLAGS.set(flags);

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -13,7 +13,7 @@ use segment::data_types::vectors::{DenseVector, VectorInternal, VectorRef};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
-use segment::types::Distance;
+use segment::types::{Distance, VectorStorageDatatype};
 use segment::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use segment::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
 use tempfile::Builder;
@@ -35,9 +35,15 @@ fn init_vector_storage(
 ) -> (VectorStorageEnum, Arc<AtomicRefCell<IdTrackerSS>>) {
     let db = open_db(path, &[DB_VECTOR_CF]).unwrap();
     let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(num)));
-    let mut storage =
-        open_simple_dense_vector_storage(db, DB_VECTOR_CF, dim, dist, &AtomicBool::new(false))
-            .unwrap();
+    let mut storage = open_simple_dense_vector_storage(
+        VectorStorageDatatype::Float32,
+        db,
+        DB_VECTOR_CF,
+        dim,
+        dist,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -368,7 +368,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
-    use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
+    use crate::common::rocksdb_wrapper::open_db;
     use crate::segment_constructor::migrate_rocksdb_id_tracker_to_mutable;
 
     const RAND_SEED: u64 = 42;
@@ -411,7 +411,7 @@ mod tests {
     #[test]
     fn test_iterator() {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
-        let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+        let db = open_db(dir.path(), &[DB_MAPPING_CF, DB_VERSIONS_CF]).unwrap();
 
         let mut id_tracker = SimpleIdTracker::open(db).unwrap();
 
@@ -438,7 +438,7 @@ mod tests {
     #[test]
     fn test_mixed_types_iterator() {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
-        let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+        let db = open_db(dir.path(), &[DB_MAPPING_CF, DB_VERSIONS_CF]).unwrap();
 
         let mut id_tracker = SimpleIdTracker::open(db).unwrap();
 
@@ -477,7 +477,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(RAND_SEED);
 
         let db_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
-        let db = open_db(db_dir.path(), &[DB_VECTOR_CF]).unwrap();
+        let db = open_db(db_dir.path(), &[DB_MAPPING_CF, DB_VERSIONS_CF]).unwrap();
 
         // Create RocksDB ID tracker and insert test points
         let mut id_tracker = SimpleIdTracker::open(db).unwrap();

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -22,8 +22,8 @@ use crate::types::{
     ProductQuantizationConfig, QuantizationConfig, ScalarQuantization, ScalarQuantizationConfig,
 };
 use crate::vector_storage::dense::simple_dense_vector_storage::{
-    open_simple_dense_byte_vector_storage, open_simple_dense_half_vector_storage,
-    open_simple_dense_vector_storage,
+    open_simple_dense_byte_vector_storage, open_simple_dense_full_vector_storage,
+    open_simple_dense_half_vector_storage,
 };
 use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::{
     open_simple_multi_dense_vector_storage, open_simple_multi_dense_vector_storage_byte,
@@ -349,7 +349,8 @@ fn create_vector_storage_f32(
 ) -> VectorStorageEnum {
     let mut rnd = StdRng::seed_from_u64(42);
     let mut vector_storage =
-        open_simple_dense_vector_storage(db, DB_VECTOR_CF, dim, distance, &false.into()).unwrap();
+        open_simple_dense_full_vector_storage(db, DB_VECTOR_CF, dim, distance, &false.into())
+            .unwrap();
     for i in 0..num_vectors {
         let vec = random_vector(&mut rnd, dim);
         let vec = match distance {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -160,7 +160,7 @@ pub(crate) fn open_vector_storage(
                 )?;
 
                 // Actively migrate away from RocksDB
-                if feature_flags().migrate_rocksdb_dense_vector_storage {
+                if feature_flags().migrate_rocksdb_vector_storage {
                     return migrate_rocksdb_dense_vector_storage_to_mmap(
                         storage,
                         vector_config.size,

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1034,11 +1034,16 @@ pub fn migrate_rocksdb_dense_vector_storage_to_mmap(
             "new dense vector storage must be empty",
         );
 
-        // Copy all vectors into new storage
+        // Copy all vectors and deletes into new storage
         let hw_counter = HardwareCounterCell::disposable();
         for internal_id in 0..old_storage.total_vector_count() as PointOffsetType {
             let vector = old_storage.get_vector_sequential(internal_id);
             new_storage.insert_vector(internal_id, vector.as_vec_ref(), &hw_counter)?;
+
+            let is_deleted = old_storage.is_deleted_vector(internal_id);
+            if is_deleted {
+                new_storage.delete_vector(internal_id)?;
+            }
         }
 
         // Flush new storage

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -47,8 +47,7 @@ use crate::types::{
     VectorStorageType,
 };
 use crate::vector_storage::dense::appendable_dense_vector_storage::{
-    open_appendable_in_ram_vector_storage, open_appendable_in_ram_vector_storage_byte,
-    open_appendable_in_ram_vector_storage_half, open_appendable_memmap_vector_storage,
+    open_appendable_in_ram_vector_storage, open_appendable_memmap_vector_storage,
     open_appendable_memmap_vector_storage_byte, open_appendable_memmap_vector_storage_half,
 };
 use crate::vector_storage::dense::memmap_dense_vector_storage::{
@@ -299,23 +298,12 @@ pub(crate) fn open_vector_storage(
                     }
                 }
             } else {
-                match storage_element_type {
-                    VectorStorageDatatype::Float32 => open_appendable_in_ram_vector_storage(
-                        vector_storage_path,
-                        vector_config.size,
-                        vector_config.distance,
-                    ),
-                    VectorStorageDatatype::Uint8 => open_appendable_in_ram_vector_storage_byte(
-                        vector_storage_path,
-                        vector_config.size,
-                        vector_config.distance,
-                    ),
-                    VectorStorageDatatype::Float16 => open_appendable_in_ram_vector_storage_half(
-                        vector_storage_path,
-                        vector_config.size,
-                        vector_config.distance,
-                    ),
-                }
+                open_appendable_in_ram_vector_storage(
+                    storage_element_type,
+                    vector_storage_path,
+                    vector_config.size,
+                    vector_config.distance,
+                )
             }
         }
     }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -56,10 +56,7 @@ use crate::vector_storage::dense::memmap_dense_vector_storage::{
     open_memmap_vector_storage, open_memmap_vector_storage_byte, open_memmap_vector_storage_half,
 };
 #[cfg(feature = "rocksdb")]
-use crate::vector_storage::dense::simple_dense_vector_storage::{
-    open_simple_dense_byte_vector_storage, open_simple_dense_half_vector_storage,
-    open_simple_dense_vector_storage,
-};
+use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     open_appendable_in_ram_multi_vector_storage, open_appendable_in_ram_multi_vector_storage_byte,
     open_appendable_in_ram_multi_vector_storage_half, open_appendable_memmap_multi_vector_storage,
@@ -153,29 +150,14 @@ pub(crate) fn open_vector_storage(
                     ),
                 }
             } else {
-                let storage = match storage_element_type {
-                    VectorStorageDatatype::Float32 => open_simple_dense_vector_storage(
-                        db_builder.require()?,
-                        &db_column_name,
-                        vector_config.size,
-                        vector_config.distance,
-                        stopped,
-                    )?,
-                    VectorStorageDatatype::Uint8 => open_simple_dense_byte_vector_storage(
-                        db_builder.require()?,
-                        &db_column_name,
-                        vector_config.size,
-                        vector_config.distance,
-                        stopped,
-                    )?,
-                    VectorStorageDatatype::Float16 => open_simple_dense_half_vector_storage(
-                        db_builder.require()?,
-                        &db_column_name,
-                        vector_config.size,
-                        vector_config.distance,
-                        stopped,
-                    )?,
-                };
+                let storage = open_simple_dense_vector_storage(
+                    storage_element_type,
+                    db_builder.require()?,
+                    &db_column_name,
+                    vector_config.size,
+                    vector_config.distance,
+                    stopped,
+                )?;
 
                 // Actively migrate away from RocksDB
                 if feature_flags().migrate_rocksdb_dense_vector_storage {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -960,7 +960,10 @@ pub fn migrate_rocksdb_id_tracker_to_mutable(
     old_id_tracker: SimpleIdTracker,
     segment_path: &Path,
 ) -> OperationResult<MutableIdTracker> {
-    log::info!("Migrating ID tracker from RocksDB into new format");
+    log::info!(
+        "Migrating {} points in ID tracker from RocksDB into new format",
+        old_id_tracker.total_point_count(),
+    );
 
     fn migrate(
         old_id_tracker: &SimpleIdTracker,
@@ -1026,7 +1029,10 @@ pub fn migrate_rocksdb_dense_vector_storage_to_mmap(
 ) -> OperationResult<VectorStorageEnum> {
     use crate::vector_storage::dense::appendable_dense_vector_storage::find_storage_files;
 
-    log::info!("Migrating dense vector storage from RocksDB into new format");
+    log::info!(
+        "Migrating {} points in dense vector storage from RocksDB into new format",
+        old_storage.total_vector_count(),
+    );
 
     fn migrate(
         old_storage: &VectorStorageEnum,

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -271,6 +271,25 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
 }
 
 pub fn open_appendable_in_ram_vector_storage(
+    storage_element_type: VectorStorageDatatype,
+    path: &Path,
+    dim: usize,
+    distance: Distance,
+) -> OperationResult<VectorStorageEnum> {
+    match storage_element_type {
+        VectorStorageDatatype::Float32 => {
+            open_appendable_in_ram_vector_storage_full(path, dim, distance)
+        }
+        VectorStorageDatatype::Float16 => {
+            open_appendable_in_ram_vector_storage_half(path, dim, distance)
+        }
+        VectorStorageDatatype::Uint8 => {
+            open_appendable_in_ram_vector_storage_byte(path, dim, distance)
+        }
+    }
+}
+
+fn open_appendable_in_ram_vector_storage_full(
     path: &Path,
     dim: usize,
     distance: Distance,
@@ -281,7 +300,7 @@ pub fn open_appendable_in_ram_vector_storage(
     Ok(VectorStorageEnum::DenseAppendableInRam(Box::new(storage)))
 }
 
-pub fn open_appendable_in_ram_vector_storage_byte(
+fn open_appendable_in_ram_vector_storage_byte(
     path: &Path,
     dim: usize,
     distance: Distance,
@@ -293,7 +312,7 @@ pub fn open_appendable_in_ram_vector_storage_byte(
     )))
 }
 
-pub fn open_appendable_in_ram_vector_storage_half(
+fn open_appendable_in_ram_vector_storage_half(
     path: &Path,
     dim: usize,
     distance: Distance,

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -90,6 +90,39 @@ fn open_simple_dense_vector_storage_impl<T: PrimitiveVectorElement>(
 }
 
 pub fn open_simple_dense_vector_storage(
+    storage_element_type: VectorStorageDatatype,
+    database: Arc<RwLock<DB>>,
+    database_column_name: &str,
+    dim: usize,
+    distance: Distance,
+    stopped: &AtomicBool,
+) -> OperationResult<VectorStorageEnum> {
+    match storage_element_type {
+        VectorStorageDatatype::Float32 => open_simple_dense_full_vector_storage(
+            database,
+            database_column_name,
+            dim,
+            distance,
+            stopped,
+        ),
+        VectorStorageDatatype::Float16 => open_simple_dense_half_vector_storage(
+            database,
+            database_column_name,
+            dim,
+            distance,
+            stopped,
+        ),
+        VectorStorageDatatype::Uint8 => open_simple_dense_byte_vector_storage(
+            database,
+            database_column_name,
+            dim,
+            distance,
+            stopped,
+        ),
+    }
+}
+
+pub fn open_simple_dense_full_vector_storage(
     database: Arc<RwLock<DB>>,
     database_column_name: &str,
     dim: usize,

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -187,6 +187,12 @@ impl<T: PrimitiveVectorElement> SimpleDenseVectorStorage<T> {
 
         Ok(())
     }
+
+    /// Destroy this vector storage, remove persisted data from RocksDB
+    pub fn destroy(self) -> OperationResult<()> {
+        self.db_wrapper.remove_column_family()?;
+        Ok(())
+    }
 }
 
 impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for SimpleDenseVectorStorage<T> {

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -339,3 +339,77 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         self.deleted.as_bitslice()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
+    use crate::segment_constructor::migrate_rocksdb_dense_vector_storage_to_mmap;
+
+    const RAND_SEED: u64 = 42;
+
+    /// Create RocksDB based ID tracker with mappings and various mutations.
+    /// Migrate it to the mutable ID tracker and ensure that the mappings are correct.
+    ///
+    /// Test based upton [`super::mutable_id_tracker::tests::test_store_load_mutated`]
+    #[test]
+    fn test_migrate_simple_to_mmap() {
+        const POINT_COUNT: PointOffsetType = 128;
+        const DIM: usize = 128;
+
+        let mut rng = StdRng::seed_from_u64(RAND_SEED);
+
+        let db_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let db = open_db(db_dir.path(), &[DB_VECTOR_CF]).unwrap();
+
+        // Create simple dense vector storage and insert test points
+        let mut storage = open_simple_dense_full_vector_storage(
+            db,
+            DB_VECTOR_CF,
+            DIM,
+            Distance::Dot,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
+        for internal_id in 0..POINT_COUNT {
+            let point = std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                .take(DIM)
+                .collect::<Vec<_>>();
+            storage
+                .insert_vector(
+                    internal_id as PointOffsetType,
+                    VectorRef::from(point.as_slice()),
+                    &HardwareCounterCell::disposable(),
+                )
+                .unwrap();
+        }
+
+        let total_vector_count = storage.total_vector_count();
+
+        // Migrate from RocksDB to mutable ID tracker
+        let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let new_storage =
+            migrate_rocksdb_dense_vector_storage_to_mmap(storage, DIM, storage_dir.path())
+                .expect("failed to migrate from RocksDB to mmap");
+
+        // We can drop RocksDB storage now
+        db_dir.close().expect("failed to drop RocksDB storage");
+
+        // Assert vector counts and data
+        let mut rng = StdRng::seed_from_u64(RAND_SEED);
+        assert_eq!(new_storage.total_vector_count(), total_vector_count);
+        for internal_id in 0..POINT_COUNT {
+            let point = std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                .take(DIM)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                new_storage.get_vector_sequential(internal_id),
+                CowVector::from(point),
+            );
+        }
+    }
+}

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -14,7 +14,7 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantizationConfig};
 use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage;
 #[cfg(feature = "rocksdb")]
-use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
+use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_full_vector_storage;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer};
@@ -336,7 +336,7 @@ fn test_delete_points_in_simple_vector_storages() {
 
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let mut storage = open_simple_dense_vector_storage(
+        let mut storage = open_simple_dense_full_vector_storage(
             db,
             DB_VECTOR_CF,
             4,
@@ -349,7 +349,7 @@ fn test_delete_points_in_simple_vector_storages() {
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage = open_simple_dense_vector_storage(
+    let _storage = open_simple_dense_full_vector_storage(
         db,
         DB_VECTOR_CF,
         4,
@@ -365,7 +365,7 @@ fn test_update_from_delete_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let mut storage = open_simple_dense_vector_storage(
+        let mut storage = open_simple_dense_full_vector_storage(
             db,
             DB_VECTOR_CF,
             4,
@@ -378,7 +378,7 @@ fn test_update_from_delete_points_simple_vector_storages() {
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage = open_simple_dense_vector_storage(
+    let _storage = open_simple_dense_full_vector_storage(
         db,
         DB_VECTOR_CF,
         4,
@@ -394,7 +394,7 @@ fn test_score_points_in_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let mut storage = open_simple_dense_vector_storage(
+        let mut storage = open_simple_dense_full_vector_storage(
             db,
             DB_VECTOR_CF,
             4,
@@ -407,7 +407,7 @@ fn test_score_points_in_simple_vector_storages() {
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage = open_simple_dense_vector_storage(
+    let _storage = open_simple_dense_full_vector_storage(
         db,
         DB_VECTOR_CF,
         4,
@@ -423,7 +423,7 @@ fn test_score_quantized_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let mut storage = open_simple_dense_vector_storage(
+        let mut storage = open_simple_dense_full_vector_storage(
             db,
             DB_VECTOR_CF,
             4,
@@ -436,7 +436,7 @@ fn test_score_quantized_points_simple_vector_storages() {
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage = open_simple_dense_vector_storage(
+    let _storage = open_simple_dense_full_vector_storage(
         db,
         DB_VECTOR_CF,
         4,


### PR DESCRIPTION
Similar to <https://github.com/qdrant/qdrant/pull/6579> with the same motivation, but for dense vector storage.

Actively migrate away from dense vector storage that still use RocksDB. On segment load, it is replaced with our appendable in-ram dense vector storage that is backed by mmaps.

The migration is behind a runtime feature flag (`migrate_rocksdb_vector_storage`). We'll likely enable it by default in one of the upcoming releases.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?