### PR TITLE
check if we try to deactivate last initializing replica

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -222,7 +222,7 @@ impl Collection {
             // Check that we are not removing the *last* replica or the last *active* replica
             //
             // `is_last_active_replica` counts both `Active` and `ReshardingScaleDown` replicas!
-            if peers.len() == 1 || replica_set.is_last_active_replica(peer_id) {
+            if peers.len() == 1 || replica_set.is_last_source_of_truth_replica(peer_id) {
                 return Err(CollectionError::BadRequest {
                     description: format!(
                         "Shard {shard_id} must have at least one active replica after removing {peer_id}",

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -432,7 +432,7 @@ impl Collection {
         // 3. Do not deactivate the last active replica
         //
         // `is_last_active_replica` counts both `Active` and `ReshardingScaleDown` replicas!
-        if replica_set.is_last_active_replica(peer_id) && !new_state.is_active() {
+        if replica_set.is_last_source_of_truth_replica(peer_id) && !new_state.is_active() {
             return Err(CollectionError::bad_input(format!(
                 "Cannot deactivate the last active replica {peer_id} of shard {shard_id}"
             )));


### PR DESCRIPTION
There is a bug, which I can't reproduce locally, but it was observed on practice multiple times:

If pod was somehow killed during collection creation or there was an error during creating a collection (due to file descriptors or something like that), it might be possible that some shards of the collection have inconsistent state between `initializing` and `dead`.

Local shard thinks the shard is `dead` while other machines in the cluster consider it `initializing`. 

Since local shard status it `dead` it needs to recover it from somewhere, but it is also the only shard in the cluster. So cluster is stuck in this inconsistent state without ability to recover (except for collection deletion).

This PR extends our check for `is_last_active_replica` and handles the case of no active replicas in more details.
