### PR TITLE
bump version to v1.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "api"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.15.0"
+version = "1.15.1"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.15.0"
+version = "1.15.1"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.15.0";
+pub const QDRANT_VERSION_STRING: &str = "1.15.1";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
```
# Changelog

## Improvements

* https://github.com/qdrant/qdrant/pull/6931 - gRPC HealthCheck method now works without authentication, making it consistent with REST methods.
* https://github.com/qdrant/qdrant/pull/6923 - Use populate storage components with `MADV_SEQUENTIAL` for better IO performance on indexing

## Bug Fixes

* https://github.com/qdrant/qdrant/pull/6932 - Fix point shard routing broken in 1.15 (**Points created in 1.15.0 in multi-shard collections might not behave properly on updates!**)
* https://github.com/qdrant/qdrant/pull/6903 - Fix compile error in MUSL builds
* https://github.com/qdrant/qdrant/pull/6910 - Fix panic in `/metrics` on empty collection data
* https://github.com/qdrant/qdrant/pull/6916 - Fix UUID index storage, resulted in missing filter results.


```