### PR TITLE
Fix Chinese stopwords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,6 @@ dependencies = [
  "irg-kvariants",
  "jieba-rs",
  "once_cell",
- "pinyin",
  "serde",
  "slice-group-by",
  "unicode-normalization",
@@ -4142,12 +4141,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pinyin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f2611cd06a1ac239a0cea4521de9eb068a6ca110324ee00631aa68daa74fc0"
 
 [[package]]
 name = "pkg-config"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -105,7 +105,6 @@ charabia = { version = "0.9.3", default-features = false, features = [
     "thai",
     "chinese-segmentation",
     "chinese-normalization",
-    "chinese-normalization-pinyin",
 ] }
 
 gridstore = { path = "../gridstore" }

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -373,20 +373,20 @@ mod tests {
         });
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens.first(), Some(&Cow::Borrowed("jīntiān")));
-        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("shì")));
-        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("xīngqīyī")));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("今天")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("是")));
+        assert_eq!(tokens.get(2), Some(&Cow::Borrowed("星期一")));
 
         tokens.clear();
 
         // Test stopwords getting applied
         // TODO(multilingual): Chinese stopwords must be hanzi or stopword list must be in pinyin! <== Currently a bug!
-        let filter = StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["shì"])), false);
+        let filter = StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["是"])), false);
         MultilingualTokenizer::tokenize(text, true, &filter, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 2);
-        assert_eq!(tokens.first(), Some(&Cow::Borrowed("jīntiān")));
-        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("xīngqīyī")));
+        assert_eq!(tokens.first(), Some(&Cow::Borrowed("今天")));
+        assert_eq!(tokens.get(1), Some(&Cow::Borrowed("星期一")));
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -380,7 +380,6 @@ mod tests {
         tokens.clear();
 
         // Test stopwords getting applied
-        // TODO(multilingual): Chinese stopwords must be hanzi or stopword list must be in pinyin! <== Currently a bug!
         let filter = StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["是"])), false);
         MultilingualTokenizer::tokenize(text, true, &filter, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");


### PR DESCRIPTION
Depends on #6762 

This PR removes [pinyin](https://de.wikipedia.org/wiki/Pinyin) conversion (eg 中国 => ["zhong", "guo"]) in our new multilingual tokenizer implementation. This fixes Chinese stopwords, because the tokens were in pinyin but our stopword list is written with Chinese letters (so basically we did `assert!(["是", "上去", ...].contains("shì"))`) 

Since Pinyin is just the romanized phonetic version of a Chinese word, we can use the original Chinese word without loosing information about the word. We even improve precision, because multiple Chinese words can map to the same Pinyin, e.g. 忘记 and 旺季 is both `["wang", "ji"]` (https://www.quora.com/Is-pinyin-romanization-a-bijective-map).