### PR TITLE
[phrase match] Generic mmap postings

### DIFF
--- a/lib/posting_list/src/lib.rs
+++ b/lib/posting_list/src/lib.rs
@@ -37,6 +37,6 @@ pub type IdsPostingListView<'a> = PostingListView<'a, ()>;
 
 pub use builder::PostingBuilder;
 pub use posting_list::{PostingChunk, PostingElement, PostingList, RemainderPosting};
-pub use value_handler::{PostingValue, SizedHandler, UnsizedHandler};
+pub use value_handler::{PostingValue, SizedHandler, UnsizedHandler, ValueHandler};
 pub use view::{PostingListComponents, PostingListView};
 pub use visitor::PostingVisitor;

--- a/lib/posting_list/src/lib.rs
+++ b/lib/posting_list/src/lib.rs
@@ -29,6 +29,11 @@ pub trait UnsizedValue {
     fn from_bytes(data: &[u8]) -> Self;
 }
 
+/// Sized value attached to each id in the posting list.
+///
+/// Concrete values are usually just `()` or `u32`.
+pub type SizedTypeFor<V> = <<V as PostingValue>::Handler as ValueHandler>::Sized;
+
 /// Posting list of ids, where ids are compressed.
 pub type IdsPostingList = PostingList<()>;
 

--- a/lib/posting_list/src/posting_list.rs
+++ b/lib/posting_list/src/posting_list.rs
@@ -7,10 +7,10 @@ use zerocopy::little_endian::U32;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::iterator::PostingIterator;
-use crate::value_handler::{PostingValue, ValueHandler};
+use crate::value_handler::PostingValue;
 use crate::view::PostingListView;
 use crate::visitor::PostingVisitor;
-use crate::{CHUNK_LEN, PostingBuilder};
+use crate::{CHUNK_LEN, PostingBuilder, SizedTypeFor};
 
 /// Generic compressed posting list.
 ///
@@ -27,9 +27,9 @@ use crate::{CHUNK_LEN, PostingBuilder};
 #[derive(Debug, Clone)]
 pub struct PostingList<V: PostingValue> {
     pub(crate) id_data: Vec<u8>,
-    pub(crate) chunks: Vec<PostingChunk<<V::Handler as ValueHandler>::Sized>>,
-    pub(crate) remainders: Vec<RemainderPosting<<V::Handler as ValueHandler>::Sized>>,
-    pub(crate) var_size_data: <<V::Handler as ValueHandler>::VarSizeData as ToOwned>::Owned,
+    pub(crate) chunks: Vec<PostingChunk<SizedTypeFor<V>>>,
+    pub(crate) remainders: Vec<RemainderPosting<SizedTypeFor<V>>>,
+    pub(crate) var_size_data: Vec<u8>,
     pub(crate) last_id: Option<PointOffsetType>,
     pub(crate) _phantom: PhantomData<V>,
 }

--- a/lib/posting_list/src/view.rs
+++ b/lib/posting_list/src/view.rs
@@ -10,7 +10,7 @@ use crate::iterator::PostingIterator;
 use crate::posting_list::RemainderPosting;
 use crate::value_handler::{PostingValue, ValueHandler};
 use crate::visitor::PostingVisitor;
-use crate::{BitPackerImpl, CHUNK_LEN, IdsPostingListView, PostingChunk, PostingList};
+use crate::{BitPackerImpl, CHUNK_LEN, PostingChunk, PostingList};
 
 /// A non-owning view of [`PostingList`].
 pub struct PostingListView<'a, V: PostingValue> {
@@ -29,26 +29,6 @@ pub struct PostingListComponents<'a, S, D> {
     pub var_size_data: &'a D,
     pub remainders: &'a [RemainderPosting<S>],
     pub last_id: Option<U32>,
-}
-
-impl<'a> IdsPostingListView<'a> {
-    pub fn from_ids_components(
-        id_data: &'a [u8],
-        chunks: &'a [PostingChunk<()>],
-        remainders: &'a [RemainderPosting<()>],
-        last_id: Option<PointOffsetType>,
-        hw_counter: ConditionedCounter<'a>,
-    ) -> Self {
-        Self {
-            id_data,
-            chunks,
-            var_size_data: &(),
-            remainders,
-            last_id,
-            hw_counter,
-            _phantom: PhantomData,
-        }
-    }
 }
 
 impl<'a, V: PostingValue> IntoIterator for PostingListView<'a, V> {

--- a/lib/posting_list/src/view.rs
+++ b/lib/posting_list/src/view.rs
@@ -8,25 +8,25 @@ use zerocopy::little_endian::U32;
 
 use crate::iterator::PostingIterator;
 use crate::posting_list::RemainderPosting;
-use crate::value_handler::{PostingValue, ValueHandler};
+use crate::value_handler::PostingValue;
 use crate::visitor::PostingVisitor;
-use crate::{BitPackerImpl, CHUNK_LEN, PostingChunk, PostingList};
+use crate::{BitPackerImpl, CHUNK_LEN, PostingChunk, PostingList, SizedTypeFor};
 
 /// A non-owning view of [`PostingList`].
 pub struct PostingListView<'a, V: PostingValue> {
     pub(crate) id_data: &'a [u8],
-    chunks: &'a [PostingChunk<<V::Handler as ValueHandler>::Sized>],
-    pub(crate) var_size_data: &'a <V::Handler as ValueHandler>::VarSizeData,
-    remainders: &'a [RemainderPosting<<V::Handler as ValueHandler>::Sized>],
+    chunks: &'a [PostingChunk<SizedTypeFor<V>>],
+    pub(crate) var_size_data: &'a [u8],
+    remainders: &'a [RemainderPosting<SizedTypeFor<V>>],
     pub(crate) last_id: Option<PointOffsetType>,
     pub(crate) hw_counter: ConditionedCounter<'a>,
     pub(crate) _phantom: PhantomData<V>,
 }
 
-pub struct PostingListComponents<'a, S, D> {
+pub struct PostingListComponents<'a, S> {
     pub id_data: &'a [u8],
     pub chunks: &'a [PostingChunk<S>],
-    pub var_size_data: &'a D,
+    pub var_size_data: &'a [u8],
     pub remainders: &'a [RemainderPosting<S>],
     pub last_id: Option<U32>,
 }
@@ -58,12 +58,7 @@ impl<'a, V: PostingValue> PostingListView<'a, V> {
         }
     }
 
-    pub fn components(
-        &self,
-    ) -> PostingListComponents<
-        <V::Handler as ValueHandler>::Sized,
-        &<V::Handler as ValueHandler>::VarSizeData,
-    > {
+    pub fn components(&self) -> PostingListComponents<SizedTypeFor<V>> {
         let Self {
             id_data,
             chunks,
@@ -85,9 +80,9 @@ impl<'a, V: PostingValue> PostingListView<'a, V> {
 
     pub fn from_components(
         id_data: &'a [u8],
-        chunks: &'a [PostingChunk<<V::Handler as ValueHandler>::Sized>],
-        var_size_data: &'a <V::Handler as ValueHandler>::VarSizeData,
-        remainders: &'a [RemainderPosting<<V::Handler as ValueHandler>::Sized>],
+        chunks: &'a [PostingChunk<SizedTypeFor<V>>],
+        var_size_data: &'a [u8],
+        remainders: &'a [RemainderPosting<SizedTypeFor<V>>],
         last_id: Option<PointOffsetType>,
         hw_counter: ConditionedCounter<'a>,
     ) -> Self {
@@ -128,25 +123,19 @@ impl<'a, V: PostingValue> PostingListView<'a, V> {
         );
     }
 
-    pub(crate) fn get_chunk_unchecked(
-        &self,
-        chunk_idx: usize,
-    ) -> &PostingChunk<<V::Handler as ValueHandler>::Sized> {
+    pub(crate) fn get_chunk_unchecked(&self, chunk_idx: usize) -> &PostingChunk<SizedTypeFor<V>> {
         self.hw_counter
             .payload_index_io_read_counter()
-            .incr_delta(size_of::<PostingChunk<<V::Handler as ValueHandler>::Sized>>());
+            .incr_delta(size_of::<PostingChunk<SizedTypeFor<V>>>());
 
         &self.chunks[chunk_idx]
     }
 
-    pub(crate) fn get_chunk(
-        &self,
-        chunk_idx: usize,
-    ) -> Option<&PostingChunk<<V::Handler as ValueHandler>::Sized>> {
+    pub(crate) fn get_chunk(&self, chunk_idx: usize) -> Option<&PostingChunk<SizedTypeFor<V>>> {
         self.chunks.get(chunk_idx).inspect(|_| {
             self.hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(size_of::<PostingChunk<<V::Handler as ValueHandler>::Sized>>());
+                .incr_delta(size_of::<PostingChunk<SizedTypeFor<V>>>());
         })
     }
 
@@ -158,16 +147,11 @@ impl<'a, V: PostingValue> PostingListView<'a, V> {
         self.remainders.len()
     }
 
-    pub(crate) fn get_remainder(
-        &self,
-        idx: usize,
-    ) -> Option<&RemainderPosting<<V::Handler as ValueHandler>::Sized>> {
+    pub(crate) fn get_remainder(&self, idx: usize) -> Option<&RemainderPosting<SizedTypeFor<V>>> {
         self.remainders.get(idx).inspect(|_| {
             self.hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(size_of::<
-                    RemainderPosting<<V::Handler as ValueHandler>::Sized>,
-                >());
+                .incr_delta(size_of::<RemainderPosting<SizedTypeFor<V>>>());
         })
     }
 
@@ -210,8 +194,7 @@ impl<'a, V: PostingValue> PostingListView<'a, V> {
 
         // Measure with complexity of the binary search
         self.hw_counter.payload_index_io_read_counter().incr_delta(
-            chunks_slice.len().ilog2() as usize
-                * size_of::<PostingChunk<<V::Handler as ValueHandler>::Sized>>(),
+            chunks_slice.len().ilog2() as usize * size_of::<PostingChunk<SizedTypeFor<V>>>(),
         );
 
         match chunks_slice.binary_search_by(|chunk| chunk.initial_id.get().cmp(&id)) {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_inverted_index.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use posting_list::{IdsPostingList, IdsPostingListView, PostingBuilder, PostingList};
+use posting_list::{IdsPostingList, IdsPostingListView, PostingBuilder, PostingList, PostingValue};
 
 use super::inverted_index::{InvertedIndex, TokenSet};
 use super::mmap_inverted_index::MmapInvertedIndex;
@@ -29,8 +29,8 @@ impl ImmutableInvertedIndex {
         let filter =
             move |idx| matches!(self.point_to_tokens_count.get(idx as usize), Some(Some(_)));
 
-        fn intersection<'a>(
-            postings: &'a [PostingList<()>],
+        fn intersection<'a, V: PostingValue>(
+            postings: &'a [PostingList<V>],
             tokens: TokenSet,
             filter: impl Fn(PointOffsetType) -> bool + 'a,
         ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
@@ -66,8 +66,8 @@ impl ImmutableInvertedIndex {
             return false;
         }
 
-        fn check_intersection(
-            postings: &[PostingList<()>],
+        fn check_intersection<V: PostingValue>(
+            postings: &[PostingList<V>],
             tokens: &TokenSet,
             point_id: PointOffsetType,
         ) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/tests.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/tests.rs
@@ -38,7 +38,8 @@ fn test_mmap_posting_lists_compatibility() {
     let old_postings = old_mmap_postings::MmapPostings::open(postings_path.clone(), true).unwrap();
 
     // open with new impl
-    let new_postings = mmap_postings::MmapPostings::open(postings_path.clone(), true).unwrap();
+    let new_postings =
+        mmap_postings::MmapPostings::<()>::open(postings_path.clone(), true).unwrap();
 
     let hw_counter = HardwareCounterCell::disposable();
 

--- a/lib/segment/src/index/field_index/full_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mod.rs
@@ -3,6 +3,7 @@ mod inverted_index;
 mod mmap_inverted_index;
 pub mod mmap_text_index;
 mod mutable_text_index;
+mod positions;
 mod posting_list;
 mod postings_iterator;
 pub mod text_index;

--- a/lib/segment/src/index/field_index/full_text_index/positions.rs
+++ b/lib/segment/src/index/field_index/full_text_index/positions.rs
@@ -1,0 +1,29 @@
+use posting_list::{PostingValue, UnsizedHandler, UnsizedValue};
+use zerocopy::{FromBytes, IntoBytes};
+
+/// Represents a list of positions of a token in a document.
+#[derive(Clone, Debug)]
+pub(super) struct Positions(Vec<u32>);
+
+impl PostingValue for Positions {
+    type Handler = UnsizedHandler<Self>;
+}
+
+impl UnsizedValue for Positions {
+    fn write_len(&self) -> usize {
+        self.0.len() * std::mem::size_of::<u32>()
+    }
+
+    fn write_to(&self, dst: &mut [u8]) {
+        self.0
+            .as_slice()
+            .write_to(dst)
+            .expect("write_len should provide correct length");
+    }
+
+    fn from_bytes(data: &[u8]) -> Self {
+        let positions =
+            <[u32]>::ref_from_bytes(data).expect("write_len should provide correct length");
+        Positions(positions.to_vec())
+    }
+}


### PR DESCRIPTION
Builds on top of #6617

Make `MmapPostings` generic over the stored value along with the ids. 

To achieve this, it was necessary to create a trait specific to full text index (`MmapPostingValue`), so that it is still compatible with previous implementation, but can also store positions if the right type is used.