### PR TITLE
rename `SnowballParameters` to `SnowballParams`

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7792,11 +7792,11 @@
         "description": "Different stemming algorithms with their configs.",
         "anyOf": [
           {
-            "$ref": "#/components/schemas/SnowballParameters"
+            "$ref": "#/components/schemas/SnowballParams"
           }
         ]
       },
-      "SnowballParameters": {
+      "SnowballParams": {
         "type": "object",
         "required": [
           "language",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -361,7 +361,7 @@ impl From<segment::data_types::index::StemmingAlgorithm> for StemmingAlgorithm {
     fn from(value: segment::data_types::index::StemmingAlgorithm) -> Self {
         let stemming_params = match value {
             segment::data_types::index::StemmingAlgorithm::Snowball(snowball_params) => {
-                let segment::data_types::index::SnowballParameters {
+                let segment::data_types::index::SnowballParams {
                     r#type: _,
                     language,
                 } = snowball_params;
@@ -550,7 +550,7 @@ impl TryFrom<StemmingParams> for segment::data_types::index::StemmingAlgorithm {
                     Status::invalid_argument(format!("Language {:?} not found.", params.language))
                 })?;
                 Ok(segment::data_types::index::StemmingAlgorithm::Snowball(
-                    segment::data_types::index::SnowballParameters {
+                    segment::data_types::index::SnowballParams {
                         r#type: segment::data_types::index::Snowball::Snowball,
                         language,
                     },

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -224,7 +224,7 @@ pub enum Snowball {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
-pub struct SnowballParameters {
+pub struct SnowballParams {
     pub r#type: Snowball,
     pub language: SnowballLanguage,
 }
@@ -233,7 +233,7 @@ pub struct SnowballParameters {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(untagged)]
 pub enum StemmingAlgorithm {
-    Snowball(SnowballParameters),
+    Snowball(SnowballParams),
 }
 
 /// Languages supported by snowball stemmer.

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -294,12 +294,12 @@ impl TokenizerConfig {
 mod tests {
     use super::*;
     use crate::data_types::index::{
-        Language, Snowball, SnowballLanguage, SnowballParameters, StemmingAlgorithm,
+        Language, Snowball, SnowballLanguage, SnowballParams, StemmingAlgorithm,
         StopwordsInterface, TextIndexType,
     };
 
     fn make_stemmer(language: SnowballLanguage) -> Stemmer {
-        Stemmer::from_algorithm(&StemmingAlgorithm::Snowball(SnowballParameters {
+        Stemmer::from_algorithm(&StemmingAlgorithm::Snowball(SnowballParams {
             r#type: Snowball::Snowball,
             language,
         }))

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
@@ -115,7 +115,7 @@ mod test {
     use charabia::Language;
 
     use super::*;
-    use crate::data_types::index::{SnowballLanguage, SnowballParameters, StemmingAlgorithm};
+    use crate::data_types::index::{SnowballLanguage, SnowballParams, StemmingAlgorithm};
     use crate::index::field_index::full_text_index::tokenizers::stemmer::Stemmer;
 
     #[test]
@@ -185,7 +185,7 @@ mod test {
     fn test_multilingual_stemming() {
         let config = TokenizerConfig {
             stemmer: Some(Stemmer::from_algorithm(&StemmingAlgorithm::Snowball(
-                SnowballParameters {
+                SnowballParams {
                     r#type: Default::default(),
                     language: SnowballLanguage::English,
                 },

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/stemmer.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/stemmer.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use rust_stemmers::Algorithm;
 
-use crate::data_types::index::{SnowballParameters, StemmingAlgorithm};
+use crate::data_types::index::{SnowballParams, StemmingAlgorithm};
 
 /// Abstraction to handle different stemming libraries and algorithms with a clean API.
 #[derive(Clone)]
@@ -23,7 +23,7 @@ impl std::fmt::Debug for Stemmer {
 impl Stemmer {
     pub fn from_algorithm(config: &StemmingAlgorithm) -> Self {
         match config {
-            StemmingAlgorithm::Snowball(SnowballParameters {
+            StemmingAlgorithm::Snowball(SnowballParams {
                 r#type: _,
                 language,
             }) => Self::Snowball(Arc::new(rust_stemmers::Stemmer::create(Algorithm::from(


### PR DESCRIPTION
Other structs of this nomenclature use `*Params`, like `TextIndexParams`. This makes snowball parameters consistent in this sense