### PR TITLE
Fix trying to delete rocksDb files when creating new segments

### DIFF
--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -69,6 +69,19 @@ impl PayloadIndices {
         })
     }
 
+    /// Check if any payload field used RocksDB or could be using rocksDB.
+    /// This means that if we have no data about an indexes' type, we still return `true`.
+    #[cfg(feature = "rocksdb")]
+    pub fn any_could_be_rocksdb(&self) -> bool {
+        self.fields.values().any(|index| {
+            index
+                .types
+                .iter()
+                .any(|t| t.storage_type == StorageType::RocksDb)
+                || index.types.is_empty()
+        }) || self.fields.is_empty()
+    }
+
     pub fn to_schemas(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
         self.fields
             .iter()

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -392,7 +392,7 @@ impl StructPayloadIndex {
 
         // If we have a RocksDB instance, but no more index using it, completely delete it here
         #[cfg(feature = "rocksdb")]
-        if !index.config.indices.any_is_rocksdb()
+        if !index.config.indices.any_could_be_rocksdb()
             && let Some(db) = index.db.take()
         {
             match Arc::try_unwrap(db) {


### PR DESCRIPTION
When building new segments, we sometimes create empty rocksDb databases for payload indices.
When loading the empty `StructPayloadIndex` directly after creating, we previously attempted to delete it again because it was detect as "not used".
This threw an error because it was actually used.

This PR fixes this warning and the attempt to delete used rocksDb database files.