### PR TITLE
use indexed vectors instead of available points for IDF computation

### DIFF
--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -178,6 +178,22 @@ impl VectorIndexEnum {
             Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
         }
     }
+
+    pub fn indexed_vectors(&self) -> usize {
+        match self {
+            Self::Plain(index) => index.indexed_vector_count(),
+            Self::Hnsw(index) => index.indexed_vector_count(),
+            Self::SparseRam(index) => index.inverted_index().vector_count(),
+            Self::SparseImmutableRam(index) => index.inverted_index().vector_count(),
+            Self::SparseMmap(index) => index.inverted_index().vector_count(),
+            Self::SparseCompressedImmutableRamF32(index) => index.inverted_index().vector_count(),
+            Self::SparseCompressedImmutableRamF16(index) => index.inverted_index().vector_count(),
+            Self::SparseCompressedImmutableRamU8(index) => index.inverted_index().vector_count(),
+            Self::SparseCompressedMmapF32(index) => index.inverted_index().vector_count(),
+            Self::SparseCompressedMmapF16(index) => index.inverted_index().vector_count(),
+            Self::SparseCompressedMmapU8(index) => index.inverted_index().vector_count(),
+        }
+    }
 }
 
 impl VectorIndex for VectorIndexEnum {


### PR DESCRIPTION
Fixes: https://github.com/qdrant/qdrant/issues/6735

Some details for the bug:

For computing IDF we were using number of available points as total number of docs and length of the posting list as a number documents with token.
In our implementation Posting List are immutable on delete (and in case of in-ram index, it is re-created on load), so it results in inconsistent numbers passed into IDF formula.

This PR uses number of indexed vectors from vector index, which is as immutable as posting-lists. So after deleting some points we still get consistent scores.