### PR TITLE
[phrase match] `ParsedQuery` as enum

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use posting_list::{IdsPostingList, IdsPostingListView, PostingBuilder};
+use posting_list::{IdsPostingList, IdsPostingListView, PostingBuilder, PostingList};
 
 use super::inverted_index::InvertedIndex;
 use super::mmap_inverted_index::MmapInvertedIndex;
@@ -18,6 +18,65 @@ pub struct ImmutableInvertedIndex {
     pub(in crate::index::field_index::full_text_index) vocab: HashMap<String, TokenId>,
     pub(in crate::index::field_index::full_text_index) point_to_tokens_count: Vec<Option<usize>>,
     pub(in crate::index::field_index::full_text_index) points_count: usize,
+}
+
+impl ImmutableInvertedIndex {
+    fn intersection_filter(
+        &self,
+        tokens: Vec<TokenId>,
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+        // in case of immutable index, deleted documents are still in the postings
+        let filter =
+            move |idx| matches!(self.point_to_tokens_count.get(idx as usize), Some(Some(_)));
+
+        fn intersection<'a>(
+            postings: &'a [PostingList<()>],
+            tokens: Vec<TokenId>,
+            filter: impl Fn(PointOffsetType) -> bool + 'a,
+        ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+            let postings_opt: Option<Vec<_>> = tokens
+                .iter()
+                .map(|&token_id| postings.get(token_id as usize))
+                .collect();
+
+            let postings = match postings_opt {
+                // All tokens must have postings and query must not be empty
+                Some(postings) if !postings.is_empty() => postings,
+                _ => return Box::new(std::iter::empty()),
+            };
+
+            let posting_readers: Vec<_> = postings.iter().map(|posting| posting.view()).collect();
+
+            intersect_compressed_postings_iterator(posting_readers, filter)
+        }
+
+        intersection(&self.postings,  tokens, filter)
+    }
+
+    fn check_intersection_match(&self, tokens: &[TokenId], point_id: PointOffsetType) -> bool {
+        if tokens.is_empty() {
+            return false;
+        }
+
+        // check presence of the document
+        if self.values_is_empty(point_id) {
+            return false;
+        }
+
+        fn check_intersection(
+            postings: &[PostingList<()>],
+            tokens: &[TokenId],
+            point_id: PointOffsetType,
+        ) -> bool {
+            // Check that all tokens are in document
+            tokens.iter().all(|token_id| {
+                let posting_list = &postings[*token_id as usize];
+                posting_list.visitor().contains(point_id)
+            })
+        }
+
+        check_intersection(&self.postings, tokens, point_id)
+    }
 }
 
 impl InvertedIndex for ImmutableInvertedIndex {
@@ -61,30 +120,9 @@ impl InvertedIndex for ImmutableInvertedIndex {
         query: ParsedQuery,
         _hw_counter: &'a HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
-        let postings_opt: Option<Vec<_>> = query
-            .tokens
-            .iter()
-            .map(|&token_id| self.postings.get(token_id as usize))
-            .collect();
-
-        let postings = match postings_opt {
-            // All tokens must have postings and query must not be empty
-            Some(postings) if !postings.is_empty() => postings,
-            _ => return Box::new(std::iter::empty()),
-        };
-
-        let posting_readers: Vec<_> = postings
-            .iter()
-            // We can safely pass hw_counter here because it's not measured.
-            // Due to lifetime issues, we can't return a disposable counter.
-            .map(|posting| posting.view())
-            .collect();
-
-        // in case of immutable index, deleted documents are still in the postings
-        let filter =
-            move |idx| matches!(self.point_to_tokens_count.get(idx as usize), Some(Some(_)));
-
-        intersect_compressed_postings_iterator(posting_readers, filter)
+        match query {
+            ParsedQuery::Tokens(tokens) => self.intersection_filter(tokens),
+        }
     }
 
     fn get_posting_len(&self, token_id: TokenId, _: &HardwareCounterCell) -> Option<usize> {
@@ -103,22 +141,11 @@ impl InvertedIndex for ImmutableInvertedIndex {
         &self,
         parsed_query: &ParsedQuery,
         point_id: PointOffsetType,
-        _: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> bool {
-        if parsed_query.tokens.is_empty() {
-            return false;
+        match parsed_query {
+            ParsedQuery::Tokens(tokens) => self.check_intersection_match(tokens, point_id),
         }
-
-        // check presence of the document
-        if self.values_is_empty(point_id) {
-            return false;
-        }
-
-        // Check that all tokens are in document
-        parsed_query.tokens.iter().all(|token_id| {
-            let posting_list = &self.postings[*token_id as usize];
-            posting_list.visitor().contains(point_id)
-        })
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -78,11 +78,11 @@ pub enum ParsedQuery {
     ///
     /// In other words this should be a subset of the document's token set.
     Tokens(TokenSet),
-    // Phrase(Vec<TokenId>),
+    // Phrase(Document),
 }
 
 impl ParsedQuery {
-    pub fn check_match(&self, document: &TokenSet) -> bool {
+    pub fn check_match(&self, tokenset: &TokenSet) -> bool {
         match self {
             ParsedQuery::Tokens(query_tokens) => {
                 if query_tokens.is_empty() {
@@ -90,7 +90,7 @@ impl ParsedQuery {
                 }
 
                 // Check that all tokens are in document
-                document.has_subset(query_tokens)
+                tokenset.has_subset(query_tokens)
             }
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -16,7 +16,9 @@ use super::inverted_index::{InvertedIndex, ParsedQuery};
 use super::postings_iterator::intersect_compressed_postings_iterator;
 use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::field_index::full_text_index::immutable_inverted_index::ImmutableInvertedIndex;
+use crate::index::field_index::full_text_index::immutable_inverted_index::{
+    ImmutableInvertedIndex,
+};
 use crate::index::field_index::full_text_index::inverted_index::TokenId;
 
 mod mmap_postings;
@@ -145,6 +147,76 @@ impl MmapInvertedIndex {
         !is_deleted
     }
 
+    pub fn intersection_filter<'a>(
+        &'a self,
+        tokens: Vec<TokenId>,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+        // in case of mmap immutable index, deleted points are still in the postings
+        let filter = move |idx| self.is_active(idx);
+
+        fn intersection<'a>(
+            postings: &'a MmapPostings,
+            tokens: Vec<TokenId>,
+            filter: impl Fn(u32) -> bool + 'a,
+            hw_counter: &'a HardwareCounterCell,
+        ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+            let postings_opt: Option<Vec<_>> = tokens
+                .iter()
+                .map(|&token_id| postings.get(token_id, hw_counter))
+                .collect();
+            let Some(posting_readers) = postings_opt else {
+                // There are unseen tokens -> no matches
+                return Box::new(std::iter::empty());
+            };
+
+            if posting_readers.is_empty() {
+                // Empty request -> no matches
+                return Box::new(std::iter::empty());
+            }
+
+            intersect_compressed_postings_iterator(posting_readers, filter)
+        }
+
+        intersection(&self.postings, tokens, filter, hw_counter)
+    }
+
+    fn check_intersection_match(
+        &self,
+        tokens: &[TokenId],
+        point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> bool {
+        // check non-empty query
+        if tokens.is_empty() {
+            return false;
+        }
+
+        // check presence of the document
+        if self.values_is_empty(point_id) {
+            return false;
+        }
+
+        fn check_intersection(
+            postings: &MmapPostings,
+            tokens: &[TokenId],
+            point_id: PointOffsetType,
+            hw_counter: &HardwareCounterCell,
+        ) -> bool {
+            // Check that all tokens are in document
+            tokens.iter().all(|query_token| {
+                postings
+                    .get(*query_token, hw_counter)
+                    // unwrap safety: all tokens exist in the vocabulary, otherwise there'd be no query tokens
+                    .unwrap()
+                    .visitor()
+                    .contains(point_id)
+            })
+        }
+
+        check_intersection(&self.postings, tokens, point_id, hw_counter)
+    }
+
     pub fn files(&self) -> Vec<PathBuf> {
         vec![
             self.path.join(POSTINGS_FILE),
@@ -231,25 +303,9 @@ impl InvertedIndex for MmapInvertedIndex {
         query: ParsedQuery,
         hw_counter: &'a HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
-        let postings_opt: Option<Vec<_>> = query
-            .tokens
-            .iter()
-            .map(|&token_id| self.postings.get(token_id, hw_counter))
-            .collect();
-        let Some(posting_readers) = postings_opt else {
-            // There are unseen tokens -> no matches
-            return Box::new(std::iter::empty());
-        };
-
-        if posting_readers.is_empty() {
-            // Empty request -> no matches
-            return Box::new(std::iter::empty());
+        match query {
+            ParsedQuery::Tokens(tokens) => self.intersection_filter(tokens, hw_counter),
         }
-
-        // in case of mmap immutable index, deleted points are still in the postings
-        let filter = move |idx| self.is_active(idx);
-
-        intersect_compressed_postings_iterator(posting_readers, filter)
     }
 
     fn get_posting_len(
@@ -276,24 +332,11 @@ impl InvertedIndex for MmapInvertedIndex {
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> bool {
-        // check non-empty query
-        if parsed_query.tokens.is_empty() {
-            return false;
+        match parsed_query {
+            ParsedQuery::Tokens(tokens) => {
+                self.check_intersection_match(tokens, point_id, hw_counter)
+            }
         }
-
-        // check presence of the document
-        if self.values_is_empty(point_id) {
-            return false;
-        }
-        // Check that all tokens are in document
-        parsed_query.tokens.iter().all(|query_token| {
-            self.postings
-                .get(*query_token, hw_counter)
-                // unwrap safety: all tokens exist in the vocabulary, otherwise there'd be no query tokens
-                .unwrap()
-                .visitor()
-                .contains(point_id)
-        })
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -164,6 +164,7 @@ impl MmapInvertedIndex {
                 .iter()
                 .map(|&token_id| postings.get(token_id, hw_counter))
                 .collect();
+
             let Some(posting_readers) = postings_opt else {
                 // There are unseen tokens -> no matches
                 return Box::new(std::iter::empty());

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -71,11 +71,12 @@ impl MutableInvertedIndex {
         self.point_to_tokens.get(idx as usize)?.as_ref()
     }
 
-    fn intersection_filter(
+    fn filter_has_subset(
         &self,
-        tokens: Vec<TokenId>,
+        tokens: TokenSet,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
         let postings_opt: Option<Vec<_>> = tokens
+            .tokens()
             .iter()
             .map(|&vocab_idx| {
                 // if a ParsedQuery token was given an index, then it must exist in the vocabulary
@@ -204,7 +205,7 @@ impl InvertedIndex for MutableInvertedIndex {
         _hw_counter: &HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
         match query {
-            ParsedQuery::Tokens(tokens) => self.intersection_filter(tokens),
+            ParsedQuery::Tokens(tokens) => self.filter_has_subset(tokens),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index.rs
@@ -70,6 +70,30 @@ impl MutableInvertedIndex {
     fn get_tokens(&self, idx: PointOffsetType) -> Option<&TokenSet> {
         self.point_to_tokens.get(idx as usize)?.as_ref()
     }
+
+    fn intersection_filter(
+        &self,
+        tokens: Vec<TokenId>,
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+        let postings_opt: Option<Vec<_>> = tokens
+            .iter()
+            .map(|&vocab_idx| {
+                // if a ParsedQuery token was given an index, then it must exist in the vocabulary
+                // dictionary. Posting list entry can be None but it exists.
+
+                self.postings.get(vocab_idx as usize)
+            })
+            .collect();
+        let Some(postings) = postings_opt else {
+            // There are unseen tokens -> no matches
+            return Box::new(std::iter::empty());
+        };
+        if postings.is_empty() {
+            // Empty request -> no matches
+            return Box::new(std::iter::empty());
+        }
+        intersect_postings_iterator(postings)
+    }
 }
 
 impl InvertedIndex for MutableInvertedIndex {
@@ -179,25 +203,9 @@ impl InvertedIndex for MutableInvertedIndex {
         query: ParsedQuery,
         _hw_counter: &HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
-        let postings_opt: Option<Vec<_>> = query
-            .tokens
-            .iter()
-            .map(|&vocab_idx| {
-                // if a ParsedQuery token was given an index, then it must exist in the vocabulary
-                // dictionary. Posting list entry can be None but it exists.
-
-                self.postings.get(vocab_idx as usize)
-            })
-            .collect();
-        let Some(postings) = postings_opt else {
-            // There are unseen tokens -> no matches
-            return Box::new(std::iter::empty());
-        };
-        if postings.is_empty() {
-            // Empty request -> no matches
-            return Box::new(std::iter::empty());
+        match query {
+            ParsedQuery::Tokens(tokens) => self.intersection_filter(tokens),
         }
-        intersect_postings_iterator(postings)
     }
 
     fn get_posting_len(&self, token_id: TokenId, _: &HardwareCounterCell) -> Option<usize> {

--- a/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
@@ -1,5 +1,5 @@
 use common::types::PointOffsetType;
-use posting_list::{IdsPostingListView, PostingListView};
+use posting_list::{PostingListView, PostingValue};
 
 use super::posting_list::PostingList;
 
@@ -21,8 +21,8 @@ pub fn intersect_postings_iterator<'a>(
     Box::new(and_iter)
 }
 
-pub fn intersect_compressed_postings_iterator<'a>(
-    mut postings: Vec<IdsPostingListView<'a>>,
+pub fn intersect_compressed_postings_iterator<'a, V: PostingValue + 'a>(
+    mut postings: Vec<PostingListView<'a, V>>,
     filter: impl Fn(PointOffsetType) -> bool + 'a,
 ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
     let smallest_posting_idx = postings

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -257,7 +257,7 @@ impl FullTextIndex {
             tokens.insert(self.get_token(token, hw_counter));
         });
         let tokens = tokens.into_iter().collect::<Option<Vec<_>>>()?;
-        Some(ParsedQuery { tokens })
+        Some(ParsedQuery::Tokens(tokens))
     }
 
     pub fn parse_document(&self, text: &str, hw_counter: &HardwareCounterCell) -> TokenSet {
@@ -618,7 +618,7 @@ mod tests {
             .iter()
             .map(|token| token_to_id(token.as_str()))
             .collect::<Option<Vec<_>>>()?;
-        Some(ParsedQuery { tokens })
+        Some(ParsedQuery::Tokens(tokens))
     }
 
     fn parse_query(query: &[String], index: &FullTextIndex) -> ParsedQuery {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -256,7 +256,7 @@ impl FullTextIndex {
         Tokenizer::tokenize_query(text, self.config(), |token| {
             tokens.insert(self.get_token(token, hw_counter));
         });
-        let tokens = tokens.into_iter().collect::<Option<Vec<_>>>()?;
+        let tokens = tokens.into_iter().collect::<Option<TokenSet>>()?;
         Some(ParsedQuery::Tokens(tokens))
     }
 
@@ -617,7 +617,7 @@ mod tests {
         let tokens = query
             .iter()
             .map(|token| token_to_id(token.as_str()))
-            .collect::<Option<Vec<_>>>()?;
+            .collect::<Option<TokenSet>>()?;
         Some(ParsedQuery::Tokens(tokens))
     }
 


### PR DESCRIPTION
Builds on top of #6486 

This is merely a refactoring to allow (with less changes) introducing phrase filtering as a separate way to use the full-text index.