### PR TITLE
Cleanup versions on segment repair

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -687,20 +687,6 @@ impl LocalShard {
         {
             let segments = self.segments.read();
 
-            // It is possible, that after recovery, if WAL flush was not enforced.
-            // We could be left with some un-versioned points.
-            // To maintain consistency, we can either remove them or try to recover.
-            for (_idx, segment) in segments.iter() {
-                match segment {
-                    LockedSegment::Original(raw_segment) => {
-                        raw_segment.write().cleanup_versions()?;
-                    }
-                    LockedSegment::Proxy(_) => {
-                        debug_assert!(false, "Proxy segment found in load_from_wal");
-                    }
-                }
-            }
-
             // Force a flush after re-applying WAL operations, to ensure we maintain on-disk data
             // consistency, if we happened to only apply *past* operations to a segment with newer
             // version.

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -466,7 +466,12 @@ impl Segment {
     }
 
     /// Check consistency of the segment's data and repair it if possible.
+    /// Removes partially persisted points.
     pub fn check_consistency_and_repair(&mut self) -> OperationResult<()> {
+        // Get rid of versionless points.
+        self.cleanup_versions()?;
+
+        // Get rid of unmapped points.
         let mut internal_ids_to_delete = HashSet::new();
         let id_tracker = self.id_tracker.borrow();
         for internal_id in id_tracker.iter_ids() {


### PR DESCRIPTION
We currently cleanup version after replaying WAL, but we should be cleaning them up BEFORE we reapply operations.

There is currently a problem where WAL replay would assign `version=Some(0)` to points which had `version=None`. If we cleanup versions before the replay, we don't need to worry about this