### PR TITLE
MMR with postprocessed score

### DIFF
--- a/lib/collection/src/collection/mmr/maximal_marginal_relevance.rs
+++ b/lib/collection/src/collection/mmr/maximal_marginal_relevance.rs
@@ -36,13 +36,11 @@ use crate::operations::universal_query::shard_query::MmrInternal;
 /// # Returns
 ///
 /// A vector of scored points.
-#[expect(clippy::too_many_arguments)]
 pub async fn mmr_from_points_with_vector(
     collection_params: &CollectionParams,
     points_with_vector: impl IntoIterator<Item = ScoredPoint>,
     mmr: MmrInternal,
     limit: usize,
-    score_threshold: Option<ScoreType>,
     search_runtime_handle: &Handle,
     timeout: Duration,
     hw_measurement_acc: HwMeasurementAcc,
@@ -105,7 +103,6 @@ pub async fn mmr_from_points_with_vector(
             candidates,
             query_similarities,
             similarity_matrix,
-            score_threshold,
             mmr.lambda,
             limit,
         ))
@@ -213,7 +210,6 @@ fn maximal_marginal_relevance(
     candidates: Vec<ScoredPoint>,
     query_similarities: Vec<ScoreType>,
     mut similarity_matrix: LazyMatrix,
-    score_threshold: Option<ScoreType>,
     lambda: f32,
     limit: usize,
 ) -> Vec<ScoredPoint> {
@@ -239,13 +235,8 @@ fn maximal_marginal_relevance(
     while selected_indices.len() < limit && !remaining_indices.is_empty() {
         let best_candidate = remaining_indices
             .iter()
-            .filter_map(|&candidate_idx| {
+            .map(|&candidate_idx| {
                 let relevance_score = query_similarities[candidate_idx];
-
-                // Exclude candidate if relevance is too low
-                if score_threshold.is_some_and(|threshold| relevance_score < threshold) {
-                    return None;
-                }
 
                 debug_assert!(
                     selected_indices
@@ -266,7 +257,7 @@ fn maximal_marginal_relevance(
                 let mmr_score =
                     lambda * relevance_score - (1.0 - lambda) * max_similarity_to_selected;
 
-                Some((candidate_idx, mmr_score))
+                (candidate_idx, mmr_score)
             })
             .max_by_key(|(_candidate_idx, mmr_score)| OrderedFloat(*mmr_score));
 
@@ -488,7 +479,6 @@ mod tests {
             points.clone(),
             mmr,
             3,
-            None,
             &handle,
             Duration::from_secs(10),
             hw_acc,
@@ -533,7 +523,6 @@ mod tests {
             empty_points,
             mmr.clone(),
             5,
-            None,
             &handle,
             Duration::from_secs(10),
             hw_acc.clone(),
@@ -555,7 +544,6 @@ mod tests {
             single_point,
             mmr,
             5,
-            None,
             &handle,
             Duration::from_secs(10),
             hw_acc,
@@ -593,7 +581,6 @@ mod tests {
             points,
             mmr,
             5,
-            None,
             &handle,
             Duration::from_secs(10),
             hw_acc,
@@ -635,7 +622,6 @@ mod tests {
             points,
             mmr,
             5,
-            None,
             &handle,
             Duration::from_secs(10),
             hw_acc,
@@ -679,7 +665,6 @@ mod tests {
                 dense_points.clone(),
                 mmr.clone(),
                 3,
-                None,
                 &handle,
                 Duration::from_secs(10),
                 hw_acc.clone(),
@@ -739,7 +724,6 @@ mod tests {
             sparse_points,
             sparse_mmr,
             3,
-            None,
             &handle,
             Duration::from_secs(10),
             hw_acc.clone(),
@@ -791,7 +775,6 @@ mod tests {
                 multi_points.clone(),
                 multi_mmr.clone(),
                 3,
-                None,
                 &handle,
                 Duration::from_secs(10),
                 hw_acc.clone(),

--- a/lib/collection/src/collection/mmr/maximal_marginal_relevance.rs
+++ b/lib/collection/src/collection/mmr/maximal_marginal_relevance.rs
@@ -274,8 +274,7 @@ fn maximal_marginal_relevance(
     selected_indices
         .into_iter()
         .map(|idx| {
-            let mut selected = candidates[idx].clone();
-            // Use query similarity as score, without post-processing.
+            // Use original score, already postprocessed.
             //
             // We prefer this over MMR score because:
             // - We already selected the top candidates based on MMR score.
@@ -285,8 +284,7 @@ fn maximal_marginal_relevance(
             //    - It makes more sense to compare by query score.
             //    - If this isn't the last rescore before sending to collection,
             //        we are only interested in the selection of points, not the score itself.
-            selected.score = query_similarities[idx];
-            selected
+            candidates[idx].clone()
         })
         .collect()
 }

--- a/lib/collection/src/collection/mmr/mod.rs
+++ b/lib/collection/src/collection/mmr/mod.rs
@@ -1,4 +1,4 @@
 mod lazy_matrix;
-mod maximum_marginal_relevance;
+mod maximal_marginal_relevance;
 
-pub use maximum_marginal_relevance::mmr_from_points_with_vector;
+pub use maximal_marginal_relevance::mmr_from_points_with_vector;

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -383,7 +383,6 @@ impl Collection {
                     points_with_vector,
                     mmr.clone(),
                     *limit,
-                    *score_threshold,
                     search_runtime_handle,
                     timeout,
                     hw_measurement_acc,

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -387,7 +387,6 @@ impl LocalShard {
                 self.mmr_rescore(
                     sources,
                     mmr,
-                    score_threshold,
                     limit,
                     search_runtime_handle,
                     timeout,
@@ -425,12 +424,10 @@ impl LocalShard {
     }
 
     /// Maximal Marginal Relevance rescoring
-    #[expect(clippy::too_many_arguments)]
     async fn mmr_rescore(
         &self,
         sources: Vec<Vec<ScoredPoint>>,
         mmr: MmrInternal,
-        score_threshold: Option<f32>,
         limit: usize,
         search_runtime_handle: &Handle,
         timeout: Duration,
@@ -460,7 +457,6 @@ impl LocalShard {
             points_with_vector,
             mmr,
             limit,
-            score_threshold,
             search_runtime_handle,
             timeout,
             hw_measurement_acc,


### PR DESCRIPTION
Fixes:
- `score_threshold` handling: we now only handle it during nearest neighbors search step
- score in the output corresponds to the similarity to the query, already postprocessed