### PR TITLE
Expose runtime feature flags in telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "ph",
  "rand 0.9.1",
  "rstest",
+ "schemars",
  "self_cell",
  "semver",
  "serde",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11238,6 +11238,16 @@
               }
             ]
           },
+          "runtime_features": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FeatureFlags"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "system": {
             "anyOf": [
               {
@@ -11285,6 +11295,46 @@
             "type": "boolean"
           },
           "gpu": {
+            "type": "boolean"
+          }
+        }
+      },
+      "FeatureFlags": {
+        "type": "object",
+        "properties": {
+          "all": {
+            "description": "Magic feature flag that enables all features.\n\nNote that this will only be applied to all flags when passed into [`init_feature_flags`].",
+            "default": false,
+            "type": "boolean"
+          },
+          "payload_index_skip_rocksdb": {
+            "description": "Whether to skip usage of RocksDB in immutable payload indices.\n\nFirst implemented in Qdrant 1.13.5. Enabled by default in Qdrant 1.14.1",
+            "default": true,
+            "type": "boolean"
+          },
+          "payload_index_skip_mutable_rocksdb": {
+            "description": "Whether to skip usage of RocksDB in mutable payload indices.",
+            "default": false,
+            "type": "boolean"
+          },
+          "incremental_hnsw_building": {
+            "description": "Whether to use incremental HNSW building.\n\nEnabled by default in Qdrant 1.14.1.",
+            "default": true,
+            "type": "boolean"
+          },
+          "hnsw_healing": {
+            "description": "Whether to enable HNSW healing.",
+            "default": false,
+            "type": "boolean"
+          },
+          "migrate_rocksdb_id_tracker": {
+            "description": "Whether to actively migrate RocksDB based ID trackers into a new format.",
+            "default": false,
+            "type": "boolean"
+          },
+          "migrate_rocksdb_vector_storage": {
+            "description": "Whether to actively migrate RocksDB based vector storages into a new format.",
+            "default": false,
             "type": "boolean"
           }
         }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -32,6 +32,7 @@ validator = { workspace = true }
 lazy_static = "1.5.0"
 memmap2 = { workspace = true }
 semver = { workspace = true }
+schemars = { workspace = true }
 thiserror = { workspace = true }
 zerocopy = { workspace = true }
 log = { workspace = true }

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -1,11 +1,12 @@
 use std::sync::OnceLock;
 
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// Global feature flags, normally initialized when starting Qdrant.
 static FEATURE_FLAGS: OnceLock<FeatureFlags> = OnceLock::new();
 
-#[derive(Debug, Deserialize, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq, JsonSchema)]
 #[serde(default)]
 pub struct FeatureFlags {
     /// Magic feature flag that enables all features.

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use chrono::{DateTime, SubsecRound, Utc};
+use common::flags::FeatureFlags;
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
@@ -56,6 +57,9 @@ pub struct AppBuildTelemetry {
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub features: Option<AppFeaturesTelemetry>,
+    #[anonymize(value = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_features: Option<FeatureFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<RunningEnvironmentTelemetry>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,6 +85,8 @@ impl AppBuildTelemetry {
                 recovery_mode: settings.storage.recovery_mode.is_some(),
                 gpu: cfg!(feature = "gpu"),
             }),
+            runtime_features: (detail.level >= DetailsLevel::Level1)
+                .then(common::flags::feature_flags),
             system: (detail.level >= DetailsLevel::Level1).then(get_system_data),
             jwt_rbac: settings.service.jwt_rbac,
             hide_jwt_dashboard: settings.service.hide_jwt_dashboard,


### PR DESCRIPTION
With details level 1, it now reports runtime feature flags in telemetry:

![image](https://github.com/user-attachments/assets/3256c037-fae8-41e0-bf5f-1d312ed0bbec)


If anonymize is set, we report no flags at all.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?