### PR TITLE
Fix read latency spikes during partial snapshot recovery

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -343,7 +343,7 @@ impl LocalShard {
         let mut segment_holder = SegmentHolder::default();
 
         for handler in load_handlers {
-            let segment = handler.join().map_err(|err| {
+            let segment = tokio::task::block_in_place(|| handler.join()).map_err(|err| {
                 CollectionError::service_error(format!(
                     "Can't join segment load thread: {:?}",
                     err.type_id()


### PR DESCRIPTION
TL;DR:
- I've noticed that all latency spikes that we observe in RW-seg cluster follow the same pattern
- following the logs/pattern I found that we call `std::thread::JoinHandle::join` ***on the async runtime*** during partial snapshot recovery
- I suspect, that the spikes are caused by this "blocking call on async runtime"
- this PR implements the most trivial workaround, so that we can quickly merge it and see if it fixes the issue on RW-seg cluster

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
