### PR TITLE
UUID index bug

### DIFF
--- a/lib/collection/src/collection/mmr/lazy_matrix.rs
+++ b/lib/collection/src/collection/mmr/lazy_matrix.rs
@@ -1,7 +1,9 @@
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::{PointOffsetType, ScoreType};
 use segment::data_types::vectors::{QueryVector, VectorInternal};
-use segment::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer};
+#[cfg(debug_assertions)]
+use segment::vector_storage::VectorStorage;
+use segment::vector_storage::{RawScorer, VectorStorageEnum, new_raw_scorer};
 
 use crate::operations::types::CollectionResult;
 

--- a/lib/common/common/src/mmap_hashmap.rs
+++ b/lib/common/common/src/mmap_hashmap.rs
@@ -550,6 +550,9 @@ mod tests {
             assert_eq!(map.get(&from_ref(k)).unwrap(), &v);
         }
 
+        let keys: Vec<_> = mmap.keys().collect();
+        assert_eq!(keys.len(), map.len());
+
         // Existing keys should return the correct values
         for (k, v) in map {
             assert_eq!(
@@ -593,20 +596,23 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
 
-        let mut map: HashMap<u128, BTreeSet<u64>> = Default::default();
+        let mut map: HashMap<u128, BTreeSet<u32>> = Default::default();
 
         map.insert(
             9812384971724u128,
             (0..100).map(|_| rng.random_range(0..=1000)).collect(),
         );
 
-        MmapHashMap::<u128, u64>::create(
+        MmapHashMap::<u128, u32>::create(
             &tmpdir.path().join("map"),
             map.iter().map(|(k, v)| (k, v.iter().copied())),
         )
         .unwrap();
 
-        let mmap = MmapHashMap::<u128, u64>::open(&tmpdir.path().join("map"), true).unwrap();
+        let mmap = MmapHashMap::<u128, u32>::open(&tmpdir.path().join("map"), true).unwrap();
+
+        let keys: Vec<_> = mmap.keys().collect();
+        assert_eq!(keys.len(), map.len());
 
         for (k, v) in map {
             assert_eq!(
@@ -614,7 +620,6 @@ mod tests {
                 &v.into_iter().collect::<Vec<_>>()
             );
         }
-
         assert!(mmap.get(&100).unwrap().is_none())
     }
 }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -1470,6 +1470,31 @@ mod tests {
     }
 
     #[test]
+    fn test_uuid_payload_index() {
+        let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
+        let mut builder = MapIndex::<UuidIntType>::builder_mmap(temp_dir.path(), false);
+
+        builder.init().unwrap();
+
+        let hw_counter = HardwareCounterCell::new();
+
+        // Single UUID value
+        let uuid: Value = Value::String("baa56dfc-e746-4ec1-bf50-94822535a46c".to_string());
+
+        for idx in 0..100 {
+            builder
+                .add_point(idx as PointOffsetType, &[&uuid], &hw_counter)
+                .unwrap();
+        }
+
+        let index = builder.finalize().unwrap();
+
+        for block in index.payload_blocks(50, PayloadKeyType::new("test_uuid")) {
+            eprintln!("block = {:#?}", block);
+        }
+    }
+
+    #[test]
     fn test_index_non_ascending_insertion() {
         let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
         let mut builder = MapIndex::<IntPayloadType>::builder_mmap(temp_dir.path(), false);

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -1347,6 +1347,7 @@ impl ValueIndexer for MapIndex<UuidIntType> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::hint::black_box;
     use std::path::Path;
 
     use rstest::rstest;
@@ -1490,7 +1491,7 @@ mod tests {
         let index = builder.finalize().unwrap();
 
         for block in index.payload_blocks(50, PayloadKeyType::new("test_uuid")) {
-            eprintln!("block = {:#?}", block);
+            black_box(block);
         }
     }
 


### PR DESCRIPTION

MmapHashMap had a problem with Entry alightment, in case if key value was u128. It required 16bit alightment, but
storage assumed, apparently, that nothing can need more than 8 bit alignment.

This PR introduces 2 unit tests + fix.
Fix is another alignment block inside MmapHashmap. If Required alignment is <8, there are no change and format exactly same as before. If required alignment >8, we put extra empty bytes __before__ bucket offsets, so that
(new_alignment + buckets) % ALIGNMENT = 0.

Compatibility: luckily (thanks to @xzfc) bucket offset is stored explicitly in the header of the file.
So the same code should be able to read both: files with and without offset, even if old files were created for u128 key.  



