### PR TITLE
add flag to break optimization loop on panic

### DIFF
--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -336,8 +336,8 @@ impl UpdateHandler {
 
                 let permit_callback = callback.clone();
 
-                permit.set_on_release(move || {
-                    // Notify scheduler that resource budget changed
+                permit.set_on_manual_release(move || {
+                    // Notify scheduler that resource budget is explicitly changed
                     permit_callback(false);
                 });
 


### PR DESCRIPTION
Currently if optimization panics, we can stuck in the loop of failures.
This PR should fix (improve) the endless loop problem.

Actual problem is

```
                permit.set_on_release(move || {
                    // Notify scheduler that resource budget changed
                    permit_callback(false);
                });
```

Which re-tries optimization unconditionally, even if permit was dropped because of panic.

What this PR does:

- Creates a flag to interrupt optimizer loop if optimization fails (this is not actually triggered in experiment, as loop exists before process can start, but still good to have as an extra safety)
- Changes behavior of `on_release` -> `on_manual_release`, to prevent triggering of the callback if permit was destroyed on error. Only explicit release for permission change counts now 
- Moves the check for available disk size before creation of the temp segment, prevents heavy segment operation in the loop.


Behavior after PR:

- Optimizer is still looped after panic, but now it is only 1 oteration in 5 seconds, which I think is Ok.
- Optimization with failed disk check doesn't create new segments anymore
