### PR TITLE
[phrase matching] Text index fixes

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7658,12 +7658,8 @@
             "type": "boolean",
             "nullable": true
           },
-          "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
-            "type": "boolean",
-            "nullable": true
-          },
           "stopwords": {
+            "description": "Ignore this set of tokens. Can select from predefined languages and/or provide a custom set.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/StopwordsInterface"
@@ -7672,6 +7668,11 @@
                 "nullable": true
               }
             ]
+          },
+          "on_disk": {
+            "description": "If true, store the index on disk. Default: false.",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -533,7 +533,7 @@ pub enum FieldIndexBuilder {
     GeoMmapIndex(GeoMapIndexMmapBuilder),
     GeoGridstoreIndex(GeoMapIndexGridstoreBuilder),
     #[cfg(feature = "rocksdb")]
-    FullTextIndex(super::full_text_index::text_index::FullTextIndexBuilder),
+    FullTextIndex(super::full_text_index::text_index::FullTextIndexRocksDbBuilder),
     FullTextMmapIndex(FullTextMmapIndexBuilder),
     FullTextGridstoreIndex(FullTextGridstoreIndexBuilder),
     #[cfg(feature = "rocksdb")]

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -45,7 +45,7 @@ pub struct MmapInvertedIndex {
 }
 
 impl MmapInvertedIndex {
-    pub fn create(path: PathBuf, inverted_index: ImmutableInvertedIndex) -> OperationResult<()> {
+    pub fn create(path: PathBuf, inverted_index: &ImmutableInvertedIndex) -> OperationResult<()> {
         let ImmutableInvertedIndex {
             postings,
             vocab,
@@ -61,9 +61,9 @@ impl MmapInvertedIndex {
         let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
         match postings {
-            ImmutablePostings::Ids(postings) => MmapPostings::create(postings_path, &postings)?,
+            ImmutablePostings::Ids(postings) => MmapPostings::create(postings_path, postings)?,
             ImmutablePostings::WithPositions(postings) => {
-                MmapPostings::create(postings_path, &postings)?
+                MmapPostings::create(postings_path, postings)?
             }
         }
 
@@ -84,7 +84,7 @@ impl MmapInvertedIndex {
         MmapBitSlice::create(&deleted_points_path, &deleted_bitslice)?;
 
         // The actual values go in the slice
-        let point_to_tokens_count_iter = point_to_tokens_count.into_iter();
+        let point_to_tokens_count_iter = point_to_tokens_count.iter().copied();
 
         MmapSlice::create(&point_to_tokens_count_path, point_to_tokens_count_iter)?;
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -462,7 +462,7 @@ mod tests {
 
         let hw_counter = HardwareCounterCell::new();
 
-        MmapInvertedIndex::create(mmap_dir.path().into(), immutable.clone()).unwrap();
+        MmapInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
         let mmap = MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching).unwrap();
 
         let imm_mmap = ImmutableInvertedIndex::from(&mmap);
@@ -527,7 +527,7 @@ mod tests {
         let mut mut_index = mutable_inverted_index(indexed_count, deleted_count, phrase_matching);
 
         let immutable = ImmutableInvertedIndex::from(mut_index.clone());
-        MmapInvertedIndex::create(mmap_dir.path().into(), immutable).unwrap();
+        MmapInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
         let mut mmap_index =
             MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching).unwrap();
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/positions.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/positions.rs
@@ -50,7 +50,7 @@ impl UnsizedValue for Positions {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TokenPosition {
     token_id: TokenId,
     position: u32,
@@ -63,6 +63,10 @@ pub struct PartialDocument(Vec<TokenPosition>);
 impl PartialDocument {
     pub fn new(mut tokens_positions: Vec<TokenPosition>) -> Self {
         tokens_positions.sort_by_key(|tok_pos| tok_pos.position);
+
+        // There should be no duplicate token with same position
+        debug_assert!(tokens_positions.windows(2).all(|window| window[0] != window[1]));
+
         Self(tokens_positions)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/positions.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/positions.rs
@@ -65,7 +65,11 @@ impl PartialDocument {
         tokens_positions.sort_by_key(|tok_pos| tok_pos.position);
 
         // There should be no duplicate token with same position
-        debug_assert!(tokens_positions.windows(2).all(|window| window[0] != window[1]));
+        debug_assert!(
+            tokens_positions
+                .windows(2)
+                .all(|window| window[0] != window[1])
+        );
 
         Self(tokens_positions)
     }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/postings_iterator.rs
@@ -157,6 +157,7 @@ pub fn check_compressed_postings_phrase<'a>(
     token_to_posting: impl Fn(&TokenId) -> Option<PostingListView<'a, Positions>>,
 ) -> bool {
     let Some(mut posting_iterators): Option<Vec<_>> = phrase
+        .to_token_set()
         .tokens()
         .iter()
         .map(|token_id| token_to_posting(token_id).map(|posting| (*token_id, posting.into_iter())))

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -18,6 +18,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 #[cfg(feature = "rocksdb")]
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::data_types::index::TextIndexParams;
+use crate::index::field_index::ValueIndexer;
 
 const GRIDSTORE_OPTIONS: StorageOptions = StorageOptions {
     compression: Some(gridstore::config::Compression::None),
@@ -329,6 +330,27 @@ impl MutableFullTextIndex {
                 .get_value(idx, &HardwareCounterCell::disposable())
                 .map(|bytes| FullTextIndex::deserialize_document(&bytes).unwrap()),
         }
+    }
+}
+
+impl ValueIndexer for MutableFullTextIndex {
+    type ValueType = String;
+
+    fn add_many(
+        &mut self,
+        idx: PointOffsetType,
+        values: Vec<String>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.add_many(idx, values, hw_counter)
+    }
+
+    fn get_value(value: &serde_json::Value) -> Option<String> {
+        FullTextIndex::get_value(value)
+    }
+
+    fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        self.remove_point(id)
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -287,7 +287,6 @@ fn test_phrase_matching() {
             .unwrap();
         assert!(index.check_match(&phrase_query, 4, &hw_counter));
 
-
         // Should only match document 4
         let filter_results: Vec<_> = index.filter_query(phrase_query, &hw_counter).collect();
         assert_eq!(filter_results.len(), 1);

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -240,7 +240,7 @@ fn test_congruence(
     #[values(false, true)] phrase_matching: bool,
 ) {
     const POINT_COUNT: usize = 500;
-    const KEYWORD_COUNT: usize = 5;
+    const KEYWORD_COUNT: usize = 20;
     const KEYWORD_LEN: usize = 2;
 
     let hw_counter = HardwareCounterCell::disposable();
@@ -424,13 +424,14 @@ fn check_phrase<const KEYWORD_COUNT: usize>(
     check_indexes: &[(FullTextIndex, IndexType)],
     phrase_matching: bool,
 ) -> Vec<Vec<String>> {
-    // From the ids, choose a random phrase of 2 words.
+    // From the ids, choose a random phrase of 4 words.
+    const PHRASE_LENGTH: usize = 4;
     let mut phrases = Vec::new();
-    let rng = &mut rand::rng();
+    let rng = &mut StdRng::seed_from_u64(43);
     for id in existing_ids {
         let doc = mutable_index.get_doc(*id).unwrap();
-        let rand_idx = rng.random_range(0..KEYWORD_COUNT - 1);
-        let phrase = doc[rand_idx..rand_idx + 2].to_vec();
+        let rand_idx = rng.random_range(0..=KEYWORD_COUNT - PHRASE_LENGTH);
+        let phrase = doc[rand_idx..rand_idx + PHRASE_LENGTH].to_vec();
 
         phrases.push(phrase);
     }

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -117,35 +117,30 @@ fn create_builder(
         ..TextIndexParams::default()
     };
 
-    let mut builder = match index_type {
-        #[cfg(feature = "rocksdb")]
-        IndexType::MutableRocksdb => IndexBuilder::MutableRocksdb(FullTextIndex::builder_rocksdb(
-            db.clone(),
-            config,
-            FIELD_NAME,
-            true
-        )),
-        IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
-            FullTextIndex::builder_gridstore(temp_dir.path().to_path_buf(), config),
-        ),
-        #[cfg(feature = "rocksdb")]
-        IndexType::ImmRamRocksDb => IndexBuilder::ImmRamRocksdb(FullTextIndex::builder_rocksdb(
-            db.clone(),
-            config,
-            FIELD_NAME,
-            false,
-        )),
-        IndexType::ImmMmap => IndexBuilder::ImmMmap(FullTextIndex::builder_mmap(
-            temp_dir.path().to_path_buf(),
-            config,
-            true,
-        )),
-        IndexType::ImmRamMmap => IndexBuilder::ImmRamMmap(FullTextIndex::builder_mmap(
-            temp_dir.path().to_path_buf(),
-            config,
-            false,
-        )),
-    };
+    let mut builder =
+        match index_type {
+            #[cfg(feature = "rocksdb")]
+            IndexType::MutableRocksdb => IndexBuilder::MutableRocksdb(
+                FullTextIndex::builder_rocksdb(db.clone(), config, FIELD_NAME, true),
+            ),
+            IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
+                FullTextIndex::builder_gridstore(temp_dir.path().to_path_buf(), config),
+            ),
+            #[cfg(feature = "rocksdb")]
+            IndexType::ImmRamRocksDb => IndexBuilder::ImmRamRocksdb(
+                FullTextIndex::builder_rocksdb(db.clone(), config, FIELD_NAME, false),
+            ),
+            IndexType::ImmMmap => IndexBuilder::ImmMmap(FullTextIndex::builder_mmap(
+                temp_dir.path().to_path_buf(),
+                config,
+                true,
+            )),
+            IndexType::ImmRamMmap => IndexBuilder::ImmRamMmap(FullTextIndex::builder_mmap(
+                temp_dir.path().to_path_buf(),
+                config,
+                false,
+            )),
+        };
     match &mut builder {
         #[cfg(feature = "rocksdb")]
         IndexBuilder::MutableRocksdb(builder) => builder.init().unwrap(),

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -448,7 +448,9 @@ impl FieldIndexBuilderTrait for FullTextIndexRocksDbBuilder {
             return Ok(FullTextIndex::Mutable(self.mutable_index));
         }
 
-        Ok(FullTextIndex::Immutable(ImmutableFullTextIndex::from_rocksdb_mutable(self.mutable_index)))
+        Ok(FullTextIndex::Immutable(
+            ImmutableFullTextIndex::from_rocksdb_mutable(self.mutable_index),
+        ))
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use std::collections::BTreeSet;
 use std::path::PathBuf;
 #[cfg(feature = "rocksdb")]
 use std::sync::Arc;
@@ -102,8 +100,9 @@ impl FullTextIndex {
         db: Arc<RwLock<DB>>,
         config: TextIndexParams,
         field: &str,
-    ) -> FullTextIndexBuilder {
-        FullTextIndexBuilder(Self::new_rocksdb(db, config, field, true))
+        keep_appendable: bool,
+    ) -> FullTextIndexRocksDbBuilder {
+        FullTextIndexRocksDbBuilder::new(db, config, field, keep_appendable)
     }
 
     pub fn builder_mmap(
@@ -240,39 +239,6 @@ impl FullTextIndex {
     #[cfg(feature = "rocksdb")]
     pub(super) fn restore_key(data: &[u8]) -> PointOffsetType {
         bincode::deserialize(data).unwrap()
-    }
-
-    /// CBOR representation is the same for BTreeSet<String> and Vec<String> if the elements are sorted, thus, we can resort to
-    /// the vec implementation always. Let's just keep this to prove this works fine during https://github.com/qdrant/qdrant/pull/6493
-    ///
-    /// We can remove this afterwards
-    #[cfg(test)]
-    pub(super) fn serialize_token_set(tokens: BTreeSet<String>) -> OperationResult<Vec<u8>> {
-        #[derive(Serialize)]
-        struct StoredTokens {
-            tokens: BTreeSet<String>,
-        }
-        let doc = StoredTokens { tokens };
-        serde_cbor::to_vec(&doc).map_err(|e| {
-            OperationError::service_error(format!("Failed to serialize document: {e}"))
-        })
-    }
-
-    /// CBOR representation is the same for BTreeSet<String> and Vec<String> if the elements are sorted, thus, we can resort to
-    /// the vec implementation always. Let's just keep this to prove this works fine during https://github.com/qdrant/qdrant/pull/6493
-    ///
-    /// We can delete this afterwards
-    #[cfg(test)]
-    pub(super) fn deserialize_token_set(data: &[u8]) -> OperationResult<BTreeSet<String>> {
-        #[derive(Deserialize)]
-        struct StoredTokens {
-            tokens: BTreeSet<String>,
-        }
-        serde_cbor::from_slice::<StoredTokens>(data)
-            .map_err(|e| {
-                OperationError::service_error(format!("Failed to deserialize document: {e}"))
-            })
-            .map(|doc| doc.tokens)
     }
 
     pub(super) fn serialize_document(tokens: Vec<String>) -> OperationResult<Vec<u8>> {
@@ -434,13 +400,38 @@ impl FullTextIndex {
     }
 }
 
-pub struct FullTextIndexBuilder(FullTextIndex);
+#[cfg(feature = "rocksdb")]
+pub struct FullTextIndexRocksDbBuilder {
+    mutable_index: MutableFullTextIndex,
+    keep_appendable: bool,
+}
 
-impl FieldIndexBuilderTrait for FullTextIndexBuilder {
+#[cfg(feature = "rocksdb")]
+impl FullTextIndexRocksDbBuilder {
+    pub fn new(
+        db: Arc<RwLock<DB>>,
+        config: TextIndexParams,
+        field: &str,
+        keep_appendable: bool,
+    ) -> Self {
+        let store_cf_name = FullTextIndex::storage_cf_name(field);
+        let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
+            db,
+            &store_cf_name,
+        ));
+        FullTextIndexRocksDbBuilder {
+            mutable_index: MutableFullTextIndex::open_rocksdb(db_wrapper, config),
+            keep_appendable,
+        }
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+impl FieldIndexBuilderTrait for FullTextIndexRocksDbBuilder {
     type FieldIndexType = FullTextIndex;
 
     fn init(&mut self) -> OperationResult<()> {
-        self.0.init()
+        self.mutable_index.init()
     }
 
     fn add_point(
@@ -449,11 +440,15 @@ impl FieldIndexBuilderTrait for FullTextIndexBuilder {
         payload: &[&Value],
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        self.0.add_point(id, payload, hw_counter)
+        self.mutable_index.add_point(id, payload, hw_counter)
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        Ok(self.0)
+        if self.keep_appendable {
+            return Ok(FullTextIndex::Mutable(self.mutable_index));
+        }
+
+        Ok(FullTextIndex::Immutable(ImmutableFullTextIndex::from_rocksdb_mutable(self.mutable_index)))
     }
 }
 
@@ -478,10 +473,7 @@ impl ValueIndexer for FullTextIndex {
     }
 
     fn get_value(value: &Value) -> Option<String> {
-        if let Value::String(keyword) = value {
-            return Some(keyword.to_owned());
-        }
-        None
+        value.as_str().map(ToOwned::to_owned)
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
@@ -610,10 +602,7 @@ impl ValueIndexer for FullTextGridstoreIndexBuilder {
     type ValueType = String;
 
     fn get_value(value: &Value) -> Option<String> {
-        match value {
-            Value::String(s) => Some(s.clone()),
-            _ => None,
-        }
+        FullTextIndex::get_value(value)
     }
 
     fn add_many(
@@ -674,472 +663,5 @@ impl FieldIndexBuilderTrait for FullTextGridstoreIndexBuilder {
         };
         index.flusher()()?;
         Ok(index)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use rand::SeedableRng;
-    use rand::rngs::StdRng;
-    use rstest::rstest;
-    use tempfile::{Builder, TempDir};
-
-    use super::*;
-    use crate::fixtures::payload_fixtures::random_full_text_payload;
-    use crate::index::field_index::field_index_base::FieldIndexBuilderTrait;
-    #[cfg(feature = "rocksdb")]
-    use crate::index::field_index::full_text_index::mutable_text_index;
-    use crate::types::ValuesCount;
-
-    const FIELD_NAME: &str = "test";
-
-    #[cfg(feature = "rocksdb")]
-    const INDEXES_COUNT: usize = 5;
-
-    #[cfg(not(feature = "rocksdb"))]
-    const INDEXES_COUNT: usize = 3;
-
-    const TYPES: [IndexType; INDEXES_COUNT] = [
-        #[cfg(feature = "rocksdb")]
-        IndexType::Mutable,
-        IndexType::MutableGridstore,
-        #[cfg(feature = "rocksdb")]
-        IndexType::Immutable,
-        IndexType::Mmap,
-        IndexType::RamMmap,
-    ];
-
-    #[derive(Clone, Copy, PartialEq, Debug)]
-    enum IndexType {
-        #[cfg(feature = "rocksdb")]
-        Mutable,
-        MutableGridstore,
-        #[cfg(feature = "rocksdb")]
-        Immutable,
-        Mmap,
-        RamMmap,
-    }
-
-    enum IndexBuilder {
-        #[cfg(feature = "rocksdb")]
-        Mutable(FullTextIndexBuilder),
-        MutableGridstore(FullTextGridstoreIndexBuilder),
-        #[cfg(feature = "rocksdb")]
-        Immutable(FullTextIndexBuilder),
-        Mmap(FullTextMmapIndexBuilder),
-        RamMmap(FullTextMmapIndexBuilder),
-    }
-
-    struct CreatedBuilder {
-        index_builder: IndexBuilder,
-        temp_dir: TempDir,
-        #[cfg(feature = "rocksdb")]
-        db: Arc<RwLock<DB>>,
-    }
-
-    struct ConstructedIndex {
-        index: FullTextIndex,
-        temp_dir: TempDir,
-        #[cfg(feature = "rocksdb")]
-        db: Arc<RwLock<DB>>,
-    }
-
-    struct IndexContext {
-        _temp_dir: TempDir,
-        #[cfg(feature = "rocksdb")]
-        _db: Arc<RwLock<DB>>,
-    }
-
-    impl IndexBuilder {
-        fn add_point(
-            &mut self,
-            id: PointOffsetType,
-            payload: &[&Value],
-            hw_counter: &HardwareCounterCell,
-        ) -> OperationResult<()> {
-            match self {
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Mutable(builder) => builder.add_point(id, payload, hw_counter),
-                IndexBuilder::MutableGridstore(builder) => {
-                    FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
-                }
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Immutable(builder) => builder.add_point(id, payload, hw_counter),
-                IndexBuilder::Mmap(builder) => {
-                    FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
-                }
-                IndexBuilder::RamMmap(builder) => {
-                    FieldIndexBuilderTrait::add_point(builder, id, payload, hw_counter)
-                }
-            }
-        }
-
-        fn finalize(self) -> OperationResult<FullTextIndex> {
-            match self {
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Mutable(builder) => builder.finalize(),
-                IndexBuilder::MutableGridstore(builder) => builder.finalize(),
-                #[cfg(feature = "rocksdb")]
-                IndexBuilder::Immutable(builder) => {
-                    let FullTextIndex::Mutable(index) = builder.finalize()? else {
-                        panic!("expected mutable index");
-                    };
-
-                    // Deconstruct mutable index, flush pending changes
-                    let MutableFullTextIndex {
-                        storage,
-                        inverted_index: _,
-                        config,
-                        tokenizer: _,
-                    } = index;
-                    let mutable_text_index::Storage::RocksDb(db_wrapper) = storage else {
-                        panic!("expected RocksDB storage for immutable index");
-                    };
-                    db_wrapper.flusher()().expect("failed to flush");
-
-                    // Open and load immutable index
-                    let mut index = ImmutableFullTextIndex::open_rocksdb(db_wrapper, config);
-                    index.load()?;
-                    let index = FullTextIndex::Immutable(index);
-                    Ok(index)
-                }
-                IndexBuilder::Mmap(builder) => builder.finalize(),
-                IndexBuilder::RamMmap(builder) => {
-                    let FullTextIndex::Mmap(index) = builder.finalize()? else {
-                        panic!("expected mmap index");
-                    };
-
-                    // Load index from mmap
-                    let mut index =
-                        FullTextIndex::Immutable(ImmutableFullTextIndex::open_mmap(*index));
-                    index.load()?;
-                    Ok(index)
-                }
-            }
-        }
-    }
-
-    #[cfg(feature = "testing")]
-    fn create_builder(index_type: IndexType, phrase_matching: bool) -> CreatedBuilder {
-        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
-        #[cfg(feature = "rocksdb")]
-        let db = crate::common::rocksdb_wrapper::open_db_with_existing_cf(
-            &temp_dir.path().join("test_db"),
-        )
-        .unwrap();
-        let config = TextIndexParams {
-            phrase_matching: Some(phrase_matching),
-            ..TextIndexParams::default()
-        };
-        let mut builder = match index_type {
-            #[cfg(feature = "rocksdb")]
-            IndexType::Mutable => IndexBuilder::Mutable(FullTextIndex::builder_rocksdb(
-                db.clone(),
-                config,
-                FIELD_NAME,
-            )),
-            IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
-                FullTextIndex::builder_gridstore(temp_dir.path().to_path_buf(), config),
-            ),
-            #[cfg(feature = "rocksdb")]
-            IndexType::Immutable => IndexBuilder::Immutable(FullTextIndex::builder_rocksdb(
-                db.clone(),
-                config,
-                FIELD_NAME,
-            )),
-            IndexType::Mmap => IndexBuilder::Mmap(FullTextIndex::builder_mmap(
-                temp_dir.path().to_path_buf(),
-                config,
-                true,
-            )),
-            IndexType::RamMmap => IndexBuilder::RamMmap(FullTextIndex::builder_mmap(
-                temp_dir.path().to_path_buf(),
-                config,
-                false,
-            )),
-        };
-        match &mut builder {
-            #[cfg(feature = "rocksdb")]
-            IndexBuilder::Mutable(builder) => builder.init().unwrap(),
-            IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
-            #[cfg(feature = "rocksdb")]
-            IndexBuilder::Immutable(builder) => builder.init().unwrap(),
-            IndexBuilder::Mmap(builder) => builder.init().unwrap(),
-            IndexBuilder::RamMmap(builder) => builder.init().unwrap(),
-        }
-        CreatedBuilder {
-            index_builder: builder,
-            temp_dir,
-            #[cfg(feature = "rocksdb")]
-            db,
-        }
-    }
-
-    fn build_random_index(
-        num_points: usize,
-        num_keywords: usize,
-        keyword_len: usize,
-        index_type: IndexType,
-        phrase_matching: bool,
-        deleted: bool,
-    ) -> ConstructedIndex {
-        let mut rnd = StdRng::seed_from_u64(42);
-        let mut created_builder = create_builder(index_type, phrase_matching);
-
-        for idx in 0..num_points {
-            let keywords = random_full_text_payload(
-                &mut rnd,
-                num_keywords..=num_keywords,
-                keyword_len..=keyword_len,
-            );
-            let array_payload = Value::Array(keywords);
-            created_builder
-                .index_builder
-                .add_point(
-                    idx as PointOffsetType,
-                    &[&array_payload],
-                    &HardwareCounterCell::new(),
-                )
-                .unwrap();
-        }
-
-        let mut index = created_builder.index_builder.finalize().unwrap();
-        assert_eq!(index.points_count(), num_points);
-
-        // Delete some points before loading into a different format
-        if deleted {
-            index.remove_point(20).unwrap();
-            index.remove_point(21).unwrap();
-            index.remove_point(22).unwrap();
-            index.remove_point(200).unwrap();
-            index.remove_point(250).unwrap();
-        }
-
-        ConstructedIndex {
-            index,
-            temp_dir: created_builder.temp_dir,
-            #[cfg(feature = "rocksdb")]
-            db: created_builder.db,
-        }
-    }
-
-    /// Tries to parse a query. If there is an unknown id to a token, returns `None`
-    fn to_parsed_query(
-        query: &[String],
-        token_to_id: impl Fn(&str) -> Option<TokenId>,
-    ) -> Option<ParsedQuery> {
-        let tokens = query
-            .iter()
-            .map(|token| token_to_id(token.as_str()))
-            .collect::<Option<TokenSet>>()?;
-        Some(ParsedQuery::Tokens(tokens))
-    }
-
-    fn parse_query(query: &[String], index: &FullTextIndex) -> ParsedQuery {
-        let hw_counter = HardwareCounterCell::disposable();
-        match index {
-            FullTextIndex::Mutable(index) => {
-                let token_to_id =
-                    |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-                to_parsed_query(query, token_to_id).unwrap()
-            }
-            FullTextIndex::Immutable(index) => {
-                let token_to_id =
-                    |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-                to_parsed_query(query, token_to_id).unwrap()
-            }
-            FullTextIndex::Mmap(index) => {
-                let token_to_id =
-                    |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-                to_parsed_query(query, token_to_id).unwrap()
-            }
-        }
-    }
-
-    #[rstest]
-    fn test_congruence(
-        #[values(false, true)] deleted: bool,
-        #[values(false, true)] phrase_matching: bool,
-    ) {
-        use std::collections::HashSet;
-
-        use crate::json_path::JsonPath;
-
-        const POINT_COUNT: usize = 500;
-        const KEYWORD_COUNT: usize = 5;
-        const KEYWORD_LEN: usize = 2;
-
-        let hw_counter = HardwareCounterCell::disposable();
-
-        let (mut indices, _data): (Vec<_>, Vec<_>) = TYPES
-            .iter()
-            .copied()
-            .map(|index_type| {
-                let constructed_index = build_random_index(
-                    POINT_COUNT,
-                    KEYWORD_COUNT,
-                    KEYWORD_LEN,
-                    index_type,
-                    phrase_matching,
-                    deleted,
-                );
-                let index_context = IndexContext {
-                    _temp_dir: constructed_index.temp_dir,
-                    #[cfg(feature = "rocksdb")]
-                    _db: constructed_index.db,
-                };
-
-                ((constructed_index.index, index_type), index_context)
-            })
-            .unzip();
-
-        // Delete some points after loading
-        if deleted {
-            for (index, _type) in indices.iter_mut() {
-                index.remove_point(10).unwrap();
-                index.remove_point(11).unwrap();
-                index.remove_point(12).unwrap();
-                index.remove_point(100).unwrap();
-                index.remove_point(150).unwrap();
-            }
-        }
-
-        // Grab 10 keywords to use for querying
-        let (FullTextIndex::Mutable(index), _) = &indices[0] else {
-            panic!("Expects mutable full text index as first");
-        };
-        let mut keywords = index
-            .inverted_index
-            .vocab
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        keywords.sort_unstable();
-        keywords.truncate(10);
-
-        for i in 1..indices.len() {
-            let ((index_a, type_a), (index_b, type_b)) = (&indices[0], &indices[i]);
-            eprintln!("Testing index type {type_a:?} vs {type_b:?}");
-
-            assert_eq!(index_a.points_count(), index_b.points_count());
-            for point_id in 0..POINT_COUNT as PointOffsetType {
-                assert_eq!(
-                    index_a.values_count(point_id),
-                    index_b.values_count(point_id),
-                );
-                assert_eq!(
-                    index_a.values_is_empty(point_id),
-                    index_b.values_is_empty(point_id),
-                );
-            }
-
-            assert_eq!(
-                index_a.get_token("doesnotexist", &hw_counter),
-                index_b.get_token("doesnotexist", &hw_counter),
-            );
-            assert!(
-                index_a.get_token(&keywords[0], &hw_counter).is_some()
-                    == index_b.get_token(&keywords[0], &hw_counter).is_some(),
-            );
-
-            for query_range in [0..1, 2..4, 5..9, 0..10] {
-                let keywords = &keywords[query_range];
-                let parsed_query_a = parse_query(keywords, index_a);
-                let parsed_query_b = parse_query(keywords, index_b);
-
-                // Mutable index behaves different versus the others on point deletion
-                // Mutable index updates postings, the others do not. Cardinality estimations are
-                // not expected to match because of it.
-                if !deleted {
-                    let field_condition = FieldCondition::new_values_count(
-                        JsonPath::new(FIELD_NAME),
-                        ValuesCount::from(0..10),
-                    );
-                    let cardinality_a = index_a.estimate_query_cardinality(
-                        &parsed_query_a,
-                        &field_condition,
-                        &hw_counter,
-                    );
-                    let cardinality_b = index_b.estimate_query_cardinality(
-                        &parsed_query_b,
-                        &field_condition,
-                        &hw_counter,
-                    );
-                    assert_eq!(cardinality_a, cardinality_b);
-                }
-
-                for point_id in 0..POINT_COUNT as PointOffsetType {
-                    assert_eq!(
-                        index_a.check_match(&parsed_query_a, point_id, &hw_counter),
-                        index_b.check_match(&parsed_query_b, point_id, &hw_counter),
-                    );
-                }
-
-                assert_eq!(
-                    index_a
-                        .filter_query(parsed_query_a, &hw_counter)
-                        .collect::<HashSet<_>>(),
-                    index_b
-                        .filter_query(parsed_query_b, &hw_counter)
-                        .collect::<HashSet<_>>(),
-                );
-            }
-
-            if !deleted {
-                for threshold in 1..=10 {
-                    assert_eq!(
-                        index_a
-                            .payload_blocks(threshold, JsonPath::new(FIELD_NAME))
-                            .count(),
-                        index_b
-                            .payload_blocks(threshold, JsonPath::new(FIELD_NAME))
-                            .count(),
-                    );
-                }
-            }
-        }
-    }
-
-    /// Test that Vec and BTreeSet are serialized the same way in CBOR
-    #[test]
-    fn test_tokenset_and_document_serde() {
-        let str_tokens = [
-            "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog",
-        ]
-        .map(String::from);
-
-        let str_tokens_set = BTreeSet::from_iter(str_tokens.clone());
-        let str_tokens_set_as_vec = str_tokens_set.iter().cloned().collect::<Vec<_>>();
-
-        let serialized_set = FullTextIndex::serialize_token_set(str_tokens_set.clone()).unwrap();
-        let serialized_vec =
-            FullTextIndex::serialize_document(str_tokens_set_as_vec.clone()).unwrap();
-
-        assert_eq!(serialized_set, serialized_vec);
-
-        eprintln!(
-            "Serialized set: {:?}",
-            serialized_set
-                .iter()
-                .map(|&b| b as char)
-                .collect::<String>()
-        );
-        eprintln!(
-            "Serialized vec: {:?}",
-            serialized_vec
-                .iter()
-                .map(|&b| b as char)
-                .collect::<String>()
-        );
-
-        // cross serialization/deserialization also gives the same result
-        assert_eq!(
-            FullTextIndex::deserialize_document(&serialized_set).unwrap(),
-            str_tokens_set_as_vec
-        );
-        assert_eq!(
-            FullTextIndex::deserialize_token_set(&serialized_vec).unwrap(),
-            str_tokens_set
-        );
     }
 }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -363,15 +363,14 @@ impl IndexSelector<'_> {
     fn text_builder(&self, field: &JsonPath, config: TextIndexParams) -> FieldIndexBuilder {
         match self {
             #[cfg(feature = "rocksdb")]
-            IndexSelector::RocksDb(IndexSelectorRocksDb {
-                db,
-                is_appendable,
-            }) => FieldIndexBuilder::FullTextIndex(FullTextIndex::builder_rocksdb(
-                Arc::clone(db),
-                config,
-                &field.to_string(),
-                *is_appendable,
-            )),
+            IndexSelector::RocksDb(IndexSelectorRocksDb { db, is_appendable }) => {
+                FieldIndexBuilder::FullTextIndex(FullTextIndex::builder_rocksdb(
+                    Arc::clone(db),
+                    config,
+                    &field.to_string(),
+                    *is_appendable,
+                ))
+            }
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 FieldIndexBuilder::FullTextMmapIndex(FullTextIndex::builder_mmap(
                     text_dir(dir, field),

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -365,11 +365,12 @@ impl IndexSelector<'_> {
             #[cfg(feature = "rocksdb")]
             IndexSelector::RocksDb(IndexSelectorRocksDb {
                 db,
-                is_appendable: _,
+                is_appendable,
             }) => FieldIndexBuilder::FullTextIndex(FullTextIndex::builder_rocksdb(
                 Arc::clone(db),
                 config,
                 &field.to_string(),
+                *is_appendable,
             )),
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 FieldIndexBuilder::FullTextMmapIndex(FullTextIndex::builder_mmap(


### PR DESCRIPTION
Builds on top of #6670.

Two fixes for text index:
- Allow immutable text index with rocks-db storage
- Phrases with repeated tokens were being incorrectly handled when checking specific ids.