### PR TITLE
Naive migration of payload indices from RocksDB to Gridstore

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11551,6 +11551,11 @@
             "description": "Whether to actively migrate RocksDB based payload storages into a new format.",
             "default": false,
             "type": "boolean"
+          },
+          "migrate_rocksdb_payload_indices": {
+            "description": "Migrate away from RocksDB based payload indices.\n\nTriggers a payload index rebuild if RocksDB is used.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -49,6 +49,12 @@ pub struct FeatureFlags {
     /// Whether to actively migrate RocksDB based payload storages into a new format.
     // TODO(1.15): enable by default
     pub migrate_rocksdb_payload_storage: bool,
+
+    /// Migrate away from RocksDB based payload indices.
+    ///
+    /// Triggers a payload index rebuild if RocksDB is used.
+    // TODO(1.15.1): enable by default
+    pub migrate_rocksdb_payload_indices: bool,
 }
 
 impl Default for FeatureFlags {
@@ -62,6 +68,7 @@ impl Default for FeatureFlags {
             migrate_rocksdb_id_tracker: false,
             migrate_rocksdb_vector_storage: false,
             migrate_rocksdb_payload_storage: false,
+            migrate_rocksdb_payload_indices: false,
         }
     }
 }
@@ -85,6 +92,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         migrate_rocksdb_id_tracker,
         migrate_rocksdb_vector_storage,
         migrate_rocksdb_payload_storage,
+        migrate_rocksdb_payload_indices,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags
@@ -96,6 +104,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         *migrate_rocksdb_id_tracker = true;
         *migrate_rocksdb_vector_storage = true;
         *migrate_rocksdb_payload_storage = true;
+        *migrate_rocksdb_payload_indices = true;
     }
 
     let res = FEATURE_FLAGS.set(flags);

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -25,6 +25,7 @@ use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::types::{SegmentConfig, SparseVectorDataConfig, VectorDataConfig, VectorName};
 
 pub type Flusher = Box<dyn FnOnce() -> OperationResult<()> + Send>;
+
 /// Check that the given vector name is part of the segment config.
 ///
 /// Returns an error if incompatible.

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -103,6 +103,14 @@ impl BoolIndex {
         }
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self {
+            BoolIndex::Simple(_) => true,
+            BoolIndex::Mmap(_) => false,
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -444,6 +444,23 @@ impl FieldIndex {
         }
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self {
+            FieldIndex::IntIndex(index) => index.is_rocksdb(),
+            FieldIndex::DatetimeIndex(index) => index.is_rocksdb(),
+            FieldIndex::IntMapIndex(index) => index.is_rocksdb(),
+            FieldIndex::KeywordIndex(index) => index.is_rocksdb(),
+            FieldIndex::FloatIndex(index) => index.is_rocksdb(),
+            FieldIndex::GeoIndex(index) => index.is_rocksdb(),
+            FieldIndex::BoolIndex(index) => index.is_rocksdb(),
+            FieldIndex::FullTextIndex(index) => index.is_rocksdb(),
+            FieldIndex::UuidIndex(index) => index.is_rocksdb(),
+            FieldIndex::UuidMapIndex(index) => index.is_rocksdb(),
+            FieldIndex::NullIndex(_) => false,
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -231,4 +231,12 @@ impl ImmutableFullTextIndex {
             },
         }
     }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Mmap(_) => false,
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -151,11 +151,11 @@ impl ImmutableFullTextIndex {
         Ok(())
     }
 
-    pub fn clear(self) -> OperationResult<()> {
+    pub fn wipe(self) -> OperationResult<()> {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
-            Storage::Mmap(index) => index.clear(),
+            Storage::Mmap(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -483,6 +483,9 @@ mod tests {
 
             // Check mutable vs mmap
             let mmap_ids = mmap
+                .storage
+                .as_ref()
+                .unwrap()
                 .postings
                 .iter_ids(token_id, &hw_counter)
                 .unwrap()
@@ -501,13 +504,27 @@ mod tests {
         for (point_id, count) in immutable.point_to_tokens_count.iter().enumerate() {
             // Check same deleted points
             assert_eq!(
-                mmap.deleted_points.get(point_id).unwrap(),
+                mmap.storage
+                    .as_ref()
+                    .unwrap()
+                    .deleted_points
+                    .get(point_id)
+                    .unwrap(),
                 *count == 0,
                 "point_id: {point_id}",
             );
 
             // Check same count
-            assert_eq!(*mmap.point_to_tokens_count.get(point_id).unwrap(), *count);
+            assert_eq!(
+                *mmap
+                    .storage
+                    .as_ref()
+                    .unwrap()
+                    .point_to_tokens_count
+                    .get(point_id)
+                    .unwrap(),
+                *count
+            );
             assert_eq!(imm_mmap.point_to_tokens_count[point_id], *count);
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -42,6 +42,10 @@ impl MmapFullTextIndex {
         })
     }
 
+    pub fn load(&self) -> bool {
+        self.inverted_index.load()
+    }
+
     pub fn files(&self) -> Vec<PathBuf> {
         self.inverted_index.files()
     }
@@ -69,7 +73,7 @@ impl MmapFullTextIndex {
     }
 
     pub fn flusher(&self) -> Flusher {
-        self.inverted_index.deleted_points.flusher()
+        self.inverted_index.flusher()
     }
 
     pub fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -54,7 +54,7 @@ impl MmapFullTextIndex {
         &self.inverted_index.path
     }
 
-    pub fn clear(self) -> OperationResult<()> {
+    pub fn wipe(self) -> OperationResult<()> {
         let files = self.files();
         let path = self.path();
         for file in files {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -382,6 +382,14 @@ impl MutableFullTextIndex {
             Storage::Gridstore(_) => StorageType::Gridstore,
         }
     }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Gridstore(_) => false,
+        }
+    }
 }
 
 impl ValueIndexer for MutableFullTextIndex {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -197,15 +197,21 @@ impl MutableFullTextIndex {
     }
 
     #[inline]
-    pub(super) fn clear(self) -> OperationResult<()> {
+    pub(super) fn wipe(self) -> OperationResult<()> {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
-            Storage::Gridstore(Some(store)) => store.write().clear().map_err(|err| {
-                OperationError::service_error(format!(
-                    "Failed to clear mutable full text index: {err}",
-                ))
-            }),
+            Storage::Gridstore(mut store @ Some(_)) => {
+                let store = store.take().unwrap();
+                let store =
+                    Arc::into_inner(store).expect("exclusive strong reference to Gridstore");
+
+                store.into_inner().wipe().map_err(|err| {
+                    OperationError::service_error(format!(
+                        "Failed to wipe mutable full text index: {err}",
+                    ))
+                })
+            }
             Storage::Gridstore(None) => Ok(()),
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -243,9 +243,18 @@ impl MutableFullTextIndex {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(Some(store)) => {
-                let store = store.clone();
+                let store = Arc::downgrade(store);
                 Box::new(move || {
-                    store.read().flush().map_err(|err| {
+                    store
+                        .upgrade()
+                        .ok_or_else(|| {
+                            OperationError::service_error(
+                                "Failed to flush mutable full text index, backing Gridstore storage is already dropped",
+                            )
+                        })?
+                        .read()
+                        .flush()
+                        .map_err(|err| {
                         OperationError::service_error(format!(
                             "Failed to flush mutable full text index gridstore: {err}"
                         ))

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -534,7 +534,7 @@ impl PayloadFieldIndex for FullTextIndex {
         match self {
             Self::Mutable(index) => index.load(),
             Self::Immutable(index) => index.load(),
-            Self::Mmap(_index) => Ok(true), // mmap index is always loaded
+            Self::Mmap(index) => Ok(index.load()),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -540,9 +540,9 @@ impl PayloadFieldIndex for FullTextIndex {
 
     fn cleanup(self) -> OperationResult<()> {
         match self {
-            Self::Mutable(index) => index.clear(),
-            Self::Immutable(index) => index.clear(),
-            Self::Mmap(index) => index.clear(),
+            Self::Mutable(index) => index.wipe(),
+            Self::Immutable(index) => index.wipe(),
+            Self::Mmap(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -385,6 +385,15 @@ impl FullTextIndex {
         }
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self {
+            FullTextIndex::Mutable(index) => index.is_rocksdb(),
+            FullTextIndex::Immutable(index) => index.is_rocksdb(),
+            FullTextIndex::Mmap(_) => false,
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -185,10 +185,15 @@ impl ImmutableGeoMapIndex {
             ));
         };
 
+        if !index.load()? {
+            return Ok(false);
+        }
+        let index_storage = index.storage.as_ref().unwrap();
+
         self.points_count = index.points_count();
         self.points_values_count = index.points_values_count();
         self.max_values_per_point = index.max_values_per_point();
-        self.counts_per_hash = index
+        self.counts_per_hash = index_storage
             .counts_per_hash
             .iter()
             .copied()
@@ -196,7 +201,7 @@ impl ImmutableGeoMapIndex {
             .collect();
 
         // Get points per geo hash and filter deleted points
-        self.points_map = index
+        self.points_map = index_storage
             .points_map
             .iter()
             .copied()
@@ -208,11 +213,11 @@ impl ImmutableGeoMapIndex {
                 } = item;
                 (
                     hash,
-                    index.points_map_ids[ids_start as usize..ids_end as usize]
+                    index_storage.points_map_ids[ids_start as usize..ids_end as usize]
                         .iter()
                         .copied()
                         // Filter deleted points
-                        .filter(|id| !index.deleted.get(*id as usize).unwrap_or_default())
+                        .filter(|id| !index_storage.deleted.get(*id as usize).unwrap_or_default())
                         .collect(),
                 )
             })
@@ -223,11 +228,11 @@ impl ImmutableGeoMapIndex {
         let mut deleted_points: Vec<(PointOffsetType, Vec<GeoPoint>)> =
             Vec::with_capacity(index.deleted_count);
         self.point_to_values = ImmutablePointToValues::new(
-            index
+            index_storage
                 .point_to_values
                 .iter()
                 .map(|(id, values)| {
-                    let is_deleted = index.deleted.get(id as usize).unwrap_or_default();
+                    let is_deleted = index_storage.deleted.get(id as usize).unwrap_or_default();
                     match (is_deleted, values) {
                         (false, Some(values)) => values.into_iter().collect(),
                         (false, None) => vec![],

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -497,4 +497,12 @@ impl ImmutableGeoMapIndex {
             },
         }
     }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Mmap(_) => false,
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -309,11 +309,11 @@ impl ImmutableGeoMapIndex {
         }
     }
 
-    pub fn clear(self) -> OperationResult<()> {
+    pub fn wipe(self) -> OperationResult<()> {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(ref db_wrapper) => db_wrapper.remove_column_family(),
-            Storage::Mmap(index) => index.clear(),
+            Storage::Mmap(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -313,7 +313,7 @@ impl MmapGeoMapIndex {
         }
     }
 
-    pub fn clear(self) -> OperationResult<()> {
+    pub fn wipe(self) -> OperationResult<()> {
         let files = self.files();
         let Self { path, .. } = self;
         for file in files {

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -63,7 +63,7 @@ impl GeoMapIndex {
     }
 
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
-        let mmap_index = MmapGeoMapIndex::load(path, is_on_disk)?;
+        let mmap_index = MmapGeoMapIndex::open(path, is_on_disk)?;
         if is_on_disk {
             Ok(GeoMapIndex::Mmap(Box::new(mmap_index)))
         } else {
@@ -539,7 +539,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexMmapBuilder {
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        Ok(GeoMapIndex::Mmap(Box::new(MmapGeoMapIndex::new(
+        Ok(GeoMapIndex::Mmap(Box::new(MmapGeoMapIndex::build(
             self.in_memory_index,
             &self.path,
             self.is_on_disk,
@@ -652,8 +652,7 @@ impl PayloadFieldIndex for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.load(),
             GeoMapIndex::Immutable(index) => index.load(),
-            // Mmap index is always loaded
-            GeoMapIndex::Mmap(_) => Ok(true),
+            GeoMapIndex::Mmap(index) => index.load(),
         }
     }
 
@@ -1501,7 +1500,7 @@ mod tests {
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),
             IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false).unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
-                MmapGeoMapIndex::load(temp_dir.path(), false).unwrap(),
+                MmapGeoMapIndex::open(temp_dir.path(), false).unwrap(),
             )),
         };
         new_index.load().unwrap();
@@ -1582,7 +1581,7 @@ mod tests {
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),
             IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false).unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
-                MmapGeoMapIndex::load(temp_dir.path(), false).unwrap(),
+                MmapGeoMapIndex::open(temp_dir.path(), false).unwrap(),
             )),
         };
         new_index.load().unwrap();

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -388,6 +388,15 @@ impl GeoMapIndex {
         }
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self {
+            GeoMapIndex::Mutable(index) => index.is_rocksdb(),
+            GeoMapIndex::Immutable(index) => index.is_rocksdb(),
+            GeoMapIndex::Mmap(_) => false,
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -659,9 +659,9 @@ impl PayloadFieldIndex for GeoMapIndex {
 
     fn cleanup(self) -> OperationResult<()> {
         match self {
-            GeoMapIndex::Mutable(index) => index.clear(),
-            GeoMapIndex::Immutable(index) => index.clear(),
-            GeoMapIndex::Mmap(index) => index.clear(),
+            GeoMapIndex::Mutable(index) => index.wipe(),
+            GeoMapIndex::Immutable(index) => index.wipe(),
+            GeoMapIndex::Mmap(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -431,6 +431,14 @@ impl MutableGeoMapIndex {
             .map(|v| v.iter())
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Gridstore(_) => false,
+        }
+    }
+
     delegate! {
         to self.in_memory_index {
             pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&GeoPoint) -> bool) -> bool;

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -308,13 +308,22 @@ impl MutableGeoMapIndex {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(Some(store)) => {
-                let store = store.clone();
+                let store = Arc::downgrade(store);
                 Box::new(move || {
-                    store.read().flush().map_err(|err| {
-                        OperationError::service_error(format!(
-                            "Failed to flush mutable geo index gridstore: {err}"
-                        ))
-                    })
+                    store
+                        .upgrade()
+                        .ok_or_else(|| {
+                            OperationError::service_error(
+                                "Failed to flush mutable numeric index, backing Gridstore storage is already dropped",
+                            )
+                        })?
+                        .read()
+                        .flush()
+                        .map_err(|err| {
+                            OperationError::service_error(format!(
+                                "Failed to flush mutable geo index gridstore: {err}"
+                            ))
+                        })
                 })
             }
             Storage::Gridstore(None) => Box::new(|| Ok(())),

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -131,7 +131,7 @@ impl Numericable for u128 {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq)]
 pub struct Histogram<T: Numericable + Serialize + DeserializeOwned> {
     max_bucket_size: usize,
     precision: f64,

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -119,7 +119,9 @@ impl IndexSelector<'_> {
                 )?)
             }
 
-            (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => self.bool_new(field)?,
+            (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => {
+                self.bool_new(field, create_if_missing)?
+            }
 
             (PayloadIndexType::UuidIndex, PayloadSchemaParams::Uuid(_)) => {
                 FieldIndex::UuidMapIndex(self.map_new(field, create_if_missing)?)
@@ -130,7 +132,8 @@ impl IndexSelector<'_> {
             }
 
             (PayloadIndexType::NullIndex, _) => {
-                let Some(null_index) = MmapNullIndex::open_if_exists(path, total_point_count)?
+                let Some(null_index) =
+                    MmapNullIndex::open_if_exists(path, total_point_count, create_if_missing)?
                 else {
                     return Ok(None);
                 };
@@ -198,7 +201,7 @@ impl IndexSelector<'_> {
                 )?)]
             }
             PayloadSchemaParams::Bool(_) => {
-                vec![self.bool_new(field)?]
+                vec![self.bool_new(field, create_if_missing)?]
             }
             PayloadSchemaParams::Datetime(_) => {
                 vec![FieldIndex::DatetimeIndex(
@@ -449,12 +452,15 @@ impl IndexSelector<'_> {
         dir: &Path,
         field: &JsonPath,
         total_point_count: usize,
+        create_if_missing: bool,
     ) -> OperationResult<Option<FieldIndex>> {
         // null index is always on disk and is appendable
-        Ok(
-            MmapNullIndex::open_if_exists(&null_dir(dir, field), total_point_count)?
-                .map(FieldIndex::NullIndex),
-        )
+        Ok(MmapNullIndex::open_if_exists(
+            &null_dir(dir, field),
+            total_point_count,
+            create_if_missing,
+        )?
+        .map(FieldIndex::NullIndex))
     }
 
     fn text_new(
@@ -536,7 +542,7 @@ impl IndexSelector<'_> {
         }
     }
 
-    fn bool_new(&self, field: &JsonPath) -> OperationResult<FieldIndex> {
+    fn bool_new(&self, field: &JsonPath, create_if_missing: bool) -> OperationResult<FieldIndex> {
         Ok(match self {
             #[cfg(feature = "rocksdb")]
             IndexSelector::RocksDb(IndexSelectorRocksDb {
@@ -548,15 +554,20 @@ impl IndexSelector<'_> {
             ))),
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 let dir = bool_dir(dir, field);
-                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open_or_create(
+                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open(
                     &dir,
                     *is_on_disk,
+                    create_if_missing,
                 )?))
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 let dir = bool_dir(dir, field);
-                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open_or_create(&dir, false)?))
+                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open(
+                    &dir,
+                    false,
+                    create_if_missing,
+                )?))
             }
         })
     }

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -416,11 +416,11 @@ where
     }
 
     #[inline]
-    pub(super) fn clear(self) -> OperationResult<()> {
+    pub(super) fn wipe(self) -> OperationResult<()> {
         match self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(db_wrapper) => db_wrapper.recreate_column_family(),
-            Storage::Mmap(index) => index.clear(),
+            Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
+            Storage::Mmap(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -191,13 +191,18 @@ where
             ));
         };
 
+        if !index.load()? {
+            return Ok(false);
+        }
+        let index_storage = index.storage.as_ref().unwrap();
+
         // Construct intermediate values to points map from backing storage
         let mapping = || {
-            index.value_to_points.iter().map(|(value, ids)| {
+            index_storage.value_to_points.iter().map(|(value, ids)| {
                 (
                     value,
                     ids.iter().copied().filter(|idx| {
-                        let is_deleted = index.deleted.get(*idx as usize).unwrap_or(false);
+                        let is_deleted = index_storage.deleted.get(*idx as usize).unwrap_or(false);
                         !is_deleted
                     }),
                 )

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -550,4 +550,12 @@ where
             },
         }
     }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Mmap(_) => false,
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -133,7 +133,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         self.deleted.flusher()
     }
 
-    pub fn clear(self) -> OperationResult<()> {
+    pub fn wipe(self) -> OperationResult<()> {
         let files = self.files();
         let Self { path, .. } = self;
         for file in files {

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -31,12 +31,19 @@ const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized> {
     path: PathBuf,
-    pub(super) value_to_points: MmapHashMap<N, PointOffsetType>,
-    point_to_values: MmapPointToValues<N>,
-    pub(super) deleted: MmapBitSliceBufferedUpdateWrapper,
+    pub(super) storage: Option<Storage<N>>,
+    // pub(super) value_to_points: MmapHashMap<N, PointOffsetType>,
+    // point_to_values: MmapPointToValues<N>,
+    // pub(super) deleted: MmapBitSliceBufferedUpdateWrapper,
     deleted_count: usize,
     total_key_value_pairs: usize,
     is_on_disk: bool,
+}
+
+pub(super) struct Storage<N: MapIndexKey + Key + ?Sized> {
+    pub(super) value_to_points: MmapHashMap<N, PointOffsetType>,
+    point_to_values: MmapPointToValues<N>,
+    pub(super) deleted: MmapBitSliceBufferedUpdateWrapper,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,10 +52,21 @@ struct MmapMapIndexConfig {
 }
 
 impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
-    pub fn load(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
+    pub fn open(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
         let hashmap_path = path.join(HASHMAP_PATH);
         let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
+
+        // If config doesn't exist, assume the index doesn't exist on disk
+        if !config_path.is_file() {
+            return Ok(Self {
+                path: path.to_path_buf(),
+                storage: None,
+                deleted_count: 0,
+                total_key_value_pairs: 0,
+                is_on_disk,
+            });
+        }
 
         let config: MmapMapIndexConfig = read_json(&config_path)?;
 
@@ -63,13 +81,20 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
 
         Ok(Self {
             path: path.to_path_buf(),
-            value_to_points: hashmap,
-            point_to_values,
-            deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+            storage: Some(Storage {
+                value_to_points: hashmap,
+                point_to_values,
+                deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+            }),
             deleted_count,
             total_key_value_pairs: config.total_key_value_pairs,
             is_on_disk,
         })
+    }
+
+    pub fn load(&self) -> OperationResult<bool> {
+        let is_loaded = self.storage.is_some();
+        Ok(is_loaded)
     }
 
     pub fn build(
@@ -126,11 +151,15 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             }
         }
 
-        Self::load(path, is_on_disk)
+        Self::open(path, is_on_disk)
     }
 
     pub fn flusher(&self) -> Flusher {
-        self.deleted.flusher()
+        if let Some(storage) = &self.storage {
+            storage.deleted.flusher()
+        } else {
+            Box::new(|| Ok(()))
+        }
     }
 
     pub fn wipe(self) -> OperationResult<()> {
@@ -149,21 +178,29 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             self.path.join(DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
-        files.extend(self.point_to_values.files());
+        if let Some(storage) = &self.storage {
+            files.extend(storage.point_to_values.files());
+        }
         files
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         let mut files = vec![self.path.join(HASHMAP_PATH), self.path.join(CONFIG_PATH)];
-        files.extend(self.point_to_values.immutable_files());
+        if let Some(storage) = &self.storage {
+            files.extend(storage.point_to_values.immutable_files());
+        }
         files
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {
+        let Some(storage) = &mut self.storage else {
+            return;
+        };
+
         let idx = idx as usize;
-        if let Some(deleted) = self.deleted.get(idx) {
+        if let Some(deleted) = storage.deleted.get(idx) {
             if !deleted {
-                self.deleted.set(idx, true);
+                storage.deleted.set(idx, true);
                 self.deleted_count += 1;
             }
         }
@@ -175,6 +212,10 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
     ) -> bool {
+        let Some(storage) = &self.storage else {
+            return false;
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
         // Measure self.deleted access.
@@ -182,11 +223,12 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             .payload_index_io_read_counter()
             .incr_delta(size_of::<bool>());
 
-        self.deleted
+        storage
+            .deleted
             .get(idx as usize)
             .filter(|b| !b)
             .is_some_and(|_| {
-                self.point_to_values.check_values_any(
+                storage.point_to_values.check_values_any(
                     idx,
                     |v| check_fn(N::from_referenced(&v)),
                     &hw_counter,
@@ -198,21 +240,39 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         &self,
         idx: PointOffsetType,
     ) -> Option<Box<dyn Iterator<Item = N::Referenced<'_>> + '_>> {
-        self.deleted.get(idx as usize).filter(|b| !b).and_then(|_| {
-            Some(Box::new(self.point_to_values.get_values(idx)?)
-                as Box<dyn Iterator<Item = N::Referenced<'_>>>)
-        })
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
+        storage
+            .deleted
+            .get(idx as usize)
+            .filter(|b| !b)
+            .and_then(|_| {
+                Some(Box::new(storage.point_to_values.get_values(idx)?)
+                    as Box<dyn Iterator<Item = N::Referenced<'_>>>)
+            })
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        self.deleted
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
+        storage
+            .deleted
             .get(idx as usize)
             .filter(|b| !b)
-            .and_then(|_| self.point_to_values.get_values_count(idx))
+            .and_then(|_| storage.point_to_values.get_values_count(idx))
     }
 
     pub fn get_indexed_points(&self) -> usize {
-        self.point_to_values
+        let Some(storage) = &self.storage else {
+            return 0;
+        };
+
+        storage
+            .point_to_values
             .len()
             .saturating_sub(self.deleted_count)
     }
@@ -224,7 +284,11 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     }
 
     pub fn get_unique_values_count(&self) -> usize {
-        self.value_to_points.keys_count()
+        let Some(storage) = &self.storage else {
+            return 0;
+        };
+
+        storage.value_to_points.keys_count()
     }
 
     pub fn get_count_for_value(
@@ -232,6 +296,10 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         value: &N,
         hw_counter: &HardwareCounterCell,
     ) -> Option<usize> {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
         // Since `value_to_points.get` doesn't actually force read from disk for all values
@@ -240,7 +308,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             .payload_index_io_read_counter()
             .incr_delta(READ_ENTRY_OVERHEAD);
 
-        match self.value_to_points.get(value) {
+        match storage.value_to_points.get(value) {
             Ok(Some(points)) => Some(points.len()),
             Ok(None) => None,
             Err(err) => {
@@ -259,9 +327,13 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         value: &N,
         hw_counter: &HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = &PointOffsetType> + '_> {
+        let Some(storage) = &self.storage else {
+            return Box::new(iter::empty());
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        match self.value_to_points.get(value) {
+        match storage.value_to_points.get(value) {
             Ok(Some(slice)) => {
                 // We're iterating over the whole (mmapped) slice
                 hw_counter
@@ -271,7 +343,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
                 Box::new(
                     slice
                         .iter()
-                        .filter(|idx| !self.deleted.get(**idx as usize).unwrap_or(false)),
+                        .filter(|idx| !storage.deleted.get(**idx as usize).unwrap_or(false)),
                 )
             }
             Ok(None) => {
@@ -293,27 +365,40 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     }
 
     pub fn iter_values(&self) -> Box<dyn Iterator<Item = &N> + '_> {
-        Box::new(self.value_to_points.keys())
+        let Some(storage) = &self.storage else {
+            return Box::new(iter::empty());
+        };
+
+        Box::new(storage.value_to_points.keys())
     }
 
-    pub fn iter_counts_per_value(&self) -> impl Iterator<Item = (&N, usize)> + '_ {
-        self.value_to_points.iter().map(|(k, v)| {
+    pub fn iter_counts_per_value(&self) -> Box<dyn Iterator<Item = (&N, usize)> + '_> {
+        let Some(storage) = &self.storage else {
+            return Box::new(iter::empty());
+        };
+
+        let iter = storage.value_to_points.iter().map(|(k, v)| {
             let count = v
                 .iter()
-                .filter(|idx| !self.deleted.get(**idx as usize).unwrap_or(true))
+                .filter(|idx| !storage.deleted.get(**idx as usize).unwrap_or(true))
                 .unique()
                 .count();
             (k, count)
-        })
+        });
+        Box::new(iter)
     }
 
     pub fn iter_values_map<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
-    ) -> impl Iterator<Item = (&'a N, IdIter<'a>)> + 'a {
+    ) -> Box<dyn Iterator<Item = (&'a N, IdIter<'a>)> + 'a> {
+        let Some(storage) = &self.storage else {
+            return Box::new(iter::empty());
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        self.value_to_points.iter().map(move |(k, v)| {
+        let iter = storage.value_to_points.iter().map(move |(k, v)| {
             hw_counter
                 .payload_index_io_read_counter()
                 .incr_delta(k.write_bytes());
@@ -323,7 +408,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
                 Box::new(
                     v.iter()
                         .copied()
-                        .filter(|idx| !self.deleted.get(*idx as usize).unwrap_or(true))
+                        .filter(|idx| !storage.deleted.get(*idx as usize).unwrap_or(true))
                         .measure_hw_with_acc(
                             hw_counter.new_accumulator(),
                             size_of::<PointOffsetType>(),
@@ -331,7 +416,8 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
                         ),
                 ) as IdIter,
             )
-        })
+        });
+        Box::new(iter)
     }
 
     fn make_conditioned_counter<'a>(
@@ -348,8 +434,10 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
-        self.value_to_points.populate()?;
-        self.point_to_values.populate();
+        if let Some(storage) = &self.storage {
+            storage.value_to_points.populate()?;
+            storage.point_to_values.populate();
+        }
         Ok(())
     }
 
@@ -361,7 +449,9 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         clear_disk_cache(&value_to_points_path)?;
         clear_disk_cache(&deleted_path)?;
 
-        self.point_to_values.clear_cache()?;
+        if let Some(storage) = &self.storage {
+            storage.point_to_values.clear_cache()?;
+        }
         Ok(())
     }
 }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -331,11 +331,11 @@ where
         self.values_count(idx) == 0
     }
 
-    fn clear(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         match self {
-            MapIndex::Mutable(index) => index.clear(),
-            MapIndex::Immutable(index) => index.clear(),
-            MapIndex::Mmap(index) => index.clear(),
+            MapIndex::Mutable(index) => index.wipe(),
+            MapIndex::Immutable(index) => index.wipe(),
+            MapIndex::Mmap(index) => index.wipe(),
         }
     }
 
@@ -725,7 +725,7 @@ impl PayloadFieldIndex for MapIndex<str> {
     }
 
     fn cleanup(self) -> OperationResult<()> {
-        self.clear()
+        self.wipe()
     }
 
     fn flusher(&self) -> Flusher {
@@ -879,7 +879,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
     }
 
     fn cleanup(self) -> OperationResult<()> {
-        self.clear()
+        self.wipe()
     }
 
     fn flusher(&self) -> Flusher {
@@ -1074,7 +1074,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
     }
 
     fn cleanup(self) -> OperationResult<()> {
-        self.clear()
+        self.wipe()
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -119,7 +119,7 @@ where
 
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
-        let mmap_index = MmapMapIndex::load(path, is_on_disk)?;
+        let mmap_index = MmapMapIndex::open(path, is_on_disk)?;
         if is_on_disk {
             // Use on mmap directly
             Ok(MapIndex::Mmap(Box::new(mmap_index)))
@@ -162,8 +162,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.load(),
             MapIndex::Immutable(index) => index.load(),
-            // Mmap based index is always loaded
-            MapIndex::Mmap(_) => Ok(true),
+            MapIndex::Mmap(index) => index.load(),
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -504,6 +504,15 @@ where
         }
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self {
+            MapIndex::Mutable(index) => index.is_rocksdb(),
+            MapIndex::Immutable(index) => index.is_rocksdb(),
+            MapIndex::Mmap(_) => false,
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -441,4 +441,12 @@ where
             Storage::Gridstore(_) => StorageType::Gridstore,
         }
     }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Gridstore(_) => false,
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -364,13 +364,22 @@ where
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(Some(store)) => {
-                let store = store.clone();
+                let store = Arc::downgrade(store);
                 Box::new(move || {
-                    store.read().flush().map_err(|err| {
-                        OperationError::service_error(format!(
-                            "Failed to flush mutable map index gridstore: {err}"
-                        ))
-                    })
+                    store
+                        .upgrade()
+                        .ok_or_else(|| {
+                            OperationError::service_error(
+                                "Failed to flush mutable map index, backing Gridstore storage is already dropped",
+                            )
+                        })?
+                        .read()
+                        .flush()
+                        .map_err(|err| {
+                            OperationError::service_error(format!(
+                                "Failed to flush mutable map index gridstore: {err}"
+                            ))
+                        })
                 })
             }
             Storage::Gridstore(None) => Box::new(|| Ok(())),

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -25,13 +25,15 @@ const IS_NULL_DIRNAME: &str = "is_null";
 /// in case of IsNull and IsEmpty conditions.
 pub struct MmapNullIndex {
     base_dir: PathBuf,
+    storage: Option<Storage>,
+    total_point_count: usize,
+}
+
+struct Storage {
     /// If true, payload field has some values.
     has_values_slice: DynamicMmapFlags,
     /// If true, then payload field contains null value.
     is_null_slice: DynamicMmapFlags,
-    total_point_count: usize,
-    /// `true` if just created.
-    is_loaded: bool,
 }
 
 /// Don't populate null index as it is not essential
@@ -40,37 +42,40 @@ const POPULATE_NULL_INDEX: bool = false;
 
 impl MmapNullIndex {
     pub fn builder(path: &Path) -> OperationResult<MmapNullIndexBuilder> {
-        Ok(MmapNullIndexBuilder(Self::open_or_create(path, 0)?))
+        Ok(MmapNullIndexBuilder(Self::open(path, 0, true)?))
     }
 
-    /// Creates a new null index at the given path.
-    /// If it already exists, loads the index.
+    /// Open or create a null index at the given path.
     ///
     /// # Arguments
     /// - `path` - The directory where the index files should live, must be exclusive to this index.
-    pub fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
+    /// - `total_point_count` - Total number of points in the segment.
+    /// - `create_if_missing` - If true, creates the index if it doesn't exist.
+    pub fn open(
+        path: &Path,
+        total_point_count: usize,
+        create_if_missing: bool,
+    ) -> OperationResult<Self> {
         let has_values_dir = path.join(HAS_VALUES_DIRNAME);
-        if has_values_dir.is_dir() {
-            Self::open(path, total_point_count)
-        } else {
-            std::fs::create_dir_all(path).map_err(|err| {
-                OperationError::service_error(format!(
-                    "Failed to create null-index directory: {err}, path: {path:?}"
-                ))
-            })?;
 
-            let mut index = Self::open(path, total_point_count)?;
-            index.is_loaded = false;
-            Ok(index)
+        // If has values directory doesn't exist, assume the index doesn't exist on disk
+        if !has_values_dir.is_dir() && !create_if_missing {
+            return Ok(Self {
+                base_dir: path.to_path_buf(),
+                storage: None,
+                total_point_count,
+            });
         }
+
+        Self::open_or_create(path, total_point_count)
     }
 
-    fn open(path: &Path, total_point_count: usize) -> OperationResult<Self> {
-        if !path.is_dir() {
-            return Err(OperationError::service_error(format!(
-                "Path is not a directory {path:?}"
-            )));
-        }
+    fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
+        std::fs::create_dir_all(path).map_err(|err| {
+            OperationError::service_error(format!(
+                "Failed to create null-index directory: {err}, path: {path:?}"
+            ))
+        })?;
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
         let has_values_slice = DynamicMmapFlags::open(&has_values_path, POPULATE_NULL_INDEX)?;
@@ -80,15 +85,23 @@ impl MmapNullIndex {
 
         Ok(Self {
             base_dir: path.to_path_buf(),
-            has_values_slice,
-            is_null_slice,
+            storage: Some(Storage {
+                has_values_slice,
+                is_null_slice,
+            }),
             total_point_count,
-            is_loaded: true,
         })
     }
 
-    pub fn open_if_exists(path: &Path, total_point_count: usize) -> OperationResult<Option<Self>> {
+    pub fn open_if_exists(
+        path: &Path,
+        total_point_count: usize,
+        create_if_missing: bool,
+    ) -> OperationResult<Option<Self>> {
         if !path.is_dir() {
+            if create_if_missing {
+                return Ok(Some(Self::open_or_create(path, total_point_count)?));
+            }
             return Ok(None);
         }
 
@@ -100,10 +113,11 @@ impl MmapNullIndex {
             let is_null_slice = DynamicMmapFlags::open(&is_null_path, POPULATE_NULL_INDEX)?;
             Ok(Some(Self {
                 base_dir: path.to_path_buf(),
-                has_values_slice,
-                is_null_slice,
+                storage: Some(Storage {
+                    has_values_slice,
+                    is_null_slice,
+                }),
                 total_point_count,
-                is_loaded: true,
             }))
         } else {
             Ok(None)
@@ -116,6 +130,12 @@ impl MmapNullIndex {
         payload: &[&Value],
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
+        let Some(storage) = &mut self.storage else {
+            return Err(OperationError::service_error(
+                "MmapNullIndex storage is not initialized".to_string(),
+            ));
+        };
+
         let mut is_null = false;
         let mut has_values = false;
         for value in payload {
@@ -151,9 +171,11 @@ impl MmapNullIndex {
 
         let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
 
-        self.has_values_slice
+        storage
+            .has_values_slice
             .set_with_resize(id, has_values, hw_counter_ref)?;
-        self.is_null_slice
+        storage
+            .is_null_slice
             .set_with_resize(id, is_null, hw_counter_ref)?;
 
         // Update total_points to track the highest point offset seen
@@ -163,32 +185,49 @@ impl MmapNullIndex {
     }
 
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        let Some(storage) = &mut self.storage else {
+            return Ok(());
+        };
+
         let disposed_hw = HardwareCounterCell::disposable(); // Deleting is unmeasured OP.
         let disposed_hw = disposed_hw.ref_payload_index_io_write_counter();
 
-        self.has_values_slice
+        storage
+            .has_values_slice
             .set_with_resize(id, false, disposed_hw)?;
-        self.is_null_slice.set_with_resize(id, false, disposed_hw)?;
+        storage
+            .is_null_slice
+            .set_with_resize(id, false, disposed_hw)?;
         Ok(())
     }
 
     pub fn values_count(&self, id: PointOffsetType) -> usize {
-        usize::from(self.has_values_slice.get(id))
+        self.storage
+            .as_ref()
+            .map_or(0, |storage| usize::from(storage.has_values_slice.get(id)))
     }
 
     pub fn values_is_empty(&self, id: PointOffsetType) -> bool {
-        !self.has_values_slice.get(id)
+        self.storage
+            .as_ref()
+            .is_none_or(|storage| !storage.has_values_slice.get(id))
     }
 
     pub fn values_is_null(&self, id: PointOffsetType) -> bool {
-        self.is_null_slice.get(id)
+        self.storage
+            .as_ref()
+            .is_some_and(|storage| storage.is_null_slice.get(id))
     }
 
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        let points_count = self
+            .storage
+            .as_ref()
+            .map_or(0, |storage| storage.has_values_slice.len());
         PayloadIndexTelemetry {
             field_name: None,
-            points_count: self.has_values_slice.len(),
-            points_values_count: self.has_values_slice.len(),
+            points_count,
+            points_values_count: points_count,
             histogram_bucket_size: None,
             index_type: "mmap_null_index",
         }
@@ -201,15 +240,19 @@ impl MmapNullIndex {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
-        self.is_null_slice.populate()?;
-        self.has_values_slice.populate()?;
+        if let Some(storage) = &self.storage {
+            storage.is_null_slice.populate()?;
+            storage.has_values_slice.populate()?;
+        }
         Ok(())
     }
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
-        self.is_null_slice.clear_cache()?;
-        self.has_values_slice.clear_cache()?;
+        if let Some(storage) = &self.storage {
+            storage.is_null_slice.clear_cache()?;
+            storage.has_values_slice.clear_cache()?;
+        }
 
         Ok(())
     }
@@ -228,12 +271,14 @@ impl MmapNullIndex {
 
 impl PayloadFieldIndex for MmapNullIndex {
     fn count_indexed_points(&self) -> usize {
-        self.has_values_slice.len()
+        self.storage
+            .as_ref()
+            .map_or(0, |storage| storage.has_values_slice.len())
     }
 
     fn load(&mut self) -> OperationResult<bool> {
-        // Nothing needed
-        Ok(self.is_loaded)
+        let is_loaded = self.storage.is_some();
+        Ok(is_loaded)
     }
 
     fn cleanup(self) -> OperationResult<()> {
@@ -242,13 +287,19 @@ impl PayloadFieldIndex for MmapNullIndex {
     }
 
     fn flusher(&self) -> Flusher {
+        let Some(storage) = &self.storage else {
+            return Box::new(|| Ok(()));
+        };
+
         let Self {
             base_dir: _,
+            storage: _,
+            total_point_count: _,
+        } = self;
+        let Storage {
             has_values_slice,
             is_null_slice,
-            total_point_count: _,
-            is_loaded: _,
-        } = self;
+        } = storage;
 
         let is_empty_flusher = has_values_slice.flusher();
         let is_null_flusher = is_null_slice.flusher();
@@ -261,13 +312,19 @@ impl PayloadFieldIndex for MmapNullIndex {
     }
 
     fn files(&self) -> Vec<PathBuf> {
+        let Some(storage) = &self.storage else {
+            return vec![];
+        };
+
         let Self {
             base_dir: _,
+            storage: _,
+            total_point_count: _,
+        } = self;
+        let Storage {
             has_values_slice,
             is_null_slice,
-            total_point_count: _,
-            is_loaded: _,
-        } = self;
+        } = storage;
 
         let mut files = has_values_slice.files();
         files.extend(is_null_slice.files());
@@ -283,6 +340,10 @@ impl PayloadFieldIndex for MmapNullIndex {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
         let FieldCondition {
             key: _,
             r#match: _,
@@ -298,38 +359,40 @@ impl PayloadFieldIndex for MmapNullIndex {
         if let Some(is_empty) = is_empty {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.has_values_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.has_values_slice.len() / u8::BITS as usize);
 
             if *is_empty {
                 // Iterate over all tracked values, but filter out those which have a value
                 let iter = (0..self.total_point_count as PointOffsetType)
-                    .filter(move |&id| !self.has_values_slice.get(id))
+                    .filter(move |&id| !storage.has_values_slice.get(id))
                     .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
                 Some(Box::new(iter))
             } else {
                 // Non-empty values are registered in the index explicitly
-                let iter =
-                    self.has_values_slice
-                        .iter_trues()
-                        .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
+                let iter = storage.has_values_slice.iter_trues().measure_hw_with_cell(
+                    hw_counter,
+                    1,
+                    |i| i.payload_index_io_read_counter(),
+                );
                 Some(Box::new(iter))
             }
         } else if let Some(is_null) = is_null {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.is_null_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.is_null_slice.len() / u8::BITS as usize);
             if *is_null {
                 // We DO have list of all null values, so we can iterate over them
                 // Null values are explicitly marked in the index
                 let iter =
-                    self.is_null_slice
+                    storage
+                        .is_null_slice
                         .iter_trues()
                         .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
                 Some(Box::new(iter))
             } else {
                 // Iterate over all tracked values, but filter out those which are null
                 let iter = (0..self.total_point_count as PointOffsetType)
-                    .filter(move |&id| !self.is_null_slice.get(id))
+                    .filter(move |&id| !storage.is_null_slice.get(id))
                     .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
                 Some(Box::new(iter))
             }
@@ -343,6 +406,10 @@ impl PayloadFieldIndex for MmapNullIndex {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> Option<CardinalityEstimation> {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
         let FieldCondition {
             key,
             r#match: _,
@@ -358,12 +425,12 @@ impl PayloadFieldIndex for MmapNullIndex {
         if let Some(is_empty) = is_empty {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.has_values_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.has_values_slice.len() / u8::BITS as usize);
             if *is_empty {
                 // We can estimate using the total_point_count, but not exactly since we don't know which are deleted
                 let estimated = self
                     .total_point_count
-                    .saturating_sub(self.has_values_slice.count_flags());
+                    .saturating_sub(storage.has_values_slice.count_flags());
 
                 Some(CardinalityEstimation {
                     min: 0,
@@ -377,7 +444,7 @@ impl PayloadFieldIndex for MmapNullIndex {
             } else {
                 // All non-empty values are explicitly marked in the index
                 Some(
-                    CardinalityEstimation::exact(self.has_values_slice.count_flags())
+                    CardinalityEstimation::exact(storage.has_values_slice.count_flags())
                         .with_primary_clause(PrimaryCondition::from(FieldCondition::new_is_empty(
                             key.clone(),
                             false,
@@ -387,12 +454,12 @@ impl PayloadFieldIndex for MmapNullIndex {
         } else if let Some(is_null) = is_null {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.is_null_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.is_null_slice.len() / u8::BITS as usize);
 
             if *is_null {
                 // Null values are explicitly marked in the index
                 Some(
-                    CardinalityEstimation::exact(self.is_null_slice.count_flags())
+                    CardinalityEstimation::exact(storage.is_null_slice.count_flags())
                         .with_primary_clause(PrimaryCondition::from(FieldCondition::new_is_null(
                             key.clone(),
                             true,
@@ -402,7 +469,7 @@ impl PayloadFieldIndex for MmapNullIndex {
                 // We can estimate the non-null values from the total number of values
                 let estimated = self
                     .total_point_count
-                    .saturating_sub(self.is_null_slice.count_flags());
+                    .saturating_sub(storage.is_null_slice.count_flags());
 
                 Some(CardinalityEstimation {
                     min: 0,                 // assuming all points are deleted

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -470,6 +470,14 @@ where
             },
         }
     }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Mmap(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -289,11 +289,11 @@ where
     }
 
     #[inline]
-    pub(super) fn clear(self) -> OperationResult<()> {
+    pub(super) fn wipe(self) -> OperationResult<()> {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.recreate_column_family(),
-            Storage::Mmap(index) => index.clear(),
+            Storage::Mmap(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -183,7 +183,7 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         })
     }
 
-    pub fn clear(self) -> OperationResult<()> {
+    pub fn wipe(self) -> OperationResult<()> {
         let files = self.files();
         let Self { path, .. } = self;
         for file in files {

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -28,14 +28,18 @@ const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 pub struct MmapNumericIndex<T: Encodable + Numericable + Default + MmapValue + 'static> {
     path: PathBuf,
-    deleted: MmapBitSliceBufferedUpdateWrapper,
-    // sorted pairs (id + value), sorted by value (by id if values are equal)
-    pairs: MmapSlice<Point<T>>,
+    pub(super) storage: Option<Storage<T>>,
     histogram: Histogram<T>,
     deleted_count: usize,
     max_values_per_point: usize,
-    pub(super) point_to_values: MmapPointToValues<T>,
     is_on_disk: bool,
+}
+
+pub(super) struct Storage<T: Encodable + Numericable + Default + MmapValue + 'static> {
+    deleted: MmapBitSliceBufferedUpdateWrapper,
+    // sorted pairs (id + value), sorted by value (by id if values are equal)
+    pairs: MmapSlice<Point<T>>,
+    pub(super) point_to_values: MmapPointToValues<T>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,13 +152,25 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
             }
         }
 
-        Self::load(path, is_on_disk)
+        Self::open(path, is_on_disk)
     }
 
-    pub fn load(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
+    pub fn open(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
         let pairs_path = path.join(PAIRS_PATH);
         let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
+
+        // If config doesn't exist, assume the index doesn't exist on disk
+        if !config_path.is_file() {
+            return Ok(Self {
+                path: path.to_path_buf(),
+                storage: None,
+                histogram: Histogram::default(),
+                deleted_count: 0,
+                max_values_per_point: 0,
+                is_on_disk,
+            });
+        }
 
         let histogram = Histogram::<T>::load(path)?;
         let config: MmapNumericIndexConfig = read_json(&config_path)?;
@@ -172,15 +188,22 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         let point_to_values = MmapPointToValues::open(path, do_populate)?;
 
         Ok(Self {
-            pairs: map,
-            deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
             path: path.to_path_buf(),
+            storage: Some(Storage {
+                pairs: map,
+                deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+                point_to_values,
+            }),
             histogram,
             deleted_count,
             max_values_per_point: config.max_values_per_point,
-            point_to_values,
             is_on_disk,
         })
+    }
+
+    pub fn load(&self) -> OperationResult<bool> {
+        let is_loaded = self.storage.is_some();
+        Ok(is_loaded)
     }
 
     pub fn wipe(self) -> OperationResult<()> {
@@ -199,20 +222,28 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
             self.path.join(DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
-        files.extend(self.point_to_values.files());
+        if let Some(storage) = &self.storage {
+            files.extend(storage.point_to_values.files());
+        }
         files.extend(Histogram::<T>::files(&self.path));
         files
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
-        files.extend(self.point_to_values.immutable_files());
+        if let Some(storage) = &self.storage {
+            files.extend(storage.point_to_values.immutable_files());
+        }
         files.extend(Histogram::<T>::immutable_files(&self.path));
         files
     }
 
     pub fn flusher(&self) -> Flusher {
-        self.deleted.flusher()
+        if let Some(storage) = &self.storage {
+            storage.deleted.flusher()
+        } else {
+            Box::new(|| Ok(()))
+        }
     }
 
     pub fn check_values_any(
@@ -221,10 +252,14 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
     ) -> bool {
+        let Some(storage) = &self.storage else {
+            return false;
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        if self.deleted.get(idx as usize) == Some(false) {
-            self.point_to_values.check_values_any(
+        if storage.deleted.get(idx as usize) == Some(false) {
+            storage.point_to_values.check_values_any(
                 idx,
                 |v| check_fn(T::from_referenced(&v)),
                 &hw_counter,
@@ -235,9 +270,14 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
-        if self.deleted.get(idx as usize) == Some(false) {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
+        if storage.deleted.get(idx as usize) == Some(false) {
             Some(Box::new(
-                self.point_to_values
+                storage
+                    .point_to_values
                     .get_values(idx)?
                     .map(|v| *T::from_referenced(&v)),
             ))
@@ -247,8 +287,12 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        if self.deleted.get(idx as usize) == Some(false) {
-            self.point_to_values.get_values_count(idx)
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
+        if storage.deleted.get(idx as usize) == Some(false) {
+            storage.point_to_values.get_values_count(idx)
         } else {
             None
         }
@@ -257,7 +301,9 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     /// Returns the number of key-value pairs in the index.
     /// Note that is doesn't count deleted pairs.
     pub(super) fn total_unique_values_count(&self) -> usize {
-        self.pairs.len()
+        self.storage
+            .as_ref()
+            .map_or(0, |storage| storage.pairs.len())
     }
 
     pub(super) fn values_range<'a>(
@@ -265,29 +311,42 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
         hw_counter: &'a HardwareCounterCell,
-    ) -> impl Iterator<Item = PointOffsetType> + 'a {
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+        let Some(iter) = self.values_range_iterator(start_bound, end_bound) else {
+            return Box::new(std::iter::empty());
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        self.values_range_iterator(start_bound, end_bound)
+        let iter = iter
             .map(|Point { idx, .. }| idx)
             .measure_hw_with_condition_cell(hw_counter, size_of::<Point<T>>(), |i| {
                 i.payload_index_io_read_counter()
-            })
+            });
+        Box::new(iter)
     }
 
     pub(super) fn orderable_values_range(
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> impl DoubleEndedIterator<Item = (T, PointOffsetType)> + '_ {
-        self.values_range_iterator(start_bound, end_bound)
-            .map(|Point { val, idx }| (val, idx))
+    ) -> Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_> {
+        let Some(iter) = self.values_range_iterator(start_bound, end_bound) else {
+            return Box::new(std::iter::empty());
+        };
+
+        let iter = iter.map(|Point { val, idx }| (val, idx));
+        Box::new(iter)
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {
+        let Some(storage) = &mut self.storage else {
+            return;
+        };
+
         let idx = idx as usize;
-        if idx < self.deleted.len() && !self.deleted.get(idx).unwrap_or(true) {
-            self.deleted.set(idx, true);
+        if idx < storage.deleted.len() && !storage.deleted.get(idx).unwrap_or(true) {
+            storage.deleted.set(idx, true);
             self.deleted_count += 1;
         }
     }
@@ -297,7 +356,9 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     }
 
     pub(super) fn get_points_count(&self) -> usize {
-        self.point_to_values.len() - self.deleted_count
+        self.storage.as_ref().map_or(0, |storage| {
+            storage.point_to_values.len() - self.deleted_count
+        })
     }
 
     pub(super) fn get_max_values_per_point(&self) -> usize {
@@ -309,8 +370,8 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
     ) -> usize {
-        let iterator = self.values_range_iterator(start_bound, end_bound);
-        iterator.end_index - iterator.start_index
+        self.values_range_iterator(start_bound, end_bound)
+            .map_or(0, |iter| iter.end_index - iter.start_index)
     }
 
     // get iterator
@@ -318,43 +379,50 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> NumericIndexPairsIterator<'_, T> {
+    ) -> Option<NumericIndexPairsIterator<'_, T>> {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
         let start_index = match start_bound {
-            Bound::Included(bound) => self.pairs.binary_search(&bound).unwrap_or_else(|idx| idx),
-            Bound::Excluded(bound) => match self.pairs.binary_search(&bound) {
+            Bound::Included(bound) => storage
+                .pairs
+                .binary_search(&bound)
+                .unwrap_or_else(|idx| idx),
+            Bound::Excluded(bound) => match storage.pairs.binary_search(&bound) {
                 Ok(idx) => idx + 1,
                 Err(idx) => idx,
             },
             Bound::Unbounded => 0,
         };
 
-        if start_index >= self.pairs.len() {
-            return NumericIndexPairsIterator {
-                pairs: &self.pairs,
-                deleted: &self.deleted,
-                start_index: self.pairs.len(),
-                end_index: self.pairs.len(),
-            };
+        if start_index >= storage.pairs.len() {
+            return Some(NumericIndexPairsIterator {
+                pairs: &storage.pairs,
+                deleted: &storage.deleted,
+                start_index: storage.pairs.len(),
+                end_index: storage.pairs.len(),
+            });
         }
 
         let end_index = match end_bound {
-            Bound::Included(bound) => match self.pairs[start_index..].binary_search(&bound) {
+            Bound::Included(bound) => match storage.pairs[start_index..].binary_search(&bound) {
                 Ok(idx) => idx + 1 + start_index,
                 Err(idx) => idx + start_index,
             },
             Bound::Excluded(bound) => {
-                let end_bound = self.pairs[start_index..].binary_search(&bound);
+                let end_bound = storage.pairs[start_index..].binary_search(&bound);
                 end_bound.unwrap_or_else(|idx| idx) + start_index
             }
-            Bound::Unbounded => self.pairs.len(),
+            Bound::Unbounded => storage.pairs.len(),
         };
 
-        NumericIndexPairsIterator {
-            pairs: &self.pairs,
-            deleted: &self.deleted,
+        Some(NumericIndexPairsIterator {
+            pairs: &storage.pairs,
+            deleted: &storage.deleted,
             start_index,
             end_index,
-        }
+        })
     }
 
     fn make_conditioned_counter<'a>(
@@ -371,8 +439,10 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
-        self.pairs.populate()?;
-        self.point_to_values.populate();
+        if let Some(storage) = &self.storage {
+            storage.pairs.populate()?;
+            storage.point_to_values.populate();
+        }
         Ok(())
     }
 
@@ -384,7 +454,9 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         clear_disk_cache(&pairs_path)?;
         clear_disk_cache(&deleted_path)?;
 
-        self.point_to_values.clear_cache()?;
+        if let Some(storage) = &self.storage {
+            storage.point_to_values.clear_cache()?;
+        }
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -188,7 +188,7 @@ where
 
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
-        let mmap_index = MmapNumericIndex::load(path, is_on_disk)?;
+        let mmap_index = MmapNumericIndex::open(path, is_on_disk)?;
         if is_on_disk {
             // Use on mmap directly
             Ok(NumericIndexInner::Mmap(mmap_index))
@@ -210,8 +210,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.load(),
             NumericIndexInner::Immutable(index) => index.load(),
-            // Mmap based index is always loaded
-            NumericIndexInner::Mmap(_) => Ok(true),
+            NumericIndexInner::Mmap(index) => index.load(),
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -858,9 +858,9 @@ where
 
     fn cleanup(self) -> OperationResult<()> {
         match self {
-            NumericIndexInner::Mutable(index) => index.clear(),
-            NumericIndexInner::Immutable(index) => index.clear(),
-            NumericIndexInner::Mmap(index) => index.clear(),
+            NumericIndexInner::Mutable(index) => index.wipe(),
+            NumericIndexInner::Immutable(index) => index.wipe(),
+            NumericIndexInner::Mmap(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -467,6 +467,15 @@ where
         }
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self {
+            NumericIndexInner::Mutable(index) => index.is_rocksdb(),
+            NumericIndexInner::Immutable(index) => index.is_rocksdb(),
+            NumericIndexInner::Mmap(_) => false,
+        }
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
@@ -610,6 +619,13 @@ where
             pub fn is_on_disk(&self) -> bool;
             pub fn populate(&self) -> OperationResult<()>;
             pub fn clear_cache(&self) -> OperationResult<()>;
+        }
+    }
+
+    #[cfg(feature = "rocksdb")]
+    delegate! {
+        to self.inner {
+            pub fn is_rocksdb(&self) -> bool;
         }
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -434,13 +434,22 @@ where
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(Some(store)) => {
-                let store = store.clone();
+                let store = Arc::downgrade(store);
                 Box::new(move || {
-                    store.read().flush().map_err(|err| {
-                        OperationError::service_error(format!(
-                            "Failed to flush mutable numeric index gridstore: {err}"
-                        ))
-                    })
+                    store
+                        .upgrade()
+                        .ok_or_else(|| {
+                            OperationError::service_error(
+                                "Failed to flush mutable numeric index, backing Gridstore storage is already dropped",
+                            )
+                        })?
+                        .read()
+                        .flush()
+                        .map_err(|err| {
+                            OperationError::service_error(format!(
+                                "Failed to flush mutable numeric index gridstore: {err}"
+                            ))
+                        })
                 })
             }
             Storage::Gridstore(None) => Box::new(|| Ok(())),

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -113,7 +113,12 @@ impl<T: Encodable + Numericable + Default + MmapValue> InMemoryNumericIndex<T> {
     ///
     /// Expensive because this reads the full mmap index.
     pub(super) fn from_mmap(mmap_index: &MmapNumericIndex<T>) -> Self {
-        (0..mmap_index.point_to_values.len() as PointOffsetType)
+        let point_count = mmap_index
+            .storage
+            .as_ref()
+            .map_or(0, |storage| storage.point_to_values.len());
+
+        (0..point_count as PointOffsetType)
             .filter_map(|idx| mmap_index.get_values(idx).map(|values| (idx, values)))
             .flat_map(|(idx, values)| values.into_iter().map(move |value| (idx, value)))
             .collect::<InMemoryNumericIndex<T>>()

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -586,4 +586,12 @@ where
             Storage::Gridstore(_) => StorageType::Gridstore,
         }
     }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocksdb(&self) -> bool {
+        match self.storage {
+            Storage::RocksDb(_) => true,
+            Storage::Gridstore(_) => false,
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -401,6 +401,26 @@ where
         }
     }
 
+    #[inline]
+    pub(super) fn wipe(self) -> OperationResult<()> {
+        match self.storage {
+            #[cfg(feature = "rocksdb")]
+            Storage::RocksDb(db_wrapper) => db_wrapper.remove_column_family(),
+            Storage::Gridstore(mut store @ Some(_)) => {
+                let store = store.take().unwrap();
+                let store =
+                    Arc::into_inner(store).expect("exclusive strong reference to Gridstore");
+
+                store.into_inner().wipe().map_err(|err| {
+                    OperationError::service_error(format!(
+                        "Failed to wipe mutable numeric index: {err}",
+                    ))
+                })
+            }
+            Storage::Gridstore(None) => Ok(()),
+        }
+    }
+
     /// Clear cache
     ///
     /// Only clears cache of Gridstore storage if used. Does not clear in-memory representation of

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -161,7 +161,7 @@ impl StructPayloadIndex {
     }
 
     fn load_from_db(
-        &self,
+        &mut self,
         field: PayloadKeyTypeRef,
         // TODO: refactor this and remove the &mut reference.
         payload_schema: &mut PayloadFieldSchemaWithIndexType,
@@ -220,6 +220,33 @@ impl StructPayloadIndex {
             }
         }
 
+        // Actively migrate away from RocksDB indices
+        // Naively implemented by just rebuilding the indices from scratch
+        #[cfg(feature = "rocksdb")]
+        if common::flags::feature_flags().migrate_rocksdb_payload_indices
+            && indexes.iter().any(|index| index.is_rocksdb())
+        {
+            log::info!("Migrating away from RocksDB indices for field `{field}`");
+
+            // Trigger rebuild
+            is_loaded = false;
+
+            // Change storage type, set skip RocksDB flag and persist, rebuilds index with Gridstore
+            match self.storage_type {
+                StorageType::RocksDbAppendable(_) => {
+                    self.storage_type = StorageType::GridstoreAppendable;
+                }
+                StorageType::GridstoreAppendable => {}
+                StorageType::RocksDbNonAppendable(_) => {
+                    self.storage_type = StorageType::GridstoreNonAppendable;
+                }
+                StorageType::GridstoreNonAppendable => {}
+            }
+            self.config.skip_rocksdb.replace(true);
+            self.save_config()?;
+        }
+
+        // If index is not properly loaded, recreate it
         if !is_loaded {
             log::debug!("Index for `{field}` was not loaded. Building...");
             indexes = self.build_field_indexes(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -214,13 +214,6 @@ impl StructPayloadIndex {
         };
 
         let mut rebuild = false;
-        for ref mut index in indexes.iter_mut() {
-            if !index.load()? {
-                rebuild = true;
-                log::debug!("Payload index for field `{field}` was not loaded, triggering rebuild");
-                break;
-            }
-        }
 
         // Actively migrate away from RocksDB indices
         // Naively implemented by just rebuilding the indices from scratch
@@ -256,7 +249,19 @@ impl StructPayloadIndex {
             }
         }
 
-        // If index is not properly loaded, recreate it
+        if !rebuild {
+            for ref mut index in indexes.iter_mut() {
+                if !index.load()? {
+                    rebuild = true;
+                    log::debug!(
+                        "Payload index for field `{field}` was not loaded, triggering rebuild",
+                    );
+                    break;
+                }
+            }
+        }
+
+        // If index is not properly loaded or when migrating, recreate it
         if rebuild {
             log::debug!("Rebuilding payload index for field `{field}`...");
             indexes = self.build_field_indexes(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -212,10 +212,10 @@ impl StructPayloadIndex {
                 .collect::<OperationResult<Vec<_>>>()?
         };
 
-        let mut is_loaded = true;
+        let mut rebuild = false;
         for ref mut index in indexes.iter_mut() {
             if !index.load()? {
-                is_loaded = false;
+                rebuild = true;
                 log::debug!("Payload index for field `{field}` was not loaded, triggering rebuild");
                 break;
             }
@@ -229,8 +229,7 @@ impl StructPayloadIndex {
         {
             log::info!("Migrating away from RocksDB indices for field `{field}`");
 
-            // Trigger rebuild
-            is_loaded = false;
+            rebuild = true;
 
             // Change storage type, set skip RocksDB flag and persist, rebuilds index with Gridstore
             match self.storage_type {
@@ -245,10 +244,19 @@ impl StructPayloadIndex {
             }
             self.config.skip_rocksdb.replace(true);
             self.save_config()?;
+
+            // Clean-up all existing indices
+            for index in indexes.drain(..) {
+                index.cleanup().map_err(|err| {
+                    OperationError::service_error(format!(
+                        "Failed to clean up payload index for field `{field}` before rebuild: {err}"
+                    ))
+                })?;
+            }
         }
 
         // If index is not properly loaded, recreate it
-        if !is_loaded {
+        if rebuild {
             log::debug!("Rebuilding payload index for field `{field}`...");
             indexes = self.build_field_indexes(
                 field,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -216,6 +216,7 @@ impl StructPayloadIndex {
         for ref mut index in indexes.iter_mut() {
             if !index.load()? {
                 is_loaded = false;
+                log::debug!("Payload index for field `{field}` was not loaded, triggering rebuild");
                 break;
             }
         }
@@ -248,7 +249,7 @@ impl StructPayloadIndex {
 
         // If index is not properly loaded, recreate it
         if !is_loaded {
-            log::debug!("Index for `{field}` was not loaded. Building...");
+            log::debug!("Rebuilding payload index for field `{field}`...");
             indexes = self.build_field_indexes(
                 field,
                 &payload_schema.schema,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -160,6 +160,7 @@ impl StructPayloadIndex {
         Ok(())
     }
 
+    #[cfg_attr(not(feature = "rocksdb"), allow(clippy::needless_pass_by_ref_mut))]
     fn load_from_db(
         &mut self,
         field: PayloadKeyTypeRef,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -178,11 +178,14 @@ impl StructPayloadIndex {
             )?;
 
             // Special null index complements every index.
-            if let Some(null_index) =
-                IndexSelector::new_null_index(&self.path, field, total_point_count)?
-            {
-                // todo: This means that null index will not be built if it is not loaded here.
-                //       Maybe we should set `is_loaded` to false to trigger index building.
+            if let Some(null_index) = IndexSelector::new_null_index(
+                &self.path,
+                field,
+                total_point_count,
+                create_if_missing,
+            )? {
+                // TODO: This means that null index will not be built if it is not loaded here.
+                //       Maybe we should set `rebuild` to true to trigger index building.
                 indexes.push(null_index);
             }
 


### PR DESCRIPTION
This PR is now a collection of:
- https://github.com/qdrant/qdrant/pull/6810
- https://github.com/qdrant/qdrant/pull/6837 (will drop when [#6860](https://github.com/qdrant/qdrant/pull/6860) is merged)
- https://github.com/qdrant/qdrant/pull/6847

---

Depends on <https://github.com/qdrant/qdrant/pull/6812>

A naive implementation for migrating payload indices based on RocksDB into Gridstore.

Rather than carefully migrating, this simply builds the payload indices from scratch.

Naive migration is triggered when a RocksDB based payload index is loaded and the `migrate_rocksdb_payload_indices` runtime feature flag is set.

In a later PR we can dive into actually migrating. I'm quite sure a proper migration will be beneficial on large deployments.

Some other changes:
- restructure payload index `clear` and `wipe` functions:
  - _clear_ empties the index but keeps files on disk, allows reusing the index
  - _wipe_ completely removes the index, also wiping files from disk
- Gridstore based payload indices now take a weak reference to storage in flushers
- Gridstore based payload indices now take ownership of storage when wiping

### Tasks

- [x] Ensure column families are properly removed
- [x] Merge <https://github.com/qdrant/qdrant/pull/6805>
- [x] Rebase on `dev`
- [x] Merge <https://github.com/qdrant/qdrant/pull/6837> into this
- [x] Merge <https://github.com/qdrant/qdrant/pull/6812>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?