### PR TITLE
Clean up `QuantizedVectors::raw_internal_scorer`

### DIFF
--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -3,6 +3,6 @@ mod quantized_mmap_storage;
 mod quantized_multi_custom_query_scorer;
 mod quantized_multi_query_scorer;
 pub mod quantized_multivector_storage;
-mod quantized_query_scorer;
+pub mod quantized_query_scorer;
 mod quantized_scorer_builder;
 pub mod quantized_vectors;


### PR DESCRIPTION
Follow up for #6729.

This PR clean ups the boilerplate in `QuantizedVectors::raw_internal_scorer`.

Also, the custom `enum QuantizedInternalScorerResult` is replaced with `Result` + custom error `InternalScorerUnsupported` which contain the original parameter. A similar pattern could be seen in the standard library: [`Sender::send`](https://doc.rust-lang.org/std/sync/mpsc/struct.Sender.html#method.send), [`Mutex::try_lock`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#method.try_lock).