### PR TITLE
Fix CI cargo --locked build (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]


### PR DESCRIPTION
CI got broken after rebasing and merging #6615: https://github.com/qdrant/qdrant/actions/runs/15780863701/job/44485920051.
Similar issue as in #6712: outdated `Cargo.lock`.

```
Run cargo build --bin qdrant --locked
    Updating crates.io index
error: the lock file /home/runner/work/qdrant/qdrant/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
Error: Process completed with exit code 101.
```

