### PR TITLE
Add Distance::preprocess_vector

### DIFF
--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -10,9 +10,7 @@ use super::vectors::{
     VectorElementType, VectorElementTypeByte, VectorElementTypeHalf, VectorInternal, VectorRef,
 };
 use crate::common::operation_error::OperationError;
-use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
-use crate::types::{Distance, VectorDataConfig, VectorName, VectorNameBuf, VectorStorageDatatype};
+use crate::types::{VectorDataConfig, VectorName, VectorNameBuf, VectorStorageDatatype};
 
 type CowKey<'a> = Cow<'a, VectorName>;
 
@@ -348,48 +346,15 @@ impl<'a> NamedVectors<'a> {
         config: &VectorDataConfig,
     ) -> DenseVector {
         match config.datatype {
-            Some(VectorStorageDatatype::Float32) | None => match config.distance {
-                Distance::Cosine => {
-                    <CosineMetric as Metric<VectorElementType>>::preprocess(dense_vector)
-                }
-                Distance::Euclid => {
-                    <EuclidMetric as Metric<VectorElementType>>::preprocess(dense_vector)
-                }
-                Distance::Dot => {
-                    <DotProductMetric as Metric<VectorElementType>>::preprocess(dense_vector)
-                }
-                Distance::Manhattan => {
-                    <ManhattanMetric as Metric<VectorElementType>>::preprocess(dense_vector)
-                }
-            },
-            Some(VectorStorageDatatype::Uint8) => match config.distance {
-                Distance::Cosine => {
-                    <CosineMetric as Metric<VectorElementTypeByte>>::preprocess(dense_vector)
-                }
-                Distance::Euclid => {
-                    <EuclidMetric as Metric<VectorElementTypeByte>>::preprocess(dense_vector)
-                }
-                Distance::Dot => {
-                    <DotProductMetric as Metric<VectorElementTypeByte>>::preprocess(dense_vector)
-                }
-                Distance::Manhattan => {
-                    <ManhattanMetric as Metric<VectorElementTypeByte>>::preprocess(dense_vector)
-                }
-            },
-            Some(VectorStorageDatatype::Float16) => match config.distance {
-                Distance::Cosine => {
-                    <CosineMetric as Metric<VectorElementTypeHalf>>::preprocess(dense_vector)
-                }
-                Distance::Euclid => {
-                    <EuclidMetric as Metric<VectorElementTypeHalf>>::preprocess(dense_vector)
-                }
-                Distance::Dot => {
-                    <DotProductMetric as Metric<VectorElementTypeHalf>>::preprocess(dense_vector)
-                }
-                Distance::Manhattan => {
-                    <ManhattanMetric as Metric<VectorElementTypeHalf>>::preprocess(dense_vector)
-                }
-            },
+            Some(VectorStorageDatatype::Float32) | None => config
+                .distance
+                .preprocess_vector::<VectorElementType>(dense_vector),
+            Some(VectorStorageDatatype::Uint8) => config
+                .distance
+                .preprocess_vector::<VectorElementTypeByte>(dense_vector),
+            Some(VectorStorageDatatype::Float16) => config
+                .distance
+                .preprocess_vector::<VectorElementTypeHalf>(dense_vector),
         }
     }
 }

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -9,8 +9,6 @@ use zerocopy::IntoBytes;
 use super::named_vectors::CowMultiVector;
 use super::vectors::TypedMultiDenseVector;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
-use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::{Distance, QuantizationConfig, VectorStorageDatatype};
 
 pub trait PrimitiveVectorElement:
@@ -167,17 +165,7 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
                 .iter()
                 .map(|&x| VectorElementType::from(x))
                 .collect_vec();
-            let preprocessed_vector = match distance {
-                Distance::Cosine => <CosineMetric as Metric<VectorElementType>>::preprocess(vector),
-                Distance::Euclid => <EuclidMetric as Metric<VectorElementType>>::preprocess(vector),
-                Distance::Dot => {
-                    <DotProductMetric as Metric<VectorElementType>>::preprocess(vector)
-                }
-                Distance::Manhattan => {
-                    <ManhattanMetric as Metric<VectorElementType>>::preprocess(vector)
-                }
-            };
-            Cow::from(preprocessed_vector)
+            Cow::from(distance.preprocess_vector::<VectorElementType>(vector))
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -15,8 +15,6 @@ use crate::data_types::vectors::{MultiDenseVectorInternal, QueryVector, VectorRe
 use crate::fixtures::index_fixtures::random_vector;
 use crate::fixtures::payload_fixtures::random_dense_byte_vector;
 use crate::index::hnsw_index::gpu::shader_builder::ShaderBuilder;
-use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::{
     BinaryQuantization, BinaryQuantizationConfig, BinaryQuantizationEncoding, Distance,
     ProductQuantization, ProductQuantizationConfig, QuantizationConfig, ScalarQuantization,
@@ -563,12 +561,7 @@ fn create_vector_storage_f32(
             .unwrap();
     for i in 0..num_vectors {
         let vec = random_vector(&mut rnd, dim);
-        let vec = match distance {
-            Distance::Cosine => <CosineMetric as Metric<VectorElementType>>::preprocess(vec),
-            Distance::Euclid => <EuclidMetric as Metric<VectorElementType>>::preprocess(vec),
-            Distance::Dot => <DotProductMetric as Metric<VectorElementType>>::preprocess(vec),
-            Distance::Manhattan => <ManhattanMetric as Metric<VectorElementType>>::preprocess(vec),
-        };
+        let vec = distance.preprocess_vector::<VectorElementType>(vec);
         let vec_ref = VectorRef::from(&vec);
         vector_storage
             .insert_vector(i as PointOffsetType, vec_ref, &HardwareCounterCell::new())
@@ -589,14 +582,7 @@ fn create_vector_storage_f16(
             .unwrap();
     for i in 0..num_vectors {
         let vec = random_vector(&mut rnd, dim);
-        let vec = match distance {
-            Distance::Cosine => <CosineMetric as Metric<VectorElementTypeHalf>>::preprocess(vec),
-            Distance::Euclid => <EuclidMetric as Metric<VectorElementTypeHalf>>::preprocess(vec),
-            Distance::Dot => <DotProductMetric as Metric<VectorElementTypeHalf>>::preprocess(vec),
-            Distance::Manhattan => {
-                <ManhattanMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
-            }
-        };
+        let vec = distance.preprocess_vector::<VectorElementTypeHalf>(vec);
         let vec_ref = VectorRef::from(&vec);
         vector_storage
             .insert_vector(i as PointOffsetType, vec_ref, &HardwareCounterCell::new())
@@ -617,14 +603,7 @@ fn create_vector_storage_u8(
             .unwrap();
     for i in 0..num_vectors {
         let vec = random_dense_byte_vector(&mut rnd, dim);
-        let vec = match distance {
-            Distance::Cosine => <CosineMetric as Metric<VectorElementTypeByte>>::preprocess(vec),
-            Distance::Euclid => <EuclidMetric as Metric<VectorElementTypeByte>>::preprocess(vec),
-            Distance::Dot => <DotProductMetric as Metric<VectorElementTypeByte>>::preprocess(vec),
-            Distance::Manhattan => {
-                <ManhattanMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
-            }
-        };
+        let vec = distance.preprocess_vector::<VectorElementTypeByte>(vec);
         let vec_ref = VectorRef::from(&vec);
         vector_storage
             .insert_vector(i as PointOffsetType, vec_ref, &HardwareCounterCell::new())
@@ -655,14 +634,7 @@ fn create_vector_storage_f32_multi(
         let num_vectors_per_points = 1 + rnd.random::<u8>() % 3;
         for _ in 0..num_vectors_per_points {
             let vec = random_vector(&mut rnd, dim);
-            let vec = match distance {
-                Distance::Cosine => <CosineMetric as Metric<VectorElementType>>::preprocess(vec),
-                Distance::Euclid => <EuclidMetric as Metric<VectorElementType>>::preprocess(vec),
-                Distance::Dot => <DotProductMetric as Metric<VectorElementType>>::preprocess(vec),
-                Distance::Manhattan => {
-                    <ManhattanMetric as Metric<VectorElementType>>::preprocess(vec)
-                }
-            };
+            let vec = distance.preprocess_vector::<VectorElementType>(vec);
             vectors.extend(vec);
         }
         let multivector = MultiDenseVectorInternal::new(vectors, dim);
@@ -696,20 +668,7 @@ fn create_vector_storage_f16_multi(
         let num_vectors_per_points = 1 + rnd.random::<u8>() % 3;
         for _ in 0..num_vectors_per_points {
             let vec = random_vector(&mut rnd, dim);
-            let vec = match distance {
-                Distance::Cosine => {
-                    <CosineMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
-                }
-                Distance::Euclid => {
-                    <EuclidMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
-                }
-                Distance::Dot => {
-                    <DotProductMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
-                }
-                Distance::Manhattan => {
-                    <ManhattanMetric as Metric<VectorElementTypeHalf>>::preprocess(vec)
-                }
-            };
+            let vec = distance.preprocess_vector::<VectorElementTypeHalf>(vec);
             vectors.extend(vec);
         }
         let multivector = MultiDenseVectorInternal::new(vectors, dim);
@@ -743,20 +702,7 @@ fn create_vector_storage_u8_multi(
         let num_vectors_per_points = 1 + rnd.random::<u8>() % 3;
         for _ in 0..num_vectors_per_points {
             let vec = random_dense_byte_vector(&mut rnd, dim);
-            let vec = match distance {
-                Distance::Cosine => {
-                    <CosineMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
-                }
-                Distance::Euclid => {
-                    <EuclidMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
-                }
-                Distance::Dot => {
-                    <DotProductMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
-                }
-                Distance::Manhattan => {
-                    <ManhattanMetric as Metric<VectorElementTypeByte>>::preprocess(vec)
-                }
-            };
+            let vec = distance.preprocess_vector::<VectorElementTypeByte>(vec);
             vectors.extend(vec);
         }
         let multivector = MultiDenseVectorInternal::new(vectors, dim);

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -34,11 +34,12 @@ use crate::data_types::index::{
     KeywordIndexParams, TextIndexParams, UuidIndexParams,
 };
 use crate::data_types::order_by::OrderValue;
-use crate::data_types::vectors::VectorStructInternal;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::{DenseVector, VectorStructInternal};
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
 use crate::json_path::JsonPath;
-use crate::spaces::metric::MetricPostProcessing;
+use crate::spaces::metric::{Metric, MetricPostProcessing};
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::utils::maybe_arc::MaybeArc;
 
@@ -303,6 +304,21 @@ impl Distance {
             Distance::Euclid => EuclidMetric::postprocess(score),
             Distance::Dot => DotProductMetric::postprocess(score),
             Distance::Manhattan => ManhattanMetric::postprocess(score),
+        }
+    }
+
+    pub fn preprocess_vector<T: PrimitiveVectorElement>(&self, vector: DenseVector) -> DenseVector
+    where
+        CosineMetric: Metric<T>,
+        EuclidMetric: Metric<T>,
+        DotProductMetric: Metric<T>,
+        ManhattanMetric: Metric<T>,
+    {
+        match self {
+            Distance::Cosine => CosineMetric::preprocess(vector),
+            Distance::Euclid => EuclidMetric::preprocess(vector),
+            Distance::Dot => DotProductMetric::preprocess(vector),
+            Distance::Manhattan => ManhattanMetric::preprocess(vector),
         }
     }
 

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -20,8 +20,6 @@ use segment::json_path::JsonPath;
 use segment::payload_json;
 use segment::segment_constructor::VectorIndexBuildArgs;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
-use segment::spaces::metric::Metric;
-use segment::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig, MultiVectorConfig,
     PayloadSchemaType, SeqNumberType,
@@ -68,20 +66,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rng, dim);
-        let preprocessed_vector = match distance {
-            Distance::Cosine => {
-                <CosineMetric as Metric<VectorElementType>>::preprocess(vector.clone())
-            }
-            Distance::Euclid => {
-                <EuclidMetric as Metric<VectorElementType>>::preprocess(vector.clone())
-            }
-            Distance::Dot => {
-                <DotProductMetric as Metric<VectorElementType>>::preprocess(vector.clone())
-            }
-            Distance::Manhattan => {
-                <ManhattanMetric as Metric<VectorElementType>>::preprocess(vector.clone())
-            }
-        };
+        let preprocessed_vector = distance.preprocess_vector::<VectorElementType>(vector.clone());
         let vector_multi = MultiDenseVectorInternal::new(preprocessed_vector, vector.len());
 
         let int_payload = random_int_payload(&mut rng, num_payload_values..=num_payload_values);


### PR DESCRIPTION
The same snippet appears 11 times in the code base:
```rust
match config.distance {
    Distance::Cosine => {
        <CosineMetric as Metric<VectorElementType>>::preprocess(dense_vector)
    }
    Distance::Euclid => {
        <EuclidMetric as Metric<VectorElementType>>::preprocess(dense_vector)
    }
    Distance::Dot => {
        <DotProductMetric as Metric<VectorElementType>>::preprocess(dense_vector)
    }
    Distance::Manhattan => {
        <ManhattanMetric as Metric<VectorElementType>>::preprocess(dense_vector)
    }
}
```

This PR deduplicates all occurrences into a new method `Distance::preprocess_vector<T: PrimitiveVectorElement>()`.