### PR TITLE
Fix naive payload migration with persisted storage type

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -28,7 +28,7 @@ use crate::json_path::JsonPath;
 use crate::types::{PayloadFieldSchema, PayloadSchemaParams};
 
 /// Selects index and index builder types based on field type.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum IndexSelector<'a> {
     /// In-memory index on RocksDB, appendable or non-appendable
     #[cfg(feature = "rocksdb")]
@@ -40,19 +40,19 @@ pub enum IndexSelector<'a> {
 }
 
 #[cfg(feature = "rocksdb")]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct IndexSelectorRocksDb<'a> {
     pub db: &'a Arc<parking_lot::RwLock<rocksdb::DB>>,
     pub is_appendable: bool,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct IndexSelectorMmap<'a> {
     pub dir: &'a Path,
     pub is_on_disk: bool,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct IndexSelectorGridstore<'a> {
     pub dir: &'a Path,
 }

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -168,8 +168,8 @@ pub struct FullPayloadIndexType {
 }
 
 impl FullPayloadIndexType {
-    pub fn mutability(&self) -> &IndexMutability {
-        &self.mutability
+    pub fn mutability(&self) -> IndexMutability {
+        self.mutability
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -677,7 +677,7 @@ impl StructPayloadIndex {
                 #[cfg(feature = "rocksdb")]
                 {
                     let (StorageType::RocksDbAppendable(db)
-                    | StorageType::RocksDbNonAppendable(db)) = &self.storage_type
+                    | StorageType::RocksDbNonAppendable(db)) = storage_type
                     else {
                         return Err(OperationError::service_error(
                             "Loading payload index failed: Configured storage type and payload schema mismatch!",

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -673,24 +673,23 @@ impl StructPayloadIndex {
             payload_config::StorageType::Gridstore => {
                 IndexSelector::Gridstore(IndexSelectorGridstore { dir: &self.path })
             }
+            #[cfg(feature = "rocksdb")]
             payload_config::StorageType::RocksDb => {
-                #[cfg(feature = "rocksdb")]
-                {
-                    let (StorageType::RocksDbAppendable(db)
-                    | StorageType::RocksDbNonAppendable(db)) = storage_type
-                    else {
-                        return Err(OperationError::service_error(
-                            "Loading payload index failed: Configured storage type and payload schema mismatch!",
-                        ));
-                    };
+                let (StorageType::RocksDbAppendable(db) | StorageType::RocksDbNonAppendable(db)) =
+                    storage_type
+                else {
+                    return Err(OperationError::service_error(
+                        "Loading payload index failed: Configured storage type and payload schema mismatch!",
+                    ));
+                };
 
-                    return Ok(IndexSelector::RocksDb(IndexSelectorRocksDb {
-                        db,
-                        is_appendable: storage_type.is_appendable(),
-                    }));
-                }
-
-                #[cfg(not(feature = "rocksdb"))]
+                return Ok(IndexSelector::RocksDb(IndexSelectorRocksDb {
+                    db,
+                    is_appendable: storage_type.is_appendable(),
+                }));
+            }
+            #[cfg(not(feature = "rocksdb"))]
+            payload_config::StorageType::RocksDb => {
                 return Err(OperationError::service_error(
                     "Loading payload index failed: Index is rocksDB but RocksDB feature is disabled.",
                 ));


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6837>

We've implemented <https://github.com/qdrant/qdrant/pull/6810> and <https://github.com/qdrant/qdrant/pull/6812> alongside each other. This PR makes the two compatible.

Note that this is only relevant for when `migrate_rocksdb_payload_indices` is explicitly set. Qdrant running the default configuration is not affected.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/6837>
- [x] Merge <https://github.com/qdrant/qdrant/pull/6810>
- [ ] Rebase on dev
- [ ] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?