### PR TITLE
Bump dev version to 1.15.2-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "api"
-version = "1.14.2-dev"
+version = "1.15.2-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.14.2-dev"
+version = "1.15.2-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.14.2-dev"
+version = "1.15.2-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.14.2-dev"
+version = "1.15.2-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.14.2-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.15.2-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Looks like we missed doing it for `1.15.*` and [tests in CM were failing](https://github.com/qdrant/cluster-manager/pull/352) because of min version requirements after recent partial snapshot improvements.

Bumps the development version to 1.15.2-dev for the [Qdrant 1.15.1](https://github.com/qdrant/qdrant/pull/6934) release.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/6588>

