### PR TITLE
Make `load_rocksdb` private everywhere

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -79,7 +79,7 @@ impl MutableFullTextIndex {
     /// Load from RocksDB storage
     ///
     /// Loads in-memory index from RocksDB storage.
-    pub fn load_rocksdb(&mut self) -> OperationResult<bool> {
+    fn load_rocksdb(&mut self) -> OperationResult<bool> {
         let Storage::RocksDb(db_wrapper) = &self.storage else {
             return Err(OperationError::service_error(
                 "Failed to load index from RocksDB, using different storage backend",

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -112,7 +112,7 @@ impl MutableGeoMapIndex {
     /// Load from RocksDB storage
     ///
     /// Loads in-memory index from RocksDB storage.
-    pub fn load_rocksdb(&mut self) -> OperationResult<bool> {
+    fn load_rocksdb(&mut self) -> OperationResult<bool> {
         let Storage::RocksDb(db_wrapper) = &self.storage else {
             return Err(OperationError::service_error(
                 "Failed to load index from RocksDB, using different storage backend",

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -111,7 +111,7 @@ where
         // and convert to immutable state
 
         let mut mutable = MutableMapIndex::<N>::open_rocksdb_db_wrapper(db_wrapper.clone());
-        let result = mutable.load_rocksdb()?;
+        let result = mutable.load()?;
         let MutableMapIndex::<N> {
             map,
             point_to_values,

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -106,7 +106,7 @@ where
     /// Load from RocksDB storage
     ///
     /// Loads in-memory index from RocksDB storage.
-    pub fn load_rocksdb(&mut self) -> OperationResult<bool> {
+    fn load_rocksdb(&mut self) -> OperationResult<bool> {
         let Storage::RocksDb(db_wrapper) = &self.storage else {
             return Err(OperationError::service_error(
                 "Failed to load index from RocksDB, using different storage backend",


### PR DESCRIPTION
Don't expose the specialized load methods for the underlying storage, as it's unnecessary and is easily misused.

A tiny cleanup that didn't necessarily fit anywhere else.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?