### PR TITLE
Wait until replicas are activated, when creating custom shards

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -549,8 +549,9 @@ impl ShardReplicaSet {
             if status {
                 Ok(())
             } else {
-                Err(CollectionError::service_error(
-                    "Failed to wait for replica set state, timed out",
+                Err(CollectionError::timeout(
+                    timeout.as_secs() as usize,
+                    "wait for replica set state",
                 ))
             }
         }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -380,6 +380,10 @@ impl ShardReplicaSet {
         replica_set
     }
 
+    pub fn shard_key(&self) -> Option<&ShardKey> {
+        self.shard_key.as_ref()
+    }
+
     pub fn this_peer_id(&self) -> PeerId {
         self.replica_state.read().this_peer_id
     }
@@ -503,17 +507,16 @@ impl ShardReplicaSet {
     /// # Cancel safety
     ///
     /// This method is cancel safe.
-    pub async fn wait_for_state(
+    pub fn wait_for_state(
         &self,
         peer_id: PeerId,
         state: ReplicaState,
         timeout: Duration,
-    ) -> CollectionResult<()> {
+    ) -> impl Future<Output = CollectionResult<()>> + 'static {
         self.wait_for(
             move |replica_set_state| replica_set_state.get_peer_state(peer_id) == Some(state),
             timeout,
         )
-        .await
     }
 
     /// Wait for a replica set state condition to be true.
@@ -523,29 +526,34 @@ impl ShardReplicaSet {
     /// # Cancel safety
     ///
     /// This method is cancel safe.
-    async fn wait_for<F>(&self, check: F, timeout: Duration) -> CollectionResult<()>
+    pub fn wait_for<F>(
+        &self,
+        check: F,
+        timeout: Duration,
+    ) -> impl Future<Output = CollectionResult<()>> + 'static
     where
         F: Fn(&ReplicaSetState) -> bool + Send + 'static,
     {
         // TODO: Propagate cancellation into `spawn_blocking` task!?
 
         let replica_state = self.replica_state.clone();
-        let timed_out =
-            !tokio::task::spawn_blocking(move || replica_state.wait_for(check, timeout))
-                .await
-                .map_err(|err| {
-                    CollectionError::service_error(format!(
-                        "Failed to wait for replica set state: {err}"
-                    ))
-                })?;
+        let task = tokio::task::spawn_blocking(move || replica_state.wait_for(check, timeout));
 
-        if timed_out {
-            return Err(CollectionError::service_error(
-                "Failed to wait for replica set state, timed out",
-            ));
+        async move {
+            let status = task.await.map_err(|err| {
+                CollectionError::service_error(format!(
+                    "Failed to wait for replica set state: {err}"
+                ))
+            })?;
+
+            if status {
+                Ok(())
+            } else {
+                Err(CollectionError::service_error(
+                    "Failed to wait for replica set state, timed out",
+                ))
+            }
         }
-
-        Ok(())
     }
 
     /// Clears the local shard data and loads an empty local shard

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -181,7 +181,7 @@ impl Dispatcher {
             };
 
             // During creation of a shard key, we must ensure that all replicas are ready to accept
-            // write requests, so the client-side script can relly on the fact that the
+            // write requests, so the client-side script can rely on the fact that the
             // shard creation request is complete.
             //
             // For this we explicitly wait for validation this, we do following checks:

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -237,7 +237,7 @@ impl Dispatcher {
                 }
 
                 while let Some(result) = wait_for_active.next().await {
-                    let _ = result?;
+                    result?;
                 }
             };
 

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -261,23 +261,23 @@ impl Dispatcher {
     ) -> Result<(), StorageError> {
         let timeout = timeout.unwrap_or(CONSENSUS_META_OP_WAIT);
 
-        if let Some(state) = self.consensus_state.as_ref() {
-            let state = state.hard_state();
-            let term = state.term;
-            let commit = state.commit;
-            let channel_service = self.toc.get_channel_service();
-            let this_peer_id = self.toc.this_peer_id;
+        let Some(state) = self.consensus_state.as_ref() else {
+            return Ok(());
+        };
 
-            channel_service
-                .await_commit_on_all_peers(this_peer_id, commit, term, timeout)
-                .await?;
+        let state = state.hard_state();
+        let term = state.term;
+        let commit = state.commit;
+        let channel_service = self.toc.get_channel_service();
+        let this_peer_id = self.toc.this_peer_id;
 
-            log::debug!("Consensus is synchronized with term: {term}, commit: {commit}");
+        channel_service
+            .await_commit_on_all_peers(this_peer_id, commit, term, timeout)
+            .await?;
 
-            Ok(())
-        } else {
-            Ok(())
-        }
+        log::debug!("Consensus is synchronized with term: {term}, commit: {commit}");
+
+        Ok(())
     }
 
     /// Waits for all shards of a specific shard key to become active.

--- a/tests/consensus_tests/test_custom_sharding.py
+++ b/tests/consensus_tests/test_custom_sharding.py
@@ -78,6 +78,9 @@ def test_shard_consistency(tmp_path: pathlib.Path):
     create_collection_with_custom_sharding(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICAS)
     wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris)
 
+    # Wait until all peers submit their metadata to consensus
+    time.sleep(2)
+
     # Create shards
     create_shard(
         peer_api_uris[0],


### PR DESCRIPTION
Follow-up to #6778.

After #6778, we initialize custom shard replicas in `Initializing` state, and so when Qdrant returns response to the client, it does not yet guarantee that custom shard is ready to accept write requests. There will be a small delay while shards switch from `Initializing` into `Active` state and fully available.

This PR adds explicit `wait_for_state` check, so that we ensure all replicas are `Active` before returning response to the client. I've also very slightly tweaked `test_shard_consistency` test, so that it should cover this check as part of existing test.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
