### PR TITLE
 Add mutable geo payload index on top of Gridstore

### DIFF
--- a/lib/gridstore/src/blob.rs
+++ b/lib/gridstore/src/blob.rs
@@ -26,6 +26,36 @@ impl Blob for Vec<ecow::EcoString> {
     }
 }
 
+impl Blob for Vec<(f64, f64)> {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.iter()
+            .flat_map(|(a, b)| {
+                a.as_bytes()
+                    .iter()
+                    .copied()
+                    .chain(b.as_bytes().iter().copied())
+            })
+            .collect()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Self {
+        assert!(
+            bytes.len().is_multiple_of(size_of::<f64>() * 2),
+            "unexpected number of bytes for Vec<(f64, f64)>",
+        );
+        bytes
+            .chunks(size_of::<f64>() * 2)
+            .map(|v| {
+                let (a, b) = v.split_at(size_of::<f64>());
+                (
+                    f64::read_from_bytes(a).expect("invalid number of bytes for type f64"),
+                    f64::read_from_bytes(b).expect("invalid number of bytes for type f64"),
+                )
+            })
+            .collect()
+    }
+}
+
 macro_rules! impl_blob_vec_zerocopy {
     ($type:ty) => {
         impl Blob for Vec<$type>

--- a/lib/gridstore/src/blob.rs
+++ b/lib/gridstore/src/blob.rs
@@ -29,12 +29,7 @@ impl Blob for Vec<ecow::EcoString> {
 impl Blob for Vec<(f64, f64)> {
     fn to_bytes(&self) -> Vec<u8> {
         self.iter()
-            .flat_map(|(a, b)| {
-                a.as_bytes()
-                    .iter()
-                    .copied()
-                    .chain(b.as_bytes().iter().copied())
-            })
+            .flat_map(|(a, b)| a.to_le_bytes().into_iter().chain(b.to_le_bytes()))
             .collect()
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -13,7 +13,7 @@ use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use super::full_text_index::text_index::{
     FullTextGridstoreIndexBuilder, FullTextIndex, FullTextIndexBuilder,
 };
-use super::geo_index::{GeoMapIndexBuilder, GeoMapIndexMmapBuilder};
+use super::geo_index::{GeoMapIndexBuilder, GeoMapIndexGridstoreBuilder, GeoMapIndexMmapBuilder};
 use super::map_index::{MapIndex, MapIndexBuilder, MapIndexGridstoreBuilder, MapIndexMmapBuilder};
 use super::numeric_index::{
     NumericIndex, NumericIndexBuilder, NumericIndexGridstoreBuilder, NumericIndexMmapBuilder,
@@ -525,6 +525,7 @@ pub enum FieldIndexBuilder {
     FloatGridstoreIndex(NumericIndexGridstoreBuilder<FloatPayloadType, FloatPayloadType>),
     GeoIndex(GeoMapIndexBuilder),
     GeoMmapIndex(GeoMapIndexMmapBuilder),
+    GeoGridstoreIndex(GeoMapIndexGridstoreBuilder),
     FullTextIndex(FullTextIndexBuilder),
     FullTextMmapIndex(FullTextMmapIndexBuilder),
     FullTextGridstoreIndex(FullTextGridstoreIndexBuilder),
@@ -558,6 +559,7 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FloatGridstoreIndex(index) => index.init(),
             Self::GeoIndex(index) => index.init(),
             Self::GeoMmapIndex(index) => index.init(),
+            Self::GeoGridstoreIndex(index) => index.init(),
             Self::BoolIndex(index) => index.init(),
             Self::BoolMmapIndex(index) => index.init(),
             Self::FullTextIndex(index) => index.init(),
@@ -594,6 +596,7 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FloatGridstoreIndex(index) => index.add_point(id, payload, hw_counter),
             Self::GeoIndex(index) => index.add_point(id, payload, hw_counter),
             Self::GeoMmapIndex(index) => index.add_point(id, payload, hw_counter),
+            Self::GeoGridstoreIndex(index) => index.add_point(id, payload, hw_counter),
             Self::BoolIndex(index) => index.add_point(id, payload, hw_counter),
             Self::BoolMmapIndex(index) => index.add_point(id, payload, hw_counter),
             Self::FullTextIndex(index) => index.add_point(id, payload, hw_counter),
@@ -629,6 +632,7 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FloatGridstoreIndex(index) => FieldIndex::FloatIndex(index.finalize()?),
             Self::GeoIndex(index) => FieldIndex::GeoIndex(index.finalize()?),
             Self::GeoMmapIndex(index) => FieldIndex::GeoIndex(index.finalize()?),
+            Self::GeoGridstoreIndex(index) => FieldIndex::GeoIndex(index.finalize()?),
             Self::BoolIndex(index) => FieldIndex::BoolIndex(index.finalize()?),
             Self::BoolMmapIndex(index) => FieldIndex::BoolIndex(index.finalize()?),
             Self::FullTextIndex(index) => FieldIndex::FullTextIndex(index.finalize()?),

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -768,6 +768,7 @@ mod tests {
     #[derive(Clone, Copy, PartialEq, Debug)]
     enum IndexType {
         Mutable,
+        MutableGridstore,
         Immutable,
         Mmap,
         RamMmap,
@@ -775,6 +776,7 @@ mod tests {
 
     enum IndexBuilder {
         Mutable(GeoMapIndexBuilder),
+        MutableGridstore(GeoMapIndexGridstoreBuilder),
         Immutable(GeoMapImmutableIndexBuilder),
         Mmap(GeoMapIndexMmapBuilder),
         RamMmap(GeoMapIndexMmapBuilder),
@@ -789,6 +791,9 @@ mod tests {
         ) -> OperationResult<()> {
             match self {
                 IndexBuilder::Mutable(builder) => builder.add_point(id, payload, hw_counter),
+                IndexBuilder::MutableGridstore(builder) => {
+                    builder.add_point(id, payload, hw_counter)
+                }
                 IndexBuilder::Immutable(builder) => builder.add_point(id, payload, hw_counter),
                 IndexBuilder::Mmap(builder) => builder.add_point(id, payload, hw_counter),
                 IndexBuilder::RamMmap(builder) => builder.add_point(id, payload, hw_counter),
@@ -798,6 +803,7 @@ mod tests {
         fn finalize(self) -> OperationResult<GeoMapIndex> {
             match self {
                 IndexBuilder::Mutable(builder) => builder.finalize(),
+                IndexBuilder::MutableGridstore(builder) => builder.finalize(),
                 IndexBuilder::Immutable(builder) => builder.finalize(),
                 IndexBuilder::Mmap(builder) => builder.finalize(),
                 IndexBuilder::RamMmap(builder) => {
@@ -861,6 +867,9 @@ mod tests {
             IndexType::Mutable => {
                 IndexBuilder::Mutable(GeoMapIndex::builder(db.clone(), FIELD_NAME))
             }
+            IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
+                GeoMapIndex::builder_gridstore(temp_dir.path().to_path_buf()),
+            ),
             IndexType::Immutable => {
                 IndexBuilder::Immutable(GeoMapIndex::builder_immutable(db.clone(), FIELD_NAME))
             }
@@ -871,6 +880,7 @@ mod tests {
         };
         match &mut builder {
             IndexBuilder::Mutable(builder) => builder.init().unwrap(),
+            IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
             IndexBuilder::Immutable(builder) => builder.init().unwrap(),
             IndexBuilder::Mmap(builder) => builder.init().unwrap(),
             IndexBuilder::RamMmap(builder) => builder.init().unwrap(),
@@ -947,6 +957,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1089,6 +1100,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1142,6 +1154,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1208,6 +1221,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1240,6 +1254,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1327,6 +1342,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1373,6 +1389,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1399,6 +1416,9 @@ mod tests {
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
         let mut new_index = match index_type {
             IndexType::Mutable => GeoMapIndex::new_memory(db, FIELD_NAME, true),
+            IndexType::MutableGridstore => {
+                GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf()).unwrap()
+            }
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),
             IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false).unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
@@ -1436,6 +1456,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1473,6 +1494,9 @@ mod tests {
         let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
         let mut new_index = match index_type {
             IndexType::Mutable => GeoMapIndex::new_memory(db, FIELD_NAME, true),
+            IndexType::MutableGridstore => {
+                GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf()).unwrap()
+            }
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),
             IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false).unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
@@ -1488,6 +1512,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1583,6 +1608,7 @@ mod tests {
 
     #[rstest]
     #[case(IndexType::Mutable)]
+    #[case(IndexType::MutableGridstore)]
     #[case(IndexType::Immutable)]
     #[case(IndexType::Mmap)]
     #[case(IndexType::RamMmap)]
@@ -1646,8 +1672,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case(&[IndexType::Mutable, IndexType::Immutable, IndexType::Mmap, IndexType::RamMmap], false)]
-    #[case(&[IndexType::Mutable, IndexType::Immutable, IndexType::RamMmap], true)]
+    #[case(&[IndexType::Mutable, IndexType::MutableGridstore, IndexType::Immutable, IndexType::Mmap, IndexType::RamMmap], false)]
+    #[case(&[IndexType::Mutable, IndexType::MutableGridstore, IndexType::Immutable, IndexType::RamMmap], true)]
     fn test_congruence(#[case] types: &[IndexType], #[case] deleted: bool) {
         const POINT_COUNT: usize = 500;
 

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -20,10 +20,14 @@ use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::index::field_index::geo_hash::{GeoHash, encode_max_precision};
 use crate::types::{GeoPoint, RawGeoPoint};
 
+/// Default options for Gridstore storage
 const GRIDSTORE_OPTIONS: StorageOptions = StorageOptions {
-    block_size_bytes: Some(size_of::<GeoPoint>()),
+    // Size of geo point values in index
+    block_size_bytes: Some(size_of::<RawGeoPoint>()),
+    // Compressing geo point values is unreasonable
     compression: Some(gridstore::config::Compression::None),
-    page_size_bytes: None,
+    // Scale page size down with block size, prevents overhead of first page when there's (almost) no values
+    page_size_bytes: Some(size_of::<RawGeoPoint>() * 8192 * 32), // 4 to 8 MiB = block_size * region_blocks * regions,
     region_size_blocks: None,
 };
 

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -305,6 +305,10 @@ impl MutableGeoMapIndex {
                     db_wrapper.put(&key, value)?;
                 }
             }
+            // We cannot store empty value, then delete instead
+            Storage::Gridstore(store) if values.is_empty() => {
+                store.write().delete_value(idx);
+            }
             Storage::Gridstore(store) => {
                 let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
                 let values = values

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -349,7 +349,7 @@ mod tests {
 
         // Create a field index for a geo point.
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = GeoMapIndex::mmap_builder(dir.path(), false);
+        let mut builder = GeoMapIndex::builder_mmap(dir.path(), false);
 
         builder.add_point(0, &[], &hw_counter).unwrap();
         builder

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1423,6 +1423,7 @@ struct GeoPointShadow {
     pub lat: f64,
 }
 
+#[derive(Debug)]
 pub struct GeoPointValidationError {
     pub lon: f64,
     pub lat: f64,
@@ -1477,7 +1478,7 @@ impl From<GeoPoint> for geo::Point {
 
 impl From<RawGeoPoint> for GeoPoint {
     fn from((lon, lat): RawGeoPoint) -> Self {
-        GeoPoint { lon, lat }
+        GeoPoint::new(lon, lat).expect("invalid GeoPoint coordinates")
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1401,6 +1401,8 @@ pub struct SegmentState {
     pub config: SegmentConfig,
 }
 
+pub type RawGeoPoint = (f64, f64);
+
 /// Geo point payload schema
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Default)]
 #[serde(try_from = "GeoPointShadow")]
@@ -1470,6 +1472,18 @@ impl TryFrom<GeoPointShadow> for GeoPoint {
 impl From<GeoPoint> for geo::Point {
     fn from(GeoPoint { lon, lat }: GeoPoint) -> Self {
         Self::new(lon, lat)
+    }
+}
+
+impl From<RawGeoPoint> for GeoPoint {
+    fn from((lon, lat): RawGeoPoint) -> Self {
+        GeoPoint { lon, lat }
+    }
+}
+
+impl From<GeoPoint> for RawGeoPoint {
+    fn from(geo_point: GeoPoint) -> Self {
+        (geo_point.lon, geo_point.lat)
     }
 }
 


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6639>

Similar to <https://github.com/qdrant/qdrant/pull/6639>, this implements Gridstore as alternative storage backend for a payload index. This implements it for the geo index.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/6639>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
