### PR TITLE
Fix storage: store index type in payload index config

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -441,10 +441,9 @@ pub trait SegmentOptimizer {
 
             let keys = payload_index
                 .config()
-                .indexed_fields
+                .indices
                 .iter()
-                .filter_map(|(key, schema)| schema.schema.is_tenant().then_some(key))
-                .cloned();
+                .filter_map(|(key, schema)| schema.schema.is_tenant().then_some(key));
             defragmentation_keys.extend(keys);
         }
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -443,7 +443,8 @@ pub trait SegmentOptimizer {
                 .config()
                 .indices
                 .iter()
-                .filter_map(|(key, schema)| schema.schema.is_tenant().then_some(key));
+                .filter(|(_, schema)| schema.schema.is_tenant())
+                .map(|(key, _)| key.clone());
             defragmentation_keys.extend(keys);
         }
 

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -128,7 +128,7 @@ impl BoolIndex {
         match self {
             #[cfg(feature = "rocksdb")]
             BoolIndex::Simple(_) => {
-                IndexMutability::Mutable(crate::index::payload_config::StorageType::RocksDB)
+                IndexMutability::Mutable(crate::index::payload_config::StorageType::RocksDb)
             }
             BoolIndex::Mmap(mmap_bool_index) => IndexMutability::Mmap {
                 is_on_disk: mmap_bool_index.is_on_disk(),

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -225,7 +225,7 @@ impl ImmutableFullTextIndex {
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Mmap(index) => StorageType::Mmap {
                 is_on_disk: index.is_on_disk(),
             },

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -378,7 +378,7 @@ impl MutableFullTextIndex {
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Gridstore(_) => StorageType::Gridstore,
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -328,7 +328,7 @@ impl MutableFullTextIndex {
         Ok(())
     }
 
-    #[cfg_attr(not(feature = "rocksdb"), expect(clippy::unnecessary_wraps))]
+    #[allow(clippy::unnecessary_wraps)]
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         // Update persisted storage
         match &self.storage {

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -491,7 +491,7 @@ impl ImmutableGeoMapIndex {
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Mmap(index) => StorageType::Mmap {
                 is_on_disk: index.is_on_disk(),
             },

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -448,7 +448,7 @@ impl MutableGeoMapIndex {
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Gridstore(_) => StorageType::Gridstore,
         }
     }

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -544,7 +544,7 @@ where
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Mmap(index) => StorageType::Mmap {
                 is_on_disk: index.is_on_disk(),
             },

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -437,7 +437,7 @@ where
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Gridstore(_) => StorageType::Gridstore,
         }
     }

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -464,7 +464,7 @@ where
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Mmap(index) => StorageType::Mmap {
                 is_on_disk: index.is_on_disk(),
             },

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -582,7 +582,7 @@ where
     pub fn storage_type(&self) -> StorageType {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
-            Storage::RocksDb(_) => StorageType::RocksDB,
+            Storage::RocksDb(_) => StorageType::RocksDb,
             Storage::Gridstore(_) => StorageType::Gridstore,
         }
     }

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -145,6 +145,7 @@ impl PayloadFieldSchemaWithIndexType {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum FullPayloadIndexType {
     IntIndex(IndexMutability),
     DatetimeIndex(IndexMutability),
@@ -178,6 +179,7 @@ impl FullPayloadIndexType {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum IndexMutability {
     Mutable(StorageType),
     Immutable(StorageType),
@@ -185,9 +187,10 @@ pub enum IndexMutability {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum StorageType {
     Gridstore,
-    RocksDB,
+    RocksDb,
     Mmap { is_on_disk: bool },
 }
 

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -21,6 +21,7 @@ pub struct PayloadConfig {
     /// This is required for migrating away from RocksDB in favor of the
     /// custom storage engine
     #[cfg(feature = "rocksdb")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub skip_rocksdb: Option<bool>,
 }
 

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -52,9 +52,7 @@ impl PayloadIndices {
     ///
     /// Returns false if empty.
     pub fn any_has_no_type(&self) -> bool {
-        self.fields
-            .values()
-            .any(|index| index.index_types.is_empty())
+        self.fields.values().any(|index| index.types.is_empty())
     }
 
     pub fn to_schemas(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
@@ -89,8 +87,8 @@ pub struct PayloadIndicesStorage {
 
     /// Map of indexed fields and their explicit index types
     ///
-    /// If empty, no explicit payload index type mappings have been stored yet.
-    /// Then use `schemas` to determine the index types.
+    /// If empty for a field, no explicit payload index type mappings have been stored yet.
+    /// Then use `schemas` to determine the index types with a best effort approach.
     ///
     /// Added since Qdrant 1.15
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -120,8 +118,8 @@ impl From<PayloadIndices> for PayloadIndicesStorage {
             (HashMap::new(), HashMap::new()),
             |(mut fields, mut types), (field, schema)| {
                 fields.insert(field.clone(), schema.schema);
-                if !schema.index_types.is_empty() {
-                    types.insert(field, schema.index_types);
+                if !schema.types.is_empty() {
+                    types.insert(field, schema.types);
                 }
                 (fields, types)
             },
@@ -136,15 +134,12 @@ impl From<PayloadIndices> for PayloadIndicesStorage {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PayloadFieldSchemaWithIndexType {
     pub schema: PayloadFieldSchema,
-    pub index_types: Vec<FullPayloadIndexType>,
+    pub types: Vec<FullPayloadIndexType>,
 }
 
 impl PayloadFieldSchemaWithIndexType {
-    pub fn new(schema: PayloadFieldSchema, index_types: Vec<FullPayloadIndexType>) -> Self {
-        Self {
-            schema,
-            index_types,
-        }
+    pub fn new(schema: PayloadFieldSchema, types: Vec<FullPayloadIndexType>) -> Self {
+        Self { schema, types }
     }
 }
 

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 
 use io::file_operations::{atomic_save_json, read_json};
@@ -47,42 +48,6 @@ pub struct PayloadIndices {
 }
 
 impl PayloadIndices {
-    /// Get index schema and type configuration for the given field
-    pub fn get(&self, field: &PayloadKeyType) -> Option<&PayloadFieldSchemaWithIndexType> {
-        self.fields.get(field)
-    }
-
-    /// Get index schema and type configuration for the given field
-    pub fn get_mut(
-        &mut self,
-        field: &PayloadKeyType,
-    ) -> Option<&mut PayloadFieldSchemaWithIndexType> {
-        self.fields.get_mut(field)
-    }
-
-    /// Add a payload field with its schema and index types
-    ///
-    /// Returns the previous value if it existed.
-    pub fn insert(
-        &mut self,
-        field: PayloadKeyType,
-        schema: PayloadFieldSchemaWithIndexType,
-    ) -> Option<PayloadFieldSchemaWithIndexType> {
-        self.fields.insert(field, schema)
-    }
-
-    pub fn remove(&mut self, field: &PayloadKeyType) -> Option<PayloadFieldSchemaWithIndexType> {
-        self.fields.remove(field)
-    }
-
-    pub fn len(&self) -> usize {
-        self.fields.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.fields.is_empty()
-    }
-
     /// Check if any payload field has no explicit types configured
     ///
     /// Returns false if empty.
@@ -92,23 +57,24 @@ impl PayloadIndices {
             .any(|index| index.index_types.is_empty())
     }
 
-    pub fn iter(
-        &self,
-    ) -> impl Iterator<Item = (&PayloadKeyType, &PayloadFieldSchemaWithIndexType)> {
-        self.fields.iter()
-    }
-
-    pub fn iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (&PayloadKeyType, &mut PayloadFieldSchemaWithIndexType)> {
-        self.fields.iter_mut()
-    }
-
     pub fn to_schemas(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
         self.fields
             .iter()
             .map(|(field, index)| (field.clone(), index.schema.clone()))
             .collect()
+    }
+}
+
+impl Deref for PayloadIndices {
+    type Target = HashMap<PayloadKeyType, PayloadFieldSchemaWithIndexType>;
+    fn deref(&self) -> &Self::Target {
+        &self.fields
+    }
+}
+
+impl DerefMut for PayloadIndices {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.fields
     }
 }
 

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -71,11 +71,7 @@ impl PlainPayloadIndex {
 
 impl PayloadIndex for PlainPayloadIndex {
     fn indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
-        self.config
-            .indexed_fields
-            .iter()
-            .map(|i| (i.0.clone(), i.1.schema.clone()))
-            .collect()
+        self.config.indices.schemas.clone()
     }
 
     fn build_index(
@@ -101,7 +97,7 @@ impl PayloadIndex for PlainPayloadIndex {
                 .collect(),
         );
 
-        let prev_schema = self.config.indexed_fields.insert(field, new_schema.clone());
+        let prev_schema = self.config.indices.insert(field, new_schema.clone());
 
         if let Some(prev_schema) = prev_schema {
             // the field is already present with the same schema, no need to save the config
@@ -125,7 +121,7 @@ impl PayloadIndex for PlainPayloadIndex {
     }
 
     fn drop_index(&mut self, field: PayloadKeyTypeRef) -> OperationResult<()> {
-        self.config.indexed_fields.remove(field);
+        self.config.indices.remove(field);
         self.save_config()
     }
 
@@ -135,8 +131,7 @@ impl PayloadIndex for PlainPayloadIndex {
         _new_payload_schema: &PayloadFieldSchema,
     ) -> OperationResult<()> {
         // Just always drop the index, as we don't have any indexes
-        self.config.indexed_fields.remove(field);
-        self.save_config()
+        self.drop_index(field)
     }
 
     fn estimate_cardinality(

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -71,7 +71,7 @@ impl PlainPayloadIndex {
 
 impl PayloadIndex for PlainPayloadIndex {
     fn indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
-        self.config.indices.schemas.clone()
+        self.config.indices.to_schemas()
     }
 
     fn build_index(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -169,7 +169,7 @@ impl StructPayloadIndex {
     ) -> OperationResult<Vec<FieldIndex>> {
         let total_point_count = self.id_tracker.borrow().total_point_count();
 
-        let mut indexes = if payload_schema.index_types.is_empty() {
+        let mut indexes = if payload_schema.types.is_empty() {
             let mut indexes = self.selector(&payload_schema.schema).new_index(
                 field,
                 &payload_schema.schema,
@@ -185,7 +185,7 @@ impl StructPayloadIndex {
                 indexes.push(null_index);
             }
 
-            payload_schema.index_types = indexes
+            payload_schema.types = indexes
                 .iter()
                 .map(|i| i.get_full_index_type())
                 .collect::<Vec<_>>();
@@ -193,7 +193,7 @@ impl StructPayloadIndex {
             indexes
         } else {
             payload_schema
-                .index_types
+                .types
                 .iter()
                 .filter_map(|index| {
                     self.selector_with_type(index)
@@ -1086,10 +1086,10 @@ mod tests {
         assert_eq!(payload_config.indices.len(), 1);
 
         let schema = payload_config.indices.get_mut(&key).unwrap();
-        check_index_types(&schema.index_types);
+        check_index_types(&schema.types);
 
         // Clear index types to check loading from an old segment.
-        schema.index_types.clear();
+        schema.types.clear();
         payload_config.save(&payload_config_path).unwrap();
         drop(payload_config);
 
@@ -1106,6 +1106,6 @@ mod tests {
         assert_eq!(payload_config.indices.len(), 1);
 
         let schema = payload_config.indices.get(&key).unwrap();
-        check_index_types(&schema.index_types);
+        check_index_types(&schema.types);
     }
 }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -43,7 +43,7 @@ use crate::types::{
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 #[derive(Debug)]
-#[expect(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names)]
 enum StorageType {
     #[cfg(feature = "rocksdb")]
     RocksDbAppendable(std::sync::Arc<parking_lot::RwLock<rocksdb::DB>>),
@@ -54,6 +54,7 @@ enum StorageType {
 }
 
 impl StorageType {
+    #[cfg(feature = "rocksdb")]
     pub fn is_appendable(&self) -> bool {
         match self {
             #[cfg(feature = "rocksdb")]

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -598,7 +598,7 @@ impl StructPayloadIndex {
                     payload_config::StorageType::Gridstore => {
                         IndexSelector::Gridstore(IndexSelectorGridstore { dir: &self.path })
                     }
-                    payload_config::StorageType::RocksDB => {
+                    payload_config::StorageType::RocksDb => {
                         #[cfg(feature = "rocksdb")]
                         {
                             let (StorageType::RocksDbAppendable(db)


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/6812>

Fixes a storage compatibility problem in <https://github.com/qdrant/qdrant/pull/6812>. Now we store it in the same format as before, and put the new payload index types at the root level.

More details here: <https://github.com/qdrant/qdrant/pull/6812#issuecomment-3057928785>

Example payload config with these changes:

```json
{
  "indexed_fields":{
    "mybool":"bool",
    "myint":"integer",
    "sections":"keyword",
    "tag":"keyword",
    "text":{
      "type":"text",
      "tokenizer":"prefix",
      "min_token_len":1,
      "max_token_len":20,
      "lowercase":true
    }
  },
  "indexed_types":{
    "mybool":[{"bool_index":{"mutable":"rocks_db"}},{"null_index":{"mmap":{"is_on_disk":true}}}],
    "myint":[{"int_map_index":{"mutable":"rocks_db"}},{"int_index":{"mutable":"rocks_db"}},{"null_index":{"mmap":{"is_on_disk":true}}}],
    "sections":[{"keyword_index":{"immutable":"rocks_db"}}],
    "tag":[{"keyword_index":{"immutable":"rocks_db"}}],
    "text":[{"full_text_index":{"immutable":"rocks_db"}}]
  }
}
```

I suggest to merge this into the above mentioned PR.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?