### PR TITLE
[gridstore] update a selection instead of a range of regions

### DIFF
--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -387,9 +387,9 @@ impl Bitmask {
             let start_region_id =
                 (bitmask_range.start / self.config.region_size_blocks) as RegionId;
             let end_region_id =
-                ((bitmask_range.end - 1) / self.config.region_size_blocks) as RegionId;
+                bitmask_range.end.div_ceil(self.config.region_size_blocks) as RegionId;
 
-            dirty_regions.extend(start_region_id..=end_region_id);
+            dirty_regions.extend(start_region_id..end_region_id);
         }
 
         self.update_region_gaps(dirty_regions);


### PR DESCRIPTION
When doing the optimization for updating bitmask in batch, we assumed that a range of regions was a good interface to select which regions should be re-analyzed for gaps. 

However, when profiling ingestion with many gridstore-backed payload indices, the amount of time `calculate_gaps` takes is very considerable, specially when flushing.

I had the suspicion that the range of region ids was including more regions than actually needed. The changes in this PR switch the method of selecting the dirty regions from a range of start_id..end_id, to a hashset of dirty regions.

Using this command,
```
bfb -n 5000000 --int-payloads 100 --int-payloads 100 --int-payloads 100 --keywords 100 --vectors-per-point 0 --max-id 2000000
```
this PR achieves a stable upsert rate of **~44k RPS, vs ~34k RPS** in dev