### PR TITLE
fix check for pure primary condition filter

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -327,7 +327,6 @@ impl MutableFullTextIndex {
         Ok(())
     }
 
-    #[cfg_attr(not(feature = "rocksdb"), expect(clippy::unnecessary_wraps))]
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         // Update persisted storage
         match &self.storage {

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -24,10 +24,12 @@ mod utils;
 
 pub use field_index_base::*;
 
+use crate::utils::maybe_arc::MaybeArc;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimaryCondition {
     Condition(Box<FieldCondition>),
-    Ids(AHashSet<PointIdType>),
+    Ids(MaybeArc<AHashSet<PointIdType>>),
     HasVector(VectorNameBuf),
 }
 
@@ -98,7 +100,7 @@ impl CardinalityEstimation {
                     _ => false,
                 },
                 PrimaryCondition::Ids(ids) => match condition {
-                    Condition::HasId(has_id) => ids == has_id.has_id.deref(),
+                    Condition::HasId(has_id) => ids.deref() == has_id.has_id.deref(),
                     _ => false,
                 },
                 PrimaryCondition::HasVector(has_vector) => match condition {

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -1,7 +1,8 @@
-use ahash::AHashSet;
-use common::types::PointOffsetType;
+use std::ops::Deref;
 
-use crate::types::{FieldCondition, VectorNameBuf};
+use ahash::AHashSet;
+
+use crate::types::{Condition, FieldCondition, PointIdType, VectorNameBuf};
 
 pub mod bool_index;
 pub(super) mod facet_index;
@@ -26,7 +27,7 @@ pub use field_index_base::*;
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimaryCondition {
     Condition(Box<FieldCondition>),
-    Ids(AHashSet<PointOffsetType>),
+    Ids(AHashSet<PointIdType>),
     HasVector(VectorNameBuf),
 }
 
@@ -83,5 +84,29 @@ impl CardinalityEstimation {
     #[cfg(test)]
     pub const fn equals_min_exp_max(&self, other: &Self) -> bool {
         self.min == other.min && self.exp == other.exp && self.max == other.max
+    }
+
+    /// Checks that the given condition is a primary condition of the estimation.
+    pub fn is_primary(&self, condition: &Condition) -> bool {
+        self.primary_clauses
+            .iter()
+            .any(|primary_condition| match primary_condition {
+                PrimaryCondition::Condition(primary_field_condition) => match condition {
+                    Condition::Field(field_condition) => {
+                        primary_field_condition.as_ref() == field_condition
+                    }
+                    _ => false,
+                },
+                PrimaryCondition::Ids(ids) => match condition {
+                    Condition::HasId(has_id) => ids == has_id.has_id.deref(),
+                    _ => false,
+                },
+                PrimaryCondition::HasVector(has_vector) => match condition {
+                    Condition::HasVector(vector_condition) => {
+                        has_vector == &vector_condition.has_vector
+                    }
+                    _ => false,
+                },
+            })
     }
 }

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -269,8 +269,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Deref;
-
     use super::*;
     use crate::json_path::JsonPath;
     use crate::types::{FieldCondition, HasIdCondition};
@@ -318,7 +316,7 @@ mod tests {
                 _ => CardinalityEstimation::unknown(TOTAL),
             },
             Condition::HasId(has_id) => CardinalityEstimation {
-                primary_clauses: vec![PrimaryCondition::Ids(has_id.has_id.deref().clone())],
+                primary_clauses: vec![PrimaryCondition::Ids(has_id.has_id.clone())],
                 min: has_id.has_id.len(),
                 exp: has_id.has_id.len(),
                 max: has_id.has_id.len(),

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -269,6 +269,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Deref;
+
     use super::*;
     use crate::json_path::JsonPath;
     use crate::types::{FieldCondition, HasIdCondition};
@@ -316,13 +318,7 @@ mod tests {
                 _ => CardinalityEstimation::unknown(TOTAL),
             },
             Condition::HasId(has_id) => CardinalityEstimation {
-                primary_clauses: vec![PrimaryCondition::Ids(
-                    has_id
-                        .has_id
-                        .iter()
-                        .map(|&x| format!("{x}").parse().unwrap()) // hack to convert ID as "number"
-                        .collect(),
-                )],
+                primary_clauses: vec![PrimaryCondition::Ids(has_id.has_id.deref().clone())],
                 min: has_id.has_id.len(),
                 exp: has_id.has_id.len(),
                 max: has_id.has_id.len(),

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::fs::create_dir_all;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use ahash::AHashSet;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
@@ -42,7 +42,7 @@ use crate::types::{
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 #[derive(Debug)]
-#[expect(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names)]
 enum StorageType {
     #[cfg(feature = "rocksdb")]
     RocksDbAppendable(std::sync::Arc<parking_lot::RwLock<rocksdb::DB>>),
@@ -105,7 +105,14 @@ impl StructPayloadIndex {
                     .iter()
                     .find_map(|field_index| field_index.filter(field_condition, hw_counter))
             }
-            PrimaryCondition::Ids(ids) => Some(Box::new(ids.iter().copied())),
+            PrimaryCondition::Ids(ids) => {
+                let id_tracker_ref = self.id_tracker.borrow();
+                let mapped_ids: Vec<PointOffsetType> = ids
+                    .iter()
+                    .filter_map(|external_id| id_tracker_ref.internal_id(*external_id))
+                    .collect();
+                Some(Box::new(mapped_ids.into_iter()))
+            }
             PrimaryCondition::HasVector(_) => None,
         }
     }
@@ -352,15 +359,10 @@ impl StructPayloadIndex {
                     .unwrap_or_else(|| CardinalityEstimation::unknown(available_points))
             }
             Condition::HasId(has_id) => {
-                let id_tracker_ref = self.id_tracker.borrow();
-                let mapped_ids: AHashSet<PointOffsetType> = has_id
-                    .has_id
-                    .iter()
-                    .filter_map(|external_id| id_tracker_ref.internal_id(*external_id))
-                    .collect();
-                let num_ids = mapped_ids.len();
+                let num_ids = has_id.has_id.len();
+                let ids = has_id.has_id.deref().clone();
                 CardinalityEstimation {
-                    primary_clauses: vec![PrimaryCondition::Ids(mapped_ids)],
+                    primary_clauses: vec![PrimaryCondition::Ids(ids)],
                     min: num_ids,
                     exp: num_ids,
                     max: num_ids,
@@ -456,10 +458,13 @@ impl StructPayloadIndex {
                 .collect();
 
             if let Some(primary_iterators) = primary_clause_iterators {
-                let num_primary_iterators = primary_iterators.len();
+                let all_conditions_are_primary = filter
+                    .iter_conditions()
+                    .all(|condition| query_cardinality.is_primary(condition));
+
                 let joined_primary_iterator = primary_iterators.into_iter().flatten();
 
-                return if num_primary_iterators == filter.total_conditions_count() {
+                return if all_conditions_are_primary {
                     // All conditions are primary clauses,
                     // We can avoid post-filtering
                     let iter = joined_primary_iterator

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fs::create_dir_all;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -360,7 +359,7 @@ impl StructPayloadIndex {
             }
             Condition::HasId(has_id) => {
                 let num_ids = has_id.has_id.len();
-                let ids = has_id.has_id.deref().clone();
+                let ids = has_id.has_id.clone();
                 CardinalityEstimation {
                     primary_clauses: vec![PrimaryCondition::Ids(ids)],
                     min: num_ids,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2916,7 +2916,7 @@ impl Condition {
             | Condition::IsNull(_)
             | Condition::CustomIdChecker(_)
             | Condition::HasId(_)
-            | Condition::HasVector(_) => 0,
+            | Condition::HasVector(_) => 1,
         }
     }
 
@@ -3296,7 +3296,7 @@ impl Filter {
     pub fn total_conditions_count(&self) -> usize {
         fn count_all_conditions(field: Option<&Vec<Condition>>) -> usize {
             field
-                .map(|i| i.len() + i.iter().map(|j| j.sub_conditions_count()).sum::<usize>())
+                .map(|i| i.iter().map(|j| j.sub_conditions_count()).sum::<usize>())
                 .unwrap_or(0)
         }
 

--- a/lib/segment/src/utils/maybe_arc.rs
+++ b/lib/segment/src/utils/maybe_arc.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 // Structure that acts as `T` most of the time but allows to interchange being wrapped within an `Arc` or not.
 // This is helpful, when a variable can become memory-intensive but must remain the ability to get cloned.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(untagged)] // Make this type transparent when de/serializing and always deserialize as `NoArc`, since it's the first enum kind that matches.
 pub enum MaybeArc<T> {
     NoArc(T),
@@ -47,6 +47,15 @@ impl<T: Clone> MaybeArc<T> {
         match self {
             Self::Arc(a) => Arc::unwrap_or_clone(a),
             Self::NoArc(a) => a,
+        }
+    }
+}
+
+impl<T: Clone> Clone for MaybeArc<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Arc(a) => Self::Arc(a.clone()),
+            Self::NoArc(a) => Self::NoArc(a.clone()),
         }
     }
 }

--- a/tests/openapi/test_filter_min_should.py
+++ b/tests/openapi/test_filter_min_should.py
@@ -11,6 +11,36 @@ def setup(on_disk_vectors, collection_name):
     drop_collection(collection_name=collection_name)
 
 
+def test_min_should_never(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/query',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "min_should": {
+                  "conditions": [
+                    {
+                      "has_id": [1,2]
+                    },
+                    {
+                      "has_id": [4,5,6]
+                    },
+                    {
+                      "has_id": [7,8,9,10]
+                    }
+                  ],
+                  "min_count": 2
+                }
+              },
+              "limit": 100
+            }
+    )
+    assert response.ok
+
+    json = response.json()
+    assert len(json['result']['points']) == 0
+
 def test_min_should(collection_name):
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',


### PR DESCRIPTION
- Fix `total_conditions_count`, so it doesn't count nested must conditions as multiple conditions
- Change `PrimaryCondition` type to store external ids for: a) easier comparison with original condition b) avoiding mapping of the conditions, which might not be even used
- Change criteria for checking if filter consists only of primary conditions. Previous problem: `min_should` can generate more primary conditions then there are conditions defined (by duplicating conditions)