### PR TITLE
MADV_POPULATE_READ on sequential mmaps

### DIFF
--- a/lib/common/memory/src/chunked_utils.rs
+++ b/lib/common/memory/src/chunked_utils.rs
@@ -44,7 +44,7 @@ impl<T: Sized + 'static> UniversalMmapChunk<T> {
     }
 
     pub fn populate(&self) -> io::Result<()> {
-        self.mmap.populate()
+        self.mmap_seq.populate()
     }
 }
 

--- a/lib/gridstore/src/page.rs
+++ b/lib/gridstore/src/page.rs
@@ -150,7 +150,7 @@ impl Page {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) {
-        self.mmap.populate();
+        self.mmap_seq.populate();
     }
 
     /// Drop disk cache.

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -245,7 +245,7 @@ impl<T: PrimitiveVectorElement> MmapDenseVectors<T> {
     }
 
     pub fn populate(&self) -> OperationResult<()> {
-        self.mmap.populate();
+        self.mmap_sequential.populate();
         Ok(())
     }
 }


### PR DESCRIPTION
It turns out `MADV_POPULATE_READ` performance is influenced by the `MADV_RANDOM` and `MADV_SEQUENTIAL` flags.
Obvious in hindsight, but still surprising that the kernel won't enable readahead unconditionlly given that it knows that it will be reading the whole file.

```c
// Slow, many 4K IOPS
madvise(ptr, size, MADV_RANDOM);
madvise(ptr, size, MADV_POPULATE_READ);
```

```c
// Fast, as uses large readahead
madvise(ptr, size, MADV_SEQUENTIAL);
madvise(ptr, size, MADV_POPULATE_READ);
```

# Fix

Since a lot of our files mmaped twice (for sequential and for random), the fix in this PR is trivial: let `populate()` use the sequential mmap if it available.

Fixed:
- Dense vector storages, except deleted flags
- Gridstore pages (used in sparse vectors)

Some mmaps are not duplicated, so these are not fixed:
- `MmapBitSlice` (deleted flags).
- Gridstore bitmasks (`bitmask.dat` and `gaps.dat`; used in sparse vectors)
- Quantized vector storage. (not used)
- Payload storages. (not used)

CPU usage/saturation on 400M benchmark (left is before this commit, right is after):
<img width="1183" height="477" alt="2025-07-18_03:16:20" src="https://github.com/user-attachments/assets/8120c377-ad7b-406e-b0a6-560a2332f537" />
