### PR TITLE
[mmr] compute similarities lazily

### DIFF
--- a/lib/collection/src/collection/mmr/lazy_matrix.rs
+++ b/lib/collection/src/collection/mmr/lazy_matrix.rs
@@ -1,0 +1,61 @@
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::types::{PointOffsetType, ScoreType};
+use segment::data_types::vectors::{QueryVector, VectorInternal};
+use segment::vector_storage::{RawScorer, VectorStorageEnum, new_raw_scorer};
+
+use crate::common::symmetric_matrix::SymmetricMatrix;
+use crate::operations::types::{CollectionError, CollectionResult};
+
+/// Compute the similarity matrix lazily.
+///
+/// Uses a symmetric matrix as a cache layer to compute similarities only once,
+/// but only those which are requested.
+pub struct LazyMatrix<'storage> {
+    scorers: Vec<Box<dyn RawScorer + 'storage>>,
+    // perf: can this Option<ScoreType> be smaller? SymmetricMatrix allocates nearly m*m/2 values
+    matrix: SymmetricMatrix<Option<ScoreType>>,
+}
+
+impl<'storage> LazyMatrix<'storage> {
+    /// Create a new lazy matrix from a list of vectors and a storage.
+    ///
+    /// Returns None if there are less than two vectors.
+    pub fn new(
+        vectors: Vec<VectorInternal>,
+        storage: &'storage VectorStorageEnum,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<Self> {
+        let matrix = SymmetricMatrix::new(vectors.len(), None).ok_or_else(|| {
+            CollectionError::service_error(
+                "There are less than 2 points for building a similarity matrix",
+            )
+        })?;
+
+        // Prepare all scorers
+        let scorers = vectors
+            .into_iter()
+            .map(|vector| {
+                let query = QueryVector::Nearest(vector);
+                Ok(new_raw_scorer(
+                    query,
+                    storage,
+                    hw_measurement_acc.get_counter_cell(),
+                )?)
+            })
+            .collect::<CollectionResult<Vec<_>>>()?;
+        Ok(Self { scorers, matrix })
+    }
+
+    pub fn get_similarity(&mut self, i: usize, j: usize) -> ScoreType {
+        if let Some(similarity) = self.matrix.get(i, j) {
+            return *similarity;
+        }
+        let similarity = self.compute_similarity(i, j);
+        self.matrix.set(i, j, Some(similarity));
+        similarity
+    }
+
+    fn compute_similarity(&self, i: usize, j: usize) -> ScoreType {
+        self.scorers[i].score_point(j as PointOffsetType)
+    }
+}

--- a/lib/collection/src/collection/mmr/lazy_matrix.rs
+++ b/lib/collection/src/collection/mmr/lazy_matrix.rs
@@ -19,7 +19,7 @@ pub struct LazyMatrix<'storage> {
 impl<'storage> LazyMatrix<'storage> {
     /// Create a new lazy matrix from a list of vectors and a storage.
     ///
-    /// Returns None if there are less than two vectors.
+    /// Returns an error if there are less than two vectors.
     pub fn new(
         vectors: Vec<VectorInternal>,
         storage: &'storage VectorStorageEnum,

--- a/lib/collection/src/collection/mmr/mod.rs
+++ b/lib/collection/src/collection/mmr/mod.rs
@@ -1,0 +1,4 @@
+mod lazy_matrix;
+mod maximum_marginal_relevance;
+
+pub use maximum_marginal_relevance::mmr_from_points_with_vector;


### PR DESCRIPTION
Another optimization for MMR.

MMR is usually used as a reranker with more candidate points than selected points.

Without this PR, MMR computes the entire similarity matrix by calculating `m*m/2` similiarites, where m=# of candidates. 

However, what we actually need to compute is `m*n/2` similarities, where m=# of candidates, and n=limit.

For cases where there are many candidates and small limit, this improves performance more dramatically, for example:

| Case | `dev` (similarities, request timing) | PR (similarities, request_timing) |
| --- | --- | --- |
| `limit=10`, `candidates_limit=1000` | 1M, 44.8ms | 10k, 16.1ms | 
| `limit=10`, `candidates_limit=500` | 250k,  19.7ms | 5k, 12.4ms | 
| `limit=10`, `candidates_limit=100` | 10k, 9.5ms | 1k, 9.0ms | 

Notice that PR is a bit slower on fewer similarities (10k on dev is faster than 5k on PR). But I believe this is fine considering the amortization for larger number of candidates.