### PR TITLE
Do no delete payload index on point deletion to avoid data inconsistency

### DIFF
--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -129,7 +129,7 @@ impl SegmentEntry for Segment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        hw_counter: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
@@ -138,19 +138,19 @@ impl SegmentEntry for Segment {
             Some(internal_id) => {
                 self.handle_point_version_and_failure(op_num, Some(internal_id), |segment| {
                     // Mark point as deleted, drop mapping
-                    segment
-                        .payload_index
-                        .borrow_mut()
-                        .clear_payload(internal_id, hw_counter)?;
                     segment.version_tracker.set_payload(Some(op_num));
 
                     segment.id_tracker.borrow_mut().drop(point_id)?;
 
-                    // Before, we propagated point deletions to also delete its vectors. This turns
-                    // out to be problematic because this sometimes makes us loose vector data
-                    // because we cannot control the order of segment flushes.
-                    // Disabled until we properly fix it or find a better way to clean up old
-                    // vectors.
+                    // Before, we propagated point deletions to also delete its vectors and payload index values.
+                    // This turns out to be problematic because this sometimes makes us lose data when the storage are not buffering writes.
+                    // Disabled until we properly fix it or find a better way to clean up old data.
+                    //
+                    // // Propagate payload index deletion
+                    // segment
+                    //    .payload_index
+                    //    .borrow_mut()
+                    //    .clear_payload(internal_id, hw_counter)?;
                     //
                     // // Propagate point deletion to all its vectors
                     // for vector_data in segment.vector_data.values() {


### PR DESCRIPTION
This PR fixes a subtle data inconsistency issue happening when crashing while a segment optimization is running.

When running with a proxy segment, the points deletion on the wrapped segment should not be executed until the proxy segment is promoted.

Otherwise the data is lost if crash occurs in between.

For this reason we use storages with lazy writes which are capturing pending changes and applying those only on explicit flush.

Importantly, a point deletion is also deleting the payload index values as well.

However some payload indexes are not buffering writes:
- `null-index`
- `mmap-bool-index`
- more maybe?

This PR proposes an easy workaround similar to the one what we did the vector deletion to avoid data inconsistency.

A better fix would be to make those payload index buffer writes but it might incur a large performance cost. 
