### PR TITLE
Fix `test_create_shard_key_read_availability` flakiness

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12784,6 +12784,13 @@
             },
             "nullable": true
           },
+          "peer_metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PeerMetadata"
+            },
+            "nullable": true
+          },
           "metadata": {
             "type": "object",
             "additionalProperties": true,
@@ -12902,6 +12909,19 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0
+          }
+        }
+      },
+      "PeerMetadata": {
+        "description": "Metadata describing extra properties for each peer",
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "description": "Peer Qdrant version",
+            "type": "string"
           }
         }
       },

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -2131,9 +2131,10 @@ pub struct IssuesReport {
 }
 
 /// Metadata describing extra properties for each peer
-#[derive(Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema)]
 pub struct PeerMetadata {
     /// Peer Qdrant version
+    #[schemars(schema_with = "String::json_schema")]
     pub(crate) version: Version,
 }
 

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -184,6 +184,7 @@ impl MetricsProvider for ClusterTelemetry {
             status,
             config: _,
             peers: _,
+            peer_metadata: _,
             metadata: _,
         } = self;
 

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use collection::operations::types::PeerMetadata;
 use collection::shards::shard::PeerId;
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
@@ -74,6 +75,8 @@ pub struct ClusterTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
     pub peers: Option<HashMap<PeerId, PeerInfo>>,
+    #[anonymize(false)]
+    pub peer_metadata: Option<HashMap<PeerId, PeerMetadata>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
 }
@@ -113,6 +116,13 @@ impl ClusterTelemetry {
                 .then(|| match dispatcher.cluster_status() {
                     ClusterStatus::Disabled => None,
                     ClusterStatus::Enabled(cluster_info) => Some(cluster_info.peers),
+                })
+                .flatten(),
+            peer_metadata: (detail.level >= DetailsLevel::Level3)
+                .then(|| {
+                    dispatcher
+                        .consensus_state()
+                        .map(|state| state.persistent.read().peer_metadata_by_id())
                 })
                 .flatten(),
             metadata: (detail.level >= DetailsLevel::Level1)

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -75,6 +75,7 @@ pub struct ClusterTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
     pub peers: Option<HashMap<PeerId, PeerInfo>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
     pub peer_metadata: Option<HashMap<PeerId, PeerMetadata>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/consensus_tests/test_custom_sharding.py
+++ b/tests/consensus_tests/test_custom_sharding.py
@@ -347,7 +347,7 @@ def check_peer_metadata(peer_url: str):
     metadata = cluster and cluster.get("peer_metadata")
     peers = cluster and cluster.get("peers")
 
-    return metadata and peers and all(metadata.get(peer) for peer in peers.keys())
+    return metadata and peers and all(metadata.get(peer) for peer in peers)
 
 def get_telemetry(peer_url: str):
     resp = requests.get(f"{peer_url}/telemetry?details_level=3")

--- a/tests/consensus_tests/test_custom_sharding.py
+++ b/tests/consensus_tests/test_custom_sharding.py
@@ -304,8 +304,8 @@ def test_create_shard_key_read_availability(tmp_path: pathlib.Path):
     # Bootstrap cluster
     peer_urls, _, _ = start_cluster(tmp_path, N_PEERS)
 
-    # Wait until all peers submit their metadata to consensus
-    time.sleep(2)
+    # Wait until all peers submit their metadata to consensus 🙄
+    wait_for_peer_metadata(peer_urls[0], )
 
     create_collection_with_custom_sharding(peer_urls[0], shard_number = N_SHARDS, replication_factor = N_PEERS)
     wait_collection_exists_and_active_on_all_peers(collection_name = COLLECTION_NAME, peer_api_uris = peer_urls)
@@ -330,6 +330,30 @@ def test_create_shard_key_read_availability(tmp_path: pathlib.Path):
 
     # Assert that all search requests succeeded while custom shard was being created
     assert all(search_future.result() for search_future in concurrent.futures.as_completed(search_futures))
+
+def wait_for_peer_metadata(peer_url: str):
+    try:
+        wait_for(check_peer_metadata, peer_url)
+    except Exception as e:
+        import json
+        print(json.dumps(get_telemetry(peer_url), indent = 2))
+        raise e
+
+def check_peer_metadata(peer_url: str):
+    telemetry = get_telemetry(peer_url)
+
+    cluster = telemetry.get("cluster")
+
+    metadata = cluster and cluster.get("peer_metadata")
+    peers = cluster and cluster.get("peers")
+
+    return metadata and peers and all(metadata.get(peer) for peer in peers.keys())
+
+def get_telemetry(peer_url: str):
+    resp = requests.get(f"{peer_url}/telemetry?details_level=3")
+    assert_http_ok(resp)
+
+    return resp.json()["result"]
 
 def try_search_random(peer_url: str, cancel: threading.Event):
     while not cancel.is_set():


### PR DESCRIPTION
`test_create_shard_key_read_availability` is dependent on "peer metadata" to propagate through cluster, so this PR exposes peer metadata in telemetry and add explicit `wait_for_peer_metadata` (instead of simple `sleep`) to the test.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
