### PR TITLE
Fix vector storage migration error

### DIFF
--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -134,7 +134,7 @@ impl DatabaseColumnScheduledUpdateWrapper {
         self.db.get_opt(key)
     }
 
-    pub fn remove_column_family(self) -> OperationResult<()> {
+    pub fn remove_column_family(&self) -> OperationResult<()> {
         self.db.remove_column_family()
     }
 }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -725,8 +724,10 @@ pub fn load_segment(path: &Path, stopped: &AtomicBool) -> OperationResult<Option
         SegmentVersion::save(path)?
     }
 
+    #[cfg_attr(not(feature = "rocksdb"), expect(unused_mut))]
     let mut segment_state = Segment::load_state(path)?;
 
+    #[cfg_attr(not(feature = "rocksdb"), expect(unused_mut))]
     let mut segment = create_segment(
         segment_state.initial_version,
         segment_state.version,
@@ -946,6 +947,8 @@ fn migrate_all_rocksdb_dense_vector_storages(
     segment: &mut Segment,
     segment_state: &mut SegmentState,
 ) -> OperationResult<()> {
+    use std::ops::Deref;
+
     for (vector_name, data) in &mut segment.vector_data {
         // Only convert simple dense and multi dense vector storages
         if !matches!(
@@ -1192,8 +1195,10 @@ fn migrate_all_rocksdb_sparse_vector_storages(
     segment: &mut Segment,
     segment_state: &mut SegmentState,
 ) -> OperationResult<()> {
+    use std::ops::Deref;
+
     for (vector_name, data) in &mut segment.vector_data {
-        // Only convert simple dense and multi dense vector storages
+        // Only convert simple sparse vector storages
         if !matches!(
             data.vector_storage.borrow().deref(),
             VectorStorageEnum::SparseSimple(_),

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -983,7 +983,6 @@ fn migrate_all_rocksdb_dense_vector_storages(
         let old_storage = std::mem::replace(&mut *data.vector_storage.borrow_mut(), new_storage);
 
         // Update storage type
-        log::warn!("Updated segment config after data migration");
         segment_state
             .config
             .vector_data
@@ -1213,7 +1212,6 @@ fn migrate_all_rocksdb_sparse_vector_storages(
         let old_storage = std::mem::replace(&mut *data.vector_storage.borrow_mut(), new_storage);
 
         // Update storage type
-        log::warn!("Updated segment config after data migration");
         segment_state
             .config
             .vector_data

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1214,10 +1214,10 @@ fn migrate_all_rocksdb_sparse_vector_storages(
         // Update storage type
         segment_state
             .config
-            .vector_data
+            .sparse_vector_data
             .get_mut(vector_name)
             .unwrap()
-            .storage_type = VectorStorageType::InRamChunkedMmap;
+            .storage_type = SparseVectorStorageType::Mmap;
         Segment::save_state(segment_state, path)?;
 
         // Destroy persisted RocksDB sparse vector data

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -222,7 +222,7 @@ impl<T: PrimitiveVectorElement> SimpleDenseVectorStorage<T> {
     }
 
     /// Destroy this vector storage, remove persisted data from RocksDB
-    pub fn destroy(self) -> OperationResult<()> {
+    pub fn destroy(&self) -> OperationResult<()> {
         self.db_wrapper.remove_column_family()?;
         Ok(())
     }

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -397,8 +397,16 @@ mod tests {
         // Migrate from RocksDB to mmap storage
         let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let new_storage =
-            migrate_rocksdb_dense_vector_storage_to_mmap(storage, DIM, storage_dir.path())
+            migrate_rocksdb_dense_vector_storage_to_mmap(&storage, DIM, storage_dir.path())
                 .expect("failed to migrate from RocksDB to mmap");
+
+        // Destroy persisted RocksDB dense vector data
+        match storage {
+            VectorStorageEnum::DenseSimple(storage) => storage.destroy().unwrap(),
+            VectorStorageEnum::DenseSimpleByte(storage) => storage.destroy().unwrap(),
+            VectorStorageEnum::DenseSimpleHalf(storage) => storage.destroy().unwrap(),
+            _ => unreachable!("unexpected vector storage type"),
+        }
 
         // We can drop RocksDB storage now
         db_dir.close().expect("failed to drop RocksDB storage");

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -323,7 +323,7 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
     }
 
     /// Destroy this vector storage, remove persisted data from RocksDB
-    pub fn destroy(self) -> OperationResult<()> {
+    pub fn destroy(&self) -> OperationResult<()> {
         self.db_wrapper.remove_column_family()?;
         Ok(())
     }

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -543,12 +543,20 @@ mod tests {
         // Migrate from RocksDB to mmap storage
         let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let new_storage = migrate_rocksdb_multi_dense_vector_storage_to_mmap(
-            storage,
+            &storage,
             DIM,
             multi_vector_config,
             storage_dir.path(),
         )
         .expect("failed to migrate from RocksDB to mmap");
+
+        // Destroy persisted RocksDB dense vector data
+        match storage {
+            VectorStorageEnum::MultiDenseSimple(storage) => storage.destroy().unwrap(),
+            VectorStorageEnum::MultiDenseSimpleByte(storage) => storage.destroy().unwrap(),
+            VectorStorageEnum::MultiDenseSimpleHalf(storage) => storage.destroy().unwrap(),
+            _ => unreachable!("unexpected vector storage type"),
+        }
 
         // We can drop RocksDB storage now
         db_dir.close().expect("failed to drop RocksDB storage");

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -333,8 +333,14 @@ mod tests {
         // Migrate from RocksDB to mmap storage
         let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let new_storage =
-            migrate_rocksdb_sparse_vector_storage_to_mmap(storage, storage_dir.path())
+            migrate_rocksdb_sparse_vector_storage_to_mmap(&storage, storage_dir.path())
                 .expect("failed to migrate from RocksDB to mmap");
+
+        // Destroy persisted RocksDB sparse vector data
+        match storage {
+            VectorStorageEnum::SparseSimple(storage) => storage.destroy().unwrap(),
+            _ => unreachable!("unexpected vector storage type"),
+        }
 
         // We can drop RocksDB storage now
         db_dir.close().expect("failed to drop RocksDB storage");

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -138,7 +138,7 @@ impl SimpleSparseVectorStorage {
     }
 
     /// Destroy this vector storage, remove persisted data from RocksDB
-    pub fn destroy(self) -> OperationResult<()> {
+    pub fn destroy(&self) -> OperationResult<()> {
         self.db_wrapper.remove_column_family()?;
         Ok(())
     }


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/6603>, <https://github.com/qdrant/qdrant/pull/6604>, <https://github.com/qdrant/qdrant/pull/6607> we migrated away from RocksDB based vector storage.

However, it forgot to update the storage type in the segment level configuration. Because of it Qdrant would still try to load the old configuration even though it was already migrated.

The logic for loading segments and their storages is nested deeply. I've implemented this in a way where I keep this nesting intact, while allowing the least amount of possible footguns.

In short: before we migrated each storage individually right after they were loaded. Now we load the full segment, and migrate each storage as part of the full segment. This allows us to access/adjust/store the segment configuration along with it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?