### PR TITLE
Introduce StableHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,7 @@ dependencies = [
  "async-trait",
  "atomicwrites",
  "bitvec",
+ "bytemuck",
  "bytes",
  "cancel",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2",
+ "siphasher 1.0.1",
  "smallvec",
  "sparse",
  "strum",
@@ -2450,7 +2451,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bfd649ac5e0f82ae98d547450f1d31af49742be255b5380c61fc8513b9df11"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.10",
 ]
 
 [[package]]
@@ -4141,7 +4142,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.10",
 ]
 
 [[package]]
@@ -6001,6 +6002,12 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ atomicwrites = "0.4.4"
 bincode = "1.3.3" # no upgrade because 2.0.x is much slower https://github.com/qdrant/qdrant/pull/6134
 bitpacking = "0.9.2"
 bytemuck = { version = "1.23.1", features = [
+    "derive",
     "extern_crate_alloc",
     "must_cast",
     "transparentwrapper_extra",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -30,6 +30,7 @@ segment = { path = "../segment", default-features = false, features = ["testing"
 pprof = { workspace = true }
 
 [dependencies]
+bytemuck = { workspace = true }
 parking_lot = { workspace = true }
 ahash = { workspace = true }
 rand = { workspace = true }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -45,6 +45,7 @@ hashring = "0.3.6"
 tinyvec = { version = "1.9.0", features = ["alloc", "latest_stable_rust"] }
 bitvec = { workspace = true }
 lazy_static = "1.5.0"
+siphasher = "1.0.1"
 smallvec = { workspace = true }
 
 tokio = { workspace = true }

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
 
+use bytemuck::TransparentWrapper as _;
+use common::stable_hash::{StableHash, StableHashed};
 use itertools::Itertools as _;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{CustomIdCheckerCondition, PointIdType};
@@ -13,7 +15,7 @@ use crate::shards::shard::ShardId;
 pub const HASH_RING_SHARD_SCALE: u32 = 100;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum HashRingRouter<T: Eq + Hash = ShardId> {
+pub enum HashRingRouter<T: Eq + StableHash + Hash = ShardId> {
     /// Single hashring
     Single(HashRing<T>),
 
@@ -22,7 +24,7 @@ pub enum HashRingRouter<T: Eq + Hash = ShardId> {
     Resharding { old: HashRing<T>, new: HashRing<T> },
 }
 
-impl<T: Copy + Eq + Hash> HashRingRouter<T> {
+impl<T: Copy + Eq + StableHash + Hash> HashRingRouter<T> {
     /// Create a new single hashring.
     ///
     /// The hashring is created with a fair distribution of points and `HASH_RING_SHARD_SCALE` scale.
@@ -135,7 +137,7 @@ impl<T: Copy + Eq + Hash> HashRingRouter<T> {
         }
     }
 
-    pub fn get<U: Hash>(&self, key: &U) -> ShardIds<T> {
+    pub fn get<U: StableHash>(&self, key: &U) -> ShardIds<T> {
         match self {
             Self::Single(ring) => ring.get(key).into_iter().copied().collect(),
             Self::Resharding { old, new } => old
@@ -151,7 +153,7 @@ impl<T: Copy + Eq + Hash> HashRingRouter<T> {
     /// Check whether the given point is in the given shard
     ///
     /// In case of resharding, the new hashring is checked.
-    pub fn is_in_shard<U: Hash>(&self, key: &U, shard: T) -> bool {
+    pub fn is_in_shard<U: StableHash>(&self, key: &U, shard: T) -> bool {
         let ring = match self {
             Self::Resharding { new, .. } => new,
             Self::Single(ring) => ring,
@@ -161,7 +163,7 @@ impl<T: Copy + Eq + Hash> HashRingRouter<T> {
     }
 }
 
-impl<T: Eq + Hash> HashRingRouter<T> {
+impl<T: Eq + StableHash + Hash> HashRingRouter<T> {
     pub fn is_resharding(&self) -> bool {
         matches!(self, Self::Resharding { .. })
     }
@@ -189,20 +191,20 @@ impl<T: Eq + Hash> HashRingRouter<T> {
 pub type ShardIds<T = ShardId> = SmallVec<[T; 2]>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum HashRing<T: Eq + Hash> {
+pub enum HashRing<T: Eq + StableHash + Hash> {
     Raw {
         nodes: HashSet<T>,
-        ring: hashring::HashRing<T>,
+        ring: hashring::HashRing<StableHashed<T>>,
     },
 
     Fair {
         nodes: HashSet<T>,
-        ring: hashring::HashRing<(T, u32)>,
+        ring: hashring::HashRing<StableHashed<(T, u32)>>,
         scale: u32,
     },
 }
 
-impl<T: Copy + Eq + Hash> HashRing<T> {
+impl<T: Copy + Eq + StableHash + Hash> HashRing<T> {
     pub fn raw() -> Self {
         Self::Raw {
             nodes: HashSet::new(),
@@ -228,12 +230,12 @@ impl<T: Copy + Eq + Hash> HashRing<T> {
 
         match self {
             HashRing::Raw { ring, .. } => {
-                ring.add(shard);
+                ring.add(StableHashed(shard));
             }
 
             HashRing::Fair { ring, scale, .. } => {
                 for idx in 0..*scale {
-                    ring.add((shard, idx));
+                    ring.add(StableHashed((shard, idx)));
                 }
             }
         }
@@ -248,12 +250,12 @@ impl<T: Copy + Eq + Hash> HashRing<T> {
 
         match self {
             HashRing::Raw { ring, .. } => {
-                ring.remove(shard);
+                ring.remove(&StableHashed(*shard));
             }
 
             HashRing::Fair { ring, scale, .. } => {
                 for idx in 0..*scale {
-                    ring.remove(&(*shard, idx));
+                    ring.remove(&StableHashed((*shard, idx)));
                 }
             }
         }
@@ -262,11 +264,12 @@ impl<T: Copy + Eq + Hash> HashRing<T> {
     }
 }
 
-impl<T: Eq + Hash> HashRing<T> {
-    pub fn get<U: Hash>(&self, key: &U) -> Option<&T> {
+impl<T: Eq + StableHash + Hash> HashRing<T> {
+    pub fn get<U: StableHash>(&self, key: &U) -> Option<&T> {
+        let key = StableHashed::wrap_ref(key);
         match self {
-            HashRing::Raw { ring, .. } => ring.get(key),
-            HashRing::Fair { ring, .. } => ring.get(key).map(|(shard, _)| shard),
+            HashRing::Raw { ring, .. } => ring.get(key).map(|StableHashed(shard)| shard),
+            HashRing::Fair { ring, .. } => ring.get(key).map(|StableHashed((shard, _))| shard),
         }
     }
 

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -20,6 +20,7 @@ pub mod num_traits;
 pub mod panic;
 pub mod rate_limiting;
 pub mod small_uint;
+pub mod stable_hash;
 pub mod tar_ext;
 pub mod tempfile_ext;
 pub mod top_k;

--- a/lib/common/common/src/stable_hash.rs
+++ b/lib/common/common/src/stable_hash.rs
@@ -1,0 +1,74 @@
+use std::hash::{Hash, Hasher};
+
+use bytemuck::TransparentWrapper;
+
+/// A hashable type, like [`Hash`], but with a stable/portable implementation.
+///
+/// According to the [`Hash`] docs, its implementations for most standard
+/// library types should not considered stable across platforms or compiler
+/// versions. Neither we can rely on implementations for types from third-party
+/// crates.
+///
+/// This trait is intended for hashes that should be stable across different
+/// Qdrant versions.
+pub trait StableHash {
+    /// Feed this value into the hasher.
+    ///
+    /// Similar to [`Hash::hash()`], but accepts [`Hasher::write()`] as a
+    /// closure. This difference prevents implementations of this trait from:
+    /// 1. Reusing [`Hash`] implementations which might be not portable.
+    /// 2. Using other [`Hasher`] methods which are non-portable. See
+    ///    <https://docs.rs/siphasher/1.0.1/siphasher/index.html#note>.
+    fn stable_hash<W: FnMut(&[u8])>(&self, write: &mut W);
+}
+
+impl StableHash for i32 {
+    fn stable_hash<W: FnMut(&[u8])>(&self, write: &mut W) {
+        // WARN: endianess-dependent; keep for backward compatibility
+        write(&self.to_ne_bytes());
+    }
+}
+
+impl StableHash for u32 {
+    fn stable_hash<W: FnMut(&[u8])>(&self, write: &mut W) {
+        // WARN: endianess-dependent; keep for backward compatibility
+        write(&self.to_ne_bytes());
+    }
+}
+
+impl StableHash for u64 {
+    fn stable_hash<W: FnMut(&[u8])>(&self, write: &mut W) {
+        // WARN: endianess-dependent; keep for backward compatibility
+        write(&self.to_ne_bytes());
+    }
+}
+
+impl StableHash for usize {
+    fn stable_hash<W: FnMut(&[u8])>(&self, write: &mut W) {
+        (*self as u64).stable_hash(write);
+    }
+}
+
+impl<A: StableHash, B: StableHash> StableHash for (A, B) {
+    fn stable_hash<W: FnMut(&[u8])>(&self, write: &mut W) {
+        let (a, b) = self;
+        a.stable_hash(write);
+        b.stable_hash(write);
+    }
+}
+
+/// Compatibility wrapper that allows to use [`StableHash`] implementation in
+/// contexts where [`Hash`] is expected.
+///
+/// This wrapper should be used in accompaniment with a stable [`Hasher`]
+/// implementation such as from the `siphasher` crate. Hashes produced by
+/// [`std::hash::DefaultHasher`] should not be relied upon over releases.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, TransparentWrapper)]
+#[repr(transparent)]
+pub struct StableHashed<T: StableHash>(pub T);
+
+impl<T: StableHash> Hash for StableHashed<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.stable_hash(&mut |bytes| state.write(bytes));
+    }
+}


### PR DESCRIPTION
Follow-up for #6932. A cleaned up/more explicit version.

For hashes to be stable, we need two things: a stable `Hash` implementation for our types, and a stable `Hasher` implementation.

The default `Hasher` used in the `hashring` crate is `SipHash24`. This PR makes it explicit.

We can't assume that `Hash` is stable neither for types from `std` [\[1\]](https://doc.rust-lang.org/std/hash/trait.Hash.html#portability), nor from third-party crates. Thus, this PR implements hashes by hand via the new trait `StableHash`, without depending on stdandard or third-party implementations. The new `StableHashed` adapter is provided to allow using the `StableHash` implementation in contexts where `Hash` is expected, e.g., in the `hashring` crate. The default `Hash` implementation is kept unstable, enabling whatever optimizations the `uuid` crate (or future Rust release) implements in contexts where `StableHash` is not used.

These changes do not affect produced hashes used in the hashring. The test `split_point_operations` ensures that.