### PR TITLE
Applying a different madvise after PopulateRead cancels its effect

### DIFF
--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -54,9 +54,9 @@ pub fn open_read_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io:
     // Because we want to read data with normal advice
     if populate {
         mmap.populate();
+    } else {
+        madvise::madvise(&mmap, advice.resolve())?;
     }
-
-    madvise::madvise(&mmap, advice.resolve())?;
 
     Ok(mmap)
 }
@@ -70,9 +70,9 @@ pub fn open_write_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io
     // Because we want to read data with normal advice
     if populate {
         mmap.populate();
+    } else {
+        madvise::madvise(&mmap, advice.resolve())?;
     }
-
-    madvise::madvise(&mmap, advice.resolve())?;
 
     Ok(mmap)
 }


### PR DESCRIPTION
Based on my manual testing, setting a different madvise right after setting `PopulateRead` cancels its effect.
It appears the kernel discards the pages loaded. 

When using a vector storage `on_disk = false`  with this patch:
- The `read_bytes` from `proc/pid/io`  is much higher on startup than `dev`
- No page faults reported during querying using `perf stat -e major-faults -p $(pidof qdrant)` unlike `dev`