### PR TITLE
Implement new multilingual tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,13 +1026,11 @@ dependencies = [
  "fst",
  "irg-kvariants",
  "jieba-rs",
- "lindera",
  "once_cell",
  "pinyin",
  "serde",
  "slice-group-by",
  "unicode-normalization",
- "wana_kana",
  "whatlang",
 ]
 
@@ -1818,85 +1816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
-dependencies = [
- "encoding-index-japanese",
- "encoding-index-korean",
- "encoding-index-simpchinese",
- "encoding-index-singlebyte",
- "encoding-index-tradchinese",
-]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
 ]
 
 [[package]]
@@ -3305,15 +3230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kanaria"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,319 +3323,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "lindera"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832c220475557e3b44a46cad1862b57f010f0c6e93d771d0e628e08689c068b1"
-dependencies = [
- "lindera-analyzer",
- "lindera-core",
- "lindera-dictionary",
- "lindera-filter",
- "lindera-tokenizer",
-]
-
-[[package]]
-name = "lindera-analyzer"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e26651714abf5167e6b6a80f5cdaa0cad41c5fcb84d8ba96bebafcb9029339"
-dependencies = [
- "anyhow",
- "bincode 1.3.3",
- "byteorder",
- "encoding",
- "kanaria",
- "lindera-cc-cedict-builder",
- "lindera-core",
- "lindera-dictionary",
- "lindera-filter",
- "lindera-ipadic-builder",
- "lindera-ko-dic-builder",
- "lindera-tokenizer",
- "lindera-unidic-builder",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "unicode-blocks",
- "unicode-normalization",
- "unicode-segmentation",
- "yada",
-]
-
-[[package]]
-name = "lindera-assets"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb01f1ca53c1e642234c6c7fdb9ac664ad0c1ab9502f33e4200201bac7e6ce7"
-dependencies = [
- "encoding",
- "flate2",
- "lindera-core",
- "tar",
- "ureq",
-]
-
-[[package]]
-name = "lindera-cc-cedict"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7618d9aa947fdd7c38eae2b79f0fd237ecb5067608f1363610ba20d20ab5a8"
-dependencies = [
- "bincode 1.3.3",
- "byteorder",
- "lindera-cc-cedict-builder",
- "lindera-core",
- "lindera-decompress",
- "once_cell",
-]
-
-[[package]]
-name = "lindera-cc-cedict-builder"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdbcb809d81428935d601a78c94bfb39500749213f7320705f427a7a1d31aec"
-dependencies = [
- "anyhow",
- "lindera-core",
- "lindera-decompress",
- "lindera-dictionary-builder",
-]
-
-[[package]]
-name = "lindera-compress"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac178afa2456dac469d3b1a2d7fbaf3e1ea796a1f52321e8ac29545a53c239c"
-dependencies = [
- "anyhow",
- "flate2",
- "lindera-decompress",
-]
-
-[[package]]
-name = "lindera-core"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649777465f48147ce593ab6db347e235e3af8f693a23f4437be94a1cdbdf5fdf"
-dependencies = [
- "anyhow",
- "bincode 1.3.3",
- "byteorder",
- "encoding_rs",
- "log",
- "once_cell",
- "serde",
- "thiserror 1.0.69",
- "yada",
-]
-
-[[package]]
-name = "lindera-decompress"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3faaceb85e43ac250021866c6db3cdc9997b44b3d3ea498594d04edc91fc45"
-dependencies = [
- "anyhow",
- "flate2",
- "serde",
-]
-
-[[package]]
-name = "lindera-dictionary"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e15b2d2d8a4ad45f2e373a084931cf3dfbde15f124044e2436bb920af3366c"
-dependencies = [
- "anyhow",
- "bincode 1.3.3",
- "byteorder",
- "lindera-cc-cedict",
- "lindera-cc-cedict-builder",
- "lindera-core",
- "lindera-ipadic",
- "lindera-ipadic-builder",
- "lindera-ipadic-neologd",
- "lindera-ipadic-neologd-builder",
- "lindera-ko-dic",
- "lindera-ko-dic-builder",
- "lindera-unidic",
- "lindera-unidic-builder",
- "serde",
- "strum",
- "strum_macros",
-]
-
-[[package]]
-name = "lindera-dictionary-builder"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59802949110545b59b663917ed3fd55dc3b3a8cde6bd20137d7fe24372cfb9aa"
-dependencies = [
- "anyhow",
- "bincode 1.3.3",
- "byteorder",
- "csv",
- "derive_builder",
- "encoding",
- "encoding_rs",
- "encoding_rs_io",
- "glob",
- "lindera-compress",
- "lindera-core",
- "lindera-decompress",
- "log",
- "yada",
-]
-
-[[package]]
-name = "lindera-filter"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1320f118c3fc9e897f4ebfc16864e5ef8c0b06ba769c0a50e53f193f9d682bf8"
-dependencies = [
- "anyhow",
- "csv",
- "kanaria",
- "lindera-cc-cedict-builder",
- "lindera-core",
- "lindera-dictionary",
- "lindera-ipadic-builder",
- "lindera-ko-dic-builder",
- "lindera-unidic-builder",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "unicode-blocks",
- "unicode-normalization",
- "unicode-segmentation",
- "yada",
-]
-
-[[package]]
-name = "lindera-ipadic"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4731bf3730f1f38266d7ee9bca7d460cd336645c9dfd4e6a1082e58ab1e993"
-dependencies = [
- "bincode 1.3.3",
- "byteorder",
- "lindera-core",
- "lindera-decompress",
- "lindera-ipadic-builder",
- "once_cell",
-]
-
-[[package]]
-name = "lindera-ipadic-builder"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309966c12e682f67205c3cd3c8dc55bbdcd1eb3b5c7c5cb41fb8acd18906d340"
-dependencies = [
- "anyhow",
- "lindera-core",
- "lindera-decompress",
- "lindera-dictionary-builder",
-]
-
-[[package]]
-name = "lindera-ipadic-neologd"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90e919b4cfb9962d24ee1e1d50a7c163bbf356376495ad66d1996e20b9f9e44"
-dependencies = [
- "bincode 1.3.3",
- "byteorder",
- "lindera-core",
- "lindera-decompress",
- "lindera-ipadic-neologd-builder",
- "once_cell",
-]
-
-[[package]]
-name = "lindera-ipadic-neologd-builder"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e517df0d501f9f8bf3126da20fc8cb9a5e37921e0eec1824d7a62f096463e02"
-dependencies = [
- "anyhow",
- "lindera-core",
- "lindera-decompress",
- "lindera-dictionary-builder",
-]
-
-[[package]]
-name = "lindera-ko-dic"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c6da4e68bc8b452a54b96d65361ebdceb4b6f36ecf262425c0e1f77960ae82"
-dependencies = [
- "bincode 1.3.3",
- "byteorder",
- "lindera-assets",
- "lindera-core",
- "lindera-decompress",
- "lindera-ko-dic-builder",
- "once_cell",
-]
-
-[[package]]
-name = "lindera-ko-dic-builder"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc95884cc8f6dfb176caf5991043a4acf94c359215bbd039ea765e00454f271"
-dependencies = [
- "anyhow",
- "lindera-core",
- "lindera-decompress",
- "lindera-dictionary-builder",
-]
-
-[[package]]
-name = "lindera-tokenizer"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122042e1232a55c3604692445952a134e523822e9b4b9ab32a53ff890037ad4"
-dependencies = [
- "bincode 1.3.3",
- "lindera-core",
- "lindera-dictionary",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "lindera-unidic"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffae1fb2f2614abdcb50f99b138476dbac19862ffa57bfdc9c7b5d5b22a90c"
-dependencies = [
- "bincode 1.3.3",
- "byteorder",
- "lindera-assets",
- "lindera-core",
- "lindera-decompress",
- "lindera-unidic-builder",
- "once_cell",
-]
-
-[[package]]
-name = "lindera-unidic-builder"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe50055327712ebd1bcc74b657cf78c728a78b9586e3f99d5dd0b6a0be221c5d"
-dependencies = [
- "anyhow",
- "lindera-core",
- "lindera-decompress",
- "lindera-dictionary-builder",
 ]
 
 [[package]]
@@ -7353,12 +6956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
-name = "unicode-blocks"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7372,12 +6969,6 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -7428,22 +7019,6 @@ checksum = "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
 dependencies = [
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "ureq"
-version = "2.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
-dependencies = [
- "base64 0.21.0",
- "log",
- "once_cell",
- "rustls 0.22.4",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "url",
- "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -7595,17 +7170,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wana_kana"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74666202acfcb4f9b995be2e3e9f7f530deb65e05a1407b8d0b30c9c451238a"
-dependencies = [
- "fnv",
- "itertools 0.10.5",
- "lazy_static",
 ]
 
 [[package]]
@@ -8262,12 +7826,6 @@ dependencies = [
  "linux-raw-sys 0.4.14",
  "rustix 0.38.40",
 ]
-
-[[package]]
-name = "yada"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,6 @@ dependencies = [
  "irg-kvariants",
  "jieba-rs",
  "once_cell",
- "pinyin",
  "serde",
  "slice-group-by",
  "unicode-normalization",
@@ -4142,12 +4141,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pinyin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f2611cd06a1ac239a0cea4521de9eb068a6ca110324ee00631aa68daa74fc0"
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ workspace = true
 
 [features]
 default = ["rocksdb"]
-multiling-chinese = ["segment/multiling-chinese"]
-multiling-japanese = ["segment/multiling-japanese"]
-multiling-korean = ["segment/multiling-korean"]
 service_debug = ["parking_lot/deadlock_detection"]
 tracing = [
     "api/tracing",
@@ -84,7 +81,12 @@ tower = { version = "0.5.2", features = ["util"] }
 tower-layer = "0.3.3"
 reqwest = { workspace = true }
 # rustls minor version must be synced with actix-web
-rustls = { version = "0.23.28", default-features = false, features = ["logging", "std", "tls12", "ring"] }
+rustls = { version = "0.23.28", default-features = false, features = [
+    "logging",
+    "std",
+    "tls12",
+    "ring",
+] }
 rustls-pki-types = "1.12.0"
 rustls-pemfile = "2.2.0"
 prometheus = { version = "0.14.0", default-features = false }
@@ -94,11 +96,18 @@ jsonwebtoken = "9.3.1"
 tempfile = { workspace = true }
 
 # Consensus related crates
-raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
-slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
+raft = { version = "0.7.0", features = [
+    "prost-codec",
+], default-features = false }
+slog = { version = "2.7.0", features = [
+    "max_level_trace",
+    "release_max_level_debug",
+] }
 slog-stdlog = "4.1.1"
 prost-for-raft = { workspace = true }
-raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false }
+raft-proto = { version = "0.7.0", features = [
+    "prost-codec",
+], default-features = false }
 
 common = { path = "lib/common/common" }
 cancel = { path = "lib/common/cancel" }
@@ -115,9 +124,18 @@ constant_time_eq = "0.4.2"
 
 # Profiling
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
-tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
-console-subscriber = { version = "0.4.1", default-features = false, features = ["parking_lot"], optional = true }
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+    "fmt",
+    "json",
+] }
+tracing-log = { version = "0.2", default-features = false, features = [
+    "log-tracer",
+    "std",
+] }
+console-subscriber = { version = "0.4.1", default-features = false, features = [
+    "parking_lot",
+], optional = true }
 tracing-tracy = { version = "0.11.4", features = ["ondemand"], optional = true }
 actix-web-extras = "0.1.0"
 
@@ -129,7 +147,11 @@ pyroscope_pprofrs = "0.2.10"
 rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+tikv-jemallocator = { version = "0.6", features = [
+    "stats",
+    "unprefixed_malloc_on_supported_platforms",
+    "background_threads",
+] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 
 [workspace.lints.clippy]
@@ -168,7 +190,11 @@ ahash = { version = "0.8.11", features = ["serde"] }
 atomicwrites = "0.4.4"
 bincode = "1.3.3" # no upgrade because 2.0.x is much slower https://github.com/qdrant/qdrant/pull/6134
 bitpacking = "0.9.2"
-bytemuck = { version = "1.23.1", features = ["extern_crate_alloc", "must_cast", "transparentwrapper_extra"] }
+bytemuck = { version = "1.23.1", features = [
+    "extern_crate_alloc",
+    "must_cast",
+    "transparentwrapper_extra",
+] }
 bytes = "1.10.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.40", features = ["derive", "env"] }
@@ -180,7 +206,12 @@ fnv = "1.0"
 futures = "0.3.31"
 futures-util = "0.3.31"
 generic-tests = "0.1.3"
-half = { version = "2.6.0", features = ["alloc", "bytemuck", "serde", "num-traits"] }
+half = { version = "2.6.0", features = [
+    "alloc",
+    "bytemuck",
+    "serde",
+    "num-traits",
+] }
 http = "1.2.0"
 humantime = "2.2.0"
 indexmap = { version = "2", features = ["serde"] }
@@ -201,9 +232,21 @@ prost-build = { version = "0.12.6", features = ["cleanup-markdown"] }
 prost-wkt-types = "0.5"
 prost-for-raft = { package = "prost", version = "=0.11.9" } # version of prost used by raft
 rand = "0.9.1"
-reqwest = { version = "0.12.20", default-features = false, features = ["json", "http2", "stream", "rustls-tls", "blocking"] }
-rstest = {  version = "0.24.0", default-features = false }
-schemars = { version = "0.8.22", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
+reqwest = { version = "0.12.20", default-features = false, features = [
+    "json",
+    "http2",
+    "stream",
+    "rustls-tls",
+    "blocking",
+] }
+rstest = { version = "0.24.0", default-features = false }
+schemars = { version = "0.8.22", features = [
+    "uuid1",
+    "preserve_order",
+    "chrono",
+    "url",
+    "indexmap2",
+] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_cbor = "0.11.2"
@@ -291,7 +334,7 @@ codegen-units = 256 # restore default value for faster compilation
 inherits = "release"
 lto = false
 opt-level = 3
-codegen-units = 256 # restore default value for faster compilation
+codegen-units = 256  # restore default value for faster compilation
 
 [profile.dev]
 debug = "line-tables-only"
@@ -320,8 +363,24 @@ extended-description = """\
 Qdrant is a high-performance vector search engine. It is designed to index and search large collections of high-dimensional vectors.\
 """
 assets = [
-    ["target/release/qdrant", "usr/bin/", "755"],
-    ["README.md", "usr/share/doc/qdrant/README", "644"],
-    ["static/*/*", "etc/qdrant/static", "644"],
-    ["config/deb.yaml", "etc/qdrant/config.yaml", "644"],
+    [
+        "target/release/qdrant",
+        "usr/bin/",
+        "755",
+    ],
+    [
+        "README.md",
+        "usr/share/doc/qdrant/README",
+        "644",
+    ],
+    [
+        "static/*/*",
+        "etc/qdrant/static",
+        "644",
+    ],
+    [
+        "config/deb.yaml",
+        "etc/qdrant/config.yaml",
+        "644",
+    ],
 ]

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -13,13 +13,6 @@ workspace = true
 
 [features]
 default = ["rocksdb"]
-multiling-chinese = [
-    "charabia/chinese-segmentation",
-    "charabia/chinese-normalization",
-    "charabia/chinese-normalization-pinyin",
-]
-multiling-japanese = ["charabia/japanese"]
-multiling-korean = ["charabia/korean"]
 testing = ["common/testing", "sparse/testing", "gpu/testing"]
 gpu = ["gpu/gpu"]
 rocksdb = ["dep:rocksdb"]
@@ -110,6 +103,9 @@ charabia = { version = "0.9.3", default-features = false, features = [
     "greek",
     "hebrew",
     "thai",
+    "chinese-segmentation",
+    "chinese-normalization",
+    "chinese-normalization-pinyin",
 ] }
 
 gridstore = { path = "../gridstore" }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -105,7 +105,6 @@ charabia = { version = "0.9.3", default-features = false, features = [
     "thai",
     "chinese-segmentation",
     "chinese-normalization",
-    "chinese-normalization-pinyin",
 ] }
 
 gridstore = { path = "../gridstore" }

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -134,9 +134,9 @@ impl ValueIndexer for FullTextMmapIndexBuilder {
 
         let mut str_tokens = Vec::new();
 
-        for value in values {
-            self.tokenizer.tokenize_doc(&value, |token| {
-                str_tokens.push(token.to_owned());
+        for value in &values {
+            self.tokenizer.tokenize_doc(value, |token| {
+                str_tokens.push(token);
             });
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -235,11 +236,11 @@ impl MutableFullTextIndex {
             return Ok(());
         }
 
-        let mut str_tokens = Vec::new();
+        let mut str_tokens: Vec<Cow<str>> = Vec::new();
 
-        for value in values {
-            self.tokenizer.tokenize_doc(&value, |token| {
-                str_tokens.push(token.to_owned());
+        for value in &values {
+            self.tokenizer.tokenize_doc(value, |token| {
+                str_tokens.push(token);
             });
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/japanese.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/japanese.rs
@@ -111,7 +111,7 @@ mod test {
         let input = "日本語のテキストです。Qdrantのコードで単体テストで使用されています。";
         let mut out = vec![];
         tokenize(input, false, &StopwordsFilter::default(), |i| {
-            out.push(&i);
+            out.push(i.to_string());
         });
         assert_eq!(
             out,
@@ -143,7 +143,7 @@ mod test {
         let input = "日本語のテキストです。It's used in Qdrant's code in a unit test";
         let mut out = vec![];
         tokenize(input, false, &StopwordsFilter::default(), |i| {
-            out.push(&i);
+            out.push(i.to_string());
         });
         assert_eq!(
             out,

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/japanese.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/japanese.rs
@@ -111,7 +111,7 @@ mod test {
         let input = "日本語のテキストです。Qdrantのコードで単体テストで使用されています。";
         let mut out = vec![];
         tokenize(input, false, &StopwordsFilter::default(), |i| {
-            out.push(i.to_string());
+            out.push(&i);
         });
         assert_eq!(
             out,
@@ -143,7 +143,7 @@ mod test {
         let input = "日本語のテキストです。It's used in Qdrant's code in a unit test";
         let mut out = vec![];
         tokenize(input, false, &StopwordsFilter::default(), |i| {
-            out.push(i.to_string());
+            out.push(&i);
         });
         assert_eq!(
             out,

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -373,20 +373,19 @@ mod tests {
         });
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens.first(), Some(&Cow::Borrowed("jīntiān")));
-        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("shì")));
-        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("xīngqīyī")));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("今天")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("是")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("星期一")));
 
         tokens.clear();
 
         // Test stopwords getting applied
-        // TODO(multilingual): Chinese stopwords must be hanzi or stopword list must be in pinyin! <== Currently a bug!
-        let filter = StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["shì"])), false);
+        let filter = StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["是"])), false);
         MultilingualTokenizer::tokenize(text, true, &filter, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 2);
-        assert_eq!(tokens.first(), Some(&Cow::Borrowed("jīntiān")));
-        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("xīngqīyī")));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("今天")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("星期一")));
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 mod japanese;
 mod multilingual;
 
-use charabia::Tokenize;
+use multilingual::MultilingualTokenizer;
 
 use crate::data_types::index::{TextIndexParams, TokenizerType};
 use crate::index::field_index::full_text_index::stop_words::StopwordsFilter;
@@ -10,8 +10,8 @@ use crate::index::field_index::full_text_index::stop_words::StopwordsFilter;
 struct WhiteSpaceTokenizer;
 
 impl WhiteSpaceTokenizer {
-    fn tokenize<C: FnMut(&str)>(
-        text: &str,
+    fn tokenize<'a, C: FnMut(Cow<'a, str>)>(
+        text: &'a str,
         lowercase: bool,
         stopwords_filter: &StopwordsFilter,
         mut callback: C,
@@ -30,7 +30,7 @@ impl WhiteSpaceTokenizer {
             if stopwords_filter.is_stopword(&token_cow) {
                 continue;
             }
-            callback(&token_cow);
+            callback(token_cow);
         }
     }
 }
@@ -38,8 +38,8 @@ impl WhiteSpaceTokenizer {
 struct WordTokenizer;
 
 impl WordTokenizer {
-    fn tokenize<C: FnMut(&str)>(
-        text: &str,
+    fn tokenize<'a, C: FnMut(Cow<'a, str>)>(
+        text: &'a str,
         lowercase: bool,
         stopwords_filter: &StopwordsFilter,
         mut callback: C,
@@ -59,7 +59,7 @@ impl WordTokenizer {
                 continue;
             }
 
-            callback(&token_cow);
+            callback(token_cow);
         }
     }
 }
@@ -67,8 +67,8 @@ impl WordTokenizer {
 struct PrefixTokenizer;
 
 impl PrefixTokenizer {
-    fn tokenize<C: FnMut(&str)>(
-        text: &str,
+    fn tokenize<'a, C: FnMut(Cow<'a, str>)>(
+        text: &'a str,
         lowercase: bool,
         stopwords_filter: &StopwordsFilter,
         min_ngram: usize,
@@ -89,11 +89,11 @@ impl PrefixTokenizer {
                 }
 
                 for n in min_ngram..=max_ngram {
-                    let ngram = word_cow.char_indices().map(|(i, _)| i).nth(n);
+                    let ngram = word_cow.as_ref().char_indices().map(|(i, _)| i).nth(n);
                     match ngram {
-                        Some(end) => callback(&word_cow[..end]),
+                        Some(end) => callback(truncate_cow_ref(&word_cow, end)),
                         None => {
-                            callback(&word_cow);
+                            callback(word_cow);
                             break;
                         }
                     }
@@ -117,8 +117,8 @@ impl PrefixTokenizer {
     /// Query tokens: `"hel"`   -> `["hel"]`
     /// Query tokens: `"hell"`  -> `["hell"]`
     /// Query tokens: `"hello"` -> `["hello"]`
-    fn tokenize_query<C: FnMut(&str)>(
-        text: &str,
+    fn tokenize_query<'a, C: FnMut(Cow<'a, str>)>(
+        text: &'a str,
         lowercase: bool,
         max_ngram: usize,
         mut callback: C,
@@ -134,37 +134,32 @@ impl PrefixTokenizer {
 
                 let ngram = word_cow.char_indices().map(|(i, _)| i).nth(max_ngram);
                 match ngram {
-                    Some(end) => callback(&word_cow[..end]),
+                    Some(end) => callback(truncate_cow(word_cow, end)),
                     None => {
-                        callback(&word_cow);
+                        callback(word_cow);
                     }
                 }
             });
     }
 }
 
-struct MultilingualTokenizer;
+/// Truncates a string inside a `Cow<str>` to the given `len` preserving the `Borrowed` and `Owned` state.
+fn truncate_cow<'a>(inp: Cow<'a, str>, len: usize) -> Cow<'a, str> {
+    match inp {
+        Cow::Borrowed(b) => Cow::Borrowed(&b[..len]),
+        Cow::Owned(mut b) => {
+            b.truncate(len);
+            Cow::Owned(b)
+        }
+    }
+}
 
-impl MultilingualTokenizer {
-    fn tokenize<C: FnMut(&str)>(
-        text: &str,
-        lowercase: bool,
-        stopwords_filter: &StopwordsFilter,
-        mut callback: C,
-    ) {
-        text.tokenize().for_each(|token| {
-            if token.is_word() {
-                let lemma = if lowercase {
-                    Cow::Owned(token.lemma.to_lowercase())
-                } else {
-                    token.lemma
-                };
-                if stopwords_filter.is_stopword(&lemma) {
-                    return;
-                }
-                callback(&lemma);
-            }
-        });
+/// Truncates a string inside a `&Cow<str>` to the given `len` preserving the `Borrowed` and `Owned` state.
+/// `truncate_cow` should be preferred over this function if Cow doesn't need to be passed as reference.
+fn truncate_cow_ref<'a>(inp: &Cow<'a, str>, len: usize) -> Cow<'a, str> {
+    match inp {
+        Cow::Borrowed(b) => Cow::Borrowed(&b[..len]),
+        Cow::Owned(b) => Cow::Owned(b[..len].to_string()),
     }
 }
 
@@ -201,11 +196,11 @@ impl Tokenizer {
         }
     }
 
-    fn doc_token_filter<'a, C: FnMut(&str) + 'a>(
+    fn doc_token_filter<'a, 'b, C: FnMut(Cow<'b, str>) + 'a>(
         &'a self,
         mut callback: C,
-    ) -> impl FnMut(&str) + 'a {
-        move |token: &str| {
+    ) -> impl FnMut(Cow<'b, str>) + 'a {
+        move |token: Cow<'b, str>| {
             if self
                 .min_token_len
                 .map(|min_len| token.len() < min_len && token.chars().count() < min_len)
@@ -225,7 +220,7 @@ impl Tokenizer {
         }
     }
 
-    pub fn tokenize_doc<C: FnMut(&str)>(&self, text: &str, mut callback: C) {
+    pub fn tokenize_doc<'a, C: FnMut(Cow<'a, str>)>(&self, text: &'a str, mut callback: C) {
         let token_filter = self.doc_token_filter(&mut callback);
         match self.tokenizer_type {
             TokenizerType::Whitespace => WhiteSpaceTokenizer::tokenize(
@@ -254,7 +249,7 @@ impl Tokenizer {
         }
     }
 
-    pub fn tokenize_query<C: FnMut(&str)>(&self, text: &str, mut callback: C) {
+    pub fn tokenize_query<C: FnMut(Cow<str>)>(&self, text: &str, mut callback: C) {
         let token_filter = self.doc_token_filter(&mut callback);
         match self.tokenizer_type {
             TokenizerType::Whitespace => WhiteSpaceTokenizer::tokenize(
@@ -292,11 +287,12 @@ mod tests {
         let text = "hello world";
         let mut tokens = Vec::new();
         WhiteSpaceTokenizer::tokenize(text, true, &StopwordsFilter::default(), |token| {
-            tokens.push(token.to_owned())
+            tokens.push(token)
         });
+
         assert_eq!(tokens.len(), 2);
-        assert_eq!(tokens.first(), Some(&"hello".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"world".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("hello")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("world")));
     }
 
     #[test]
@@ -304,13 +300,13 @@ mod tests {
         let text = "hello, world! Привет, мир!";
         let mut tokens = Vec::new();
         WordTokenizer::tokenize(text, true, &StopwordsFilter::default(), |token| {
-            tokens.push(token.to_owned())
+            tokens.push(token)
         });
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens.first(), Some(&"hello".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"world".to_owned()));
-        assert_eq!(tokens.get(2), Some(&"привет".to_owned()));
-        assert_eq!(tokens.get(3), Some(&"мир".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("hello")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("world")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("привет")));
+        assert_eq!(tokens.get(3), Some(&Cow::Borrowed("мир")));
     }
 
     #[test]
@@ -318,59 +314,79 @@ mod tests {
         let text = "hello, мир!";
         let mut tokens = Vec::new();
         PrefixTokenizer::tokenize(text, true, &StopwordsFilter::default(), 1, 4, |token| {
-            tokens.push(token.to_owned())
+            tokens.push(token)
         });
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 7);
-        assert_eq!(tokens.first(), Some(&"h".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"he".to_owned()));
-        assert_eq!(tokens.get(2), Some(&"hel".to_owned()));
-        assert_eq!(tokens.get(3), Some(&"hell".to_owned()));
-        assert_eq!(tokens.get(4), Some(&"м".to_owned()));
-        assert_eq!(tokens.get(5), Some(&"ми".to_owned()));
-        assert_eq!(tokens.get(6), Some(&"мир".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("h")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("he")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("hel")));
+        assert_eq!(tokens.get(3), Some(&Cow::Borrowed("hell")));
+        assert_eq!(tokens.get(4), Some(&Cow::Borrowed("м")));
+        assert_eq!(tokens.get(5), Some(&Cow::Borrowed("ми")));
+        assert_eq!(tokens.get(6), Some(&Cow::Borrowed("мир")));
     }
 
     #[test]
     fn test_prefix_query_tokenizer() {
         let text = "hello, мир!";
         let mut tokens = Vec::new();
-        PrefixTokenizer::tokenize_query(text, true, 4, |token| tokens.push(token.to_owned()));
+        PrefixTokenizer::tokenize_query(text, true, 4, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 2);
-        assert_eq!(tokens.first(), Some(&"hell".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"мир".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("hell")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("мир")));
     }
 
-    #[cfg(feature = "multiling-japanese")]
     #[test]
     fn test_multilingual_tokenizer_japanese() {
         let text = "本日の日付は";
         let mut tokens = Vec::new();
         MultilingualTokenizer::tokenize(text, true, &StopwordsFilter::default(), |token| {
-            tokens.push(token.to_owned())
+            tokens.push(token)
         });
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens.first(), Some(&"本日".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"の".to_owned()));
-        assert_eq!(tokens.get(2), Some(&"日付".to_owned()));
-        assert_eq!(tokens.get(3), Some(&"は".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("本日")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("の")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("日付")));
+        assert_eq!(tokens.get(3), Some(&Cow::Borrowed("は")));
+
+        tokens.clear();
+
+        // Test stopwords getting applied
+        let filter =
+            StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["の", "は"])), false);
+        MultilingualTokenizer::tokenize(text, true, &filter, |token| tokens.push(token));
+        eprintln!("tokens = {tokens:#?}");
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("本日")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("日付")));
     }
 
-    #[cfg(feature = "multiling-chinese")]
     #[test]
     fn test_multilingual_tokenizer_chinese() {
         let text = "今天是星期一";
         let mut tokens = Vec::new();
         MultilingualTokenizer::tokenize(text, true, &StopwordsFilter::default(), |token| {
-            tokens.push(token.to_owned())
+            tokens.push(token)
         });
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens.first(), Some(&"jīntiān".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"shì".to_owned()));
-        assert_eq!(tokens.get(2), Some(&"xīngqīyī".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("jīntiān")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("shì")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("xīngqīyī")));
+
+        tokens.clear();
+
+        // Test stopwords getting applied
+        // TODO(multilingual): Chinese stopwords must be hanzi or stopword list must be in pinyin! <== Currently a bug!
+        let filter = StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["shì"])), false);
+        MultilingualTokenizer::tokenize(text, true, &filter, |token| tokens.push(token));
+        eprintln!("tokens = {tokens:#?}");
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("jīntiān")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("xīngqīyī")));
     }
 
     #[test]
@@ -378,14 +394,14 @@ mod tests {
         let text = "มาทำงานกันเถอะ";
         let mut tokens = Vec::new();
         MultilingualTokenizer::tokenize(text, true, &StopwordsFilter::default(), |token| {
-            tokens.push(token.to_owned())
+            tokens.push(token)
         });
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens.first(), Some(&"มา".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"ทางาน".to_owned()));
-        assert_eq!(tokens.get(2), Some(&"กน".to_owned()));
-        assert_eq!(tokens.get(3), Some(&"เถอะ".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("มา")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("ทางาน")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("กน")));
+        assert_eq!(tokens.get(3), Some(&Cow::Borrowed("เถอะ")));
     }
 
     #[test]
@@ -393,15 +409,15 @@ mod tests {
         let text = "What are you waiting for?";
         let mut tokens = Vec::new();
         MultilingualTokenizer::tokenize(text, true, &StopwordsFilter::default(), |token| {
-            tokens.push(token.to_owned())
+            tokens.push(token)
         });
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 5);
-        assert_eq!(tokens.first(), Some(&"what".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"are".to_owned()));
-        assert_eq!(tokens.get(2), Some(&"you".to_owned()));
-        assert_eq!(tokens.get(3), Some(&"waiting".to_owned()));
-        assert_eq!(tokens.get(4), Some(&"for".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("what")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("are")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("you")));
+        assert_eq!(tokens.get(3), Some(&Cow::Borrowed("waiting")));
+        assert_eq!(tokens.get(4), Some(&Cow::Borrowed("for")));
     }
 
     #[test]
@@ -421,16 +437,16 @@ mod tests {
 
         let tokenizer = Tokenizer::new(&params);
 
-        tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+        tokenizer.tokenize_doc(text, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 7);
-        assert_eq!(tokens.first(), Some(&"h".to_owned()));
-        assert_eq!(tokens.get(1), Some(&"he".to_owned()));
-        assert_eq!(tokens.get(2), Some(&"hel".to_owned()));
-        assert_eq!(tokens.get(3), Some(&"hell".to_owned()));
-        assert_eq!(tokens.get(4), Some(&"м".to_owned()));
-        assert_eq!(tokens.get(5), Some(&"ми".to_owned()));
-        assert_eq!(tokens.get(6), Some(&"мир".to_owned()));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("h")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("he")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("hel")));
+        assert_eq!(tokens.get(3), Some(&Cow::Borrowed("hell")));
+        assert_eq!(tokens.get(4), Some(&Cow::Borrowed("м")));
+        assert_eq!(tokens.get(5), Some(&Cow::Borrowed("ми")));
+        assert_eq!(tokens.get(6), Some(&Cow::Borrowed("мир")));
     }
 
     #[test]
@@ -451,20 +467,20 @@ mod tests {
 
         let tokenizer = Tokenizer::new(&params);
 
-        tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+        tokenizer.tokenize_doc(text, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
 
         // Check that stopwords are filtered out
-        assert!(!tokens.contains(&"the".to_owned()));
-        assert!(!tokens.contains(&"over".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("the")));
+        assert!(!tokens.contains(&Cow::Borrowed("over")));
 
         // Check that non-stopwords are present
-        assert!(tokens.contains(&"quick".to_owned()));
-        assert!(tokens.contains(&"brown".to_owned()));
-        assert!(tokens.contains(&"fox".to_owned()));
-        assert!(tokens.contains(&"jumps".to_owned()));
-        assert!(tokens.contains(&"lazy".to_owned()));
-        assert!(tokens.contains(&"dog".to_owned()));
+        assert!(tokens.contains(&Cow::Borrowed("quick")));
+        assert!(tokens.contains(&Cow::Borrowed("brown")));
+        assert!(tokens.contains(&Cow::Borrowed("fox")));
+        assert!(tokens.contains(&Cow::Borrowed("jumps")));
+        assert!(tokens.contains(&Cow::Borrowed("lazy")));
+        assert!(tokens.contains(&Cow::Borrowed("dog")));
     }
 
     #[test]
@@ -492,15 +508,15 @@ mod tests {
 
             let tokenizer = Tokenizer::new(&params);
 
-            tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+            tokenizer.tokenize_doc(text, |token| tokens.push(token));
 
             // Check that stopwords are filtered out
-            assert!(!tokens.contains(&"you".to_owned()));
-            assert!(!tokens.contains(&"ll".to_owned()));
-            assert!(!tokens.contains(&"you'll".to_owned()));
+            assert!(!tokens.contains(&Cow::Borrowed("you")));
+            assert!(!tokens.contains(&Cow::Borrowed("ll")));
+            assert!(!tokens.contains(&Cow::Borrowed("you'll")));
 
             // Check that non-stopwords are present
-            assert!(tokens.contains(&"town".to_owned()));
+            assert!(tokens.contains(&Cow::Borrowed("town")));
         }
     }
 
@@ -525,22 +541,22 @@ mod tests {
         };
 
         let tokenizer = Tokenizer::new(&params);
-        tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+        tokenizer.tokenize_doc(text, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
 
         // Check that English stopwords are filtered out
-        assert!(!tokens.contains(&"the".to_owned()));
-        assert!(!tokens.contains(&"over".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("the")));
+        assert!(!tokens.contains(&Cow::Borrowed("over")));
 
         // Check that custom stopwords are filtered out
-        assert!(!tokens.contains(&"quick".to_owned()));
-        assert!(!tokens.contains(&"fox".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("quick")));
+        assert!(!tokens.contains(&Cow::Borrowed("fox")));
 
         // Check that non-stopwords are present
-        assert!(tokens.contains(&"brown".to_owned()));
-        assert!(tokens.contains(&"jumps".to_owned()));
-        assert!(tokens.contains(&"lazy".to_owned()));
-        assert!(tokens.contains(&"dog".to_owned()));
+        assert!(tokens.contains(&Cow::Borrowed("brown")));
+        assert!(tokens.contains(&Cow::Borrowed("jumps")));
+        assert!(tokens.contains(&Cow::Borrowed("lazy")));
+        assert!(tokens.contains(&Cow::Borrowed("dog")));
     }
 
     #[test]
@@ -560,23 +576,23 @@ mod tests {
 
         let tokenizer = Tokenizer::new(&params);
 
-        tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+        tokenizer.tokenize_doc(text, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
 
         // stopwords are filtered out
-        assert!(!tokens.contains(&"as".to_owned()));
-        assert!(!tokens.contains(&"the".to_owned()));
-        assert!(!tokens.contains(&"a".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("as")));
+        assert!(!tokens.contains(&Cow::Borrowed("the")));
+        assert!(!tokens.contains(&Cow::Borrowed("a")));
 
         // non-stopwords are present
-        assert!(tokens.contains(&"quick".to_owned()));
-        assert!(tokens.contains(&"brown".to_owned()));
-        assert!(tokens.contains(&"fox".to_owned()));
-        assert!(tokens.contains(&"jumps".to_owned()));
-        assert!(tokens.contains(&"over".to_owned()));
-        assert!(tokens.contains(&"lazy".to_owned()));
-        assert!(tokens.contains(&"dog".to_owned()));
-        assert!(tokens.contains(&"test".to_owned()));
+        assert!(tokens.contains(&Cow::Borrowed("quick")));
+        assert!(tokens.contains(&Cow::Borrowed("brown")));
+        assert!(tokens.contains(&Cow::Borrowed("fox")));
+        assert!(tokens.contains(&Cow::Borrowed("jumps")));
+        assert!(tokens.contains(&Cow::Borrowed("over")));
+        assert!(tokens.contains(&Cow::Borrowed("lazy")));
+        assert!(tokens.contains(&Cow::Borrowed("dog")));
+        assert!(tokens.contains(&Cow::Borrowed("test")));
     }
 
     #[test]
@@ -597,20 +613,20 @@ mod tests {
 
         let tokenizer = Tokenizer::new(&params);
 
-        tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+        tokenizer.tokenize_doc(text, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
 
         // Check that English stopwords are filtered out
-        assert!(!tokens.contains(&"the".to_owned()));
-        assert!(!tokens.contains(&"over".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("the")));
+        assert!(!tokens.contains(&Cow::Borrowed("over")));
 
         // Check that non-stopwords are present
-        assert!(tokens.contains(&"quick".to_owned()));
-        assert!(tokens.contains(&"brown".to_owned()));
-        assert!(tokens.contains(&"fox".to_owned()));
-        assert!(tokens.contains(&"jumps".to_owned()));
-        assert!(tokens.contains(&"lazy".to_owned()));
-        assert!(tokens.contains(&"dog".to_owned()));
+        assert!(tokens.contains(&Cow::Borrowed("quick")));
+        assert!(tokens.contains(&Cow::Borrowed("brown")));
+        assert!(tokens.contains(&Cow::Borrowed("fox")));
+        assert!(tokens.contains(&Cow::Borrowed("jumps")));
+        assert!(tokens.contains(&Cow::Borrowed("lazy")));
+        assert!(tokens.contains(&Cow::Borrowed("dog")));
     }
 
     #[test]
@@ -634,27 +650,27 @@ mod tests {
 
         let tokenizer = Tokenizer::new(&params);
 
-        tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+        tokenizer.tokenize_doc(text, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
 
         // Check that English stopwords are filtered out
-        assert!(!tokens.contains(&"the".to_owned()));
-        assert!(!tokens.contains(&"over".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("the")));
+        assert!(!tokens.contains(&Cow::Borrowed("over")));
 
         // Check that Spanish stopwords are filtered out
-        assert!(!tokens.contains(&"y".to_owned()));
-        assert!(!tokens.contains(&"de".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("y")));
+        assert!(!tokens.contains(&Cow::Borrowed("de")));
 
         // Check that custom stopwords are filtered out
-        assert!(!tokens.contains(&"i'd".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("i'd")));
 
         // Check that non-stopwords are present
-        assert!(tokens.contains(&"quick".to_owned()));
-        assert!(tokens.contains(&"brown".to_owned()));
-        assert!(tokens.contains(&"fox".to_owned()));
-        assert!(tokens.contains(&"jumps".to_owned()));
-        assert!(tokens.contains(&"lazy".to_owned()));
-        assert!(tokens.contains(&"dog".to_owned()));
+        assert!(tokens.contains(&Cow::Borrowed("quick")));
+        assert!(tokens.contains(&Cow::Borrowed("brown")));
+        assert!(tokens.contains(&Cow::Borrowed("fox")));
+        assert!(tokens.contains(&Cow::Borrowed("jumps")));
+        assert!(tokens.contains(&Cow::Borrowed("lazy")));
+        assert!(tokens.contains(&Cow::Borrowed("dog")));
     }
 
     #[test]
@@ -674,22 +690,22 @@ mod tests {
 
         let tokenizer = Tokenizer::new(&params);
 
-        tokenizer.tokenize_doc(text, |token| tokens.push(token.to_owned()));
+        tokenizer.tokenize_doc(text, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
 
         // Check that exact case stopwords are filtered out
-        assert!(!tokens.contains(&"The".to_owned()));
-        assert!(!tokens.contains(&"the".to_owned()));
+        assert!(!tokens.contains(&Cow::Borrowed("The")));
+        assert!(!tokens.contains(&Cow::Borrowed("the")));
 
         // Check that different case stopwords are not filtered out
-        assert!(tokens.contains(&"lazy".to_owned())); // "LAZY" is in stopwords, but "lazy" is not
+        assert!(tokens.contains(&Cow::Borrowed("lazy"))); // "LAZY" is in stopwords, but "lazy" is not
 
         // Check that non-stopwords are present
-        assert!(tokens.contains(&"quick".to_owned()));
-        assert!(tokens.contains(&"brown".to_owned()));
-        assert!(tokens.contains(&"fox".to_owned()));
-        assert!(tokens.contains(&"jumps".to_owned()));
-        assert!(tokens.contains(&"over".to_owned()));
-        assert!(tokens.contains(&"dog".to_owned()));
+        assert!(tokens.contains(&Cow::Borrowed("quick")));
+        assert!(tokens.contains(&Cow::Borrowed("brown")));
+        assert!(tokens.contains(&Cow::Borrowed("fox")));
+        assert!(tokens.contains(&Cow::Borrowed("jumps")));
+        assert!(tokens.contains(&Cow::Borrowed("over")));
+        assert!(tokens.contains(&Cow::Borrowed("dog")));
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
@@ -113,7 +113,7 @@ impl MultilingualTokenizer {
     }
 }
 
-/// Applies `lowercase` to the given input, returing a cow.
+/// Applies `lowercase` to the given input, returning a cow.
 fn apply_casing<'a>(input: Cow<'a, str>, lowercase: bool) -> Cow<'a, str> {
     if lowercase {
         Cow::Owned(input.to_lowercase())


### PR DESCRIPTION
Implements the new multilingual tokenizer. In detail, this PR changes the following:

- Remove `multilingual-*` cargo features and enable multilingual by default
- Minor refactor of tokenizer to use `Cow<str>` for less cloning and easier string manipulation
- Integration of the new `MultilingualV2` tokenizer (renamed to `MultilingualTokenizer`)
- Less code duplication and other minor code improvements in the new `MultilingualTokenizer`
- End to end tests for stopwords in Japanese and Chinese tokenization test.

Due to lifetimes issues, caused by the underlying tokenization libraries, not all tokenization functions can benefit from clone-less `Cow` usage. This is kept as open TODO and could be investigated in a future PR.