### PR TITLE
Enable pod role based auth for s3 snapshots

### DIFF
--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -60,7 +60,7 @@ impl SnapshotStorageManager {
                 Ok(SnapshotStorageManager::LocalFS(SnapshotStorageLocalFS))
             }
             SnapshotsStorageConfig::S3 => {
-                let mut builder = AmazonS3Builder::new();
+                let mut builder = AmazonS3Builder::from_env();
                 if let Some(s3_config) = &snapshots_config.s3_config {
                     builder = builder.with_bucket_name(&s3_config.bucket);
 


### PR DESCRIPTION
We'd like to be able to run back-ups from EKS pods that use role based authentication to our S3 buckets.  To support this, it seems qdrant must use the [AmazonS3Builder::from_env](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env) method to populate the builder with information from the environment per this feature request from the [object-store](https://github.com/apache/arrow-rs-object-store/issues/282) library.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
