### PR TITLE
Buffer when writing into mmap dense vector storage

### DIFF
--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -239,12 +239,10 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
                 deleted_ids.push(start_index as PointOffsetType + offset as PointOffsetType);
             }
         }
-        vectors_file.flush()?;
         vectors_file
             .into_inner()
-            // unwrap safety: never fails, we flushed above
-            .unwrap()
-            .sync_all()?;
+            .map_err(io::IntoInnerError::into_error)?
+            .sync_data()?;
 
         // Load store with updated files
         self.mmap_store.replace(MmapDenseVectors::open(

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -263,6 +263,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
             check_process_stopped(stopped)?;
             store.delete(id);
         }
+        store.flusher()()?;
 
         Ok(start_index..end_index)
     }

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions, create_dir_all};
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::mem::MaybeUninit;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -225,7 +225,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
             .unwrap_or(get_async_scorer());
 
         // Extend vectors file, write other vectors into it
-        let mut vectors_file = open_append(&self.vectors_path)?;
+        let mut vectors_file = BufWriter::new(open_append(&self.vectors_path)?);
         let mut deleted_ids = vec![];
         for (offset, (other_vector, other_deleted)) in other_vectors.enumerate() {
             check_process_stopped(stopped)?;
@@ -239,8 +239,12 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
                 deleted_ids.push(start_index as PointOffsetType + offset as PointOffsetType);
             }
         }
-        vectors_file.sync_all()?;
-        drop(vectors_file);
+        vectors_file.flush()?;
+        vectors_file
+            .into_inner()
+            // unwrap safety: never fails, we flushed above
+            .unwrap()
+            .sync_all()?;
 
         // Load store with updated files
         self.mmap_store.replace(MmapDenseVectors::open(


### PR DESCRIPTION
Minor change, buffer writes when putting vectors on disk.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?