### PR TITLE
Preprocess query vectors, sort sparse vectors

### DIFF
--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -34,6 +34,21 @@ impl VectorInternal {
             VectorInternal::MultiDense(multivec) => multivec.vectors_count(),
         }
     }
+
+    /// Preprocess the vector
+    ///
+    /// For a sparce vector, indices will be sorted.
+    pub fn preprocess(&mut self) {
+        match self {
+            VectorInternal::Dense(_) => {}
+            VectorInternal::Sparse(sparse) => {
+                if !sparse.is_sorted() {
+                    sparse.sort_by_indices();
+                }
+            }
+            VectorInternal::MultiDense(_) => {}
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/tests/openapi/test_sparse_vector_validations.py
+++ b/tests/openapi/test_sparse_vector_validations.py
@@ -38,6 +38,42 @@ def sparse_collection_setup(collection_name='test_collection'):
     )
     assert response.ok
 
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "text": {
+                            "indices": [0, 2], "values": [0.1, 0.2],
+                        }
+                    }
+                },
+                {
+                    "id": 2,
+                    "vector": {
+                        "text": {
+                            "indices": [1, 3], "values": [0.3, 0.4],
+                        }
+                    }
+                },
+                {
+                    "id": 3,
+                    "vector": {
+                        "text": {
+                            "indices": [0, 1], "values": [0.5, 0.6],
+                        }
+                    }
+                },
+            ]
+        }
+    )
+    assert response.ok
+
 
 def test_sparse_vector_validations(collection_name):
     response = request_with_validation(
@@ -79,3 +115,22 @@ def test_sparse_vector_validations(collection_name):
     assert not response.ok
     assert 'Validation error' in response.json()["status"]["error"]
     assert 'points[0].vector.?.indices: Validation error: must be unique [{}]' in response.json()["status"]["error"]
+
+
+def test_sorted_sparse_vector(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/query',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "query": {
+                "nearest": {"indices": [2, 0, 1], "values": [0.1, 0.2, 0.3]},
+                "mmr": {
+                    "diversity": 0.5,
+                    "candidates_limit": 10,
+                },
+            },
+            "using": "text"
+        }
+    )
+    assert response.ok


### PR DESCRIPTION
Preprocess query vectors so that sparse vectors will be sorted by their indices.

Fixes a debug assertion here: https://github.com/qdrant/qdrant/blob/10de8cc59574fe2ca290b8bf6d2cf22081e0e09a/lib/sparse/src/common/sparse_vector.rs#L151-L152

I've added a test to reproduce the problematic case. It proves this fixes the problem.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?