### PR TITLE
add consistency param for count api in openapi

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5689,6 +5689,15 @@
             }
           },
           {
+            "name": "consistency",
+            "in": "query",
+            "description": "Define read consistency guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReadConsistency"
+            }
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "If set, overrides global timeout for this request. Unit is seconds.",
@@ -5696,15 +5705,6 @@
             "schema": {
               "type": "integer",
               "minimum": 1
-            }
-          },
-          {
-            "name": "consistency",
-            "in": "query",
-            "description": "Define read consistency guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/ReadConsistency"
             }
           }
         ],
@@ -5797,6 +5797,15 @@
             }
           },
           {
+            "name": "consistency",
+            "in": "query",
+            "description": "Define read consistency guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReadConsistency"
+            }
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "If set, overrides global timeout for this request. Unit is seconds.",
@@ -5804,15 +5813,6 @@
             "schema": {
               "type": "integer",
               "minimum": 1
-            }
-          },
-          {
-            "name": "consistency",
-            "in": "query",
-            "description": "Define read consistency guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/ReadConsistency"
             }
           }
         ],

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5440,7 +5440,7 @@
           "Search"
         ],
         "summary": "Discover points",
-        "description": "Use context and a target to find the most similar points to the target, constrained by the context.\nWhen using only the context (without a target), a special search - called context search - is performed where pairs of points are used to generate a loss that guides the search towards the zone where most positive examples overlap. This means that the score minimizes the scenario of finding a point closer to a negative than to a positive part of a pair.\nSince the score of a context relates to loss, the maximum score a point can get is 0.0, and it becomes normal that many points can have a score of 0.0.\nWhen using target (with or without context), the score behaves a little different: The  integer part of the score represents the rank with respect to the context, while the decimal part of the score relates to the distance to the target. The context part of the score for  each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,  and -1 otherwise.\n",
+        "description": "Use context and a target to find the most similar points to the target, constrained by the context.\nWhen using only the context (without a target), a special search - called context search - is performed where pairs of points are used to generate a loss that guides the search towards the zone where most positive examples overlap. This means that the score minimizes the scenario of finding a point closer to a negative than to a positive part of a pair.\nSince the score of a context relates to loss, the maximum score a point can get is 0.0, and it becomes normal that many points can have a score of 0.0.\nWhen using target (with or without context), the score behaves a little different: The integer part of the score represents the rank with respect to the context, while the decimal part of the score relates to the distance to the target. The context part of the score for each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, and -1 otherwise.\n",
         "operationId": "discover_points",
         "requestBody": {
           "description": "Request points based on {positive, negative} pairs of examples, and/or a target",
@@ -5696,6 +5696,15 @@
             "schema": {
               "type": "integer",
               "minimum": 1
+            }
+          },
+          {
+            "name": "consistency",
+            "in": "query",
+            "description": "Define read consistency guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReadConsistency"
             }
           }
         ],

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -527,10 +527,10 @@ paths:
         Since the score of a context relates to loss, the maximum score a point can get is 0.0,
         and it becomes normal that many points can have a score of 0.0.
 
-        When using target (with or without context), the score behaves a little different: The 
+        When using target (with or without context), the score behaves a little different: The
         integer part of the score represents the rank with respect to the context, while the
-        decimal part of the score relates to the distance to the target. The context part of the score for 
-        each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, 
+        decimal part of the score relates to the distance to the target. The context part of the score for
+        each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,
         and -1 otherwise.
       operationId: discover_points
       requestBody:
@@ -627,6 +627,12 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - name: consistency
+          in: query
+          description: Define read consistency guarantees for the operation
+          required: false
+          schema:
+            $ref: "#/components/schemas/ReadConsistency"
       responses: #@ response(reference("CountResult"))
 
   /collections/{collection_name}/facet:
@@ -664,7 +670,7 @@ paths:
           schema:
             $ref: "#/components/schemas/ReadConsistency"
       responses: #@ response(reference("FacetResponse"))
-      
+
   /collections/{collection_name}/points/query:
     post:
       tags:
@@ -672,13 +678,13 @@ paths:
       summary: Query points
       description: Universally query points. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
       operationId: query_points
-      requestBody: 
+      requestBody:
         description: Describes the query to make to the collection
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/QueryRequest"
-              
+
 
       parameters:
         - name: collection_name

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -620,6 +620,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: consistency
+          in: query
+          description: Define read consistency guarantees for the operation
+          required: false
+          schema:
+            $ref: "#/components/schemas/ReadConsistency"
         - name: timeout
           in: query
           description: If set, overrides global timeout for this request. Unit is seconds.
@@ -627,12 +633,6 @@ paths:
           schema:
             type: integer
             minimum: 1
-        - name: consistency
-          in: query
-          description: Define read consistency guarantees for the operation
-          required: false
-          schema:
-            $ref: "#/components/schemas/ReadConsistency"
       responses: #@ response(reference("CountResult"))
 
   /collections/{collection_name}/facet:
@@ -656,6 +656,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: consistency
+          in: query
+          description: Define read consistency guarantees for the operation
+          required: false
+          schema:
+            $ref: "#/components/schemas/ReadConsistency"
         - name: timeout
           in: query
           description: If set, overrides global timeout for this request. Unit is seconds.
@@ -663,12 +669,6 @@ paths:
           schema:
             type: integer
             minimum: 1
-        - name: consistency
-          in: query
-          description: Define read consistency guarantees for the operation
-          required: false
-          schema:
-            $ref: "#/components/schemas/ReadConsistency"
       responses: #@ response(reference("FacetResponse"))
 
   /collections/{collection_name}/points/query:


### PR DESCRIPTION
read `consistency` query param is already there and can be used but it was not part of openapi spec.

This adds it to openapi in the same way as other read operations