### PR TITLE
Fix duplicates in hardware counter metrics

### DIFF
--- a/lib/api/src/rest/models.rs
+++ b/lib/api/src/rest/models.rs
@@ -76,7 +76,7 @@ fn is_usage_none_or_empty(u: &Option<Usage>) -> bool {
 }
 
 /// Usage of the hardware resources, spent to process the request
-#[derive(Debug, Serialize, JsonSchema, Anonymize, Clone)]
+#[derive(Debug, Default, Serialize, JsonSchema, Anonymize, Clone)]
 #[serde(rename_all = "snake_case")]
 #[anonymize(false)]
 pub struct HardwareUsage {

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -324,74 +324,78 @@ impl MetricsProvider for MemoryTelemetry {
     }
 }
 
+impl HardwareTelemetry {
+    // Helper function to create counter metrics of a single Hw type, like cpu.
+    pub(crate) fn make_metric_counters<F: Fn(&HardwareUsage) -> usize>(&self, f: F) -> Vec<Metric> {
+        self.collection_data
+            .iter()
+            .map(|i| counter(f(i.1) as f64, &[("id", i.0)]))
+            .collect::<Vec<_>>()
+    }
+}
+
 impl MetricsProvider for HardwareTelemetry {
     fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
-        for (collection, hw_info) in self.collection_data.iter() {
-            let HardwareUsage {
-                cpu,
-                payload_io_read,
-                payload_io_write,
-                payload_index_io_read,
-                payload_index_io_write,
-                vector_io_read,
-                vector_io_write,
-            } = hw_info;
+        // Keep a dummy type decomposition of HwUsage here to ensure new fields must be covered.
+        // This gets optimized away by the compiler: https://godbolt.org/z/9cMTzcYr4
+        let HardwareUsage {
+            cpu: _,
+            payload_io_read: _,
+            payload_io_write: _,
+            payload_index_io_read: _,
+            payload_index_io_write: _,
+            vector_io_read: _,
+            vector_io_write: _,
+        } = HardwareUsage::default();
 
-            metrics.push(metric_family(
-                "collection_hardware_metric_cpu",
-                "CPU measurements of a collection",
-                MetricType::COUNTER,
-                vec![counter(*cpu as f64, &[("id", collection)])],
-            ));
+        metrics.push(metric_family(
+            "collection_hardware_metric_cpu",
+            "CPU measurements of a collection",
+            MetricType::COUNTER,
+            self.make_metric_counters(|hw| hw.cpu),
+        ));
 
-            metrics.push(metric_family(
-                "collection_hardware_metric_payload_io_read",
-                "Total IO payload read metrics of a collection",
-                MetricType::COUNTER,
-                vec![counter(*payload_io_read as f64, &[("id", collection)])],
-            ));
+        metrics.push(metric_family(
+            "collection_hardware_metric_payload_io_read",
+            "Total IO payload read metrics of a collection",
+            MetricType::COUNTER,
+            self.make_metric_counters(|hw| hw.payload_io_read),
+        ));
 
-            metrics.push(metric_family(
-                "collection_hardware_metric_payload_index_io_read",
-                "Total IO payload index read metrics of a collection",
-                MetricType::COUNTER,
-                vec![counter(
-                    *payload_index_io_read as f64,
-                    &[("id", collection)],
-                )],
-            ));
+        metrics.push(metric_family(
+            "collection_hardware_metric_payload_index_io_read",
+            "Total IO payload index read metrics of a collection",
+            MetricType::COUNTER,
+            self.make_metric_counters(|hw| hw.payload_index_io_read),
+        ));
 
-            metrics.push(metric_family(
-                "collection_hardware_metric_payload_index_io_write",
-                "Total IO payload index write metrics of a collection",
-                MetricType::COUNTER,
-                vec![counter(
-                    *payload_index_io_write as f64,
-                    &[("id", collection)],
-                )],
-            ));
+        metrics.push(metric_family(
+            "collection_hardware_metric_payload_index_io_write",
+            "Total IO payload index write metrics of a collection",
+            MetricType::COUNTER,
+            self.make_metric_counters(|hw| hw.payload_index_io_write),
+        ));
 
-            metrics.push(metric_family(
-                "collection_hardware_metric_payload_io_write",
-                "Total IO payload write metrics of a collection",
-                MetricType::COUNTER,
-                vec![counter(*payload_io_write as f64, &[("id", collection)])],
-            ));
+        metrics.push(metric_family(
+            "collection_hardware_metric_payload_io_write",
+            "Total IO payload write metrics of a collection",
+            MetricType::COUNTER,
+            self.make_metric_counters(|hw| hw.payload_io_write),
+        ));
 
-            metrics.push(metric_family(
-                "collection_hardware_metric_vector_io_read",
-                "Total IO vector read metrics of a collection",
-                MetricType::COUNTER,
-                vec![counter(*vector_io_read as f64, &[("id", collection)])],
-            ));
+        metrics.push(metric_family(
+            "collection_hardware_metric_vector_io_read",
+            "Total IO vector read metrics of a collection",
+            MetricType::COUNTER,
+            self.make_metric_counters(|hw| hw.vector_io_read),
+        ));
 
-            metrics.push(metric_family(
-                "collection_hardware_metric_vector_io_write",
-                "Total IO vector write metrics of a collection",
-                MetricType::COUNTER,
-                vec![counter(*vector_io_write as f64, &[("id", collection)])],
-            ));
-        }
+        metrics.push(metric_family(
+            "collection_hardware_metric_vector_io_write",
+            "Total IO vector write metrics of a collection",
+            MetricType::COUNTER,
+            self.make_metric_counters(|hw| hw.vector_io_write),
+        ));
     }
 }
 

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -326,17 +326,17 @@ impl MetricsProvider for MemoryTelemetry {
 
 impl HardwareTelemetry {
     // Helper function to create counter metrics of a single Hw type, like cpu.
-    pub(crate) fn make_metric_counters<F: Fn(&HardwareUsage) -> usize>(&self, f: F) -> Vec<Metric> {
+    fn make_metric_counters<F: Fn(&HardwareUsage) -> usize>(&self, f: F) -> Vec<Metric> {
         self.collection_data
             .iter()
-            .map(|i| counter(f(i.1) as f64, &[("id", i.0)]))
-            .collect::<Vec<_>>()
+            .map(|(collection_id, hw_usage)| counter(f(hw_usage) as f64, &[("id", collection_id)]))
+            .collect()
     }
 }
 
 impl MetricsProvider for HardwareTelemetry {
     fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
-        // Keep a dummy type decomposition of HwUsage here to ensure new fields must be covered.
+        // Keep a dummy type decomposition of HwUsage here to enforce coverage of new fields in metrics.
         // This gets optimized away by the compiler: https://godbolt.org/z/9cMTzcYr4
         let HardwareUsage {
             cpu: _,


### PR DESCRIPTION
Fixes #6793

Before we created a new prometheus-counter for each collection.
Now we create only one counter with multiple values which is the correct approach.

Linting verified using https://o11y.tools/metricslint/