### PR TITLE
remove max indexing threads from config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,11 +64,6 @@ storage:
     # Number of parallel threads used for search operations. If 0 - auto selection.
     max_search_threads: 0
 
-    # Max number of threads (jobs) for running optimizations across all collections, each thread runs one job.
-    # If 0 - have no limit and choose dynamically to saturate CPU.
-    # Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
-    max_optimization_threads: 0
-
     # CPU budget, how many CPUs (threads) to allocate for an optimization job.
     # If 0 - auto selection, keep 1 or more CPUs unallocated depending on CPU size
     # If negative - subtract this number of CPUs from the available CPUs.

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -29,7 +29,7 @@ pub type PeerMetadataById = HashMap<PeerId, PeerMetadata>;
 pub struct PerformanceConfig {
     pub max_search_threads: usize,
     #[serde(default)]
-    pub max_optimization_threads: usize,
+    pub max_optimization_runtime_threads: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update_rate_limit: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -51,7 +51,7 @@ fn test_alias_operation() {
         wal: Default::default(),
         performance: PerformanceConfig {
             max_search_threads: 1,
-            max_optimization_threads: 1,
+            max_optimization_runtime_threads: 1,
             optimizer_cpu_budget: 0,
             optimizer_io_budget: 0,
             update_rate_limit: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,9 +306,13 @@ fn main() -> anyhow::Result<()> {
     let search_runtime = create_search_runtime(settings.storage.performance.max_search_threads)
         .expect("Can't search create runtime.");
 
-    let update_runtime =
-        create_update_runtime(settings.storage.performance.max_optimization_runtime_threads)
-            .expect("Can't optimizer create runtime.");
+    let update_runtime = create_update_runtime(
+        settings
+            .storage
+            .performance
+            .max_optimization_runtime_threads,
+    )
+    .expect("Can't optimizer create runtime.");
 
     let general_runtime =
         create_general_purpose_runtime().expect("Can't optimizer general purpose runtime.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,7 +307,7 @@ fn main() -> anyhow::Result<()> {
         .expect("Can't search create runtime.");
 
     let update_runtime =
-        create_update_runtime(settings.storage.performance.max_optimization_threads)
+        create_update_runtime(settings.storage.performance.max_optimization_runtime_threads)
             .expect("Can't optimizer create runtime.");
 
     let general_runtime =


### PR DESCRIPTION
Two reasons for it:

- option is obsolete and there are no cases to use it anymore. It's functionality is completely replaces by `optimizer_cpu_budget`
- this option might be confusing, as its name overlaps with per-collection configuration, which have different semantics and different behavior for 0 value



- **remove max_optimization_threads from config.yaml**
- **fmt**
