### PR TITLE
Fix mmap payload index load, load in stages

### DIFF
--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -25,6 +25,7 @@ use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::types::{SegmentConfig, SparseVectorDataConfig, VectorDataConfig, VectorName};
 
 pub type Flusher = Box<dyn FnOnce() -> OperationResult<()> + Send>;
+
 /// Check that the given vector name is part of the segment config.
 ///
 /// Returns an error if incompatible.

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -483,6 +483,9 @@ mod tests {
 
             // Check mutable vs mmap
             let mmap_ids = mmap
+                .storage
+                .as_ref()
+                .unwrap()
                 .postings
                 .iter_ids(token_id, &hw_counter)
                 .unwrap()
@@ -501,13 +504,27 @@ mod tests {
         for (point_id, count) in immutable.point_to_tokens_count.iter().enumerate() {
             // Check same deleted points
             assert_eq!(
-                mmap.deleted_points.get(point_id).unwrap(),
+                mmap.storage
+                    .as_ref()
+                    .unwrap()
+                    .deleted_points
+                    .get(point_id)
+                    .unwrap(),
                 *count == 0,
                 "point_id: {point_id}",
             );
 
             // Check same count
-            assert_eq!(*mmap.point_to_tokens_count.get(point_id).unwrap(), *count);
+            assert_eq!(
+                *mmap
+                    .storage
+                    .as_ref()
+                    .unwrap()
+                    .point_to_tokens_count
+                    .get(point_id)
+                    .unwrap(),
+                *count
+            );
             assert_eq!(imm_mmap.point_to_tokens_count[point_id], *count);
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -42,6 +42,10 @@ impl MmapFullTextIndex {
         })
     }
 
+    pub fn load(&self) -> bool {
+        self.inverted_index.load()
+    }
+
     pub fn files(&self) -> Vec<PathBuf> {
         self.inverted_index.files()
     }
@@ -69,7 +73,7 @@ impl MmapFullTextIndex {
     }
 
     pub fn flusher(&self) -> Flusher {
-        self.inverted_index.deleted_points.flusher()
+        self.inverted_index.flusher()
     }
 
     pub fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -525,7 +525,7 @@ impl PayloadFieldIndex for FullTextIndex {
         match self {
             Self::Mutable(index) => index.load(),
             Self::Immutable(index) => index.load(),
-            Self::Mmap(_index) => Ok(true), // mmap index is always loaded
+            Self::Mmap(index) => Ok(index.load()),
         }
     }
 

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -185,10 +185,15 @@ impl ImmutableGeoMapIndex {
             ));
         };
 
+        if !index.load()? {
+            return Ok(false);
+        }
+        let index_storage = index.storage.as_ref().unwrap();
+
         self.points_count = index.points_count();
         self.points_values_count = index.points_values_count();
         self.max_values_per_point = index.max_values_per_point();
-        self.counts_per_hash = index
+        self.counts_per_hash = index_storage
             .counts_per_hash
             .iter()
             .copied()
@@ -196,7 +201,7 @@ impl ImmutableGeoMapIndex {
             .collect();
 
         // Get points per geo hash and filter deleted points
-        self.points_map = index
+        self.points_map = index_storage
             .points_map
             .iter()
             .copied()
@@ -208,11 +213,11 @@ impl ImmutableGeoMapIndex {
                 } = item;
                 (
                     hash,
-                    index.points_map_ids[ids_start as usize..ids_end as usize]
+                    index_storage.points_map_ids[ids_start as usize..ids_end as usize]
                         .iter()
                         .copied()
                         // Filter deleted points
-                        .filter(|id| !index.deleted.get(*id as usize).unwrap_or_default())
+                        .filter(|id| !index_storage.deleted.get(*id as usize).unwrap_or_default())
                         .collect(),
                 )
             })
@@ -223,11 +228,11 @@ impl ImmutableGeoMapIndex {
         let mut deleted_points: Vec<(PointOffsetType, Vec<GeoPoint>)> =
             Vec::with_capacity(index.deleted_count);
         self.point_to_values = ImmutablePointToValues::new(
-            index
+            index_storage
                 .point_to_values
                 .iter()
                 .map(|(id, values)| {
-                    let is_deleted = index.deleted.get(id as usize).unwrap_or_default();
+                    let is_deleted = index_storage.deleted.get(id as usize).unwrap_or_default();
                     match (is_deleted, values) {
                         (false, Some(values)) => values.into_iter().collect(),
                         (false, None) => vec![],

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -63,7 +63,7 @@ impl GeoMapIndex {
     }
 
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
-        let mmap_index = MmapGeoMapIndex::load(path, is_on_disk)?;
+        let mmap_index = MmapGeoMapIndex::open(path, is_on_disk)?;
         if is_on_disk {
             Ok(GeoMapIndex::Mmap(Box::new(mmap_index)))
         } else {
@@ -530,7 +530,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexMmapBuilder {
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        Ok(GeoMapIndex::Mmap(Box::new(MmapGeoMapIndex::new(
+        Ok(GeoMapIndex::Mmap(Box::new(MmapGeoMapIndex::build(
             self.in_memory_index,
             &self.path,
             self.is_on_disk,
@@ -643,8 +643,7 @@ impl PayloadFieldIndex for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.load(),
             GeoMapIndex::Immutable(index) => index.load(),
-            // Mmap index is always loaded
-            GeoMapIndex::Mmap(_) => Ok(true),
+            GeoMapIndex::Mmap(index) => index.load(),
         }
     }
 
@@ -1492,7 +1491,7 @@ mod tests {
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),
             IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false).unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
-                MmapGeoMapIndex::load(temp_dir.path(), false).unwrap(),
+                MmapGeoMapIndex::open(temp_dir.path(), false).unwrap(),
             )),
         };
         new_index.load().unwrap();
@@ -1573,7 +1572,7 @@ mod tests {
             IndexType::Immutable => GeoMapIndex::new_memory(db, FIELD_NAME, false),
             IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false).unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(
-                MmapGeoMapIndex::load(temp_dir.path(), false).unwrap(),
+                MmapGeoMapIndex::open(temp_dir.path(), false).unwrap(),
             )),
         };
         new_index.load().unwrap();

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -131,7 +131,7 @@ impl Numericable for u128 {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq)]
 pub struct Histogram<T: Numericable + Serialize + DeserializeOwned> {
     max_bucket_size: usize,
     precision: f64,

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -119,7 +119,9 @@ impl IndexSelector<'_> {
                 )?)
             }
 
-            (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => self.bool_new(field)?,
+            (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => {
+                self.bool_new(field, create_if_missing)?
+            }
 
             (PayloadIndexType::UuidIndex, PayloadSchemaParams::Uuid(_)) => {
                 FieldIndex::UuidMapIndex(self.map_new(field, create_if_missing)?)
@@ -130,7 +132,8 @@ impl IndexSelector<'_> {
             }
 
             (PayloadIndexType::NullIndex, _) => {
-                let Some(null_index) = MmapNullIndex::open_if_exists(path, total_point_count)?
+                let Some(null_index) =
+                    MmapNullIndex::open_if_exists(path, total_point_count, create_if_missing)?
                 else {
                     return Ok(None);
                 };
@@ -198,7 +201,7 @@ impl IndexSelector<'_> {
                 )?)]
             }
             PayloadSchemaParams::Bool(_) => {
-                vec![self.bool_new(field)?]
+                vec![self.bool_new(field, create_if_missing)?]
             }
             PayloadSchemaParams::Datetime(_) => {
                 vec![FieldIndex::DatetimeIndex(
@@ -449,12 +452,15 @@ impl IndexSelector<'_> {
         dir: &Path,
         field: &JsonPath,
         total_point_count: usize,
+        create_if_missing: bool,
     ) -> OperationResult<Option<FieldIndex>> {
         // null index is always on disk and is appendable
-        Ok(
-            MmapNullIndex::open_if_exists(&null_dir(dir, field), total_point_count)?
-                .map(FieldIndex::NullIndex),
-        )
+        Ok(MmapNullIndex::open_if_exists(
+            &null_dir(dir, field),
+            total_point_count,
+            create_if_missing,
+        )?
+        .map(FieldIndex::NullIndex))
     }
 
     fn text_new(
@@ -536,7 +542,7 @@ impl IndexSelector<'_> {
         }
     }
 
-    fn bool_new(&self, field: &JsonPath) -> OperationResult<FieldIndex> {
+    fn bool_new(&self, field: &JsonPath, create_if_missing: bool) -> OperationResult<FieldIndex> {
         Ok(match self {
             #[cfg(feature = "rocksdb")]
             IndexSelector::RocksDb(IndexSelectorRocksDb {
@@ -548,15 +554,20 @@ impl IndexSelector<'_> {
             ))),
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 let dir = bool_dir(dir, field);
-                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open_or_create(
+                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open(
                     &dir,
                     *is_on_disk,
+                    create_if_missing,
                 )?))
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 let dir = bool_dir(dir, field);
-                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open_or_create(&dir, false)?))
+                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open(
+                    &dir,
+                    false,
+                    create_if_missing,
+                )?))
             }
         })
     }

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -191,13 +191,18 @@ where
             ));
         };
 
+        if !index.load()? {
+            return Ok(false);
+        }
+        let index_storage = index.storage.as_ref().unwrap();
+
         // Construct intermediate values to points map from backing storage
         let mapping = || {
-            index.value_to_points.iter().map(|(value, ids)| {
+            index_storage.value_to_points.iter().map(|(value, ids)| {
                 (
                     value,
                     ids.iter().copied().filter(|idx| {
-                        let is_deleted = index.deleted.get(*idx as usize).unwrap_or(false);
+                        let is_deleted = index_storage.deleted.get(*idx as usize).unwrap_or(false);
                         !is_deleted
                     }),
                 )

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -119,7 +119,7 @@ where
 
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
-        let mmap_index = MmapMapIndex::load(path, is_on_disk)?;
+        let mmap_index = MmapMapIndex::open(path, is_on_disk)?;
         if is_on_disk {
             // Use on mmap directly
             Ok(MapIndex::Mmap(Box::new(mmap_index)))
@@ -162,8 +162,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.load(),
             MapIndex::Immutable(index) => index.load(),
-            // Mmap based index is always loaded
-            MapIndex::Mmap(_) => Ok(true),
+            MapIndex::Mmap(index) => index.load(),
         }
     }
 

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -25,13 +25,15 @@ const IS_NULL_DIRNAME: &str = "is_null";
 /// in case of IsNull and IsEmpty conditions.
 pub struct MmapNullIndex {
     base_dir: PathBuf,
+    storage: Option<Storage>,
+    total_point_count: usize,
+}
+
+struct Storage {
     /// If true, payload field has some values.
     has_values_slice: DynamicMmapFlags,
     /// If true, then payload field contains null value.
     is_null_slice: DynamicMmapFlags,
-    total_point_count: usize,
-    /// `true` if just created.
-    is_loaded: bool,
 }
 
 /// Don't populate null index as it is not essential
@@ -40,37 +42,40 @@ const POPULATE_NULL_INDEX: bool = false;
 
 impl MmapNullIndex {
     pub fn builder(path: &Path) -> OperationResult<MmapNullIndexBuilder> {
-        Ok(MmapNullIndexBuilder(Self::open_or_create(path, 0)?))
+        Ok(MmapNullIndexBuilder(Self::open(path, 0, true)?))
     }
 
-    /// Creates a new null index at the given path.
-    /// If it already exists, loads the index.
+    /// Open or create a null index at the given path.
     ///
     /// # Arguments
     /// - `path` - The directory where the index files should live, must be exclusive to this index.
-    pub fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
+    /// - `total_point_count` - Total number of points in the segment.
+    /// - `create_if_missing` - If true, creates the index if it doesn't exist.
+    pub fn open(
+        path: &Path,
+        total_point_count: usize,
+        create_if_missing: bool,
+    ) -> OperationResult<Self> {
         let has_values_dir = path.join(HAS_VALUES_DIRNAME);
-        if has_values_dir.is_dir() {
-            Self::open(path, total_point_count)
-        } else {
-            std::fs::create_dir_all(path).map_err(|err| {
-                OperationError::service_error(format!(
-                    "Failed to create null-index directory: {err}, path: {path:?}"
-                ))
-            })?;
 
-            let mut index = Self::open(path, total_point_count)?;
-            index.is_loaded = false;
-            Ok(index)
+        // If has values directory doesn't exist, assume the index doesn't exist on disk
+        if !has_values_dir.is_dir() && !create_if_missing {
+            return Ok(Self {
+                base_dir: path.to_path_buf(),
+                storage: None,
+                total_point_count,
+            });
         }
+
+        Self::open_or_create(path, total_point_count)
     }
 
-    fn open(path: &Path, total_point_count: usize) -> OperationResult<Self> {
-        if !path.is_dir() {
-            return Err(OperationError::service_error(format!(
-                "Path is not a directory {path:?}"
-            )));
-        }
+    fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
+        std::fs::create_dir_all(path).map_err(|err| {
+            OperationError::service_error(format!(
+                "Failed to create null-index directory: {err}, path: {path:?}"
+            ))
+        })?;
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
         let has_values_slice = DynamicMmapFlags::open(&has_values_path, POPULATE_NULL_INDEX)?;
@@ -80,15 +85,23 @@ impl MmapNullIndex {
 
         Ok(Self {
             base_dir: path.to_path_buf(),
-            has_values_slice,
-            is_null_slice,
+            storage: Some(Storage {
+                has_values_slice,
+                is_null_slice,
+            }),
             total_point_count,
-            is_loaded: true,
         })
     }
 
-    pub fn open_if_exists(path: &Path, total_point_count: usize) -> OperationResult<Option<Self>> {
+    pub fn open_if_exists(
+        path: &Path,
+        total_point_count: usize,
+        create_if_missing: bool,
+    ) -> OperationResult<Option<Self>> {
         if !path.is_dir() {
+            if create_if_missing {
+                return Ok(Some(Self::open_or_create(path, total_point_count)?));
+            }
             return Ok(None);
         }
 
@@ -100,10 +113,11 @@ impl MmapNullIndex {
             let is_null_slice = DynamicMmapFlags::open(&is_null_path, POPULATE_NULL_INDEX)?;
             Ok(Some(Self {
                 base_dir: path.to_path_buf(),
-                has_values_slice,
-                is_null_slice,
+                storage: Some(Storage {
+                    has_values_slice,
+                    is_null_slice,
+                }),
                 total_point_count,
-                is_loaded: true,
             }))
         } else {
             Ok(None)
@@ -116,6 +130,12 @@ impl MmapNullIndex {
         payload: &[&Value],
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
+        let Some(storage) = &mut self.storage else {
+            return Err(OperationError::service_error(
+                "MmapNullIndex storage is not initialized".to_string(),
+            ));
+        };
+
         let mut is_null = false;
         let mut has_values = false;
         for value in payload {
@@ -151,9 +171,11 @@ impl MmapNullIndex {
 
         let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
 
-        self.has_values_slice
+        storage
+            .has_values_slice
             .set_with_resize(id, has_values, hw_counter_ref)?;
-        self.is_null_slice
+        storage
+            .is_null_slice
             .set_with_resize(id, is_null, hw_counter_ref)?;
 
         // Update total_points to track the highest point offset seen
@@ -163,32 +185,49 @@ impl MmapNullIndex {
     }
 
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        let Some(storage) = &mut self.storage else {
+            return Ok(());
+        };
+
         let disposed_hw = HardwareCounterCell::disposable(); // Deleting is unmeasured OP.
         let disposed_hw = disposed_hw.ref_payload_index_io_write_counter();
 
-        self.has_values_slice
+        storage
+            .has_values_slice
             .set_with_resize(id, false, disposed_hw)?;
-        self.is_null_slice.set_with_resize(id, false, disposed_hw)?;
+        storage
+            .is_null_slice
+            .set_with_resize(id, false, disposed_hw)?;
         Ok(())
     }
 
     pub fn values_count(&self, id: PointOffsetType) -> usize {
-        usize::from(self.has_values_slice.get(id))
+        self.storage
+            .as_ref()
+            .map_or(0, |storage| usize::from(storage.has_values_slice.get(id)))
     }
 
     pub fn values_is_empty(&self, id: PointOffsetType) -> bool {
-        !self.has_values_slice.get(id)
+        self.storage
+            .as_ref()
+            .is_none_or(|storage| !storage.has_values_slice.get(id))
     }
 
     pub fn values_is_null(&self, id: PointOffsetType) -> bool {
-        self.is_null_slice.get(id)
+        self.storage
+            .as_ref()
+            .is_some_and(|storage| storage.is_null_slice.get(id))
     }
 
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        let points_count = self
+            .storage
+            .as_ref()
+            .map_or(0, |storage| storage.has_values_slice.len());
         PayloadIndexTelemetry {
             field_name: None,
-            points_count: self.has_values_slice.len(),
-            points_values_count: self.has_values_slice.len(),
+            points_count,
+            points_values_count: points_count,
             histogram_bucket_size: None,
             index_type: "mmap_null_index",
         }
@@ -201,15 +240,19 @@ impl MmapNullIndex {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
-        self.is_null_slice.populate()?;
-        self.has_values_slice.populate()?;
+        if let Some(storage) = &self.storage {
+            storage.is_null_slice.populate()?;
+            storage.has_values_slice.populate()?;
+        }
         Ok(())
     }
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
-        self.is_null_slice.clear_cache()?;
-        self.has_values_slice.clear_cache()?;
+        if let Some(storage) = &self.storage {
+            storage.is_null_slice.clear_cache()?;
+            storage.has_values_slice.clear_cache()?;
+        }
 
         Ok(())
     }
@@ -228,12 +271,14 @@ impl MmapNullIndex {
 
 impl PayloadFieldIndex for MmapNullIndex {
     fn count_indexed_points(&self) -> usize {
-        self.has_values_slice.len()
+        self.storage
+            .as_ref()
+            .map_or(0, |storage| storage.has_values_slice.len())
     }
 
     fn load(&mut self) -> OperationResult<bool> {
-        // Nothing needed
-        Ok(self.is_loaded)
+        let is_loaded = self.storage.is_some();
+        Ok(is_loaded)
     }
 
     fn cleanup(self) -> OperationResult<()> {
@@ -242,13 +287,19 @@ impl PayloadFieldIndex for MmapNullIndex {
     }
 
     fn flusher(&self) -> Flusher {
+        let Some(storage) = &self.storage else {
+            return Box::new(|| Ok(()));
+        };
+
         let Self {
             base_dir: _,
+            storage: _,
+            total_point_count: _,
+        } = self;
+        let Storage {
             has_values_slice,
             is_null_slice,
-            total_point_count: _,
-            is_loaded: _,
-        } = self;
+        } = storage;
 
         let is_empty_flusher = has_values_slice.flusher();
         let is_null_flusher = is_null_slice.flusher();
@@ -261,13 +312,19 @@ impl PayloadFieldIndex for MmapNullIndex {
     }
 
     fn files(&self) -> Vec<PathBuf> {
+        let Some(storage) = &self.storage else {
+            return vec![];
+        };
+
         let Self {
             base_dir: _,
+            storage: _,
+            total_point_count: _,
+        } = self;
+        let Storage {
             has_values_slice,
             is_null_slice,
-            total_point_count: _,
-            is_loaded: _,
-        } = self;
+        } = storage;
 
         let mut files = has_values_slice.files();
         files.extend(is_null_slice.files());
@@ -283,6 +340,10 @@ impl PayloadFieldIndex for MmapNullIndex {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
         let FieldCondition {
             key: _,
             r#match: _,
@@ -298,38 +359,40 @@ impl PayloadFieldIndex for MmapNullIndex {
         if let Some(is_empty) = is_empty {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.has_values_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.has_values_slice.len() / u8::BITS as usize);
 
             if *is_empty {
                 // Iterate over all tracked values, but filter out those which have a value
                 let iter = (0..self.total_point_count as PointOffsetType)
-                    .filter(move |&id| !self.has_values_slice.get(id))
+                    .filter(move |&id| !storage.has_values_slice.get(id))
                     .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
                 Some(Box::new(iter))
             } else {
                 // Non-empty values are registered in the index explicitly
-                let iter =
-                    self.has_values_slice
-                        .iter_trues()
-                        .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
+                let iter = storage.has_values_slice.iter_trues().measure_hw_with_cell(
+                    hw_counter,
+                    1,
+                    |i| i.payload_index_io_read_counter(),
+                );
                 Some(Box::new(iter))
             }
         } else if let Some(is_null) = is_null {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.is_null_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.is_null_slice.len() / u8::BITS as usize);
             if *is_null {
                 // We DO have list of all null values, so we can iterate over them
                 // Null values are explicitly marked in the index
                 let iter =
-                    self.is_null_slice
+                    storage
+                        .is_null_slice
                         .iter_trues()
                         .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
                 Some(Box::new(iter))
             } else {
                 // Iterate over all tracked values, but filter out those which are null
                 let iter = (0..self.total_point_count as PointOffsetType)
-                    .filter(move |&id| !self.is_null_slice.get(id))
+                    .filter(move |&id| !storage.is_null_slice.get(id))
                     .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
                 Some(Box::new(iter))
             }
@@ -343,6 +406,10 @@ impl PayloadFieldIndex for MmapNullIndex {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> Option<CardinalityEstimation> {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
         let FieldCondition {
             key,
             r#match: _,
@@ -358,12 +425,12 @@ impl PayloadFieldIndex for MmapNullIndex {
         if let Some(is_empty) = is_empty {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.has_values_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.has_values_slice.len() / u8::BITS as usize);
             if *is_empty {
                 // We can estimate using the total_point_count, but not exactly since we don't know which are deleted
                 let estimated = self
                     .total_point_count
-                    .saturating_sub(self.has_values_slice.count_flags());
+                    .saturating_sub(storage.has_values_slice.count_flags());
 
                 Some(CardinalityEstimation {
                     min: 0,
@@ -377,7 +444,7 @@ impl PayloadFieldIndex for MmapNullIndex {
             } else {
                 // All non-empty values are explicitly marked in the index
                 Some(
-                    CardinalityEstimation::exact(self.has_values_slice.count_flags())
+                    CardinalityEstimation::exact(storage.has_values_slice.count_flags())
                         .with_primary_clause(PrimaryCondition::from(FieldCondition::new_is_empty(
                             key.clone(),
                             false,
@@ -387,12 +454,12 @@ impl PayloadFieldIndex for MmapNullIndex {
         } else if let Some(is_null) = is_null {
             hw_counter
                 .payload_index_io_read_counter()
-                .incr_delta(self.is_null_slice.len() / u8::BITS as usize);
+                .incr_delta(storage.is_null_slice.len() / u8::BITS as usize);
 
             if *is_null {
                 // Null values are explicitly marked in the index
                 Some(
-                    CardinalityEstimation::exact(self.is_null_slice.count_flags())
+                    CardinalityEstimation::exact(storage.is_null_slice.count_flags())
                         .with_primary_clause(PrimaryCondition::from(FieldCondition::new_is_null(
                             key.clone(),
                             true,
@@ -402,7 +469,7 @@ impl PayloadFieldIndex for MmapNullIndex {
                 // We can estimate the non-null values from the total number of values
                 let estimated = self
                     .total_point_count
-                    .saturating_sub(self.is_null_slice.count_flags());
+                    .saturating_sub(storage.is_null_slice.count_flags());
 
                 Some(CardinalityEstimation {
                     min: 0,                 // assuming all points are deleted

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -28,14 +28,18 @@ const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 pub struct MmapNumericIndex<T: Encodable + Numericable + Default + MmapValue + 'static> {
     path: PathBuf,
-    deleted: MmapBitSliceBufferedUpdateWrapper,
-    // sorted pairs (id + value), sorted by value (by id if values are equal)
-    pairs: MmapSlice<Point<T>>,
+    pub(super) storage: Option<Storage<T>>,
     histogram: Histogram<T>,
     deleted_count: usize,
     max_values_per_point: usize,
-    pub(super) point_to_values: MmapPointToValues<T>,
     is_on_disk: bool,
+}
+
+pub(super) struct Storage<T: Encodable + Numericable + Default + MmapValue + 'static> {
+    deleted: MmapBitSliceBufferedUpdateWrapper,
+    // sorted pairs (id + value), sorted by value (by id if values are equal)
+    pairs: MmapSlice<Point<T>>,
+    pub(super) point_to_values: MmapPointToValues<T>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,13 +152,25 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
             }
         }
 
-        Self::load(path, is_on_disk)
+        Self::open(path, is_on_disk)
     }
 
-    pub fn load(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
+    pub fn open(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
         let pairs_path = path.join(PAIRS_PATH);
         let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
+
+        // If config doesn't exist, assume the index doesn't exist on disk
+        if !config_path.is_file() {
+            return Ok(Self {
+                path: path.to_path_buf(),
+                storage: None,
+                histogram: Histogram::default(),
+                deleted_count: 0,
+                max_values_per_point: 0,
+                is_on_disk,
+            });
+        }
 
         let histogram = Histogram::<T>::load(path)?;
         let config: MmapNumericIndexConfig = read_json(&config_path)?;
@@ -172,15 +188,22 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         let point_to_values = MmapPointToValues::open(path, do_populate)?;
 
         Ok(Self {
-            pairs: map,
-            deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
             path: path.to_path_buf(),
+            storage: Some(Storage {
+                pairs: map,
+                deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+                point_to_values,
+            }),
             histogram,
             deleted_count,
             max_values_per_point: config.max_values_per_point,
-            point_to_values,
             is_on_disk,
         })
+    }
+
+    pub fn load(&self) -> OperationResult<bool> {
+        let is_loaded = self.storage.is_some();
+        Ok(is_loaded)
     }
 
     pub fn clear(self) -> OperationResult<()> {
@@ -199,20 +222,28 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
             self.path.join(DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
-        files.extend(self.point_to_values.files());
+        if let Some(storage) = &self.storage {
+            files.extend(storage.point_to_values.files());
+        }
         files.extend(Histogram::<T>::files(&self.path));
         files
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
-        files.extend(self.point_to_values.immutable_files());
+        if let Some(storage) = &self.storage {
+            files.extend(storage.point_to_values.immutable_files());
+        }
         files.extend(Histogram::<T>::immutable_files(&self.path));
         files
     }
 
     pub fn flusher(&self) -> Flusher {
-        self.deleted.flusher()
+        if let Some(storage) = &self.storage {
+            storage.deleted.flusher()
+        } else {
+            Box::new(|| Ok(()))
+        }
     }
 
     pub fn check_values_any(
@@ -221,10 +252,14 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
     ) -> bool {
+        let Some(storage) = &self.storage else {
+            return false;
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        if self.deleted.get(idx as usize) == Some(false) {
-            self.point_to_values.check_values_any(
+        if storage.deleted.get(idx as usize) == Some(false) {
+            storage.point_to_values.check_values_any(
                 idx,
                 |v| check_fn(T::from_referenced(&v)),
                 &hw_counter,
@@ -235,9 +270,14 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
-        if self.deleted.get(idx as usize) == Some(false) {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
+        if storage.deleted.get(idx as usize) == Some(false) {
             Some(Box::new(
-                self.point_to_values
+                storage
+                    .point_to_values
                     .get_values(idx)?
                     .map(|v| *T::from_referenced(&v)),
             ))
@@ -247,8 +287,12 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        if self.deleted.get(idx as usize) == Some(false) {
-            self.point_to_values.get_values_count(idx)
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
+        if storage.deleted.get(idx as usize) == Some(false) {
+            storage.point_to_values.get_values_count(idx)
         } else {
             None
         }
@@ -257,7 +301,9 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     /// Returns the number of key-value pairs in the index.
     /// Note that is doesn't count deleted pairs.
     pub(super) fn total_unique_values_count(&self) -> usize {
-        self.pairs.len()
+        self.storage
+            .as_ref()
+            .map_or(0, |storage| storage.pairs.len())
     }
 
     pub(super) fn values_range<'a>(
@@ -265,29 +311,42 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
         hw_counter: &'a HardwareCounterCell,
-    ) -> impl Iterator<Item = PointOffsetType> + 'a {
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+        let Some(iter) = self.values_range_iterator(start_bound, end_bound) else {
+            return Box::new(std::iter::empty());
+        };
+
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        self.values_range_iterator(start_bound, end_bound)
+        let iter = iter
             .map(|Point { idx, .. }| idx)
             .measure_hw_with_condition_cell(hw_counter, size_of::<Point<T>>(), |i| {
                 i.payload_index_io_read_counter()
-            })
+            });
+        Box::new(iter)
     }
 
     pub(super) fn orderable_values_range(
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> impl DoubleEndedIterator<Item = (T, PointOffsetType)> + '_ {
-        self.values_range_iterator(start_bound, end_bound)
-            .map(|Point { val, idx }| (val, idx))
+    ) -> Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_> {
+        let Some(iter) = self.values_range_iterator(start_bound, end_bound) else {
+            return Box::new(std::iter::empty());
+        };
+
+        let iter = iter.map(|Point { val, idx }| (val, idx));
+        Box::new(iter)
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {
+        let Some(storage) = &mut self.storage else {
+            return;
+        };
+
         let idx = idx as usize;
-        if idx < self.deleted.len() && !self.deleted.get(idx).unwrap_or(true) {
-            self.deleted.set(idx, true);
+        if idx < storage.deleted.len() && !storage.deleted.get(idx).unwrap_or(true) {
+            storage.deleted.set(idx, true);
             self.deleted_count += 1;
         }
     }
@@ -297,7 +356,9 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     }
 
     pub(super) fn get_points_count(&self) -> usize {
-        self.point_to_values.len() - self.deleted_count
+        self.storage.as_ref().map_or(0, |storage| {
+            storage.point_to_values.len() - self.deleted_count
+        })
     }
 
     pub(super) fn get_max_values_per_point(&self) -> usize {
@@ -309,8 +370,8 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
     ) -> usize {
-        let iterator = self.values_range_iterator(start_bound, end_bound);
-        iterator.end_index - iterator.start_index
+        self.values_range_iterator(start_bound, end_bound)
+            .map_or(0, |iter| iter.end_index - iter.start_index)
     }
 
     // get iterator
@@ -318,43 +379,50 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> NumericIndexPairsIterator<'_, T> {
+    ) -> Option<NumericIndexPairsIterator<'_, T>> {
+        let Some(storage) = &self.storage else {
+            return None;
+        };
+
         let start_index = match start_bound {
-            Bound::Included(bound) => self.pairs.binary_search(&bound).unwrap_or_else(|idx| idx),
-            Bound::Excluded(bound) => match self.pairs.binary_search(&bound) {
+            Bound::Included(bound) => storage
+                .pairs
+                .binary_search(&bound)
+                .unwrap_or_else(|idx| idx),
+            Bound::Excluded(bound) => match storage.pairs.binary_search(&bound) {
                 Ok(idx) => idx + 1,
                 Err(idx) => idx,
             },
             Bound::Unbounded => 0,
         };
 
-        if start_index >= self.pairs.len() {
-            return NumericIndexPairsIterator {
-                pairs: &self.pairs,
-                deleted: &self.deleted,
-                start_index: self.pairs.len(),
-                end_index: self.pairs.len(),
-            };
+        if start_index >= storage.pairs.len() {
+            return Some(NumericIndexPairsIterator {
+                pairs: &storage.pairs,
+                deleted: &storage.deleted,
+                start_index: storage.pairs.len(),
+                end_index: storage.pairs.len(),
+            });
         }
 
         let end_index = match end_bound {
-            Bound::Included(bound) => match self.pairs[start_index..].binary_search(&bound) {
+            Bound::Included(bound) => match storage.pairs[start_index..].binary_search(&bound) {
                 Ok(idx) => idx + 1 + start_index,
                 Err(idx) => idx + start_index,
             },
             Bound::Excluded(bound) => {
-                let end_bound = self.pairs[start_index..].binary_search(&bound);
+                let end_bound = storage.pairs[start_index..].binary_search(&bound);
                 end_bound.unwrap_or_else(|idx| idx) + start_index
             }
-            Bound::Unbounded => self.pairs.len(),
+            Bound::Unbounded => storage.pairs.len(),
         };
 
-        NumericIndexPairsIterator {
-            pairs: &self.pairs,
-            deleted: &self.deleted,
+        Some(NumericIndexPairsIterator {
+            pairs: &storage.pairs,
+            deleted: &storage.deleted,
             start_index,
             end_index,
-        }
+        })
     }
 
     fn make_conditioned_counter<'a>(
@@ -371,8 +439,10 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
-        self.pairs.populate()?;
-        self.point_to_values.populate();
+        if let Some(storage) = &self.storage {
+            storage.pairs.populate()?;
+            storage.point_to_values.populate();
+        }
         Ok(())
     }
 
@@ -384,7 +454,9 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         clear_disk_cache(&pairs_path)?;
         clear_disk_cache(&deleted_path)?;
 
-        self.point_to_values.clear_cache()?;
+        if let Some(storage) = &self.storage {
+            storage.point_to_values.clear_cache()?;
+        }
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -188,7 +188,7 @@ where
 
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
-        let mmap_index = MmapNumericIndex::load(path, is_on_disk)?;
+        let mmap_index = MmapNumericIndex::open(path, is_on_disk)?;
         if is_on_disk {
             // Use on mmap directly
             Ok(NumericIndexInner::Mmap(mmap_index))
@@ -210,8 +210,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.load(),
             NumericIndexInner::Immutable(index) => index.load(),
-            // Mmap based index is always loaded
-            NumericIndexInner::Mmap(_) => Ok(true),
+            NumericIndexInner::Mmap(index) => index.load(),
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -113,7 +113,12 @@ impl<T: Encodable + Numericable + Default + MmapValue> InMemoryNumericIndex<T> {
     ///
     /// Expensive because this reads the full mmap index.
     pub(super) fn from_mmap(mmap_index: &MmapNumericIndex<T>) -> Self {
-        (0..mmap_index.point_to_values.len() as PointOffsetType)
+        let point_count = mmap_index
+            .storage
+            .as_ref()
+            .map_or(0, |storage| storage.point_to_values.len());
+
+        (0..point_count as PointOffsetType)
             .filter_map(|idx| mmap_index.get_values(idx).map(|values| (idx, values)))
             .flat_map(|(idx, values)| values.into_iter().map(move |value| (idx, value)))
             .collect::<InMemoryNumericIndex<T>>()

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -177,11 +177,14 @@ impl StructPayloadIndex {
             )?;
 
             // Special null index complements every index.
-            if let Some(null_index) =
-                IndexSelector::new_null_index(&self.path, field, total_point_count)?
-            {
-                // todo: This means that null index will not be built if it is not loaded here.
-                //       Maybe we should set `is_loaded` to false to trigger index building.
+            if let Some(null_index) = IndexSelector::new_null_index(
+                &self.path,
+                field,
+                total_point_count,
+                create_if_missing,
+            )? {
+                // TODO: This means that null index will not be built if it is not loaded here.
+                //       Maybe we should set `rebuild` to true to trigger index building.
                 indexes.push(null_index);
             }
 


### PR DESCRIPTION
Exactly the same as <https://github.com/qdrant/qdrant/pull/6837>, but merging into `dev` asynchronously to make <https://github.com/qdrant/qdrant/pull/6810> smaller.

---

Applies the same change as in <https://github.com/qdrant/qdrant/pull/6805>, but to our mmap payload indices.

This separates loading of our mmap payload indices into two stages. First is opening them. Second is loading. Only loading should fail if files don't exist on disk. This is important to make the interface consistent.

While this currently isn't very well implemented - using `Option`'s to wrap mmap types - I'd consider this good enough for now. It currently is possible to have these mmap payload indices in illegal state (functioning index with no files on disk). But we try to prevent this in practice by failing on load.

This PR does not change the runtime behavior of indices, and in practice, they should behave exactly the same. It does change behavior of opening/loading indices, but that is only when loading a segment. Other than that, the indices remain the same.

The plan is to do significant refactoring of payload index creation and opening. That will make the interfaces much simpler and will prevent the illegal state.

### Tasks
- [x] do same treatment to bool mmap index?
- [x] do same treatment to null mmap index?
- [x] fix warning about payload index cache clearing (if mmap files don't exist)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?