### PR TITLE
[decay formula] allow [0,1] range for midpoint in lin_decay

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2565,7 +2565,7 @@ The JSON representation for `Value` is a JSON value.
 | x | [Expression](#qdrant-Expression) |  | The variable to decay |
 | target | [Expression](#qdrant-Expression) | optional | The target value to start decaying from. Defaults to 0. |
 | scale | [float](#float) | optional | The scale factor of the decay, in terms of `x`. Defaults to 1.0. Must be a non-zero positive number. |
-| midpoint | [float](#float) | optional | The midpoint of the decay. Defaults to 0.5. Output will be this value when `|x - target| == scale`. |
+| midpoint | [float](#float) | optional | The midpoint of the decay. Should be between 0 and 1. Defaults to 0.5. Output will be this value when `|x - target| == scale`. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15166,7 +15166,7 @@
             "nullable": true
           },
           "midpoint": {
-            "description": "The midpoint of the decay. Defaults to 0.5. Output will be this value when `|x - target| == scale`.",
+            "description": "The midpoint of the decay. Should be between 0 and 1.Defaults to 0.5. Output will be this value when `|x - target| == scale`.",
             "type": "number",
             "format": "float",
             "nullable": true

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -636,7 +636,7 @@ message DecayParamsExpression {
     optional Expression target = 2;
     // The scale factor of the decay, in terms of `x`. Defaults to 1.0. Must be a non-zero positive number.
     optional float scale = 3;
-    // The midpoint of the decay. Defaults to 0.5. Output will be this value when `|x - target| == scale`.
+    // The midpoint of the decay. Should be between 0 and 1. Defaults to 0.5. Output will be this value when `|x - target| == scale`.
     optional float midpoint = 4;
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5571,7 +5571,7 @@ pub struct DecayParamsExpression {
     /// The scale factor of the decay, in terms of `x`. Defaults to 1.0. Must be a non-zero positive number.
     #[prost(float, optional, tag = "3")]
     pub scale: ::core::option::Option<f32>,
-    /// The midpoint of the decay. Defaults to 0.5. Output will be this value when `|x - target| == scale`.
+    /// The midpoint of the decay. Should be between 0 and 1. Defaults to 0.5. Output will be this value when `|x - target| == scale`.
     #[prost(float, optional, tag = "4")]
     pub midpoint: ::core::option::Option<f32>,
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -823,7 +823,7 @@ pub struct DecayParamsExpression {
     pub target: Option<Box<Expression>>,
     /// The scale factor of the decay, in terms of `x`. Defaults to 1.0. Must be a non-zero positive number.
     pub scale: Option<f32>,
-    /// The midpoint of the decay. Defaults to 0.5. Output will be this value when `|x - target| == scale`.
+    /// The midpoint of the decay. Should be between 0 and 1.Defaults to 0.5. Output will be this value when `|x - target| == scale`.
     pub midpoint: Option<f32>,
 }
 

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -172,7 +172,7 @@ impl ParsedExpression {
 
         match kind {
             DecayKind::Lin => {
-                if midpoint < 0.0 || midpoint > 1.0 {
+                if !(0.0..=1.0).contains(&midpoint) {
                     return Err(OperationError::validation_error(format!(
                         "Decay midpoint should be between 0.0 (inclusive) and 1.0 (exclusive), got {midpoint}."
                     )));

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -174,14 +174,14 @@ impl ParsedExpression {
             DecayKind::Lin => {
                 if !(0.0..=1.0).contains(&midpoint) {
                     return Err(OperationError::validation_error(format!(
-                        "Decay midpoint should be between 0.0 (inclusive) and 1.0 (exclusive), got {midpoint}."
+                        "Linear decay midpoint should be in the range [0.0, 1.0], got {midpoint}."
                     )));
                 }
             }
             DecayKind::Gauss | DecayKind::Exp => {
                 if midpoint <= 0.0 || midpoint >= 1.0 {
                     return Err(OperationError::validation_error(format!(
-                        "Decay midpoint should be between 0.0 and 1.0 (exclusive), got {midpoint}."
+                        "Decay midpoint should be in the range (0.0, 1.0), got {midpoint}."
                     )));
                 }
             }

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -170,10 +170,21 @@ impl ParsedExpression {
         let midpoint = PreciseScore::from(midpoint.unwrap_or(DEFAULT_DECAY_MIDPOINT));
         let scale = PreciseScore::from(scale.unwrap_or(DEFAULT_DECAY_SCALE));
 
-        if midpoint <= 0.0 || midpoint >= 1.0 {
-            return Err(OperationError::validation_error(format!(
-                "Decay midpoint should be between 0.0 and 1.0 (exclusive), got {midpoint}."
-            )));
+        match kind {
+            DecayKind::Lin => {
+                if midpoint < 0.0 || midpoint > 1.0 {
+                    return Err(OperationError::validation_error(format!(
+                        "Decay midpoint should be between 0.0 (inclusive) and 1.0 (exclusive), got {midpoint}."
+                    )));
+                }
+            }
+            DecayKind::Gauss | DecayKind::Exp => {
+                if midpoint <= 0.0 || midpoint >= 1.0 {
+                    return Err(OperationError::validation_error(format!(
+                        "Decay midpoint should be between 0.0 and 1.0 (exclusive), got {midpoint}."
+                    )));
+                }
+            }
         }
 
         if scale <= 0.0 {


### PR DESCRIPTION
We had restricted `midpoint` to be in the range (0,1) for the sake of gauss and exp decay. Linear decay can actually accept in the range [0,1]. This PR enables this possibility