### PR TITLE
Int index param defaults

### DIFF
--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -455,10 +455,10 @@ message KeywordIndexParams {
 }
 
 message IntegerIndexParams {
-  optional bool lookup = 1; // If true - support direct lookups.
-  optional bool range = 2; // If true - support ranges filters.
-  optional bool is_principal = 3; // If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
-  optional bool on_disk = 4; // If true - store index on disk.
+  optional bool lookup = 1; // If true - support direct lookups. Default is true.
+  optional bool range = 2; // If true - support ranges filters. Default is true.
+  optional bool is_principal = 3; // If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests. Default is false.
+  optional bool on_disk = 4; // If true - store index on disk. Default is false.
 }
 
 message FloatIndexParams {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -786,16 +786,16 @@ pub struct KeywordIndexParams {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IntegerIndexParams {
-    /// If true - support direct lookups.
+    /// If true - support direct lookups. Default is true.
     #[prost(bool, optional, tag = "1")]
     pub lookup: ::core::option::Option<bool>,
-    /// If true - support ranges filters.
+    /// If true - support ranges filters. Default is true.
     #[prost(bool, optional, tag = "2")]
     pub range: ::core::option::Option<bool>,
-    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
+    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests. Default is false.
     #[prost(bool, optional, tag = "3")]
     pub is_principal: ::core::option::Option<bool>,
-    /// If true - store index on disk.
+    /// If true - store index on disk. Default is false.
     #[prost(bool, optional, tag = "4")]
     pub on_disk: ::core::option::Option<bool>,
 }

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -563,15 +563,15 @@ fn schema_capabilities(value: &PayloadFieldSchema) -> HashSet<FieldIndexType> {
         PayloadFieldSchema::FieldParams(payload_schema_params) => match payload_schema_params {
             PayloadSchemaParams::Keyword(_) => index_types.insert(FieldIndexType::KeywordMatch),
             PayloadSchemaParams::Integer(integer_index_params) => {
-                if integer_index_params.lookup == Some(true) {
+                if integer_index_params.lookup.unwrap_or(true) {
                     index_types.insert(FieldIndexType::IntMatch);
                 }
-                if integer_index_params.range == Some(true) {
+                if integer_index_params.range.unwrap_or(true) {
                     index_types.insert(FieldIndexType::IntRange);
                 }
                 debug_assert!(
                     !index_types.is_empty(),
-                    "lookup or range must be true for Integer payload index"
+                    "lookup or range must be true for Integer payload index",
                 );
                 // unifying match arm types
                 true

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -46,16 +46,20 @@ pub struct IntegerIndexParams {
     pub r#type: IntegerIndexType,
 
     /// If true - support direct lookups.
+    /// Default is true.
     pub lookup: Option<bool>,
 
     /// If true - support ranges filters.
+    /// Default is true.
     pub range: Option<bool>,
 
     /// If true - use this key to organize storage of the collection data.
     /// This option assumes that this key will be used in majority of filtered requests.
+    /// Default is false.
     pub is_principal: Option<bool>,
 
     /// If true, store the index on disk. Default: false.
+    /// Default is false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_disk: Option<bool>,
 }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/6731>

When creating a parameterized integer index, without specifying the `range`/`lookup` parameter, I can trigger a debug assertion. The problem is in the issues API, which incorrectly assumes the default for those parameters is false.

It produces a fun stack trace: https://gist.github.com/timvisee/2c7d6f7993aa2d31afe518f5ec71359c

Along with this I've updated the parameter descriptions to specify what the default value is. I hope to prevent people being confused like in <https://github.com/qdrant/qdrant/issues/6731>.

Snippet to trigger debug panic:

```
# - Create collection with integer in payload

PUT collections/benchmark/index
{
  "field_name": "c",
  "field_schema": {
    "type": "integer"
  }
}

POST collections/benchmark/points/scroll
{
  "filter": {
    "must": {
      "key": "c",
      "match": {
        "value": 10
      }
    }
  }
}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?