### PR TITLE
[phrase matching] expose phrase condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,7 +6005,6 @@ dependencies = [
  "atomic_refcell",
  "atomicwrites",
  "bincode",
- "bitpacking",
  "bitvec",
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,6 @@ zerocopy = { version = "0.8.26", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"
 thiserror = "2.0.12"
-libc = "0.2"
 bitvec = "1.0.1"
 smallvec = { version = "1.15.1", features = ["write"] }
 merge = "0.1.0"

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1617,6 +1617,7 @@ Note: 1kB = 1 vector of size 256. |
 | max_token_len | [uint64](#uint64) | optional | Maximal token length |
 | on_disk | [bool](#bool) | optional | If true - store index on disk. |
 | stopwords | [StopwordsSet](#qdrant-StopwordsSet) | optional | Stopwords for the text index |
+| phrase_matching | [bool](#bool) | optional | If true - support phrase matching. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3295,6 +3295,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | integers | [RepeatedIntegers](#qdrant-RepeatedIntegers) |  | Match multiple integers |
 | except_integers | [RepeatedIntegers](#qdrant-RepeatedIntegers) |  | Match any other value except those integers |
 | except_keywords | [RepeatedStrings](#qdrant-RepeatedStrings) |  | Match any other value except those keywords |
+| phrase | [string](#string) |  | Match phrase text |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7658,12 +7658,8 @@
             "type": "boolean",
             "nullable": true
           },
-          "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
-            "type": "boolean",
-            "nullable": true
-          },
           "stopwords": {
+            "description": "Ignore this set of tokens. Can select from predefined languages and/or provide a custom set.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/StopwordsInterface"
@@ -7672,6 +7668,11 @@
                 "nullable": true
               }
             ]
+          },
+          "on_disk": {
+            "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7653,6 +7653,11 @@
             "type": "boolean",
             "nullable": true
           },
+          "phrase_matching": {
+            "description": "If true, support phrase matching. Default: false.",
+            "type": "boolean",
+            "nullable": true
+          },
           "on_disk": {
             "description": "If true, store the index on disk. Default: false.",
             "type": "boolean",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8513,6 +8513,9 @@
             "$ref": "#/components/schemas/MatchText"
           },
           {
+            "$ref": "#/components/schemas/MatchPhrase"
+          },
+          {
             "$ref": "#/components/schemas/MatchAny"
           },
           {
@@ -8554,6 +8557,18 @@
         ],
         "properties": {
           "text": {
+            "type": "string"
+          }
+        }
+      },
+      "MatchPhrase": {
+        "description": "Full-text phrase match of the string.",
+        "type": "object",
+        "required": [
+          "phrase"
+        ],
+        "properties": {
+          "phrase": {
             "type": "string"
           }
         }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1765,6 +1765,7 @@ impl TryFrom<Match> for segment::types::Match {
                 MatchValue::Integer(int) => int.into(),
                 MatchValue::Boolean(flag) => flag.into(),
                 MatchValue::Text(text) => segment::types::Match::Text(text.into()),
+                MatchValue::Phrase(phrase) => segment::types::Match::Phrase(phrase.into()),
                 MatchValue::Keywords(kwds) => kwds.strings.into(),
                 MatchValue::Integers(ints) => ints.integers.into(),
                 MatchValue::ExceptIntegers(kwds) => {
@@ -1789,6 +1790,9 @@ impl From<segment::types::Match> for Match {
             },
             segment::types::Match::Text(segment::types::MatchText { text }) => {
                 MatchValue::Text(text)
+            }
+            segment::types::Match::Phrase(segment::types::MatchPhrase { phrase }) => {
+                MatchValue::Phrase(phrase)
             }
             segment::types::Match::Any(any) => match any.any {
                 segment::types::AnyVariants::Strings(strings) => {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -213,8 +213,8 @@ impl From<segment::data_types::index::TextIndexParams> for PayloadIndexParams {
             min_token_len,
             max_token_len,
             lowercase,
+            phrase_matching,
             on_disk,
-            phrase_matching: _, // todo(phrase_matching): populate this
             stopwords,
         } = params;
         let tokenizer = TokenizerType::from(tokenizer);
@@ -228,6 +228,7 @@ impl From<segment::data_types::index::TextIndexParams> for PayloadIndexParams {
                 lowercase,
                 min_token_len: min_token_len.map(|x| x as u64),
                 max_token_len: max_token_len.map(|x| x as u64),
+                phrase_matching,
                 on_disk,
                 stopwords: stopwords_set,
             })),
@@ -479,6 +480,7 @@ impl TryFrom<TextIndexParams> for segment::data_types::index::TextIndexParams {
             lowercase,
             min_token_len,
             max_token_len,
+            phrase_matching,
             on_disk,
             stopwords,
         } = params;
@@ -500,8 +502,8 @@ impl TryFrom<TextIndexParams> for segment::data_types::index::TextIndexParams {
             lowercase,
             min_token_len: min_token_len.map(|x| x as usize),
             max_token_len: max_token_len.map(|x| x as usize),
+            phrase_matching,
             on_disk,
-            phrase_matching: None, // todo(phrase_matching): populate this
             stopwords: stopwords_converted,
         })
     }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -483,6 +483,7 @@ message TextIndexParams {
   optional uint64 max_token_len = 4; // Maximal token length
   optional bool on_disk = 5; // If true - store index on disk.
   optional StopwordsSet stopwords = 6; // Stopwords for the text index
+  optional bool phrase_matching = 7; // If true - support phrase matching.
 }
 
 message BoolIndexParams {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -425,7 +425,7 @@ enum RecommendStrategy {
   // examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`.
   // If the `max_neg_score` is chosen then it is squared and negated.
   BestScore = 1;
-  
+
   // Uses custom search objective. Compares against all inputs, sums all the scores.
   // Scores against positive vectors are added, against negatives are subtracted.
   SumScores = 2;
@@ -631,13 +631,13 @@ message PowExpression {
 
 message DecayParamsExpression {
     // The variable to decay
-    Expression x = 1; 
+    Expression x = 1;
     // The target value to start decaying from. Defaults to 0.
-    optional Expression target = 2; 
+    optional Expression target = 2;
     // The scale factor of the decay, in terms of `x`. Defaults to 1.0. Must be a non-zero positive number.
-    optional float scale = 3; 
+    optional float scale = 3;
     // The midpoint of the decay. Defaults to 0.5. Output will be this value when `|x - target| == scale`.
-    optional float midpoint = 4; 
+    optional float midpoint = 4;
 }
 
 message Query {
@@ -1081,6 +1081,7 @@ message Match {
     RepeatedIntegers integers = 6; // Match multiple integers
     RepeatedIntegers except_integers = 7; // Match any other value except those integers
     RepeatedStrings except_keywords = 8; // Match any other value except those keywords
+    string phrase = 9; // Match phrase text
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6525,7 +6525,7 @@ pub struct FieldCondition {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Match {
-    #[prost(oneof = "r#match::MatchValue", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
+    #[prost(oneof = "r#match::MatchValue", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
     pub match_value: ::core::option::Option<r#match::MatchValue>,
 }
 /// Nested message and enum types in `Match`.
@@ -6558,6 +6558,9 @@ pub mod r#match {
         /// Match any other value except those keywords
         #[prost(message, tag = "8")]
         ExceptKeywords(super::RepeatedStrings),
+        /// Match phrase text
+        #[prost(string, tag = "9")]
+        Phrase(::prost::alloc::string::String),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -863,6 +863,9 @@ pub struct TextIndexParams {
     /// Stopwords for the text index
     #[prost(message, optional, tag = "6")]
     pub stopwords: ::core::option::Option<StopwordsSet>,
+    /// If true - support phrase matching.
+    #[prost(bool, optional, tag = "7")]
+    pub phrase_matching: ::core::option::Option<bool>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -8,6 +8,7 @@ use http::{HeaderMap, HeaderValue, Method, Uri};
 use issues::{Action, Code, ImmediateSolution, Issue, Solution};
 use itertools::Itertools;
 use segment::common::operation_error::OperationError;
+use segment::data_types::index::{TextIndexParams, TextIndexType};
 use segment::index::query_optimization::rescore_formula::parsed_formula::VariableId;
 use segment::json_path::JsonPath;
 use segment::types::{
@@ -384,10 +385,7 @@ impl<'a> Extractor<'a> {
         let full_key = JsonPath::extend_or_new(nested_prefix, key);
 
         if self.needs_index(&full_key, &required_index) {
-            let schemas = required_index
-                .into_iter()
-                .map(PayloadSchemaType::from)
-                .map(PayloadFieldSchema::FieldType);
+            let schemas = required_index.into_iter().map(PayloadFieldSchema::from);
             self.unindexed_schema
                 .entry(full_key)
                 .or_default()
@@ -515,10 +513,7 @@ impl<'a> Extractor<'a> {
         }
 
         if self.needs_index(&key, &required_index) {
-            let schemas = required_index
-                .into_iter()
-                .map(PayloadSchemaType::from)
-                .map(PayloadFieldSchema::FieldType);
+            let schemas = required_index.into_iter().map(PayloadFieldSchema::from);
             self.unindexed_schema
                 .entry(key)
                 .or_default()
@@ -585,27 +580,45 @@ fn schema_capabilities(value: &PayloadFieldSchema) -> HashSet<FieldIndexType> {
             PayloadSchemaParams::Bool(_) => index_types.insert(FieldIndexType::BoolMatch),
             PayloadSchemaParams::Float(_) => index_types.insert(FieldIndexType::FloatRange),
             PayloadSchemaParams::Geo(_) => index_types.insert(FieldIndexType::Geo),
-            PayloadSchemaParams::Text(_) => index_types.insert(FieldIndexType::Text),
+            PayloadSchemaParams::Text(TextIndexParams {
+                phrase_matching, ..
+            }) => {
+                if phrase_matching.unwrap_or_default() {
+                    index_types.insert(FieldIndexType::TextPhrase);
+                }
+                index_types.insert(FieldIndexType::Text)
+            }
             PayloadSchemaParams::Datetime(_) => index_types.insert(FieldIndexType::DatetimeRange),
         },
     };
+
     index_types
 }
 
-impl From<FieldIndexType> for PayloadSchemaType {
+impl From<FieldIndexType> for PayloadFieldSchema {
     fn from(val: FieldIndexType) -> Self {
         match val {
-            FieldIndexType::IntMatch => PayloadSchemaType::Integer,
-            FieldIndexType::IntRange => PayloadSchemaType::Integer,
-            FieldIndexType::KeywordMatch => PayloadSchemaType::Keyword,
-            FieldIndexType::FloatRange => PayloadSchemaType::Float,
-            FieldIndexType::Text => PayloadSchemaType::Text,
-            FieldIndexType::TextPhrase => PayloadSchemaType::Text,
-            FieldIndexType::BoolMatch => PayloadSchemaType::Bool,
-            FieldIndexType::UuidMatch => PayloadSchemaType::Uuid,
-            FieldIndexType::UuidRange => PayloadSchemaType::Uuid,
-            FieldIndexType::DatetimeRange => PayloadSchemaType::Datetime,
-            FieldIndexType::Geo => PayloadSchemaType::Geo,
+            FieldIndexType::IntMatch => PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
+            FieldIndexType::IntRange => PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
+            FieldIndexType::KeywordMatch => {
+                PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)
+            }
+            FieldIndexType::FloatRange => PayloadFieldSchema::FieldType(PayloadSchemaType::Float),
+            FieldIndexType::Text => PayloadFieldSchema::FieldType(PayloadSchemaType::Text),
+            FieldIndexType::TextPhrase => {
+                PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(TextIndexParams {
+                    r#type: TextIndexType::Text,
+                    phrase_matching: Some(true),
+                    ..Default::default()
+                }))
+            }
+            FieldIndexType::BoolMatch => PayloadFieldSchema::FieldType(PayloadSchemaType::Bool),
+            FieldIndexType::UuidMatch => PayloadFieldSchema::FieldType(PayloadSchemaType::Uuid),
+            FieldIndexType::UuidRange => PayloadFieldSchema::FieldType(PayloadSchemaType::Uuid),
+            FieldIndexType::DatetimeRange => {
+                PayloadFieldSchema::FieldType(PayloadSchemaType::Datetime)
+            }
+            FieldIndexType::Geo => PayloadFieldSchema::FieldType(PayloadSchemaType::Geo),
         }
     }
 }

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -228,6 +228,7 @@ fn infer_index_from_field_condition(field_condition: &FieldCondition) -> Vec<Fie
         required_indexes.extend(match r#match {
             Match::Value(match_value) => infer_index_from_match_value(match_value),
             Match::Text(_match_text) => vec![FieldIndexType::Text],
+            Match::Phrase(_match_text) => vec![FieldIndexType::TextPhrase],
             Match::Any(match_any) => infer_index_from_any_variants(&match_any.any),
             Match::Except(match_except) => infer_index_from_any_variants(&match_except.except),
         })
@@ -534,6 +535,7 @@ enum FieldIndexType {
     KeywordMatch,
     FloatRange,
     Text,
+    TextPhrase,
     BoolMatch,
     UuidMatch,
     UuidRange,
@@ -598,6 +600,7 @@ impl From<FieldIndexType> for PayloadSchemaType {
             FieldIndexType::KeywordMatch => PayloadSchemaType::Keyword,
             FieldIndexType::FloatRange => PayloadSchemaType::Float,
             FieldIndexType::Text => PayloadSchemaType::Text,
+            FieldIndexType::TextPhrase => PayloadSchemaType::Text,
             FieldIndexType::BoolMatch => PayloadSchemaType::Bool,
             FieldIndexType::UuidMatch => PayloadSchemaType::Uuid,
             FieldIndexType::UuidRange => PayloadSchemaType::Uuid,

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -48,7 +48,6 @@ anyhow = "1.0.98"
 pprof = { workspace = true }
 
 [dependencies]
-bitpacking = "0.9.2"
 bytemuck = { workspace = true }
 data-encoding = { workspace = true }
 delegate = { workspace = true }

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -195,16 +195,17 @@ pub struct TextIndexParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lowercase: Option<bool>,
 
+    /// If true, support phrase matching. Default: false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phrase_matching: Option<bool>,
+
+    /// Ignore this set of tokens. Can select from predefined languages and/or provide a custom set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stopwords: Option<StopwordsInterface>,
+
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_disk: Option<bool>,
-
-    // todo(phrase_match): remove skip
-    #[serde(skip)]
-    pub phrase_matching: Option<bool>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stopwords: Option<StopwordsInterface>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Hash, Eq)]

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -533,7 +533,7 @@ pub enum FieldIndexBuilder {
     GeoMmapIndex(GeoMapIndexMmapBuilder),
     GeoGridstoreIndex(GeoMapIndexGridstoreBuilder),
     #[cfg(feature = "rocksdb")]
-    FullTextIndex(super::full_text_index::text_index::FullTextIndexBuilder),
+    FullTextIndex(super::full_text_index::text_index::FullTextIndexRocksDbBuilder),
     FullTextMmapIndex(FullTextMmapIndexBuilder),
     FullTextGridstoreIndex(FullTextGridstoreIndexBuilder),
     #[cfg(feature = "rocksdb")]

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -28,8 +28,8 @@ use crate::index::field_index::numeric_index::NumericIndexInner;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
-    DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, PayloadKeyType,
-    RangeInterface, UuidIntType, UuidPayloadType,
+    DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchPhrase,
+    MatchText, PayloadKeyType, RangeInterface, UuidIntType, UuidPayloadType,
 };
 
 pub trait PayloadFieldIndex {
@@ -182,9 +182,12 @@ impl FieldIndex {
             FieldIndex::GeoIndex(_) => None,
             FieldIndex::BoolIndex(_) => None,
             FieldIndex::FullTextIndex(full_text_index) => match &condition.r#match {
-                Some(Match::Text(match_text)) => {
-                    Some(full_text_index.check_payload_match(payload_value, match_text, hw_counter))
-                }
+                Some(Match::Text(MatchText { text })) => Some(
+                    full_text_index.check_payload_match::<false>(payload_value, text, hw_counter),
+                ),
+                Some(Match::Phrase(MatchPhrase { phrase })) => Some(
+                    full_text_index.check_payload_match::<true>(payload_value, phrase, hw_counter),
+                ),
                 _ => None,
             },
             FieldIndex::UuidIndex(_) => None,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -45,7 +45,7 @@ pub struct MmapInvertedIndex {
 }
 
 impl MmapInvertedIndex {
-    pub fn create(path: PathBuf, inverted_index: ImmutableInvertedIndex) -> OperationResult<()> {
+    pub fn create(path: PathBuf, inverted_index: &ImmutableInvertedIndex) -> OperationResult<()> {
         let ImmutableInvertedIndex {
             postings,
             vocab,
@@ -61,9 +61,9 @@ impl MmapInvertedIndex {
         let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
         match postings {
-            ImmutablePostings::Ids(postings) => MmapPostings::create(postings_path, &postings)?,
+            ImmutablePostings::Ids(postings) => MmapPostings::create(postings_path, postings)?,
             ImmutablePostings::WithPositions(postings) => {
-                MmapPostings::create(postings_path, &postings)?
+                MmapPostings::create(postings_path, postings)?
             }
         }
 
@@ -84,7 +84,7 @@ impl MmapInvertedIndex {
         MmapBitSlice::create(&deleted_points_path, &deleted_bitslice)?;
 
         // The actual values go in the slice
-        let point_to_tokens_count_iter = point_to_tokens_count.into_iter();
+        let point_to_tokens_count_iter = point_to_tokens_count.iter().copied();
 
         MmapSlice::create(&point_to_tokens_count_path, point_to_tokens_count_iter)?;
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -462,7 +462,7 @@ mod tests {
 
         let hw_counter = HardwareCounterCell::new();
 
-        MmapInvertedIndex::create(mmap_dir.path().into(), immutable.clone()).unwrap();
+        MmapInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
         let mmap = MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching).unwrap();
 
         let imm_mmap = ImmutableInvertedIndex::from(&mmap);
@@ -527,7 +527,7 @@ mod tests {
         let mut mut_index = mutable_inverted_index(indexed_count, deleted_count, phrase_matching);
 
         let immutable = ImmutableInvertedIndex::from(mut_index.clone());
-        MmapInvertedIndex::create(mmap_dir.path().into(), immutable).unwrap();
+        MmapInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
         let mut mmap_index =
             MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching).unwrap();
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/positions.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/positions.rs
@@ -50,7 +50,7 @@ impl UnsizedValue for Positions {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TokenPosition {
     token_id: TokenId,
     position: u32,
@@ -63,6 +63,14 @@ pub struct PartialDocument(Vec<TokenPosition>);
 impl PartialDocument {
     pub fn new(mut tokens_positions: Vec<TokenPosition>) -> Self {
         tokens_positions.sort_by_key(|tok_pos| tok_pos.position);
+
+        // There should be no duplicate token with same position
+        debug_assert!(
+            tokens_positions
+                .windows(2)
+                .all(|window| window[0] != window[1])
+        );
+
         Self(tokens_positions)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/postings_iterator.rs
@@ -157,6 +157,7 @@ pub fn check_compressed_postings_phrase<'a>(
     token_to_posting: impl Fn(&TokenId) -> Option<PostingListView<'a, Positions>>,
 ) -> bool {
     let Some(mut posting_iterators): Option<Vec<_>> = phrase
+        .to_token_set()
         .tokens()
         .iter()
         .map(|token_id| token_to_posting(token_id).map(|posting| (*token_id, posting.into_iter())))

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -18,6 +18,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 #[cfg(feature = "rocksdb")]
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::data_types::index::TextIndexParams;
+use crate::index::field_index::ValueIndexer;
 
 const GRIDSTORE_OPTIONS: StorageOptions = StorageOptions {
     compression: Some(gridstore::config::Compression::None),
@@ -329,6 +330,27 @@ impl MutableFullTextIndex {
                 .get_value(idx, &HardwareCounterCell::disposable())
                 .map(|bytes| FullTextIndex::deserialize_document(&bytes).unwrap()),
         }
+    }
+}
+
+impl ValueIndexer for MutableFullTextIndex {
+    type ValueType = String;
+
+    fn add_many(
+        &mut self,
+        idx: PointOffsetType,
+        values: Vec<String>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.add_many(idx, values, hw_counter)
+    }
+
+    fn get_value(value: &serde_json::Value) -> Option<String> {
+        FullTextIndex::get_value(value)
+    }
+
+    fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        self.remove_point(id)
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -160,9 +160,9 @@ fn test_prefix_search() {
         min_token_len: None,
         max_token_len: None,
         lowercase: None,
-        on_disk: None,
         phrase_matching: None,
         stopwords: None,
+        on_disk: None,
     };
 
     let mut index =
@@ -208,6 +208,7 @@ fn test_phrase_matching() {
         lowercase: Some(true),
         on_disk: None,
         phrase_matching: Some(true), // Enable phrase matching
+        stopwords: None,
     };
 
     let mut mutable_index =

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -226,7 +226,7 @@ fn test_phrase_matching() {
         (1, "brown fox quick the jumps over lazy dog".to_string()),
         (2, "quick brown fox runs fast".to_string()),
         (3, "the lazy dog sleeps peacefully".to_string()),
-        (4, "brown brown fox".to_string()),
+        (4, "the brown brown fox".to_string()),
     ];
 
     for (point_id, text) in documents {
@@ -245,18 +245,25 @@ fn test_phrase_matching() {
         let text_query = index
             .parse_text_query("quick brown fox", &hw_counter)
             .unwrap();
-        let regular_results: Vec<_> = index.filter_query(text_query, &hw_counter).collect();
+        assert!(index.check_match(&text_query, 0, &hw_counter));
+        assert!(index.check_match(&text_query, 1, &hw_counter));
+        assert!(index.check_match(&text_query, 2, &hw_counter));
+
+        let text_results: Vec<_> = index.filter_query(text_query, &hw_counter).collect();
 
         // Should match documents 0, 1, and 2 (all contain "quick", "brown", "fox")
-        assert_eq!(regular_results.len(), 3);
-        assert!(regular_results.contains(&0));
-        assert!(regular_results.contains(&1));
-        assert!(regular_results.contains(&2));
+        assert_eq!(text_results.len(), 3);
+        assert!(text_results.contains(&0));
+        assert!(text_results.contains(&1));
+        assert!(text_results.contains(&2));
 
         // Test phrase matching (should only match documents with exact phrase in order)
         let phrase_query = index
             .parse_phrase_query("quick brown fox", &hw_counter)
             .unwrap();
+        assert!(index.check_match(&phrase_query, 0, &hw_counter));
+        assert!(index.check_match(&phrase_query, 2, &hw_counter));
+
         let phrase_results: Vec<_> = index.filter_query(phrase_query, &hw_counter).collect();
 
         // Should only match documents 0 and 2 (contain "quick brown fox" in that exact order)
@@ -278,11 +285,12 @@ fn test_phrase_matching() {
         let phrase_query = index
             .parse_phrase_query("brown brown fox", &hw_counter)
             .unwrap();
-        let phrase_results: Vec<_> = index.filter_query(phrase_query, &hw_counter).collect();
+        assert!(index.check_match(&phrase_query, 4, &hw_counter));
 
         // Should only match document 4
-        assert_eq!(phrase_results.len(), 1);
-        assert!(phrase_results.contains(&4));
+        let filter_results: Vec<_> = index.filter_query(phrase_query, &hw_counter).collect();
+        assert_eq!(filter_results.len(), 1);
+        assert!(filter_results.contains(&4));
     };
 
     check_matching(mutable_index);

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -14,16 +14,13 @@ use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::data_types::index::TextIndexParams;
 use crate::fixtures::payload_fixtures::random_full_text_payload;
 use crate::index::field_index::field_index_base::PayloadFieldIndex;
-use crate::index::field_index::full_text_index::immutable_text_index::ImmutableFullTextIndex;
 use crate::index::field_index::full_text_index::inverted_index::{
     Document, InvertedIndex, ParsedQuery, TokenId, TokenSet,
 };
 use crate::index::field_index::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
-#[cfg(feature = "rocksdb")]
-use crate::index::field_index::full_text_index::mutable_text_index;
 use crate::index::field_index::full_text_index::mutable_text_index::MutableFullTextIndex;
 #[cfg(feature = "rocksdb")]
-use crate::index::field_index::full_text_index::text_index::FullTextIndexBuilder;
+use crate::index::field_index::full_text_index::text_index::FullTextIndexRocksDbBuilder;
 use crate::index::field_index::full_text_index::text_index::{
     FullTextGridstoreIndexBuilder, FullTextIndex,
 };
@@ -39,33 +36,33 @@ type Database = ();
 const FIELD_NAME: &str = "test";
 const TYPES: &[IndexType] = &[
     #[cfg(feature = "rocksdb")]
-    IndexType::Mutable,
+    IndexType::MutableRocksdb,
     IndexType::MutableGridstore,
     #[cfg(feature = "rocksdb")]
-    IndexType::Immutable,
-    IndexType::Mmap,
-    IndexType::RamMmap,
+    IndexType::ImmRamRocksDb,
+    IndexType::ImmMmap,
+    IndexType::ImmRamMmap,
 ];
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum IndexType {
     #[cfg(feature = "rocksdb")]
-    Mutable,
+    MutableRocksdb,
     MutableGridstore,
     #[cfg(feature = "rocksdb")]
-    Immutable,
-    Mmap,
-    RamMmap,
+    ImmRamRocksDb,
+    ImmMmap,
+    ImmRamMmap,
 }
 
 enum IndexBuilder {
     #[cfg(feature = "rocksdb")]
-    Mutable(FullTextIndexBuilder),
+    MutableRocksdb(FullTextIndexRocksDbBuilder),
     MutableGridstore(FullTextGridstoreIndexBuilder),
     #[cfg(feature = "rocksdb")]
-    Immutable(FullTextIndexBuilder),
-    Mmap(FullTextMmapIndexBuilder),
-    RamMmap(FullTextMmapIndexBuilder),
+    ImmRamRocksdb(FullTextIndexRocksDbBuilder),
+    ImmMmap(FullTextMmapIndexBuilder),
+    ImmRamMmap(FullTextMmapIndexBuilder),
 }
 
 impl IndexBuilder {
@@ -77,16 +74,16 @@ impl IndexBuilder {
     ) -> OperationResult<()> {
         match self {
             #[cfg(feature = "rocksdb")]
-            IndexBuilder::Mutable(builder) => builder.add_point(id, payload, hw_counter),
+            IndexBuilder::MutableRocksdb(builder) => builder.add_point(id, payload, hw_counter),
             IndexBuilder::MutableGridstore(builder) => {
                 FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
             }
             #[cfg(feature = "rocksdb")]
-            IndexBuilder::Immutable(builder) => builder.add_point(id, payload, hw_counter),
-            IndexBuilder::Mmap(builder) => {
+            IndexBuilder::ImmRamRocksdb(builder) => builder.add_point(id, payload, hw_counter),
+            IndexBuilder::ImmMmap(builder) => {
                 FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
             }
-            IndexBuilder::RamMmap(builder) => {
+            IndexBuilder::ImmRamMmap(builder) => {
                 FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
             }
         }
@@ -95,43 +92,12 @@ impl IndexBuilder {
     fn finalize(self) -> OperationResult<FullTextIndex> {
         match self {
             #[cfg(feature = "rocksdb")]
-            IndexBuilder::Mutable(builder) => builder.finalize(),
+            IndexBuilder::MutableRocksdb(builder) => builder.finalize(),
             IndexBuilder::MutableGridstore(builder) => builder.finalize(),
             #[cfg(feature = "rocksdb")]
-            IndexBuilder::Immutable(builder) => {
-                let FullTextIndex::Mutable(index) = builder.finalize()? else {
-                    panic!("expected mutable index");
-                };
-
-                // Deconstruct mutable index, flush pending changes
-                let MutableFullTextIndex {
-                    storage,
-                    inverted_index: _,
-                    config,
-                    tokenizer: _,
-                } = index;
-                let mutable_text_index::Storage::RocksDb(db_wrapper) = storage else {
-                    panic!("expected RocksDB storage for immutable index");
-                };
-                db_wrapper.flusher()().expect("failed to flush");
-
-                // Open and load immutable index
-                let mut index = ImmutableFullTextIndex::open_rocksdb(db_wrapper, config);
-                index.load()?;
-                let index = FullTextIndex::Immutable(index);
-                Ok(index)
-            }
-            IndexBuilder::Mmap(builder) => builder.finalize(),
-            IndexBuilder::RamMmap(builder) => {
-                let FullTextIndex::Mmap(index) = builder.finalize()? else {
-                    panic!("expected mmap index");
-                };
-
-                // Load index from mmap
-                let mut index = FullTextIndex::Immutable(ImmutableFullTextIndex::open_mmap(*index));
-                index.load()?;
-                Ok(index)
-            }
+            IndexBuilder::ImmRamRocksdb(builder) => builder.finalize(),
+            IndexBuilder::ImmMmap(builder) => builder.finalize(),
+            IndexBuilder::ImmRamMmap(builder) => builder.finalize(),
         }
     }
 }
@@ -151,41 +117,38 @@ fn create_builder(
         ..TextIndexParams::default()
     };
 
-    let mut builder = match index_type {
-        #[cfg(feature = "rocksdb")]
-        IndexType::Mutable => IndexBuilder::Mutable(FullTextIndex::builder_rocksdb(
-            db.clone(),
-            config,
-            FIELD_NAME,
-        )),
-        IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
-            FullTextIndex::builder_gridstore(temp_dir.path().to_path_buf(), config),
-        ),
-        #[cfg(feature = "rocksdb")]
-        IndexType::Immutable => IndexBuilder::Immutable(FullTextIndex::builder_rocksdb(
-            db.clone(),
-            config,
-            FIELD_NAME,
-        )),
-        IndexType::Mmap => IndexBuilder::Mmap(FullTextIndex::builder_mmap(
-            temp_dir.path().to_path_buf(),
-            config,
-            true,
-        )),
-        IndexType::RamMmap => IndexBuilder::RamMmap(FullTextIndex::builder_mmap(
-            temp_dir.path().to_path_buf(),
-            config,
-            false,
-        )),
-    };
+    let mut builder =
+        match index_type {
+            #[cfg(feature = "rocksdb")]
+            IndexType::MutableRocksdb => IndexBuilder::MutableRocksdb(
+                FullTextIndex::builder_rocksdb(db.clone(), config, FIELD_NAME, true),
+            ),
+            IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
+                FullTextIndex::builder_gridstore(temp_dir.path().to_path_buf(), config),
+            ),
+            #[cfg(feature = "rocksdb")]
+            IndexType::ImmRamRocksDb => IndexBuilder::ImmRamRocksdb(
+                FullTextIndex::builder_rocksdb(db.clone(), config, FIELD_NAME, false),
+            ),
+            IndexType::ImmMmap => IndexBuilder::ImmMmap(FullTextIndex::builder_mmap(
+                temp_dir.path().to_path_buf(),
+                config,
+                true,
+            )),
+            IndexType::ImmRamMmap => IndexBuilder::ImmRamMmap(FullTextIndex::builder_mmap(
+                temp_dir.path().to_path_buf(),
+                config,
+                false,
+            )),
+        };
     match &mut builder {
         #[cfg(feature = "rocksdb")]
-        IndexBuilder::Mutable(builder) => builder.init().unwrap(),
+        IndexBuilder::MutableRocksdb(builder) => builder.init().unwrap(),
         IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
         #[cfg(feature = "rocksdb")]
-        IndexBuilder::Immutable(builder) => builder.init().unwrap(),
-        IndexBuilder::Mmap(builder) => builder.init().unwrap(),
-        IndexBuilder::RamMmap(builder) => builder.init().unwrap(),
+        IndexBuilder::ImmRamRocksdb(builder) => builder.init().unwrap(),
+        IndexBuilder::ImmMmap(builder) => builder.init().unwrap(),
+        IndexBuilder::ImmRamMmap(builder) => builder.init().unwrap(),
     }
     (builder, temp_dir, db)
 }
@@ -272,7 +235,7 @@ fn test_congruence(
     #[values(false, true)] phrase_matching: bool,
 ) {
     const POINT_COUNT: usize = 500;
-    const KEYWORD_COUNT: usize = 5;
+    const KEYWORD_COUNT: usize = 20;
     const KEYWORD_LEN: usize = 2;
 
     let hw_counter = HardwareCounterCell::disposable();
@@ -456,13 +419,14 @@ fn check_phrase<const KEYWORD_COUNT: usize>(
     check_indexes: &[(FullTextIndex, IndexType)],
     phrase_matching: bool,
 ) -> Vec<Vec<String>> {
-    // From the ids, choose a random phrase of 2 words.
+    // From the ids, choose a random phrase of 4 words.
+    const PHRASE_LENGTH: usize = 4;
     let mut phrases = Vec::new();
-    let rng = &mut rand::rng();
+    let rng = &mut StdRng::seed_from_u64(43);
     for id in existing_ids {
         let doc = mutable_index.get_doc(*id).unwrap();
-        let rand_idx = rng.random_range(0..KEYWORD_COUNT - 1);
-        let phrase = doc[rand_idx..rand_idx + 2].to_vec();
+        let rand_idx = rng.random_range(0..=KEYWORD_COUNT - PHRASE_LENGTH);
+        let phrase = doc[rand_idx..rand_idx + PHRASE_LENGTH].to_vec();
 
         phrases.push(phrase);
     }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use std::collections::BTreeSet;
 use std::path::PathBuf;
 #[cfg(feature = "rocksdb")]
 use std::sync::Arc;
@@ -102,8 +100,9 @@ impl FullTextIndex {
         db: Arc<RwLock<DB>>,
         config: TextIndexParams,
         field: &str,
-    ) -> FullTextIndexBuilder {
-        FullTextIndexBuilder(Self::new_rocksdb(db, config, field, true))
+        keep_appendable: bool,
+    ) -> FullTextIndexRocksDbBuilder {
+        FullTextIndexRocksDbBuilder::new(db, config, field, keep_appendable)
     }
 
     pub fn builder_mmap(
@@ -240,39 +239,6 @@ impl FullTextIndex {
     #[cfg(feature = "rocksdb")]
     pub(super) fn restore_key(data: &[u8]) -> PointOffsetType {
         bincode::deserialize(data).unwrap()
-    }
-
-    /// CBOR representation is the same for BTreeSet<String> and Vec<String> if the elements are sorted, thus, we can resort to
-    /// the vec implementation always. Let's just keep this to prove this works fine during https://github.com/qdrant/qdrant/pull/6493
-    ///
-    /// We can remove this afterwards
-    #[cfg(test)]
-    pub(super) fn serialize_token_set(tokens: BTreeSet<String>) -> OperationResult<Vec<u8>> {
-        #[derive(Serialize)]
-        struct StoredTokens {
-            tokens: BTreeSet<String>,
-        }
-        let doc = StoredTokens { tokens };
-        serde_cbor::to_vec(&doc).map_err(|e| {
-            OperationError::service_error(format!("Failed to serialize document: {e}"))
-        })
-    }
-
-    /// CBOR representation is the same for BTreeSet<String> and Vec<String> if the elements are sorted, thus, we can resort to
-    /// the vec implementation always. Let's just keep this to prove this works fine during https://github.com/qdrant/qdrant/pull/6493
-    ///
-    /// We can delete this afterwards
-    #[cfg(test)]
-    pub(super) fn deserialize_token_set(data: &[u8]) -> OperationResult<BTreeSet<String>> {
-        #[derive(Deserialize)]
-        struct StoredTokens {
-            tokens: BTreeSet<String>,
-        }
-        serde_cbor::from_slice::<StoredTokens>(data)
-            .map_err(|e| {
-                OperationError::service_error(format!("Failed to deserialize document: {e}"))
-            })
-            .map(|doc| doc.tokens)
     }
 
     pub(super) fn serialize_document(tokens: Vec<String>) -> OperationResult<Vec<u8>> {
@@ -434,13 +400,38 @@ impl FullTextIndex {
     }
 }
 
-pub struct FullTextIndexBuilder(FullTextIndex);
+#[cfg(feature = "rocksdb")]
+pub struct FullTextIndexRocksDbBuilder {
+    mutable_index: MutableFullTextIndex,
+    keep_appendable: bool,
+}
 
-impl FieldIndexBuilderTrait for FullTextIndexBuilder {
+#[cfg(feature = "rocksdb")]
+impl FullTextIndexRocksDbBuilder {
+    pub fn new(
+        db: Arc<RwLock<DB>>,
+        config: TextIndexParams,
+        field: &str,
+        keep_appendable: bool,
+    ) -> Self {
+        let store_cf_name = FullTextIndex::storage_cf_name(field);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            &store_cf_name,
+        ));
+        FullTextIndexRocksDbBuilder {
+            mutable_index: MutableFullTextIndex::open_rocksdb(db_wrapper, config),
+            keep_appendable,
+        }
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+impl FieldIndexBuilderTrait for FullTextIndexRocksDbBuilder {
     type FieldIndexType = FullTextIndex;
 
     fn init(&mut self) -> OperationResult<()> {
-        self.0.init()
+        self.mutable_index.init()
     }
 
     fn add_point(
@@ -449,11 +440,17 @@ impl FieldIndexBuilderTrait for FullTextIndexBuilder {
         payload: &[&Value],
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        self.0.add_point(id, payload, hw_counter)
+        self.mutable_index.add_point(id, payload, hw_counter)
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        Ok(self.0)
+        if self.keep_appendable {
+            return Ok(FullTextIndex::Mutable(self.mutable_index));
+        }
+
+        Ok(FullTextIndex::Immutable(
+            ImmutableFullTextIndex::from_rocksdb_mutable(self.mutable_index),
+        ))
     }
 }
 
@@ -478,10 +475,7 @@ impl ValueIndexer for FullTextIndex {
     }
 
     fn get_value(value: &Value) -> Option<String> {
-        if let Value::String(keyword) = value {
-            return Some(keyword.to_owned());
-        }
-        None
+        value.as_str().map(ToOwned::to_owned)
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
@@ -610,10 +604,7 @@ impl ValueIndexer for FullTextGridstoreIndexBuilder {
     type ValueType = String;
 
     fn get_value(value: &Value) -> Option<String> {
-        match value {
-            Value::String(s) => Some(s.clone()),
-            _ => None,
-        }
+        FullTextIndex::get_value(value)
     }
 
     fn add_many(
@@ -674,472 +665,5 @@ impl FieldIndexBuilderTrait for FullTextGridstoreIndexBuilder {
         };
         index.flusher()()?;
         Ok(index)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use rand::SeedableRng;
-    use rand::rngs::StdRng;
-    use rstest::rstest;
-    use tempfile::{Builder, TempDir};
-
-    use super::*;
-    use crate::fixtures::payload_fixtures::random_full_text_payload;
-    use crate::index::field_index::field_index_base::FieldIndexBuilderTrait;
-    #[cfg(feature = "rocksdb")]
-    use crate::index::field_index::full_text_index::mutable_text_index;
-    use crate::types::ValuesCount;
-
-    const FIELD_NAME: &str = "test";
-
-    #[cfg(feature = "rocksdb")]
-    const INDEXES_COUNT: usize = 5;
-
-    #[cfg(not(feature = "rocksdb"))]
-    const INDEXES_COUNT: usize = 3;
-
-    const TYPES: [IndexType; INDEXES_COUNT] = [
-        #[cfg(feature = "rocksdb")]
-        IndexType::Mutable,
-        IndexType::MutableGridstore,
-        #[cfg(feature = "rocksdb")]
-        IndexType::Immutable,
-        IndexType::Mmap,
-        IndexType::RamMmap,
-    ];
-
-    #[derive(Clone, Copy, PartialEq, Debug)]
-    enum IndexType {
-        #[cfg(feature = "rocksdb")]
-        Mutable,
-        MutableGridstore,
-        #[cfg(feature = "rocksdb")]
-        Immutable,
-        Mmap,
-        RamMmap,
-    }
-
-    enum IndexBuilder {
-        #[cfg(feature = "rocksdb")]
-        Mutable(FullTextIndexBuilder),
-        MutableGridstore(FullTextGridstoreIndexBuilder),
-        #[cfg(feature = "rocksdb")]
-        Immutable(FullTextIndexBuilder),
-        Mmap(FullTextMmapIndexBuilder),
-        RamMmap(FullTextMmapIndexBuilder),
-    }
-
-    struct CreatedBuilder {
-        index_builder: IndexBuilder,
-        temp_dir: TempDir,
-        #[cfg(feature = "rocksdb")]
-        db: Arc<RwLock<DB>>,
-    }
-
-    struct ConstructedIndex {
-        index: FullTextIndex,
-        temp_dir: TempDir,
-        #[cfg(feature = "rocksdb")]
-        db: Arc<RwLock<DB>>,
-    }
-
-    struct IndexContext {
-        _temp_dir: TempDir,
-        #[cfg(feature = "rocksdb")]
-        _db: Arc<RwLock<DB>>,
-    }
-
-    impl IndexBuilder {
-        fn add_point(
-            &mut self,
-            id: PointOffsetType,
-            payload: &[&Value],
-            hw_counter: &HardwareCounterCell,
-        ) -> OperationResult<()> {
-            match self {
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Mutable(builder) => builder.add_point(id, payload, hw_counter),
-                IndexBuilder::MutableGridstore(builder) => {
-                    FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
-                }
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Immutable(builder) => builder.add_point(id, payload, hw_counter),
-                IndexBuilder::Mmap(builder) => {
-                    FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
-                }
-                IndexBuilder::RamMmap(builder) => {
-                    FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
-                }
-            }
-        }
-
-        fn finalize(self) -> OperationResult<FullTextIndex> {
-            match self {
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Mutable(builder) => builder.finalize(),
-                IndexBuilder::MutableGridstore(builder) => builder.finalize(),
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Immutable(builder) => {
-                    let FullTextIndex::Mutable(index) = builder.finalize()? else {
-                        panic!("expected mutable index");
-                    };
-
-                    // Deconstruct mutable index, flush pending changes
-                    let MutableFullTextIndex {
-                        storage,
-                        inverted_index: _,
-                        config,
-                        tokenizer: _,
-                    } = index;
-                    let mutable_text_index::Storage::RocksDb(db_wrapper) = storage else {
-                        panic!("expected RocksDB storage for immutable index");
-                    };
-                    db_wrapper.flusher()().expect("failed to flush");
-
-                    // Open and load immutable index
-                    let mut index = ImmutableFullTextIndex::open_rocksdb(db_wrapper, config);
-                    index.load()?;
-                    let index = FullTextIndex::Immutable(index);
-                    Ok(index)
-                }
-                IndexBuilder::Mmap(builder) => builder.finalize(),
-                IndexBuilder::RamMmap(builder) => {
-                    let FullTextIndex::Mmap(index) = builder.finalize()? else {
-                        panic!("expected mmap index");
-                    };
-
-                    // Load index from mmap
-                    let mut index =
-                        FullTextIndex::Immutable(ImmutableFullTextIndex::open_mmap(*index));
-                    index.load()?;
-                    Ok(index)
-                }
-            }
-        }
-    }
-
-    #[cfg(feature = "testing")]
-    fn create_builder(index_type: IndexType, phrase_matching: bool) -> CreatedBuilder {
-        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
-        #[cfg(feature = "rocksdb")]
-        let db = crate::common::rocksdb_wrapper::open_db_with_existing_cf(
-            &temp_dir.path().join("test_db"),
-        )
-        .unwrap();
-        let config = TextIndexParams {
-            phrase_matching: Some(phrase_matching),
-            ..TextIndexParams::default()
-        };
-        let mut builder = match index_type {
-            #[cfg(feature = "rocksdb")]
-            IndexType::Mutable => IndexBuilder::Mutable(FullTextIndex::builder_rocksdb(
-                db.clone(),
-                config,
-                FIELD_NAME,
-            )),
-            IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
-                FullTextIndex::builder_gridstore(temp_dir.path().to_path_buf(), config),
-            ),
-            #[cfg(feature = "rocksdb")]
-            IndexType::Immutable => IndexBuilder::Immutable(FullTextIndex::builder_rocksdb(
-                db.clone(),
-                config,
-                FIELD_NAME,
-            )),
-            IndexType::Mmap => IndexBuilder::Mmap(FullTextIndex::builder_mmap(
-                temp_dir.path().to_path_buf(),
-                config,
-                true,
-            )),
-            IndexType::RamMmap => IndexBuilder::RamMmap(FullTextIndex::builder_mmap(
-                temp_dir.path().to_path_buf(),
-                config,
-                false,
-            )),
-        };
-        match &mut builder {
-            #[cfg(feature = "rocksdb")]
-            IndexBuilder::Mutable(builder) => builder.init().unwrap(),
-            IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
-            #[cfg(feature = "rocksdb")]
-            IndexBuilder::Immutable(builder) => builder.init().unwrap(),
-            IndexBuilder::Mmap(builder) => builder.init().unwrap(),
-            IndexBuilder::RamMmap(builder) => builder.init().unwrap(),
-        }
-        CreatedBuilder {
-            index_builder: builder,
-            temp_dir,
-            #[cfg(feature = "rocksdb")]
-            db,
-        }
-    }
-
-    fn build_random_index(
-        num_points: usize,
-        num_keywords: usize,
-        keyword_len: usize,
-        index_type: IndexType,
-        phrase_matching: bool,
-        deleted: bool,
-    ) -> ConstructedIndex {
-        let mut rnd = StdRng::seed_from_u64(42);
-        let mut created_builder = create_builder(index_type, phrase_matching);
-
-        for idx in 0..num_points {
-            let keywords = random_full_text_payload(
-                &mut rnd,
-                num_keywords..=num_keywords,
-                keyword_len..=keyword_len,
-            );
-            let array_payload = Value::Array(keywords);
-            created_builder
-                .index_builder
-                .add_point(
-                    idx as PointOffsetType,
-                    &[&array_payload],
-                    &HardwareCounterCell::new(),
-                )
-                .unwrap();
-        }
-
-        let mut index = created_builder.index_builder.finalize().unwrap();
-        assert_eq!(index.points_count(), num_points);
-
-        // Delete some points before loading into a different format
-        if deleted {
-            index.remove_point(20).unwrap();
-            index.remove_point(21).unwrap();
-            index.remove_point(22).unwrap();
-            index.remove_point(200).unwrap();
-            index.remove_point(250).unwrap();
-        }
-
-        ConstructedIndex {
-            index,
-            temp_dir: created_builder.temp_dir,
-            #[cfg(feature = "rocksdb")]
-            db: created_builder.db,
-        }
-    }
-
-    /// Tries to parse a query. If there is an unknown id to a token, returns `None`
-    fn to_parsed_query(
-        query: &[String],
-        token_to_id: impl Fn(&str) -> Option<TokenId>,
-    ) -> Option<ParsedQuery> {
-        let tokens = query
-            .iter()
-            .map(|token| token_to_id(token.as_str()))
-            .collect::<Option<TokenSet>>()?;
-        Some(ParsedQuery::Tokens(tokens))
-    }
-
-    fn parse_query(query: &[String], index: &FullTextIndex) -> ParsedQuery {
-        let hw_counter = HardwareCounterCell::disposable();
-        match index {
-            FullTextIndex::Mutable(index) => {
-                let token_to_id =
-                    |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-                to_parsed_query(query, token_to_id).unwrap()
-            }
-            FullTextIndex::Immutable(index) => {
-                let token_to_id =
-                    |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-                to_parsed_query(query, token_to_id).unwrap()
-            }
-            FullTextIndex::Mmap(index) => {
-                let token_to_id =
-                    |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-                to_parsed_query(query, token_to_id).unwrap()
-            }
-        }
-    }
-
-    #[rstest]
-    fn test_congruence(
-        #[values(false, true)] deleted: bool,
-        #[values(false, true)] phrase_matching: bool,
-    ) {
-        use std::collections::HashSet;
-
-        use crate::json_path::JsonPath;
-
-        const POINT_COUNT: usize = 500;
-        const KEYWORD_COUNT: usize = 5;
-        const KEYWORD_LEN: usize = 2;
-
-        let hw_counter = HardwareCounterCell::disposable();
-
-        let (mut indices, _data): (Vec<_>, Vec<_>) = TYPES
-            .iter()
-            .copied()
-            .map(|index_type| {
-                let constructed_index = build_random_index(
-                    POINT_COUNT,
-                    KEYWORD_COUNT,
-                    KEYWORD_LEN,
-                    index_type,
-                    phrase_matching,
-                    deleted,
-                );
-                let index_context = IndexContext {
-                    _temp_dir: constructed_index.temp_dir,
-                    #[cfg(feature = "rocksdb")]
-                    _db: constructed_index.db,
-                };
-
-                ((constructed_index.index, index_type), index_context)
-            })
-            .unzip();
-
-        // Delete some points after loading
-        if deleted {
-            for (index, _type) in indices.iter_mut() {
-                index.remove_point(10).unwrap();
-                index.remove_point(11).unwrap();
-                index.remove_point(12).unwrap();
-                index.remove_point(100).unwrap();
-                index.remove_point(150).unwrap();
-            }
-        }
-
-        // Grab 10 keywords to use for querying
-        let (FullTextIndex::Mutable(index), _) = &indices[0] else {
-            panic!("Expects mutable full text index as first");
-        };
-        let mut keywords = index
-            .inverted_index
-            .vocab
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        keywords.sort_unstable();
-        keywords.truncate(10);
-
-        for i in 1..indices.len() {
-            let ((index_a, type_a), (index_b, type_b)) = (&indices[0], &indices[i]);
-            eprintln!("Testing index type {type_a:?} vs {type_b:?}");
-
-            assert_eq!(index_a.points_count(), index_b.points_count());
-            for point_id in 0..POINT_COUNT as PointOffsetType {
-                assert_eq!(
-                    index_a.values_count(point_id),
-                    index_b.values_count(point_id),
-                );
-                assert_eq!(
-                    index_a.values_is_empty(point_id),
-                    index_b.values_is_empty(point_id),
-                );
-            }
-
-            assert_eq!(
-                index_a.get_token("doesnotexist", &hw_counter),
-                index_b.get_token("doesnotexist", &hw_counter),
-            );
-            assert!(
-                index_a.get_token(&keywords[0], &hw_counter).is_some()
-                    == index_b.get_token(&keywords[0], &hw_counter).is_some(),
-            );
-
-            for query_range in [0..1, 2..4, 5..9, 0..10] {
-                let keywords = &keywords[query_range];
-                let parsed_query_a = parse_query(keywords, index_a);
-                let parsed_query_b = parse_query(keywords, index_b);
-
-                // Mutable index behaves different versus the others on point deletion
-                // Mutable index updates postings, the others do not. Cardinality estimations are
-                // not expected to match because of it.
-                if !deleted {
-                    let field_condition = FieldCondition::new_values_count(
-                        JsonPath::new(FIELD_NAME),
-                        ValuesCount::from(0..10),
-                    );
-                    let cardinality_a = index_a.estimate_query_cardinality(
-                        &parsed_query_a,
-                        &field_condition,
-                        &hw_counter,
-                    );
-                    let cardinality_b = index_b.estimate_query_cardinality(
-                        &parsed_query_b,
-                        &field_condition,
-                        &hw_counter,
-                    );
-                    assert_eq!(cardinality_a, cardinality_b);
-                }
-
-                for point_id in 0..POINT_COUNT as PointOffsetType {
-                    assert_eq!(
-                        index_a.check_match(&parsed_query_a, point_id, &hw_counter),
-                        index_b.check_match(&parsed_query_b, point_id, &hw_counter),
-                    );
-                }
-
-                assert_eq!(
-                    index_a
-                        .filter_query(parsed_query_a, &hw_counter)
-                        .collect::<HashSet<_>>(),
-                    index_b
-                        .filter_query(parsed_query_b, &hw_counter)
-                        .collect::<HashSet<_>>(),
-                );
-            }
-
-            if !deleted {
-                for threshold in 1..=10 {
-                    assert_eq!(
-                        index_a
-                            .payload_blocks(threshold, JsonPath::new(FIELD_NAME))
-                            .count(),
-                        index_b
-                            .payload_blocks(threshold, JsonPath::new(FIELD_NAME))
-                            .count(),
-                    );
-                }
-            }
-        }
-    }
-
-    /// Test that Vec and BTreeSet are serialized the same way in CBOR
-    #[test]
-    fn test_tokenset_and_document_serde() {
-        let str_tokens = [
-            "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog",
-        ]
-        .map(String::from);
-
-        let str_tokens_set = BTreeSet::from_iter(str_tokens.clone());
-        let str_tokens_set_as_vec = str_tokens_set.iter().cloned().collect::<Vec<_>>();
-
-        let serialized_set = FullTextIndex::serialize_token_set(str_tokens_set.clone()).unwrap();
-        let serialized_vec =
-            FullTextIndex::serialize_document(str_tokens_set_as_vec.clone()).unwrap();
-
-        assert_eq!(serialized_set, serialized_vec);
-
-        eprintln!(
-            "Serialized set: {:?}",
-            serialized_set
-                .iter()
-                .map(|&b| b as char)
-                .collect::<String>()
-        );
-        eprintln!(
-            "Serialized vec: {:?}",
-            serialized_vec
-                .iter()
-                .map(|&b| b as char)
-                .collect::<String>()
-        );
-
-        // cross serialization/deserialization also gives the same result
-        assert_eq!(
-            FullTextIndex::deserialize_document(&serialized_set).unwrap(),
-            str_tokens_set_as_vec
-        );
-        assert_eq!(
-            FullTextIndex::deserialize_token_set(&serialized_vec).unwrap(),
-            str_tokens_set
-        );
     }
 }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -363,14 +363,14 @@ impl IndexSelector<'_> {
     fn text_builder(&self, field: &JsonPath, config: TextIndexParams) -> FieldIndexBuilder {
         match self {
             #[cfg(feature = "rocksdb")]
-            IndexSelector::RocksDb(IndexSelectorRocksDb {
-                db,
-                is_appendable: _,
-            }) => FieldIndexBuilder::FullTextIndex(FullTextIndex::builder_rocksdb(
-                Arc::clone(db),
-                config,
-                &field.to_string(),
-            )),
+            IndexSelector::RocksDb(IndexSelectorRocksDb { db, is_appendable }) => {
+                FieldIndexBuilder::FullTextIndex(FullTextIndex::builder_rocksdb(
+                    Arc::clone(db),
+                    config,
+                    &field.to_string(),
+                    *is_appendable,
+                ))
+            }
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 FieldIndexBuilder::FullTextMmapIndex(FullTextIndex::builder_mmap(
                     text_dir(dir, field),

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::types::{
     AnyVariants, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPoint,
-    GeoPolygon, GeoRadius, Match, MatchAny, MatchExcept, MatchText, MatchValue, Range,
+    GeoPolygon, GeoRadius, Match, MatchAny, MatchExcept, MatchPhrase, MatchText, MatchValue, Range,
     RangeInterface, ValueVariants, ValuesCount,
 };
 
@@ -159,10 +159,12 @@ impl ValueChecker for Match {
                 }
                 _ => false,
             },
-            Match::Text(MatchText { text }) => match payload {
-                Value::String(stored) => stored.contains(text),
-                _ => false,
-            },
+            Match::Text(MatchText { text }) | Match::Phrase(MatchPhrase { phrase: text }) => {
+                match payload {
+                    Value::String(stored) => stored.contains(text),
+                    _ => false,
+                }
+            }
             Match::Any(MatchAny { any }) => match (payload, any) {
                 (Value::String(stored), AnyVariants::Strings(list)) => {
                     if list.len() < INDEXSET_ITER_THRESHOLD {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1860,7 +1860,30 @@ impl Display for PayloadFieldSchema {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             PayloadFieldSchema::FieldType(t) => write!(f, "{}", t.name()),
-            PayloadFieldSchema::FieldParams(p) => write!(f, "{}", p.name()),
+            PayloadFieldSchema::FieldParams(params) => match params {
+                PayloadSchemaParams::Keyword(_)
+                | PayloadSchemaParams::Float(_)
+                | PayloadSchemaParams::Geo(_)
+                | PayloadSchemaParams::Bool(_)
+                | PayloadSchemaParams::Datetime(_)
+                | PayloadSchemaParams::Uuid(_) => write!(f, "{}", params.name()),
+                PayloadSchemaParams::Integer(integer_params) => {
+                    let range = integer_params.range.unwrap_or(true);
+                    let lookup = integer_params.lookup.unwrap_or(true);
+                    if range && lookup {
+                        write!(f, "integer")
+                    } else {
+                        write!(f, "integer (with range: {}, lookup: {})", range, lookup)
+                    }
+                }
+                PayloadSchemaParams::Text(text_params) => {
+                    if text_params.phrase_matching.unwrap_or_default() {
+                        write!(f, "text (with phrase_matching: true)")
+                    } else {
+                        write!(f, "text")
+                    }
+                }
+            },
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1873,7 +1873,7 @@ impl Display for PayloadFieldSchema {
                     if range && lookup {
                         write!(f, "integer")
                     } else {
-                        write!(f, "integer (with range: {}, lookup: {})", range, lookup)
+                        write!(f, "integer (with range: {range}, lookup: {lookup})")
                     }
                 }
                 PayloadSchemaParams::Text(text_params) => {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2046,6 +2046,21 @@ impl<S: Into<String>> From<S> for MatchText {
     }
 }
 
+/// Full-text phrase match of the string.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct MatchPhrase {
+    pub phrase: String,
+}
+
+impl<S: Into<String>> From<S> for MatchPhrase {
+    fn from(text: S) -> Self {
+        MatchPhrase {
+            phrase: text.into(),
+        }
+    }
+}
+
 /// Exact match on any of the given values
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -2066,6 +2081,7 @@ pub struct MatchExcept {
 pub enum MatchInterface {
     Value(MatchValue),
     Text(MatchText),
+    Phrase(MatchPhrase),
     Any(MatchAny),
     Except(MatchExcept),
 }
@@ -2076,6 +2092,7 @@ pub enum MatchInterface {
 pub enum Match {
     Value(MatchValue),
     Text(MatchText),
+    Phrase(MatchPhrase),
     Any(MatchAny),
     Except(MatchExcept),
 }
@@ -2087,6 +2104,12 @@ impl Match {
 
     pub fn new_text(text: &str) -> Self {
         Self::Text(MatchText { text: text.into() })
+    }
+
+    pub fn new_phrase(phrase: &str) -> Self {
+        Self::Phrase(MatchPhrase {
+            phrase: phrase.into(),
+        })
     }
 
     pub fn new_any(any: AnyVariants) -> Self {
@@ -2113,6 +2136,7 @@ impl From<MatchInterface> for Match {
             MatchInterface::Except(except) => Self::Except(MatchExcept {
                 except: except.except,
             }),
+            MatchInterface::Phrase(MatchPhrase { phrase }) => Self::Phrase(MatchPhrase { phrase }),
         }
     }
 }
@@ -2624,6 +2648,7 @@ impl FieldCondition {
             Match::Except(match_except) => match_except.except.len(),
             Match::Value(_) => 0,
             Match::Text(_) => 0,
+            Match::Phrase(_) => 0,
         }
     }
 }

--- a/tests/openapi/test_phrase_matching.py
+++ b/tests/openapi/test_phrase_matching.py
@@ -61,6 +61,7 @@ def setup_phrase_collection(
         "deep learning neural networks",
         "brown sugar and quick oats",
         "New York City is a bustling metropolis",
+        "writing tests is very very very important",
     ]
 
     test_data = [
@@ -125,6 +126,8 @@ def phrase_collection():
             "longer phrase match",
         ),
         ("", 0, set(), "empty phrase"),
+        ("very very very", 1, {11}, "repeated word"),
+        ("very very very very", 0, set(), "repeated word too many times"),
     ],
 )
 def test_phrase_matching(

--- a/tests/openapi/test_phrase_matching.py
+++ b/tests/openapi/test_phrase_matching.py
@@ -1,0 +1,202 @@
+import pytest
+import random
+
+from .helpers.collection_setup import (
+    drop_collection,
+)
+from .helpers.helpers import (
+    request_with_validation,
+)
+
+# Field name constant
+FIELD_NAME = "text"
+
+
+def setup_phrase_collection(
+    collection_name="test_phrase_collection",
+):
+    """Setup a collection with phrase matching enabled for text fields."""
+    drop_collection(collection_name)
+
+    # Create collection
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {
+                "size": 4,
+                "distance": "Dot",
+            },
+        },
+    )
+    assert response.ok
+
+    # Create text index with phrase matching enabled
+    response = request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "field_name": FIELD_NAME,
+            "field_schema": {
+                "type": "text",
+                "tokenizer": "word",
+                "phrase_matching": True,
+            },
+        },
+    )
+    assert response.ok
+
+    # Insert test points with various sentences
+    phrases = [
+        "the quick brown fox jumps over the lazy dog",
+        "a quick brown cat runs through the garden",
+        "the brown fox is very quick and agile",
+        "lazy dogs sleep all day long",
+        "machine learning algorithms are powerful tools",
+        "natural language processing with transformers",
+        "the artificial intelligence revolution",
+        "deep learning neural networks",
+        "brown sugar and quick oats",
+        "New York City is a bustling metropolis",
+    ]
+
+    test_data = [
+        {
+            "id": i + 1,
+            "vector": [random.random() for _ in range(4)],
+            "payload": {FIELD_NAME: phrase},
+        }
+        for i, phrase in enumerate(phrases)
+    ]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={"points": test_data},
+    )
+    assert response.ok
+
+    return collection_name
+
+
+@pytest.fixture(scope="module")
+def phrase_collection():
+    collection_name = setup_phrase_collection()
+    yield collection_name
+    drop_collection(collection_name)
+
+
+@pytest.mark.parametrize(
+    "phrase,expected_count,expected_ids,description",
+    [
+        (
+            "quick brown fox",
+            1,
+            {1},
+            "exact sequence match",
+        ),
+        (
+            "brown quick",
+            0,
+            set(),
+            "wrong order no match",
+        ),
+        (
+            "quick brown",
+            2,
+            {1, 2},
+            "correct order",
+        ),
+        (
+            "brown",
+            4,
+            {1, 2, 3, 9},
+            "single word phrase",
+        ),
+        (
+            "machine learning algorithms are powerful tools",
+            1,
+            {5},
+            "longer phrase match",
+        ),
+        ("", 0, set(), "empty phrase"),
+    ],
+)
+def test_phrase_matching(
+    phrase_collection,
+    phrase,
+    expected_count,
+    expected_ids,
+    description,
+):
+    """Test phrase matching with various phrases and expected results."""
+
+    # Test scroll endpoint
+    scroll_response = request_with_validation(
+        api="/collections/{collection_name}/points/scroll",
+        method="POST",
+        path_params={"collection_name": phrase_collection},
+        body={
+            "limit": 10,
+            "with_payload": True,
+            "with_vector": False,
+            "filter": {
+                "must": [
+                    {
+                        "key": FIELD_NAME,
+                        "match": {"phrase": phrase},
+                    }
+                ]
+            },
+        },
+    )
+
+    assert scroll_response.ok
+    scroll_result = scroll_response.json()["result"]
+
+    # Verify expected count
+    assert len(scroll_result["points"]) == expected_count, (
+        f"Failed for {description}: expected {expected_count} points"
+    )
+
+    # Verify expected IDs if any matches
+    if expected_count > 0:
+        matched_ids = {point["id"] for point in scroll_result["points"]}
+        assert matched_ids == expected_ids, (
+            f"Failed for {description}: expected IDs {expected_ids}, got {matched_ids}"
+        )
+
+        # Verify that phrase appears in matched documents (except empty phrase)
+        if phrase:
+            for point in scroll_result["points"]:
+                assert phrase in point["payload"][FIELD_NAME], (
+                    f"Phrase '{phrase}' not found in matched document"
+                )
+
+    # Check count
+    count_response = request_with_validation(
+        api="/collections/{collection_name}/points/count",
+        method="POST",
+        path_params={"collection_name": phrase_collection},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": FIELD_NAME,
+                        "match": {"phrase": phrase},
+                    }
+                ]
+            },
+        },
+    )
+
+    assert count_response.ok
+    count_result = count_response.json()["result"]
+
+    # Verify count matches scroll results
+    assert count_result["count"] == expected_count, f"Count endpoint mismatch for {description}"


### PR DESCRIPTION
- Adds a `Match::Phrase` variant to specify that a text must match by phrase.
- Adds a `phrase_matching` flag to the text index params so that text index registers positions.

Exposes it on rest and grpc