### PR TITLE
[Bm25] Execution implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,6 +3644,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "git+https://github.com/stusmall/murmur3?rev=2c39087#2c39087f094ae982a463e1cda9cf4d483a09192b"
+
+[[package]]
 name = "names"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +4705,7 @@ dependencies = [
  "jsonwebtoken",
  "log",
  "memory",
+ "murmur3",
  "parking_lot",
  "prometheus",
  "prost 0.11.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,6 +3648,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "rand 0.9.1",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,6 +4739,7 @@ dependencies = [
  "jsonwebtoken",
  "log",
  "memory",
+ "mockito",
  "murmur3",
  "parking_lot",
  "prometheus",
@@ -5990,6 +6025,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6326,7 +6367,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.60.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7427,37 +7468,15 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
-dependencies = [
- "windows-collections 0.1.1",
- "windows-core 0.60.1",
- "windows-future 0.1.1",
- "windows-link",
- "windows-numerics 0.1.1",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
-dependencies = [
- "windows-core 0.60.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -7483,19 +7502,6 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.60.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface 0.59.1",
- "windows-link",
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -7504,17 +7510,7 @@ dependencies = [
  "windows-interface 0.59.1",
  "windows-link",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
-dependencies = [
- "windows-core 0.60.1",
- "windows-link",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7533,17 +7529,6 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7591,16 +7576,6 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-numerics"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
-dependencies = [
- "windows-core 0.60.1",
- "windows-link",
-]
-
-[[package]]
-name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
@@ -7623,15 +7598,6 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ prometheus = { version = "0.14.0", default-features = false }
 validator = { workspace = true }
 jsonwebtoken = "9.3.1"
 
+murmur3 = { git = "https://github.com/stusmall/murmur3", rev = "2c39087" }
+
 tempfile = { workspace = true }
 
 # Consensus related crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ sealed_test = "1.1.0"
 tempfile = { workspace = true }
 rusty-hook = "^0.11.2"
 
+mockito = "1.7"
+
 
 [dependencies]
 parking_lot = { workspace = true }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -17,6 +17,7 @@ use segment::data_types::vectors::{
 };
 use segment::types::{Filter, Payload, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
+use sparse::common::types::{DimId, DimWeight};
 use strum::{EnumDiscriminants, EnumIter};
 use validator::{Validate, ValidationErrors};
 
@@ -59,7 +60,7 @@ pub enum VectorPersisted {
 }
 
 impl VectorPersisted {
-    pub fn new_sparse(indices: Vec<u32>, values: Vec<f32>) -> Self {
+    pub fn new_sparse(indices: Vec<DimId>, values: Vec<DimWeight>) -> Self {
         Self::Sparse(sparse::common::sparse_vector::SparseVector { indices, values })
     }
 

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -58,6 +58,16 @@ pub enum VectorPersisted {
     MultiDense(MultiDenseVector),
 }
 
+impl VectorPersisted {
+    pub fn new_sparse(indices: Vec<u32>, values: Vec<f32>) -> Self {
+        Self::Sparse(sparse::common::sparse_vector::SparseVector { indices, values })
+    }
+
+    pub fn empty_sparse() -> Self {
+        Self::new_sparse(vec![], vec![])
+    }
+}
+
 impl Debug for VectorPersisted {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/lib/segment/src/index/field_index/full_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mod.rs
@@ -4,7 +4,7 @@ pub mod mmap_text_index;
 mod mutable_text_index;
 pub mod stop_words;
 pub mod text_index;
-mod tokenizers;
+pub mod tokenizers;
 
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use super::stemmer::Stemmer;
 use crate::index::field_index::full_text_index::stop_words::StopwordsFilter;
@@ -7,7 +7,7 @@ use crate::index::field_index::full_text_index::stop_words::StopwordsFilter;
 #[derive(Debug, Clone, Default)]
 pub struct TokenizerConfig {
     pub lowercase: bool,
-    pub stopwords_filter: StopwordsFilter,
+    pub stopwords_filter: Arc<StopwordsFilter>, // TDOO(rocksdb): Remove once rocksdb has been removed!
     pub stemmer: Option<Stemmer>,
     pub min_token_len: Option<usize>,
     pub max_token_len: Option<usize>,

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/config.rs
@@ -1,4 +1,5 @@
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
+use std::sync::Arc;
 
 use super::stemmer::Stemmer;
 use crate::index::field_index::full_text_index::stop_words::StopwordsFilter;

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 pub mod config;
 mod japanese;
 mod multilingual;
@@ -170,7 +171,7 @@ impl Tokenizer {
         } = params;
 
         let lowercase = lowercase.unwrap_or(true);
-        let stopwords_filter = StopwordsFilter::new(stopwords, lowercase);
+        let stopwords_filter = Arc::new(StopwordsFilter::new(stopwords, lowercase));
 
         let config = TokenizerConfig {
             lowercase,
@@ -322,7 +323,7 @@ mod tests {
         // Test stopwords getting applied
         let filter =
             StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["の", "は"])), false);
-        config.stopwords_filter = filter;
+        config.stopwords_filter = Arc::new(filter);
         MultilingualTokenizer::tokenize(text, &config, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 2);
@@ -347,7 +348,7 @@ mod tests {
 
         // Test stopwords getting applied
         let filter = StopwordsFilter::new(&Some(StopwordsInterface::new_custom(&["是"])), false);
-        config.stopwords_filter = filter;
+        config.stopwords_filter = Arc::new(filter);
         MultilingualTokenizer::tokenize(text, &config, |token| tokens.push(token));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 3);

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -6,7 +6,7 @@ mod stemmer;
 
 pub use config::TokenizerConfig;
 use multilingual::MultilingualTokenizer;
-use stemmer::Stemmer;
+pub use stemmer::Stemmer;
 
 use crate::data_types::index::{TextIndexParams, TokenizerType};
 use crate::index::field_index::full_text_index::stop_words::StopwordsFilter;
@@ -203,7 +203,7 @@ impl Tokenizer {
         }
     }
 
-    pub fn tokenize_query<C: FnMut(Cow<str>)>(&self, text: &str, callback: C) {
+    pub fn tokenize_query<'a, C: FnMut(Cow<'a, str>)>(&self, text: &'a str, callback: C) {
         match self.tokenizer_type {
             TokenizerType::Whitespace => {
                 WhiteSpaceTokenizer::tokenize(text, &self.config, callback)

--- a/src/common/inference/bm25.rs
+++ b/src/common/inference/bm25.rs
@@ -1,0 +1,147 @@
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap};
+
+use collection::operations::point_ops::VectorPersisted;
+use murmur3::murmur3_32_of_slice;
+use segment::data_types::index::{StemmingAlgorithm, StopwordsInterface, TokenizerType};
+use segment::index::field_index::full_text_index::stop_words::StopwordsFilter;
+use segment::index::field_index::full_text_index::tokenizers::{
+    Stemmer, Tokenizer, TokenizerConfig,
+};
+use serde::{Deserialize, Serialize};
+
+/// Configuration of the local bm25 models.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Bm25Config {
+    #[serde(default = "default_model_name")]
+    pub model_name: String,
+    #[serde(default = "default_k")]
+    pub k: f64,
+    #[serde(default = "default_b")]
+    pub b: f64,
+    #[serde(default = "default_avg_len")]
+    pub avg_len: f64,
+    #[serde(default)]
+    pub tokenizer: TokenizerType,
+    #[serde(default)]
+    pub tokenizer_config: Option<InferenceTokenizerConfig>,
+}
+
+/// Bm25 tokenizer configurations.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct InferenceTokenizerConfig {
+    #[serde(default)]
+    pub lowercase: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stopwords_filter: Option<StopwordsInterface>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stemmer: Option<StemmingAlgorithm>,
+    pub min_token_len: Option<usize>,
+    pub max_token_len: Option<usize>,
+}
+
+fn default_model_name() -> String {
+    "bm25".to_string()
+}
+
+const fn default_k() -> f64 {
+    1.2
+}
+
+const fn default_b() -> f64 {
+    0.75
+}
+
+const fn default_avg_len() -> f64 {
+    256.0
+}
+
+impl Default for Bm25Config {
+    fn default() -> Self {
+        Self {
+            model_name: default_model_name(),
+            k: default_k(),
+            b: default_b(),
+            avg_len: default_avg_len(),
+            tokenizer: Default::default(),
+            tokenizer_config: Default::default(),
+        }
+    }
+}
+
+/// Bm25 implementation
+#[derive(Debug)]
+pub struct Bm25 {
+    config: Bm25Config,
+    tokenizer: Tokenizer,
+}
+
+impl Bm25 {
+    pub fn new(config: Bm25Config) -> Self {
+        let tokenizer_config =
+            TokenizerConfig::from(config.tokenizer_config.clone().unwrap_or_default());
+        let tokenizer = Tokenizer::new(config.tokenizer, tokenizer_config);
+        Self { config, tokenizer }
+    }
+
+    /// Tokenizes the `input` with the configured tokenizer options.
+    fn tokenize<'b>(&self, input: &'b str) -> Vec<Cow<'b, str>> {
+        let mut out = vec![];
+        self.tokenizer.tokenize_query(input, |i| out.push(i));
+        out
+    }
+
+    /// Embedds the given input using the Bm25 algorithm and configured options/hyperparameters.
+    pub fn embed(&self, input: &str) -> VectorPersisted {
+        let tokens = self.tokenize(input);
+
+        if tokens.is_empty() {
+            return VectorPersisted::empty_sparse();
+        }
+
+        let tf_map = self.term_frequency(&tokens);
+        let (indices, values): (Vec<u32>, Vec<f32>) = tf_map.into_iter().unzip();
+        VectorPersisted::new_sparse(indices, values)
+    }
+
+    fn term_frequency(&self, tokens: &[Cow<str>]) -> BTreeMap<u32, f32> {
+        let mut tf_map = BTreeMap::new();
+        let doc_len = tokens.len() as f64;
+
+        let mut counter: HashMap<&str, u32> = HashMap::new();
+
+        tokens
+            .iter()
+            .for_each(|token| *counter.entry(token.as_ref()).or_insert(0) += 1);
+
+        let k = self.config.k;
+        let b = self.config.b;
+        let avg_len = self.config.avg_len;
+
+        for (token, count) in &counter {
+            let token_id = Self::compute_token_id(token);
+            let num_occurrences = f64::from(*count);
+            let mut tf = num_occurrences * (k + 1.0);
+            tf /= k.mul_add(1.0 - b + b * doc_len / avg_len, num_occurrences);
+            tf_map.insert(token_id, tf as f32);
+        }
+
+        tf_map
+    }
+
+    fn compute_token_id(token: &str) -> u32 {
+        (murmur3_32_of_slice(token.as_bytes(), 0) as i32).unsigned_abs()
+    }
+}
+
+impl From<InferenceTokenizerConfig> for TokenizerConfig {
+    fn from(value: InferenceTokenizerConfig) -> Self {
+        Self {
+            lowercase: value.lowercase,
+            stopwords_filter: StopwordsFilter::new(&value.stopwords_filter, value.lowercase),
+            stemmer: value.stemmer.map(|i| Stemmer::from_algorithm(&i)),
+            min_token_len: value.min_token_len,
+            max_token_len: value.max_token_len,
+        }
+    }
+}

--- a/src/common/inference/bm25.rs
+++ b/src/common/inference/bm25.rs
@@ -14,8 +14,6 @@ use serde::{Deserialize, Serialize};
 /// Configuration of the local bm25 models.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Bm25Config {
-    #[serde(default = "default_model_name")]
-    pub model_name: String,
     #[serde(default = "default_k")]
     pub k: f64,
     #[serde(default = "default_b")]
@@ -41,10 +39,6 @@ pub struct InferenceTokenizerConfig {
     pub max_token_len: Option<usize>,
 }
 
-fn default_model_name() -> String {
-    "bm25".to_string()
-}
-
 const fn default_k() -> f64 {
     1.2
 }
@@ -60,7 +54,6 @@ const fn default_avg_len() -> f64 {
 impl Default for Bm25Config {
     fn default() -> Self {
         Self {
-            model_name: default_model_name(),
             k: default_k(),
             b: default_b(),
             avg_len: default_avg_len(),

--- a/src/common/inference/bm25.rs
+++ b/src/common/inference/bm25.rs
@@ -23,13 +23,13 @@ pub struct Bm25Config {
     pub avg_len: f64,
     #[serde(default)]
     pub tokenizer: TokenizerType,
-    #[serde(default)]
-    pub tokenizer_config: Option<InferenceTokenizerConfig>,
+    #[serde(default, flatten)]
+    pub text_preprocessing_config: Option<TextPreprocessingConfig>,
 }
 
 /// Bm25 tokenizer configurations.
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
-pub struct InferenceTokenizerConfig {
+pub struct TextPreprocessingConfig {
     #[serde(default)]
     pub lowercase: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -59,7 +59,7 @@ impl Default for Bm25Config {
             b: default_b(),
             avg_len: default_avg_len(),
             tokenizer: Default::default(),
-            tokenizer_config: Default::default(),
+            text_preprocessing_config: Default::default(),
         }
     }
 }
@@ -73,7 +73,7 @@ pub struct Bm25 {
 
 impl Bm25 {
     pub fn new(mut config: Bm25Config) -> Self {
-        let tokenizer_conf = std::mem::take(&mut config.tokenizer_config);
+        let tokenizer_conf = std::mem::take(&mut config.text_preprocessing_config);
         let tokenizer_config = TokenizerConfig::from(tokenizer_conf.unwrap_or_default());
         let tokenizer = Tokenizer::new(config.tokenizer, tokenizer_config);
         Self { config, tokenizer }
@@ -147,8 +147,8 @@ impl Bm25 {
     }
 }
 
-impl From<InferenceTokenizerConfig> for TokenizerConfig {
-    fn from(value: InferenceTokenizerConfig) -> Self {
+impl From<TextPreprocessingConfig> for TokenizerConfig {
+    fn from(value: TextPreprocessingConfig) -> Self {
         Self {
             lowercase: value.lowercase,
             stopwords_filter: Arc::new(StopwordsFilter::new(

--- a/src/common/inference/inference_input.rs
+++ b/src/common/inference/inference_input.rs
@@ -19,8 +19,10 @@ pub struct InferenceInput {
 
 impl InferenceInput {
     /// Attempts to parse the input's options into a local model config.
-    pub fn parse_bm25_config(&self) -> Result<Bm25Config, StorageError> {
-        let options = self.options.clone().unwrap_or_default();
+    pub fn parse_bm25_config(
+        options: Option<HashMap<String, Value>>,
+    ) -> Result<Bm25Config, StorageError> {
+        let options = options.unwrap_or_default();
         Bm25Config::deserialize(options.into_deserializer())
             .map_err(|err| StorageError::bad_input(format!("Invalid BM25 config: {err:#?}")))
     }

--- a/src/common/inference/inference_input.rs
+++ b/src/common/inference/inference_input.rs
@@ -12,7 +12,7 @@ use super::service::InferenceData;
 #[derive(Debug, Serialize, Clone)]
 pub struct InferenceInput {
     pub data: Value,
-    pub data_type: String,
+    pub data_type: InferenceDataType,
     pub model: String,
     pub options: Option<HashMap<String, Value>>,
 }
@@ -26,9 +26,13 @@ impl InferenceInput {
     }
 }
 
-const DOCUMENT_DATA_TYPE: &str = "text";
-const IMAGE_DATA_TYPE: &str = "image";
-const OBJECT_DATA_TYPE: &str = "object";
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum InferenceDataType {
+    Text,
+    Image,
+    Object,
+}
 
 impl From<InferenceData> for InferenceInput {
     fn from(value: InferenceData) -> Self {
@@ -41,7 +45,7 @@ impl From<InferenceData> for InferenceInput {
                 } = doc;
                 InferenceInput {
                     data: Value::String(text),
-                    data_type: DOCUMENT_DATA_TYPE.to_string(),
+                    data_type: InferenceDataType::Text,
                     model: model.to_string(),
                     options: options.options,
                 }
@@ -54,7 +58,7 @@ impl From<InferenceData> for InferenceInput {
                 } = img;
                 InferenceInput {
                     data: image,
-                    data_type: IMAGE_DATA_TYPE.to_string(),
+                    data_type: InferenceDataType::Image,
                     model: model.to_string(),
                     options: options.options,
                 }
@@ -67,7 +71,7 @@ impl From<InferenceData> for InferenceInput {
                 } = obj;
                 InferenceInput {
                     data: object,
-                    data_type: OBJECT_DATA_TYPE.to_string(),
+                    data_type: InferenceDataType::Object,
                     model: model.to_string(),
                     options: options.options,
                 }

--- a/src/common/inference/inference_input.rs
+++ b/src/common/inference/inference_input.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use api::rest::{Document, Image, InferenceObject};
+use serde::de::IntoDeserializer;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use storage::content_manager::errors::StorageError;
+
+use super::bm25::Bm25Config;
+use super::local_model::LocalModelConfig;
+use super::service::InferenceData;
+
+#[derive(Debug, Serialize, Clone)]
+pub struct InferenceInput {
+    pub data: Value,
+    pub data_type: String,
+    pub model: String,
+    pub options: Option<HashMap<String, Value>>,
+}
+
+const LOCAL_MODEL_KEY: &str = "local_model";
+const BM_25_MODEL: &str = "bm25";
+
+impl InferenceInput {
+    /// Tries to parse the given options as `Bm25Config`. Returns an error if the options can't be parsed.
+    fn try_parse_bm25_config(options: &HashMap<String, Value>) -> Result<Bm25Config, StorageError> {
+        Bm25Config::deserialize(options.clone().into_deserializer())
+            .map_err(|err| StorageError::bad_input(format!("Invalid BM25 config: {err:#?}")))
+    }
+
+    /// Attempts to parse the input's options into a local model config.
+    pub fn try_parse_local_model_input(&self) -> Result<Option<LocalModelConfig>, StorageError> {
+        let Some(options) = self.options.as_ref() else {
+            return Ok(None);
+        };
+
+        let Some(local_model_field) = options.get(LOCAL_MODEL_KEY) else {
+            return Ok(None);
+        };
+
+        let Value::String(local_model_field) = local_model_field else {
+            return Err(StorageError::bad_input(format!(
+                "The field {LOCAL_MODEL_KEY:} must be of type String"
+            )));
+        };
+
+        let config = match local_model_field.as_str() {
+            BM_25_MODEL => LocalModelConfig::Bm25(Self::try_parse_bm25_config(options)?),
+            _ => {
+                return Err(StorageError::bad_input(format!(
+                    "Invalid local model {local_model_field:?}"
+                )));
+            }
+        };
+
+        Ok(Some(config))
+    }
+}
+
+const DOCUMENT_DATA_TYPE: &str = "text";
+const IMAGE_DATA_TYPE: &str = "image";
+const OBJECT_DATA_TYPE: &str = "object";
+
+impl From<InferenceData> for InferenceInput {
+    fn from(value: InferenceData) -> Self {
+        match value {
+            InferenceData::Document(doc) => {
+                let Document {
+                    text,
+                    model,
+                    options,
+                } = doc;
+                InferenceInput {
+                    data: Value::String(text),
+                    data_type: DOCUMENT_DATA_TYPE.to_string(),
+                    model: model.to_string(),
+                    options: options.options,
+                }
+            }
+            InferenceData::Image(img) => {
+                let Image {
+                    image,
+                    model,
+                    options,
+                } = img;
+                InferenceInput {
+                    data: image,
+                    data_type: IMAGE_DATA_TYPE.to_string(),
+                    model: model.to_string(),
+                    options: options.options,
+                }
+            }
+            InferenceData::Object(obj) => {
+                let InferenceObject {
+                    object,
+                    model,
+                    options,
+                } = obj;
+                InferenceInput {
+                    data: object,
+                    data_type: OBJECT_DATA_TYPE.to_string(),
+                    model: model.to_string(),
+                    options: options.options,
+                }
+            }
+        }
+    }
+}

--- a/src/common/inference/local_model.rs
+++ b/src/common/inference/local_model.rs
@@ -1,0 +1,78 @@
+use collection::operations::point_ops::VectorPersisted;
+use storage::content_manager::errors::StorageError;
+
+use super::bm25::{Bm25, Bm25Config};
+use super::service::{InferenceInput, InferenceType, PositionItem};
+
+/// Model service for embedding using local models.
+pub struct LocalModelEmbedder {
+    model_config: LocalModelConfig,
+}
+
+impl LocalModelEmbedder {
+    pub fn new(model_config: LocalModelConfig) -> Self {
+        Self { model_config }
+    }
+
+    pub fn doc_embed(&self, input: &str) -> VectorPersisted {
+        match &self.model_config {
+            LocalModelConfig::Bm25(bm25_config) => Bm25::new(bm25_config.clone()).doc_embed(input),
+        }
+    }
+
+    pub fn search_embed(&self, input: &str) -> VectorPersisted {
+        match &self.model_config {
+            LocalModelConfig::Bm25(bm25_config) => {
+                Bm25::new(bm25_config.clone()).search_embed(input)
+            }
+        }
+    }
+}
+
+/// Embeds multiple InferenceInputs that target a local model.
+pub fn embed_many(
+    input: Vec<PositionItem<(InferenceInput, Result<LocalModelConfig, StorageError>)>>,
+    inference_type: InferenceType,
+) -> Result<Vec<PositionItem<VectorPersisted>>, StorageError> {
+    input
+        .into_iter()
+        .map(|item| -> Result<_, StorageError> {
+            let (input, local_model) = item.item;
+            let local_model = local_model?;
+
+            let input_str = input.data.as_str().ok_or_else(|| {
+                StorageError::service_error("Only strings supported for local models!")
+            })?;
+
+            let local_model_service = LocalModelEmbedder::new(local_model);
+
+            let embedding = match inference_type {
+                InferenceType::Update => local_model_service.doc_embed(input_str),
+                InferenceType::Search => local_model_service.search_embed(input_str),
+            };
+
+            Ok(PositionItem::new(embedding, item.position))
+        })
+        .collect()
+}
+
+/// Specifies the type of local inference model along with its dedicated config.
+#[derive(Clone)]
+pub enum LocalModelConfig {
+    Bm25(Bm25Config),
+}
+
+impl LocalModelConfig {
+    pub fn is_bm25(&self) -> bool {
+        matches!(self, Self::Bm25(..))
+    }
+
+    pub fn as_bm25(&self) -> Option<&Bm25Config> {
+        #[allow(irrefutable_let_patterns)]
+        if let Self::Bm25(bm25_config) = self {
+            Some(bm25_config)
+        } else {
+            None
+        }
+    }
+}

--- a/src/common/inference/local_model.rs
+++ b/src/common/inference/local_model.rs
@@ -1,78 +1,53 @@
 use collection::operations::point_ops::VectorPersisted;
 use storage::content_manager::errors::StorageError;
 
-use super::bm25::{Bm25, Bm25Config};
-use super::service::{InferenceInput, InferenceType, PositionItem};
+use super::bm25::Bm25;
+use super::service::{InferenceInput, InferenceType};
 
-/// Model service for embedding using local models.
-pub struct LocalModelEmbedder {
-    model_config: LocalModelConfig,
-}
+/// Model name for BM25 that should be processed by Qdrant itself.
+pub const BM25_LOCAL_MODEL_NAME: &str = "qdrant/bm25";
 
-impl LocalModelEmbedder {
-    pub fn new(model_config: LocalModelConfig) -> Self {
-        Self { model_config }
-    }
-
-    pub fn doc_embed(&self, input: &str) -> VectorPersisted {
-        match &self.model_config {
-            LocalModelConfig::Bm25(bm25_config) => Bm25::new(bm25_config.clone()).doc_embed(input),
-        }
-    }
-
-    pub fn search_embed(&self, input: &str) -> VectorPersisted {
-        match &self.model_config {
-            LocalModelConfig::Bm25(bm25_config) => {
-                Bm25::new(bm25_config.clone()).search_embed(input)
-            }
-        }
-    }
-}
-
-/// Embeds multiple InferenceInputs that target a local model.
-pub fn embed_many(
-    input: Vec<PositionItem<(InferenceInput, Result<LocalModelConfig, StorageError>)>>,
+/// Run inference with only local models.
+///
+/// # Panics
+/// Panics if one inference input did not target a local model.
+pub fn infer_local(
+    inference_inputs: Vec<InferenceInput>,
     inference_type: InferenceType,
-) -> Result<Vec<PositionItem<VectorPersisted>>, StorageError> {
-    input
-        .into_iter()
-        .map(|item| -> Result<_, StorageError> {
-            let (input, local_model) = item.item;
-            let local_model = local_model?;
+) -> Result<Vec<VectorPersisted>, StorageError> {
+    let mut out = Vec::with_capacity(inference_inputs.len());
 
-            let input_str = input.data.as_str().ok_or_else(|| {
-                StorageError::service_error("Only strings supported for local models!")
-            })?;
+    for input in inference_inputs {
+        let input_str = input.data.as_str().ok_or_else(|| {
+            StorageError::service_error("Only strings supported for local models!")
+        })?;
 
-            let local_model_service = LocalModelEmbedder::new(local_model);
+        let embedding = match input.model.to_lowercase().as_str() {
+            BM25_LOCAL_MODEL_NAME => {
+                let bm25 = Bm25::new(input.parse_bm25_config()?);
 
-            let embedding = match inference_type {
-                InferenceType::Update => local_model_service.doc_embed(input_str),
-                InferenceType::Search => local_model_service.search_embed(input_str),
-            };
+                match inference_type {
+                    InferenceType::Update => bm25.doc_embed(input_str),
+                    InferenceType::Search => bm25.search_embed(input_str),
+                }
+            }
+            _ => unreachable!(
+                "Non local model has been passed to infer_local(). This can happen if a newly added model wasn't added to infer_local()"
+            ),
+        };
 
-            Ok(PositionItem::new(embedding, item.position))
-        })
-        .collect()
-}
-
-/// Specifies the type of local inference model along with its dedicated config.
-#[derive(Clone)]
-pub enum LocalModelConfig {
-    Bm25(Bm25Config),
-}
-
-impl LocalModelConfig {
-    pub fn is_bm25(&self) -> bool {
-        matches!(self, Self::Bm25(..))
+        out.push(embedding);
     }
 
-    pub fn as_bm25(&self) -> Option<&Bm25Config> {
-        #[allow(irrefutable_let_patterns)]
-        if let Self::Bm25(bm25_config) = self {
-            Some(bm25_config)
-        } else {
-            None
-        }
+    Ok(out)
+}
+
+/// Returns `true` if the provided `model_name` targets a local model. Local models
+/// are models that are handled by Qdrant and are not forwarded to a remote inference service.
+pub fn is_local_model(model_name: &str) -> bool {
+    #[allow(clippy::match_like_matches_macro)]
+    match model_name {
+        BM25_LOCAL_MODEL_NAME => true,
+        _ => false,
     }
 }

--- a/src/common/inference/mod.rs
+++ b/src/common/inference/mod.rs
@@ -10,6 +10,8 @@ mod batch_processing_grpc;
 pub(crate) mod bm25;
 pub(crate) mod config;
 mod infer_processing;
+pub mod inference_input;
+mod local_model;
 pub mod query_requests_grpc;
 pub mod query_requests_rest;
 pub mod service;

--- a/src/common/inference/mod.rs
+++ b/src/common/inference/mod.rs
@@ -7,6 +7,7 @@ use actix_web::{FromRequest, HttpMessage};
 
 mod batch_processing;
 mod batch_processing_grpc;
+pub(crate) mod bm25;
 pub(crate) mod config;
 mod infer_processing;
 pub mod query_requests_grpc;

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -15,10 +15,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use storage::content_manager::errors::StorageError;
 
+use super::bm25::{Bm25, Bm25Config};
 use crate::common::inference::InferenceToken;
 use crate::common::inference::config::InferenceConfig;
-
-use super::bm25::{Bm25, Bm25Config};
 
 const DOCUMENT_DATA_TYPE: &str = "text";
 const IMAGE_DATA_TYPE: &str = "image";

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -337,6 +337,7 @@ mod test {
 
     use super::*;
     use crate::common::inference::bm25::{Bm25, Bm25Config};
+    use crate::common::inference::inference_input::InferenceDataType;
 
     const BM25_LOCAL_MODEL_NAME: &str = "bm25";
 
@@ -406,7 +407,7 @@ mod test {
 
         InferenceInput {
             data: Value::String(input.to_string()),
-            data_type: "".to_string(),
+            data_type: InferenceDataType::Text,
             model: "anyModel".to_string(),
             options,
         }
@@ -420,7 +421,7 @@ mod test {
 
         InferenceInput {
             data: Value::String(input.to_string()),
-            data_type: "".to_string(),
+            data_type: InferenceDataType::Text,
             model: BM25_LOCAL_MODEL_NAME.to_string(),
             options: Some(options),
         }

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -337,7 +337,8 @@ mod test {
 
     use super::*;
     use crate::common::inference::bm25::{Bm25, Bm25Config};
-    use crate::common::inference::local_model::BM25_LOCAL_MODEL_NAME;
+
+    const BM25_LOCAL_MODEL_NAME: &str = "bm25";
 
     #[test]
     fn test_merge_position_items() {

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -586,7 +586,7 @@ mod test {
         let res = service
             .infer(
                 inference_inputs,
-                InferenceType::Search,
+                InferenceType::Update,
                 InferenceToken::new("key".to_string()),
             )
             .await

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -228,7 +228,11 @@ impl InferenceService {
                         "Only strings supported as text type in BM25 inference!",
                     )
                 })?;
-                let embedding = Bm25::new(bm25_config).embed(input_str);
+                let bm25 = Bm25::new(bm25_config);
+                let embedding = match inference_type {
+                    InferenceType::Update => bm25.doc_embed(input_str),
+                    InferenceType::Search => bm25.search_embed(input_str),
+                };
                 Ok(PositionItem::new(embedding, item.position))
             })
             .collect::<Result<_, _>>()?;
@@ -524,7 +528,7 @@ mod test {
                 let bm25_config = input.try_parse_bm25_config().unwrap().unwrap();
 
                 // Re-run bm25 and check that response is correct.
-                let bm25 = Bm25::new(bm25_config).embed(input.data.as_str().unwrap());
+                let bm25 = Bm25::new(bm25_config).doc_embed(input.data.as_str().unwrap());
                 assert_eq!(response, bm25);
             } else {
                 let expected_vector = VectorPersisted::Dense(vec![0.0; idx]);

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -435,7 +435,7 @@ mod test {
                 // In our test-setup, only BM25 returns sparse vectors. Normal inference is mocked
                 // and always returns dense vectors.
                 assert!(matches!(response, VectorPersisted::Sparse(..)));
-                let bm25_config = input.parse_bm25_config().unwrap();
+                let bm25_config = InferenceInput::parse_bm25_config(input.options).unwrap();
 
                 // Re-run bm25 and check that response is correct.
                 let bm25 = Bm25::new(bm25_config).doc_embed(input.data.as_str().unwrap());


### PR DESCRIPTION
Supersedes #6893 and #6904
Depends on https://github.com/qdrant/qdrant/pull/6891
Implements Bm25 by parsing the inference object's options.

## Request example
A possible request could look like this:

```json
{
  "query": {
    "model": "qdrant/bm25",  // Must be set but value can be arbitrary.
    "text": "Some input to embedd with bm25",
    "options": {
      "use_bm25": true,        // Required to parse this options as BM25 configuration.
      "k": 1.0,                // Optional hyperparameters. Same for `b` and `avg_len`.
      "tokenizer": "word",     // Optional 
      "lowercase": true       // Optional
    }
  },
  "using": "sparse"
}
```

## Error handling
In case the option "use_bm25" is enabled but the configuration is invalid, a detailed error is returned:
```
{
  "error": "Wrong input: Invalid BM25 config: Error(\"unknown variant `ord`, expected one of `prefix`, `whitespace`, `word`, `multilingual`\", line: 0, column: 0)"
}
```

## Test coverage
There are also tests for the new BM25 and remote-inference logic that almost cover all parts of `infer()` and >97% of bm25.rs. "Almost" because returning errors are not covered.
These tests 'mock' an inference server and ensure that we correctly merge bm25 and remote items together.