### PR TITLE
Run unit tests in CI without RocksDB flag

### DIFF
--- a/.github/workflows/actions/branch-build-and-push/action.yaml
+++ b/.github/workflows/actions/branch-build-and-push/action.yaml
@@ -9,37 +9,37 @@ runs:
       run: |
         buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit" | tr '\n' ' ')
         buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit" | tr '\n' ' ')
-        
+
         if [ -n "$buildx_containers" ]; then
           echo "Buildx containers to delete: $buildx_containers"
           docker container rm -f $buildx_containers
         fi
-        
+
         if [ -n "$buildx_volumes" ]; then
           echo "Buildx volumes to delete: $buildx_volumes"
           docker volume rm -f $buildx_volumes
         fi
-        
+
         branch_tmp=$(git rev-parse --abbrev-ref HEAD)
         branch=${branch_tmp//\//-} # replace all / with -
         echo "Building branch $branch"
-        
+
         # Create build container
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker buildx create --use
-        
+
         # Authenticate on registries
         docker login https://ghcr.io -u qdrant --password "${DOCKER_PASSWORD}"
-        
+
         ARCH=${ARCH:-regular}
         # use full git commit sha
         GIT_COMMIT_ID="$(git rev-parse HEAD)"
-        
+
         if [ "$ARCH" == "regular" ]; then
           # Build regular image for Github Registry
           GITHUB_TAG="-t ghcr.io/qdrant/qdrant:$branch-${GIT_COMMIT_ID} -t ghcr.io/qdrant/qdrant:$branch"
           echo "Building tag $branch-${GIT_COMMIT_ID}"
-  
+
           # Pull, retag and push to GitHub packages
           docker buildx build --platform='linux/amd64,linux/arm64' --build-arg GIT_COMMIT_ID=${GIT_COMMIT_ID} $GITHUB_TAG --push --label "org.opencontainers.image.revision"=${GIT_COMMIT_ID} .
         elif [ "$ARCH" == "gpu" ]; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,3 +110,42 @@ jobs:
         with:
           filename: .github/ISSUE_TEMPLATE/flaky_test.md
           update_existing: true
+
+  # Temporary job that runs tests without the RocksDB feature flag
+  # We will remove this once RocksDB will be disabled by default
+  rust-tests-no-rocksdb:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+
+    steps:
+    - name: Install minimal stable
+      uses: dtolnay/rust-toolchain@stable
+    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install mold
+      uses: rui314/setup-mold@v1
+    - name: Enable mold on Linux
+      run: |
+        mkdir .cargo
+        echo "[target.x86_64-unknown-linux-gnu]" >> .cargo/config.toml
+        echo "linker = \"clang\"" >> .cargo/config.toml
+        echo "rustflags = [\"-C\", \"link-arg=-fuse-ld=/usr/local/bin/mold\"]" >> .cargo/config.toml
+      shell: bash
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+    - name: Build
+      run: cargo build --tests --workspace --locked --no-default-features
+    - name: Run tests
+      # Profile "ci" is configured in .config/nextest.toml
+      run: cargo nextest run --workspace --profile ci --locked --no-default-features
+    - name: Upload test report
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-${{ matrix.os }}.xml
+        path: target/nextest/ci/junit.xml


### PR DESCRIPTION
Add a temporary CI job to also run all our unit tests without the `rocksdb` feature flag.

I'd like to test the RocksDB-less code too, as we'll be mainlining it in the future.

I didn't just replace the existing tests, because we'll still be releasing a few versions that include RocksDB. Therefore we must still test our RocksDB code until we actually remove it.

Once we disable RocksDB by default, we can remove this extra test job.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?