### PR TITLE
WIP: Buffered dynamic mmap flags

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -209,6 +209,10 @@ name = "mmap_bitslice_buffered_update_wrapper"
 harness = false
 
 [[bench]]
+name = "mmap_null_index_buffered"
+harness = false
+
+[[bench]]
 name = "scorer_mmap"
 harness = false
 

--- a/lib/segment/benches/mmap_null_index_buffered.rs
+++ b/lib/segment/benches/mmap_null_index_buffered.rs
@@ -1,0 +1,206 @@
+#[cfg(not(target_os = "windows"))]
+mod prof;
+
+use std::hint::black_box;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use criterion::{Criterion, criterion_group, criterion_main};
+use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
+use segment::index::field_index::null_index::mmap_null_index::MmapNullIndex;
+use segment::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex};
+use segment::json_path::JsonPath;
+use segment::types::FieldCondition;
+use serde_json::Value;
+use tempfile::Builder;
+
+const NUM_POINTS: usize = 10_000; // Smaller for initial testing
+const ADDITIONAL_POINTS: usize = 1_000;
+// Removed unused FILTER_CHECKS constant
+
+/// Benchmark for testing MmapNullIndex performance with buffered updates.
+///
+/// This benchmark measures:
+/// 1. Basic filtering performance after flushing data to disk
+/// 2. Performance impact of buffered updates on filtering operations
+/// 3. Cost of flushing buffered updates to disk
+/// 4. Direct method call performance (values_is_empty, values_is_null)
+///
+/// Two main scenarios:
+/// - mmap_null_index_benchmark: Tests baseline performance with flushed data
+/// - buffered_updates_benchmark: Tests performance impact of having buffered updates
+fn create_is_empty_filter(is_empty: bool) -> FieldCondition {
+    FieldCondition::new_is_empty(JsonPath::new("test_field"), is_empty)
+}
+
+fn create_is_null_filter(is_null: bool) -> FieldCondition {
+    FieldCondition::new_is_null(JsonPath::new("test_field"), is_null)
+}
+
+fn mmap_null_index_benchmark(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut group = c.benchmark_group("mmap-null-index");
+
+    let hw_counter = HardwareCounterCell::new();
+
+    // Scenario 1: Basic functionality test
+    let dir = Builder::new().prefix("null_index_test").tempdir().unwrap();
+    let mut builder = MmapNullIndex::builder(dir.path()).unwrap();
+    builder.init().unwrap();
+
+    // Insert some test data
+    for point_id in 0..NUM_POINTS {
+        let has_value = rng.random_bool(0.7); // 70% chance of having a value
+        let value = if has_value {
+            Value::Number(42.into())
+        } else {
+            Value::Null
+        };
+        let payload = [&value];
+        builder
+            .add_point(point_id as PointOffsetType, &payload, &hw_counter)
+            .unwrap();
+    }
+
+    let index = builder.finalize().unwrap();
+    index.flusher()().unwrap();
+
+    // Simple benchmark: filter for non-empty values
+    let has_values_filter = create_is_empty_filter(false);
+    group.bench_function("filter-has-values", |b| {
+        b.iter(|| {
+            let results: Vec<_> = index
+                .filter(&has_values_filter, &hw_counter)
+                .unwrap()
+                .take(10)
+                .collect();
+            black_box(results);
+        });
+    });
+
+    // Simple benchmark: filter for null values
+    let is_null_filter = create_is_null_filter(true);
+    group.bench_function("filter-is-null", |b| {
+        b.iter(|| {
+            let results: Vec<_> = index
+                .filter(&is_null_filter, &hw_counter)
+                .unwrap()
+                .take(10)
+                .collect();
+            black_box(results);
+        });
+    });
+
+    // Simple benchmark: direct method calls
+    group.bench_function("values-is-empty-check", |b| {
+        b.iter(|| {
+            for i in 0..10 {
+                let point_id = (i * NUM_POINTS / 10) as PointOffsetType;
+                black_box(index.values_is_empty(point_id));
+            }
+        });
+    });
+
+    group.bench_function("values-is-null-check", |b| {
+        b.iter(|| {
+            for i in 0..10 {
+                let point_id = (i * NUM_POINTS / 10) as PointOffsetType;
+                black_box(index.values_is_null(point_id));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+fn buffered_updates_benchmark(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut group = c.benchmark_group("mmap-null-index-buffered");
+
+    let hw_counter = HardwareCounterCell::new();
+
+    // Create index with initial data, flush, then add more data (buffered)
+    let dir = Builder::new()
+        .prefix("null_index_buffered")
+        .tempdir()
+        .unwrap();
+    let mut builder = MmapNullIndex::builder(dir.path()).unwrap();
+    builder.init().unwrap();
+
+    // Initial data
+    for point_id in 0..NUM_POINTS {
+        let has_value = rng.random_bool(0.7);
+        let value = if has_value {
+            Value::Number(42.into())
+        } else {
+            Value::Null
+        };
+        let payload = [&value];
+        builder
+            .add_point(point_id as PointOffsetType, &payload, &hw_counter)
+            .unwrap();
+    }
+
+    let mut index = builder.finalize().unwrap();
+    index.flusher()().unwrap(); // Flush to disk
+
+    // Add buffered data
+    for point_id in NUM_POINTS..(NUM_POINTS + ADDITIONAL_POINTS) {
+        let has_value = rng.random_bool(0.7);
+        let value = if has_value {
+            Value::Number(42.into())
+        } else {
+            Value::Null
+        };
+        let payload = [&value];
+        index
+            .add_point(point_id as PointOffsetType, &payload, &hw_counter)
+            .unwrap();
+    }
+
+    // Benchmark filtering with buffered data
+    let has_values_filter = create_is_empty_filter(false);
+    group.bench_function("filter-with-buffered-data", |b| {
+        b.iter(|| {
+            let results: Vec<_> = index
+                .filter(&has_values_filter, &hw_counter)
+                .unwrap()
+                .take(10)
+                .collect();
+            black_box(results);
+        });
+    });
+
+    // Benchmark flush operation
+    group.bench_function("flush-buffered-updates", |b| {
+        b.iter(|| {
+            // Add a few points and flush
+            for i in 0..10 {
+                let point_id = (NUM_POINTS + ADDITIONAL_POINTS + i) as PointOffsetType;
+                let value = Value::Number(i.into());
+                let payload = [&value];
+                index.add_point(point_id, &payload, &hw_counter).unwrap();
+            }
+            let _ = black_box(index.flusher()().ok());
+        });
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
+    targets = mmap_null_index_benchmark, buffered_updates_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = mmap_null_index_benchmark, buffered_updates_benchmark
+}
+
+criterion_main!(benches);

--- a/lib/segment/src/common/dynamic_mmap_flags_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/dynamic_mmap_flags_buffered_update_wrapper.rs
@@ -1,0 +1,248 @@
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use common::counter::referenced_counter::HwMetricRefCounter;
+use parking_lot::{Mutex, RwLock};
+
+use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
+use crate::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
+
+/// A wrapper around `DynamicMmapFlags` that delays writing changes to the underlying file until they get
+/// flushed manually.
+#[derive(Debug)]
+pub struct DynamicMmapFlagsBufferedUpdateWrapper {
+    flags: Arc<RwLock<DynamicMmapFlags>>,
+    pending_updates: Arc<Mutex<AHashMap<u32, bool>>>,
+    /// Cached length to avoid repeated calculation for iter_trues
+    cached_len: usize,
+}
+
+impl DynamicMmapFlagsBufferedUpdateWrapper {
+    pub fn new(flags: DynamicMmapFlags) -> Self {
+        let initial_len = flags.len();
+        Self {
+            flags: Arc::new(RwLock::new(flags)),
+            pending_updates: Arc::new(Mutex::new(AHashMap::new())),
+            cached_len: initial_len,
+        }
+    }
+
+    /// Sets the flag at `index` to `value` buffered.
+    ///
+    /// Returns the previous value of the flag (considering pending updates).
+    pub fn set(&mut self, key: u32, value: bool, hw_counter_ref: HwMetricRefCounter) -> bool {
+        let previous_value = self.get(key);
+        self.pending_updates.lock().insert(key, value);
+
+        // Update cached length if this key extends beyond current length
+        if value {
+            let new_required_len = key as usize + 1;
+            if new_required_len > self.cached_len {
+                self.cached_len = new_required_len;
+            }
+        }
+
+        hw_counter_ref.incr_delta(size_of::<bool>());
+        previous_value
+    }
+
+    /// Gets the value of the flag at `key`, considering pending updates.
+    pub fn get(&self, key: u32) -> bool {
+        // Check pending updates first
+        if let Some(value) = self.pending_updates.lock().get(&key) {
+            return *value;
+        }
+
+        // Fall back to the underlying flags
+        self.flags.read().get(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.cached_len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Count number of set flags, considering pending updates.
+    pub fn count_flags(&self) -> usize {
+        self.iter_trues().count()
+    }
+
+    /// Set the length of the flags, buffered.
+    /// This will be applied during flush.
+    pub fn set_len(&mut self, new_len: usize) -> OperationResult<()> {
+        // For simplicity, we'll handle resizing during flush
+        // For now, just ensure we don't shrink below pending updates
+        let current_len = self.flags.read().len();
+        if new_len < current_len {
+            return Err(
+                crate::common::operation_error::OperationError::service_error(format!(
+                    "Cannot shrink the buffered mmap flags from {current_len} to {new_len}",
+                )),
+            );
+        }
+
+        // Update cached length
+        if new_len > self.cached_len {
+            self.cached_len = new_len;
+        }
+
+        Ok(())
+    }
+
+    /// Iterate over all "true" flags, considering pending updates.
+    /// Uses cached length for efficient 0..len iteration.
+    pub fn iter_trues(&self) -> impl Iterator<Item = u32> {
+        let len = self.len();
+        let flags = self.flags.read();
+        let pending = self.pending_updates.lock();
+
+        (0..len).filter_map(move |i| {
+            let i_u32 = i as u32;
+            let is_true = if let Some(&pending_value) = pending.get(&i_u32) {
+                // Check pending updates first
+                pending_value
+            } else if i < flags.len() {
+                // Check underlying flags
+                flags.get(i)
+            } else {
+                // Beyond underlying flags length, not set
+                false
+            };
+
+            if is_true { Some(i_u32) } else { None }
+        })
+    }
+
+    /// Removes from `pending_updates` all results that are flushed.
+    /// If values in `pending_updates` are changed, do not remove them.
+    fn clear_flushed_updates(
+        flushed: AHashMap<u32, bool>,
+        pending_updates: Arc<Mutex<AHashMap<u32, bool>>>,
+    ) {
+        pending_updates
+            .lock()
+            .retain(|point_id, a| flushed.get(point_id).is_none_or(|b| a != b));
+    }
+
+    pub fn flusher(&self) -> Flusher {
+        let pending_updates_clone = self.pending_updates.lock().clone();
+        let flags = self.flags.clone();
+        let pending_updates_arc = self.pending_updates.clone();
+
+        Box::new(move || {
+            let mut flags_write = flags.write();
+
+            // First, determine if we need to resize
+            if let Some(max_key) = pending_updates_clone.keys().max() {
+                let required_len = *max_key as usize + 1;
+                if required_len > flags_write.len() {
+                    flags_write.set_len(required_len)?;
+                }
+            }
+
+            // Apply all pending updates
+            for (index, value) in pending_updates_clone.iter() {
+                flags_write.set(*index as usize, *value);
+            }
+
+            // Flush the underlying flags
+            flags_write.flusher()()?;
+
+            // Clear the flushed updates
+            Self::clear_flushed_updates(pending_updates_clone, pending_updates_arc);
+
+            Ok(())
+        })
+    }
+
+    /// Get a reference to the underlying flags for read-only operations.
+    /// Note: This does not consider pending updates.
+    pub fn get_underlying_flags(&self) -> Arc<RwLock<DynamicMmapFlags>> {
+        self.flags.clone()
+    }
+}
+
+impl From<DynamicMmapFlags> for DynamicMmapFlagsBufferedUpdateWrapper {
+    fn from(flags: DynamicMmapFlags) -> Self {
+        Self::new(flags)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use tempfile::Builder;
+
+    use super::*;
+
+    #[test]
+    fn test_buffered_updates() {
+        let dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+        let mut wrapper = DynamicMmapFlagsBufferedUpdateWrapper::new(flags);
+
+        // Test basic set/get operations
+        let hw_counter = HardwareCounterCell::disposable();
+        let hw_ref = hw_counter.ref_payload_index_io_write_counter();
+        assert!(!wrapper.set(0, true, hw_ref));
+        assert!(wrapper.get(0));
+
+        // Test that underlying flags don't have the update yet
+        assert!(!wrapper.flags.read().get(0));
+
+        // Flush and check
+        wrapper.flusher()().unwrap();
+        assert!(wrapper.flags.read().get(0));
+        assert!(wrapper.get(0));
+    }
+
+    #[test]
+    fn test_buffered_count() {
+        let dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let mut flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+        flags.set_len(10).unwrap();
+        let mut wrapper = DynamicMmapFlagsBufferedUpdateWrapper::new(flags);
+
+        // Set some flags in buffer
+        let hw_counter = HardwareCounterCell::disposable();
+        let hw_ref = hw_counter.ref_payload_index_io_write_counter();
+        wrapper.set(0, true, hw_ref);
+        wrapper.set(5, true, hw_ref);
+        wrapper.set(9, true, hw_ref);
+
+        assert_eq!(wrapper.count_flags(), 3);
+
+        // Flush and verify count is still correct
+        wrapper.flusher()().unwrap();
+        assert_eq!(wrapper.count_flags(), 3);
+    }
+
+    #[test]
+    fn test_iter_trues() {
+        let dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let mut flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+        flags.set_len(10).unwrap();
+        let mut wrapper = DynamicMmapFlagsBufferedUpdateWrapper::new(flags);
+
+        // Set some flags
+        let hw_counter = HardwareCounterCell::disposable();
+        let hw_ref = hw_counter.ref_payload_index_io_write_counter();
+        wrapper.set(1, true, hw_ref);
+        wrapper.set(3, true, hw_ref);
+        wrapper.set(7, true, hw_ref);
+
+        let mut trues: Vec<u32> = wrapper.iter_trues().collect();
+        trues.sort();
+        assert_eq!(trues, vec![1, 3, 7]);
+
+        // Flush and verify iter_trues still works correctly
+        wrapper.flusher()().unwrap();
+        let mut trues_after_flush: Vec<u32> = wrapper.iter_trues().collect();
+        trues_after_flush.sort();
+        assert_eq!(trues_after_flush, vec![1, 3, 7]);
+    }
+}

--- a/lib/segment/src/common/dynamic_mmap_flags_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/dynamic_mmap_flags_buffered_update_wrapper.rs
@@ -82,7 +82,7 @@ impl DynamicMmapFlagsBufferedUpdateWrapper {
             flags.get(i)
         };
 
-        (0..len as u32).filter_map(move |i| is_true(i).then_some(i))
+        (0..len as u32).filter(move |i| is_true(*i))
     }
 
     /// Iterate over all "false" flags, considering pending updates.
@@ -100,7 +100,7 @@ impl DynamicMmapFlagsBufferedUpdateWrapper {
             !flags.get(i)
         };
 
-        (0..len as u32).filter_map(move |i| is_false(i).then_some(i))
+        (0..len as u32).filter(move |i| is_false(*i))
     }
 
     /// Removes from `pending_updates` all results that are flushed.
@@ -124,7 +124,7 @@ impl DynamicMmapFlagsBufferedUpdateWrapper {
             let mut flags_write = flags.write();
 
             // First, determine if we need to resize
-            let required_len = cached_len as usize;
+            let required_len = cached_len;
             if required_len > flags_write.len() {
                 flags_write.set_len(required_len)?;
             }

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod anonymize;
+pub mod dynamic_mmap_flags_buffered_update_wrapper;
 pub mod error_logging;
 pub mod macros;
 pub mod mmap_bitslice_buffered_update_wrapper;

--- a/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mmap_null_index.rs
@@ -387,9 +387,11 @@ impl PayloadFieldIndex for MmapNullIndex {
 
             if *is_empty {
                 // Iterate over all tracked values, but filter out those which have a value
-                let iter = (0..self.total_point_count as PointOffsetType)
-                    .filter(move |&id| !storage.has_values_slice.get(id))
-                    .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
+                let iter = storage.has_values_slice.iter_falses().measure_hw_with_cell(
+                    hw_counter,
+                    1,
+                    |i| i.payload_index_io_read_counter(),
+                );
                 Some(Box::new(iter))
             } else {
                 // Non-empty values are registered in the index explicitly
@@ -415,9 +417,11 @@ impl PayloadFieldIndex for MmapNullIndex {
                 Some(Box::new(iter))
             } else {
                 // Iterate over all tracked values, but filter out those which are null
-                let iter = (0..self.total_point_count as PointOffsetType)
-                    .filter(move |&id| !storage.is_null_slice.get(id))
-                    .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
+                let iter =
+                    storage
+                        .is_null_slice
+                        .iter_falses()
+                        .measure_hw_with_cell(hw_counter, 1, |i| i.payload_index_io_read_counter());
                 Some(Box::new(iter))
             }
         } else {


### PR DESCRIPTION
Implement dynamic mmap flags wrapped with a buffer which writes only on flush.


Right now it destroys performance 😢 
```console
     Running benches/mmap_null_index_buffered.rs (target/release/deps/mmap_null_index_buffered-3a47ce4ef6067935)
Gnuplot not found, using plotters backend
Benchmarking mmap-null-index/filter-has-values: Collecting 100 samples in estimated 5.0007 s (mmap-null-index/filter-has-values
                        time:   [150.50 ns 151.37 ns 152.21 ns]
                        change: [−8.2455% −7.1393% −5.9960%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking mmap-null-index/filter-is-null: Collecting 100 samples in estimated 5.0009 s (24Mmmap-null-index/filter-is-null
                        time:   [209.98 ns 210.57 ns 211.21 ns]
                        change: [+37.256% +37.722% +38.163%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Benchmarking mmap-null-index/values-is-empty-check: Collecting 100 samples in estimated 5.0002mmap-null-index/values-is-empty-check
                        time:   [175.30 ns 175.70 ns 176.09 ns]
                        change: [+1234.1% +1237.0% +1240.0%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking mmap-null-index/values-is-null-check: Collecting 100 samples in estimated 5.0004 mmap-null-index/values-is-null-check
                        time:   [174.13 ns 177.36 ns 181.70 ns]
                        change: [+1239.4% +1255.3% +1274.2%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  5 (5.00%) high severe

Benchmarking mmap-null-index-buffered/filter-with-buffered-data: Collecting 100 samples in estmmap-null-index-buffered/filter-with-buffered-data
                        time:   [165.20 ns 165.53 ns 165.86 ns]
                        change: [+7.3960% +7.7216% +8.0681%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low mild
  6 (6.00%) high mild
  1 (1.00%) high severe
Benchmarking mmap-null-index-buffered/flush-buffered-updates: Collecting 100 samples in estimammap-null-index-buffered/flush-buffered-updates
                        time:   [12.561 µs 13.043 µs 13.558 µs]
                        change: [+2202.0% +2254.0% +2303.8%] (p = 0.00 < 0.05)
                        Performance has regressed.
```