### PR TITLE
[gridstore] Priority queue for max gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "memmap2",
  "memory",
  "parking_lot",
+ "priority-queue",
  "proptest",
  "rand 0.9.1",
  "rocksdb",
@@ -4518,6 +4519,17 @@ checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "priority-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5676d703dda103cbb035b653a9f11448c0a7216c7926bd35fcb5865475d0c970"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap 2.9.0",
 ]
 
 [[package]]

--- a/lib/gridstore/Cargo.toml
+++ b/lib/gridstore/Cargo.toml
@@ -34,6 +34,7 @@ common = { path = "../common/common" }
 
 # this is not on dev-dependencies because dev-dependencies cannot be optional :(
 rocksdb = { version = "0.23.0", optional = true }
+priority-queue = "2.5.0"
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/lib/gridstore/benches/bustle_bench/main.rs
+++ b/lib/gridstore/benches/bustle_bench/main.rs
@@ -15,11 +15,12 @@ type PayloadStorage = Gridstore<Payload>;
 
 fn default_opts(workload: &mut Workload) -> &mut Workload {
     let seed = [42; 32];
-    workload.initial_capacity_log2(21).seed(seed)
+    workload.initial_capacity_log2(23).seed(seed)
 }
 
 fn main() {
-    for num_threads in [1, 2] {
+    #[allow(clippy::single_element_loop)]
+    for num_threads in [1] {
         println!("------------ {num_threads} thread(s) -------------");
         // Read heavy
         println!("**read_heavy** with prefill_fraction 0.95");

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -82,7 +82,7 @@ pub(super) struct BitmaskGaps {
     mmap_slice: MmapSlice<RegionGaps>,
 
     /// A priority queue which tracks the region with the largest gap.
-    pq: PriorityQueue<RegionId, u16>,
+    pq: PriorityQueue<RegionId, u16, ahash::RandomState>,
     /// The region that was latest written to, tries to reuse it if possible
     latest_written_region: Option<RegionId>,
 }

--- a/lib/gridstore/src/config.rs
+++ b/lib/gridstore/src/config.rs
@@ -31,7 +31,7 @@ pub struct StorageOptions {
     /// Default is 128 bytes
     pub block_size_bytes: Option<usize>,
 
-    /// Size of a region in blocks
+    /// Size of a region in blocks, can't be bigger than [`u16::MAX`]
     ///
     /// Default is 8192 blocks
     pub region_size_blocks: Option<u16>,

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -821,9 +821,7 @@ mod tests {
 
     #[test]
     fn test_update_single_payload() {
-        // One page spans one region to restrict the priority queue to choose the same region
-        let (_dir, mut storage) =
-            empty_storage_sized(DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS);
+        let (_dir, mut storage) = empty_storage();
 
         let hw_counter = HardwareCounterCell::new();
         let hw_counter_ref = hw_counter.ref_payload_io_write_counter();

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -821,7 +821,9 @@ mod tests {
 
     #[test]
     fn test_update_single_payload() {
-        let (_dir, mut storage) = empty_storage();
+        // One page spans one region to restrict the priority queue to choose the same region
+        let (_dir, mut storage) =
+            empty_storage_sized(DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS);
 
         let hw_counter = HardwareCounterCell::new();
         let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -834,12 +836,13 @@ mod tests {
                 );
 
                 storage.put_value(0, &payload, hw_counter_ref).unwrap();
+
                 assert_eq!(storage.pages.len(), 1);
                 assert_eq!(storage.tracker.read().mapping_len(), 1);
 
-                let page_mapping = storage.get_pointer(0).unwrap();
-                assert_eq!(page_mapping.page_id, 0); // first page
-                assert_eq!(page_mapping.block_offset, expected_block_offset);
+                let pointer = storage.get_pointer(0).unwrap();
+                assert_eq!(pointer.page_id, 0); // first page
+                assert_eq!(pointer.block_offset, expected_block_offset);
 
                 let hw_counter = HardwareCounterCell::new();
                 let stored_payload = storage.get_value(0, &hw_counter);


### PR DESCRIPTION
This is an optimization that changes insertion from taking `O(n)`, to taking `O(log(n))` (bait headline 🙊 🎣).

In reality finding the region with a fitting gap, although being strictly a linear scan, was really fast, because it is already scoped out enough to not be noticeable with decently-sized workloads (under 2M values).

However, the problem starts to become apparent on larger datasets.

This PR trades finding the right region in `O(n)` and updating it in `O(1)`, with finding it in `O(1)` and updating it in `O(log(n))`. We still have the full-scan fallback in case there is no big enough `max` gap and we need to analyze merging in leading and trailing gaps, but it should be the vast minority of the times.

An added benefit from this, considering that analyzing a particular region is one of the more expensive operations of writes, is that this change allows us to use smaller regions to improve performance.

Here is some basic benchmark results, assuming a dataset of ~8M values in the `bustle_bench`:

| build | region_size_blocks | read_heavy workload (time/op) | insert_heavy workload (time/op) | update_heavy workload (time/op) |
| - | - | - | - | - |
| dev | 8192 (default) | 653ns | 1.743µs | 1.48µs |
| PR | 8192 (default) | 631ns | 1.518µs | 1.474µs |
| dev | 4096 | 630ns | 1.807µs | 1.304µs |
| PR | 4096 | 618ns | 1.442µs | 1.215µs |

