### PR TITLE
Fix sq internal vector encoding

### DIFF
--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -518,14 +518,13 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
                 self.metadata.actual_dim as f32 * self.metadata.offset * self.metadata.offset
             }
         };
-        let offset_difference = if self.metadata.vector_parameters.invert {
-            -offset_difference
-        } else {
-            offset_difference
-        };
 
         let (query_offset, q_ptr) = self.get_vec_ptr(id);
-        let query_offset = query_offset + offset_difference;
+        let query_offset = if self.metadata.vector_parameters.invert {
+            query_offset + offset_difference
+        } else {
+            query_offset - offset_difference
+        };
         Some(EncodedQueryU8 {
             offset: query_offset,
             encoded_query: unsafe {

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -509,7 +509,23 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
     }
 
     fn encode_internal_vector(&self, id: u32) -> Option<EncodedQueryU8> {
+        let offset_difference = match self.metadata.vector_parameters.distance_type {
+            DistanceType::Dot => {
+                self.metadata.actual_dim as f32 * self.metadata.offset * self.metadata.offset
+            }
+            DistanceType::L1 => 0.0,
+            DistanceType::L2 => {
+                self.metadata.actual_dim as f32 * self.metadata.offset * self.metadata.offset
+            }
+        };
+        let offset_difference = if self.metadata.vector_parameters.invert {
+            -offset_difference
+        } else {
+            offset_difference
+        };
+
         let (query_offset, q_ptr) = self.get_vec_ptr(id);
+        let query_offset = query_offset + offset_difference;
         Some(EncodedQueryU8 {
             offset: query_offset,
             encoded_query: unsafe {


### PR DESCRIPTION
This PR fixes SQ accuracy lost after https://github.com/qdrant/qdrant/pull/6729.

The problem was with the calculation of the vector's `offset` value (what is the `offset` value for an SQ vector? You can find it here: https://qdrant.tech/articles/scalar-quantization/). 

This value is dirrerent between vector and query. For query (in Dot metric) it's
```
values.iter().cloned().sum::<f32>()
    * self.metadata.alpha
    * self.metadata.offset
```

For the vector it's
```
dim as f32 * offset * offset + values.iter().cloned().sum::<f32>()
    * self.metadata.alpha
    * self.metadata.offset
```

This PR fixes difference in query internal method. Test included.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
