### PR TITLE
[gridstore] use seq mmap in iter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,7 +3239,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]


### PR DESCRIPTION
Most changes are related to a refactor to use const generics, which removes a bit of code duplication by drilling down a const generic.

Main change is to use the seq mmap in the `Gridstore::iter` function. Looks like we missed this when introducing the seq mmap