### PR TITLE
Optimize payload filtering to avoid redundant matching

### DIFF
--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -458,8 +458,9 @@ impl StructPayloadIndex {
                 Some(move |id| struct_filtered_context.check(id))
             };
 
-            // add a full scan from id_tracker to compensate unhandled conditions
+            // If even one iterator is None, we should replace the whole thing with an iterator over all ids.
             if require_full_scan_fallback {
+                primary_iters.clear();
                 let full_scan = Box::new(id_tracker.iter_ids().measure_hw_with_cell(
                     hw_counter,
                     size_of::<PointOffsetType>(),


### PR DESCRIPTION
Detects when the primary clause covers all necessary ids to avoid performing an additional matching.

This speeds up all payload filter requests with a single condition that is being used as a primary clause.

In a future PR I want to investigate a more generalized approach that works when there is more than one condition.