### PR TITLE
Remove hardware measurement from fulltext index

### DIFF
--- a/lib/posting_list/src/posting_list.rs
+++ b/lib/posting_list/src/posting_list.rs
@@ -1,7 +1,6 @@
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
-use common::counter::conditioned_counter::ConditionedCounter;
 use common::types::PointOffsetType;
 use zerocopy::little_endian::U32;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -102,7 +101,6 @@ impl<V: PostingValue> PostingList<V> {
             var_size_data.borrow(),
             remainders,
             *last_id,
-            ConditionedCounter::never(),
         )
     }
 

--- a/lib/posting_list/src/value_handler.rs
+++ b/lib/posting_list/src/value_handler.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use common::counter::conditioned_counter::ConditionedCounter;
 use zerocopy::little_endian::U32;
 
 use crate::{SizedValue, UnsizedValue};
@@ -47,12 +46,7 @@ pub trait ValueHandler {
     ///
     /// - For sized values it returns the first argument.
     /// - For variable-size values it returns the value between the two sized values in var_data.
-    fn get_value<N>(
-        sized_value: Self::Sized,
-        next_sized_value: N,
-        var_data: &[u8],
-        hw_counter: &ConditionedCounter,
-    ) -> Self::Value
+    fn get_value<N>(sized_value: Self::Sized, next_sized_value: N, var_data: &[u8]) -> Self::Value
     where
         N: Fn() -> Option<Self::Sized>;
 }
@@ -69,12 +63,7 @@ impl<V: SizedValue> ValueHandler for SizedHandler<V> {
         (values, Vec::new())
     }
 
-    fn get_value<N>(
-        sized_value: V,
-        _next_sized_value: N,
-        _var_data: &[u8],
-        _hw_counter: &ConditionedCounter,
-    ) -> V
+    fn get_value<N>(sized_value: V, _next_sized_value: N, _var_data: &[u8]) -> V
     where
         N: Fn() -> Option<Self::Sized>,
     {
@@ -119,12 +108,7 @@ impl<V: UnsizedValue> ValueHandler for UnsizedHandler<V> {
         (offsets, var_sized_data)
     }
 
-    fn get_value<N>(
-        sized_value: Self::Sized,
-        next_sized_value: N,
-        var_data: &[u8],
-        hw_counter: &ConditionedCounter,
-    ) -> Self::Value
+    fn get_value<N>(sized_value: Self::Sized, next_sized_value: N, var_data: &[u8]) -> Self::Value
     where
         N: Fn() -> Option<Self::Sized>,
     {
@@ -132,10 +116,6 @@ impl<V: UnsizedValue> ValueHandler for UnsizedHandler<V> {
             Some(next_value) => sized_value.get() as usize..next_value.get() as usize,
             None => sized_value.get() as usize..var_data.len(),
         };
-
-        hw_counter
-            .payload_index_io_read_counter()
-            .incr_delta(range.len());
 
         V::from_bytes(&var_data[range])
     }

--- a/lib/posting_list/src/visitor.rs
+++ b/lib/posting_list/src/visitor.rs
@@ -161,12 +161,8 @@ impl<'a, V: PostingValue> PostingVisitor<'a, V> {
                     .or_else(|| self.list.get_remainder(0).map(|e| e.value))
             };
 
-            let value = V::Handler::get_value(
-                sized_value,
-                next_sized_value,
-                self.list.var_size_data,
-                &self.list.hw_counter,
-            );
+            let value =
+                V::Handler::get_value(sized_value, next_sized_value, self.list.var_size_data);
 
             return Some(PostingElement { id, value });
         }
@@ -175,12 +171,7 @@ impl<'a, V: PostingValue> PostingVisitor<'a, V> {
         self.list.get_remainder(local_offset).map(|e| {
             let id = e.id;
             let next_sized_value = || self.list.get_remainder(local_offset + 1).map(|r| r.value);
-            let value = V::Handler::get_value(
-                e.value,
-                next_sized_value,
-                self.list.var_size_data,
-                &self.list.hw_counter,
-            );
+            let value = V::Handler::get_value(e.value, next_sized_value, self.list.var_size_data);
 
             PostingElement {
                 id: id.get(),

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
@@ -405,18 +405,16 @@ impl From<&MmapInvertedIndex> for ImmutableInvertedIndex {
             };
         };
 
-        let hw_counter = HardwareCounterCell::disposable();
-
         let postings = match &index_storage.postings {
             MmapPostingsEnum::Ids(postings) => ImmutablePostings::Ids(
                 postings
-                    .iter_postings(&hw_counter)
+                    .iter_postings()
                     .map(PostingListView::to_owned)
                     .collect(),
             ),
             MmapPostingsEnum::WithPositions(postings) => ImmutablePostings::WithPositions(
                 postings
-                    .iter_postings(&hw_counter)
+                    .iter_postings()
                     .map(PostingListView::to_owned)
                     .collect(),
             ),

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mmap_postings_enum.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mmap_postings_enum.rs
@@ -1,4 +1,3 @@
-use common::counter::hardware_counter::HardwareCounterCell;
 #[cfg(test)]
 use common::types::PointOffsetType;
 
@@ -19,17 +18,11 @@ impl MmapPostingsEnum {
         }
     }
 
-    pub fn posting_len(
-        &self,
-        token_id: TokenId,
-        hw_counter: &HardwareCounterCell,
-    ) -> Option<usize> {
+    pub fn posting_len(&self, token_id: TokenId) -> Option<usize> {
         match self {
-            MmapPostingsEnum::Ids(postings) => {
-                postings.get(token_id, hw_counter).map(|view| view.len())
-            }
+            MmapPostingsEnum::Ids(postings) => postings.get(token_id).map(|view| view.len()),
             MmapPostingsEnum::WithPositions(postings) => {
-                postings.get(token_id, hw_counter).map(|view| view.len())
+                postings.get(token_id).map(|view| view.len())
             }
         }
     }
@@ -38,19 +31,16 @@ impl MmapPostingsEnum {
     pub fn iter_ids<'a>(
         &'a self,
         token_id: TokenId,
-        hw_counter: &'a HardwareCounterCell,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match self {
-            MmapPostingsEnum::Ids(postings) => postings.get(token_id, hw_counter).map(|view| {
+            MmapPostingsEnum::Ids(postings) => postings.get(token_id).map(|view| {
                 Box::new(view.into_iter().map(|elem| elem.id))
                     as Box<dyn Iterator<Item = PointOffsetType>>
             }),
-            MmapPostingsEnum::WithPositions(postings) => {
-                postings.get(token_id, hw_counter).map(|view| {
-                    Box::new(view.into_iter().map(|elem| elem.id))
-                        as Box<dyn Iterator<Item = PointOffsetType>>
-                })
-            }
+            MmapPostingsEnum::WithPositions(postings) => postings.get(token_id).map(|view| {
+                Box::new(view.into_iter().map(|elem| elem.id))
+                    as Box<dyn Iterator<Item = PointOffsetType>>
+            }),
         }
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -183,7 +183,6 @@ impl MmapInvertedIndex {
     pub fn filter_has_subset<'a>(
         &'a self,
         tokens: TokenSet,
-        hw_counter: &'a HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         let Some(storage) = &self.storage else {
             return Box::new(std::iter::empty());
@@ -196,12 +195,11 @@ impl MmapInvertedIndex {
             postings: &'a MmapPostings<V>,
             tokens: TokenSet,
             filter: impl Fn(u32) -> bool + 'a,
-            hw_counter: &'a HardwareCounterCell,
         ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
             let postings_opt: Option<Vec<_>> = tokens
                 .tokens()
                 .iter()
-                .map(|&token_id| postings.get(token_id, hw_counter))
+                .map(|&token_id| postings.get(token_id))
                 .collect();
 
             let Some(posting_readers) = postings_opt else {
@@ -221,10 +219,8 @@ impl MmapInvertedIndex {
         }
 
         match &storage.postings {
-            MmapPostingsEnum::Ids(postings) => intersection(postings, tokens, filter, hw_counter),
-            MmapPostingsEnum::WithPositions(postings) => {
-                intersection(postings, tokens, filter, hw_counter)
-            }
+            MmapPostingsEnum::Ids(postings) => intersection(postings, tokens, filter),
+            MmapPostingsEnum::WithPositions(postings) => intersection(postings, tokens, filter),
         }
     }
 
@@ -248,14 +244,10 @@ impl MmapInvertedIndex {
             tokens: &TokenSet,
             point_id: PointOffsetType,
         ) -> bool {
-            // Do not track the HW counter for reading the query posting list because:
-            // - it is repeated many times (once per matched point_id)
-            // - it is most likely mmap cached after the first call
-            let disposable = HardwareCounterCell::disposable();
             // Check that all tokens are in document
             tokens.tokens().iter().all(|query_token| {
                 postings
-                    .get(*query_token, &disposable)
+                    .get(*query_token)
                     // unwrap safety: all tokens exist in the vocabulary, otherwise there'd be no query tokens
                     .unwrap()
                     .visitor()
@@ -275,7 +267,6 @@ impl MmapInvertedIndex {
     pub fn filter_has_phrase<'a>(
         &'a self,
         phrase: Document,
-        hw_counter: &'a HardwareCounterCell,
     ) -> impl Iterator<Item = PointOffsetType> + 'a {
         let Some(storage) = &self.storage else {
             return Either::Left(std::iter::empty());
@@ -288,7 +279,7 @@ impl MmapInvertedIndex {
             MmapPostingsEnum::WithPositions(postings) => {
                 Either::Right(intersect_compressed_postings_phrase_iterator(
                     phrase,
-                    |token_id| postings.get(*token_id, hw_counter),
+                    |token_id| postings.get(*token_id),
                     is_active,
                 ))
             }
@@ -309,12 +300,8 @@ impl MmapInvertedIndex {
 
         match &storage.postings {
             MmapPostingsEnum::WithPositions(postings) => {
-                // Do not track the HW counter for reading the phrase posting lists because:
-                // - it is repeated many times (once per matched point_id)
-                // - it is most likely mmap cached after the first call
-                let disposable = HardwareCounterCell::disposable();
                 check_compressed_postings_phrase(phrase, point_id, |token_id| {
-                    postings.get(*token_id, &disposable)
+                    postings.get(*token_id)
                 })
             }
             // cannot do phrase matching if there's no positional information
@@ -428,23 +415,20 @@ impl InvertedIndex for MmapInvertedIndex {
     fn filter<'a>(
         &'a self,
         query: ParsedQuery,
-        hw_counter: &'a HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         match query {
-            ParsedQuery::Tokens(tokens) => self.filter_has_subset(tokens, hw_counter),
-            ParsedQuery::Phrase(phrase) => Box::new(self.filter_has_phrase(phrase, hw_counter)),
+            ParsedQuery::Tokens(tokens) => self.filter_has_subset(tokens),
+            ParsedQuery::Phrase(phrase) => Box::new(self.filter_has_phrase(phrase)),
         }
     }
 
     fn get_posting_len(
         &self,
         token_id: TokenId,
-        hw_counter: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> Option<usize> {
-        self.storage
-            .as_ref()?
-            .postings
-            .posting_len(token_id, hw_counter)
+        self.storage.as_ref()?.postings.posting_len(token_id)
     }
 
     // TODO(payload-index-non-optional-storage): remove Either, just return pure iterator
@@ -453,12 +437,10 @@ impl InvertedIndex for MmapInvertedIndex {
             return Either::Right(std::iter::empty());
         };
 
-        let hw_counter = HardwareCounterCell::disposable(); // No propagation needed here because this function is only used for building HNSW index.
-
         let iter = self.iter_vocab().filter_map(move |(token, &token_id)| {
             storage
                 .postings
-                .posting_len(token_id, &hw_counter)
+                .posting_len(token_id)
                 .map(|posting_len| (token, posting_len))
         });
         Either::Left(iter)

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -482,7 +482,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .postings
-                .iter_ids(token_id, &hw_counter)
+                .iter_ids(token_id)
                 .unwrap()
                 .collect();
             assert_eq!(mutable_ids, mmap_ids);


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/6833

We have decided to simply remove the hardware measurement in the fulltext index via the posting list infrastructure.

The reasons are:
- we do not want to introduce yet another `disposable` metric black hole
- the measured values are small and do not bring much in steady state