### PR TITLE
[text index] don't optimize when loading a mmap-backed immutable index

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -125,8 +125,6 @@ impl ImmutableFullTextIndex {
         };
         self.inverted_index = ImmutableInvertedIndex::from(&index.inverted_index);
 
-        index.inverted_index.clear_cache()?;
-
         // Index is now loaded into memory, clear cache of backing mmap storage
         if let Err(err) = index.clear_cache() {
             log::warn!("Failed to clear mmap cache of ram mmap full text index: {err}");

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -125,6 +125,8 @@ impl ImmutableFullTextIndex {
         };
         self.inverted_index = ImmutableInvertedIndex::from(&index.inverted_index);
 
+        index.inverted_index.clear_cache()?;
+
         // Index is now loaded into memory, clear cache of backing mmap storage
         if let Err(err) = index.clear_cache() {
             log::warn!("Failed to clear mmap cache of ram mmap full text index: {err}");

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mmap_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mmap_postings.rs
@@ -309,7 +309,9 @@ impl<V: MmapPostingValue> MmapPostings<V> {
     pub fn iter_postings<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
-    ) -> impl Iterator<Item = Option<PostingListView<'a, V>>> {
-        (0..self.header.posting_count as u32).map(|posting_idx| self.get(posting_idx, hw_counter))
+    ) -> impl Iterator<Item = PostingListView<'a, V>> {
+        (0..self.header.posting_count as u32)
+            // we are iterating over existing posting lists, all of them should return `Some`
+            .filter_map(|posting_idx| self.get(posting_idx, hw_counter))
     }
 }


### PR DESCRIPTION
In `dev`, loading a mmap-backed immutable index involved optimizing in the same way as when mutable turns immutable. This removed posting lists which have no items, and tries to reduce vocabulary size.

However, in the case of mmap->immutable, I don't think this is critical, and requires practically rebuilding the index on load. 

This PR, makes it possible to just turn the mmap structures into in-memory immutable ones by copying the content.