### PR TITLE
Refactor token processing in `TokenizerConfig`

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
@@ -29,8 +29,8 @@ impl TokenizerConfig {
     /// Returns `None` if:
     /// - The token is empty.
     /// - The token is a stopword.
-    /// - The token's chars length is outside of the `min_token_len` and `max_token_len` range.
-    pub fn process_token<'a>(&self, token: &'a str) -> Option<Cow<'a, str>> {
+    /// - The token's chars length is outside of the `min_token_len` and (optionally) `max_token_len` range.
+    pub fn process_token<'a>(&self, token: &'a str, check_max_len: bool) -> Option<Cow<'a, str>> {
         let Self {
             lowercase,
             stopwords_filter,
@@ -62,7 +62,8 @@ impl TokenizerConfig {
 
         // Handle token length
         if min_token_len.is_some_and(|min_len| token_cow.chars().count() < min_len)
-            || max_token_len.is_some_and(|max_len| token_cow.chars().count() > max_len)
+            || (check_max_len
+                && max_token_len.is_some_and(|max_len| token_cow.chars().count() > max_len))
         {
             return None;
         }

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
@@ -23,4 +23,50 @@ impl TokenizerConfig {
 
         stemmer.stem(input)
     }
+
+    /// Processes a token for indexing. Applies all configured options to the token.
+    ///
+    /// Returns `None` if:
+    /// - The token is empty.
+    /// - The token is a stopword.
+    /// - The token's chars length is outside of the `min_token_len` and `max_token_len` range.
+    pub fn process_token<'a>(&self, token: &'a str) -> Option<Cow<'a, str>> {
+        let Self {
+            lowercase,
+            stopwords_filter,
+            stemmer,
+            min_token_len,
+            max_token_len,
+        } = self;
+
+        if token.is_empty() {
+            return None;
+        }
+
+        // Handle lowercase
+        let mut token_cow = if *lowercase {
+            Cow::Owned(token.to_lowercase())
+        } else {
+            Cow::Borrowed(token)
+        };
+
+        // Handle stopwords
+        if stopwords_filter.is_stopword(&token_cow) {
+            return None;
+        }
+
+        // Handle stemming
+        if let Some(stemmer) = stemmer.as_ref() {
+            token_cow = stemmer.stem(token_cow);
+        };
+
+        // Handle token length
+        if min_token_len.is_some_and(|min_len| token_cow.chars().count() < min_len)
+            || max_token_len.is_some_and(|max_len| token_cow.chars().count() > max_len)
+        {
+            return None;
+        }
+
+        Some(token_cow)
+    }
 }

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -20,7 +20,7 @@ impl WhiteSpaceTokenizer {
         mut callback: C,
     ) {
         for token in text.split_whitespace() {
-            let Some(token_cow) = config.process_token(token) else {
+            let Some(token_cow) = config.process_token(token, true) else {
                 continue;
             };
 
@@ -38,7 +38,7 @@ impl WordTokenizer {
         mut callback: C,
     ) {
         for token in text.split(|c| !char::is_alphanumeric(c)) {
-            let Some(token_cow) = config.process_token(token) else {
+            let Some(token_cow) = config.process_token(token, true) else {
                 continue;
             };
 
@@ -59,7 +59,7 @@ impl PrefixTokenizer {
         let max_ngram = config.max_token_len.unwrap_or(usize::MAX);
 
         text.split(|c| !char::is_alphanumeric(c)).for_each(|word| {
-            let Some(word_cow) = config.process_token(word) else {
+            let Some(word_cow) = config.process_token(word, false) else {
                 return;
             };
 


### PR DESCRIPTION
Depends on #6891 

This is a nice-to-have refactor of token processing, which centralizes the processing of all tokenizer options in a single place which applies all the configured ones.