### PR TITLE
Fix flushing of dynamic mmap flags

### DIFF
--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -167,6 +167,9 @@ impl DynamicMmapFlags {
         let current_capacity = mmap_max_current_size(self.status.len);
 
         if new_len > current_capacity {
+            // Flush the current mmaps before resizing
+            self.flags.flusher()()?;
+
             // Don't read the whole file on resize
             let populate = false;
             let flags = Self::open_mmap(new_len, &self.directory, populate)?;
@@ -233,9 +236,6 @@ impl DynamicMmapFlags {
         let key: usize = key.as_();
         if key >= self.status.len {
             if value {
-                // Explicitly flush so we don't lose dirty pages
-                self.flusher()()?;
-
                 let new_len = key + 1;
                 hw_counter_ref.incr_delta(new_len - self.status.len);
                 self.set_len(new_len)?;


### PR DESCRIPTION
Fix flushing behavior in the dynamic mmap flags structure, affecting the null and boolean indices.

This makes two changes:
1. on flush, directly flush flags (don't use single-use flusher that noop's on the next flush)
2. before resizing mmap, explicitly flush dirty pages (looks like we lose dirty pages if we don't)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
3. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
4. [x] Have you checked your code using `cargo clippy --all --all-features` command?