### PR TITLE
Fix bug that causes all replicas to die if node is restarted during resharding

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -240,7 +240,7 @@ impl Collection {
 
                 // ...and cancel transfer tasks and remove transfers from internal state
                 for transfer in transfers {
-                    self.abort_shard_transfer(transfer.key(), Some(&shard_holder))
+                    self.abort_shard_transfer_and_resharding(transfer.key(), Some(&shard_holder))
                         .await?;
                 }
             }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -477,7 +477,8 @@ impl Collection {
 
             // Terminate transfer if source or target replicas are now dead
             for transfer in related_transfers {
-                self.abort_shard_transfer(transfer.key(), None).await?;
+                self.abort_shard_transfer_and_resharding(transfer.key(), None)
+                    .await?;
             }
 
             // Propagate resharding errors now
@@ -582,7 +583,8 @@ impl Collection {
         }
 
         for transfer in self.get_related_transfers(peer_id).await {
-            self.abort_shard_transfer(transfer.key(), None).await?;
+            self.abort_shard_transfer_and_resharding(transfer.key(), None)
+                .await?;
         }
 
         self.shards_holder

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -216,12 +216,9 @@ impl Collection {
 
         // Abort all resharding transfer related to this specific resharding operation
         let resharding_transfers =
-            shard_holder.get_transfers(|t| t.is_specific_resharding(&resharding_key));
+            shard_holder.get_transfers(|t| t.is_related_to_resharding(&resharding_key));
         for transfer in resharding_transfers {
-            let _is_resharding_transfer = self
-                .abort_shard_transfer_and_report_resharding(transfer.key(), &shard_holder)
-                .await?;
-            // We don't need to abort resharding again since we are already aborting it
+            self.abort_shard_transfer(transfer, &shard_holder).await?;
         }
 
         drop(shard_holder); // drop the read lock before acquiring write lock

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -251,8 +251,10 @@ impl Collection {
         let resharding_transfers = shard_holder
             .get_transfers(|t| t.method == Some(ShardTransferMethod::ReshardingStreamRecords));
         for transfer in resharding_transfers {
-            self.abort_shard_transfer(transfer.key(), Some(&shard_holder))
+            let _is_resharding_transfer = self
+                .abort_shard_transfer_and_report_resharding(transfer.key(), &shard_holder)
                 .await?;
+            // We don't need to abort resharding again since we are already aborting it in next step
         }
 
         shard_holder

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -181,7 +181,7 @@ impl Collection {
             "Invalidating local cleanup tasks and aborting resharding {resharding_key} (force: {force})"
         );
 
-        let mut shard_holder = self.shards_holder.write().await;
+        let shard_holder = self.shards_holder.read().await;
 
         if !force {
             shard_holder.check_abort_resharding(&resharding_key)?;
@@ -256,6 +256,9 @@ impl Collection {
                 .await?;
             // We don't need to abort resharding again since we are already aborting it in next step
         }
+
+        drop(shard_holder); // drop the read lock before acquiring write lock
+        let mut shard_holder = self.shards_holder.write().await;
 
         shard_holder
             .abort_resharding(resharding_key.clone(), force, is_in_progress)

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -222,7 +222,7 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn check_abort_resharding(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
+    pub fn check_abort_resharding(&self, resharding_key: &ReshardKey) -> CollectionResult<()> {
         let state = self.resharding_state.read();
 
         // - do not abort if no resharding operation is ongoing

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -57,8 +57,12 @@ impl ShardTransfer {
         }
     }
 
+    pub fn is_resharding(&self) -> bool {
+        self.method.is_some_and(|method| method.is_resharding())
+    }
+
     /// Check if this transfer is related to a specific resharding operation
-    pub fn is_specific_resharding(&self, key: &ReshardKey) -> bool {
+    pub fn is_related_to_resharding(&self, key: &ReshardKey) -> bool {
         // Must be a resharding transfer
         if !self.method.is_some_and(|method| method.is_resharding()) {
             return false;

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -591,7 +591,9 @@ impl TableOfContent {
                     &collection.state().await.transfers,
                 )?;
                 log::warn!("Aborting shard transfer: {reason}");
-                collection.abort_shard_transfer(transfer, None).await?;
+                collection
+                    .abort_shard_transfer_and_resharding(transfer, None)
+                    .await?;
             }
         };
         Ok(())


### PR DESCRIPTION
Fixing the bug found in chaos testing debug cluster (reproduced in a test [here](https://github.com/qdrant/cluster-manager/pull/345)). It led to a scenario where all the replicas of a shard get marked as Dead on all nodes and they can't recover from each other since every replica is Dead. The root cause was  exactly what I hypothesised [here](https://github.com/qdrant/qdrant/pull/6771#issuecomment-3013167593). 

Put simply if you:
- Have resharding shard streaming transfer between: n1 shard 3 -> n2 shard 2
- Then if node n0 dies and also had an `Resharding/ReshardingScaleDown` replica (say shard 1), we abort resharding and abort any streaming resharding transfers related to n0 (but we don't abort the above mentioned n1:3 -> n2:2 transfer)
- When the n1:3 -> n2:2 is finished, every node sees that resharding isn't ongoing anymore and hence each node marks their Shard 2 as Dead
- Optional: Even if n0 now comes back online, it will also redo the same operation and also mark it's shard 2 as Dead (if it exists locally)

This PR adds a simple fix that after ensuring basic checks (like the cluster hasn't gone beyond `ReadHashRingCommitted` resharding stage), it will abort any resharding transfer (`method == ReshardingStreamRecords`) ongoing in the cluster.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
