### PR TITLE
bump tower-http-0.6.6 (0.6.5 yanked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,9 +6728,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",


### PR DESCRIPTION
Tower-http 0.6.5 was yanked a month ago due to a panic in header management.

https://github.com/tower-rs/tower-http/releases/tag/tower-http-0.6.6
https://crates.io/crates/tower-http/versions