### PR TITLE
[text index] Faster mutable posting list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,6 +5384,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "robust"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5888,6 +5898,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "rmp-serde",
+ "roaring",
  "rocksdb",
  "rstest",
  "schemars",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -124,6 +124,7 @@ macro_rules_attribute = "0.2.2"
 nom = "8.0.0"
 half = { workspace = true }
 merge = { workspace = true }
+roaring = { version = "0.10.12" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/posting_list.rs
@@ -1,33 +1,23 @@
 use common::types::PointOffsetType;
+use roaring::RoaringBitmap;
 
 #[derive(Clone, Debug, Default)]
 pub struct PostingList {
-    list: Vec<PointOffsetType>,
+    list: RoaringBitmap,
 }
 
 impl PostingList {
     pub fn insert(&mut self, idx: PointOffsetType) {
-        if self.list.is_empty() || idx > *self.list.last().unwrap() {
-            self.list.push(idx);
-        } else if let Err(insertion_idx) = self.list.binary_search(&idx) {
-            // Yes, this is O(n) but:
-            // 1. That would give us maximal search performance with minimal memory usage
-            // 2. Documents are inserted mostly sequentially, especially in large segments
-            // 3. Vector indexing is more expensive anyway
-            // 4. For loading, insertion is strictly in increasing order
-            self.list.insert(insertion_idx, idx);
-        }
+        self.list.insert(idx);
     }
 
     pub fn remove(&mut self, idx: PointOffsetType) {
-        if let Ok(removal_idx) = self.list.binary_search(&idx) {
-            self.list.remove(removal_idx);
-        }
+        self.list.remove(idx);
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.list.len()
+        self.list.len() as usize
     }
 
     #[inline]
@@ -37,11 +27,11 @@ impl PostingList {
 
     #[inline]
     pub fn contains(&self, val: PointOffsetType) -> bool {
-        self.list.binary_search(&val).is_ok()
+        self.list.contains(val)
     }
 
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = PointOffsetType> + '_ {
-        self.list.iter().copied()
+        self.list.iter()
     }
 }


### PR DESCRIPTION
The mutable inverted index currently uses a `Vec` as a container for ids, this means that, while it is expensive to keep adding random values to it, it is still good to binary-search over it.

From the history, we can see that it was switched from `BTreeSet` to `Vec` in the past. However, indexing with `Vec` means that we have to shift elements all over the place every time we insert a new id which is lower than the max in the list. This creates a bottleneck directly on ingestion, not during optimization, which "breaks" the mental model of ingestion being separated from optimization because it's supposed to be quick.

Since changing the container is a small (but big impact) change, I've ran the following experiment:

```terminal
// For upsert
bfb -n 5000000 --text-payloads --text-payload-length 100 --vectors-per-point 0 --max-id 2000000

// For queries
bfb -n 100000 --text-payloads --text-payload-length 100 --vectors-per-point 0 --skip-create --skip-upload --scroll
```
These were the results:

| Container | Final upsert RPS | Median Scroll RPS | Memory usage |
| --- | --- | --- | --- |
| Vec | < 2,300 | 4373 | 1725M
| BTreeSet | ~10,996 | 2399 | 2741M
| RoaringBitmap | **~15,115** | **5201** | **1322M**
