### PR TITLE
Upgrade `indicatif` to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ half = { version = "2.6.0", features = [
 http = "1.2.0"
 humantime = "2.2.0"
 indexmap = { version = "2", features = ["serde"] }
-indicatif = { version = "0.17.12", features = ["rayon"] }
+indicatif = { version = "0.18.0", features = ["rayon"] }
 itertools = "0.14.0"
 log = "0.4.27"
 memmap2 = "0.9.5"


### PR DESCRIPTION
Fixes building `dev`. `indicatif` 0.17.12 was published few days ago (and dependabot bumped dependency on `dev`), but [0.17.12 was yanked][0.18.0-release] (yesterday or today?) and 0.18.0 published instead.

[0.18.0-release]: https://github.com/console-rs/indicatif/pull/715

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
