### PR TITLE
Fix broken is_empty filter on new points

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -132,8 +132,11 @@ impl IndexSelector<'_> {
             }
 
             (PayloadIndexType::NullIndex, _) => {
-                let Some(null_index) =
-                    MmapNullIndex::open_if_exists(path, total_point_count, create_if_missing)?
+                let Some(null_index) = MmapNullIndex::open_if_exists(
+                    &null_dir(path, field),
+                    total_point_count,
+                    create_if_missing,
+                )?
                 else {
                     return Ok(None);
                 };

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -184,7 +184,7 @@ impl MmapNullIndex {
             .is_null_slice
             .set_with_resize(id, is_null, hw_counter_ref)?;
 
-        // Update total_points to track the highest point offset seen
+        // Bump total points
         self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
 
         Ok(())
@@ -204,6 +204,14 @@ impl MmapNullIndex {
         storage
             .is_null_slice
             .set_with_resize(id, false, disposed_hw)?;
+
+        // Bump total points
+        // We MUST bump the total point count when removing a point too
+        // On upsert without this respective field, remove point is called rather than add point
+        // Bumping the total point count ensures we correctly iterate over all empty points
+        // Bug: <https://github.com/qdrant/qdrant/issues/6880>
+        self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
+
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -93,6 +93,12 @@ impl MmapNullIndex {
         })
     }
 
+    /// Open a null index at the given path, only if it exists.
+    ///
+    /// # Arguments
+    /// - `path` - The directory where the index files should live, must be exclusive to this index.
+    /// - `total_point_count` - Total number of points in the segment.
+    /// - `create_if_missing` - If true, creates the index if it doesn't exist.
     pub fn open_if_exists(
         path: &Path,
         total_point_count: usize,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -179,7 +179,14 @@ impl StructPayloadIndex {
                 create_if_missing,
             )?;
 
-            // Special null index complements every index.
+            debug_assert!(
+                !indexes
+                    .iter()
+                    .any(|index| matches!(index, FieldIndex::NullIndex(_))),
+                "index selector is not expected to provide null index",
+            );
+
+            // Special null index complements every index
             if let Some(null_index) = IndexSelector::new_null_index(
                 &self.path,
                 field,

--- a/tests/openapi/test_filter_is_empty.py
+++ b/tests/openapi/test_filter_is_empty.py
@@ -47,18 +47,6 @@ def create_collection(collection_name):
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{collection_name}/index',
-        method="PUT",
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={
-            "field_name": "b",
-            "field_schema": "keyword",
-        }
-    )
-    assert response.ok
-
-    response = request_with_validation(
         api='/collections/{collection_name}/points',
         method="PUT",
         path_params={'collection_name': collection_name},
@@ -68,17 +56,14 @@ def create_collection(collection_name):
                 {
                     "id": 1,
                     "vector": [0.05, 0.61, 0.76],
-                    "payload": {"a": "foo"}
                 },
                 {
                     "id": 2,
                     "vector": [0.19, 0.81, 0.75],
-                    "payload": {"a": "foo"}
                 },
                 {
                     "id": 3,
                     "vector": [0.36, 0.55, 0.47],
-                    "payload": {"a": "foo"}
                 },
             ]
         }
@@ -99,12 +84,8 @@ def test_filter_is_empty(collection_name):
             "filter": {
                 "must": [
                     {
-                        "key": "a",
-                        "match": { "value": "foo" }
-                    },
-                    {
                         "is_empty": {
-                            "key": "b"
+                            "key": "a"
                         }
                     }
                 ]

--- a/tests/openapi/test_filter_is_empty.py
+++ b/tests/openapi/test_filter_is_empty.py
@@ -1,0 +1,119 @@
+import pytest
+
+from .helpers.collection_setup import multivec_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(collection_name):
+    create_collection(collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def create_collection(collection_name):
+    drop_collection(collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": 3,
+                "distance": "Dot",
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/index',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "field_name": "a",
+            "field_schema": "keyword",
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/index',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "field_name": "b",
+            "field_schema": "keyword",
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76],
+                    "payload": {"a": "foo"}
+                },
+                {
+                    "id": 2,
+                    "vector": [0.19, 0.81, 0.75],
+                    "payload": {"a": "foo"}
+                },
+                {
+                    "id": 3,
+                    "vector": [0.36, 0.55, 0.47],
+                    "payload": {"a": "foo"}
+                },
+            ]
+        }
+    )
+    assert response.ok
+
+
+def test_filter_is_empty(collection_name):
+    """
+    Bug: <https://github.com/qdrant/qdrant/issues/6880>
+    """
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/query',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "a",
+                        "match": { "value": "foo" }
+                    },
+                    {
+                        "is_empty": {
+                            "key": "b"
+                        }
+                    }
+                ]
+            },
+            "query": [0.1, 0.1, 0.1],
+            "limit": 2,
+        }
+    )
+    assert response.ok
+
+    json = response.json()
+    assert len(json['result']['points']) == 2, json


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/6880>

When upserting new points, the `is_empty` filter did not work properly. I did not always include the newly upserted points during filtering. 

More specifically, this problem appears when upserting points in which the payload field (of the null index) is absent. The null index relies on knowing the exact (segment) point count to reliably filter points. When upserting a point in which the payload field is absent, we don't add the point to the index and therefore don't bump the point count.

When the payload field is absent, instead of adding ([set](https://github.com/qdrant/qdrant/blob/4f9884de3ace92cf0fe99a9443d411f35f3810ce/lib/segment/src/index/struct_payload_index.rs#L1030), [overwrite](https://github.com/qdrant/qdrant/blob/4f9884de3ace92cf0fe99a9443d411f35f3810ce/lib/segment/src/index/struct_payload_index.rs#L994)) the point to the index, we actually remove ([set](https://github.com/qdrant/qdrant/blob/4f9884de3ace92cf0fe99a9443d411f35f3810ce/lib/segment/src/index/struct_payload_index.rs#L1034), [overwrite](https://github.com/qdrant/qdrant/blob/4f9884de3ace92cf0fe99a9443d411f35f3810ce/lib/segment/src/index/struct_payload_index.rs#L998)) it from the index. To fix the filtering problem, I now also bump the point count when removing a point. This will ensure that new upsertions without the field still set the correct point count.

This PR fixes two problems:
- not setting the total point count (described above)
- loading the null index from the wrong path (in some scenarios)

I also add a test to assert correct behavior.

Existing deployments do not have permanent damage because of this bug. All (existing) null indices are fixed on restart.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?