### PR TITLE
[gridstore] flush before dropping in ignored test

### DIFF
--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -1108,6 +1108,7 @@ mod tests {
                     .unwrap();
                 point_offset += 1;
             }
+            storage.flush().unwrap();
             point_offset
         }
 
@@ -1162,6 +1163,7 @@ mod tests {
         storage_double_pass_is_consistent(&storage, 0);
 
         // drop storage
+        storage.flush().unwrap();
         drop(storage);
 
         // reopen storage


### PR DESCRIPTION
This test was silently broken since it is marked as `ignore`d. At some point we removed the `Drop` implementation for gridstore, and this test wasn't updated. This PR fixes it