### PR TITLE
[map index] use roaring bitmap in mutable map index

### DIFF
--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -18,7 +18,7 @@ use rocksdb::DB;
 #[cfg(feature = "rocksdb")]
 use super::MapIndex;
 use super::mmap_map_index::MmapMapIndex;
-use super::{IdIter, IdRefIter, MapIndexKey};
+use super::{IdIter, MapIndexKey};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 #[cfg(feature = "rocksdb")]
@@ -514,12 +514,12 @@ where
         self.value_to_points.keys().map(move |k| {
             (
                 k.borrow(),
-                Box::new(self.get_iterator(k.borrow()).copied()) as IdIter,
+                Box::new(self.get_iterator(k.borrow())) as IdIter,
             )
         })
     }
 
-    pub fn get_iterator(&self, value: &N) -> IdRefIter<'_> {
+    pub fn get_iterator(&self, value: &N) -> IdIter<'_> {
         if let Some(entry) = self.value_to_points.get(value) {
             let range = entry.range.start as usize..entry.range.end as usize;
 
@@ -534,11 +534,11 @@ where
                 .iter()
                 .zip(deleted_flags)
                 .filter(|(_, is_deleted)| !is_deleted)
-                .map(|(idx, _)| idx);
+                .map(|(idx, _)| *idx);
 
             Box::new(values)
         } else {
-            Box::new(iter::empty::<&PointOffsetType>())
+            Box::new(iter::empty::<PointOffsetType>())
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -322,11 +322,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         }
     }
 
-    pub fn get_iterator(
-        &self,
-        value: &N,
-        hw_counter: &HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = &PointOffsetType> + '_> {
+    pub fn get_iterator(&self, value: &N, hw_counter: &HardwareCounterCell) -> IdIter<'_> {
         let Some(storage) = &self.storage else {
             return Box::new(iter::empty());
         };
@@ -343,7 +339,8 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
                 Box::new(
                     slice
                         .iter()
-                        .filter(|idx| !storage.deleted.get(**idx as usize).unwrap_or(false)),
+                        .filter(|idx| !storage.deleted.get(**idx as usize).unwrap_or(false))
+                        .copied(),
                 )
             }
             Ok(None) => {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -234,7 +234,7 @@ where
         }
     }
 
-    fn get_iterator(&self, value: &N, hw_counter: &HardwareCounterCell) -> IdRefIter<'_> {
+    fn get_iterator(&self, value: &N, hw_counter: &HardwareCounterCell) -> IdIter<'_> {
         match self {
             MapIndex::Mutable(index) => index.get_iterator(value),
             MapIndex::Immutable(index) => index.get_iterator(value),
@@ -490,7 +490,7 @@ where
         Box::new(
             self.iter_values()
                 .filter(|key| !excluded.contains((*key).borrow()))
-                .flat_map(move |key| self.get_iterator(key.borrow(), hw_counter).copied())
+                .flat_map(move |key| self.get_iterator(key.borrow(), hw_counter))
                 .unique(),
         )
     }
@@ -746,9 +746,9 @@ impl PayloadFieldIndex for MapIndex<str> {
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match &condition.r#match {
             Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(keyword) => Some(Box::new(
-                    self.get_iterator(keyword.as_str(), hw_counter).copied(),
-                )),
+                ValueVariants::String(keyword) => {
+                    Some(Box::new(self.get_iterator(keyword.as_str(), hw_counter)))
+                }
                 ValueVariants::Integer(_) => None,
                 ValueVariants::Bool(_) => None,
             },
@@ -756,9 +756,7 @@ impl PayloadFieldIndex for MapIndex<str> {
                 AnyVariants::Strings(keywords) => Some(Box::new(
                     keywords
                         .iter()
-                        .flat_map(move |keyword| {
-                            self.get_iterator(keyword.as_str(), hw_counter).copied()
-                        })
+                        .flat_map(move |keyword| self.get_iterator(keyword.as_str(), hw_counter))
                         .unique(),
                 )),
                 AnyVariants::Integers(integers) => {
@@ -902,9 +900,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
             Some(Match::Value(MatchValue { value })) => match value {
                 ValueVariants::String(uuid_string) => {
                     let uuid = Uuid::from_str(uuid_string).ok()?;
-                    Some(Box::new(
-                        self.get_iterator(&uuid.as_u128(), hw_counter).copied(),
-                    ))
+                    Some(Box::new(self.get_iterator(&uuid.as_u128(), hw_counter)))
                 }
                 ValueVariants::Integer(_) => None,
                 ValueVariants::Bool(_) => None,
@@ -921,7 +917,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
                     Some(Box::new(
                         uuids
                             .into_iter()
-                            .flat_map(move |uuid| self.get_iterator(&uuid, hw_counter).copied())
+                            .flat_map(move |uuid| self.get_iterator(&uuid, hw_counter))
                             .unique(),
                     ))
                 }
@@ -944,7 +940,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
                     let exclude_iter = self
                         .iter_values()
                         .filter(move |key| !excluded_uuids.contains(*key))
-                        .flat_map(move |key| self.get_iterator(key, hw_counter).copied())
+                        .flat_map(move |key| self.get_iterator(key, hw_counter))
                         .unique();
                     Some(Box::new(exclude_iter))
                 }
@@ -1097,7 +1093,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
             Some(Match::Value(MatchValue { value })) => match value {
                 ValueVariants::String(_) => None,
                 ValueVariants::Integer(integer) => {
-                    Some(Box::new(self.get_iterator(integer, hw_counter).copied()))
+                    Some(Box::new(self.get_iterator(integer, hw_counter)))
                 }
                 ValueVariants::Bool(_) => None,
             },
@@ -1112,7 +1108,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                 AnyVariants::Integers(integers) => Some(Box::new(
                     integers
                         .iter()
-                        .flat_map(move |integer| self.get_iterator(integer, hw_counter).copied())
+                        .flat_map(move |integer| self.get_iterator(integer, hw_counter))
                         .unique(),
                 )),
             },


### PR DESCRIPTION
Similar to #6685, swaps the container of ids per value in mutable map index from `BTreeSet<u32>` to `RoaringBitmap`.

This is not too noticeable on "normal" workloads, but when there is many values per point, it does provide a bit of advantage on insertion. 

For example, with the following command (100k points):

```
bfb -n 300000 --max-keywords 1000 --keywords 10000  --search --match-any 900
```

This is the performance improvement (edit: reran with release build of bfb and perf builds of qdrant)

| build | final upsert RPS | total upsert time | median search RPS | 
| --- | --- | --- | --- |
| dev (perf build) | 1685 | 00:02:57 | 526
| PR (perf build) | 3159 | 00:01:34 | 525

And, with just 1 keyword per point

```
bfb -n 300000 --keywords 10000 --search --match-any 900
```

| build | final upsert RPS | total upsert time | median search RPS | 
| --- | --- | --- | --- | 
| dev (perf build) | 147385 | 00:00:02 | 618
| PR (perf build) | 161625 | 00:00:01 | 628