### PR TITLE
Bump Cargo.lock, syn 2.0.104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,7 +3239,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]


### PR DESCRIPTION
The `syn` crate is aggressively bumped to a newer version in our `Cargo.lock`.

For example, `cargo check --workspace` will create this same change.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?