### PR TITLE
Fix payload index migration config and edge case handling

### DIFF
--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -56,6 +56,19 @@ impl PayloadIndices {
         self.fields.values().any(|index| index.types.is_empty())
     }
 
+    /// Check if any payload field used RocksDB
+    ///
+    /// Returns false if empty.
+    #[cfg(feature = "rocksdb")]
+    pub fn any_is_rocksdb(&self) -> bool {
+        self.fields.values().any(|index| {
+            index
+                .types
+                .iter()
+                .any(|t| t.storage_type == StorageType::RocksDb)
+        })
+    }
+
     pub fn to_schemas(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
         self.fields
             .iter()

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -254,7 +254,7 @@ impl StructPayloadIndex {
             }
         }
 
-        // Load all indices, trigger rebuild if load is not succesful
+        // Load all indices, trigger rebuild if load is not successful
         if !rebuild {
             for ref mut index in indexes.iter_mut() {
                 if !index.load()? {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -271,6 +271,10 @@ impl StructPayloadIndex {
                 &payload_schema.schema,
                 &HardwareCounterCell::disposable(), // Internal operation
             )?;
+
+            // Persist exact payload index types of newly built indices
+            is_dirty = true;
+            payload_schema.types = indexes.iter().map(|i| i.get_full_index_type()).collect();
         }
 
         Ok((indexes, is_dirty))


### PR DESCRIPTION
Fix two problems in payload index migrations that has recently been merged in <https://github.com/qdrant/qdrant/pull/6810>.

The first fix is in configuration handling. This config describes the exact type of payload index being used, it is used when loading an index. The implementation was saving changes a bit too aggressively, saving an incomplete configuration in some cases. It must only persist at the end based on a dirty flag. It looks like we lost this logic due to a bad conflict resolution.

The second fix is to make payload index loading more robust. It ensures that we still open RocksDB if any of the indices on disk still relies on it, no matter if we enable migrations or not. Without the fix loading could fail resulting in a dummy segment.

Here's a case that failed before, which is now fixed in this PR:
- start Qdrant with `QDRANT__FEATURE_FLAGS__ALL=false`
- restore 'Qdrant Web Documentation' from sample snapshots in web UI
- restart Qdrant with `QDRANT__FEATURE_FLAGS__ALL=true`
- watch it fail to load in the middle of migration

The second problem was about 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?