### PR TITLE
Change retain to extract_if where we depend on retain result

### DIFF
--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -376,11 +376,9 @@ impl ShardHolder {
     }
 
     pub fn register_finish_transfer(&self, key: &ShardTransferKey) -> CollectionResult<bool> {
-        let any_removed = self.shard_transfers.write(|transfers| {
-            let before_remove = transfers.len();
-            transfers.retain(|transfer| !key.check(transfer));
-            before_remove != transfers.len()
-        })?;
+        let any_removed = self
+            .shard_transfers
+            .write(|transfers| transfers.extract_if(|transfer| key.check(transfer)).count() > 0)?;
         let _ = self
             .shard_transfer_changes
             .send(ShardTransferChange::Finish(*key));
@@ -388,11 +386,9 @@ impl ShardHolder {
     }
 
     pub fn register_abort_transfer(&self, key: &ShardTransferKey) -> CollectionResult<bool> {
-        let any_removed = self.shard_transfers.write(|transfers| {
-            let before_remove = transfers.len();
-            transfers.retain(|transfer| !key.check(transfer));
-            before_remove != transfers.len()
-        })?;
+        let any_removed = self
+            .shard_transfers
+            .write(|transfers| transfers.extract_if(|transfer| key.check(transfer)).count() > 0)?;
         let _ = self
             .shard_transfer_changes
             .send(ShardTransferChange::Abort(*key));

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -162,13 +162,11 @@ impl Persistent {
     fn remove_unknown_peer_metadata(&self) -> Result<(), StorageError> {
         let is_updated = {
             let mut peer_metadata = self.peer_metadata_by_id.write();
-            let peer_metadata_len = peer_metadata.len();
-
             let peer_address = self.peer_address_by_id.read();
-            peer_metadata.retain(|peer_id, _| peer_address.contains_key(peer_id));
-
-            // Check, if peer metadata was updated
-            peer_metadata_len != peer_metadata.len()
+            peer_metadata
+                .extract_if(|peer_id, _| !peer_address.contains_key(peer_id))
+                .count()
+                > 0
         };
 
         if is_updated {


### PR DESCRIPTION
Something very minor I came across in our code base.

Change [`retain`](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.retain) to [`extract_if`](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.extract_if), in cases where we rely on whether retain has removed any items.

This prevents storing the original list length and checking if it has changed, by just checking whether `extract_if` had extracted any items at all.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
