### PR TITLE
Fix CI cargo --locked build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7695,7 +7695,7 @@ checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7717,7 +7717,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]


### PR DESCRIPTION
Fix CI [error](https://github.com/qdrant/qdrant/actions/runs/15698923226/job/44229405343) 

```
Run cargo build --tests --workspace --locked
    Updating crates.io index
error: the lock file /home/runner/work/qdrant/qdrant/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

I assume a missing rebase while merging the Dependabot PRs.