### PR TITLE
After payload index migration, delete RocksDB files

### DIFF
--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -392,7 +392,9 @@ impl StructPayloadIndex {
 
         // If we have a RocksDB instance, but no more index using it, completely delete it here
         #[cfg(feature = "rocksdb")]
-        if !index.config.indices.any_is_rocksdb() && let Some(db) = index.db.take() {
+        if !index.config.indices.any_is_rocksdb()
+            && let Some(db) = index.db.take()
+        {
             match Arc::try_unwrap(db) {
                 Ok(db) => {
                     log::trace!(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -412,6 +412,10 @@ impl StructPayloadIndex {
                         }
                     }
                 }
+                // Here we don't have exclusive ownership of RocksDB, which prevents us from
+                // controlling and closing the instance. Because of it, we cannot destroy the
+                // RocksDB files, and leave them behind. We don't consider this a problem, because
+                // a future optimization run will get rid of these files.
                 Err(db) => {
                     log::warn!(
                         "RocksDB for payload indices could not be deleted, does not have exclusive ownership"

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -392,8 +392,8 @@ impl StructPayloadIndex {
 
         // If we have a RocksDB instance, but no more index using it, completely delete it here
         #[cfg(feature = "rocksdb")]
-        if index.db.is_some() && !index.config.indices.any_is_rocksdb() {
-            match Arc::try_unwrap(index.db.take().unwrap()) {
+        if !index.config.indices.any_is_rocksdb() && let Some(db) = index.db.take() {
+            match Arc::try_unwrap(db) {
                 Ok(db) => {
                     log::trace!(
                         "Deleting RocksDB for payload indices, no payload index uses it anymore"


### PR DESCRIPTION
Delete RocksDB files for payload indices if they are not in use anymore.

More specifically:
- if we open a RocksDB instance if any index still relied on it
- we migrate (all) indices away from RocksDB
- RocksDB is not in use anymore
- we now explicitly delete its files

This is not necessary as a new optimization run will delete these files implicitly. But it's nice to clean up garbage. 🗑️🧻

Files before migration, still using RocksDB:

```bash
# Files before migration, still using RocksDB:

$ ls -lh storage/collections/test/0/segments/1078a4b4-48cb-49f5-8dbd-0e6896ab9fbf/payload_index
total 4,0M
-rw-r--r-- 1 130K jul 15 10:38 000014.sst
-rw-r--r-- 1 3,4M jul 15 10:38 000015.sst
-rw-r--r-- 1 305K jul 15 10:38 000016.sst
-rw-r--r-- 1    0 jul 15 10:38 000031.log
-rw-rw-r-- 1  451 jul 15 10:38 config.json
-rw-r--r-- 1   16 jul 15 10:38 CURRENT
-rw-r--r-- 1   36 jul 15 10:38 IDENTITY
-rw-r--r-- 1    0 jul 15 10:38 LOCK
-rw-r--r-- 1  48K jul 15 10:38 LOG
-rw-r--r-- 1  727 jul 15 10:38 MANIFEST-000032
-rw-r--r-- 1  21K jul 15 10:38 OPTIONS-000030
-rw-r--r-- 1  21K jul 15 10:38 OPTIONS-000034

# Files after migration, without garbage collection:

$ ls -lh storage/collections/test/0/segments/1078a4b4-48cb-49f5-8dbd-0e6896ab9fbf/payload_index
total 108K
-rw-r--r-- 1    0 jul 15 10:39 000031.log
drwxrwxr-x 2 4,0K jul 15 10:39 588779n6fs75u2d5ilu6b583-tag-map/
drwxrwxr-x 4 4,0K jul 15 10:39 588779n6fs75u2d5ilu6b583-tag-null/
drwxrwxr-x 2 4,0K jul 15 10:39 8qbuuchd3fkp50ub5g7jvsgj-sections-map/
drwxrwxr-x 4 4,0K jul 15 10:39 8qbuuchd3fkp50ub5g7jvsgj-sections-null/
-rw-rw-r-- 1  813 jul 15 10:39 config.json
-rw-r--r-- 1   16 jul 15 10:39 CURRENT
-rw-r--r-- 1   36 jul 15 10:38 IDENTITY
drwxrwxr-x 4 4,0K jul 15 10:39 j0mpsflpirqljphjuj8p9nnj-text-null/
drwxrwxr-x 2 4,0K jul 15 10:39 j0mpsflpirqljphjuj8p9nnj-text-text/
-rw-r--r-- 1    0 jul 15 10:38 LOCK
-rw-r--r-- 1  48K jul 15 10:39 LOG
-rw-r--r-- 1  790 jul 15 10:39 MANIFEST-000032
-rw-r--r-- 1  12K jul 15 10:39 OPTIONS-000038
-rw-r--r-- 1 7,5K jul 15 10:39 OPTIONS-000040

# Files after migration, with garbage collection in this PR:

$ ls -lh storage/collections/test/0/segments/1078a4b4-48cb-49f5-8dbd-0e6896ab9fbf/payload_index
total 28K
drwxrwxr-x 2 4,0K jul 15 10:37 588779n6fs75u2d5ilu6b583-tag-map/
drwxrwxr-x 4 4,0K jul 15 10:37 588779n6fs75u2d5ilu6b583-tag-null/
drwxrwxr-x 2 4,0K jul 15 10:37 8qbuuchd3fkp50ub5g7jvsgj-sections-map/
drwxrwxr-x 4 4,0K jul 15 10:37 8qbuuchd3fkp50ub5g7jvsgj-sections-null/
-rw-rw-r-- 1  813 jul 15 10:37 config.json
drwxrwxr-x 4 4,0K jul 15 10:37 j0mpsflpirqljphjuj8p9nnj-text-null/
drwxrwxr-x 2 4,0K jul 15 10:37 j0mpsflpirqljphjuj8p9nnj-text-text/

```



### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?