### PR TITLE
Asymmetric binary quantization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,6 +4715,7 @@ dependencies = [
 name = "quantization"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "cc",
  "common",
  "criterion",
@@ -4727,6 +4728,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "strum",
  "tempfile",
 ]
 

--- a/lib/quantization/Cargo.toml
+++ b/lib/quantization/Cargo.toml
@@ -24,6 +24,8 @@ num-traits = { workspace = true }
 memory = { path = "../common/memory" }
 common = { path = "../common/common" }
 io = { path = "../common/io" }
+strum = { workspace = true }
+bytemuck = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/lib/quantization/benches/binary.rs
+++ b/lib/quantization/benches/binary.rs
@@ -4,7 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
 use permutation_iterator::Permutor;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-use quantization::encoded_vectors_binary::{EncodedVectorsBin, Encoding};
+use quantization::encoded_vectors_binary::{EncodedVectorsBin, Encoding, QueryEncoding};
 use rand::{Rng, SeedableRng};
 
 fn generate_number(rng: &mut rand::rngs::StdRng) -> f32 {
@@ -40,6 +40,7 @@ fn binary_bench(c: &mut Criterion) {
             invert: false,
         },
         Encoding::OneBit,
+        QueryEncoding::SameAsStorage,
         &AtomicBool::new(false),
     )
     .unwrap();
@@ -80,6 +81,7 @@ fn binary_bench(c: &mut Criterion) {
             invert: false,
         },
         Encoding::OneBit,
+        QueryEncoding::SameAsStorage,
         &AtomicBool::new(false),
     )
     .unwrap();

--- a/lib/quantization/build.rs
+++ b/lib/quantization/build.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rerun-if-changed=cpp");
     let mut builder = cc::Build::new();
 
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH")

--- a/lib/quantization/cpp/neon.c
+++ b/lib/quantization/cpp/neon.c
@@ -67,13 +67,10 @@ EXPORT uint32_t impl_xor_popcnt_neon_uint64(
 }
 
 EXPORT uint32_t impl_xor_popcnt_scalar8_neon_uint128(
-    const uint8_t* query_ptr,
-    const uint8_t* vector_ptr,
+    const uint8_t* q_ptr,
+    const uint8_t* v_ptr,
     uint32_t count
 ) {
-    const uint8_t* v_ptr = vector_ptr;
-    const uint8_t* q_ptr = query_ptr;
-
     uint16x8_t result1 = vdupq_n_u16(0);
     uint16x8_t result2 = vdupq_n_u16(0);
     uint16x8_t result3 = vdupq_n_u16(0);
@@ -119,13 +116,10 @@ EXPORT uint32_t impl_xor_popcnt_scalar8_neon_uint128(
 }
 
 EXPORT uint32_t impl_xor_popcnt_scalar4_neon_uint128(
-    const uint8_t* query_ptr,
-    const uint8_t* vector_ptr,
+    const uint8_t* q_ptr,
+    const uint8_t* v_ptr,
     uint32_t count
 ) {
-    const uint8_t* v_ptr = vector_ptr;
-    const uint8_t* q_ptr = query_ptr;
-
     uint16x8_t result1 = vdupq_n_u16(0);
     uint16x8_t result2 = vdupq_n_u16(0);
     uint16x8_t result3 = vdupq_n_u16(0);
@@ -150,6 +144,278 @@ EXPORT uint32_t impl_xor_popcnt_scalar4_neon_uint128(
     uint32_t r2 = vaddvq_u16(result2);
     uint32_t r3 = vaddvq_u16(result3);
     uint32_t r4 = vaddvq_u16(result4);
+    return r1 + (r2 << 1) + (r3 << 2) + (r4 << 3);
+}
+
+EXPORT uint32_t impl_xor_popcnt_scalar8_neon_u8(
+    const uint8_t* q_ptr,
+    const uint8_t* v_ptr,
+    uint32_t count
+) {
+    uint16x4_t result1 = vdup_n_u16(0);
+    uint16x4_t result2 = vdup_n_u16(0);
+    uint16x4_t result3 = vdup_n_u16(0);
+    uint16x4_t result4 = vdup_n_u16(0);
+    uint16x4_t result5 = vdup_n_u16(0);
+    uint16x4_t result6 = vdup_n_u16(0);
+    uint16x4_t result7 = vdup_n_u16(0);
+    uint16x4_t result8 = vdup_n_u16(0);
+    for (uint32_t _i = 0; _i < count / 8; _i++) {
+        uint8x8_t v = vld1_u8(v_ptr);
+
+        uint8_t values1[8] = {
+            *(q_ptr + 0),
+            *(q_ptr + 8),
+            *(q_ptr + 16),
+            *(q_ptr + 24),
+            *(q_ptr + 32),
+            *(q_ptr + 40),
+            *(q_ptr + 48),
+            *(q_ptr + 56),
+        };
+        uint8x8_t x1 = veor_u8(vld1_u8(values1), v);
+
+        uint8_t values2[8] = {
+            *(q_ptr + 1),
+            *(q_ptr + 9),
+            *(q_ptr + 17),
+            *(q_ptr + 25),
+            *(q_ptr + 33),
+            *(q_ptr + 41),
+            *(q_ptr + 49),
+            *(q_ptr + 57),
+        };
+        uint8x8_t x2 = veor_u8(vld1_u8(values2), v);
+
+        uint8_t values3[8] = {
+            *(q_ptr + 2),
+            *(q_ptr + 10),
+            *(q_ptr + 18),
+            *(q_ptr + 26),
+            *(q_ptr + 34),
+            *(q_ptr + 42),
+            *(q_ptr + 50),
+            *(q_ptr + 58),
+        };
+        uint8x8_t x3 = veor_u8(vld1_u8(values3), v);
+
+        uint8_t values4[8] = {
+            *(q_ptr + 3),
+            *(q_ptr + 11),
+            *(q_ptr + 19),
+            *(q_ptr + 27),
+            *(q_ptr + 35),
+            *(q_ptr + 43),
+            *(q_ptr + 51),
+            *(q_ptr + 59),
+        };
+        uint8x8_t x4 = veor_u8(vld1_u8(values4), v);
+
+        uint8_t values5[8] = {
+            *(q_ptr + 4),
+            *(q_ptr + 12),
+            *(q_ptr + 20),
+            *(q_ptr + 28),
+            *(q_ptr + 36),
+            *(q_ptr + 44),
+            *(q_ptr + 52),
+            *(q_ptr + 60),
+        };
+        uint8x8_t x5 = veor_u8(vld1_u8(values5), v);
+
+        uint8_t values6[8] = {
+            *(q_ptr + 5),
+            *(q_ptr + 13),
+            *(q_ptr + 21),
+            *(q_ptr + 29),
+            *(q_ptr + 37),
+            *(q_ptr + 45),
+            *(q_ptr + 53),
+            *(q_ptr + 61),
+        };
+        uint8x8_t x6 = veor_u8(vld1_u8(values6), v);
+
+        uint8_t values7[8] = {
+            *(q_ptr + 6),
+            *(q_ptr + 14),
+            *(q_ptr + 22),
+            *(q_ptr + 30),
+            *(q_ptr + 38),
+            *(q_ptr + 46),
+            *(q_ptr + 54),
+            *(q_ptr + 62),
+        };
+        uint8x8_t x7 = veor_u8(vld1_u8(values7), v);
+
+        uint8_t values8[8] = {
+            *(q_ptr + 7),
+            *(q_ptr + 15),
+            *(q_ptr + 23),
+            *(q_ptr + 31),
+            *(q_ptr + 39),
+            *(q_ptr + 47),
+            *(q_ptr + 55),
+            *(q_ptr + 63),
+        };
+        uint8x8_t x8 = veor_u8(vld1_u8(values8), v);
+
+        result1 = vpadal_u8(result1, vcnt_u8(x1));
+        result2 = vpadal_u8(result2, vcnt_u8(x2));
+        result3 = vpadal_u8(result3, vcnt_u8(x3));
+        result4 = vpadal_u8(result4, vcnt_u8(x4));
+        result5 = vpadal_u8(result5, vcnt_u8(x5));
+        result6 = vpadal_u8(result6, vcnt_u8(x6));
+        result7 = vpadal_u8(result7, vcnt_u8(x7));
+        result8 = vpadal_u8(result8, vcnt_u8(x8));
+
+        v_ptr += 8;
+        q_ptr += 64;
+    }
+
+    uint32_t dr1 = 0;
+    uint32_t dr2 = 0;
+    uint32_t dr3 = 0;
+    uint32_t dr4 = 0;
+    uint32_t dr5 = 0;
+    uint32_t dr6 = 0;
+    uint32_t dr7 = 0;
+    uint32_t dr8 = 0;
+    for (uint32_t _i = count % 8; _i > 0; _i--) {
+        uint8_t v = *(v_ptr++);
+        uint8_t q1 = *(q_ptr++);
+        uint8_t q2 = *(q_ptr++);
+        uint8_t q3 = *(q_ptr++);
+        uint8_t q4 = *(q_ptr++);
+        uint8_t q5 = *(q_ptr++);
+        uint8_t q6 = *(q_ptr++);
+        uint8_t q7 = *(q_ptr++);
+        uint8_t q8 = *(q_ptr++);
+        
+        uint8_t x1 = v ^ q1;
+        uint8_t x2 = v ^ q2;
+        uint8_t x3 = v ^ q3;
+        uint8_t x4 = v ^ q4;
+        uint8_t x5 = v ^ q5;
+        uint8_t x6 = v ^ q6;
+        uint8_t x7 = v ^ q7;
+        uint8_t x8 = v ^ q8;
+
+        dr1 += __builtin_popcount(x1);
+        dr2 += __builtin_popcount(x2);
+        dr3 += __builtin_popcount(x3);
+        dr4 += __builtin_popcount(x4);
+        dr5 += __builtin_popcount(x5);
+        dr6 += __builtin_popcount(x6);
+        dr7 += __builtin_popcount(x7);
+        dr8 += __builtin_popcount(x8);
+    }
+
+    uint32_t r1 = vaddv_u16(result1) + dr1;
+    uint32_t r2 = vaddv_u16(result2) + dr2;
+    uint32_t r3 = vaddv_u16(result3) + dr3;
+    uint32_t r4 = vaddv_u16(result4) + dr4;
+    uint32_t r5 = vaddv_u16(result5) + dr5;
+    uint32_t r6 = vaddv_u16(result6) + dr6;
+    uint32_t r7 = vaddv_u16(result7) + dr7;
+    uint32_t r8 = vaddv_u16(result8) + dr8;
+
+    return r1 + (r2 << 1) + (r3 << 2) + (r4 << 3) + (r5 << 4) + (r6 << 5) + (r7 << 6) + (r8 << 7);
+}
+
+EXPORT uint32_t impl_xor_popcnt_scalar4_neon_u8(
+    const uint8_t* q_ptr,
+    const uint8_t* v_ptr,
+    uint32_t count
+) {
+    uint16x4_t result1 = vdup_n_u16(0);
+    uint16x4_t result2 = vdup_n_u16(0);
+    uint16x4_t result3 = vdup_n_u16(0);
+    uint16x4_t result4 = vdup_n_u16(0);
+    for (uint32_t _i = 0; _i < count / 8; _i++) {
+        uint8x8_t v = vld1_u8(v_ptr);
+
+        uint8_t values1[8] = {
+            *(q_ptr + 0),
+            *(q_ptr + 4),
+            *(q_ptr + 8),
+            *(q_ptr + 12),
+            *(q_ptr + 16),
+            *(q_ptr + 20),
+            *(q_ptr + 24),
+            *(q_ptr + 28),
+        };
+        uint8x8_t x1 = veor_u8(vld1_u8(values1), v);
+
+        uint8_t values2[8] = {
+            *(q_ptr + 1),
+            *(q_ptr + 5),
+            *(q_ptr + 9),
+            *(q_ptr + 13),
+            *(q_ptr + 17),
+            *(q_ptr + 21),
+            *(q_ptr + 25),
+            *(q_ptr + 29),
+        };
+        uint8x8_t x2 = veor_u8(vld1_u8(values2), v);
+
+        uint8_t values3[8] = {
+            *(q_ptr + 2),
+            *(q_ptr + 6),
+            *(q_ptr + 10),
+            *(q_ptr + 14),
+            *(q_ptr + 18),
+            *(q_ptr + 22),
+            *(q_ptr + 26),
+            *(q_ptr + 30),
+        };
+        uint8x8_t x3 = veor_u8(vld1_u8(values3), v);
+
+        uint8_t values4[8] = {
+            *(q_ptr + 3),
+            *(q_ptr + 7),
+            *(q_ptr + 11),
+            *(q_ptr + 15),
+            *(q_ptr + 19),
+            *(q_ptr + 23),
+            *(q_ptr + 27),
+            *(q_ptr + 31),
+        };
+        uint8x8_t x4 = veor_u8(vld1_u8(values4), v);
+
+        result1 = vpadal_u8(result1, vcnt_u8(x1));
+        result2 = vpadal_u8(result2, vcnt_u8(x2));
+        result3 = vpadal_u8(result3, vcnt_u8(x3));
+        result4 = vpadal_u8(result4, vcnt_u8(x4));
+
+        v_ptr += 8;
+        q_ptr += 32;
+    }
+
+    uint32_t dr1 = 0;
+    uint32_t dr2 = 0;
+    uint32_t dr3 = 0;
+    uint32_t dr4 = 0;
+    for (uint32_t _i = count % 8; _i > 0; _i--) {
+        uint8_t v = *(v_ptr++);
+        uint8_t q1 = *(q_ptr++);
+        uint8_t q2 = *(q_ptr++);
+        uint8_t q3 = *(q_ptr++);
+        uint8_t q4 = *(q_ptr++);
+        
+        uint8_t x1 = v ^ q1;
+        uint8_t x2 = v ^ q2;
+        uint8_t x3 = v ^ q3;
+        uint8_t x4 = v ^ q4;
+        dr1 += __builtin_popcount(x1);
+        dr2 += __builtin_popcount(x2);
+        dr3 += __builtin_popcount(x3);
+        dr4 += __builtin_popcount(x4);
+    }
+
+    uint32_t r1 = vaddv_u16(result1) + dr1;
+    uint32_t r2 = vaddv_u16(result2) + dr2;
+    uint32_t r3 = vaddv_u16(result3) + dr3;
+    uint32_t r4 = vaddv_u16(result4) + dr4;
     return r1 + (r2 << 1) + (r3 << 2) + (r4 << 3);
 }
 

--- a/lib/quantization/cpp/neon.c
+++ b/lib/quantization/cpp/neon.c
@@ -71,27 +71,27 @@ EXPORT uint32_t impl_xor_popcnt_scalar8_neon_uint128(
     const uint8_t* vector_ptr,
     uint32_t count
 ) {
-    const uint64_t* v_ptr = (const uint64_t*)vector_ptr;
-    const uint64_t* q_ptr = (const uint64_t*)query_ptr;
+    const uint8_t* v_ptr = vector_ptr;
+    const uint8_t* q_ptr = query_ptr;
 
-    uint8x16_t result1 = vdupq_n_u32(0);
-    uint8x16_t result2 = vdupq_n_u32(0);
-    uint8x16_t result3 = vdupq_n_u32(0);
-    uint8x16_t result4 = vdupq_n_u32(0);
-    uint8x16_t result5 = vdupq_n_u32(0);
-    uint8x16_t result6 = vdupq_n_u32(0);
-    uint8x16_t result7 = vdupq_n_u32(0);
-    uint8x16_t result8 = vdupq_n_u32(0);
+    uint16x8_t result1 = vdupq_n_u16(0);
+    uint16x8_t result2 = vdupq_n_u16(0);
+    uint16x8_t result3 = vdupq_n_u16(0);
+    uint16x8_t result4 = vdupq_n_u16(0);
+    uint16x8_t result5 = vdupq_n_u16(0);
+    uint16x8_t result6 = vdupq_n_u16(0);
+    uint16x8_t result7 = vdupq_n_u16(0);
+    uint16x8_t result8 = vdupq_n_u16(0);
     for (uint32_t _i = 0; _i < count; _i++) {
         uint8x16_t v = vld1q_u8(v_ptr);
-        uint8x16_t x1 = veorq_u8(vld1q_u8(q_ptr), v);
-        uint8x16_t x2 = veorq_u8(vld1q_u8(q_ptr + 2), v);
-        uint8x16_t x3 = veorq_u8(vld1q_u8(q_ptr + 4), v);
-        uint8x16_t x4 = veorq_u8(vld1q_u8(q_ptr + 6), v);
-        uint8x16_t x5 = veorq_u8(vld1q_u8(q_ptr + 8), v);
-        uint8x16_t x6 = veorq_u8(vld1q_u8(q_ptr + 10), v);
-        uint8x16_t x7 = veorq_u8(vld1q_u8(q_ptr + 12), v);
-        uint8x16_t x8 = veorq_u8(vld1q_u8(q_ptr + 14), v);
+        uint8x16_t x1 = veorq_u8(vld1q_u8(q_ptr + 0), v);
+        uint8x16_t x2 = veorq_u8(vld1q_u8(q_ptr + 16), v);
+        uint8x16_t x3 = veorq_u8(vld1q_u8(q_ptr + 32), v);
+        uint8x16_t x4 = veorq_u8(vld1q_u8(q_ptr + 48), v);
+        uint8x16_t x5 = veorq_u8(vld1q_u8(q_ptr + 64), v);
+        uint8x16_t x6 = veorq_u8(vld1q_u8(q_ptr + 80), v);
+        uint8x16_t x7 = veorq_u8(vld1q_u8(q_ptr + 96), v);
+        uint8x16_t x8 = veorq_u8(vld1q_u8(q_ptr + 112), v);
 
         result1 = vpadalq_u8(result1, vcntq_u8(x1));
         result2 = vpadalq_u8(result2, vcntq_u8(x2));
@@ -102,49 +102,18 @@ EXPORT uint32_t impl_xor_popcnt_scalar8_neon_uint128(
         result7 = vpadalq_u8(result7, vcntq_u8(x7));
         result8 = vpadalq_u8(result8, vcntq_u8(x8));
 
-        v_ptr += 2;
-        q_ptr += 16;
+        v_ptr += 16;
+        q_ptr += 128;
     }
 
-    uint8x8_t result1_low = vget_low_u8(result1);
-    uint8x8_t result1_high = vget_high_u8(result1);
-    uint16x8_t sum1 = vaddl_u8(result1_low, result1_high);
-    uint32_t r1 = vaddvq_u16(sum1);
-
-    uint8x8_t result2_low = vget_low_u8(result2);
-    uint8x8_t result2_high = vget_high_u8(result2);
-    uint16x8_t sum2 = vaddl_u8(result2_low, result2_high);
-    uint32_t r2 = vaddvq_u16(sum2);
-
-    uint8x8_t result3_low = vget_low_u8(result3);
-    uint8x8_t result3_high = vget_high_u8(result3);
-    uint16x8_t sum3 = vaddl_u8(result3_low, result3_high);
-    uint32_t r3 = vaddvq_u16(sum3);
-
-    uint8x8_t result4_low = vget_low_u8(result4);
-    uint8x8_t result4_high = vget_high_u8(result4);
-    uint16x8_t sum4 = vaddl_u8(result4_low, result4_high);
-    uint32_t r4 = vaddvq_u16(sum4);
-
-    uint8x8_t result5_low = vget_low_u8(result5);
-    uint8x8_t result5_high = vget_high_u8(result5);
-    uint16x8_t sum5 = vaddl_u8(result5_low, result5_high);
-    uint32_t r5 = vaddvq_u16(sum5);
-
-    uint8x8_t result6_low = vget_low_u8(result6);
-    uint8x8_t result6_high = vget_high_u8(result6);
-    uint16x8_t sum6 = vaddl_u8(result6_low, result6_high);
-    uint32_t r6 = vaddvq_u16(sum6);
-
-    uint8x8_t result7_low = vget_low_u8(result7);
-    uint8x8_t result7_high = vget_high_u8(result7);
-    uint16x8_t sum7 = vaddl_u8(result7_low, result7_high);
-    uint32_t r7 = vaddvq_u16(sum7);
-
-    uint8x8_t result8_low = vget_low_u8(result8);
-    uint8x8_t result8_high = vget_high_u8(result8);
-    uint16x8_t sum8 = vaddl_u8(result8_low, result8_high);
-    uint32_t r8 = vaddvq_u16(sum8);
+    uint32_t r1 = vaddvq_u16(result1);
+    uint32_t r2 = vaddvq_u16(result2);
+    uint32_t r3 = vaddvq_u16(result3);
+    uint32_t r4 = vaddvq_u16(result4);
+    uint32_t r5 = vaddvq_u16(result5);
+    uint32_t r6 = vaddvq_u16(result6);
+    uint32_t r7 = vaddvq_u16(result7);
+    uint32_t r8 = vaddvq_u16(result8);
 
     return r1 + (r2 << 1) + (r3 << 2) + (r4 << 3) + (r5 << 4) + (r6 << 5) + (r7 << 6) + (r8 << 7);
 }
@@ -154,49 +123,33 @@ EXPORT uint32_t impl_xor_popcnt_scalar4_neon_uint128(
     const uint8_t* vector_ptr,
     uint32_t count
 ) {
-    const uint64_t* v_ptr = (const uint64_t*)vector_ptr;
-    const uint64_t* q_ptr = (const uint64_t*)query_ptr;
+    const uint8_t* v_ptr = vector_ptr;
+    const uint8_t* q_ptr = query_ptr;
 
-    uint8x16_t result1 = vdupq_n_u32(0);
-    uint8x16_t result2 = vdupq_n_u32(0);
-    uint8x16_t result3 = vdupq_n_u32(0);
-    uint8x16_t result4 = vdupq_n_u32(0);
+    uint16x8_t result1 = vdupq_n_u16(0);
+    uint16x8_t result2 = vdupq_n_u16(0);
+    uint16x8_t result3 = vdupq_n_u16(0);
+    uint16x8_t result4 = vdupq_n_u16(0);
     for (uint32_t _i = 0; _i < count; _i++) {
         uint8x16_t v = vld1q_u8(v_ptr);
         uint8x16_t x1 = veorq_u8(vld1q_u8(q_ptr + 0), v);
-        uint8x16_t x2 = veorq_u8(vld1q_u8(q_ptr + 2), v);
-        uint8x16_t x3 = veorq_u8(vld1q_u8(q_ptr + 4), v);
-        uint8x16_t x4 = veorq_u8(vld1q_u8(q_ptr + 6), v);
+        uint8x16_t x2 = veorq_u8(vld1q_u8(q_ptr + 16), v);
+        uint8x16_t x3 = veorq_u8(vld1q_u8(q_ptr + 32), v);
+        uint8x16_t x4 = veorq_u8(vld1q_u8(q_ptr + 48), v);
 
         result1 = vpadalq_u8(result1, vcntq_u8(x1));
         result2 = vpadalq_u8(result2, vcntq_u8(x2));
         result3 = vpadalq_u8(result3, vcntq_u8(x3));
         result4 = vpadalq_u8(result4, vcntq_u8(x4));
 
-        v_ptr += 2;
-        q_ptr += 8;
+        v_ptr += 16;
+        q_ptr += 64;
     }
 
-    uint8x8_t result1_low = vget_low_u8(result1);
-    uint8x8_t result1_high = vget_high_u8(result1);
-    uint16x8_t sum1 = vaddl_u8(result1_low, result1_high);
-    uint32_t r1 = vaddvq_u16(sum1);
-
-    uint8x8_t result2_low = vget_low_u8(result2);
-    uint8x8_t result2_high = vget_high_u8(result2);
-    uint16x8_t sum2 = vaddl_u8(result2_low, result2_high);
-    uint32_t r2 = vaddvq_u16(sum2);
-
-    uint8x8_t result3_low = vget_low_u8(result3);
-    uint8x8_t result3_high = vget_high_u8(result3);
-    uint16x8_t sum3 = vaddl_u8(result3_low, result3_high);
-    uint32_t r3 = vaddvq_u16(sum3);
-
-    uint8x8_t result4_low = vget_low_u8(result4);
-    uint8x8_t result4_high = vget_high_u8(result4);
-    uint16x8_t sum4 = vaddl_u8(result4_low, result4_high);
-    uint32_t r4 = vaddvq_u16(sum4);
-
+    uint32_t r1 = vaddvq_u16(result1);
+    uint32_t r2 = vaddvq_u16(result2);
+    uint32_t r3 = vaddvq_u16(result3);
+    uint32_t r4 = vaddvq_u16(result4);
     return r1 + (r2 << 1) + (r3 << 2) + (r4 << 3);
 }
 

--- a/lib/quantization/cpp/neon.c
+++ b/lib/quantization/cpp/neon.c
@@ -66,6 +66,140 @@ EXPORT uint32_t impl_xor_popcnt_neon_uint64(
     return (uint32_t)vaddv_u16(result);
 }
 
+EXPORT uint32_t impl_xor_popcnt_scalar8_neon_uint128(
+    const uint8_t* query_ptr,
+    const uint8_t* vector_ptr,
+    uint32_t count
+) {
+    const uint64_t* v_ptr = (const uint64_t*)vector_ptr;
+    const uint64_t* q_ptr = (const uint64_t*)query_ptr;
+
+    uint8x16_t result1 = vdupq_n_u32(0);
+    uint8x16_t result2 = vdupq_n_u32(0);
+    uint8x16_t result3 = vdupq_n_u32(0);
+    uint8x16_t result4 = vdupq_n_u32(0);
+    uint8x16_t result5 = vdupq_n_u32(0);
+    uint8x16_t result6 = vdupq_n_u32(0);
+    uint8x16_t result7 = vdupq_n_u32(0);
+    uint8x16_t result8 = vdupq_n_u32(0);
+    for (uint32_t _i = 0; _i < count; _i++) {
+        uint8x16_t v = vld1q_u8(v_ptr);
+        uint8x16_t x1 = veorq_u8(vld1q_u8(q_ptr), v);
+        uint8x16_t x2 = veorq_u8(vld1q_u8(q_ptr + 2), v);
+        uint8x16_t x3 = veorq_u8(vld1q_u8(q_ptr + 4), v);
+        uint8x16_t x4 = veorq_u8(vld1q_u8(q_ptr + 6), v);
+        uint8x16_t x5 = veorq_u8(vld1q_u8(q_ptr + 8), v);
+        uint8x16_t x6 = veorq_u8(vld1q_u8(q_ptr + 10), v);
+        uint8x16_t x7 = veorq_u8(vld1q_u8(q_ptr + 12), v);
+        uint8x16_t x8 = veorq_u8(vld1q_u8(q_ptr + 14), v);
+
+        result1 = vpadalq_u8(result1, vcntq_u8(x1));
+        result2 = vpadalq_u8(result2, vcntq_u8(x2));
+        result3 = vpadalq_u8(result3, vcntq_u8(x3));
+        result4 = vpadalq_u8(result4, vcntq_u8(x4));
+        result5 = vpadalq_u8(result5, vcntq_u8(x5));
+        result6 = vpadalq_u8(result6, vcntq_u8(x6));
+        result7 = vpadalq_u8(result7, vcntq_u8(x7));
+        result8 = vpadalq_u8(result8, vcntq_u8(x8));
+
+        v_ptr += 2;
+        q_ptr += 16;
+    }
+
+    uint8x8_t result1_low = vget_low_u8(result1);
+    uint8x8_t result1_high = vget_high_u8(result1);
+    uint16x8_t sum1 = vaddl_u8(result1_low, result1_high);
+    uint32_t r1 = vaddvq_u16(sum1);
+
+    uint8x8_t result2_low = vget_low_u8(result2);
+    uint8x8_t result2_high = vget_high_u8(result2);
+    uint16x8_t sum2 = vaddl_u8(result2_low, result2_high);
+    uint32_t r2 = vaddvq_u16(sum2);
+
+    uint8x8_t result3_low = vget_low_u8(result3);
+    uint8x8_t result3_high = vget_high_u8(result3);
+    uint16x8_t sum3 = vaddl_u8(result3_low, result3_high);
+    uint32_t r3 = vaddvq_u16(sum3);
+
+    uint8x8_t result4_low = vget_low_u8(result4);
+    uint8x8_t result4_high = vget_high_u8(result4);
+    uint16x8_t sum4 = vaddl_u8(result4_low, result4_high);
+    uint32_t r4 = vaddvq_u16(sum4);
+
+    uint8x8_t result5_low = vget_low_u8(result5);
+    uint8x8_t result5_high = vget_high_u8(result5);
+    uint16x8_t sum5 = vaddl_u8(result5_low, result5_high);
+    uint32_t r5 = vaddvq_u16(sum5);
+
+    uint8x8_t result6_low = vget_low_u8(result6);
+    uint8x8_t result6_high = vget_high_u8(result6);
+    uint16x8_t sum6 = vaddl_u8(result6_low, result6_high);
+    uint32_t r6 = vaddvq_u16(sum6);
+
+    uint8x8_t result7_low = vget_low_u8(result7);
+    uint8x8_t result7_high = vget_high_u8(result7);
+    uint16x8_t sum7 = vaddl_u8(result7_low, result7_high);
+    uint32_t r7 = vaddvq_u16(sum7);
+
+    uint8x8_t result8_low = vget_low_u8(result8);
+    uint8x8_t result8_high = vget_high_u8(result8);
+    uint16x8_t sum8 = vaddl_u8(result8_low, result8_high);
+    uint32_t r8 = vaddvq_u16(sum8);
+
+    return r1 + (r2 << 1) + (r3 << 2) + (r4 << 3) + (r5 << 4) + (r6 << 5) + (r7 << 6) + (r8 << 7);
+}
+
+EXPORT uint32_t impl_xor_popcnt_scalar4_neon_uint128(
+    const uint8_t* query_ptr,
+    const uint8_t* vector_ptr,
+    uint32_t count
+) {
+    const uint64_t* v_ptr = (const uint64_t*)vector_ptr;
+    const uint64_t* q_ptr = (const uint64_t*)query_ptr;
+
+    uint8x16_t result1 = vdupq_n_u32(0);
+    uint8x16_t result2 = vdupq_n_u32(0);
+    uint8x16_t result3 = vdupq_n_u32(0);
+    uint8x16_t result4 = vdupq_n_u32(0);
+    for (uint32_t _i = 0; _i < count; _i++) {
+        uint8x16_t v = vld1q_u8(v_ptr);
+        uint8x16_t x1 = veorq_u8(vld1q_u8(q_ptr + 0), v);
+        uint8x16_t x2 = veorq_u8(vld1q_u8(q_ptr + 2), v);
+        uint8x16_t x3 = veorq_u8(vld1q_u8(q_ptr + 4), v);
+        uint8x16_t x4 = veorq_u8(vld1q_u8(q_ptr + 6), v);
+
+        result1 = vpadalq_u8(result1, vcntq_u8(x1));
+        result2 = vpadalq_u8(result2, vcntq_u8(x2));
+        result3 = vpadalq_u8(result3, vcntq_u8(x3));
+        result4 = vpadalq_u8(result4, vcntq_u8(x4));
+
+        v_ptr += 2;
+        q_ptr += 8;
+    }
+
+    uint8x8_t result1_low = vget_low_u8(result1);
+    uint8x8_t result1_high = vget_high_u8(result1);
+    uint16x8_t sum1 = vaddl_u8(result1_low, result1_high);
+    uint32_t r1 = vaddvq_u16(sum1);
+
+    uint8x8_t result2_low = vget_low_u8(result2);
+    uint8x8_t result2_high = vget_high_u8(result2);
+    uint16x8_t sum2 = vaddl_u8(result2_low, result2_high);
+    uint32_t r2 = vaddvq_u16(sum2);
+
+    uint8x8_t result3_low = vget_low_u8(result3);
+    uint8x8_t result3_high = vget_high_u8(result3);
+    uint16x8_t sum3 = vaddl_u8(result3_low, result3_high);
+    uint32_t r3 = vaddvq_u16(sum3);
+
+    uint8x8_t result4_low = vget_low_u8(result4);
+    uint8x8_t result4_high = vget_high_u8(result4);
+    uint16x8_t sum4 = vaddl_u8(result4_low, result4_high);
+    uint32_t r4 = vaddvq_u16(sum4);
+
+    return r1 + (r2 << 1) + (r3 << 2) + (r4 << 3);
+}
+
 EXPORT float impl_score_l1_neon(
    const uint8_t * query_ptr,
    const uint8_t * vector_ptr,

--- a/lib/quantization/cpp/sse.c
+++ b/lib/quantization/cpp/sse.c
@@ -4,6 +4,11 @@
 
 #include "export_macro.h"
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#define __builtin_popcount __popcnt
+#endif
+
 #define HSUM128_PS(X, R) \
     float R = 0.0f; \
     { \

--- a/lib/quantization/cpp/sse.c
+++ b/lib/quantization/cpp/sse.c
@@ -175,28 +175,19 @@ EXPORT uint32_t impl_xor_popcnt_scalar4_sse_uint128(
         uint64_t v_1 = *v_ptr;
         uint64_t v_2 = *(v_ptr + 1);
 
-        uint64_t q_1_1 = *q_ptr;
-        uint64_t q_2_1 = *(q_ptr + 1);
-        uint64_t q_1_2 = *(q_ptr + 2);
-        uint64_t q_2_2 = *(q_ptr + 3);
-        uint64_t q_1_3 = *(q_ptr + 4);
-        uint64_t q_2_3 = *(q_ptr + 5);
-        uint64_t q_1_4 = *(q_ptr + 6);
-        uint64_t q_2_4 = *(q_ptr + 7);
-
         __m128i popcnt1 = _mm_set_epi32(
-            _mm_popcnt_u64(v_1 ^ q_1_1),
-            _mm_popcnt_u64(v_1 ^ q_1_2),
-            _mm_popcnt_u64(v_1 ^ q_1_3),
-            _mm_popcnt_u64(v_1 ^ q_1_4)
+            _mm_popcnt_u64(v_1 ^ *(q_ptr + 0)),
+            _mm_popcnt_u64(v_1 ^ *(q_ptr + 2)),
+            _mm_popcnt_u64(v_1 ^ *(q_ptr + 4)),
+            _mm_popcnt_u64(v_1 ^ *(q_ptr + 6))
         );
         sum = _mm_add_epi32(sum, popcnt1);
 
         __m128i popcnt2 = _mm_set_epi32(
-            _mm_popcnt_u64(v_2 ^ q_2_1),
-            _mm_popcnt_u64(v_2 ^ q_2_2),
-            _mm_popcnt_u64(v_2 ^ q_2_3),
-            _mm_popcnt_u64(v_2 ^ q_2_4)
+            _mm_popcnt_u64(v_2 ^ *(q_ptr + 1)),
+            _mm_popcnt_u64(v_2 ^ *(q_ptr + 3)),
+            _mm_popcnt_u64(v_2 ^ *(q_ptr + 5)),
+            _mm_popcnt_u64(v_2 ^ *(q_ptr + 7))
         );
         sum = _mm_add_epi32(sum, popcnt2);
 

--- a/lib/quantization/cpp/sse.c
+++ b/lib/quantization/cpp/sse.c
@@ -200,6 +200,270 @@ EXPORT uint32_t impl_xor_popcnt_scalar4_sse_uint128(
     return (uint32_t)mul_scalar;
 }
 
+EXPORT uint32_t impl_xor_popcnt_scalar8_sse_u8(
+    const uint8_t* q_ptr,
+    const uint8_t* v_ptr,
+    uint32_t count
+) {
+    __m128i sum1 = _mm_set1_epi32(0);
+    __m128i sum2 = _mm_set1_epi32(0);
+    for (uint32_t _i = 0; _i < count / 8; _i++) {
+        uint64_t v = *((const uint64_t*)v_ptr);
+
+        uint8_t values1[8] = {
+            *(q_ptr + 0),
+            *(q_ptr + 8),
+            *(q_ptr + 16),
+            *(q_ptr + 24),
+            *(q_ptr + 32),
+            *(q_ptr + 40),
+            *(q_ptr + 48),
+            *(q_ptr + 56),
+        };
+        uint8_t values2[8] = {
+            *(q_ptr + 1),
+            *(q_ptr + 9),
+            *(q_ptr + 17),
+            *(q_ptr + 25),
+            *(q_ptr + 33),
+            *(q_ptr + 41),
+            *(q_ptr + 49),
+            *(q_ptr + 57),
+        };
+        uint8_t values3[8] = {
+            *(q_ptr + 2),
+            *(q_ptr + 10),
+            *(q_ptr + 18),
+            *(q_ptr + 26),
+            *(q_ptr + 34),
+            *(q_ptr + 42),
+            *(q_ptr + 50),
+            *(q_ptr + 58),
+        };
+        uint8_t values4[8] = {
+            *(q_ptr + 3),
+            *(q_ptr + 11),
+            *(q_ptr + 19),
+            *(q_ptr + 27),
+            *(q_ptr + 35),
+            *(q_ptr + 43),
+            *(q_ptr + 51),
+            *(q_ptr + 59),
+        };
+        uint8_t values5[8] = {
+            *(q_ptr + 4),
+            *(q_ptr + 12),
+            *(q_ptr + 20),
+            *(q_ptr + 28),
+            *(q_ptr + 36),
+            *(q_ptr + 44),
+            *(q_ptr + 52),
+            *(q_ptr + 60),
+        };
+        uint8_t values6[8] = {
+            *(q_ptr + 5),
+            *(q_ptr + 13),
+            *(q_ptr + 21),
+            *(q_ptr + 29),
+            *(q_ptr + 37),
+            *(q_ptr + 45),
+            *(q_ptr + 53),
+            *(q_ptr + 61),
+        };
+        uint8_t values7[8] = {
+            *(q_ptr + 6),
+            *(q_ptr + 14),
+            *(q_ptr + 22),
+            *(q_ptr + 30),
+            *(q_ptr + 38),
+            *(q_ptr + 46),
+            *(q_ptr + 54),
+            *(q_ptr + 62),
+        };
+        uint8_t values8[8] = {
+            *(q_ptr + 7),
+            *(q_ptr + 15),
+            *(q_ptr + 23),
+            *(q_ptr + 31),
+            *(q_ptr + 39),
+            *(q_ptr + 47),
+            *(q_ptr + 55),
+            *(q_ptr + 63),
+        };
+
+        uint64_t values1_u64 = *((const uint64_t*)values1);
+        uint64_t values2_u64 = *((const uint64_t*)values2);
+        uint64_t values3_u64 = *((const uint64_t*)values3);
+        uint64_t values4_u64 = *((const uint64_t*)values4);
+        uint64_t values5_u64 = *((const uint64_t*)values5);
+        uint64_t values6_u64 = *((const uint64_t*)values6);
+        uint64_t values7_u64 = *((const uint64_t*)values7);
+        uint64_t values8_u64 = *((const uint64_t*)values8);
+
+        __m128i popcnt1 = _mm_set_epi32(
+            _mm_popcnt_u64(v ^ values1_u64),
+            _mm_popcnt_u64(v ^ values2_u64),
+            _mm_popcnt_u64(v ^ values3_u64),
+            _mm_popcnt_u64(v ^ values4_u64)
+        );
+        sum1 = _mm_add_epi32(sum1, popcnt1);
+
+        __m128i popcnt2 = _mm_set_epi32(
+            _mm_popcnt_u64(v ^ values5_u64),
+            _mm_popcnt_u64(v ^ values6_u64),
+            _mm_popcnt_u64(v ^ values7_u64),
+            _mm_popcnt_u64(v ^ values8_u64)
+        );
+        sum2 = _mm_add_epi32(sum2, popcnt2);
+
+        v_ptr += 8;
+        q_ptr += 64;
+    }
+
+    uint32_t dr1 = 0;
+    uint32_t dr2 = 0;
+    uint32_t dr3 = 0;
+    uint32_t dr4 = 0;
+    uint32_t dr5 = 0;
+    uint32_t dr6 = 0;
+    uint32_t dr7 = 0;
+    uint32_t dr8 = 0;
+    for (uint32_t _i = count % 8; _i > 0; _i--) {
+        uint8_t v = *(v_ptr++);
+        uint8_t q1 = *(q_ptr++);
+        uint8_t q2 = *(q_ptr++);
+        uint8_t q3 = *(q_ptr++);
+        uint8_t q4 = *(q_ptr++);
+        uint8_t q5 = *(q_ptr++);
+        uint8_t q6 = *(q_ptr++);
+        uint8_t q7 = *(q_ptr++);
+        uint8_t q8 = *(q_ptr++);
+        
+        uint8_t x1 = v ^ q1;
+        uint8_t x2 = v ^ q2;
+        uint8_t x3 = v ^ q3;
+        uint8_t x4 = v ^ q4;
+        uint8_t x5 = v ^ q5;
+        uint8_t x6 = v ^ q6;
+        uint8_t x7 = v ^ q7;
+        uint8_t x8 = v ^ q8;
+
+        dr1 += __builtin_popcount(x1);
+        dr2 += __builtin_popcount(x2);
+        dr3 += __builtin_popcount(x3);
+        dr4 += __builtin_popcount(x4);
+        dr5 += __builtin_popcount(x5);
+        dr6 += __builtin_popcount(x6);
+        dr7 += __builtin_popcount(x7);
+        dr8 += __builtin_popcount(x8);
+    }
+
+    __m128i factor1 = _mm_set_epi32(1, 2, 4, 8);
+    __m128i factor2 = _mm_set_epi32(16, 32, 64, 128);
+    __m128 result_mm128 = _mm_cvtepi32_ps(
+        _mm_add_epi32(
+            _mm_mullo_epi32(sum1, factor1),
+            _mm_mullo_epi32(sum2, factor2)
+        )
+    );
+    HSUM128_PS(result_mm128, mul_scalar);
+    return (uint32_t)mul_scalar + dr1 + (dr2 << 1) + (dr3 << 2) + (dr4 << 3) + (dr5 << 4) + (dr6 << 5) + (dr7 << 6) + (dr8 << 7);
+}
+
+EXPORT uint32_t impl_xor_popcnt_scalar4_sse_u8(
+    const uint8_t* q_ptr,
+    const uint8_t* v_ptr,
+    uint32_t count
+) {
+    __m128i sum = _mm_set1_epi32(0);
+    for (uint32_t _i = 0; _i < count / 8; _i++) {
+        uint64_t v = *((const uint64_t*)v_ptr);
+
+        uint8_t values1[8] = {
+            *(q_ptr + 0),
+            *(q_ptr + 4),
+            *(q_ptr + 8),
+            *(q_ptr + 12),
+            *(q_ptr + 16),
+            *(q_ptr + 20),
+            *(q_ptr + 24),
+            *(q_ptr + 28),
+        };
+        uint8_t values2[8] = {
+            *(q_ptr + 1),
+            *(q_ptr + 5),
+            *(q_ptr + 9),
+            *(q_ptr + 13),
+            *(q_ptr + 17),
+            *(q_ptr + 21),
+            *(q_ptr + 25),
+            *(q_ptr + 29),
+        };
+        uint8_t values3[8] = {
+            *(q_ptr + 2),
+            *(q_ptr + 6),
+            *(q_ptr + 10),
+            *(q_ptr + 14),
+            *(q_ptr + 18),
+            *(q_ptr + 22),
+            *(q_ptr + 26),
+            *(q_ptr + 30),
+        };
+        uint8_t values4[8] = {
+            *(q_ptr + 3),
+            *(q_ptr + 7),
+            *(q_ptr + 11),
+            *(q_ptr + 15),
+            *(q_ptr + 19),
+            *(q_ptr + 23),
+            *(q_ptr + 27),
+            *(q_ptr + 31),
+        };
+
+        uint64_t values1_u64 = *((const uint64_t*)values1);
+        uint64_t values2_u64 = *((const uint64_t*)values2);
+        uint64_t values3_u64 = *((const uint64_t*)values3);
+        uint64_t values4_u64 = *((const uint64_t*)values4);
+
+        __m128i popcnt = _mm_set_epi32(
+            _mm_popcnt_u64(v ^ values1_u64),
+            _mm_popcnt_u64(v ^ values2_u64),
+            _mm_popcnt_u64(v ^ values3_u64),
+            _mm_popcnt_u64(v ^ values4_u64)
+        );
+        sum = _mm_add_epi32(sum, popcnt);
+
+        v_ptr += 8;
+        q_ptr += 32;
+    }
+
+    uint32_t dr1 = 0;
+    uint32_t dr2 = 0;
+    uint32_t dr3 = 0;
+    uint32_t dr4 = 0;
+    for (uint32_t _i = count % 8; _i > 0; _i--) {
+        uint8_t v = *(v_ptr++);
+        uint8_t q1 = *(q_ptr++);
+        uint8_t q2 = *(q_ptr++);
+        uint8_t q3 = *(q_ptr++);
+        uint8_t q4 = *(q_ptr++);
+        
+        uint8_t x1 = v ^ q1;
+        uint8_t x2 = v ^ q2;
+        uint8_t x3 = v ^ q3;
+        uint8_t x4 = v ^ q4;
+        dr1 += __builtin_popcount(x1);
+        dr2 += __builtin_popcount(x2);
+        dr3 += __builtin_popcount(x3);
+        dr4 += __builtin_popcount(x4);
+    }
+
+    __m128i factor = _mm_set_epi32(1, 2, 4, 8);
+    __m128 result_mm128 = _mm_cvtepi32_ps(_mm_mullo_epi32(sum, factor));
+    HSUM128_PS(result_mm128, mul_scalar);
+    return (uint32_t)mul_scalar + dr1 + (dr2 << 1) + (dr3 << 2) + (dr4 << 3);
+}
+
 EXPORT float impl_score_l1_sse(
     const uint8_t* query_ptr,
     const uint8_t* vector_ptr,

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -35,7 +35,31 @@ impl Encoding {
     }
 }
 
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize, Default)]
+pub enum QueryEncoding {
+    #[default]
+    SameAsStorage,
+    Scalar4bits,
+    Scalar8bits,
+}
+
+impl QueryEncoding {
+    pub fn is_same_as_storage(&self) -> bool {
+        matches!(self, QueryEncoding::SameAsStorage)
+    }
+}
+
+pub enum EncodedQueryBQ<TBitsStoreType: BitsStoreType> {
+    Binary(EncodedBinVector<TBitsStoreType>),
+    Scalar4bits(EncodedScalarVector<TBitsStoreType>),
+    Scalar8bits(EncodedScalarVector<TBitsStoreType>),
+}
+
 pub struct EncodedBinVector<TBitsStoreType: BitsStoreType> {
+    encoded_vector: Vec<TBitsStoreType>,
+}
+
+pub struct EncodedScalarVector<TBitsStoreType: BitsStoreType> {
     encoded_vector: Vec<TBitsStoreType>,
 }
 
@@ -45,6 +69,9 @@ struct Metadata {
     #[serde(default)]
     #[serde(skip_serializing_if = "Encoding::is_one")]
     encoding: Encoding,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "QueryEncoding::is_same_as_storage")]
+    query_encoding: QueryEncoding,
 }
 
 pub trait BitsStoreType:
@@ -53,13 +80,20 @@ pub trait BitsStoreType:
     + Clone
     + core::ops::BitOrAssign
     + std::ops::Shl<usize, Output = Self>
+    + std::ops::Shr<usize, Output = Self>
+    + std::ops::BitAnd<Output = Self>
     + num_traits::identities::One
+    + num_traits::cast::FromPrimitive
+    + num_traits::cast::ToPrimitive
+    + std::fmt::Debug
 {
     /// Xor vectors and return the number of bits set to 1
     ///
     /// Assume that `v1` and `v2` are aligned to `BITS_STORE_TYPE_SIZE` with both with zeros
     /// So it does not affect the resulting number of bits set to 1
     fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize;
+
+    fn xor_popcnt_scalar(v1: &[Self], v2: &[Self], bits_count: usize) -> usize;
 
     /// Estimates how many `StorageType` elements are needed to store `size` bits
     fn get_storage_size(size: usize) -> usize;
@@ -120,6 +154,18 @@ impl BitsStoreType for u8 {
         result
     }
 
+    fn xor_popcnt_scalar(v1: &[Self], v2: &[Self], bits_count: usize) -> usize {
+        debug_assert!(v2.len() >= v1.len() * bits_count);
+
+        let mut result = 0;
+        for (&b1, b2_chunk) in v1.iter().zip(v2.chunks_exact(bits_count)) {
+            for (i, &b2) in b2_chunk.iter().enumerate() {
+                result += (b1 ^ b2).count_ones() << i;
+            }
+        }
+        result as usize
+    }
+
     fn get_storage_size(size: usize) -> usize {
         let bytes_count = if size > 128 {
             std::mem::size_of::<u128>()
@@ -173,6 +219,81 @@ impl BitsStoreType for u128 {
         result
     }
 
+    fn xor_popcnt_scalar(v1: &[Self], v2: &[Self], bits_count: usize) -> usize {
+        debug_assert!(v2.len() >= v1.len() * bits_count);
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            if bits_count == 8 {
+                unsafe {
+                    return impl_xor_popcnt_scalar8_neon_uint128(
+                        v2.as_ptr().cast::<u8>(),
+                        v1.as_ptr().cast::<u8>(),
+                        v1.len() as u32,
+                    ) as usize;
+                }
+            } else if bits_count == 4 {
+                unsafe {
+                    return impl_xor_popcnt_scalar4_neon_uint128(
+                        v2.as_ptr().cast::<u8>(),
+                        v1.as_ptr().cast::<u8>(),
+                        v1.len() as u32,
+                    ) as usize;
+                }
+            }
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("sse4.2") {
+            if bits_count == 8 {
+                unsafe {
+                    return impl_xor_popcnt_scalar8_avx_uint128(
+                        v2.as_ptr().cast::<u8>(),
+                        v1.as_ptr().cast::<u8>(),
+                        v1.len() as u32,
+                    ) as usize;
+                }
+            } else if bits_count == 4 {
+                unsafe {
+                    return impl_xor_popcnt_scalar4_avx_uint128(
+                        v2.as_ptr().cast::<u8>(),
+                        v1.as_ptr().cast::<u8>(),
+                        v1.len() as u32,
+                    ) as usize;
+                }
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if is_x86_feature_detected!("sse4.2") {
+            if bits_count == 8 {
+                unsafe {
+                    return impl_xor_popcnt_scalar8_sse_uint128(
+                        v2.as_ptr().cast::<u8>(),
+                        v1.as_ptr().cast::<u8>(),
+                        v1.len() as u32,
+                    ) as usize;
+                }
+            } else if bits_count == 4 {
+                unsafe {
+                    return impl_xor_popcnt_scalar4_sse_uint128(
+                        v2.as_ptr().cast::<u8>(),
+                        v1.as_ptr().cast::<u8>(),
+                        v1.len() as u32,
+                    ) as usize;
+                }
+            }
+        }
+
+        let mut result = 0;
+        for (&b1, b2_chunk) in v1.iter().zip(v2.chunks_exact(bits_count)) {
+            for (i, &b2) in b2_chunk.iter().enumerate() {
+                result += (b1 ^ b2).count_ones() << i;
+            }
+        }
+        result as usize
+    }
+
     fn get_storage_size(size: usize) -> usize {
         let bits_count = u8::BITS as usize * std::mem::size_of::<Self>();
         let mut result = size / bits_count;
@@ -195,6 +316,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         mut storage_builder: impl EncodedStorageBuilder<Storage = TStorage>,
         vector_parameters: &VectorParameters,
         encoding: Encoding,
+        query_encoding: QueryEncoding,
         stopped: &AtomicBool,
     ) -> Result<Self, EncodingError> {
         debug_assert!(validate_vector_parameters(orig_data.clone(), vector_parameters).is_ok());
@@ -222,6 +344,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
             metadata: Metadata {
                 vector_parameters: vector_parameters.clone(),
                 encoding,
+                query_encoding,
             },
             vector_stats,
             bits_store_type: PhantomData,
@@ -377,6 +500,89 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         }
     }
 
+    fn encode_query_vector(
+        query: &[f32],
+        vector_stats: &Option<VectorStats>,
+        encoding: Encoding,
+        query_encoding: QueryEncoding,
+    ) -> EncodedQueryBQ<TBitsStoreType> {
+        match query_encoding {
+            QueryEncoding::SameAsStorage => {
+                EncodedQueryBQ::Binary(Self::encode_vector(query, vector_stats, encoding))
+            }
+            QueryEncoding::Scalar8bits => EncodedQueryBQ::Scalar8bits(
+                Self::encode_scalar_query_vector(query, encoding, u8::BITS as usize),
+            ),
+            QueryEncoding::Scalar4bits => EncodedQueryBQ::Scalar4bits(
+                Self::encode_scalar_query_vector(query, encoding, (u8::BITS / 2) as usize),
+            ),
+        }
+    }
+
+    fn encode_scalar_query_vector(
+        query: &[f32],
+        encoding: Encoding,
+        bits_count: usize,
+    ) -> EncodedScalarVector<TBitsStoreType> {
+        match encoding {
+            Encoding::OneBit => Self::encode_scalar_extended_query_vector(query, bits_count),
+            Encoding::TwoBits => {
+                let mut extended_query = query.to_vec();
+                extended_query.extend_from_slice(query);
+                Self::encode_scalar_extended_query_vector(&extended_query, bits_count)
+            }
+            Encoding::OneAndHalfBits => {
+                let mut extended_query = query.to_vec();
+                extended_query.extend(query.chunks(2).map(|v| {
+                    if v.len() == 2 {
+                        if v[0] > v[1] { v[0] } else { v[1] }
+                    } else {
+                        v[0]
+                    }
+                }));
+                Self::encode_scalar_extended_query_vector(&extended_query, bits_count)
+            }
+        }
+    }
+
+    fn encode_scalar_extended_query_vector(
+        query: &[f32],
+        bits_count: usize,
+    ) -> EncodedScalarVector<TBitsStoreType> {
+        let encoded_query_size = TBitsStoreType::get_storage_size(query.len().max(1)) * bits_count;
+        let mut encoded_query: Vec<TBitsStoreType> = vec![Default::default(); encoded_query_size];
+
+        let max_abs_value = query.iter().map(|x| x.abs()).fold(0.0, f32::max);
+        let max = max_abs_value;
+        let min = -max_abs_value;
+
+        let ranges = (1usize << bits_count) - 1;
+        let delta = (max - min) / ranges as f32;
+
+        let storage_bits_count = std::mem::size_of::<TBitsStoreType>() * u8::BITS as usize;
+        for (chunk_index, chunk) in query.chunks(storage_bits_count).enumerate() {
+            for (shift, value) in chunk.iter().enumerate() {
+                let shifted_value = value - min;
+                let delted_value = if delta > f32::EPSILON {
+                    shifted_value / delta
+                } else {
+                    0.0
+                };
+                let rounded_value = delted_value.round() as usize;
+                let quantized = rounded_value % (ranges + 1);
+                let quantized = TBitsStoreType::from_usize(quantized).unwrap_or_default();
+                for b in 0..bits_count {
+                    let bit_value = ((quantized >> b) & TBitsStoreType::one()) << shift;
+                    encoded_query[bits_count * chunk_index + b] |= bit_value;
+                }
+            }
+        }
+
+        EncodedScalarVector {
+            encoded_vector: encoded_query,
+        }
+    }
+
     pub fn get_quantized_vector_size_from_params(dim: usize, encoding: Encoding) -> usize {
         let extended_dim = match encoding {
             Encoding::OneBit => dim,
@@ -394,7 +600,12 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         )
     }
 
-    fn calculate_metric(&self, v1: &[TBitsStoreType], v2: &[TBitsStoreType]) -> f32 {
+    fn calculate_metric(
+        &self,
+        v1: &[TBitsStoreType],
+        v2: &[TBitsStoreType],
+        v2_bits_count: usize,
+    ) -> f32 {
         // Dot product in a range [-1; 1] is approximated by NXOR in a range [0; 1]
         // L1 distance in range [-1; 1] (alpha=2) is approximated by alpha*XOR in a range [0; 1]
         // L2 distance in range [-1; 1] (alpha=2) is approximated by alpha*sqrt(XOR) in a range [0; 1]
@@ -412,7 +623,12 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         // | 1 | 0 | 0    | 1
         // | 1 | 1 | 1    | 0
 
-        let xor_product = TBitsStoreType::xor_popcnt(v1, v2) as f32;
+        let xor_product = if v2_bits_count == 1 {
+            TBitsStoreType::xor_popcnt(v1, v2) as f32
+        } else {
+            let xor_product = TBitsStoreType::xor_popcnt_scalar(v1, v2, v2_bits_count);
+            (xor_product as f32) / (((1 << v2_bits_count) - 1) as f32)
+        };
 
         let dim = self.metadata.vector_parameters.dim as f32;
         let zeros_count = dim - xor_product;
@@ -448,12 +664,19 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         vector_stats_path.push("vector_stats.json");
         Some(vector_stats_path)
     }
+
+    pub fn encode_internal_query(&self, point_id: u32) -> EncodedQueryBQ<TBitsStoreType> {
+        let encoded_data = self.get_quantized_vector(point_id).to_vec();
+        EncodedQueryBQ::Binary(EncodedBinVector {
+            encoded_vector: transmute_from_u8_to_slice(&encoded_data).to_vec(),
+        })
+    }
 }
 
 impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
     for EncodedVectorsBin<TBitsStoreType, TStorage>
 {
-    type EncodedQuery = EncodedBinVector<TBitsStoreType>;
+    type EncodedQuery = EncodedQueryBQ<TBitsStoreType>;
 
     fn save(&self, data_path: &Path, meta_path: &Path) -> std::io::Result<()> {
         meta_path.parent().map(std::fs::create_dir_all);
@@ -520,14 +743,19 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
         self.encoded_vectors.is_on_disk()
     }
 
-    fn encode_query(&self, query: &[f32]) -> EncodedBinVector<TBitsStoreType> {
+    fn encode_query(&self, query: &[f32]) -> EncodedQueryBQ<TBitsStoreType> {
         debug_assert!(query.len() == self.metadata.vector_parameters.dim);
-        Self::encode_vector(query, &self.vector_stats, self.metadata.encoding)
+        Self::encode_query_vector(
+            query,
+            &self.vector_stats,
+            self.metadata.encoding,
+            self.metadata.query_encoding,
+        )
     }
 
     fn score_point(
         &self,
-        query: &EncodedBinVector<TBitsStoreType>,
+        query: &EncodedQueryBQ<TBitsStoreType>,
         i: u32,
         hw_counter: &HardwareCounterCell,
     ) -> f32 {
@@ -537,11 +765,23 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
 
         let vector_data_usize_1 = transmute_from_u8_to_slice(vector_data_1);
 
-        hw_counter
-            .cpu_counter()
-            .incr_delta(query.encoded_vector.len());
+        hw_counter.cpu_counter().incr_delta(vector_data_1.len());
 
-        self.calculate_metric(vector_data_usize_1, &query.encoded_vector)
+        match query {
+            EncodedQueryBQ::Binary(encoded_vector) => {
+                self.calculate_metric(vector_data_usize_1, &encoded_vector.encoded_vector, 1)
+            }
+            EncodedQueryBQ::Scalar8bits(encoded_vector) => self.calculate_metric(
+                vector_data_usize_1,
+                &encoded_vector.encoded_vector,
+                u8::BITS as usize,
+            ),
+            EncodedQueryBQ::Scalar4bits(encoded_vector) => self.calculate_metric(
+                vector_data_usize_1,
+                &encoded_vector.encoded_vector,
+                u8::BITS as usize / 2,
+            ),
+        }
     }
 
     fn score_internal(&self, i: u32, j: u32, hw_counter: &HardwareCounterCell) -> f32 {
@@ -563,21 +803,21 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
             .cpu_counter()
             .incr_delta(vector_data_usize_2.len());
 
-        self.calculate_metric(vector_data_usize_1, vector_data_usize_2)
+        self.calculate_metric(vector_data_usize_1, vector_data_usize_2, 1)
     }
 
     fn quantized_vector_size(&self) -> usize {
         self.get_quantized_vector_size()
     }
 
-    fn encode_internal_vector(&self, id: u32) -> Option<EncodedBinVector<TBitsStoreType>> {
-        Some(EncodedBinVector {
+    fn encode_internal_vector(&self, id: u32) -> Option<EncodedQueryBQ<TBitsStoreType>> {
+        Some(EncodedQueryBQ::Binary(EncodedBinVector {
             encoded_vector: transmute_from_u8_to_slice(
                 self.encoded_vectors
                     .get_vector_data(id as _, self.get_quantized_vector_size()),
             )
             .to_vec(),
-        })
+        }))
     }
 }
 
@@ -588,6 +828,30 @@ unsafe extern "C" {
     fn impl_xor_popcnt_sse_uint64(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
 
     fn impl_xor_popcnt_sse_uint32(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
+
+    fn impl_xor_popcnt_scalar8_sse_uint128(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
+
+    fn impl_xor_popcnt_scalar4_sse_uint128(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
+
+    fn impl_xor_popcnt_scalar8_avx_uint128(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
+
+    fn impl_xor_popcnt_scalar4_avx_uint128(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
@@ -596,4 +860,16 @@ unsafe extern "C" {
     -> u32;
 
     fn impl_xor_popcnt_neon_uint64(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
+
+    fn impl_xor_popcnt_scalar8_neon_uint128(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
+
+    fn impl_xor_popcnt_scalar4_neon_uint128(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
 }

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -203,17 +203,17 @@ impl BitsStoreType for u8 {
             if query_bits_count == 8 {
                 unsafe {
                     return impl_xor_popcnt_scalar8_neon_u8(
-                        v2.as_ptr().cast::<u8>(),
-                        v1.as_ptr().cast::<u8>(),
-                        v1.len() as u32,
+                        query.as_ptr().cast::<u8>(),
+                        vector.as_ptr().cast::<u8>(),
+                        vector.len() as u32,
                     ) as usize;
                 }
             } else if query_bits_count == 4 {
                 unsafe {
                     return impl_xor_popcnt_scalar4_neon_u8(
-                        v2.as_ptr().cast::<u8>(),
-                        v1.as_ptr().cast::<u8>(),
-                        v1.len() as u32,
+                        query.as_ptr().cast::<u8>(),
+                        vector.as_ptr().cast::<u8>(),
+                        vector.len() as u32,
                     ) as usize;
                 }
             }
@@ -310,17 +310,17 @@ impl BitsStoreType for u128 {
             if query_bits_count == 8 {
                 unsafe {
                     return impl_xor_popcnt_scalar8_neon_uint128(
-                        v2.as_ptr().cast::<u8>(),
-                        v1.as_ptr().cast::<u8>(),
-                        v1.len() as u32,
+                        query.as_ptr().cast::<u8>(),
+                        vector.as_ptr().cast::<u8>(),
+                        vector.len() as u32,
                     ) as usize;
                 }
             } else if query_bits_count == 4 {
                 unsafe {
                     return impl_xor_popcnt_scalar4_neon_uint128(
-                        v2.as_ptr().cast::<u8>(),
-                        v1.as_ptr().cast::<u8>(),
-                        v1.len() as u32,
+                        query.as_ptr().cast::<u8>(),
+                        vector.as_ptr().cast::<u8>(),
+                        vector.len() as u32,
                     ) as usize;
                 }
             }

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -88,7 +88,7 @@ pub struct EncodedBinVector<TBitsStoreType: BitsStoreType> {
 /// This layout enables efficient batch operations:
 /// - Extract a single TBitsStoreType value from the BQ vector
 /// - Perform N parallel operations with corresponding scalar bits
-/// - Use shift operations to compute the final score: 
+/// - Use shift operations to compute the final score:
 ///   (scalar_1[0] ^ bq_vector[0] + ) << 0 +
 ///   (scalar_1[0] ^ bq_vector[0] + ) << 1 +
 ///   (scalar_1[0] ^ bq_vector[0] + ) << 2 ...
@@ -130,7 +130,7 @@ pub trait BitsStoreType:
     fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize;
 
     /// Calculate score between BQ encoded vector and `EncodedScalarVector<Self>` query.
-    /// 
+    ///
     /// It calculates sum of XOR popcount between each bit of the `vector` and the corresponding scalar value in the `query`.
     /// XOR between scalar and bit is a XOR for each bit of the scalar value.
     /// See `EncodedScalarVector` docs for more details about the transposition optimization to avoid extracting bits from BQ vectors.
@@ -618,13 +618,11 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
             Encoding::OneAndHalfBits => {
                 // For one and half bits encoding we need to extend the query vector
                 let mut extended_query = query.to_vec();
-                extended_query.extend(query.chunks(2).map(|v| {
-                    if v.len() == 2 {
-                        v[0].max(v[1])
-                    } else {
-                        v[0]
-                    }
-                }));
+                extended_query.extend(
+                    query
+                        .chunks(2)
+                        .map(|v| if v.len() == 2 { v[0].max(v[1]) } else { v[0] }),
+                );
                 Self::_encode_scalar_query_vector(&extended_query, bits_count)
             }
         }

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -567,11 +567,11 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         bits_count: usize,
     ) -> EncodedScalarVector<TBitsStoreType> {
         match encoding {
-            Encoding::OneBit => Self::encode_scalar_extended_query_vector(query, bits_count),
+            Encoding::OneBit => Self::_encode_scalar_query_vector(query, bits_count),
             Encoding::TwoBits => {
                 let mut extended_query = query.to_vec();
                 extended_query.extend_from_slice(query);
-                Self::encode_scalar_extended_query_vector(&extended_query, bits_count)
+                Self::_encode_scalar_query_vector(&extended_query, bits_count)
             }
             Encoding::OneAndHalfBits => {
                 let mut extended_query = query.to_vec();
@@ -582,12 +582,12 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
                         v[0]
                     }
                 }));
-                Self::encode_scalar_extended_query_vector(&extended_query, bits_count)
+                Self::_encode_scalar_query_vector(&extended_query, bits_count)
             }
         }
     }
 
-    fn encode_scalar_extended_query_vector(
+    fn _encode_scalar_query_vector(
         query: &[f32],
         bits_count: usize,
     ) -> EncodedScalarVector<TBitsStoreType> {

--- a/lib/quantization/tests/integration/empty_storage.rs
+++ b/lib/quantization/tests/integration/empty_storage.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use quantization::EncodedVectorsPQ;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::encoded_vectors_binary::EncodedVectorsBin;
+    use quantization::encoded_vectors_binary::{EncodedVectorsBin, QueryEncoding};
     use quantization::encoded_vectors_u8::EncodedVectorsU8;
     use tempfile::Builder;
 
@@ -102,6 +102,7 @@ mod tests {
             Vec::<u8>::new(),
             &vector_parameters,
             quantization::encoded_vectors_binary::Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();

--- a/lib/quantization/tests/integration/test_binary.rs
+++ b/lib/quantization/tests/integration/test_binary.rs
@@ -4,7 +4,9 @@ mod tests {
 
     use common::counter::hardware_counter::HardwareCounterCell;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::encoded_vectors_binary::{BitsStoreType, EncodedVectorsBin, Encoding};
+    use quantization::encoded_vectors_binary::{
+        BitsStoreType, EncodedVectorsBin, Encoding, QueryEncoding,
+    };
     use rand::{Rng, SeedableRng};
 
     use crate::metrics::{dot_similarity, l1_similarity, l2_similarity};
@@ -50,6 +52,7 @@ mod tests {
                 invert: false,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -97,6 +100,7 @@ mod tests {
                 invert: true,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -144,6 +148,7 @@ mod tests {
                 invert: false,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -188,6 +193,7 @@ mod tests {
                 invert: true,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -231,6 +237,7 @@ mod tests {
                 invert: false,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -293,6 +300,7 @@ mod tests {
                 invert: true,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -355,6 +363,7 @@ mod tests {
                 invert: false,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -414,6 +423,7 @@ mod tests {
                 invert: true,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -473,6 +483,7 @@ mod tests {
                 invert: false,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -535,6 +546,7 @@ mod tests {
                 invert: true,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -597,6 +609,7 @@ mod tests {
                 invert: false,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -656,6 +669,7 @@ mod tests {
                 invert: true,
             },
             Encoding::OneBit,
+            QueryEncoding::SameAsStorage,
             &AtomicBool::new(false),
         )
         .unwrap();
@@ -682,5 +696,52 @@ mod tests {
         let sorted_original_indices: Vec<_> = original_scores.into_iter().map(|(_, i)| i).collect();
 
         assert_eq!(sorted_original_indices, sorted_indices);
+    }
+
+    #[test]
+    fn test_binary_scalar_internal() {
+        test_binary_scalar_internal_impl::<u8>(16, Encoding::OneBit);
+        test_binary_scalar_internal_impl::<u8>(129, Encoding::OneBit);
+        test_binary_scalar_internal_impl::<u8>(16, Encoding::TwoBits);
+        test_binary_scalar_internal_impl::<u8>(129, Encoding::TwoBits);
+        test_binary_scalar_internal_impl::<u8>(16, Encoding::OneAndHalfBits);
+        test_binary_scalar_internal_impl::<u8>(129, Encoding::OneAndHalfBits);
+    }
+
+    fn test_binary_scalar_internal_impl<TBitsStoreType: BitsStoreType>(
+        vector_dim: usize,
+        encoding: Encoding,
+    ) {
+        let vectors_count = 128;
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(41);
+        let mut vector_data: Vec<Vec<f32>> = Vec::new();
+        for _ in 0..vectors_count {
+            vector_data.push(generate_vector(vector_dim, &mut rng));
+        }
+
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
+            vector_data.iter(),
+            Vec::<u8>::new(),
+            &VectorParameters {
+                dim: vector_dim,
+                count: vectors_count,
+                distance_type: DistanceType::Dot,
+                invert: false,
+            },
+            encoding,
+            quantization::encoded_vectors_binary::QueryEncoding::Scalar4bits,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
+
+        let query_encoded = encoded.encode_query(&vector_data[0]);
+
+        let other = 1;
+        let counter = HardwareCounterCell::new();
+        let score = encoded.score_point(&query_encoded, other as u32, &counter);
+        let score_internal = encoded.score_internal(0, other as u32, &counter);
+
+        assert_eq!(score, score_internal);
     }
 }

--- a/lib/quantization/tests/integration/test_binary_encodings.rs
+++ b/lib/quantization/tests/integration/test_binary_encodings.rs
@@ -8,6 +8,7 @@ mod tests {
         BitsStoreType, EncodedVectorsBin, Encoding, QueryEncoding,
     };
     use rand::{Rng, SeedableRng};
+    use strum::IntoEnumIterator;
 
     use crate::metrics::dot_similarity;
 
@@ -160,15 +161,8 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let query_encodings = [
-            QueryEncoding::SameAsStorage,
-            QueryEncoding::Scalar4bits,
-            QueryEncoding::Scalar8bits,
-        ];
-
-        let encoded: Vec<_> = query_encodings
-            .iter()
-            .map(|&query_encoding| {
+        let encoded: Vec<_> = QueryEncoding::iter()
+            .map(|query_encoding| {
                 EncodedVectorsBin::<TBitsStoreType, _>::encode(
                     vector_data.iter(),
                     Vec::<u8>::new(),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -950,7 +950,7 @@ impl QuantizedVectors {
                     storage_builder,
                     vector_parameters,
                     encoding,
-                    quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
+                    quantization::encoded_vectors_binary::QueryEncoding::SameAsStorage,
                     stopped,
                 )?,
             ))
@@ -967,7 +967,7 @@ impl QuantizedVectors {
                     storage_builder,
                     vector_parameters,
                     encoding,
-                    quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
+                    quantization::encoded_vectors_binary::QueryEncoding::SameAsStorage,
                     stopped,
                 )?,
             ))
@@ -1011,7 +1011,7 @@ impl QuantizedVectors {
                 storage_builder,
                 vector_parameters,
                 encoding,
-                quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
+                quantization::encoded_vectors_binary::QueryEncoding::SameAsStorage,
                 stopped,
             )?;
             Ok(QuantizedVectorStorage::BinaryRamMulti(
@@ -1034,7 +1034,7 @@ impl QuantizedVectors {
                 storage_builder,
                 vector_parameters,
                 encoding,
-                quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
+                quantization::encoded_vectors_binary::QueryEncoding::SameAsStorage,
                 stopped,
             )?;
             let offsets_path = path.join(QUANTIZED_OFFSETS_PATH);

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -950,6 +950,7 @@ impl QuantizedVectors {
                     storage_builder,
                     vector_parameters,
                     encoding,
+                    quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
                     stopped,
                 )?,
             ))
@@ -966,6 +967,7 @@ impl QuantizedVectors {
                     storage_builder,
                     vector_parameters,
                     encoding,
+                    quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
                     stopped,
                 )?,
             ))
@@ -1009,6 +1011,7 @@ impl QuantizedVectors {
                 storage_builder,
                 vector_parameters,
                 encoding,
+                quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
                 stopped,
             )?;
             Ok(QuantizedVectorStorage::BinaryRamMulti(
@@ -1031,6 +1034,7 @@ impl QuantizedVectors {
                 storage_builder,
                 vector_parameters,
                 encoding,
+                quantization::encoded_vectors_binary::QueryEncoding::Scalar8bits,
                 stopped,
             )?;
             let offsets_path = path.join(QUANTIZED_OFFSETS_PATH);


### PR DESCRIPTION
This PR introduces an internal implementation for an upcoming feature: asymmetric binary quantization.
API PR is here: https://github.com/qdrant/qdrant/pull/6201

Motivation
Asymmetric quantization is a quantization where vector and query have different quantization algorithms. In this PR we introduce only one asymmetric option: BQ with query encoded as SQ.

Such methods allow for increased accuracy because a more accurate query produces a more accurate score. But scoring will be more complicated, as not each use case is suitable for asymmetric mechanisms.

An example of BQ quantization with SQ query is a [RaBitQ quantization](https://arxiv.org/pdf/2405.12497). We want to have something similar.


We don't use RaBitQ alg, encoding is different, and only scoring is the same. We have our vision instead. As a pros, we don't need to store additional precomputed constants for each vector, and our approach is compatible with `score_internal` method. As a cons, we require negative numbers in vectors to make it work like in a regular BQ.

We don't use asymmetric BQ in HNSW construction because experiments have shown that HNSW accuracy is poor. No GPU integration is required.

Results on test laion 400M:
```
Regular BQ: Average precision: 62.37%
Asymmetric BQ 8bit query: Average precision: 70.46%
```