### PR TITLE
Exclude primary condition from filter to avoid duplicated matching

### DIFF
--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -84,4 +84,17 @@ impl CardinalityEstimation {
     pub const fn equals_min_exp_max(&self, other: &Self) -> bool {
         self.min == other.min && self.exp == other.exp && self.max == other.max
     }
+
+    // TODO input should be a Condition
+    pub fn has_primary_condition(&self, condition: &FieldCondition) -> bool {
+        self.primary_clauses
+            .iter()
+            .any(|primary_condition| match primary_condition {
+                PrimaryCondition::Condition(field_condition) => {
+                    field_condition.as_ref() == condition
+                }
+                PrimaryCondition::Ids(_) => false,
+                PrimaryCondition::HasVector(_) => false,
+            })
+    }
 }

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -16,7 +16,7 @@ use crate::index::query_optimization::optimized_filter::{OptimizedCondition, che
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::json_path::JsonPath;
-use crate::types::{DateTimePayloadType, GeoPoint};
+use crate::types::{DateTimePayloadType, FieldCondition, GeoPoint};
 
 const DEFAULT_SCORE: PreciseScore = 0.0;
 const DEFAULT_DECAY_TARGET: PreciseScore = 0.0;
@@ -78,8 +78,15 @@ impl StructPayloadIndex {
 
         let payload_provider = PayloadProvider::new(self.payload.clone());
         let total = self.available_point_count();
+        let exclude_condition_box: Box<dyn Fn(&FieldCondition) -> bool> = Box::new(|_| false);
         let condition_checkers = self
-            .convert_conditions(conditions, payload_provider, total, hw_counter)
+            .convert_conditions(
+                conditions,
+                &exclude_condition_box,
+                payload_provider,
+                total,
+                hw_counter,
+            )
             .into_iter()
             .map(|(checker, _estimation)| checker)
             .collect();

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -73,7 +73,8 @@ impl Segment {
                 // aka. read from facet index
                 //
                 // This is more similar to a full-scan, but we won't be hashing so many times.
-                context = payload_index.struct_filtered_context(filter, hw_counter);
+                context =
+                    payload_index.struct_filtered_context(filter, Box::new(|_| false), hw_counter);
 
                 let iter = facet_index
                     .iter_values_map(hw_counter)


### PR DESCRIPTION
The following happens when performing a payload filter:

1. compute primary condition based on cardinality estimation
2. query using primary condition (that is the most restrictive condition)
3. run filter matcher on all resulting points to make sure they match all conditions in the filter (not only the primary one)

Effectively we are checking the primary condition twice, because the primary condition is not excluded from the matcher in the filtering phase.

e.g.

```
POST /collections/benchmark/points/query
{
    "query": 2,
    "filter": {
        "must": [
            {
                "key": "t",
                "match": {
                    "text": "word_2 word_10"
                }
            }
        ]
    }
}
```

In that case the primary condition is the full text filter and the secondary condition is a synthetic `must not have id = 2` for the recommendation.

This PR proposes to not rerun the fulltext validation and simply match point based on the remaining `HasId` condition.
Intersecting posting list for each point id is pretty expensive.

Therefore this change yields a nice performance gain for the plain filtered vector search.

### Before

```
Search with HNSW and high cardinality: 2.063 millis
Search with small cardinality: 21.316 millis  <---
Text search as secondary condition with high cardinality: 4.173 millis
Text search as secondary condition with low cardinality: 4.006 millis
```

### After

```
Search with HNSW and high cardinality: 1.985 millis
Search with small cardinality: 11.503 millis  <---
Text search as secondary condition with high cardinality: 4.215 millis
Text search as secondary condition with low cardinality: 3.944 millis
```

## Review notes

The implementation could not modify the initial filter as all inputs are tied to the same lifetime.
The solution adapted here relies on filtering out primary conditions before the filter optimization phase

Also I only applied this transformation to `must` clause as I doing it as well on `should` clauses breaks a test.
