### PR TITLE
Report usage of RocksDB feature flag in telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11268,6 +11268,7 @@
           "debug",
           "gpu",
           "recovery_mode",
+          "rocksdb",
           "service_debug_feature"
         ],
         "properties": {
@@ -11281,6 +11282,9 @@
             "type": "boolean"
           },
           "gpu": {
+            "type": "boolean"
+          },
+          "rocksdb": {
             "type": "boolean"
           }
         }

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -26,6 +26,7 @@ pub struct AppFeaturesTelemetry {
     pub service_debug_feature: bool,
     pub recovery_mode: bool,
     pub gpu: bool,
+    pub rocksdb: bool,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
@@ -78,6 +79,7 @@ impl AppBuildTelemetry {
                 service_debug_feature: cfg!(feature = "service_debug"),
                 recovery_mode: settings.storage.recovery_mode.is_some(),
                 gpu: cfg!(feature = "gpu"),
+                rocksdb: cfg!(feature = "rocksdb"),
             }),
             system: (detail.level >= DetailsLevel::Level1).then(get_system_data),
             jwt_rbac: settings.service.jwt_rbac,


### PR DESCRIPTION
In telemetry, report whether the compile time RocksDB feature flag is set.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?