### PR TITLE
Change FnOnce to Fn in MmapFlusher

### DIFF
--- a/lib/common/memory/src/mmap_type.rs
+++ b/lib/common/memory/src/mmap_type.rs
@@ -36,7 +36,7 @@ use crate::mmap_ops;
 /// Result for mmap errors.
 type Result<T> = std::result::Result<T, Error>;
 
-pub type MmapFlusher = Box<dyn FnOnce() -> Result<()> + Send>;
+pub type MmapFlusher = Box<dyn Fn() -> Result<()> + Send>;
 
 /// Type `T` on a memory mapped file
 ///

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -177,9 +177,10 @@ impl DynamicMmapFlags {
             let populate = false;
             let (flags, flags_flusher) = Self::open_mmap(new_len, &self.directory, populate)?;
 
-            // Swap operation. It is important this section is not interrupted by errors.
             {
                 let mut flags_flusher_lock = self.flags_flusher.lock();
+                flags_flusher_lock()?;
+                // Swap operation. It is important this section is not interrupted by errors.
                 self.flags = flags;
                 *flags_flusher_lock = flags_flusher;
             }


### PR DESCRIPTION
`DynamicMmapFlags` only actually flushed the flags once per flusher, as it was taking the flusher out of the `Option`:

https://github.com/qdrant/qdrant/blob/bd34d52578399a368f203ffe029780a37d817136/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs#L264-L266

By making `MmapFlusher` a `Fn` rather than `FnOnce`, we can reuse the flusher and avoid taking it from option.

I believe this is safe, since this is the implementation of a mmap flusher:

https://github.com/qdrant/qdrant/blob/bd34d52578399a368f203ffe029780a37d817136/lib/common/memory/src/mmap_type.rs#L160-L174