### PR TITLE
fix cardinality estimation for has id

### DIFF
--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -1,8 +1,9 @@
 use std::ops::Deref;
 
-use crate::types::{Condition, FieldCondition, PointIdType, VectorNameBuf};
 use ahash::AHashSet;
 use common::types::PointOffsetType;
+
+use crate::types::{Condition, FieldCondition, PointIdType, VectorNameBuf};
 
 pub mod bool_index;
 pub(super) mod facet_index;

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -1,8 +1,8 @@
 use std::ops::Deref;
 
-use ahash::AHashSet;
-
 use crate::types::{Condition, FieldCondition, PointIdType, VectorNameBuf};
+use ahash::AHashSet;
+use common::types::PointOffsetType;
 
 pub mod bool_index;
 pub(super) mod facet_index;
@@ -27,9 +27,18 @@ pub use field_index_base::*;
 use crate::utils::maybe_arc::MaybeArc;
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedHasId {
+    /// Original IDs, as provided in filtering condition
+    pub point_ids: MaybeArc<AHashSet<PointIdType>>,
+
+    /// Resolved point offsets, which are specific to the segment.
+    pub resolved_point_offsets: Vec<PointOffsetType>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum PrimaryCondition {
     Condition(Box<FieldCondition>),
-    Ids(MaybeArc<AHashSet<PointIdType>>),
+    Ids(ResolvedHasId),
     HasVector(VectorNameBuf),
 }
 
@@ -100,7 +109,7 @@ impl CardinalityEstimation {
                     _ => false,
                 },
                 PrimaryCondition::Ids(ids) => match condition {
-                    Condition::HasId(has_id) => ids.deref() == has_id.has_id.deref(),
+                    Condition::HasId(has_id) => ids.point_ids.deref() == has_id.has_id.deref(),
                     _ => false,
                 },
                 PrimaryCondition::HasVector(has_vector) => match condition {

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -270,6 +270,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::index::field_index::ResolvedHasId;
     use crate::json_path::JsonPath;
     use crate::types::{FieldCondition, HasIdCondition};
 
@@ -316,7 +317,14 @@ mod tests {
                 _ => CardinalityEstimation::unknown(TOTAL),
             },
             Condition::HasId(has_id) => CardinalityEstimation {
-                primary_clauses: vec![PrimaryCondition::Ids(has_id.has_id.clone())],
+                primary_clauses: vec![PrimaryCondition::Ids(ResolvedHasId {
+                    point_ids: has_id.has_id.clone(),
+                    resolved_point_offsets: has_id
+                        .has_id
+                        .iter()
+                        .map(|id| id.to_string().parse().unwrap())
+                        .collect(),
+                })],
                 min: has_id.has_id.len(),
                 exp: has_id.has_id.len(),
                 max: has_id.has_id.len(),

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -104,7 +104,9 @@ impl StructPayloadIndex {
                     .iter()
                     .find_map(|field_index| field_index.filter(field_condition, hw_counter))
             }
-            PrimaryCondition::Ids(ids) => Some(Box::new(ids.resolved_point_offsets.iter().copied())),
+            PrimaryCondition::Ids(ids) => {
+                Some(Box::new(ids.resolved_point_offsets.iter().copied()))
+            }
             PrimaryCondition::HasVector(_) => None,
         }
     }


### PR DESCRIPTION
Last fix in https://github.com/qdrant/qdrant/pull/6840 broke the cardinality estimation for HasId condition.

Instead of counting points which actually exist in segment, it used total number of points.

This PR returns previous behavior.

