### PR TITLE
Finalize mutable payload index on Gridstore

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -387,12 +387,12 @@ impl IndexSelector<'_> {
                     *is_on_disk,
                 )?))
             }
-            // TODO(payload-index-gridstore): replace with Gridstore implementation
-            IndexSelector::Gridstore(IndexSelectorGridstore { db, dir: _ }) => {
-                Ok(FieldIndexBuilder::BoolIndex(SimpleBoolIndex::builder(
-                    Arc::clone(db),
-                    &field.to_string(),
-                )))
+            // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+                let dir = bool_dir(dir, field);
+                Ok(FieldIndexBuilder::BoolMmapIndex(MmapBoolIndex::builder(
+                    &dir, false,
+                )?))
             }
         }
     }
@@ -413,12 +413,10 @@ impl IndexSelector<'_> {
                     *is_on_disk,
                 )?))
             }
-            // TODO(payload-index-gridstore): replace with Gridstore implementation
-            IndexSelector::Gridstore(IndexSelectorGridstore { db, dir: _ }) => {
-                FieldIndex::BoolIndex(BoolIndex::Simple(SimpleBoolIndex::new(
-                    Arc::clone(db),
-                    &field.to_string(),
-                )))
+            // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+                let dir = bool_dir(dir, field);
+                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open_or_create(&dir, false)?))
             }
         })
     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -55,10 +55,6 @@ pub struct IndexSelectorMmap<'a> {
 #[derive(Copy, Clone)]
 pub struct IndexSelectorGridstore<'a> {
     pub dir: &'a Path,
-
-    // Temporary fallback to RocksDB for indices that don't support Gridstore yet
-    // TODO(payload-index-gridstore): remove once all indices use Gridstore
-    pub db: &'a Arc<RwLock<DB>>,
 }
 
 impl IndexSelector<'_> {
@@ -192,7 +188,7 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 MapIndex::new_mmap(&map_dir(dir, field), *is_on_disk)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 MapIndex::new_gridstore(map_dir(dir, field))?
             }
         })
@@ -215,7 +211,7 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 make_mmap(MapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk))
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(MapIndex::builder_gridstore(map_dir(dir, field)))
             }
         }
@@ -235,7 +231,7 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field))?
             }
         })
@@ -263,7 +259,7 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
                 NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk),
             ),
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))
             }
         }
@@ -277,7 +273,7 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 GeoMapIndex::new_mmap(&map_dir(dir, field), *is_on_disk)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 GeoMapIndex::new_gridstore(map_dir(dir, field))?
             }
         })
@@ -297,7 +293,7 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 make_mmap(GeoMapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk))
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(GeoMapIndex::builder_gridstore(map_dir(dir, field)))
             }
         }
@@ -339,7 +335,7 @@ impl IndexSelector<'_> {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 FullTextIndex::new_mmap(text_dir(dir, field), config, *is_on_disk)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 FullTextIndex::new_gridstore(text_dir(dir, field), config)?
             }
         })
@@ -362,7 +358,7 @@ impl IndexSelector<'_> {
                     *is_on_disk,
                 ))
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 FieldIndexBuilder::FullTextGridstoreIndex(FullTextIndex::builder_gridstore(
                     text_dir(dir, field),
                     config,
@@ -388,7 +384,7 @@ impl IndexSelector<'_> {
                 )?))
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 let dir = bool_dir(dir, field);
                 Ok(FieldIndexBuilder::BoolMmapIndex(MmapBoolIndex::builder(
                     &dir, false,
@@ -414,7 +410,7 @@ impl IndexSelector<'_> {
                 )?))
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir, db: _ }) => {
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 let dir = bool_dir(dir, field);
                 FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open_or_create(&dir, false)?))
             }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -437,10 +437,7 @@ impl StructPayloadIndex {
         match &self.storage_type {
             StorageType::Appendable(db) => {
                 if feature_flags().payload_index_skip_mutable_rocksdb {
-                    IndexSelector::Gridstore(IndexSelectorGridstore {
-                        dir: &self.path,
-                        db,
-                    })
+                    IndexSelector::Gridstore(IndexSelectorGridstore { dir: &self.path })
                 } else {
                     IndexSelector::RocksDb(IndexSelectorRocksDb {
                         db,


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6644>

Finalize the implementation of mutable payload indices on Gridstore.

A small PR that does two things:
1. bypass Gridstore index selector for boolean index, use existing mmap index because it's mutable already
2. remove RocksDB placeholder in Gridstore index selector

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/6644>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
4. [x] Have you checked your code using `cargo clippy --all --all-features` command?