### PR TITLE
In the collection crate, propagate the RocksDB feature flag

### DIFF
--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 testing = []
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 data-consistency-check = []
-rocksdb = []
+rocksdb = ["segment/rocksdb"]
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/pull/6646#discussion_r2140028298>

The `collection` crate has the `rocksdb` feature flag. But it doesn't propagate that to it's `segment` dependency.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?