### PR TITLE
[MMR] Optimize SymmetricMatrix

### DIFF
--- a/lib/collection/src/collection/mmr.rs
+++ b/lib/collection/src/collection/mmr.rs
@@ -222,14 +222,14 @@ fn similarity_matrix(
     // Compute similarities only for upper triangle to optimize (i < j)
     // Since similarity is symmetric: sim(i,j) == sim(j,i), we can avoid duplicate computation
 
-    let mut scores = vec![0.0; num_vectors - 1];
+    let mut scores_buf = vec![0.0; num_vectors];
 
-    for (i, raw_scorer) in raw_scorers.iter().enumerate().take(num_vectors) {
+    for (i, raw_scorer) in raw_scorers.iter().enumerate() {
         // Only compute scores for the upper triangle
         let upper_offsets: Vec<u32> = ((i + 1)..num_vectors).map(|j| j as u32).collect();
 
         if !upper_offsets.is_empty() {
-            let scores = &mut scores[..upper_offsets.len()];
+            let scores = &mut scores_buf[..upper_offsets.len()];
             raw_scorer.score_points(&upper_offsets, scores);
 
             for (&vector_idx, similarity) in upper_offsets.iter().zip(scores) {

--- a/lib/collection/src/collection/mmr.rs
+++ b/lib/collection/src/collection/mmr.rs
@@ -229,10 +229,10 @@ fn similarity_matrix(
         let upper_offsets: Vec<u32> = ((i + 1)..num_vectors).map(|j| j as u32).collect();
 
         if !upper_offsets.is_empty() {
-            scores.resize(upper_offsets.len(), 0.0);
-            raw_scorer.score_points(&upper_offsets, &mut scores);
+            let scores = &mut scores[..upper_offsets.len()];
+            raw_scorer.score_points(&upper_offsets, scores);
 
-            for (&vector_idx, similarity) in upper_offsets.iter().zip(&scores) {
+            for (&vector_idx, similarity) in upper_offsets.iter().zip(scores) {
                 let j = vector_idx as usize;
                 similarity_matrix.set(i, j, *similarity);
             }
@@ -259,6 +259,7 @@ pub fn maximal_marginal_relevance(
     candidates: Vec<ScoredPoint>,
     query_similarities: Vec<ScoreType>,
     similarity_matrix: &SimilarityMatrix,
+    score_threshold: Option<ScoreType>,
     lambda: f32,
     limit: usize,
 ) -> Vec<ScoredPoint> {

--- a/lib/collection/src/collection/mmr.rs
+++ b/lib/collection/src/collection/mmr.rs
@@ -15,9 +15,13 @@ use segment::vector_storage::sparse::volatile_sparse_vector_storage::new_volatil
 use segment::vector_storage::{VectorStorage, VectorStorageEnum, new_raw_scorer};
 use tokio::runtime::Handle;
 
+use crate::common::diagonal_matrix::DiagonalMatrix;
 use crate::config::CollectionParams;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::shard_query::MmrInternal;
+
+/// (Diagonal) matrix of point similarities.
+type SimilarityMatrix = DiagonalMatrix<ScoreType>;
 
 /// Calculate the MMR (Maximal Marginal Relevance) score for a set of points with vectors.
 ///
@@ -184,7 +188,7 @@ fn similarity_matrix(
     volatile_storage: &VectorStorageEnum,
     vectors: Vec<VectorInternal>,
     hw_measurement_acc: HwMeasurementAcc,
-) -> CollectionResult<Vec<Vec<ScoreType>>> {
+) -> CollectionResult<SimilarityMatrix> {
     let num_vectors = vectors.len();
 
     // if we have less than 2 points, we can't build a matrix
@@ -199,7 +203,7 @@ fn similarity_matrix(
     }
 
     // Initialize similarity matrix with zeros
-    let mut similarity_matrix = vec![vec![0.0; num_vectors]; num_vectors];
+    let mut similarity_matrix = SimilarityMatrix::new(num_vectors, 0.0).unwrap();
 
     // Prepare all scorers
     let raw_scorers = vectors
@@ -226,9 +230,7 @@ fn similarity_matrix(
 
             for (&vector_idx, similarity) in upper_offsets.iter().zip(scores) {
                 let j = vector_idx as usize;
-                // Set both (i,j) and (j,i) since similarity is symmetric
-                similarity_matrix[i][j] = similarity;
-                similarity_matrix[j][i] = similarity;
+                similarity_matrix.set(i, j, similarity);
             }
         }
         // Diagonal elements remain 0.0 (self-similarity excluded)
@@ -252,8 +254,7 @@ fn similarity_matrix(
 pub fn maximal_marginal_relevance(
     candidates: Vec<ScoredPoint>,
     query_similarities: Vec<ScoreType>,
-    similarity_matrix: &[Vec<ScoreType>],
-    score_threshold: Option<ScoreType>,
+    similarity_matrix: &SimilarityMatrix,
     lambda: f32,
     limit: usize,
 ) -> Vec<ScoredPoint> {
@@ -296,7 +297,7 @@ pub fn maximal_marginal_relevance(
                 // Find maximum similarity to any already selected point
                 let max_similarity_to_selected = selected_indices
                     .iter()
-                    .map(|selected_idx| similarity_matrix[candidate_idx][*selected_idx])
+                    .map(|selected_idx| *similarity_matrix.get(candidate_idx, *selected_idx))
                     .max_by_key(|&sim| OrderedFloat(sim))
                     .unwrap_or(0.0);
 

--- a/lib/collection/src/collection/mmr.rs
+++ b/lib/collection/src/collection/mmr.rs
@@ -15,13 +15,13 @@ use segment::vector_storage::sparse::volatile_sparse_vector_storage::new_volatil
 use segment::vector_storage::{VectorStorage, VectorStorageEnum, new_raw_scorer};
 use tokio::runtime::Handle;
 
-use crate::common::diagonal_matrix::DiagonalMatrix;
+use crate::common::symmetric_matrix::SymmetricMatrix;
 use crate::config::CollectionParams;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::shard_query::MmrInternal;
 
-/// (Diagonal) matrix of point similarities.
-type SimilarityMatrix = DiagonalMatrix<ScoreType>;
+/// (Symmetric) matrix of point similarities.
+type SimilarityMatrix = SymmetricMatrix<ScoreType>;
 
 /// Calculate the MMR (Maximal Marginal Relevance) score for a set of points with vectors.
 ///

--- a/lib/collection/src/common/diagonal_matrix.rs
+++ b/lib/collection/src/common/diagonal_matrix.rs
@@ -53,6 +53,15 @@ impl<T> DiagonalMatrix<T> {
     /// Calculates the flattened index given the row and column. Parameters aren't allowed to be swapped!
     #[inline]
     fn calculate_index(&self, row: usize, column: usize) -> usize {
+        // Prevent an out of bounds column to access elements from the next row.
+        // Disabled in release for performance.
+        debug_assert!(
+            column < self.size,
+            "Column index {column} out of bounds for {}x{} matrix",
+            self.size,
+            self.size
+        );
+
         ((row * self.size) + column) - Self::triangular(row)
     }
 
@@ -70,7 +79,6 @@ mod test {
     #[test]
     fn test_matrix() {
         let size = 10;
-
         let mut matrix = DiagonalMatrix::<usize>::new(size, 0).unwrap();
 
         let mut c = 0;
@@ -90,5 +98,13 @@ mod test {
                 c += 1;
             }
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_oob() {
+        let size = 10;
+        let mut matrix = DiagonalMatrix::<usize>::new(size, 0).unwrap();
+        matrix.set(0, 10, 1);
     }
 }

--- a/lib/collection/src/common/diagonal_matrix.rs
+++ b/lib/collection/src/common/diagonal_matrix.rs
@@ -1,0 +1,94 @@
+/// Memory efficient and performant diagonal matrix implementation.
+#[derive(Clone)]
+pub struct DiagonalMatrix<I> {
+    // Stores only the upper part matrix, flattened.
+    inner: Vec<I>,
+
+    /// Size of matrix. Size of 3 means 3 rows and 3 columns.
+    size: usize,
+}
+
+impl<T: Copy> DiagonalMatrix<T> {
+    /// Creates a new diagonal matrix with `init` as initial value.
+    /// Returns `None` if `size` is smaller than 2 because this is the minimum size of a matrix.
+    pub fn new(size: usize, init: T) -> Option<Self> {
+        if size < 2 {
+            return None;
+        }
+
+        Some(Self {
+            inner: vec![init; Self::triangular(size)],
+            size,
+        })
+    }
+}
+
+impl<T> DiagonalMatrix<T> {
+    /// Set the value at row x column. Since it's a diagonal matrix, column and row can be swapped.
+    #[inline]
+    pub fn set(&mut self, row: usize, column: usize, value: T) {
+        let (row, column) = Self::handle_index(row, column);
+        let index = self.calculate_index(row, column);
+        self.inner[index] = value;
+    }
+
+    /// Sets the value at row x column. Since it's a diagonal matrix, column and row can be swapped.
+    #[inline]
+    pub fn get(&self, row: usize, column: usize) -> &T {
+        let (row, column) = Self::handle_index(row, column);
+        let index = self.calculate_index(row, column);
+        &self.inner[index]
+    }
+
+    /// Swap input parameters to always target the upper diagonal.
+    #[inline]
+    fn handle_index(row: usize, column: usize) -> (usize, usize) {
+        if column < row {
+            (column, row)
+        } else {
+            (row, column)
+        }
+    }
+
+    /// Calculates the flattened index given the row and column. Parameters aren't allowed to be swapped!
+    #[inline]
+    fn calculate_index(&self, row: usize, column: usize) -> usize {
+        ((row * self.size) + column) - Self::triangular(row)
+    }
+
+    /// Triangular function: https://en.wikipedia.org/wiki/Triangular_number
+    #[inline]
+    fn triangular(x: usize) -> usize {
+        (x * (x + 1)) / 2
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_matrix() {
+        let size = 10;
+
+        let mut matrix = DiagonalMatrix::<usize>::new(size, 0).unwrap();
+
+        let mut c = 0;
+        for x in 0..size {
+            for y in x..size {
+                matrix.set(x, y, c);
+                c += 1;
+            }
+        }
+
+        c = 0;
+
+        for x in 0..size {
+            for y in x..size {
+                assert_eq!(*matrix.get(x, y), c);
+                assert_eq!(*matrix.get(y, x), c);
+                c += 1;
+            }
+        }
+    }
+}

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod batching;
 pub mod collection_size_stats;
+pub mod diagonal_matrix;
 pub mod eta_calculator;
 pub mod fetch_vectors;
 pub mod file_utils;

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -1,6 +1,5 @@
 pub mod batching;
 pub mod collection_size_stats;
-pub mod diagonal_matrix;
 pub mod eta_calculator;
 pub mod fetch_vectors;
 pub mod file_utils;
@@ -12,4 +11,5 @@ pub mod snapshots_manager;
 pub mod stoppable_task;
 pub mod stoppable_task_async;
 pub mod stopping_guard;
+pub mod symmetric_matrix;
 pub mod transpose_iterator;

--- a/lib/collection/src/common/symmetric_matrix.rs
+++ b/lib/collection/src/common/symmetric_matrix.rs
@@ -1,6 +1,6 @@
-/// Memory efficient and performant diagonal matrix implementation.
+/// Memory efficient and performant symmetric matrix implementation.
 #[derive(Clone)]
-pub struct DiagonalMatrix<I> {
+pub struct SymmetricMatrix<I> {
     // Stores only the upper part matrix, flattened.
     inner: Vec<I>,
 
@@ -8,8 +8,8 @@ pub struct DiagonalMatrix<I> {
     size: usize,
 }
 
-impl<T: Copy> DiagonalMatrix<T> {
-    /// Creates a new diagonal matrix with `init` as initial value.
+impl<T: Copy> SymmetricMatrix<T> {
+    /// Creates a new symmetric matrix with `init` as initial value.
     /// Returns `None` if `size` is smaller than 2 because this is the minimum size of a matrix.
     pub fn new(size: usize, init: T) -> Option<Self> {
         if size < 2 {
@@ -23,8 +23,8 @@ impl<T: Copy> DiagonalMatrix<T> {
     }
 }
 
-impl<T> DiagonalMatrix<T> {
-    /// Set the value at row x column. Since it's a diagonal matrix, column and row can be swapped.
+impl<T> SymmetricMatrix<T> {
+    /// Set the value at row x column. Since it's a symmetric matrix, column and row can be swapped.
     #[inline]
     pub fn set(&mut self, row: usize, column: usize, value: T) {
         let (row, column) = Self::handle_index(row, column);
@@ -32,7 +32,7 @@ impl<T> DiagonalMatrix<T> {
         self.inner[index] = value;
     }
 
-    /// Sets the value at row x column. Since it's a diagonal matrix, column and row can be swapped.
+    /// Sets the value at row x column. Since it's a symmetric matrix, column and row can be swapped.
     #[inline]
     pub fn get(&self, row: usize, column: usize) -> &T {
         let (row, column) = Self::handle_index(row, column);
@@ -40,7 +40,7 @@ impl<T> DiagonalMatrix<T> {
         &self.inner[index]
     }
 
-    /// Swap input parameters to always target the upper diagonal.
+    /// Swap input parameters to always target the upper symmetric.
     #[inline]
     fn handle_index(row: usize, column: usize) -> (usize, usize) {
         if column < row {
@@ -79,7 +79,7 @@ mod test {
     #[test]
     fn test_matrix() {
         let size = 10;
-        let mut matrix = DiagonalMatrix::<usize>::new(size, 0).unwrap();
+        let mut matrix = SymmetricMatrix::<usize>::new(size, 0).unwrap();
 
         let mut c = 0;
         for x in 0..size {
@@ -104,7 +104,7 @@ mod test {
     #[should_panic]
     fn test_oob() {
         let size = 10;
-        let mut matrix = DiagonalMatrix::<usize>::new(size, 0).unwrap();
+        let mut matrix = SymmetricMatrix::<usize>::new(size, 0).unwrap();
         matrix.set(0, 10, 1);
     }
 }

--- a/lib/collection/src/common/symmetric_matrix.rs
+++ b/lib/collection/src/common/symmetric_matrix.rs
@@ -137,14 +137,13 @@ mod test {
         }
 
         // Compare all values
+        #[allow(clippy::needless_range_loop)]
         for row in 0..size {
             for col in 0..size {
                 assert_eq!(
                     *symmetric_matrix.get(row, col),
                     naive_matrix[row][col],
-                    "Mismatch at position ({}, {})",
-                    row,
-                    col
+                    "Mismatch at position ({row}, {col})",
                 );
             }
         }

--- a/lib/collection/src/common/symmetric_matrix.rs
+++ b/lib/collection/src/common/symmetric_matrix.rs
@@ -107,4 +107,46 @@ mod test {
         let mut matrix = SymmetricMatrix::<usize>::new(size, 0).unwrap();
         matrix.set(0, 10, 1);
     }
+
+    #[test]
+    fn test_matrix_vs_naive_implementation() {
+        let size = 5;
+        let init_value = 42;
+
+        // Create symmetric matrix
+        let mut symmetric_matrix = SymmetricMatrix::<i32>::new(size, init_value).unwrap();
+
+        // Create naive 2D vector matrix
+        let mut naive_matrix = vec![vec![init_value; size]; size];
+
+        // Set some values in both matrices
+        let test_values = vec![
+            (0, 1, 10),
+            (1, 3, 20),
+            (2, 4, 30),
+            (0, 4, 40),
+            (1, 2, 50),
+            (3, 3, 100), // Also supports the diagonal elements
+        ];
+
+        for (row, col, value) in &test_values {
+            symmetric_matrix.set(*row, *col, *value);
+            // Insert into naive matrix
+            naive_matrix[*row][*col] = *value;
+            naive_matrix[*col][*row] = *value;
+        }
+
+        // Compare all values
+        for row in 0..size {
+            for col in 0..size {
+                assert_eq!(
+                    *symmetric_matrix.get(row, col),
+                    naive_matrix[row][col],
+                    "Mismatch at position ({}, {})",
+                    row,
+                    col
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Builds on #6797 

Optimizes the diagonal matrix used in MMR to only store half of the data in a single, flattened vector.