### PR TITLE
Configurable HNSW healing threshold

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11362,6 +11362,16 @@
               }
             ]
           },
+          "hnsw_global_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HnswGlobalConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "system": {
             "anyOf": [
               {
@@ -11436,11 +11446,6 @@
             "default": true,
             "type": "boolean"
           },
-          "hnsw_healing": {
-            "description": "Whether to enable HNSW healing.",
-            "default": false,
-            "type": "boolean"
-          },
           "migrate_rocksdb_id_tracker": {
             "description": "Whether to actively migrate RocksDB based ID trackers into a new format.",
             "default": false,
@@ -11450,6 +11455,19 @@
             "description": "Whether to actively migrate RocksDB based vector storages into a new format.",
             "default": false,
             "type": "boolean"
+          }
+        }
+      },
+      "HnswGlobalConfig": {
+        "type": "object",
+        "properties": {
+          "healing_threshold": {
+            "description": "Enable HNSW healing if the ratio of missing points is no more than this value. To disable healing completely, set this value to `0.0`.",
+            "default": 0.3,
+            "type": "number",
+            "format": "double",
+            "maximum": 1,
+            "minimum": 0
           }
         }
       },

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -13,7 +13,7 @@ use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::{
     VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment, build_simple_segment,
 };
-use segment::types::{Distance, Payload, PointIdType, SeqNumberType};
+use segment::types::{Distance, HnswGlobalConfig, Payload, PointIdType, SeqNumberType};
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
@@ -241,6 +241,7 @@ pub(crate) fn get_merge_optimizer(
             ..CollectionParams::empty()
         },
         Default::default(),
+        HnswGlobalConfig::default(),
         Default::default(),
     )
 }
@@ -266,6 +267,7 @@ pub(crate) fn get_indexing_optimizer(
             ..CollectionParams::empty()
         },
         Default::default(),
+        HnswGlobalConfig::default(),
         Default::default(),
     )
 }

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::index::sparse_index::sparse_index_config::SparseIndexType;
-use segment::types::{HnswConfig, Indexes, QuantizationConfig, SegmentType, VectorName};
+use segment::types::{
+    HnswConfig, HnswGlobalConfig, Indexes, QuantizationConfig, SegmentType, VectorName,
+};
 
 use crate::collection_manager::holders::segment_holder::{LockedSegmentHolder, SegmentId};
 use crate::collection_manager::optimizers::segment_optimizer::{
@@ -26,6 +28,7 @@ pub struct ConfigMismatchOptimizer {
     collection_temp_dir: PathBuf,
     collection_params: CollectionParams,
     hnsw_config: HnswConfig,
+    hnsw_global_config: HnswGlobalConfig,
     quantization_config: Option<QuantizationConfig>,
     telemetry_durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
 }
@@ -37,6 +40,7 @@ impl ConfigMismatchOptimizer {
         collection_temp_dir: PathBuf,
         collection_params: CollectionParams,
         hnsw_config: HnswConfig,
+        hnsw_global_config: HnswGlobalConfig,
         quantization_config: Option<QuantizationConfig>,
     ) -> Self {
         ConfigMismatchOptimizer {
@@ -45,6 +49,7 @@ impl ConfigMismatchOptimizer {
             collection_temp_dir,
             collection_params,
             hnsw_config,
+            hnsw_global_config,
             quantization_config,
             telemetry_durations_aggregator: OperationDurationsAggregator::new(),
         }
@@ -233,6 +238,10 @@ impl SegmentOptimizer for ConfigMismatchOptimizer {
         &self.hnsw_config
     }
 
+    fn hnsw_global_config(&self) -> &HnswGlobalConfig {
+        &self.hnsw_global_config
+    }
+
     fn quantization_config(&self) -> Option<QuantizationConfig> {
         self.quantization_config.clone()
     }
@@ -338,6 +347,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params.clone(),
             hnsw_config.clone(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
         let mut config_mismatch_optimizer = ConfigMismatchOptimizer::new(
@@ -346,6 +356,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params,
             hnsw_config.clone(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
 
@@ -500,6 +511,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params.clone(),
             hnsw_config_collection.clone(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
         let mut config_mismatch_optimizer = ConfigMismatchOptimizer::new(
@@ -508,6 +520,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params,
             hnsw_config_collection.clone(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
 
@@ -669,6 +682,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params.clone(),
             Default::default(),
+            HnswGlobalConfig::default(),
             Some(quantization_config_collection.clone()),
         );
         let mut config_mismatch_optimizer = ConfigMismatchOptimizer::new(
@@ -677,6 +691,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params,
             Default::default(),
+            HnswGlobalConfig::default(),
             Some(quantization_config_collection),
         );
 

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::OperationDurationsAggregator;
-use segment::types::{HnswConfig, QuantizationConfig, SegmentType};
+use segment::types::{HnswConfig, HnswGlobalConfig, QuantizationConfig, SegmentType};
 
 use crate::collection_manager::holders::segment_holder::{
     LockedSegmentHolder, SegmentHolder, SegmentId,
@@ -28,11 +28,13 @@ pub struct IndexingOptimizer {
     collection_temp_dir: PathBuf,
     collection_params: CollectionParams,
     hnsw_config: HnswConfig,
+    hnsw_global_config: HnswGlobalConfig,
     quantization_config: Option<QuantizationConfig>,
     telemetry_durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
 }
 
 impl IndexingOptimizer {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         default_segments_number: usize,
         thresholds_config: OptimizerThresholds,
@@ -40,6 +42,7 @@ impl IndexingOptimizer {
         collection_temp_dir: PathBuf,
         collection_params: CollectionParams,
         hnsw_config: HnswConfig,
+        hnsw_global_config: HnswGlobalConfig,
         quantization_config: Option<QuantizationConfig>,
     ) -> Self {
         IndexingOptimizer {
@@ -49,6 +52,7 @@ impl IndexingOptimizer {
             collection_temp_dir,
             collection_params,
             hnsw_config,
+            hnsw_global_config,
             quantization_config,
             telemetry_durations_aggregator: OperationDurationsAggregator::new(),
         }
@@ -256,6 +260,10 @@ impl SegmentOptimizer for IndexingOptimizer {
         &self.hnsw_config
     }
 
+    fn hnsw_global_config(&self) -> &HnswGlobalConfig {
+        &self.hnsw_global_config
+    }
+
     fn quantization_config(&self) -> Option<QuantizationConfig> {
         self.quantization_config.clone()
     }
@@ -365,6 +373,7 @@ mod tests {
                 ..CollectionParams::empty()
             },
             Default::default(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
         let locked_holder: Arc<RwLock<_, _>> = Arc::new(RwLock::new(holder));
@@ -474,6 +483,7 @@ mod tests {
                 ..CollectionParams::empty()
             },
             Default::default(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
 
@@ -781,6 +791,7 @@ mod tests {
                 ..CollectionParams::empty()
             },
             Default::default(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
 
@@ -882,6 +893,7 @@ mod tests {
                 temp_dir.path().to_owned(),
                 collection_params.clone(),
                 hnsw_config.clone(),
+                HnswGlobalConfig::default(),
                 Default::default(),
             );
             let config_mismatch_optimizer = ConfigMismatchOptimizer::new(
@@ -890,6 +902,7 @@ mod tests {
                 temp_dir.path().to_owned(),
                 collection_params.clone(),
                 hnsw_config.clone(),
+                HnswGlobalConfig::default(),
                 Default::default(),
             );
 
@@ -946,6 +959,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params.clone(),
             hnsw_config.clone(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
         let config_mismatch_optimizer = ConfigMismatchOptimizer::new(
@@ -954,6 +968,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params,
             hnsw_config,
+            HnswGlobalConfig::default(),
             Default::default(),
         );
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::OperationDurationsAggregator;
-use segment::types::{HnswConfig, QuantizationConfig, SegmentType};
+use segment::types::{HnswConfig, HnswGlobalConfig, QuantizationConfig, SegmentType};
 
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
@@ -29,6 +29,7 @@ pub struct MergeOptimizer {
     collection_temp_dir: PathBuf,
     collection_params: CollectionParams,
     hnsw_config: HnswConfig,
+    hnsw_global_config: HnswGlobalConfig,
     quantization_config: Option<QuantizationConfig>,
     telemetry_durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
 }
@@ -42,6 +43,7 @@ impl MergeOptimizer {
         collection_temp_dir: PathBuf,
         collection_params: CollectionParams,
         hnsw_config: HnswConfig,
+        hnsw_global_config: HnswGlobalConfig,
         quantization_config: Option<QuantizationConfig>,
     ) -> Self {
         MergeOptimizer {
@@ -51,6 +53,7 @@ impl MergeOptimizer {
             collection_temp_dir,
             collection_params,
             hnsw_config,
+            hnsw_global_config,
             quantization_config,
             telemetry_durations_aggregator: OperationDurationsAggregator::new(),
         }
@@ -76,6 +79,10 @@ impl SegmentOptimizer for MergeOptimizer {
 
     fn hnsw_config(&self) -> &HnswConfig {
         &self.hnsw_config
+    }
+
+    fn hnsw_global_config(&self) -> &HnswGlobalConfig {
+        &self.hnsw_global_config
     }
 
     fn quantization_config(&self) -> Option<QuantizationConfig> {

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -20,7 +20,9 @@ use segment::index::sparse_index::sparse_index_config::SparseIndexType;
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::{HnswConfig, Indexes, QuantizationConfig, SegmentConfig, VectorStorageType};
+use segment::types::{
+    HnswConfig, HnswGlobalConfig, Indexes, QuantizationConfig, SegmentConfig, VectorStorageType,
+};
 
 use crate::collection_manager::holders::proxy_segment::{self, ProxyIndexChange, ProxySegment};
 use crate::collection_manager::holders::segment_holder::{
@@ -62,6 +64,9 @@ pub trait SegmentOptimizer {
 
     /// Get HNSW config
     fn hnsw_config(&self) -> &HnswConfig;
+
+    /// Get HNSW global config
+    fn hnsw_global_config(&self) -> &HnswGlobalConfig;
 
     /// Get quantization config
     fn quantization_config(&self) -> Option<QuantizationConfig>;
@@ -300,6 +305,7 @@ pub trait SegmentOptimizer {
             self.segments_path(),
             self.temp_path(),
             &optimized_config,
+            self.hnsw_global_config(),
         )?)
     }
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -7,7 +7,7 @@ use parking_lot::Mutex;
 use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::entry::entry_point::SegmentEntry;
 use segment::index::VectorIndex;
-use segment::types::{HnswConfig, QuantizationConfig, SegmentType};
+use segment::types::{HnswConfig, HnswGlobalConfig, QuantizationConfig, SegmentType};
 use segment::vector_storage::VectorStorage;
 
 use crate::collection_manager::holders::segment_holder::{
@@ -32,6 +32,7 @@ pub struct VacuumOptimizer {
     collection_temp_dir: PathBuf,
     collection_params: CollectionParams,
     hnsw_config: HnswConfig,
+    hnsw_global_config: HnswGlobalConfig,
     quantization_config: Option<QuantizationConfig>,
     telemetry_durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
 }
@@ -46,6 +47,7 @@ impl VacuumOptimizer {
         collection_temp_dir: PathBuf,
         collection_params: CollectionParams,
         hnsw_config: HnswConfig,
+        hnsw_global_config: HnswGlobalConfig,
         quantization_config: Option<QuantizationConfig>,
     ) -> Self {
         VacuumOptimizer {
@@ -57,6 +59,7 @@ impl VacuumOptimizer {
             collection_params,
             hnsw_config,
             quantization_config,
+            hnsw_global_config,
             telemetry_durations_aggregator: OperationDurationsAggregator::new(),
         }
     }
@@ -181,6 +184,10 @@ impl SegmentOptimizer for VacuumOptimizer {
 
     fn hnsw_config(&self) -> &HnswConfig {
         &self.hnsw_config
+    }
+
+    fn hnsw_global_config(&self) -> &HnswGlobalConfig {
+        &self.hnsw_global_config
     }
 
     fn quantization_config(&self) -> Option<QuantizationConfig> {
@@ -326,6 +333,7 @@ mod tests {
                 ..CollectionParams::empty()
             },
             Default::default(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
 
@@ -474,6 +482,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params.clone(),
             hnsw_config.clone(),
+            HnswGlobalConfig::default(),
             Default::default(),
         );
         let vacuum_optimizer = VacuumOptimizer::new(
@@ -484,6 +493,7 @@ mod tests {
             temp_dir.path().to_owned(),
             collection_params,
             hnsw_config,
+            HnswGlobalConfig::default(),
             Default::default(),
         );
 

--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -2,6 +2,8 @@ use std::default;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
+use segment::types::HnswGlobalConfig;
+
 use crate::common::snapshots_manager::SnapshotsConfig;
 use crate::operations::types::NodeType;
 use crate::shards::transfer::ShardTransferMethod;
@@ -31,6 +33,7 @@ pub struct SharedStorageConfig {
     pub outgoing_shard_transfers_limit: Option<usize>,
     pub snapshots_path: String,
     pub snapshots_config: SnapshotsConfig,
+    pub hnsw_global_config: HnswGlobalConfig,
     pub search_thread_count: usize,
 }
 
@@ -49,6 +52,7 @@ impl Default for SharedStorageConfig {
             outgoing_shard_transfers_limit: DEFAULT_IO_SHARD_TRANSFER_LIMIT,
             snapshots_path: DEFAULT_SNAPSHOTS_PATH.to_string(),
             snapshots_config: default::Default::default(),
+            hnsw_global_config: HnswGlobalConfig::default(),
             search_thread_count: common::defaults::search_thread_count(common::cpu::get_num_cpus()),
         }
     }
@@ -69,6 +73,7 @@ impl SharedStorageConfig {
         outgoing_shard_transfers_limit: Option<usize>,
         snapshots_path: String,
         snapshots_config: SnapshotsConfig,
+        hnsw_global_config: HnswGlobalConfig,
         search_thread_count: usize,
     ) -> Self {
         let update_queue_size = update_queue_size.unwrap_or(match node_type {
@@ -88,6 +93,7 @@ impl SharedStorageConfig {
             outgoing_shard_transfers_limit,
             snapshots_path,
             snapshots_config,
+            hnsw_global_config,
             search_thread_count,
         }
     }

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::index::hnsw_index::num_rayon_threads;
-use segment::types::{HnswConfig, QuantizationConfig};
+use segment::types::{HnswConfig, HnswGlobalConfig, QuantizationConfig};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -153,6 +153,7 @@ pub fn build_optimizers(
     collection_params: &CollectionParams,
     optimizers_config: &OptimizersConfig,
     hnsw_config: &HnswConfig,
+    hnsw_global_config: &HnswGlobalConfig,
     quantization_config: &Option<QuantizationConfig>,
 ) -> Arc<Vec<Arc<Optimizer>>> {
     let num_indexing_threads = num_rayon_threads(hnsw_config.max_indexing_threads);
@@ -168,6 +169,7 @@ pub fn build_optimizers(
             temp_segments_path.clone(),
             collection_params.clone(),
             hnsw_config.clone(),
+            hnsw_global_config.clone(),
             quantization_config.clone(),
         )),
         Arc::new(IndexingOptimizer::new(
@@ -177,6 +179,7 @@ pub fn build_optimizers(
             temp_segments_path.clone(),
             collection_params.clone(),
             hnsw_config.clone(),
+            hnsw_global_config.clone(),
             quantization_config.clone(),
         )),
         Arc::new(VacuumOptimizer::new(
@@ -187,6 +190,7 @@ pub fn build_optimizers(
             temp_segments_path.clone(),
             collection_params.clone(),
             hnsw_config.clone(),
+            hnsw_global_config.clone(),
             quantization_config.clone(),
         )),
         Arc::new(ConfigMismatchOptimizer::new(
@@ -195,6 +199,7 @@ pub fn build_optimizers(
             temp_segments_path,
             collection_params.clone(),
             hnsw_config.clone(),
+            hnsw_global_config.clone(),
             quantization_config.clone(),
         )),
     ])

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -385,6 +385,7 @@ impl LocalShard {
             &collection_config_read.params,
             &effective_optimizers_config,
             &collection_config_read.hnsw_config,
+            &shared_storage_config.hnsw_global_config,
             &collection_config_read.quantization_config,
         );
 
@@ -554,6 +555,7 @@ impl LocalShard {
             &config.params,
             &effective_optimizers_config,
             &config.hnsw_config,
+            &shared_storage_config.hnsw_global_config,
             &config.quantization_config,
         );
 
@@ -765,6 +767,7 @@ impl LocalShard {
             &config.params,
             &config.optimizer_config,
             &config.hnsw_config,
+            &self.shared_storage_config.hnsw_global_config,
             &config.quantization_config,
         );
         update_handler.optimizers = new_optimizers;

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -29,9 +29,6 @@ pub struct FeatureFlags {
     /// Enabled by default in Qdrant 1.14.1.
     pub incremental_hnsw_building: bool,
 
-    /// Whether to enable HNSW healing.
-    pub hnsw_healing: bool,
-
     /// Whether to actively migrate RocksDB based ID trackers into a new format.
     // TODO(1.15): enable by default
     pub migrate_rocksdb_id_tracker: bool,
@@ -48,7 +45,6 @@ impl Default for FeatureFlags {
             payload_index_skip_rocksdb: true,
             payload_index_skip_mutable_rocksdb: false,
             incremental_hnsw_building: true,
-            hnsw_healing: false,
             migrate_rocksdb_id_tracker: false,
             migrate_rocksdb_vector_storage: false,
         }
@@ -70,7 +66,6 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         payload_index_skip_rocksdb,
         payload_index_skip_mutable_rocksdb,
         incremental_hnsw_building,
-        hnsw_healing,
         migrate_rocksdb_id_tracker,
         migrate_rocksdb_vector_storage,
     } = &mut flags;
@@ -80,7 +75,6 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         *payload_index_skip_rocksdb = true;
         *payload_index_skip_mutable_rocksdb = true;
         *incremental_hnsw_building = true;
-        *hnsw_healing = true;
         *migrate_rocksdb_id_tracker = true;
         *migrate_rocksdb_vector_storage = true;
     }

--- a/lib/segment/benches/hnsw_incremental_build.rs
+++ b/lib/segment/benches/hnsw_incremental_build.rs
@@ -35,7 +35,9 @@ use segment::index::{VectorIndex as _, VectorIndexEnum};
 use segment::segment::Segment;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
-use segment::types::{Distance, ExtendedPointId, HnswConfig, SearchParams, SeqNumberType};
+use segment::types::{
+    Distance, ExtendedPointId, HnswConfig, HnswGlobalConfig, SearchParams, SeqNumberType,
+};
 use sha2::Digest as _;
 use tap::Pipe as _;
 use tempfile::Builder;
@@ -130,12 +132,7 @@ fn main() {
         .filter_level(log::LevelFilter::Debug)
         .init();
 
-    init_feature_flags({
-        let mut feature_flags = FeatureFlags::default();
-        feature_flags.incremental_hnsw_building = true;
-        feature_flags.hnsw_healing = true;
-        feature_flags
-    });
+    init_feature_flags(FeatureFlags::default());
 
     let args = Args::parse();
     log::info!("args={args:?}");
@@ -398,6 +395,7 @@ fn build_hnsw_index<R: Rng + ?Sized>(
             gpu_device: None,
             rng,
             stopped: &AtomicBool::new(false),
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: feature_flags(),
         },
     )

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -17,8 +17,8 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::segment_constructor::{VectorIndexBuildArgs, build_segment};
 use segment::types::Distance::{Dot, Euclid};
 use segment::types::{
-    Distance, HnswConfig, Indexes, MultiVectorConfig, SegmentConfig, SeqNumberType,
-    VectorDataConfig, VectorStorageType,
+    Distance, HnswConfig, HnswGlobalConfig, Indexes, MultiVectorConfig, SegmentConfig,
+    SeqNumberType, VectorDataConfig, VectorStorageType,
 };
 use tempfile::Builder;
 
@@ -128,6 +128,7 @@ fn make_segment_index<R: Rng + ?Sized>(rng: &mut R, distance: Distance) -> HNSWI
             gpu_device: None,
             stopped: &stopped,
             rng,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -15,7 +15,7 @@ use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use crate::index::hnsw_index::num_rayon_threads;
 use crate::segment_constructor::VectorIndexBuildArgs;
 use crate::segment_constructor::simple_segment_constructor::build_simple_segment;
-use crate::types::{Distance, HnswConfig, SeqNumberType};
+use crate::types::{Distance, HnswConfig, HnswGlobalConfig, SeqNumberType};
 
 #[test]
 fn test_graph_connectivity() {
@@ -81,6 +81,7 @@ fn test_graph_connectivity() {
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -46,8 +46,8 @@ use crate::segment_constructor::{
     VectorIndexBuildArgs, VectorIndexOpenArgs, build_vector_index, load_segment,
 };
 use crate::types::{
-    CompactExtendedPointId, ExtendedPointId, PayloadFieldSchema, PayloadKeyType, SegmentConfig,
-    SegmentState, SeqNumberType, VectorNameBuf,
+    CompactExtendedPointId, ExtendedPointId, HnswGlobalConfig, PayloadFieldSchema, PayloadKeyType,
+    SegmentConfig, SegmentState, SeqNumberType, VectorNameBuf,
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
@@ -59,6 +59,7 @@ pub struct SegmentBuilder {
     payload_storage: PayloadStorageEnum,
     vector_data: HashMap<VectorNameBuf, VectorData>,
     segment_config: SegmentConfig,
+    hnsw_global_config: HnswGlobalConfig,
 
     // The path, where fully created segment will be moved
     destination_path: PathBuf,
@@ -80,6 +81,7 @@ impl SegmentBuilder {
         segments_path: &Path,
         temp_dir: &Path,
         segment_config: &SegmentConfig,
+        hnsw_global_config: &HnswGlobalConfig,
     ) -> OperationResult<Self> {
         let temp_dir = create_temp_dir(temp_dir)?;
 
@@ -154,7 +156,7 @@ impl SegmentBuilder {
             payload_storage,
             vector_data,
             segment_config: segment_config.clone(),
-
+            hnsw_global_config: hnsw_global_config.clone(),
             destination_path,
             temp_dir,
             indexed_fields: Default::default(),
@@ -468,6 +470,7 @@ impl SegmentBuilder {
                 payload_storage,
                 mut vector_data,
                 segment_config,
+                hnsw_global_config,
                 destination_path,
                 temp_dir,
                 indexed_fields,
@@ -592,6 +595,7 @@ impl SegmentBuilder {
                         gpu_device: gpu_device.as_ref(),
                         stopped,
                         rng,
+                        hnsw_global_config: &hnsw_global_config,
                         feature_flags: feature_flags(),
                     },
                 )?;

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -47,9 +47,9 @@ use crate::segment::{SEGMENT_STATE_FILE, Segment, SegmentVersion, VectorData};
 #[cfg(feature = "rocksdb")]
 use crate::types::MultiVectorConfig;
 use crate::types::{
-    Distance, Indexes, PayloadStorageType, SegmentConfig, SegmentState, SegmentType, SeqNumberType,
-    SparseVectorStorageType, VectorDataConfig, VectorName, VectorStorageDatatype,
-    VectorStorageType,
+    Distance, HnswGlobalConfig, Indexes, PayloadStorageType, SegmentConfig, SegmentState,
+    SegmentType, SeqNumberType, SparseVectorStorageType, VectorDataConfig, VectorName,
+    VectorStorageDatatype, VectorStorageType,
 };
 use crate::vector_storage::dense::appendable_dense_vector_storage::{
     open_appendable_in_ram_vector_storage, open_appendable_memmap_vector_storage,
@@ -280,6 +280,7 @@ pub struct VectorIndexBuildArgs<'a, R: Rng + ?Sized> {
     pub gpu_device: Option<&'a LockedGpuDevice<'a>>,
     pub rng: &'a mut R,
     pub stopped: &'a AtomicBool,
+    pub hnsw_global_config: &'a HnswGlobalConfig,
     pub feature_flags: FeatureFlags,
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -573,6 +573,24 @@ impl HnswConfig {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Anonymize, Clone)]
+#[serde(rename_all = "snake_case", default)]
+#[anonymize(false)]
+pub struct HnswGlobalConfig {
+    /// Enable HNSW healing if the ratio of missing points is no more than this value.
+    /// To disable healing completely, set this value to `0.0`.
+    #[validate(range(min = 0.0, max = 1.0))]
+    pub healing_threshold: f64,
+}
+
+impl Default for HnswGlobalConfig {
+    fn default() -> Self {
+        Self {
+            healing_threshold: 0.3,
+        }
+    }
+}
+
 const fn default_max_indexing_threads() -> usize {
     0
 }

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -19,8 +19,8 @@ use segment::payload_json;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, SeqNumberType,
-    WithPayload,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig, PayloadSchemaType,
+    SeqNumberType, WithPayload,
 };
 use tempfile::Builder;
 
@@ -164,6 +164,7 @@ fn test_batch_and_single_request_equivalency() {
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -56,7 +56,7 @@ fn test_byte_storage_hnsw(
     use segment::json_path::JsonPath;
     use segment::payload_json;
     use segment::segment_constructor::VectorIndexBuildArgs;
-    use segment::types::PayloadSchemaType;
+    use segment::types::{HnswGlobalConfig, PayloadSchemaType};
 
     let stopped = AtomicBool::new(false);
 
@@ -201,6 +201,7 @@ fn test_byte_storage_hnsw(
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -20,9 +20,9 @@ use segment::index::{PayloadIndex, VectorIndex};
 use segment::segment_constructor::build_segment;
 use segment::types::{
     BinaryQuantizationConfig, CompressionRatio, Condition, Distance, FieldCondition, Filter,
-    HnswConfig, Indexes, PayloadSchemaType, ProductQuantizationConfig, QuantizationSearchParams,
-    Range, ScalarQuantizationConfig, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
-    VectorStorageDatatype, VectorStorageType,
+    HnswConfig, HnswGlobalConfig, Indexes, PayloadSchemaType, ProductQuantizationConfig,
+    QuantizationSearchParams, Range, ScalarQuantizationConfig, SearchParams, SegmentConfig,
+    SeqNumberType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
 };
 use segment::vector_storage::VectorStorageEnum;
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -350,6 +350,7 @@ fn test_byte_storage_binary_quantization_hnsw(
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -13,7 +13,7 @@ use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::{
     VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment,
 };
-use segment::types::Distance;
+use segment::types::{Distance, HnswGlobalConfig};
 use segment::vector_storage::VectorStorage;
 use tempfile::Builder;
 
@@ -90,8 +90,13 @@ fn test_rebuild_with_removed_vectors() {
         reference.push(vec);
     }
 
-    let mut builder =
-        SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
+    let mut builder = SegmentBuilder::new(
+        dir.path(),
+        temp_dir.path(),
+        &segment1.segment_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
 
     builder.update(&[&segment1, &segment2], &stopped).unwrap();
 

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -19,8 +19,8 @@ use segment::payload_json;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, Range,
-    SearchParams, SeqNumberType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig, PayloadSchemaType,
+    Range, SearchParams, SeqNumberType,
 };
 use tempfile::Builder;
 
@@ -143,6 +143,7 @@ fn exact_search_test() {
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -21,8 +21,8 @@ use segment::payload_json;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, Range,
-    SearchParams, SeqNumberType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig, PayloadSchemaType,
+    Range, SearchParams, SeqNumberType,
 };
 use tempfile::Builder;
 
@@ -163,6 +163,7 @@ fn _test_filterable_hnsw(
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -20,8 +20,8 @@ use segment::payload_json;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, Range,
-    SearchParams, SeqNumberType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig, PayloadSchemaType,
+    Range, SearchParams, SeqNumberType,
 };
 use tempfile::Builder;
 
@@ -143,6 +143,7 @@ fn test_gpu_filterable_hnsw() {
             gpu_device: Some(&locked_device), // enable GPU
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -18,8 +18,8 @@ use segment::payload_json;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, PayloadSchemaType, SearchParams,
-    SeqNumberType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig, PayloadSchemaType,
+    SearchParams, SeqNumberType,
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use tempfile::Builder;
@@ -116,6 +116,7 @@ fn hnsw_discover_precision() {
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )
@@ -241,6 +242,7 @@ fn filtered_hnsw_discover_precision() {
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/hnsw_incremental_build.rs
+++ b/lib/segment/tests/integration/hnsw_incremental_build.rs
@@ -21,7 +21,7 @@ use segment::index::hnsw_index::num_rayon_threads;
 use segment::segment::Segment;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
-use segment::types::{Distance, ExtendedPointId, HnswConfig, SeqNumberType};
+use segment::types::{Distance, ExtendedPointId, HnswConfig, HnswGlobalConfig, SeqNumberType};
 use tap::Tap as _;
 use tempfile::Builder;
 
@@ -153,6 +153,7 @@ fn build_hnsw_index<R: Rng + ?Sized>(
             gpu_device: None,
             rng,
             stopped: &AtomicBool::new(false),
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default().tap_mut(|flags| {
                 flags.incremental_hnsw_building = true;
             }),

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -24,8 +24,8 @@ use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
-    CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes,
-    ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams,
+    CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig,
+    Indexes, ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams,
     ScalarQuantizationConfig, SearchParams,
 };
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -137,6 +137,7 @@ fn hnsw_quantized_search_test(
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )
@@ -424,7 +425,13 @@ fn test_build_hnsw_using_quantization() {
     let permit = ResourcePermit::dummy(permit_cpu_count as u32);
     let hw_counter = HardwareCounterCell::new();
 
-    let mut builder = SegmentBuilder::new(dir.path(), temp_dir.path(), &config).unwrap();
+    let mut builder = SegmentBuilder::new(
+        dir.path(),
+        temp_dir.path(),
+        &config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
 
     builder.update(&[&segment1], &stopped).unwrap();
 

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -43,6 +43,7 @@ fn test_multi_filterable_hnsw(
     use segment::json_path::JsonPath;
     use segment::payload_json;
     use segment::segment_constructor::VectorIndexBuildArgs;
+    use segment::types::HnswGlobalConfig;
 
     let stopped = AtomicBool::new(false);
 
@@ -145,6 +146,7 @@ fn test_multi_filterable_hnsw(
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -23,8 +23,8 @@ use segment::segment_constructor::simple_segment_constructor::build_simple_segme
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HnswConfig, MultiVectorConfig, PayloadSchemaType,
-    SeqNumberType,
+    Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig, MultiVectorConfig,
+    PayloadSchemaType, SeqNumberType,
 };
 use segment::vector_storage::VectorStorage;
 use segment::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_in_ram_multi_vector_storage_full;
@@ -146,6 +146,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -179,6 +179,7 @@ fn test_multivector_quantization_hnsw(
 ) {
     use segment::payload_json;
     use segment::segment_constructor::VectorIndexBuildArgs;
+    use segment::types::HnswGlobalConfig;
 
     let stopped = AtomicBool::new(false);
 
@@ -327,6 +328,7 @@ fn test_multivector_quantization_hnsw(
             gpu_device: None,
             rng: &mut rng,
             stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
             feature_flags: FeatureFlags::default(),
         },
     )

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -42,9 +42,9 @@ use segment::types::PayloadFieldSchema::{FieldParams, FieldType};
 use segment::types::PayloadSchemaType::{Integer, Keyword};
 use segment::types::{
     AnyVariants, Condition, Distance, FieldCondition, Filter, GeoBoundingBox, GeoLineString,
-    GeoPoint, GeoPolygon, GeoRadius, HnswConfig, Indexes, IsEmptyCondition, Match, Payload,
-    PayloadField, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType, Range, SegmentConfig,
-    ValueVariants, VectorDataConfig, VectorStorageType, WithPayload,
+    GeoPoint, GeoPolygon, GeoRadius, HnswConfig, HnswGlobalConfig, Indexes, IsEmptyCondition,
+    Match, Payload, PayloadField, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType,
+    Range, SegmentConfig, ValueVariants, VectorDataConfig, VectorStorageType, WithPayload,
 };
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tempfile::{Builder, TempDir};
@@ -284,6 +284,7 @@ impl TestSegments {
             path,
             &path.with_extension("tmp"),
             &Self::make_simple_config(false),
+            &HnswGlobalConfig::default(),
         )
         .unwrap();
 

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -17,8 +17,8 @@ use segment::segment::Segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment_with_payload_storage;
 use segment::types::{
-    Distance, Indexes, PayloadContainer, PayloadFieldSchema, PayloadKeyType, PayloadSchemaType,
-    PayloadStorageType, SegmentConfig, VectorDataConfig, VectorStorageType,
+    Distance, HnswGlobalConfig, Indexes, PayloadContainer, PayloadFieldSchema, PayloadKeyType,
+    PayloadSchemaType, PayloadStorageType, SegmentConfig, VectorDataConfig, VectorStorageType,
 };
 use serde_json::Value;
 use sparse::common::sparse_vector::SparseVector;
@@ -40,8 +40,13 @@ fn test_building_new_segment() {
     let segment1 = build_segment_1(dir.path());
     let mut segment2 = build_segment_2(dir.path());
 
-    let mut builder =
-        SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
+    let mut builder = SegmentBuilder::new(
+        dir.path(),
+        temp_dir.path(),
+        &segment1.segment_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -123,8 +128,13 @@ fn test_building_new_defragmented_segment() {
         .create_field_index(17, &defragment_key, Some(&payload_schema), &hw_counter)
         .unwrap();
 
-    let mut builder =
-        SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
+    let mut builder = SegmentBuilder::new(
+        dir.path(),
+        temp_dir.path(),
+        &segment1.segment_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
 
     // Include overlapping with segment1 to check the
     segment2
@@ -250,8 +260,13 @@ fn test_building_new_sparse_segment() {
     let segment1 = build_segment_sparse_1(dir.path());
     let mut segment2 = build_segment_sparse_2(dir.path());
 
-    let mut builder =
-        SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
+    let mut builder = SegmentBuilder::new(
+        dir.path(),
+        temp_dir.path(),
+        &segment1.segment_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
 
     // Include overlapping with segment1 to check the
     let vec = SparseVector::new(vec![0, 1, 2, 3], vec![0.0, 0.0, 0.0, 0.0]).unwrap();
@@ -332,7 +347,13 @@ fn estimate_build_time(segment: &Segment, stop_delay_millis: Option<u64>) -> (u6
         payload_storage_type: Default::default(),
     };
 
-    let mut builder = SegmentBuilder::new(dir.path(), temp_dir.path(), &segment_config).unwrap();
+    let mut builder = SegmentBuilder::new(
+        dir.path(),
+        temp_dir.path(),
+        &segment_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
 
     builder.update(&[segment], &stopped).unwrap();
 
@@ -382,8 +403,13 @@ fn test_building_new_segment_bug_5614() {
     let mut segment1 = build_segment_1(dir.path());
     let mut segment2 = build_segment_2(dir.path());
 
-    let mut builder =
-        SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
+    let mut builder = SegmentBuilder::new(
+        dir.path(),
+        temp_dir.path(),
+        &segment1.segment_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
 
     let vector_100_low = only_default_vector(&[1., 1., 0., 0.]);
     let vector_101_low = only_default_vector(&[2., 2., 0., 0.]);
@@ -546,6 +572,7 @@ fn test_building_new_segment_with_mmap_payload() {
         segment_dir.path(),
         temp_dir.path(),
         &segment1.segment_config,
+        &HnswGlobalConfig::default(),
     )
     .unwrap();
 

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -27,6 +27,7 @@ use tempfile::Builder;
 #[case::streamable(SnapshotFormat::Streamable)]
 fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
     use common::counter::hardware_counter::HardwareCounterCell;
+    use segment::types::HnswGlobalConfig;
 
     let _ = env_logger::builder().is_test(true).try_init();
 
@@ -131,6 +132,7 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
         segment_base_dir.path(),
         segment_builder_dir.path(),
         &segment_config,
+        &HnswGlobalConfig::default(),
     )
     .unwrap();
     segment_builder.update(&[&segment], &false.into()).unwrap();

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -17,7 +17,7 @@ use memory::madvise;
 use schemars::JsonSchema;
 use segment::common::anonymize::{Anonymize, anonymize_collection_with_u64_hashable_key};
 use segment::data_types::collection_defaults::CollectionConfigDefaults;
-use segment::types::HnswConfig;
+use segment::types::{HnswConfig, HnswGlobalConfig};
 use serde::{Deserialize, Serialize};
 use tonic::transport::Uri;
 use validator::Validate;
@@ -83,6 +83,9 @@ pub struct StorageConfig {
     pub performance: PerformanceConfig,
     #[validate(nested)]
     pub hnsw_index: HnswConfig,
+    #[validate(nested)]
+    #[serde(default)]
+    pub hnsw_global_config: HnswGlobalConfig,
     #[serde(default = "default_mmap_advice")]
     pub mmap_advice: madvise::Advice,
     #[serde(default)]
@@ -127,6 +130,7 @@ impl StorageConfig {
             self.performance.outgoing_shard_transfers_limit,
             self.snapshots_path.clone(),
             self.snapshots_config.clone(),
+            self.hnsw_global_config.clone(),
             common::defaults::search_thread_count(self.performance.max_search_threads),
         )
     }

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -61,6 +61,7 @@ fn test_alias_operation() {
             async_scorer: None,
         },
         hnsw_index: Default::default(),
+        hnsw_global_config: Default::default(),
         mmap_advice: madvise::Advice::Random,
         node_type: Default::default(),
         update_queue_size: Default::default(),

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -5,6 +5,7 @@ use common::flags::FeatureFlags;
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
+use segment::types::HnswGlobalConfig;
 use serde::Serialize;
 
 use crate::settings::Settings;
@@ -61,6 +62,8 @@ pub struct AppBuildTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_features: Option<FeatureFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub hnsw_global_config: Option<HnswGlobalConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<RunningEnvironmentTelemetry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jwt_rbac: Option<bool>,
@@ -87,6 +90,8 @@ impl AppBuildTelemetry {
             }),
             runtime_features: (detail.level >= DetailsLevel::Level1)
                 .then(common::flags::feature_flags),
+            hnsw_global_config: (detail.level >= DetailsLevel::Level1)
+                .then(|| settings.storage.hnsw_global_config.clone()),
             system: (detail.level >= DetailsLevel::Level1).then(get_system_data),
             jwt_rbac: settings.service.jwt_rbac,
             hide_jwt_dashboard: settings.service.hide_jwt_dashboard,


### PR DESCRIPTION
This PR makes HNSW healing treshold configurable through a new setting.

Particularly:
1. HNSW healing is enabled by default.
2. The default healing threshold is changed from 10% to 30%.
3. Added float setting `QDRANT__STORAGE__HNSW_GLOBAL_CONFIG__HEALING_THRESHOLD`, (`0.3` by default).
4. Removed boolean setting `QDRANT__FEATURE_FLAGS__HNSW_HEALING`.
   To disable healing completely, set the new setting to `0.0`.

The new setting value is exposed in telemetry when `details_level >= 1`:
```json
{
  "id": "2ad2b301-494c-4160-bdc7-ac786d9fc79a",
  "app": {
    "name": "qdrant",
    "version": "1.14.2-dev",
    "features": {
      "debug": false,
      "service_debug_feature": false,
      "recovery_mode": false,
      "gpu": false,
      "rocksdb": true
    },
    "runtime_features": {
      "all": false,
      "payload_index_skip_rocksdb": true,
      "payload_index_skip_mutable_rocksdb": false,
      "incremental_hnsw_building": true,
      "hnsw_healing": true,
      "migrate_rocksdb_id_tracker": false,
      "migrate_rocksdb_vector_storage": false
    },
    "hnsw_global_config": {
      "healing_threshold": 0.3        // ←
    },
```

