### PR TITLE
[phrase match | strict mode] Allow phrase condition when enabled in index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,7 +6005,6 @@ dependencies = [
  "atomic_refcell",
  "atomicwrites",
  "bincode",
- "bitpacking",
  "bitvec",
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,6 @@ zerocopy = { version = "0.8.26", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"
 thiserror = "2.0.12"
-libc = "0.2"
 bitvec = "1.0.1"
 smallvec = { version = "1.15.1", features = ["write"] }
 merge = "0.1.0"

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -8,6 +8,7 @@ use http::{HeaderMap, HeaderValue, Method, Uri};
 use issues::{Action, Code, ImmediateSolution, Issue, Solution};
 use itertools::Itertools;
 use segment::common::operation_error::OperationError;
+use segment::data_types::index::TextIndexParams;
 use segment::index::query_optimization::rescore_formula::parsed_formula::VariableId;
 use segment::json_path::JsonPath;
 use segment::types::{
@@ -585,10 +586,18 @@ fn schema_capabilities(value: &PayloadFieldSchema) -> HashSet<FieldIndexType> {
             PayloadSchemaParams::Bool(_) => index_types.insert(FieldIndexType::BoolMatch),
             PayloadSchemaParams::Float(_) => index_types.insert(FieldIndexType::FloatRange),
             PayloadSchemaParams::Geo(_) => index_types.insert(FieldIndexType::Geo),
-            PayloadSchemaParams::Text(_) => index_types.insert(FieldIndexType::Text),
+            PayloadSchemaParams::Text(TextIndexParams {
+                phrase_matching, ..
+            }) => {
+                if phrase_matching.unwrap_or_default() {
+                    index_types.insert(FieldIndexType::TextPhrase);
+                }
+                index_types.insert(FieldIndexType::Text)
+            }
             PayloadSchemaParams::Datetime(_) => index_types.insert(FieldIndexType::DatetimeRange),
         },
     };
+
     index_types
 }
 

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -8,7 +8,7 @@ use http::{HeaderMap, HeaderValue, Method, Uri};
 use issues::{Action, Code, ImmediateSolution, Issue, Solution};
 use itertools::Itertools;
 use segment::common::operation_error::OperationError;
-use segment::data_types::index::TextIndexParams;
+use segment::data_types::index::{TextIndexParams, TextIndexType};
 use segment::index::query_optimization::rescore_formula::parsed_formula::VariableId;
 use segment::json_path::JsonPath;
 use segment::types::{
@@ -385,10 +385,7 @@ impl<'a> Extractor<'a> {
         let full_key = JsonPath::extend_or_new(nested_prefix, key);
 
         if self.needs_index(&full_key, &required_index) {
-            let schemas = required_index
-                .into_iter()
-                .map(PayloadSchemaType::from)
-                .map(PayloadFieldSchema::FieldType);
+            let schemas = required_index.into_iter().map(PayloadFieldSchema::from);
             self.unindexed_schema
                 .entry(full_key)
                 .or_default()
@@ -516,10 +513,7 @@ impl<'a> Extractor<'a> {
         }
 
         if self.needs_index(&key, &required_index) {
-            let schemas = required_index
-                .into_iter()
-                .map(PayloadSchemaType::from)
-                .map(PayloadFieldSchema::FieldType);
+            let schemas = required_index.into_iter().map(PayloadFieldSchema::from);
             self.unindexed_schema
                 .entry(key)
                 .or_default()
@@ -601,20 +595,30 @@ fn schema_capabilities(value: &PayloadFieldSchema) -> HashSet<FieldIndexType> {
     index_types
 }
 
-impl From<FieldIndexType> for PayloadSchemaType {
+impl From<FieldIndexType> for PayloadFieldSchema {
     fn from(val: FieldIndexType) -> Self {
         match val {
-            FieldIndexType::IntMatch => PayloadSchemaType::Integer,
-            FieldIndexType::IntRange => PayloadSchemaType::Integer,
-            FieldIndexType::KeywordMatch => PayloadSchemaType::Keyword,
-            FieldIndexType::FloatRange => PayloadSchemaType::Float,
-            FieldIndexType::Text => PayloadSchemaType::Text,
-            FieldIndexType::TextPhrase => PayloadSchemaType::Text,
-            FieldIndexType::BoolMatch => PayloadSchemaType::Bool,
-            FieldIndexType::UuidMatch => PayloadSchemaType::Uuid,
-            FieldIndexType::UuidRange => PayloadSchemaType::Uuid,
-            FieldIndexType::DatetimeRange => PayloadSchemaType::Datetime,
-            FieldIndexType::Geo => PayloadSchemaType::Geo,
+            FieldIndexType::IntMatch => PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
+            FieldIndexType::IntRange => PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
+            FieldIndexType::KeywordMatch => {
+                PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)
+            }
+            FieldIndexType::FloatRange => PayloadFieldSchema::FieldType(PayloadSchemaType::Float),
+            FieldIndexType::Text => PayloadFieldSchema::FieldType(PayloadSchemaType::Text),
+            FieldIndexType::TextPhrase => {
+                PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(TextIndexParams {
+                    r#type: TextIndexType::Text,
+                    phrase_matching: Some(true),
+                    ..Default::default()
+                }))
+            }
+            FieldIndexType::BoolMatch => PayloadFieldSchema::FieldType(PayloadSchemaType::Bool),
+            FieldIndexType::UuidMatch => PayloadFieldSchema::FieldType(PayloadSchemaType::Uuid),
+            FieldIndexType::UuidRange => PayloadFieldSchema::FieldType(PayloadSchemaType::Uuid),
+            FieldIndexType::DatetimeRange => {
+                PayloadFieldSchema::FieldType(PayloadSchemaType::Datetime)
+            }
+            FieldIndexType::Geo => PayloadFieldSchema::FieldType(PayloadSchemaType::Geo),
         }
     }
 }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -48,7 +48,6 @@ anyhow = "1.0.98"
 pprof = { workspace = true }
 
 [dependencies]
-bitpacking = "0.9.2"
 bytemuck = { workspace = true }
 data-encoding = { workspace = true }
 delegate = { workspace = true }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1860,7 +1860,30 @@ impl Display for PayloadFieldSchema {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             PayloadFieldSchema::FieldType(t) => write!(f, "{}", t.name()),
-            PayloadFieldSchema::FieldParams(p) => write!(f, "{}", p.name()),
+            PayloadFieldSchema::FieldParams(params) => match params {
+                PayloadSchemaParams::Keyword(_)
+                | PayloadSchemaParams::Float(_)
+                | PayloadSchemaParams::Geo(_)
+                | PayloadSchemaParams::Bool(_)
+                | PayloadSchemaParams::Datetime(_)
+                | PayloadSchemaParams::Uuid(_) => write!(f, "{}", params.name()),
+                PayloadSchemaParams::Integer(integer_params) => {
+                    let range = integer_params.range.unwrap_or(true);
+                    let lookup = integer_params.lookup.unwrap_or(true);
+                    if range && lookup {
+                        write!(f, "integer")
+                    } else {
+                        write!(f, "integer (with range: {}, lookup: {})", range, lookup)
+                    }
+                }
+                PayloadSchemaParams::Text(text_params) => {
+                    if text_params.phrase_matching.unwrap_or_default() {
+                        write!(f, "text (with phrase_matching: true)")
+                    } else {
+                        write!(f, "text")
+                    }
+                }
+            },
         }
     }
 }


### PR DESCRIPTION
Builds on top of #6670 

Fixes the check for phrase index, so that strict mode allows phrase conditions when the text index has `phrase_matching` enabled