### PR TITLE
Remove option from immutable_inverted_index

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -429,15 +429,12 @@ mod tests {
             // Check same deleted points
             assert_eq!(
                 mmap.deleted_points.get(point_id).unwrap(),
-                count.is_none(),
+                *count == 0,
                 "point_id: {point_id}",
             );
 
             // Check same count
-            assert_eq!(
-                *mmap.point_to_tokens_count.get(point_id).unwrap(),
-                count.unwrap_or(0)
-            );
+            assert_eq!(*mmap.point_to_tokens_count.get(point_id).unwrap(), *count);
             assert_eq!(imm_mmap.point_to_tokens_count[point_id], *count);
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_inverted_index/mod.rs
@@ -82,14 +82,12 @@ impl MmapInvertedIndex {
         // None values are represented as deleted in the bitslice
         let deleted_bitslice: BitVec = point_to_tokens_count
             .iter()
-            .map(|count| count.is_none())
+            .map(|count| *count == 0)
             .collect();
         MmapBitSlice::create(&deleted_points_path, &deleted_bitslice)?;
 
         // The actual values go in the slice
-        let point_to_tokens_count_iter = point_to_tokens_count
-            .into_iter()
-            .map(|count| count.unwrap_or(0));
+        let point_to_tokens_count_iter = point_to_tokens_count.into_iter();
 
         MmapSlice::create(&point_to_tokens_count_path, point_to_tokens_count_iter)?;
 


### PR DESCRIPTION
Converts `Vec<Option<usize>>` to `Vec<usize>`, using `0` as replacement for `None` to make immutable_inverted_index consistent with mmap_inverted_index