### PR TITLE
Remove parking lot feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ default-run = "qdrant"
 workspace = true
 
 [features]
-default = ["web", "parking_lot", "rocksdb"]
+default = ["web", "rocksdb"]
 web = ["actix-web"]
 multiling-chinese = ["segment/multiling-chinese"]
 multiling-japanese = ["segment/multiling-japanese"]
 multiling-korean = ["segment/multiling-korean"]
-service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
+service_debug = ["parking_lot/deadlock_detection"]
 tracing = [
     "api/tracing",
     "collection/tracing",
@@ -54,7 +54,7 @@ rusty-hook = "^0.11.2"
 
 
 [dependencies]
-parking_lot = { workspace = true, optional = true }
+parking_lot = { workspace = true }
 
 thiserror = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
Remove the `parking_lot` feature flag, as we cannot compile without it.

I do expect that it was optional before. But now we probably use it in a lot more places, requiring parking lot in all cases.

I suggest to remove the flag.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?