### PR TITLE
Fix hardware measurement for quantized multivector

### DIFF
--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -8,7 +8,9 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{MultiDenseVectorInternal, TypedMultiDenseVector};
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
-use crate::vector_storage::quantized::quantized_multivector_storage::MultivectorOffsets;
+use crate::vector_storage::quantized::quantized_multivector_storage::{
+    MultivectorOffset, MultivectorOffsets,
+};
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -98,10 +100,12 @@ where
     type TVector = [TElement];
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        let sub_vectors_count = self.quantized_multivector_storage.get_offset(idx).count as usize;
+        let multi_vector_offset = self.quantized_multivector_storage.get_offset(idx);
+        let sub_vectors_count = multi_vector_offset.count as usize;
         // compute vector IO read once for all examples
         self.hardware_counter.vector_io_read().incr_delta(
-            self.quantized_multivector_storage.quantized_vector_size() * sub_vectors_count,
+            size_of::<MultivectorOffset>()
+                + self.quantized_multivector_storage.quantized_vector_size() * sub_vectors_count,
         );
         self.query.score_by(|this| {
             // quantized multivector storage handles hardware counter to batch vector IO


### PR DESCRIPTION
On top of the quantized vectors, we also read the multivector offset from disk.

```
 Change (kB)    Path
======================================================================
8552    /home/agourlay/Workspace/qdrant/target/debug/qdrant
 316    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/97454785-08bd-4d14-852b-226310d4a9b3/vector_storage-dense_vector/quantized.data
 316    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/93e9b742-8ee7-4b04-a7f6-e20fa43a0fe3/vector_storage-dense_vector/quantized.data
 312    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/4e2ee6fd-ad41-4ec8-9814-2631d9cb3dd7/vector_storage-dense_vector/quantized.data
 312    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/9911cae0-3189-4a1a-8a42-e4f56c23a7ba/vector_storage-dense_vector/quantized.data
 160    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/499550e7-1aa4-4403-985d-6896fae7ffcf/vector_storage-dense_vector/quantized.data
 160    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/73c5127d-4b7b-46ff-90d3-d0a2f103a10b/vector_storage-dense_vector/quantized.data
  80    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/4e2ee6fd-ad41-4ec8-9814-2631d9cb3dd7/vector_storage-dense_vector/quantized.offsets.data
  80    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/9911cae0-3189-4a1a-8a42-e4f56c23a7ba/vector_storage-dense_vector/quantized.offsets.data
  80    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/97454785-08bd-4d14-852b-226310d4a9b3/vector_storage-dense_vector/quantized.offsets.data
  80    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/93e9b742-8ee7-4b04-a7f6-e20fa43a0fe3/vector_storage-dense_vector/quantized.offsets.data
  40    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/499550e7-1aa4-4403-985d-6896fae7ffcf/vector_storage-dense_vector/quantized.offsets.data
  40    /home/agourlay/Workspace/qdrant/storage/collections/17203633782032440859/0/segments/73c5127d-4b7b-46ff-90d3-d0a2f103a10b/vector_storage-dense_vector/quantized.offsets.data
```