### PR TITLE
Avoid creating partial snapshot if snapshot manifest contains no changes

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -997,7 +997,7 @@ impl SegmentHolder {
         segments_path: &Path,
         collection_params: Option<&CollectionParams>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-        mut f: F,
+        mut operation: F,
     ) -> OperationResult<()>
     where
         F: FnMut(Arc<RwLock<dyn SegmentEntry>>) -> OperationResult<()>,
@@ -1034,7 +1034,7 @@ impl SegmentHolder {
             };
 
             // Call provided function on segment
-            if let Err(err) = f(segment) {
+            if let Err(err) = operation(segment) {
                 result = Err(OperationError::service_error(format!(
                     "Applying function to a proxied shard segment {proxy_id} failed: {err}"
                 )));

--- a/lib/segment/src/data_types/segment_manifest.rs
+++ b/lib/segment/src/data_types/segment_manifest.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::types::SeqNumberType;
 
-#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct SegmentManifests {
     manifests: HashMap<String, SegmentManifest>,

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -46,6 +46,7 @@ impl From<StorageError> for Status {
                 tonic::Code::ResourceExhausted
             }
             StorageError::ShardUnavailable { .. } => tonic::Code::Unavailable,
+            StorageError::EmptyPartialSnapshot { .. } => tonic::Code::FailedPrecondition,
         };
         let mut status = Status::new(error_code, format!("{error}"));
         // add metadata headers

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -3,6 +3,7 @@ use std::io::Error as IoError;
 use std::time::Duration;
 
 use collection::operations::types::CollectionError;
+use collection::shards::shard::ShardId;
 use io::file_operations::FileStorageError;
 use tempfile::PersistError;
 use thiserror::Error;
@@ -44,6 +45,8 @@ pub enum StorageError {
     },
     #[error("Shard temporarily unavailable: {description}")]
     ShardUnavailable { description: String },
+    #[error("Partial snapshot for shard {shard_id} contains no changes")]
+    EmptyPartialSnapshot { shard_id: ShardId },
 }
 
 impl StorageError {

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -235,6 +235,7 @@ impl HttpError {
             StorageError::PreconditionFailed { .. } => {}
             StorageError::InferenceError { .. } => {}
             StorageError::ShardUnavailable { .. } => {}
+            StorageError::EmptyPartialSnapshot { .. } => {}
         }
         headers
     }
@@ -256,6 +257,7 @@ impl ResponseError for HttpError {
             StorageError::InferenceError { .. } => http::StatusCode::BAD_REQUEST,
             StorageError::RateLimitExceeded { .. } => http::StatusCode::TOO_MANY_REQUESTS,
             StorageError::ShardUnavailable { .. } => http::StatusCode::SERVICE_UNAVAILABLE,
+            StorageError::EmptyPartialSnapshot { .. } => http::StatusCode::NOT_MODIFIED,
         }
     }
 }

--- a/tests/consensus_tests/test_partial_snapshot.py
+++ b/tests/consensus_tests/test_partial_snapshot.py
@@ -133,7 +133,7 @@ def test_partial_snapshot_not_modified(tmp_path: pathlib.Path):
     assert_project_root()
 
     peer = bootstrap_peer(tmp_path, 6331)
-    bootstrap_collection(peer, 1_000)
+    bootstrap_collection(peer, bootstrap_points = 1_000)
 
     resp = create_partial_snapshot(peer, manifest = get_snapshot_manifest(peer))
     assert resp.status_code == 304


### PR DESCRIPTION
Small optimization for partial snapshots: instead of creating an "empty" partial snapshot, when snapshot manifest contains no changes (e.g., when snapshot manifest provided by "read" replica is the same as current data on "write" replica), we simply return `NOT MODIFIED` response and "short-circuit" the whole recovery.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
