### PR TITLE
Add mutable full text payload index on top of Gridstore

### DIFF
--- a/lib/gridstore/src/blob.rs
+++ b/lib/gridstore/src/blob.rs
@@ -6,6 +6,16 @@ pub trait Blob {
     fn from_bytes(bytes: &[u8]) -> Self;
 }
 
+impl Blob for Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.clone()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Self {
+        bytes.to_vec()
+    }
+}
+
 impl Blob for Vec<ecow::EcoString> {
     fn to_bytes(&self) -> Vec<u8> {
         serde_cbor::to_vec(self).expect("Failed to serialize Vec<ecow::EcoString>")

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -517,9 +517,13 @@ impl<V: Blob> Gridstore<V> {
     }
 
     /// Iterate over all the values in the storage
-    pub fn iter<F>(&self, mut callback: F, hw_counter: HwMetricRefCounter) -> std::io::Result<()>
+    pub fn iter<F, E>(
+        &self,
+        mut callback: F,
+        hw_counter: HwMetricRefCounter,
+    ) -> std::result::Result<(), E>
     where
-        F: FnMut(PointOffset, &V) -> std::io::Result<bool>,
+        F: FnMut(PointOffset, &V) -> std::result::Result<bool, E>,
     {
         for (point_offset, pointer) in
             self.tracker

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -10,7 +10,9 @@ use super::bool_index::mmap_bool_index::MmapBoolIndexBuilder;
 use super::bool_index::simple_bool_index::BoolIndexBuilder;
 use super::facet_index::FacetIndexEnum;
 use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
-use super::full_text_index::text_index::{FullTextIndex, FullTextIndexBuilder};
+use super::full_text_index::text_index::{
+    FullTextGridstoreIndexBuilder, FullTextIndex, FullTextIndexBuilder,
+};
 use super::geo_index::{GeoMapIndexBuilder, GeoMapIndexMmapBuilder};
 use super::map_index::{MapIndex, MapIndexBuilder, MapIndexGridstoreBuilder, MapIndexMmapBuilder};
 use super::numeric_index::{
@@ -525,6 +527,7 @@ pub enum FieldIndexBuilder {
     GeoMmapIndex(GeoMapIndexMmapBuilder),
     FullTextIndex(FullTextIndexBuilder),
     FullTextMmapIndex(FullTextMmapIndexBuilder),
+    FullTextGridstoreIndex(FullTextGridstoreIndexBuilder),
     BoolIndex(BoolIndexBuilder),
     BoolMmapIndex(MmapBoolIndexBuilder),
     UuidIndex(MapIndexBuilder<UuidIntType>),
@@ -559,6 +562,7 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::BoolMmapIndex(index) => index.init(),
             Self::FullTextIndex(index) => index.init(),
             Self::FullTextMmapIndex(builder) => builder.init(),
+            Self::FullTextGridstoreIndex(builder) => builder.init(),
             Self::UuidIndex(index) => index.init(),
             Self::UuidMmapIndex(index) => index.init(),
             Self::UuidGridstoreIndex(index) => index.init(),
@@ -596,6 +600,9 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FullTextMmapIndex(builder) => {
                 FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
             }
+            Self::FullTextGridstoreIndex(builder) => {
+                FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
+            }
             Self::UuidIndex(index) => index.add_point(id, payload, hw_counter),
             Self::UuidMmapIndex(index) => index.add_point(id, payload, hw_counter),
             Self::UuidGridstoreIndex(index) => index.add_point(id, payload, hw_counter),
@@ -626,6 +633,7 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::BoolMmapIndex(index) => FieldIndex::BoolIndex(index.finalize()?),
             Self::FullTextIndex(index) => FieldIndex::FullTextIndex(index.finalize()?),
             Self::FullTextMmapIndex(builder) => FieldIndex::FullTextIndex(builder.finalize()?),
+            Self::FullTextGridstoreIndex(builder) => FieldIndex::FullTextIndex(builder.finalize()?),
             Self::UuidIndex(index) => FieldIndex::UuidMapIndex(index.finalize()?),
             Self::UuidMmapIndex(index) => FieldIndex::UuidMapIndex(index.finalize()?),
             Self::UuidGridstoreIndex(index) => FieldIndex::UuidMapIndex(index.finalize()?),

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -142,7 +142,7 @@ impl ImmutableFullTextIndex {
             Storage::RocksDb(_) => Ok(()),
             Storage::Mmap(index) => index.clear_cache().map_err(|err| {
                 OperationError::service_error(format!(
-                    "Failed to clear mutable numeric index gridstore cache: {err}"
+                    "Failed to clear immutable full text index gridstore cache: {err}"
                 ))
             }),
         }

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -133,6 +133,21 @@ impl ImmutableFullTextIndex {
         }
     }
 
+    /// Clear cache
+    ///
+    /// Only clears cache of mmap storage if used. Does not clear in-memory representation of
+    /// index.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match &self.storage {
+            Storage::RocksDb(_) => Ok(()),
+            Storage::Mmap(index) => index.clear_cache().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to clear mutable numeric index gridstore cache: {err}"
+                ))
+            }),
+        }
+    }
+
     pub fn files(&self) -> Vec<PathBuf> {
         match self.storage {
             Storage::RocksDb(_) => vec![],

--- a/lib/segment/src/index/field_index/full_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mod.rs
@@ -14,5 +14,6 @@ mod tokenizers;
 mod compressed_posting;
 mod immutable_inverted_index;
 mod mutable_inverted_index;
+mod mutable_inverted_index_builder;
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index_builder.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_inverted_index_builder.rs
@@ -1,0 +1,72 @@
+use std::collections::BTreeSet;
+
+use common::types::PointOffsetType;
+
+use super::inverted_index::{InvertedIndex, TokenSet};
+use super::mutable_inverted_index::MutableInvertedIndex;
+use crate::common::operation_error::OperationResult;
+
+#[derive(Default)]
+pub struct MutableInvertedIndexBuilder {
+    index: MutableInvertedIndex,
+}
+
+impl MutableInvertedIndexBuilder {
+    /// Add a vector to the inverted index builder
+    pub fn add(
+        &mut self,
+        idx: PointOffsetType,
+        str_tokens: BTreeSet<String>,
+        // TODO(phrase-index): add param for including phrase field
+    ) {
+        self.index.points_count += 1;
+
+        if self.index.point_to_tokens.len() <= idx as usize {
+            self.index
+                .point_to_tokens
+                .resize_with(idx as usize + 1, Default::default);
+        }
+
+        let tokens = self
+            .index
+            .register_tokens(str_tokens.iter().map(String::as_str));
+        let tokens_set = TokenSet::from_iter(tokens);
+        self.index.point_to_tokens[idx as usize] = Some(tokens_set);
+    }
+
+    pub fn add_iter(
+        &mut self,
+        iter: impl Iterator<Item = OperationResult<(PointOffsetType, BTreeSet<String>)>>,
+        // TODO(phrase-index): add param for including phrase field
+    ) -> OperationResult<()> {
+        for item in iter {
+            let (idx, str_tokens) = item?;
+            self.add(idx, str_tokens);
+        }
+        Ok(())
+    }
+
+    /// Consumes the builder and returns an InvertedIndexRam
+    pub fn build(mut self) -> MutableInvertedIndex {
+        // build postings from point_to_docs
+        // build in order to increase document id
+        for (idx, doc) in self.index.point_to_tokens.iter().enumerate() {
+            if let Some(doc) = doc {
+                for token_idx in doc.tokens() {
+                    if self.index.postings.len() <= *token_idx as usize {
+                        self.index
+                            .postings
+                            .resize_with(*token_idx as usize + 1, Default::default);
+                    }
+                    self.index
+                        .postings
+                        .get_mut(*token_idx as usize)
+                        .expect("posting must exist")
+                        .insert(idx as PointOffsetType);
+                }
+            }
+        }
+
+        self.index
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -26,10 +26,10 @@ const GRIDSTORE_OPTIONS: StorageOptions = StorageOptions {
 pub struct MutableFullTextIndex {
     pub(super) inverted_index: MutableInvertedIndex,
     pub(super) config: TextIndexParams,
-    storage: Storage,
+    pub(super) storage: Storage,
 }
 
-enum Storage {
+pub(super) enum Storage {
     RocksDb(DatabaseColumnScheduledDeleteWrapper),
     Gridstore(Arc<RwLock<Gridstore<Vec<u8>>>>),
 }
@@ -135,14 +135,6 @@ impl MutableFullTextIndex {
         self.inverted_index = MutableInvertedIndex::build_index(iter)?;
 
         Ok(true)
-    }
-
-    #[cfg(test)]
-    pub(super) fn db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
-        match &self.storage {
-            Storage::RocksDb(db_wrapper) => Some(db_wrapper),
-            Storage::Gridstore(_) => None,
-        }
     }
 
     #[inline]

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -243,10 +243,6 @@ impl MutableFullTextIndex {
             Storage::RocksDb(db_wrapper) => {
                 db_wrapper.put(db_idx, db_document)?;
             }
-            // We cannot store empty value, then delete instead
-            Storage::Gridstore(store) if db_document.is_empty() => {
-                store.write().delete_value(idx);
-            }
             Storage::Gridstore(store) => {
                 let hw_counter = HardwareCounterCell::disposable();
                 store

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -118,7 +118,7 @@ impl MutableFullTextIndex {
         let mut iter: Vec<(PointOffsetType, Vec<u8>)> = vec![];
         store
             .read()
-            .iter(
+            .iter::<_, ()>(
                 |idx, value| {
                     iter.push((idx, value.clone()));
                     Ok(true)

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -142,7 +142,7 @@ impl MutableFullTextIndex {
             Storage::RocksDb(db_wrapper) => db_wrapper.recreate_column_family(),
             Storage::Gridstore(store) => store.write().clear().map_err(|err| {
                 OperationError::service_error(format!(
-                    "Failed to clear mutable numeric index: {err}",
+                    "Failed to clear mutable full text index: {err}",
                 ))
             }),
         }
@@ -154,7 +154,7 @@ impl MutableFullTextIndex {
             Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
             Storage::Gridstore(store) => store.write().clear().map_err(|err| {
                 OperationError::service_error(format!(
-                    "Failed to clear mutable numeric index: {err}",
+                    "Failed to clear mutable full text index: {err}",
                 ))
             }),
         }
@@ -169,7 +169,7 @@ impl MutableFullTextIndex {
             Storage::RocksDb(_) => Ok(()),
             Storage::Gridstore(index) => index.read().clear_cache().map_err(|err| {
                 OperationError::service_error(format!(
-                    "Failed to clear mutable numeric index gridstore cache: {err}"
+                    "Failed to clear mutable full text index gridstore cache: {err}"
                 ))
             }),
         }
@@ -192,7 +192,7 @@ impl MutableFullTextIndex {
                 Box::new(move || {
                     store.read().flush().map_err(|err| {
                         OperationError::service_error(format!(
-                            "Failed to flush mutable numeric index gridstore: {err}"
+                            "Failed to flush mutable full text index gridstore: {err}"
                         ))
                     })
                 })

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -1,39 +1,95 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use gridstore::Gridstore;
+use gridstore::config::StorageOptions;
+use parking_lot::RwLock;
 
 use super::inverted_index::{Document, InvertedIndex, TokenSet};
 use super::mutable_inverted_index::MutableInvertedIndex;
 use super::text_index::FullTextIndex;
 use super::tokenizers::Tokenizer;
-use crate::common::operation_error::OperationResult;
+use crate::common::Flusher;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::data_types::index::TextIndexParams;
 
+const GRIDSTORE_OPTIONS: StorageOptions = StorageOptions {
+    compression: Some(gridstore::config::Compression::None),
+    page_size_bytes: None,
+    block_size_bytes: None,
+    region_size_blocks: None,
+};
+
 pub struct MutableFullTextIndex {
     pub(super) inverted_index: MutableInvertedIndex,
-    pub(super) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
     pub(super) config: TextIndexParams,
+    storage: Storage,
+}
+
+enum Storage {
+    RocksDb(DatabaseColumnScheduledDeleteWrapper),
+    Gridstore(Arc<RwLock<Gridstore<Vec<u8>>>>),
 }
 
 impl MutableFullTextIndex {
-    pub fn new(db_wrapper: DatabaseColumnScheduledDeleteWrapper, config: TextIndexParams) -> Self {
+    /// Open mutable full text index from RocksDB storage
+    ///
+    /// Note: after opening, the data must be loaded into memory separately using [`load`].
+    pub fn open_rocksdb(
+        db_wrapper: DatabaseColumnScheduledDeleteWrapper,
+        config: TextIndexParams,
+    ) -> Self {
         Self {
             inverted_index: Default::default(),
-            db_wrapper,
             config,
+            storage: Storage::RocksDb(db_wrapper),
         }
     }
 
-    pub fn init(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
+    /// Open mutable full text index from Gridstore storage
+    ///
+    /// Note: after opening, the data must be loaded into memory separately using [`load`].
+    pub fn open_gridstore(path: PathBuf, config: TextIndexParams) -> OperationResult<Self> {
+        let store = Gridstore::open_or_create(path, GRIDSTORE_OPTIONS).map_err(|err| {
+            OperationError::service_error(format!(
+                "failed to open mutable full text index on gridstore: {err}"
+            ))
+        })?;
+        Ok(Self {
+            inverted_index: Default::default(),
+            config,
+            storage: Storage::Gridstore(Arc::new(RwLock::new(store))),
+        })
     }
 
-    pub fn load(&mut self) -> OperationResult<bool> {
-        if !self.db_wrapper.has_column_family()? {
+    /// Load storage
+    ///
+    /// Loads in-memory index from backing RocksDB or Gridstore storage.
+    pub(super) fn load(&mut self) -> OperationResult<bool> {
+        match self.storage {
+            Storage::RocksDb(_) => self.load_rocksdb(),
+            Storage::Gridstore(_) => self.load_gridstore(),
+        }
+    }
+
+    /// Load from RocksDB storage
+    ///
+    /// Loads in-memory index from RocksDB storage.
+    pub fn load_rocksdb(&mut self) -> OperationResult<bool> {
+        let Storage::RocksDb(db_wrapper) = &self.storage else {
+            return Err(OperationError::service_error(
+                "Failed to load index from RocksDB, using different storage backend",
+            ));
+        };
+
+        if !db_wrapper.has_column_family()? {
             return Ok(false);
         };
 
-        let db = self.db_wrapper.lock_db();
+        let db = db_wrapper.lock_db();
         let iter = db.iter()?.map(|(key, value)| {
             let idx = FullTextIndex::restore_key(&key);
             let str_tokens = FullTextIndex::deserialize_document(&value)?;
@@ -43,6 +99,114 @@ impl MutableFullTextIndex {
         self.inverted_index = MutableInvertedIndex::build_index(iter)?;
 
         Ok(true)
+    }
+
+    /// Load from Gridstore storage
+    ///
+    /// Loads in-memory index from Gridstore storage.
+    fn load_gridstore(&mut self) -> OperationResult<bool> {
+        let Storage::Gridstore(store) = &self.storage else {
+            return Err(OperationError::service_error(
+                "Failed to load index from Gridstore, using different storage backend",
+            ));
+        };
+
+        let hw_counter = HardwareCounterCell::disposable();
+        let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
+
+        // TODO: remove intermediate buffer and iterator!
+        let mut iter: Vec<(PointOffsetType, Vec<u8>)> = vec![];
+        store
+            .read()
+            .iter(
+                |idx, value| {
+                    iter.push((idx, value.clone()));
+                    Ok(true)
+                },
+                hw_counter_ref,
+            )
+            // unwrap safety: never returns an error
+            .unwrap();
+        let iter = iter.into_iter().map(|(idx, value)| {
+            let tokens = FullTextIndex::deserialize_document(&value)?;
+            Ok((idx, tokens))
+        });
+
+        self.inverted_index = MutableInvertedIndex::build_index(iter)?;
+
+        Ok(true)
+    }
+
+    #[cfg(test)]
+    pub(super) fn db_wrapper(&self) -> Option<&DatabaseColumnScheduledDeleteWrapper> {
+        match &self.storage {
+            Storage::RocksDb(db_wrapper) => Some(db_wrapper),
+            Storage::Gridstore(_) => None,
+        }
+    }
+
+    #[inline]
+    pub(super) fn init(&self) -> OperationResult<()> {
+        match &self.storage {
+            Storage::RocksDb(db_wrapper) => db_wrapper.recreate_column_family(),
+            Storage::Gridstore(store) => store.write().clear().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to clear mutable numeric index: {err}",
+                ))
+            }),
+        }
+    }
+
+    #[inline]
+    pub(super) fn clear(self) -> OperationResult<()> {
+        match self.storage {
+            Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
+            Storage::Gridstore(store) => store.write().clear().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to clear mutable numeric index: {err}",
+                ))
+            }),
+        }
+    }
+
+    /// Clear cache
+    ///
+    /// Only clears cache of Gridstore storage if used. Does not clear in-memory representation of
+    /// index.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match &self.storage {
+            Storage::RocksDb(_) => Ok(()),
+            Storage::Gridstore(index) => index.read().clear_cache().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to clear mutable numeric index gridstore cache: {err}"
+                ))
+            }),
+        }
+    }
+
+    #[inline]
+    pub(super) fn files(&self) -> Vec<PathBuf> {
+        match &self.storage {
+            Storage::RocksDb(_) => vec![],
+            Storage::Gridstore(store) => store.read().files(),
+        }
+    }
+
+    #[inline]
+    pub(super) fn flusher(&self) -> Flusher {
+        match &self.storage {
+            Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
+            Storage::Gridstore(store) => {
+                let store = store.clone();
+                Box::new(move || {
+                    store.read().flush().map_err(|err| {
+                        OperationError::service_error(format!(
+                            "Failed to flush mutable numeric index gridstore: {err}"
+                        ))
+                    })
+                })
+            }
+        }
     }
 
     pub fn add_many(
@@ -82,22 +246,51 @@ impl MutableFullTextIndex {
         let db_document =
             FullTextIndex::serialize_document_tokens(str_tokens.into_iter().collect())?;
 
-        self.db_wrapper.put(db_idx, db_document)?;
-
-        Ok(())
-    }
-
-    pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        if self.inverted_index.remove(id) {
-            let db_doc_id = FullTextIndex::store_key(id);
-            self.db_wrapper.remove(db_doc_id)?;
+        // Update persisted storage
+        match &self.storage {
+            Storage::RocksDb(db_wrapper) => {
+                db_wrapper.put(db_idx, db_document)?;
+            }
+            // We cannot store empty value, then delete instead
+            Storage::Gridstore(store) if db_document.is_empty() => {
+                store.write().delete_value(idx);
+            }
+            Storage::Gridstore(store) => {
+                let hw_counter = HardwareCounterCell::disposable();
+                store
+                    .write()
+                    .put_value(
+                        idx,
+                        &db_document,
+                        hw_counter.ref_payload_index_io_write_counter(),
+                    )
+                    .map_err(|err| {
+                        OperationError::service_error(format!(
+                            "failed to put value in mutable full text index gridstore: {err}"
+                        ))
+                    })?;
+            }
         }
 
         Ok(())
     }
 
-    pub fn clear(self) -> OperationResult<()> {
-        self.db_wrapper.remove_column_family()
+    pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        // Update persisted storage
+        match &self.storage {
+            Storage::RocksDb(db_wrapper) => {
+                if self.inverted_index.remove(id) {
+                    let db_doc_id = FullTextIndex::store_key(id);
+                    db_wrapper.remove(db_doc_id)?;
+                }
+            }
+            Storage::Gridstore(store) => {
+                self.inverted_index.remove(id);
+                store.write().delete_value(id);
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -272,8 +272,9 @@ impl MutableFullTextIndex {
                 }
             }
             Storage::Gridstore(store) => {
-                self.inverted_index.remove(id);
-                store.write().delete_value(id);
+                if self.inverted_index.remove(id) {
+                    store.write().delete_value(id);
+                }
             }
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -561,6 +561,7 @@ mod tests {
     use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
     use crate::fixtures::payload_fixtures::random_full_text_payload;
     use crate::index::field_index::field_index_base::FieldIndexBuilderTrait;
+    use crate::index::field_index::full_text_index::mutable_text_index;
     use crate::types::ValuesCount;
 
     const FIELD_NAME: &str = "test";
@@ -609,10 +610,13 @@ mod tests {
 
                     // Deconstruct mutable index, flush pending changes
                     let MutableFullTextIndex {
-                        db_wrapper,
+                        storage,
                         inverted_index: _,
                         config,
                     } = index;
+                    let mutable_text_index::Storage::RocksDb(db_wrapper) = storage else {
+                        panic!("expected RocksDB storage for immutable index");
+                    };
                     db_wrapper.flusher()().expect("failed to flush");
 
                     // Open and load immutable index

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -494,7 +494,6 @@ impl ValueIndexer for FullTextGridstoreIndexBuilder {
         values: Vec<Self::ValueType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        // TODO: skip these intermediate conversions!
         let values: Vec<Value> = values.into_iter().map(Value::String).collect();
         let values: Vec<&Value> = values.iter().collect();
         FieldIndexBuilderTrait::add_point(self, id, &values, hw_counter)

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -304,8 +304,9 @@ impl FullTextIndex {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         match self {
-            FullTextIndex::Mutable(_) => {}   // Not a mmap
-            FullTextIndex::Immutable(_) => {} // Not a mmap
+            FullTextIndex::Mutable(_) => {}
+            // Only clears backing mmap storage if used, not in-memory representation
+            FullTextIndex::Immutable(index) => index.clear_cache()?,
             FullTextIndex::Mmap(index) => index.clear_cache()?,
         }
         Ok(())

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -339,9 +339,8 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 FullTextIndex::new_mmap(text_dir(dir, field), config, *is_on_disk)?
             }
-            // TODO(payload-index-gridstore): replace with Gridstore implementation
-            IndexSelector::Gridstore(IndexSelectorGridstore { db, dir: _ }) => {
-                FullTextIndex::new_rocksdb(Arc::clone(db), config, &field.to_string(), true)
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+                FullTextIndex::new_gridstore(text_dir(dir, field), config)?
             }
         })
     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -362,12 +362,10 @@ impl IndexSelector<'_> {
                     *is_on_disk,
                 ))
             }
-            // TODO(payload-index-gridstore): replace with Gridstore implementation
-            IndexSelector::Gridstore(IndexSelectorGridstore { db, dir: _ }) => {
-                FieldIndexBuilder::FullTextIndex(FullTextIndex::builder_rocksdb(
-                    Arc::clone(db),
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+                FieldIndexBuilder::FullTextGridstoreIndex(FullTextIndex::builder_gridstore(
+                    text_dir(dir, field),
                     config,
-                    &field.to_string(),
                 ))
             }
         }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -156,7 +156,7 @@ where
         let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
         store
             .read()
-            .iter(
+            .iter::<_, ()>(
                 |idx, values| {
                     for value in values {
                         if self.point_to_values.len() <= idx as usize {

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -333,7 +333,7 @@ where
         let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
         store
             .read()
-            .iter(
+            .iter::<_, ()>(
                 |idx, values| {
                     self.in_memory_index.add_many_to_list(idx, values.clone());
                     Ok(true)


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6634>

Similar to <https://github.com/qdrant/qdrant/pull/6634>, this implements Gridstore as alternative storage backend for a payload index. This implements it for the full text index.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/6634>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
