### PR TITLE
Deleted leftover test openapi collections

### DIFF
--- a/tests/openapi/test_discovery.py
+++ b/tests/openapi/test_discovery.py
@@ -35,10 +35,12 @@ def count_ids_in_examples(context, target) -> int:
 
 
 @pytest.fixture(autouse=True, scope="module")
-def setup(on_disk_vectors, collection_name):
+def setup(on_disk_vectors, collection_name, collection_name_lookup):
     basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
     yield
     drop_collection(collection_name=collection_name)
+    # delete potential lookup_collection as well
+    drop_collection(collection_name=collection_name_lookup)
 
 
 # Context is when we don't include a target vector

--- a/tests/openapi/test_init_from_collection.py
+++ b/tests/openapi/test_init_from_collection.py
@@ -19,7 +19,7 @@ def set_serializer(source_collection_name):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def setup(collection_name):
+def setup(collection_name, source_collection_name):
     yield
     drop_collection(collection_name=collection_name)
     drop_collection(collection_name=source_collection_name)

--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 
 from .helpers.collection_setup import drop_collection
 from .helpers.helpers import request_with_validation

--- a/tests/openapi/test_multicollection_reco.py
+++ b/tests/openapi/test_multicollection_reco.py
@@ -9,10 +9,12 @@ def collection_name2(collection_name):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def setup(on_disk_vectors, collection_name):
+def setup(on_disk_vectors, collection_name, collection_name2):
     basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
     yield
     drop_collection(collection_name=collection_name)
+    # delete potential auxiliary collection as well
+    drop_collection(collection_name=collection_name2)
 
 
 def test_recommend_with_wrong_vector_size(on_disk_vectors, collection_name, collection_name2):

--- a/tests/openapi/test_query_full.py
+++ b/tests/openapi/test_query_full.py
@@ -18,7 +18,7 @@ def lookup_collection_name(collection_name):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def setup(on_disk_vectors, collection_name):
+def setup(on_disk_vectors, collection_name, lookup_collection_name):
     full_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
 
     # keyword index on `city`
@@ -75,6 +75,8 @@ def setup(on_disk_vectors, collection_name):
 
     yield
     drop_collection(collection_name=collection_name)
+    # delete potential lookup_collection as well
+    drop_collection(collection_name=lookup_collection_name)
 
 
 def root_and_rescored_query(collection_name, query, using, filter=None, limit=None, with_payload=None):


### PR DESCRIPTION
This PR removes all the leftover collections after running the `openapi` tests.