### PR TITLE
Optimize more ahash for u32

### DIFF
--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
+use ahash::AHashMap;
 use api::rest::PointVectors;
 use api::rest::schema::ShardKeySelector;
 use schemars::JsonSchema;
@@ -100,8 +101,8 @@ impl SplitByShard for VectorOperations {
                             .map(move |shard_id| (shard_id, point.clone()))
                     })
                     .fold(
-                        HashMap::new(),
-                        |mut map: HashMap<u32, Vec<PointVectorsPersisted>>, (shard_id, points)| {
+                        AHashMap::new(),
+                        |mut map: AHashMap<u32, Vec<PointVectorsPersisted>>, (shard_id, points)| {
                             map.entry(shard_id).or_default().push(points);
                             map
                         },


### PR DESCRIPTION
We know based on experience that `ahash` is much faster for `u32` keys.

This PR migrates the remaining usages of the std hasher.