### PR TITLE
Use peer_id instead of default_peer_id

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -272,7 +272,7 @@ fn main() -> anyhow::Result<()> {
         &settings.storage.storage_path,
         bootstrap.is_none(),
         args.reinit,
-        settings.cluster.default_peer_id,
+        settings.cluster.peer_id,
     )?;
 
     let is_distributed_deployment = settings.cluster.enabled;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -70,7 +70,7 @@ pub struct ClusterConfig {
     pub enabled: bool, // disabled by default
     #[serde(default)]
     #[validate(range(min = 1, max = MAX_PEER_ID))]
-    pub default_peer_id: Option<PeerId>,
+    pub peer_id: Option<PeerId>,
     #[serde(default = "default_timeout_ms")]
     #[validate(range(min = 1))]
     pub grpc_timeout_ms: u64,


### PR DESCRIPTION
Improvement of https://github.com/qdrant/qdrant/pull/6783 as suggested by @ffuugoo. Now we you need to setup default peer ID using `QDRANT__CLUSTER__PEER_ID=XXX` to pass a peer ID instead of `QDRANT__CLUSTER__DEFAULT_PEER_ID=XXX`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

