### PR TITLE
adjsut default values for better performance

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -129,11 +129,11 @@ storage:
     memmap_threshold_kb: null
 
     # Maximum size (in KiloBytes) of vectors allowed for plain index.
-    # Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
+    # Default value based on experiments and observations.
     # Note: 1Kb = 1 vector of size 256
     # To explicitly disable vector indexing, set to `0`.
     # If not set, the default value will be used.
-    indexing_threshold_kb: 20000
+    indexing_threshold_kb: 10000
 
     # Interval between forced flushes.
     flush_interval_sec: 5
@@ -152,7 +152,7 @@ storage:
   #  default_segment_number: 0
   #  max_segment_size_kb: null
   #  memmap_threshold_kb: null
-  #  indexing_threshold_kb: 20000
+  #  indexing_threshold_kb: 10000
   #  flush_interval_sec: 5
   #  max_optimization_threads: null
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1480,8 +1480,8 @@ impl SparseVectorDataConfig {
     }
 }
 
-/// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
-pub const DEFAULT_FULL_SCAN_THRESHOLD: usize = 20_000;
+/// Default value based on experiments and observations
+pub const DEFAULT_FULL_SCAN_THRESHOLD: usize = 10_000;
 
 pub const DEFAULT_SPARSE_FULL_SCAN_THRESHOLD: usize = 5_000;
 


### PR DESCRIPTION
* `indexing_threshold`: 20k -> 10k
* default `max_segment_size`: 200mb -> 256mb per CPU core
* Default number of segments: 1 -> 2 per CPU