### PR TITLE
Optimize SearchResultAggregator by hashing only once

### DIFF
--- a/lib/collection/src/collection_manager/search_result_aggregator.rs
+++ b/lib/collection/src/collection_manager/search_result_aggregator.rs
@@ -22,9 +22,8 @@ impl SearchResultAggregator {
     }
 
     pub fn push(&mut self, point: ScoredPoint) {
-        let point_id = point.id;
-        if !self.seen.contains(&point_id) {
-            self.seen.insert(point_id);
+        // track new value in `queue`
+        if self.seen.insert(point.id) {
             self.queue.push(point);
         }
     }


### PR DESCRIPTION
Tiny PR to avoid hashing a point id twice in a row.

The function is rather hot when search handles large result sets.