### PR TITLE
GraphLayersHealer: use quantized vectors

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -394,7 +394,8 @@ impl HNSWIndex {
                     config.ef_construct,
                 );
                 let old_vector_storage = old_index.index.vector_storage.borrow();
-                healer.heal(&pool, &old_vector_storage)?;
+                let old_quantized_vectors = old_index.index.quantized_vectors.borrow();
+                healer.heal(&pool, &old_vector_storage, old_quantized_vectors.as_ref())?;
                 healer.save_into_builder(&graph_layers_builder);
 
                 for vector_id in ids_iter {


### PR DESCRIPTION
This PR updates `GraphLayersHealer::heal()` to use quantized vectors when available.

Found during profiling: when memory is low, regular vectors are getting evicted from the disk cache, and the healing process performs a lot of IOPS to retrieve vectors.

Since we use quantized vectors during the regular HNSW build, we'd need the similar for the healing.