### PR TITLE
migrate_point_on_level: heal up to level_m

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1625,18 +1625,18 @@ impl OldIndex<'_> {
 
         let level_m = if level == 0 { self.m0 } else { self.m };
         let mut new_links = Vec::with_capacity(level_m);
-        let mut need_fixing = 0;
+        let mut need_fixing = false;
 
         for link in links.links(src_old, level).take(level_m) {
             if let Some(new_link) = self.old_to_new[link as usize] {
                 new_links.push(new_link);
             } else {
-                need_fixing += 1;
+                need_fixing = true;
             }
         }
 
         // The "healing" case
-        if need_fixing > 0 {
+        if need_fixing {
             // First: generate list of candidates
             let shortcuts = builder
                 .search_shortcuts_on_level(src_old, level, old_scorer, self)
@@ -1649,7 +1649,8 @@ impl OldIndex<'_> {
                 let b_old = self.new_to_old[b as usize].unwrap();
                 old_scorer.score_internal(a_old, b_old)
             };
-            container.fill_from_sorted_with_heuristic(shortcuts, need_fixing, new_scorer);
+            let links_needed = level_m - new_links.len();
+            container.fill_from_sorted_with_heuristic(shortcuts, links_needed, new_scorer);
             new_links.extend_from_slice(container.links());
         }
 


### PR DESCRIPTION
This PR changes the amount of points the healing algorithm tries to add.

Previously, when healing a graph node with $X$ alive neighbors and $Y$ deleted neighbors, the healing algorithm would add up to $Y$ new points to the node, total $X + Y$. Now, it will add up to $m_{level} - X$ new points, total $m_{level}$.

While the first approach was better on random datasets, it turned out it was worse on the laion dataset in the [`transform.py`] experiment.

Accuracy results before this change (`dev` 01e5fab9):
| dataset1 | dataset2 | change |
| -------: | -------: | -----: |
|   0.9828 |   0.9683 | -1.48% |
|   0.9668 |   0.9648 | -0.21% |
|   0.9805 |   0.9599 | -2.10% |
|   0.9517 |   0.9461 | -0.59% |
|   0.9850 |   0.9471 | -3.85% |
|   0.9854 |   0.9447 | -4.13% |
|   0.9878 |   0.9694 | -1.86% |
|   0.9762 |   0.9588 | -1.78% |
|   0.9808 |   0.9642 | -1.69% |
|   0.9867 |   0.9684 | -1.85% |
|   0.9805 |   0.9496 | -3.15% |
|   0.9664 |   0.9619 | -0.47% |


Results after this change:
| dataset1 | dataset2 | change |
| -------: | -------: | -----: |
|   0.9878 |   0.9763 | -1.16% |
|   0.9805 |   0.9797 | -0.08% |
|   0.9852 |   0.9748 | -1.06% |
|   0.9875 |   0.9839 | -0.36% |
|   0.9349 |   0.9390 | +0.44% |
|   0.9757 |   0.9745 | -0.12% |
|   0.9829 |   0.9593 | -2.40% |
|   0.9831 |   0.9482 | -3.55% |
|   0.9842 |   0.9569 | -2.77% |
|   0.9758 |   0.9753 | -0.05% |
|   0.9873 |   0.9772 | -1.02% |
|   0.9843 |   0.9635 | -2.11% |

[`transform.py`]: https://github.com/qdrant/vector-db-benchmark/blob/93bd4214761525395959c020a6924be4eaa8c5fe/ansible/playbooks/roles/run-hnsw-indexing-transform/files/transform.py