### PR TITLE
Fix checkfs in MUSL builds

### DIFF
--- a/lib/common/memory/src/checkfs.rs
+++ b/lib/common/memory/src/checkfs.rs
@@ -113,7 +113,8 @@ fn get_filesystem_type(path: impl AsRef<Path>) -> Result<FsType, String> {
     {
         let f_type = stat.filesystem_type().0;
 
-        let fs_type = FsType::from_magic(f_type);
+        // Convert into correct number type as MUSL expects i64, not u64
+        let fs_type = FsType::from_magic(f_type as _);
         Ok(fs_type)
     }
 }


### PR DESCRIPTION
MUSL builds currently fail because `FsType::from_magic(..)` expects a different number type. :man_shrugging: 

Failure example: https://github.com/qdrant/qdrant/actions/runs/16371351831/job/46260244211#step:7:899

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?