### PR TITLE
Enable Gridstore in mutable payload indices, don't eagerly create storage

### DIFF
--- a/lib/segment/benches/boolean_filtering.rs
+++ b/lib/segment/benches/boolean_filtering.rs
@@ -104,6 +104,7 @@ pub fn keyword_index_boolean_query_points(c: &mut Criterion) {
         std::collections::HashMap::new(),
         dir.path(),
         true,
+        true,
     )
     .unwrap();
 

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -68,6 +68,7 @@ fn range_filtering(c: &mut Criterion) {
         std::collections::HashMap::new(),
         dir.path(),
         true,
+        true,
     )
     .unwrap();
 
@@ -129,6 +130,7 @@ fn range_filtering(c: &mut Criterion) {
         std::collections::HashMap::new(),
         dir.path(),
         false,
+        true,
     )
     .unwrap();
 

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -54,6 +54,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
         std::collections::HashMap::new(),
         payload_dir.path(),
         true,
+        true,
     )
     .unwrap();
     let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -263,6 +263,7 @@ pub fn create_struct_payload_index(
         std::collections::HashMap::new(),
         path,
         true,
+        true,
     )
     .unwrap();
 

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -47,6 +47,7 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
         std::collections::HashMap::new(),
         payload_dir,
         true,
+        true,
     )?;
     let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -38,7 +38,7 @@ pub struct MutableFullTextIndex {
 pub(super) enum Storage {
     #[cfg(feature = "rocksdb")]
     RocksDb(DatabaseColumnScheduledDeleteWrapper),
-    Gridstore(Arc<RwLock<Gridstore<Vec<u8>>>>),
+    Gridstore(Option<Arc<RwLock<Gridstore<Vec<u8>>>>>),
 }
 
 impl MutableFullTextIndex {
@@ -63,12 +63,33 @@ impl MutableFullTextIndex {
     /// Open mutable full text index from Gridstore storage
     ///
     /// Note: after opening, the data must be loaded into memory separately using [`load`].
-    pub fn open_gridstore(path: PathBuf, config: TextIndexParams) -> OperationResult<Self> {
-        let store = Gridstore::open_or_create(path, GRIDSTORE_OPTIONS).map_err(|err| {
-            OperationError::service_error(format!(
-                "failed to open mutable full text index on gridstore: {err}"
-            ))
-        })?;
+    ///
+    /// The `create` parameter indicates whether to create a new Gridstore if it does not exist. If
+    /// false and files don't exist, the load function will indicate nothing could be loaded.
+    pub fn open_gridstore(
+        path: PathBuf,
+        config: TextIndexParams,
+        create: bool,
+    ) -> OperationResult<Self> {
+        let store = if create {
+            Some(Arc::new(RwLock::new(
+                Gridstore::open_or_create(path, GRIDSTORE_OPTIONS).map_err(|err| {
+                    OperationError::service_error(format!(
+                        "failed to open mutable full text index on gridstore: {err}"
+                    ))
+                })?,
+            )))
+        } else if path.exists() {
+            Some(Arc::new(RwLock::new(Gridstore::open(path).map_err(
+                |err| {
+                    OperationError::service_error(format!(
+                        "failed to open mutable full text index on gridstore: {err}"
+                    ))
+                },
+            )?)))
+        } else {
+            None
+        };
 
         let phrase_matching = config.phrase_matching.unwrap_or_default();
         let tokenizer = Tokenizer::new(&config);
@@ -76,7 +97,7 @@ impl MutableFullTextIndex {
         Ok(Self {
             inverted_index: MutableInvertedIndex::new(phrase_matching),
             config,
-            storage: Storage::Gridstore(Arc::new(RwLock::new(store))),
+            storage: Storage::Gridstore(store),
             tokenizer,
         })
     }
@@ -88,7 +109,8 @@ impl MutableFullTextIndex {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(_) => self.load_rocksdb(),
-            Storage::Gridstore(_) => self.load_gridstore(),
+            Storage::Gridstore(Some(_)) => self.load_gridstore(),
+            Storage::Gridstore(None) => Ok(false),
         }
     }
 
@@ -124,8 +146,7 @@ impl MutableFullTextIndex {
     ///
     /// Loads in-memory index from Gridstore storage.
     fn load_gridstore(&mut self) -> OperationResult<bool> {
-        #[allow(irrefutable_let_patterns)]
-        let Storage::Gridstore(store) = &self.storage else {
+        let Storage::Gridstore(Some(store)) = &self.storage else {
             return Err(OperationError::service_error(
                 "Failed to load index from Gridstore, using different storage backend",
             ));
@@ -162,11 +183,14 @@ impl MutableFullTextIndex {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.recreate_column_family(),
-            Storage::Gridstore(store) => store.write().clear().map_err(|err| {
+            Storage::Gridstore(Some(store)) => store.write().clear().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to clear mutable full text index: {err}",
                 ))
             }),
+            Storage::Gridstore(None) => Err(OperationError::service_error(
+                "Failed to init full text index, backing Gridstore storage does not exist",
+            )),
         }
     }
 
@@ -175,11 +199,12 @@ impl MutableFullTextIndex {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
-            Storage::Gridstore(store) => store.write().clear().map_err(|err| {
+            Storage::Gridstore(Some(store)) => store.write().clear().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to clear mutable full text index: {err}",
                 ))
             }),
+            Storage::Gridstore(None) => Ok(()),
         }
     }
 
@@ -191,11 +216,12 @@ impl MutableFullTextIndex {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(_) => Ok(()),
-            Storage::Gridstore(index) => index.read().clear_cache().map_err(|err| {
+            Storage::Gridstore(Some(index)) => index.read().clear_cache().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to clear mutable full text index gridstore cache: {err}"
                 ))
             }),
+            Storage::Gridstore(None) => Ok(()),
         }
     }
 
@@ -204,7 +230,8 @@ impl MutableFullTextIndex {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(_) => vec![],
-            Storage::Gridstore(store) => store.read().files(),
+            Storage::Gridstore(Some(store)) => store.read().files(),
+            Storage::Gridstore(None) => vec![],
         }
     }
 
@@ -213,7 +240,7 @@ impl MutableFullTextIndex {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
-            Storage::Gridstore(store) => {
+            Storage::Gridstore(Some(store)) => {
                 let store = store.clone();
                 Box::new(move || {
                     store.read().flush().map_err(|err| {
@@ -223,6 +250,7 @@ impl MutableFullTextIndex {
                     })
                 })
             }
+            Storage::Gridstore(None) => Box::new(|| Ok(())),
         }
     }
 
@@ -274,7 +302,7 @@ impl MutableFullTextIndex {
                 let db_idx = FullTextIndex::store_key(idx);
                 db_wrapper.put(db_idx, db_document)?;
             }
-            Storage::Gridstore(store) => {
+            Storage::Gridstore(Some(store)) => {
                 store
                     .write()
                     .put_value(
@@ -287,6 +315,11 @@ impl MutableFullTextIndex {
                             "failed to put value in mutable full text index gridstore: {err}"
                         ))
                     })?;
+            }
+            Storage::Gridstore(None) => {
+                return Err(OperationError::service_error(
+                    "Failed to add values to mutable full text index, backing Gridstore storage does not exist",
+                ));
             }
         }
 
@@ -304,10 +337,15 @@ impl MutableFullTextIndex {
                     db_wrapper.remove(db_doc_id)?;
                 }
             }
-            Storage::Gridstore(store) => {
+            Storage::Gridstore(Some(store)) => {
                 if self.inverted_index.remove(id) {
                     store.write().delete_value(id);
                 }
+            }
+            Storage::Gridstore(None) => {
+                return Err(OperationError::service_error(
+                    "Failed to remove values to mutable full text index, backing Gridstore storage does not exist",
+                ));
             }
         }
 
@@ -327,6 +365,8 @@ impl MutableFullTextIndex {
                 .unwrap()
             }
             Storage::Gridstore(gridstore) => gridstore
+                .as_ref()
+                .expect("Gridstore should be initialized")
                 .read()
                 .get_value(idx, &HardwareCounterCell::disposable())
                 .map(|bytes| FullTextIndex::deserialize_document(&bytes).unwrap()),
@@ -408,7 +448,7 @@ mod tests {
 
         {
             let mut index =
-                FullTextIndex::new_gridstore(temp_dir.path().join("test_db"), config.clone())
+                FullTextIndex::new_gridstore(temp_dir.path().join("test_db"), config.clone(), true)
                     .unwrap();
             let loaded = index.load().unwrap();
             assert!(loaded);
@@ -479,7 +519,8 @@ mod tests {
 
         {
             let mut index =
-                FullTextIndex::new_gridstore(temp_dir.path().join("test_db"), config).unwrap();
+                FullTextIndex::new_gridstore(temp_dir.path().join("test_db"), config, true)
+                    .unwrap();
             let loaded = index.load().unwrap();
             assert!(loaded);
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -64,14 +64,15 @@ impl MutableFullTextIndex {
     ///
     /// Note: after opening, the data must be loaded into memory separately using [`load`].
     ///
-    /// The `create` parameter indicates whether to create a new Gridstore if it does not exist. If
-    /// false and files don't exist, the load function will indicate nothing could be loaded.
+    /// The `create_if_missing` parameter indicates whether to create a new Gridstore if it does
+    /// not exist. If false and files don't exist, the load function will indicate nothing could be
+    /// loaded.
     pub fn open_gridstore(
         path: PathBuf,
         config: TextIndexParams,
-        create: bool,
+        create_if_missing: bool,
     ) -> OperationResult<Self> {
-        let store = if create {
+        let store = if create_if_missing {
             Some(Arc::new(RwLock::new(
                 Gridstore::open_or_create(path, GRIDSTORE_OPTIONS).map_err(|err| {
                     OperationError::service_error(format!(

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -167,7 +167,7 @@ fn test_prefix_search() {
     };
 
     let mut index =
-        FullTextIndex::new_gridstore(temp_dir.path().to_path_buf(), config.clone()).unwrap();
+        FullTextIndex::new_gridstore(temp_dir.path().to_path_buf(), config.clone(), true).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -76,9 +76,13 @@ impl FullTextIndex {
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf, config: TextIndexParams) -> OperationResult<Self> {
+    pub fn new_gridstore(
+        dir: PathBuf,
+        config: TextIndexParams,
+        create: bool,
+    ) -> OperationResult<Self> {
         Ok(Self::Mutable(MutableFullTextIndex::open_gridstore(
-            dir, config,
+            dir, config, create,
         )?))
     }
 
@@ -640,6 +644,7 @@ impl FieldIndexBuilderTrait for FullTextGridstoreIndexBuilder {
         self.index.replace(FullTextIndex::new_gridstore(
             self.dir.clone(),
             self.config.clone(),
+            true,
         )?);
         Ok(())
     }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -79,10 +79,12 @@ impl FullTextIndex {
     pub fn new_gridstore(
         dir: PathBuf,
         config: TextIndexParams,
-        create: bool,
+        create_if_missing: bool,
     ) -> OperationResult<Self> {
         Ok(Self::Mutable(MutableFullTextIndex::open_gridstore(
-            dir, config, create,
+            dir,
+            config,
+            create_if_missing,
         )?))
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -72,9 +72,10 @@ impl GeoMapIndex {
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
+    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
         Ok(GeoMapIndex::Mutable(MutableGeoMapIndex::open_gridstore(
-            dir, create,
+            dir,
+            create_if_missing,
         )?))
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -72,9 +72,9 @@ impl GeoMapIndex {
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf) -> OperationResult<Self> {
+    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
         Ok(GeoMapIndex::Mutable(MutableGeoMapIndex::open_gridstore(
-            dir,
+            dir, create,
         )?))
     }
 
@@ -585,7 +585,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexGridstoreBuilder {
             "index must be initialized exactly once",
         );
         self.index
-            .replace(GeoMapIndex::new_gridstore(self.dir.clone())?);
+            .replace(GeoMapIndex::new_gridstore(self.dir.clone(), true)?);
         Ok(())
     }
 
@@ -1466,7 +1466,7 @@ mod tests {
             #[cfg(feature = "rocksdb")]
             IndexType::Mutable => GeoMapIndex::new_memory(db, FIELD_NAME, true),
             IndexType::MutableGridstore => {
-                GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf()).unwrap()
+                GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf(), true).unwrap()
             }
             #[cfg(feature = "rocksdb")]
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),
@@ -1547,7 +1547,7 @@ mod tests {
             #[cfg(feature = "rocksdb")]
             IndexType::Mutable => GeoMapIndex::new_memory(db, FIELD_NAME, true),
             IndexType::MutableGridstore => {
-                GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf()).unwrap()
+                GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf(), true).unwrap()
             }
             #[cfg(feature = "rocksdb")]
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -94,10 +94,11 @@ impl MutableGeoMapIndex {
     ///
     /// Note: after opening, the data must be loaded into memory separately using [`load`].
     ///
-    /// The `create` parameter indicates whether to create a new Gridstore if it does not exist. If
-    /// false and files don't exist, the load function will indicate nothing could be loaded.
-    pub fn open_gridstore(path: PathBuf, create: bool) -> OperationResult<Self> {
-        let store = if create {
+    /// The `create_if_missing` parameter indicates whether to create a new Gridstore if it does
+    /// not exist. If false and files don't exist, the load function will indicate nothing could be
+    /// loaded.
+    pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
+        let store = if create_if_missing {
             Some(Arc::new(RwLock::new(
                 Gridstore::open_or_create(path, GRIDSTORE_OPTIONS).map_err(|err| {
                     OperationError::service_error(format!(

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -130,8 +130,10 @@ where
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf) -> OperationResult<Self> {
-        Ok(MapIndex::Mutable(MutableMapIndex::open_gridstore(dir)?))
+    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
+        Ok(MapIndex::Mutable(MutableMapIndex::open_gridstore(
+            dir, create,
+        )?))
     }
 
     #[cfg(feature = "rocksdb")]
@@ -655,7 +657,7 @@ where
             "index must be initialized exactly once",
         );
         self.index
-            .replace(MapIndex::new_gridstore(self.dir.clone())?);
+            .replace(MapIndex::new_gridstore(self.dir.clone(), true)?);
         Ok(())
     }
 
@@ -1413,7 +1415,7 @@ mod tests {
                 true,
             ),
             IndexType::MutableGridstore => {
-                MapIndex::<N>::new_gridstore(path.to_path_buf()).unwrap()
+                MapIndex::<N>::new_gridstore(path.to_path_buf(), true).unwrap()
             }
             #[cfg(feature = "rocksdb")]
             IndexType::Immutable => MapIndex::<N>::new_rocksdb(

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -130,9 +130,10 @@ where
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
+    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
         Ok(MapIndex::Mutable(MutableMapIndex::open_gridstore(
-            dir, create,
+            dir,
+            create_if_missing,
         )?))
     }
 

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -86,10 +86,11 @@ where
     ///
     /// Note: after opening, the data must be loaded into memory separately using [`load`].
     ///
-    /// The `create` parameter indicates whether to create a new Gridstore if it does not exist. If
-    /// false and files don't exist, the load function will indicate nothing could be loaded.
-    pub fn open_gridstore(path: PathBuf, create: bool) -> OperationResult<Self> {
-        let store = if create {
+    /// The `create_if_missing` parameter indicates whether to create a new Gridstore if it does
+    /// not exist. If false and files don't exist, the load function will indicate nothing could be
+    /// loaded.
+    pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
+        let store = if create_if_missing {
             let options = default_gridstore_options(N::gridstore_block_size());
             Some(Arc::new(RwLock::new(
                 Gridstore::open_or_create(path, options).map_err(|err| {

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -199,9 +199,9 @@ where
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf) -> OperationResult<Self> {
+    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
         Ok(NumericIndexInner::Mutable(
-            MutableNumericIndex::open_gridstore(dir)?,
+            MutableNumericIndex::open_gridstore(dir, create)?,
         ))
     }
 
@@ -522,9 +522,9 @@ where
         })
     }
 
-    pub fn new_gridstore(dir: PathBuf) -> OperationResult<Self> {
+    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
         Ok(Self {
-            inner: NumericIndexInner::new_gridstore(dir)?,
+            inner: NumericIndexInner::new_gridstore(dir, create)?,
             _phantom: PhantomData,
         })
     }
@@ -779,7 +779,7 @@ where
             "index must be initialized exactly once",
         );
         self.index
-            .replace(NumericIndex::new_gridstore(self.dir.clone())?);
+            .replace(NumericIndex::new_gridstore(self.dir.clone(), true)?);
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -199,9 +199,9 @@ where
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
+    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
         Ok(NumericIndexInner::Mutable(
-            MutableNumericIndex::open_gridstore(dir, create)?,
+            MutableNumericIndex::open_gridstore(dir, create_if_missing)?,
         ))
     }
 
@@ -522,9 +522,9 @@ where
         })
     }
 
-    pub fn new_gridstore(dir: PathBuf, create: bool) -> OperationResult<Self> {
+    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
         Ok(Self {
-            inner: NumericIndexInner::new_gridstore(dir, create)?,
+            inner: NumericIndexInner::new_gridstore(dir, create_if_missing)?,
             _phantom: PhantomData,
         })
     }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -266,10 +266,11 @@ where
     ///
     /// Note: after opening, the data must be loaded into memory separately using [`load`].
     ///
-    /// The `create` parameter indicates whether to create a new Gridstore if it does not exist. If
-    /// false and files don't exist, the load function will indicate nothing could be loaded.
-    pub fn open_gridstore(path: PathBuf, create: bool) -> OperationResult<Self> {
-        let store = if create {
+    /// The `create_if_missing` parameter indicates whether to create a new Gridstore if it does
+    /// not exist. If false and files don't exist, the load function will indicate nothing could be
+    /// loaded.
+    pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
+        let store = if create_if_missing {
             let options = default_gridstore_options::<T>();
             Some(Arc::new(RwLock::new(
                 Gridstore::open_or_create(path, options).map_err(|err| {

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -389,10 +389,11 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         IndexType::Mutable => {
             NumericIndexInner::<FloatPayloadType>::new_rocksdb(db.unwrap(), COLUMN_NAME, true)
         }
-        IndexType::MutableGridstore => {
-            NumericIndexInner::<FloatPayloadType>::new_gridstore(temp_dir.path().to_path_buf())
-                .unwrap()
-        }
+        IndexType::MutableGridstore => NumericIndexInner::<FloatPayloadType>::new_gridstore(
+            temp_dir.path().to_path_buf(),
+            true,
+        )
+        .unwrap(),
         #[cfg(feature = "rocksdb")]
         IndexType::Immutable => {
             NumericIndexInner::<FloatPayloadType>::new_rocksdb(db.unwrap(), COLUMN_NAME, false)

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -9,7 +9,6 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::either_variant::EitherVariant;
 use common::types::PointOffsetType;
-use log::debug;
 use schemars::_serde_json::Value;
 
 use super::field_index::FieldIndexBuilderTrait as _;
@@ -158,14 +157,14 @@ impl StructPayloadIndex {
                 break;
             }
         }
+
+        // If index is not properly loaded, recreate it
         if !is_loaded {
-            debug!("Index for `{field}` was not loaded. Building...");
-            debug_assert!(false, "Index should not need to be loaded during testing");
-            // todo(ivan): decide what to do with indexes, which were not loaded
+            log::debug!("Index for `{field}` was not loaded. Building...");
             indexes = self.build_field_indexes(
                 field,
                 payload_schema,
-                &HardwareCounterCell::disposable(), // Internal operation.
+                &HardwareCounterCell::disposable(), // Internal operation
             )?;
         }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -187,7 +187,12 @@ impl StructPayloadIndex {
             #[cfg(feature = "rocksdb")]
             {
                 let mut new_config = PayloadConfig::default();
-                if common::flags::feature_flags().payload_index_skip_rocksdb && !is_appendable {
+                let skip_rocksdb = if is_appendable {
+                    common::flags::feature_flags().payload_index_skip_mutable_rocksdb
+                } else {
+                    common::flags::feature_flags().payload_index_skip_rocksdb
+                };
+                if skip_rocksdb {
                     new_config.skip_rocksdb = Some(true);
                 }
                 new_config

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -119,11 +119,11 @@ impl StructPayloadIndex {
         self.config.save(&config_path)
     }
 
-    fn load_all_fields(&mut self, create: bool) -> OperationResult<()> {
+    fn load_all_fields(&mut self, create_if_missing: bool) -> OperationResult<()> {
         let mut field_indexes: IndexesMap = Default::default();
 
         for (field, payload_schema) in &self.config.indexed_fields {
-            let field_index = self.load_from_db(field, payload_schema, create)?;
+            let field_index = self.load_from_db(field, payload_schema, create_if_missing)?;
             field_indexes.insert(field.clone(), field_index);
         }
         self.field_indexes = field_indexes;
@@ -134,11 +134,11 @@ impl StructPayloadIndex {
         &self,
         field: PayloadKeyTypeRef,
         payload_schema: &PayloadFieldSchema,
-        create: bool,
+        create_if_missing: bool,
     ) -> OperationResult<Vec<FieldIndex>> {
-        let mut indexes = self
-            .selector(payload_schema)
-            .new_index(field, payload_schema, create)?;
+        let mut indexes =
+            self.selector(payload_schema)
+                .new_index(field, payload_schema, create_if_missing)?;
 
         let total_point_count = self.id_tracker.borrow().total_point_count();
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -551,6 +551,7 @@ impl SegmentBuilder {
                 vector_storages_arc.clone(),
                 &payload_index_path,
                 appendable_flag,
+                true,
             )?;
             for (field, payload_schema) in indexed_fields {
                 payload_index.set_indexed(&field, payload_schema, hw_counter)?;

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -437,6 +437,7 @@ fn create_segment(
     segment_path: &Path,
     config: &SegmentConfig,
     stopped: &AtomicBool,
+    create: bool,
 ) -> OperationResult<Segment> {
     #[cfg(feature = "rocksdb")]
     let mut db_builder = RocksDbBuilder::new(segment_path, config)?;
@@ -504,6 +505,7 @@ fn create_segment(
         vector_storages.clone(),
         &payload_index_path,
         appendable_flag,
+        create,
     )?);
 
     let mut vector_data = HashMap::new();
@@ -740,6 +742,7 @@ pub fn load_segment(path: &Path, stopped: &AtomicBool) -> OperationResult<Option
         path,
         &segment_state.config,
         stopped,
+        false,
     )?;
 
     #[cfg(feature = "rocksdb")]
@@ -782,7 +785,14 @@ pub fn build_segment(
 
     std::fs::create_dir_all(&segment_path)?;
 
-    let segment = create_segment(None, None, &segment_path, config, &AtomicBool::new(false))?;
+    let segment = create_segment(
+        None,
+        None,
+        &segment_path,
+        config,
+        &AtomicBool::new(false),
+        true,
+    )?;
     segment.save_current_state()?;
 
     // Version is the last file to save, as it will be used to check if segment was built correctly.

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -77,6 +77,7 @@ fn test_filtering_context_consistency() {
         HashMap::new(),
         dir.path(),
         true,
+        true,
     )
     .unwrap();
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1196,6 +1196,7 @@ fn test_update_payload_index_type() {
         HashMap::new(),
         dir.path(),
         true,
+        true,
     )
     .unwrap();
 


### PR DESCRIPTION
The main goal of this PR is to enable support for Gridstore in mutable payload indices unconditionally. It doesn't mean that Gridstore is always used, _yet_. It does mean Gridstore _can_ always be used. Along with this, some other necessary adjustments are made.

So, first, this enableds Gridstore on the mutable payload indices. Before, Gridstore was only supported when compiling without RocksDB.

Initialization of mutable payload indices has been adjusted. It prevents Gridstore from creating files on disk, even if we just try to load an existing index. Before, trying to load when no index exists results in loading an empty index instead, breaking our index.

Now we detect an index load failure when Gridstore is used. When no data exists on disk, we fail on load, and trigger index rebuilding. We now follow the same semantics as our other payload index storage backends.

Respect the `payload_index_skip_mutable_rocksdb` runtime feature flag. Setting it to true will now result in Gridstore being used in all new mutable segments. We used `payload_index_skip_rocksdb` for both mutable and immutable segments before, which was incorrect.

I added a boolean `create_if_missing` parameter to payload index opening. When this is false, we prevent creating files on disk if Gridstore is used. I don't think this implementation is great, but it keeps the payload index interface the same. I think this part of the code - that creates/opens indices - would benefit from refactoring. But we better do that after the release, when there's less time pressure.

In future PRs we'll implement proper migrations, and we'll make payload index loading more robust by explicitly persisting what type of index storage is used.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
