### PR TITLE
Insert backlinks during healing

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -334,7 +334,7 @@ impl GraphLayers {
 
         let links = GraphLinks::load_from_file(&plain_path, true, GraphLinksFormat::Plain)?;
         let original_size = plain_path.metadata()?.len();
-        GraphLinksSerializer::new(links.into_edges(), GraphLinksFormat::Compressed, hnsw_m)
+        GraphLinksSerializer::new(links.to_edges(), GraphLinksFormat::Compressed, hnsw_m)
             .save_as(&compressed_path)?;
         let new_size = compressed_path.metadata()?.len();
 
@@ -360,12 +360,9 @@ impl GraphLayers {
             GraphLinksSerializer::new(Vec::new(), GraphLinksFormat::Plain, HnswM::new(0, 0))
                 .to_graph_links_ram();
         let links = std::mem::replace(&mut self.links, dummy);
-        self.links = GraphLinksSerializer::new(
-            links.into_edges(),
-            GraphLinksFormat::Compressed,
-            self.hnsw_m,
-        )
-        .to_graph_links_ram();
+        self.links =
+            GraphLinksSerializer::new(links.to_edges(), GraphLinksFormat::Compressed, self.hnsw_m)
+                .to_graph_links_ram();
     }
 
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -534,6 +534,7 @@ impl GraphLayersBuilder {
             existing_links.links().to_vec()
         };
 
+        // Insert backlinks.
         let mut items = ItemsBuffer::default();
         for &other_point in &selected_nearest {
             self.links_layers[other_point as usize][curr_level]

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 use bitvec::prelude::BitVec;
 use common::ext::BitSliceExt;
-use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoredPointOffset};
 use io::file_operations::atomic_save_bin;
 use parking_lot::{Mutex, MutexGuard, RwLock};
@@ -15,7 +14,6 @@ use rand::distr::Uniform;
 use super::HnswM;
 use super::graph_layers::GraphLayerData;
 use super::graph_links::{GraphLinks, GraphLinksFormat};
-use super::hnsw::OldIndex;
 use super::links_container::{ItemsBuffer, LinksContainer};
 use crate::common::operation_error::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
@@ -24,7 +22,6 @@ use crate::index::hnsw_index::graph_links::GraphLinksSerializer;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::search_context::SearchContext;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
-use crate::vector_storage::RawScorer;
 
 pub type LockedLinkContainer = RwLock<LinksContainer>;
 pub type LockedLayersContainer = Vec<LockedLinkContainer>;
@@ -588,145 +585,6 @@ impl GraphLayersBuilder {
         } else {
             sum as f32 / count as f32
         }
-    }
-
-    /// Greedy search for non-deleted points accessible through deleted points.
-    ///
-    /// This method combines following concepts:
-    ///
-    /// # Dual-graph search
-    ///
-    /// Search is performed using two graphs at once, in a copy-on-write manner.
-    /// The decision which graph to use is made per point based on whether
-    /// it's marked as ready or not. If a point is ready, then links from the
-    /// new graph are used, otherwise links from the old graph are used.
-    ///
-    /// # Traverse through deleted points
-    ///
-    /// Regular search ([`GraphLayers::search_on_level`]):
-    /// - BFS (queue-based).
-    /// - Deleted points are ignored.
-    /// - Non-deleted points are added into the result AND the search queue.
-    ///
-    /// This method:
-    /// - DFS (stack-based).
-    /// - Deleted points are added into the search queue, but not into the
-    ///   result.
-    /// - Non-deleted points are added into the result, but not into the search
-    ///   queue.
-    ///
-    /// In other words, we search in the scope of deleted points, but
-    /// we want to use points on the border between deleted and non-deleted as candidates
-    /// for the shortcut.
-    pub(super) fn search_shortcuts_on_level(
-        &self,
-        old_offset: PointOffsetType,
-        level: usize,
-        old_scorer: &dyn RawScorer,
-        old_index: &OldIndex,
-    ) -> FixedLengthPriorityQueue<ScoredPointOffset> {
-        let mut visited_list = old_index.graph().get_visited_list_from_pool();
-
-        // Result of the search is stored here.
-        let mut search_context = SearchContext::new(self.ef_construct);
-
-        // Old graph can have extra links, but we don't want to use them (yet)
-        let limit = old_index.graph().get_m(level);
-
-        let mut neighbours_old: Vec<PointOffsetType> = Vec::with_capacity(2 * limit);
-        let mut scores_buffer = Vec::with_capacity(limit);
-
-        // Candidates for the search stack.
-        // ToDo: Try later, instead of using stack, we can use proper priority queue
-        // ToDo: So that in the deleted sub-graph we can navigate towards the point with better scores
-        let mut pending = Vec::new();
-
-        // Find entry into "deleted" sub-graph, do not consider non-deleted neighbors
-        // as they already connected to the "healing" point.
-        visited_list.check_and_update_visited(old_offset);
-        for point in old_index.graph().links.links(old_offset, level).take(limit) {
-            if old_index.old_to_new[point as usize].is_some() {
-                visited_list.check_and_update_visited(point);
-            } else {
-                pending.push(ScoredPointOffset {
-                    idx: point,
-                    score: old_scorer.score_point(point),
-                });
-            }
-        }
-
-        // At this moment `pending` is initialized with at least one deleted point,
-        // now we need to find borders of all "deleted" points sub-graphs
-        while let Some(candidate_old) = pending.pop() {
-            if search_context.nearest.is_full()
-                && candidate_old.score < search_context.nearest.top().unwrap().score
-            {
-                // Stop the search branch early, if it is not promising
-                continue;
-            }
-            if visited_list.check_and_update_visited(candidate_old.idx) {
-                continue;
-            }
-
-            // Here we decide which graph to use to look for neighbors
-            // It might be, that the neighbor was already "healed", so we can
-            // use healed neighbors.
-            // If we detect this case, we need to use the new graph to find neighbors instead of
-            // the old one.
-            let offset_new_ready = old_index.old_to_new[candidate_old.idx as usize]
-                .filter(|&new_offset| self.ready_list.read()[new_offset as usize]);
-
-            neighbours_old.clear();
-            if let Some(offset_new) = offset_new_ready {
-                // This is "already healed" case
-                self.links_map(offset_new, level, |new_link| {
-                    if let Some(old_link) = old_index.new_to_old[new_link as usize] {
-                        // We do the search in context of old ids,
-                        // so we need to convert new id to old id
-                        neighbours_old.push(old_link);
-                    } else {
-                        debug_assert!(
-                            false,
-                            "The new graph points expected to be a subset of the old graph points"
-                        );
-                    }
-                });
-            } else {
-                old_index
-                    .graph()
-                    .links_map(candidate_old.idx, level, |old_link| {
-                        neighbours_old.push(old_link);
-                    });
-            }
-
-            neighbours_old.truncate(limit);
-            neighbours_old.retain(|point_id| !visited_list.check(*point_id));
-
-            if scores_buffer.len() < neighbours_old.len() {
-                scores_buffer.resize(neighbours_old.len(), 0.0);
-            }
-
-            old_scorer.score_points(&neighbours_old, &mut scores_buffer[..neighbours_old.len()]);
-            for (&idx, &score) in neighbours_old.iter().zip(&scores_buffer) {
-                if let Some(new_offset) = old_index.old_to_new[idx as usize] {
-                    // This point is on the "border", as it is reachable from the deleted
-                    // And is not deleted itself
-                    search_context.process_candidate(ScoredPointOffset {
-                        idx: new_offset,
-                        score,
-                    });
-                } else {
-                    // This is just another deleted point
-                    debug_assert!(
-                        offset_new_ready.is_none(),
-                        "For ready points, every neighbor expected to be in the new graph"
-                    );
-                    pending.push(ScoredPointOffset { idx, score });
-                }
-            }
-        }
-
-        search_context.nearest
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
@@ -1,0 +1,237 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
+use common::types::{PointOffsetType, ScoredPointOffset};
+use parking_lot::RwLock;
+use rayon::ThreadPool;
+use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
+
+use crate::common::operation_error::OperationResult;
+use crate::index::hnsw_index::HnswM;
+use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph_layers_builder::{GraphLayersBuilder, LockedLayersContainer};
+use crate::index::hnsw_index::links_container::LinksContainer;
+use crate::index::hnsw_index::search_context::SearchContext;
+use crate::index::visited_pool::VisitedPool;
+use crate::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer};
+
+pub struct GraphLayersHealer<'a> {
+    links_layers: Vec<LockedLayersContainer>,
+    to_heal: Vec<(PointOffsetType, usize)>,
+    old_to_new: &'a [Option<PointOffsetType>],
+    hnsw_m: HnswM,
+    ef_construct: usize,
+    visited_pool: VisitedPool,
+}
+
+impl<'a> GraphLayersHealer<'a> {
+    pub fn new(
+        graph_layers: &GraphLayers,
+        old_to_new: &'a [Option<PointOffsetType>],
+        ef_construct: usize,
+    ) -> Self {
+        let mut to_heal = Vec::new();
+        let links_layers = {
+            graph_layers.links.to_edges_impl(|point_id, level| {
+                let level_m = graph_layers.hnsw_m.level_m(level);
+                let mut container = LinksContainer::with_capacity(level_m);
+                container.fill_from(graph_layers.links.links(point_id, level).take(level_m));
+                if container
+                    .iter()
+                    .any(|neighbor| old_to_new[neighbor as usize].is_none())
+                {
+                    to_heal.push((point_id, level));
+                }
+                RwLock::new(container)
+            })
+        };
+
+        Self {
+            links_layers,
+            to_heal,
+            old_to_new,
+            hnsw_m: graph_layers.hnsw_m,
+            ef_construct,
+            visited_pool: VisitedPool::new(),
+        }
+    }
+
+    fn point_deleted(&self, point: PointOffsetType) -> bool {
+        self.old_to_new[point as usize].is_none()
+    }
+
+    /// Greedy search for non-deleted points accessible through deleted points.
+    ///
+    /// Unlike the regular search ([`search_on_level`]) which:
+    /// - BFS (queue-based).
+    /// - Deleted points are ignored.
+    /// - Non-deleted points are added into the result AND the search queue.
+    ///
+    /// This method:
+    /// - DFS (stack-based).
+    /// - Deleted points are added into the search queue, but not into the
+    ///   result.
+    /// - Non-deleted points are added into the result, but not into the search
+    ///   queue.
+    ///
+    /// In other words, we search in the scope of deleted points, but
+    /// we want to use points on the border between deleted and non-deleted as candidates
+    /// for the shortcut.
+    ///
+    /// [`search_on_level`]: crate::index::hnsw_index::graph_layers::GraphLayersBase::search_on_level
+    fn search_shortcuts_on_level(
+        &self,
+        offset: PointOffsetType,
+        level: usize,
+        scorer: &dyn RawScorer,
+    ) -> FixedLengthPriorityQueue<ScoredPointOffset> {
+        let mut visited_list = self.visited_pool.get(self.links_layers.len());
+
+        // Result of the search is stored here.
+        let mut search_context = SearchContext::new(self.ef_construct);
+
+        let limit = self.hnsw_m.level_m(level);
+
+        let mut neighbours: Vec<PointOffsetType> = Vec::with_capacity(2 * limit);
+        let mut scores_buffer = Vec::with_capacity(limit);
+
+        // Candidates for the search stack.
+        // ToDo: Try later, instead of using stack, we can use proper priority queue
+        // ToDo: So that in the deleted sub-graph we can navigate towards the point with better scores
+        let mut pending = Vec::new();
+
+        // Find entry into "deleted" sub-graph, do not consider non-deleted neighbors
+        // as they already connected to the "healing" point.
+        visited_list.check_and_update_visited(offset);
+        {
+            let links = self.links_layers[offset as usize][level].read();
+            for &point in links.links() {
+                if !self.point_deleted(point) {
+                    visited_list.check_and_update_visited(point);
+                } else {
+                    pending.push(ScoredPointOffset {
+                        idx: point,
+                        score: scorer.score_point(point),
+                    });
+                }
+            }
+        }
+
+        // At this moment `pending` is initialized with at least one deleted point,
+        // now we need to find borders of all "deleted" points sub-graphs
+        while let Some(candidate) = pending.pop() {
+            if search_context.nearest.is_full()
+                && candidate.score < search_context.nearest.top().unwrap().score
+            {
+                // Stop the search branch early, if it is not promising
+                continue;
+            }
+            if visited_list.check_and_update_visited(candidate.idx) {
+                continue;
+            }
+
+            neighbours.clear();
+            neighbours.extend(
+                self.links_layers[candidate.idx as usize][level]
+                    .read()
+                    .links()
+                    .iter()
+                    .filter(|&&link| !visited_list.check(link)),
+            );
+
+            if scores_buffer.len() < neighbours.len() {
+                scores_buffer.resize(neighbours.len(), 0.0);
+            }
+
+            scorer.score_points(&neighbours, &mut scores_buffer[..neighbours.len()]);
+            for (&idx, &score) in neighbours.iter().zip(&scores_buffer) {
+                if !self.point_deleted(idx) {
+                    // This point is on the "border", as it is reachable from the deleted
+                    // And is not deleted itself
+                    search_context.process_candidate(ScoredPointOffset { idx, score });
+                } else {
+                    // This is just another deleted point
+                    pending.push(ScoredPointOffset { idx, score });
+                }
+            }
+        }
+
+        search_context.nearest
+    }
+
+    fn heal_point_on_level(&self, offset: PointOffsetType, level: usize, scorer: &dyn RawScorer) {
+        let level_m = self.hnsw_m.level_m(level);
+
+        // Get current links and filter out deleted ones
+        let mut valid_links = Vec::with_capacity(level_m);
+        valid_links.extend(
+            self.links_layers[offset as usize][level]
+                .read()
+                .links()
+                .iter()
+                .filter(|&&idx| !self.point_deleted(idx)),
+        );
+
+        // First: generate list of candidates using shortcuts search
+        let shortcuts = self.search_shortcuts_on_level(offset, level, scorer);
+
+        // Second: process list of candidates with heuristic
+        let mut container = LinksContainer::with_capacity(level_m);
+        let scorer_fn = |a, b| scorer.score_internal(a, b);
+        container.fill_from_sorted_with_heuristic(
+            shortcuts.into_iter_sorted(),
+            level_m - valid_links.len(),
+            scorer_fn,
+        );
+        for &link in &valid_links {
+            container.push(link);
+        }
+
+        self.links_layers[offset as usize][level]
+            .write()
+            .fill_from(container.into_vec().into_iter());
+    }
+
+    pub fn heal(
+        &mut self,
+        pool: &ThreadPool,
+        vector_storage: &VectorStorageEnum,
+    ) -> OperationResult<()> {
+        pool.install(|| {
+            std::mem::take(&mut self.to_heal)
+                .into_par_iter()
+                .try_for_each(|(offset, level)| {
+                    // Internal operation. No measurements needed.
+                    let internal_hardware_counter = HardwareCounterCell::disposable();
+                    let scorer = new_raw_scorer(
+                        vector_storage.get_vector(offset).as_vec_ref().into(),
+                        vector_storage,
+                        internal_hardware_counter,
+                    )?;
+                    self.heal_point_on_level(offset, level, scorer.as_ref());
+                    Ok(())
+                })
+        })
+    }
+
+    pub fn save_into_builder(self, builder: &GraphLayersBuilder) {
+        for (old_offset, layers) in self.links_layers.into_iter().enumerate() {
+            let Some(new_offset) = self.old_to_new[old_offset] else {
+                continue;
+            };
+
+            let links_by_level = layers
+                .into_iter()
+                .map(|layer| {
+                    layer
+                        .into_inner()
+                        .into_vec()
+                        .into_iter()
+                        .filter_map(|link| self.old_to_new[link as usize])
+                        .collect()
+                })
+                .collect();
+
+            builder.add_new_point(new_offset, links_by_level);
+        }
+    }
+}

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -6,6 +6,7 @@ mod config;
 mod entry_points;
 pub mod graph_layers;
 pub mod graph_layers_builder;
+mod graph_layers_healer;
 pub mod graph_links;
 pub mod hnsw;
 mod links_container;


### PR DESCRIPTION
This PR updates lets the healing algorithm not just heal points, but also to insert back-links to the healed note into its neighbors.

Because this change is not compatible with the copy-on-write approach introduced in #6543, this PR switches to a more straightforward approach: copy the old graph into `GraphLayersHealer`, then heal the copy, then copy it back. So, most of the changes are refactoring, and the main change (which is small) is distilled in the last commit.

Supercedes #6624.


Accuracy measurement on [`transform.py`](https://github.com/qdrant/vector-db-benchmark/blob/93bd4214761525395959c020a6924be4eaa8c5fe/ansible/playbooks/roles/run-hnsw-indexing-transform/files/transform.py):
<table>
  <tr>
    <th>commit<br>
    <th>dataset1<br>(avg)
    <th>dataset2<br>(avg)
    <th>diff<br>(avg)
  <tr>
    <td>dev
    <td>0.979517
    <td>0.957425
    <td>-2.20925%
  <tr>
    <td>this PR
    <td>0.97746
    <td>0.960938
    <td>-1.65225%
</table>

<details><summary>Raw data (dev)</summary>

dataset1|dataset2|diff
-------|--------|-------
0.9853 | 0.9671 | -1.82%
0.9695 | 0.9467 | -2.28%
0.9798 | 0.9470 | -3.28%
0.9730 | 0.9357 | -3.73%
0.9736 | 0.9657 | -0.79%
0.9834 | 0.9618 | -2.16%
0.9875 | 0.9468 | -4.07%
0.9885 | 0.9568 | -3.17%
0.9815 | 0.9485 | -3.30%
0.9818 | 0.9605 | -2.13%
0.9752 | 0.9537 | -2.15%
0.9573 | 0.9629 | +0.56%
0.9876 | 0.9639 | -2.37%
0.9789 | 0.9647 | -1.42%
0.9798 | 0.9665 | -1.33%
0.9877 | 0.9639 | -2.38%
0.9745 | 0.9566 | -1.79%
0.9876 | 0.9678 | -1.98%
0.9877 | 0.9672 | -2.05%
0.9848 | 0.9633 | -2.15%
0.9831 | 0.9492 | -3.39%
0.9863 | 0.9520 | -3.43%
0.9778 | 0.9618 | -1.60%
0.9871 | 0.9713 | -1.58%
0.9812 | 0.9486 | -3.26%
0.9876 | 0.9492 | -3.84%
0.9674 | 0.9600 | -0.74%
0.9775 | 0.9564 | -2.11%
0.9876 | 0.9684 | -1.92%
0.9722 | 0.9307 | -4.15%
0.9875 | 0.9683 | -1.92%
0.9865 | 0.9575 | -2.90%
0.9845 | 0.9489 | -3.56%
0.9649 | 0.9531 | -1.18%
0.9871 | 0.9644 | -2.27%
0.9743 | 0.9666 | -0.77%
0.9706 | 0.9702 | -0.04%
0.9832 | 0.9612 | -2.20%
0.9767 | 0.9443 | -3.24%
0.9526 | 0.9478 | -0.48%

</details>

<details><summary>Raw data (this PR)</summary>

dataset1|dataset2|diff
-------|--------|-------
0.9828 | 0.9798 | -0.30%
0.9323 | 0.9355 | +0.32%
0.9880 | 0.9666 | -2.14%
0.9838 | 0.9762 | -0.76%
0.9866 | 0.9558 | -3.08%
0.9878 | 0.9887 | +0.09%
0.9674 | 0.9546 | -1.28%
0.9877 | 0.9450 | -4.27%
0.9688 | 0.9649 | -0.39%
0.9670 | 0.9323 | -3.47%
0.9748 | 0.9730 | -0.18%
0.9814 | 0.9737 | -0.77%
0.9732 | 0.9478 | -2.54%
0.9870 | 0.9210 | -6.60%
0.9877 | 0.9857 | -0.20%
0.9761 | 0.9779 | +0.18%
0.9539 | 0.9434 | -1.05%
0.9680 | 0.9329 | -3.51%
0.9716 | 0.9523 | -1.93%
0.9807 | 0.9788 | -0.19%
0.9529 | 0.9676 | +1.47%
0.9877 | 0.9830 | -0.47%
0.9812 | 0.8980 | -8.32%
0.9857 | 0.9831 | -0.26%
0.9773 | 0.9433 | -3.40%
0.9864 | 0.9767 | -0.97%
0.9866 | 0.9682 | -1.84%
0.9826 | 0.9629 | -1.97%
0.9871 | 0.9818 | -0.53%
0.9864 | 0.9816 | -0.48%
0.9821 | 0.9283 | -5.38%
0.9635 | 0.9654 | +0.19%
0.9833 | 0.9609 | -2.24%
0.9874 | 0.9644 | -2.30%
0.9876 | 0.9767 | -1.09%
0.9867 | 0.9829 | -0.38%
0.9570 | 0.9659 | +0.89%
0.9762 | 0.9121 | -6.41%
0.9848 | 0.9833 | -0.15%
0.9693 | 0.9655 | -0.38%

</details>
