### PR TITLE
Optimize has_id with ahash

### DIFF
--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use ahash::AHashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -109,7 +110,7 @@ impl StructPayloadIndex {
             }
             // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
             Condition::HasId(has_id) => {
-                let segment_ids: HashSet<_> = has_id
+                let segment_ids: AHashSet<_> = has_id
                     .has_id
                     .iter()
                     .filter_map(|external_id| id_tracker.internal_id(*external_id))

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use ahash::AHashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -183,7 +183,7 @@ impl StructPayloadIndex {
                 })
             }
             Condition::CustomIdChecker(cond) => {
-                let segment_ids: HashSet<_> = id_tracker
+                let segment_ids: AHashSet<_> = id_tracker
                     .iter_external()
                     .filter(|&point_id| cond.check(point_id))
                     .filter_map(|external_id| id_tracker.internal_id(external_id))


### PR DESCRIPTION
This `has_id` implementation is is a prime candidate for `AHashSet` because it tests the membership in a set of `u32`.

With some naive benchmarking, I get a 10% latency improvements on large distance matrix requests.

e.g.

```http
POST /collections/benchmark/points/search/matrix/pairs
{
  "sample": 500,
  "limit": 1000
}
```