### PR TITLE
Buffered mutable bool index

### DIFF
--- a/lib/segment/src/common/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/buffered_dynamic_flags.rs
@@ -85,7 +85,9 @@ impl BufferedDynamicFlags {
         self.len.saturating_sub(self.count_trues())
     }
 
-    pub fn set(&mut self, index: PointOffsetType, value: bool) {
+    /// Set the value of a flag at the given index.
+    /// Returns the previous value of the flag.
+    pub fn set(&mut self, index: PointOffsetType, value: bool) -> bool {
         // queue write in buffer
         self.buffer.write().insert(index, value);
 
@@ -97,10 +99,14 @@ impl BufferedDynamicFlags {
 
         // update bitmap
         if value {
-            self.bitmap.insert(index);
+            !self.bitmap.insert(index)
         } else {
-            self.bitmap.remove(index);
+            self.bitmap.remove(index)
         }
+    }
+
+    pub fn get_bitmap(&self) -> &RoaringBitmap {
+        &self.bitmap
     }
 
     pub fn clear_cache(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -283,9 +283,8 @@ impl MutableBoolIndex {
         false
     }
 
-    /// Populate all pages in the mmap.
-    /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
+        // The true and false flags are always in memory
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -1,13 +1,13 @@
 use std::path::{Path, PathBuf};
 
-use bitvec::slice::BitSlice;
-use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::types::PointOffsetType;
-use itertools::{Either, Itertools};
+use itertools::Either;
+use roaring::RoaringBitmap;
 
 use super::BoolIndex;
+use crate::common::buffered_dynamic_flags::BufferedDynamicFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::map_index::IdIter;
 use crate::index::field_index::{
@@ -16,30 +16,28 @@ use crate::index::field_index::{
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, MatchValue, PayloadKeyType, ValueVariants};
-use crate::vector_storage::common::PAGE_SIZE_BYTES;
 use crate::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
 
 const TRUES_DIRNAME: &str = "trues";
 const FALSES_DIRNAME: &str = "falses";
 
-/// Payload index for boolean values, stored in memory-mapped files.
-pub struct MmapBoolIndex {
-    base_dir: PathBuf,
+/// Payload index for boolean values, in-memory via roaring bitmaps, stored in memory-mapped bitslices.
+pub struct MutableBoolIndex {
     indexed_count: usize,
     trues_count: usize,
     falses_count: usize,
     storage: Option<Storage>,
-    populated: bool,
 }
 
 struct Storage {
-    trues_slice: DynamicMmapFlags,
-    falses_slice: DynamicMmapFlags,
+    base_dir: PathBuf,
+    trues_flags: BufferedDynamicFlags,
+    falses_flags: BufferedDynamicFlags,
 }
 
-impl MmapBoolIndex {
-    pub fn builder(path: &Path, is_on_disk: bool) -> OperationResult<MmapBoolIndexBuilder> {
-        Ok(MmapBoolIndexBuilder(Self::open(path, is_on_disk, true)?))
+impl MutableBoolIndex {
+    pub fn builder(path: &Path) -> OperationResult<MutableBoolIndexBuilder> {
+        Ok(MutableBoolIndexBuilder(Self::open(path, true)?))
     }
 
     /// Open or create a boolean index at the given path.
@@ -48,71 +46,53 @@ impl MmapBoolIndex {
     /// - `path` - The directory where the index files should live, must be exclusive to this index.
     /// - `is_on_disk` - If the index should be kept on disk. Memory will be populated if false.
     /// - `create_if_missing` - If true, creates the index if it doesn't exist.
-    pub fn open(path: &Path, is_on_disk: bool, create_if_missing: bool) -> OperationResult<Self> {
+    pub fn open(path: &Path, create_if_missing: bool) -> OperationResult<Self> {
         let falses_dir = path.join(FALSES_DIRNAME);
 
         // If falses directory doesn't exist, assume the index doesn't exist on disk
         if !falses_dir.is_dir() && !create_if_missing {
             return Ok(Self {
-                base_dir: path.to_path_buf(),
                 storage: None,
                 indexed_count: 0,
                 trues_count: 0,
                 falses_count: 0,
-                populated: !is_on_disk,
             });
         }
 
-        Self::open_or_create(path, is_on_disk)
+        Self::open_or_create(path)
     }
 
-    fn open_or_create(path: &Path, is_on_disk: bool) -> OperationResult<Self> {
+    fn open_or_create(path: &Path) -> OperationResult<Self> {
         std::fs::create_dir_all(path).map_err(|err| {
             OperationError::service_error(format!(
                 "Failed to create mmap bool index directory: {err}"
             ))
         })?;
 
-        let populate = !is_on_disk;
         // Trues bitslice
         let trues_path = path.join(TRUES_DIRNAME);
-        let trues_slice = DynamicMmapFlags::open(&trues_path, populate)?;
+        let trues_slice = DynamicMmapFlags::open(&trues_path, false)?;
+        let trues_flags = BufferedDynamicFlags::new(trues_slice);
 
         // Falses bitslice
         let falses_path = path.join(FALSES_DIRNAME);
-        let falses_slice = DynamicMmapFlags::open(&falses_path, populate)?;
+        let falses_slice = DynamicMmapFlags::open(&falses_path, false)?;
+        let falses_flags = BufferedDynamicFlags::new(falses_slice);
 
         Ok(Self {
-            base_dir: path.to_path_buf(),
             storage: Some(Storage {
-                trues_slice,
-                falses_slice,
+                base_dir: path.to_path_buf(),
+                trues_flags,
+                falses_flags,
             }),
             // loading is done after opening during `PayloadFieldIndex::load()`
             indexed_count: 0,
             trues_count: 0,
             falses_count: 0,
-            populated: populate,
         })
     }
 
-    fn make_conditioned_counter<'a>(
-        &self,
-        hw_counter: &'a HardwareCounterCell,
-    ) -> ConditionedCounter<'a> {
-        let on_disk = !self.populated; // Measure if on disk.
-        ConditionedCounter::new(on_disk, hw_counter)
-    }
-
-    fn set_or_insert(
-        &mut self,
-        id: u32,
-        has_true: bool,
-        has_false: bool,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        let hw_counter = self.make_conditioned_counter(hw_counter);
-
+    fn set_or_insert(&mut self, id: u32, has_true: bool, has_false: bool) -> OperationResult<()> {
         let Some(storage) = &mut self.storage else {
             return Err(OperationError::service_error(
                 "MmapBoolIndex storage is not initialized",
@@ -120,14 +100,8 @@ impl MmapBoolIndex {
         };
 
         // Set or insert the flags
-        let prev_true =
-            set_or_insert_flag(&mut storage.trues_slice, id as usize, has_true, &hw_counter)?;
-        let prev_false = set_or_insert_flag(
-            &mut storage.falses_slice,
-            id as usize,
-            has_false,
-            &hw_counter,
-        )?;
+        let prev_true = storage.trues_flags.set(id, has_true);
+        let prev_false = storage.falses_flags.set(id, has_false);
 
         let was_indexed = prev_true || prev_false;
         let is_indexed = has_true || has_false;
@@ -168,16 +142,18 @@ impl MmapBoolIndex {
         Ok(())
     }
 
-    fn get_slice_for(&self, value: bool) -> &BitSlice {
+    fn get_bitmap_for(&self, value: bool) -> Option<&RoaringBitmap> {
         let Some(storage) = &self.storage else {
-            return BitSlice::from_slice(&[]);
+            return None;
         };
 
-        if value {
-            storage.trues_slice.get_bitslice()
+        let bitmap = if value {
+            storage.trues_flags.get_bitmap()
         } else {
-            storage.falses_slice.get_bitslice()
-        }
+            storage.falses_flags.get_bitmap()
+        };
+
+        Some(bitmap)
     }
 
     fn get_count_for(&self, value: bool) -> usize {
@@ -188,42 +164,15 @@ impl MmapBoolIndex {
         }
     }
 
-    fn bitslice_usize_view(bitslice: &BitSlice) -> &[usize] {
-        let (head, body, tail) = bitslice
-            .domain()
-            .region()
-            .expect("BitSlice should be bigger than one usize");
-
-        debug_assert!(head.is_none(), "BitSlice should be aligned to usize");
-        debug_assert!(tail.is_none(), "BitSlice should be aligned to usize");
-
-        body
-    }
-
     /// Calculates the count of true values of the union of both slices.
     fn calculate_indexed_count(&self) -> u32 {
-        // indexed_count would be trues_bitslice.union_count(falses_bitslice), but there is no such operation yet.
-        // So we do it manually.
-        let trues = Self::bitslice_usize_view(self.get_slice_for(true));
-        let falses = Self::bitslice_usize_view(self.get_slice_for(false));
-
-        let mut indexed_count = 0;
-        for elem in trues.iter().zip_longest(falses) {
-            match elem {
-                itertools::EitherOrBoth::Both(trues_elem, falses_elem) => {
-                    let union = trues_elem | falses_elem;
-                    indexed_count += union.count_ones();
-                }
-                itertools::EitherOrBoth::Left(trues_elem) => {
-                    indexed_count += trues_elem.count_ones();
-                }
-                itertools::EitherOrBoth::Right(falses_elem) => {
-                    indexed_count += falses_elem.count_ones();
-                }
-            }
+        if let Some(storage) = &self.storage {
+            let trues = storage.trues_flags.get_bitmap();
+            let falses = storage.falses_flags.get_bitmap();
+            trues.union_len(falses) as u32
+        } else {
+            0
         }
-
-        indexed_count
     }
 
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
@@ -241,39 +190,29 @@ impl MmapBoolIndex {
             return 0;
         };
 
-        let has_true = storage.trues_slice.get(point_id as usize);
-        let has_false = storage.falses_slice.get(point_id as usize);
+        let has_true = storage.trues_flags.get(point_id);
+        let has_false = storage.falses_flags.get(point_id);
         usize::from(has_true) + usize::from(has_false)
     }
 
-    pub fn check_values_any(
-        &self,
-        point_id: PointOffsetType,
-        is_true: bool,
-        hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    pub fn check_values_any(&self, point_id: PointOffsetType, is_true: bool) -> bool {
         let Some(storage) = &self.storage else {
             return false;
         };
 
-        let hw_counter = self.make_conditioned_counter(hw_counter);
-
-        hw_counter
-            .payload_index_io_read_counter()
-            .incr_delta(size_of::<bool>());
         if is_true {
-            storage.trues_slice.get(point_id as usize)
+            storage.trues_flags.get(point_id)
         } else {
-            storage.falses_slice.get(point_id as usize)
+            storage.falses_flags.get(point_id)
         }
     }
 
-    pub fn values_is_empty(&self, point_id: u32) -> bool {
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
         let Some(storage) = &self.storage else {
             return true;
         };
 
-        !storage.trues_slice.get(point_id as usize) && !storage.falses_slice.get(point_id as usize)
+        !storage.trues_flags.get(point_id) && !storage.falses_flags.get(point_id)
     }
 
     // TODO(payload-index-non-optional-storage): remove Either, just return pure iterator
@@ -281,15 +220,13 @@ impl MmapBoolIndex {
         &'a self,
         hw_counter: &'a HardwareCounterCell,
     ) -> impl Iterator<Item = (bool, IdIter<'a>)> + 'a {
-        let hw_counter = self.make_conditioned_counter(hw_counter);
-
         let Some(storage) = &self.storage else {
             return Either::Right(std::iter::empty());
         };
 
         let iter = [
-            (false, Box::new(storage.falses_slice.iter_trues()) as IdIter),
-            (true, Box::new(storage.trues_slice.iter_trues()) as IdIter),
+            (false, Box::new(storage.falses_flags.iter_trues()) as IdIter),
+            (true, Box::new(storage.trues_flags.iter_trues()) as IdIter),
         ]
         .into_iter()
         .measure_hw_with_acc(hw_counter.new_accumulator(), u8::BITS as usize, |i| {
@@ -305,8 +242,8 @@ impl MmapBoolIndex {
         };
 
         let iter = [
-            storage.falses_slice.iter_trues().next().map(|_| false),
-            storage.trues_slice.iter_trues().next().map(|_| true),
+            storage.falses_flags.iter_trues().next().map(|_| false),
+            storage.trues_flags.iter_trues().next().map(|_| true),
         ]
         .into_iter()
         .flatten();
@@ -320,8 +257,8 @@ impl MmapBoolIndex {
         };
 
         let iter = [
-            (false, storage.falses_slice.count_flags()),
-            (true, storage.trues_slice.count_flags()),
+            (false, storage.falses_flags.count_trues()),
+            (true, storage.trues_flags.count_trues()),
         ]
         .into_iter();
         Either::Left(iter)
@@ -333,8 +270,8 @@ impl MmapBoolIndex {
         };
 
         [
-            storage.trues_slice.get(point_id as usize).then_some(true),
-            storage.falses_slice.get(point_id as usize).then_some(false),
+            storage.trues_flags.get(point_id).then_some(true),
+            storage.falses_flags.get(point_id).then_some(false),
         ]
         .into_iter()
         .flatten()
@@ -342,67 +279,29 @@ impl MmapBoolIndex {
     }
 
     pub fn is_on_disk(&self) -> bool {
-        !self.populated
+        false
     }
 
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
-        if let Some(storage) = &self.storage {
-            storage.trues_slice.populate()?;
-            storage.falses_slice.populate()?;
-        }
-
         Ok(())
     }
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         if let Some(storage) = &self.storage {
-            storage.trues_slice.clear_cache()?;
-            storage.falses_slice.clear_cache()?;
+            storage.trues_flags.clear_cache()?;
+            storage.falses_flags.clear_cache()?;
         }
 
         Ok(())
     }
 }
 
-/// Set or insert a flag in the given flags. Returns previous value.
-///
-/// Resizes if needed to set to true.
-fn set_or_insert_flag(
-    flags: &mut DynamicMmapFlags,
-    key: usize,
-    value: bool,
-    hw_counter: &ConditionedCounter,
-) -> OperationResult<bool> {
-    let counter = hw_counter.payload_index_io_write_counter();
+pub struct MutableBoolIndexBuilder(MutableBoolIndex);
 
-    // Measure writing bool.
-    counter.incr_delta(size_of::<bool>());
-
-    // Set to true
-    if value {
-        // Make sure the key fits
-        if key >= flags.len() {
-            let new_len = (key + 1).next_multiple_of(PAGE_SIZE_BYTES);
-            counter.incr_delta(new_len - flags.len());
-            flags.set_len(new_len)?;
-        }
-        return Ok(flags.set(key, value));
-    }
-
-    // Set to false
-    if key < flags.len() {
-        return Ok(flags.set(key, value));
-    }
-
-    Ok(false)
-}
-
-pub struct MmapBoolIndexBuilder(MmapBoolIndex);
-
-impl FieldIndexBuilderTrait for MmapBoolIndexBuilder {
+impl FieldIndexBuilderTrait for MutableBoolIndexBuilder {
     type FieldIndexType = BoolIndex;
 
     fn init(&mut self) -> OperationResult<()> {
@@ -424,14 +323,14 @@ impl FieldIndexBuilderTrait for MmapBoolIndexBuilder {
     }
 }
 
-impl ValueIndexer for MmapBoolIndex {
+impl ValueIndexer for MutableBoolIndex {
     type ValueType = bool;
 
     fn add_many(
         &mut self,
         id: PointOffsetType,
         values: Vec<Self::ValueType>,
-        hw_counter: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         if values.is_empty() {
             return Ok(());
@@ -440,7 +339,7 @@ impl ValueIndexer for MmapBoolIndex {
         let has_true = values.iter().any(|v| *v);
         let has_false = values.iter().any(|v| !*v);
 
-        self.set_or_insert(id, has_true, has_false, hw_counter)?;
+        self.set_or_insert(id, has_true, has_false)?;
 
         Ok(())
     }
@@ -450,12 +349,12 @@ impl ValueIndexer for MmapBoolIndex {
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        let disposable_hw = HardwareCounterCell::disposable();
-        self.set_or_insert(id, false, false, &disposable_hw)?;
+        self.set_or_insert(id, false, false)?;
         Ok(())
     }
 }
-impl PayloadFieldIndex for MmapBoolIndex {
+
+impl PayloadFieldIndex for MutableBoolIndex {
     fn count_indexed_points(&self) -> usize {
         self.indexed_count
     }
@@ -470,27 +369,29 @@ impl PayloadFieldIndex for MmapBoolIndex {
 
         // Destructure to not forget any fields
         let Self {
-            base_dir: _,
             indexed_count,
             storage,
             trues_count,
             falses_count,
-            populated: _,
         } = self;
         let Storage {
-            trues_slice,
-            falses_slice,
+            base_dir: _,
+            trues_flags,
+            falses_flags,
         } = storage.as_ref().unwrap();
 
         *indexed_count = calculated_indexed_count as usize;
-        *trues_count = trues_slice.count_flags();
-        *falses_count = falses_slice.count_flags();
+        *trues_count = trues_flags.count_trues();
+        *falses_count = falses_flags.count_trues();
 
         Ok(true)
     }
 
     fn cleanup(self) -> OperationResult<()> {
-        std::fs::remove_dir_all(self.base_dir)?;
+        if let Some(storage) = self.storage {
+            std::fs::remove_dir_all(storage.base_dir)?;
+        };
+
         Ok(())
     }
 
@@ -500,20 +401,19 @@ impl PayloadFieldIndex for MmapBoolIndex {
         };
 
         let Self {
-            base_dir: _,
             indexed_count: _,
             trues_count: _,
             falses_count: _,
             storage: _,
-            populated: _,
         } = self;
         let Storage {
-            trues_slice,
-            falses_slice,
+            base_dir: _,
+            trues_flags,
+            falses_flags,
         } = storage;
 
-        let trues_flusher = trues_slice.flusher();
-        let falses_flusher = falses_slice.flusher();
+        let trues_flusher = trues_flags.flusher();
+        let falses_flusher = falses_flags.flusher();
 
         Box::new(move || {
             trues_flusher()?;
@@ -527,8 +427,8 @@ impl PayloadFieldIndex for MmapBoolIndex {
             return vec![];
         };
 
-        let mut files = storage.trues_slice.files();
-        files.extend(storage.falses_slice.files());
+        let mut files = storage.trues_flags.files();
+        files.extend(storage.falses_flags.files());
         files
     }
 
@@ -541,15 +441,13 @@ impl PayloadFieldIndex for MmapBoolIndex {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
-        let hw_counter = self.make_conditioned_counter(hw_counter);
-
         match &condition.r#match {
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Bool(value),
             })) => {
                 let iter = self
-                    .get_slice_for(*value)
-                    .iter_ones()
+                    .get_bitmap_for(*value)?
+                    .iter()
                     .map(|x| x as PointOffsetType)
                     .measure_hw_with_acc_and_fraction(
                         hw_counter.new_accumulator(),
@@ -567,8 +465,6 @@ impl PayloadFieldIndex for MmapBoolIndex {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> Option<CardinalityEstimation> {
-        let hw_counter = self.make_conditioned_counter(hw_counter);
-
         match &condition.r#match {
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Bool(value),
@@ -628,13 +524,13 @@ mod tests {
     use tempfile::TempDir;
     use walkdir::WalkDir;
 
-    use super::MmapBoolIndex;
+    use super::MutableBoolIndex;
     use crate::index::field_index::PayloadFieldIndex;
 
     #[test]
     fn test_files() {
         let dir = TempDir::with_prefix("test_mmap_bool_index").unwrap();
-        let index = MmapBoolIndex::open(dir.path(), false, true).unwrap();
+        let index = MutableBoolIndex::open(dir.path(), true).unwrap();
 
         let reported = index.files().into_iter().collect::<HashSet<_>>();
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -6,7 +6,7 @@ use common::types::PointOffsetType;
 use serde_json::Value;
 
 use super::bool_index::BoolIndex;
-use super::bool_index::mmap_bool_index::MmapBoolIndexBuilder;
+use super::bool_index::mutable_bool_index::MutableBoolIndexBuilder;
 use super::facet_index::FacetIndexEnum;
 use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use super::full_text_index::text_index::{FullTextGridstoreIndexBuilder, FullTextIndex};
@@ -613,7 +613,7 @@ pub enum FieldIndexBuilder {
     FullTextGridstoreIndex(FullTextGridstoreIndexBuilder),
     #[cfg(feature = "rocksdb")]
     BoolIndex(super::bool_index::simple_bool_index::BoolIndexBuilder),
-    BoolMmapIndex(MmapBoolIndexBuilder),
+    BoolMmapIndex(MutableBoolIndexBuilder),
     #[cfg(feature = "rocksdb")]
     UuidIndex(MapIndexBuilder<UuidIntType>),
     UuidMmapIndex(MapIndexMmapBuilder<UuidIntType>),

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use gridstore::Blob;
 
 use super::bool_index::BoolIndex;
-use super::bool_index::mmap_bool_index::MmapBoolIndex;
+use super::bool_index::mutable_bool_index::MutableBoolIndex;
 #[cfg(feature = "rocksdb")]
 use super::bool_index::simple_bool_index::SimpleBoolIndex;
 use super::geo_index::{GeoMapIndexGridstoreBuilder, GeoMapIndexMmapBuilder};
@@ -524,18 +524,17 @@ impl IndexSelector<'_> {
                 Arc::clone(db),
                 &field.to_string(),
             ))),
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => {
                 let dir = bool_dir(dir, field);
-                Ok(FieldIndexBuilder::BoolMmapIndex(MmapBoolIndex::builder(
+                Ok(FieldIndexBuilder::BoolMmapIndex(MutableBoolIndex::builder(
                     &dir,
-                    *is_on_disk,
                 )?))
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 let dir = bool_dir(dir, field);
-                Ok(FieldIndexBuilder::BoolMmapIndex(MmapBoolIndex::builder(
-                    &dir, false,
+                Ok(FieldIndexBuilder::BoolMmapIndex(MutableBoolIndex::builder(
+                    &dir,
                 )?))
             }
         }
@@ -551,20 +550,18 @@ impl IndexSelector<'_> {
                 Arc::clone(db),
                 &field.to_string(),
             ))),
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => {
                 let dir = bool_dir(dir, field);
-                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open(
+                FieldIndex::BoolIndex(BoolIndex::Mmap(MutableBoolIndex::open(
                     &dir,
-                    *is_on_disk,
                     create_if_missing,
                 )?))
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 let dir = bool_dir(dir, field);
-                FieldIndex::BoolIndex(BoolIndex::Mmap(MmapBoolIndex::open(
+                FieldIndex::BoolIndex(BoolIndex::Mmap(MutableBoolIndex::open(
                     &dir,
-                    false,
                     create_if_missing,
                 )?))
             }


### PR DESCRIPTION
Builds on top of #6954 

Same approach implemented in #6954, but for bool index. Since bool index also used unbuffered updates, this PR switches their flags component to leverage `BufferedDynamicFlags`.