### PR TITLE
Fix `DateTimeWrapper` parsing

### DIFF
--- a/lib/collection/src/operations/universal_query/formula.rs
+++ b/lib/collection/src/operations/universal_query/formula.rs
@@ -81,11 +81,13 @@ impl ExpressionInternal {
                 ParsedExpression::new_geo_distance(origin, to)
             }
             ExpressionInternal::Datetime(dt_str) => {
-                ParsedExpression::Datetime(DatetimeExpression::Constant(
-                    dt_str
-                        .parse()
-                        .map_err(|err: chrono::ParseError| err.to_string())?,
-                ))
+                ParsedExpression::Datetime(DatetimeExpression::Constant(dt_str.parse().map_err(
+                    |err: chrono::ParseError| {
+                        CollectionError::bad_input(format!(
+                            "failed to parse date-time {dt_str:?}: {err}"
+                        ))
+                    },
+                )?))
             }
             ExpressionInternal::DatetimeKey(json_path) => {
                 payload_vars.insert(json_path.clone());

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3510,6 +3510,13 @@ mod tests {
     }
 
     #[test]
+    fn test_datetime_wrapper_transcoding() {
+        let expected = DateTimeWrapper(chrono::Utc::now());
+        let transcoded = DateTimeWrapper::from_str(&expected.to_string()).unwrap();
+        assert_eq!(expected, transcoded);
+    }
+
+    #[test]
     fn test_timezone_ordering() {
         let datetimes = [
             "2000-06-08 00:18:53+0900",

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -99,6 +99,8 @@ impl FromStr for DateTimePayloadType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Attempt to parse the input string in RFC 3339 format
         if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(s)
+            // Attempt to parse default to-string format
+            .or_else(|_| chrono::DateTime::from_str(s))
             // Attempt to parse the input string in the specified formats:
             // - YYYY-MM-DD'T'HH:MM:SS-HHMM (timezone without colon)
             // - YYYY-MM-DD HH:MM:SS-HHMM (timezone without colon)


### PR DESCRIPTION
`DateTimeWrapper` could not parse it's own `to_string` output. Oops. Fixed now.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
