### PR TITLE
Create new custom shards in `Initializing` state instead of `Active`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6525,6 +6525,7 @@ dependencies = [
  "reqwest",
  "schemars",
  "segment",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -284,7 +284,7 @@ impl Collection {
 
             let results_from_shards = all_searches_res
                 .iter_mut()
-                .map(|res| mem::take(&mut res[batch_index]));
+                .map(|res| res.get_mut(batch_index).map_or(Vec::new(), mem::take));
 
             let merged_iter = match order {
                 Order::LargeBetter => Either::Left(results_from_shards.kmerge_by(|a, b| a > b)),

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -989,7 +989,7 @@ pub const fn default_exact_count() -> bool {
     true
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Default, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct CountResult {
     /// Number of points which satisfy the conditions

--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::fmt::Write as _;
 use std::ops::Deref as _;
 
@@ -56,6 +57,7 @@ impl ShardReplicaSet {
 
         let local_count = usize::from(self.peer_state(self.this_peer_id()).is_some());
         let active_local_count = usize::from(self.peer_is_active(self.this_peer_id()));
+        let initializing_local_count = usize::from(self.peer_is_initializing(self.this_peer_id()));
 
         let remotes = self.remotes.read().await;
 
@@ -66,11 +68,16 @@ impl ShardReplicaSet {
             .iter()
             .filter(|remote| self.peer_is_active(remote.peer_id))
             .count();
+        let initializing_remotes_count = remotes
+            .iter()
+            .filter(|remote| self.peer_is_initializing(remote.peer_id))
+            .count();
 
         let total_count = local_count + remotes_count;
         let active_count = active_local_count + active_remotes_count;
+        let initializing_count = initializing_local_count + initializing_remotes_count;
 
-        let (required_successful_results, condition) = match read_consistency {
+        let (mut required_successful_results, condition) = match read_consistency {
             ReadConsistency::Type(ReadConsistencyType::All) => (total_count, ResolveCondition::All),
 
             ReadConsistency::Type(ReadConsistencyType::Majority) => {
@@ -86,12 +93,19 @@ impl ShardReplicaSet {
             }
         };
 
-        if active_count < required_successful_results {
+        if active_count + initializing_count < required_successful_results {
             return Err(CollectionError::service_error(format!(
                 "The replica set for shard {} on peer {} does not have enough active replicas",
                 self.shard_id,
                 self.this_peer_id(),
             )));
+        }
+
+        if active_count < required_successful_results {
+            required_successful_results = cmp::max(
+                required_successful_results.saturating_sub(initializing_count),
+                active_count,
+            );
         }
 
         let mut responses = self

--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -116,7 +116,9 @@ impl ShardReplicaSet {
             )
             .await?;
 
-        if responses.len() == 1 {
+        if responses.is_empty() {
+            Ok(Res::default())
+        } else if responses.len() == 1 {
             Ok(responses.pop().unwrap())
         } else {
             Ok(Res::resolve(responses, condition))

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1016,9 +1016,12 @@ impl ShardReplicaSet {
             )
         );
 
-        let is_locally_disabled = self.is_locally_disabled(peer_id);
+        is_active_or_resharding && !self.is_locally_disabled(peer_id)
+    }
 
-        is_active_or_resharding && !is_locally_disabled
+    fn peer_is_initializing(&self, peer_id: PeerId) -> bool {
+        let is_initializing = matches!(self.peer_state(peer_id), Some(ReplicaState::Initializing));
+        is_initializing && !self.is_locally_disabled(peer_id)
     }
 
     fn is_locally_disabled(&self, peer_id: PeerId) -> bool {

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -27,7 +27,7 @@ impl ResolveCondition {
     }
 }
 
-pub trait Resolve: Sized {
+pub trait Resolve: Default + Sized {
     fn resolve(responses: Vec<Self>, condition: ResolveCondition) -> Self;
 }
 

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -86,6 +86,7 @@ pub struct FacetHit<T: FacetValueTrait> {
     pub count: usize,
 }
 
+#[derive(Clone, Debug, Default)]
 pub struct FacetResponse {
     pub hits: Vec<FacetValueHit>,
 }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -38,6 +38,7 @@ tar = { workspace = true }
 chrono = { workspace = true }
 validator = { workspace = true }
 dashmap = { workspace = true }
+semver = { workspace = true }
 
 # Consensus related
 atomicwrites = { workspace = true }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -192,10 +192,6 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             .collect()
     }
 
-    pub fn peers_count(&self) -> usize {
-        self.persistent.read().peer_address_by_id.read().len()
-    }
-
     pub fn first_voter(&self) -> PeerId {
         let state = self.persistent.read();
 

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -192,6 +192,10 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             .collect()
     }
 
+    pub fn peers_count(&self) -> usize {
+        self.persistent.read().peer_address_by_id.read().len()
+    }
+
     pub fn first_voter(&self) -> PeerId {
         let state = self.persistent.read();
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -625,23 +625,10 @@ impl TableOfContent {
             ReplicaState::Active
         };
 
-        let local_replicas = self
-            .get_collection_unchecked(&operation.collection_name)
+        self.get_collection_unchecked(&operation.collection_name)
             .await?
             .create_shard_key(operation.shard_key, operation.placement, init_state)
             .await?;
-
-        if use_initializing_state {
-            for shard_id in local_replicas {
-                self.send_set_replica_state_proposal(
-                    operation.collection_name.clone(),
-                    self.this_peer_id(),
-                    shard_id,
-                    ReplicaState::Active,
-                    Some(ReplicaState::Initializing),
-                )?;
-            }
-        }
 
         Ok(())
     }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use collection::collection_state;
 use collection::config::ShardingMethod;
@@ -17,6 +18,9 @@ use crate::content_manager::collections_ops::Checker as _;
 use crate::content_manager::consensus_ops::ConsensusOperations;
 use crate::content_manager::errors::StorageError;
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
+
+static CREATE_CUSTOM_SHARDS_IN_INITIALIZING_STATE: LazyLock<semver::Version> =
+    LazyLock::new(|| semver::Version::parse("1.14.2-dev").unwrap());
 
 impl TableOfContent {
     pub(super) fn perform_collection_meta_op_sync(
@@ -610,10 +614,35 @@ impl TableOfContent {
     }
 
     async fn create_shard_key(&self, operation: CreateShardKey) -> Result<(), StorageError> {
-        self.get_collection_unchecked(&operation.collection_name)
+        let use_initializing_state = self.is_distributed()
+            && self
+                .get_channel_service()
+                .all_peers_at_version(&CREATE_CUSTOM_SHARDS_IN_INITIALIZING_STATE);
+
+        let init_state = if use_initializing_state {
+            ReplicaState::Initializing
+        } else {
+            ReplicaState::Active
+        };
+
+        let local_replicas = self
+            .get_collection_unchecked(&operation.collection_name)
             .await?
-            .create_shard_key(operation.shard_key, operation.placement)
+            .create_shard_key(operation.shard_key, operation.placement, init_state)
             .await?;
+
+        if use_initializing_state {
+            for shard_id in local_replicas {
+                self.send_set_replica_state_proposal(
+                    operation.collection_name.clone(),
+                    self.this_peer_id(),
+                    shard_id,
+                    ReplicaState::Active,
+                    Some(ReplicaState::Initializing),
+                )?;
+            }
+        }
+
         Ok(())
     }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -699,7 +699,7 @@ impl Consensus {
     }
 
     fn is_single_peer(&self) -> bool {
-        self.node.store().peers_count() == 1
+        self.node.store().peer_count() == 1
     }
 
     fn is_leader(&self) -> bool {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -530,9 +530,10 @@ impl Consensus {
             // If we only sent outgoing Raft messages, but did not change any state during `on_ready`,
             // we consider Raft node to be "idle"
             if is_idle {
-                // If we received new Raft messages (i.e., we are still connected to Raft leader)
-                // and Raft node is idle, count "idle cycle"
-                if raft_messages > 0 {
+                // If current node is the only peer in the cluster, or if we received new Raft messages
+                // (i.e., we are still connected to Raft leader/peers), and Raft node is idle,
+                // count "idle cycle"
+                if raft_messages > 0 || (self.is_single_peer() && self.is_leader()) {
                     idle_cycles += 1;
                 }
             } else {
@@ -695,6 +696,14 @@ impl Consensus {
         }
 
         Ok(())
+    }
+
+    fn is_single_peer(&self) -> bool {
+        self.node.store().peers_count() == 1
+    }
+
+    fn is_leader(&self) -> bool {
+        self.node.status().ss.raft_state == raft::StateRole::Leader
     }
 
     fn try_sync_local_state(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
Currently, new custom shards are initialized directly in `Active` state. In this case peer A (that did not receive custom shard replica) might expect replica to already exist on peer B, but peer B might still be initializing local replica of new custom shard. This leads to annoying errors during search while custom shard is being created.

This PR tries to mitigate this by initializing replicas in `Inititalizing` state (so that each peer would not assume that remote replicas are *instantly* available) and then switching each replica into `Active` state after it's initialized.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
