### PR TITLE
Cancel test jobs fast 

### DIFF
--- a/.github/actions/cancel-other-running-jobs/action.yml
+++ b/.github/actions/cancel-other-running-jobs/action.yml
@@ -1,0 +1,52 @@
+name: 'Cancel Other Running Jobs'
+description: 'Cancels all other running jobs in the current workflow run'
+inputs:
+  github-token:
+    description: 'GitHub token with actions:write permission'
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cancel other running jobs
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const { owner, repo } = context.repo;
+          const run_id = context.runId;
+          
+          console.log(`Checking jobs for workflow run ${run_id}...`);
+          
+          // Get all jobs for this workflow run
+          const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+            owner,
+            repo,
+            run_id
+          });
+          
+          // Check if there are other running jobs
+          const otherRunningJobs = jobs.filter(job => 
+            job.status === 'in_progress' && job.id !== context.job
+          );
+          
+          console.log(`Found ${otherRunningJobs.length} other running jobs`);
+          
+          if (otherRunningJobs.length > 0) {
+            console.log('Cancelling workflow run to stop all running jobs...');
+            
+            try {
+              await github.rest.actions.cancelWorkflowRun({
+                owner,
+                repo,
+                run_id: run_id
+              });
+              console.log('Successfully initiated workflow cancellation');
+            } catch (error) {
+              console.error(`Failed to cancel workflow: ${error.message}`);
+              throw error;
+            }
+          } else {
+            console.log('No other running jobs found - skipping cancellation');
+          }

--- a/.github/actions/cancel-workflow-run/action.yml
+++ b/.github/actions/cancel-workflow-run/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'GitHub token with actions:write permission'
     required: false
     default: ${{ github.token }}
+  reason:
+    description: 'Reason for cancelling the workflow'
+    required: false
+    default: 'A critical job failed'
 
 runs:
   using: 'composite'
@@ -16,6 +20,7 @@ runs:
         script: |
           const { owner, repo } = context.repo;
           const run_id = context.runId;
+          const currentJob = process.env.GITHUB_JOB;
           
           console.log(`Checking jobs for workflow run ${run_id}...`);
           
@@ -26,15 +31,21 @@ runs:
             run_id
           });
           
+          // Find current job details
+          const currentJobDetails = jobs.find(job => job.name === currentJob);
+          
           // Check if there are other running jobs
           const otherRunningJobs = jobs.filter(job => 
-            job.status === 'in_progress' && job.id !== context.job
+            job.status === 'in_progress' && job.id !== currentJobDetails?.id
           );
           
           console.log(`Found ${otherRunningJobs.length} other running jobs`);
           
           if (otherRunningJobs.length > 0) {
-            console.log('Cancelling workflow run to stop all running jobs...');
+            // Create an error annotation to make it clear why the workflow was cancelled
+            core.error(`Cancelling workflow run due to failure in job '${currentJob}': ${{ inputs.reason }}`);
+            
+            console.log('Cancelling workflow run to stop all other running jobs...');
             
             try {
               await github.rest.actions.cancelWorkflowRun({
@@ -43,6 +54,15 @@ runs:
                 run_id: run_id
               });
               console.log('Successfully initiated workflow cancellation');
+              
+              // Add a summary to the workflow
+              await core.summary
+                .addHeading('Workflow Cancelled', 2)
+                .addRaw(`This workflow was cancelled because job <strong>${currentJob}</strong> failed.`)
+                .addBreak()
+                .addRaw(`<strong>Reason:</strong> ${{ inputs.reason }}`)
+                .write();
+              
             } catch (error) {
               console.error(`Failed to cancel workflow: ${error.message}`);
               throw error;

--- a/.github/actions/cancel-workflow-run/action.yml
+++ b/.github/actions/cancel-workflow-run/action.yml
@@ -19,7 +19,7 @@ runs:
         script: |
           const { owner, repo } = context.repo;
           const run_id = context.runId;
-          const currentJob = process.env.GITHUB_JOB;
+          const currentJobId = process.env.GITHUB_JOB;
           
           console.log(`Checking jobs for workflow run ${run_id}...`);
           
@@ -31,18 +31,21 @@ runs:
           });
           
           // Find current job details
-          const currentJobDetails = jobs.find(job => job.name === currentJob);
+          const currentJobDetails = jobs.find(
+            job => job.name === currentJobId || job.id === Number(process.env.GITHUB_JOB_ID)
+          );
           
           // Check if there are other running jobs
+          const cancellableStates = new Set(['queued', 'waiting', 'in_progress']);
           const otherRunningJobs = jobs.filter(job => 
-            job.status === 'in_progress' && job.id !== currentJobDetails?.id
+            job => cancellableStates.has(job.status) && job.id !== currentJobDetails?.id
           );
           
           console.log(`Found ${otherRunningJobs.length} other running jobs`);
           
           if (otherRunningJobs.length > 0) {
             // Create an error annotation to make it clear why the workflow was cancelled
-            core.error(`Cancelling workflow run due to failure in job '${currentJob}': ${{ inputs.reason }}`);
+            core.error(`Cancelling workflow run due to failure in job '${currentJobId}': ${{ inputs.reason }}`);
             
             console.log('Cancelling workflow run to stop all other running jobs...');
             

--- a/.github/actions/cancel-workflow-run/action.yml
+++ b/.github/actions/cancel-workflow-run/action.yml
@@ -37,7 +37,7 @@ runs:
           
           // Check if there are other running jobs
           const cancellableStates = new Set(['queued', 'waiting', 'in_progress']);
-          const otherRunningJobs = jobs.filter(job => 
+          const otherRunningJobs = jobs.filter( 
             job => cancellableStates.has(job.status) && job.id !== currentJobDetails?.id
           );
           

--- a/.github/actions/cancel-workflow-run/action.yml
+++ b/.github/actions/cancel-workflow-run/action.yml
@@ -60,7 +60,7 @@ runs:
               // Add a summary to the workflow
               await core.summary
                 .addHeading('Workflow Cancelled', 2)
-                .addRaw(`This workflow was cancelled because job <strong>${currentJob}</strong> failed.`)
+                .addRaw(`This workflow was cancelled because job <strong>${currentJobId}</strong> failed.`)
                 .addBreak()
                 .addRaw(`<strong>Reason:</strong> ${{ inputs.reason }}`)
                 .write();

--- a/.github/actions/cancel-workflow-run/action.yml
+++ b/.github/actions/cancel-workflow-run/action.yml
@@ -3,8 +3,7 @@ description: 'Cancels all other running jobs in the current workflow run'
 inputs:
   github-token:
     description: 'GitHub token with actions:write permission'
-    required: false
-    default: ${{ github.token }}
+    required: true
   reason:
     description: 'Reason for cancelling the workflow'
     required: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -143,18 +143,9 @@ jobs:
         with:
           context: tools/schema2openapi
           tags: schema2openapi
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-schema2openapi
-            type=gha,scope=${{ github.base_ref }}-schema2openapi
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
           load: true
           build-args: |
             PROFILE=ci
-      - name: Cancel other jobs in a run if Docker build failed
-        if: failure() && steps.docker-build.outcome == 'failure'
-        uses: ./.github/actions/cancel-workflow-run
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,183 +42,183 @@ jobs:
         run: poetry --project tests run bash ./tests/integration-tests.sh
         shell: bash
 
-#  integration-tests-consensus:
-#
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: actions/checkout@v4
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - name: Install dependencies
-#        run: sudo apt-get install clang
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#      - name: Install dependencies
-#        run: |
-#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-#
-#          poetry -C tests check --lock
-#          poetry -C tests install --no-root
-#      - name: Build
-#        run: cargo build --features "service_debug data-consistency-check" --locked
-#      - name: Run integration tests - 1 peer
-#        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
-#        shell: bash
-#      - name: Run integration tests - multiple peers - pytest
-#        run: poetry --project tests run pytest tests/consensus_tests --durations=10
-#        timeout-minutes: 60
-#      - name: upload logs
-#        uses: actions/upload-artifact@v4
-#        if: always()
-#        with:
-#          path: consensus_test_logs
-#          name: consensus-test-logs
-#          retention-days: 10
-#
-#  test-consensus-compose:
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#      - name: Install dependencies
-#        run: |
-#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-#
-#          poetry -C tests check --lock
-#          poetry -C tests install --no-root
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Docker build
-#        id: docker-build
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: .
-#          tags: qdrant_consensus
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}
-#            type=gha,scope=${{ github.base_ref }}
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-#          load: true
-#          build-args: |
-#            PROFILE=ci
-#      - name: Cancel other jobs in a run if Docker build failed
-#        if: failure() && steps.docker-build.outcome == 'failure'
-#        uses: ./.github/actions/cancel-workflow-run
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Run integration tests - multiple peers - compose
-#        run: poetry run bash ./test_restart.sh
-#        working-directory: ./tests/consensus_tests
-#
-#  test-consistency:
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: actions/checkout@v4
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Install dependencies
-#        run: sudo apt-get install -y clang jq
-#      - name: Docker build
-#        id: docker-build
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: tools/schema2openapi
-#          tags: schema2openapi
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}-schema2openapi
-#            type=gha,scope=${{ github.base_ref }}-schema2openapi
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
-#          load: true
-#          build-args: |
-#            PROFILE=ci
-#      - name: Cancel other jobs in a run if Docker build failed
-#        if: failure() && steps.docker-build.outcome == 'failure'
-#        uses: ./.github/actions/cancel-workflow-run
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: gRPC file consistency check
-#        run: ./tests/grpc_consistency_check.sh
-#      - name: OpenAPI file consistency check
-#        run: ./tests/openapi_consistency_check.sh
-#
-#  test-shard-snapshot-api-s3-minio:
-#    runs-on: ubuntu-latest
-#    # Setup minio server
-#    services:
-#      minio:
-#        image: satantime/minio-server
-#        ports:
-#          - 9000:9000
-#        env:
-#          MINIO_ACCESS_KEY: "minioadmin"
-#          MINIO_SECRET_KEY: "minioadmin"
-#    steps:
-#      - name: Setup test bucket
-#        env:
-#          AWS_ACCESS_KEY_ID: "minioadmin"
-#          AWS_SECRET_ACCESS_KEY: "minioadmin"
-#          AWS_EC2_METADATA_DISABLED: "true"
-#        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - uses: actions/checkout@v4
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Install dependencies
-#        run: sudo apt-get install clang jq
-#      - name: Build
-#        run: cargo build --bin qdrant --locked
-#      - name: Run Shard Snapshot API Tests (local)
-#        shell: bash
-#        run: |
-#          cargo run &
-#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-#          sleep 10
-#
-#          ./tests/shard-snapshot-api.sh test-all
-#      - name: Run Shard Snapshot API Tests (s3)
-#        shell: bash
-#        run: |
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
-#
-#          cargo run &
-#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-#          sleep 10
-#
-#          ./tests/shard-snapshot-api.sh test-all
+  integration-tests-consensus:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - name: Install dependencies
+        run: sudo apt-get install clang
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+
+          poetry -C tests check --lock
+          poetry -C tests install --no-root
+      - name: Build
+        run: cargo build --features "service_debug data-consistency-check" --locked
+      - name: Run integration tests - 1 peer
+        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
+        shell: bash
+      - name: Run integration tests - multiple peers - pytest
+        run: poetry --project tests run pytest tests/consensus_tests --durations=10
+        timeout-minutes: 60
+      - name: upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          path: consensus_test_logs
+          name: consensus-test-logs
+          retention-days: 10
+
+  test-consensus-compose:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+
+          poetry -C tests check --lock
+          poetry -C tests install --no-root
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker build
+        id: docker-build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: qdrant_consensus
+          cache-from: |
+            type=gha,scope=${{ github.ref }}
+            type=gha,scope=${{ github.base_ref }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Cancel other jobs in a run if Docker build failed
+        if: failure() && steps.docker-build.outcome == 'failure'
+        uses: ./.github/actions/cancel-workflow-run
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run integration tests - multiple peers - compose
+        run: poetry run bash ./test_restart.sh
+        working-directory: ./tests/consensus_tests
+
+  test-consistency:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install dependencies
+        run: sudo apt-get install -y clang jq
+      - name: Docker build
+        id: docker-build
+        uses: docker/build-push-action@v6
+        with:
+          context: tools/schema2openapi
+          tags: schema2openapi
+          cache-from: |
+            type=gha,scope=${{ github.ref }}-schema2openapi
+            type=gha,scope=${{ github.base_ref }}-schema2openapi
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Cancel other jobs in a run if Docker build failed
+        if: failure() && steps.docker-build.outcome == 'failure'
+        uses: ./.github/actions/cancel-workflow-run
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: gRPC file consistency check
+        run: ./tests/grpc_consistency_check.sh
+      - name: OpenAPI file consistency check
+        run: ./tests/openapi_consistency_check.sh
+
+  test-shard-snapshot-api-s3-minio:
+    runs-on: ubuntu-latest
+    # Setup minio server
+    services:
+      minio:
+        image: satantime/minio-server
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ACCESS_KEY: "minioadmin"
+          MINIO_SECRET_KEY: "minioadmin"
+    steps:
+      - name: Setup test bucket
+        env:
+          AWS_ACCESS_KEY_ID: "minioadmin"
+          AWS_SECRET_ACCESS_KEY: "minioadmin"
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: sudo apt-get install clang jq
+      - name: Build
+        run: cargo build --bin qdrant --locked
+      - name: Run Shard Snapshot API Tests (local)
+        shell: bash
+        run: |
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all
+      - name: Run Shard Snapshot API Tests (s3)
+        shell: bash
+        run: |
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -257,24 +257,19 @@ jobs:
         run: |
           poetry -C tests check --lock
           poetry -C tests install --no-root
-#      - name: Build Qdrant Docker image
-#        id: docker-build
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: .
-#          tags: qdrant/qdrant:e2e-tests
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}-e2e
-#            type=gha,scope=${{ github.base_ref }}-e2e
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
-#          load: true
-#          build-args: |
-#            PROFILE=ci
       - name: Build Qdrant Docker image
         id: docker-build
-        run: |
-          echo "Failing for testing"
-          exit 1
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: qdrant/qdrant:e2e-tests
+          cache-from: |
+            type=gha,scope=${{ github.ref }}-e2e
+            type=gha,scope=${{ github.base_ref }}-e2e
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
+          load: true
+          build-args: |
+            PROFILE=ci
       - name: Cancel other jobs in a run if Docker build failed
         if: failure() && steps.docker-build.outcome == 'failure'
         uses: ./.github/actions/cancel-workflow-run

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,183 +42,183 @@ jobs:
         run: poetry --project tests run bash ./tests/integration-tests.sh
         shell: bash
 
-  integration-tests-consensus:
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - name: Install dependencies
-        run: sudo apt-get install clang
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-
-          poetry -C tests check --lock
-          poetry -C tests install --no-root
-      - name: Build
-        run: cargo build --features "service_debug data-consistency-check" --locked
-      - name: Run integration tests - 1 peer
-        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
-        shell: bash
-      - name: Run integration tests - multiple peers - pytest
-        run: poetry --project tests run pytest tests/consensus_tests --durations=10
-        timeout-minutes: 60
-      - name: upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          path: consensus_test_logs
-          name: consensus-test-logs
-          retention-days: 10
-
-  test-consensus-compose:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-
-          poetry -C tests check --lock
-          poetry -C tests install --no-root
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker build
-        id: docker-build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: qdrant_consensus
-          cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Cancel other jobs in a run if Docker build failed
-        if: failure() && steps.docker-build.outcome == 'failure'
-        uses: ./.github/actions/cancel-workflow-run
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run integration tests - multiple peers - compose
-        run: poetry run bash ./test_restart.sh
-        working-directory: ./tests/consensus_tests
-
-  test-consistency:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install dependencies
-        run: sudo apt-get install -y clang jq
-      - name: Docker build
-        id: docker-build
-        uses: docker/build-push-action@v6
-        with:
-          context: tools/schema2openapi
-          tags: schema2openapi
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-schema2openapi
-            type=gha,scope=${{ github.base_ref }}-schema2openapi
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Cancel other jobs in a run if Docker build failed
-        if: failure() && steps.docker-build.outcome == 'failure'
-        uses: ./.github/actions/cancel-workflow-run
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: gRPC file consistency check
-        run: ./tests/grpc_consistency_check.sh
-      - name: OpenAPI file consistency check
-        run: ./tests/openapi_consistency_check.sh
-
-  test-shard-snapshot-api-s3-minio:
-    runs-on: ubuntu-latest
-    # Setup minio server
-    services:
-      minio:
-        image: satantime/minio-server
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ACCESS_KEY: "minioadmin"
-          MINIO_SECRET_KEY: "minioadmin"
-    steps:
-      - name: Setup test bucket
-        env:
-          AWS_ACCESS_KEY_ID: "minioadmin"
-          AWS_SECRET_ACCESS_KEY: "minioadmin"
-          AWS_EC2_METADATA_DISABLED: "true"
-        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        run: sudo apt-get install clang jq
-      - name: Build
-        run: cargo build --bin qdrant --locked
-      - name: Run Shard Snapshot API Tests (local)
-        shell: bash
-        run: |
-          cargo run &
-          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-          sleep 10
-
-          ./tests/shard-snapshot-api.sh test-all
-      - name: Run Shard Snapshot API Tests (s3)
-        shell: bash
-        run: |
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
-
-          cargo run &
-          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-          sleep 10
-
-          ./tests/shard-snapshot-api.sh test-all
+#  integration-tests-consensus:
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: actions/checkout@v4
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - name: Install dependencies
+#        run: sudo apt-get install clang
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Install dependencies
+#        run: |
+#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+#
+#          poetry -C tests check --lock
+#          poetry -C tests install --no-root
+#      - name: Build
+#        run: cargo build --features "service_debug data-consistency-check" --locked
+#      - name: Run integration tests - 1 peer
+#        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
+#        shell: bash
+#      - name: Run integration tests - multiple peers - pytest
+#        run: poetry --project tests run pytest tests/consensus_tests --durations=10
+#        timeout-minutes: 60
+#      - name: upload logs
+#        uses: actions/upload-artifact@v4
+#        if: always()
+#        with:
+#          path: consensus_test_logs
+#          name: consensus-test-logs
+#          retention-days: 10
+#
+#  test-consensus-compose:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Install dependencies
+#        run: |
+#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+#
+#          poetry -C tests check --lock
+#          poetry -C tests install --no-root
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#      - name: Docker build
+#        id: docker-build
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          tags: qdrant_consensus
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}
+#            type=gha,scope=${{ github.base_ref }}
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+#          load: true
+#          build-args: |
+#            PROFILE=ci
+#      - name: Cancel other jobs in a run if Docker build failed
+#        if: failure() && steps.docker-build.outcome == 'failure'
+#        uses: ./.github/actions/cancel-workflow-run
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Run integration tests - multiple peers - compose
+#        run: poetry run bash ./test_restart.sh
+#        working-directory: ./tests/consensus_tests
+#
+#  test-consistency:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: actions/checkout@v4
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#      - name: Install dependencies
+#        run: sudo apt-get install -y clang jq
+#      - name: Docker build
+#        id: docker-build
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: tools/schema2openapi
+#          tags: schema2openapi
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}-schema2openapi
+#            type=gha,scope=${{ github.base_ref }}-schema2openapi
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
+#          load: true
+#          build-args: |
+#            PROFILE=ci
+#      - name: Cancel other jobs in a run if Docker build failed
+#        if: failure() && steps.docker-build.outcome == 'failure'
+#        uses: ./.github/actions/cancel-workflow-run
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: gRPC file consistency check
+#        run: ./tests/grpc_consistency_check.sh
+#      - name: OpenAPI file consistency check
+#        run: ./tests/openapi_consistency_check.sh
+#
+#  test-shard-snapshot-api-s3-minio:
+#    runs-on: ubuntu-latest
+#    # Setup minio server
+#    services:
+#      minio:
+#        image: satantime/minio-server
+#        ports:
+#          - 9000:9000
+#        env:
+#          MINIO_ACCESS_KEY: "minioadmin"
+#          MINIO_SECRET_KEY: "minioadmin"
+#    steps:
+#      - name: Setup test bucket
+#        env:
+#          AWS_ACCESS_KEY_ID: "minioadmin"
+#          AWS_SECRET_ACCESS_KEY: "minioadmin"
+#          AWS_EC2_METADATA_DISABLED: "true"
+#        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - uses: actions/checkout@v4
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Install dependencies
+#        run: sudo apt-get install clang jq
+#      - name: Build
+#        run: cargo build --bin qdrant --locked
+#      - name: Run Shard Snapshot API Tests (local)
+#        shell: bash
+#        run: |
+#          cargo run &
+#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+#          sleep 10
+#
+#          ./tests/shard-snapshot-api.sh test-all
+#      - name: Run Shard Snapshot API Tests (s3)
+#        shell: bash
+#        run: |
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+#
+#          cargo run &
+#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+#          sleep 10
+#
+#          ./tests/shard-snapshot-api.sh test-all
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -257,19 +257,24 @@ jobs:
         run: |
           poetry -C tests check --lock
           poetry -C tests install --no-root
+#      - name: Build Qdrant Docker image
+#        id: docker-build
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          tags: qdrant/qdrant:e2e-tests
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}-e2e
+#            type=gha,scope=${{ github.base_ref }}-e2e
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
+#          load: true
+#          build-args: |
+#            PROFILE=ci
       - name: Build Qdrant Docker image
         id: docker-build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: qdrant/qdrant:e2e-tests
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-e2e
-            type=gha,scope=${{ github.base_ref }}-e2e
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
-          load: true
-          build-args: |
-            PROFILE=ci
+        run: |
+          echo "Failing for testing"
+          exit 1
       - name: Cancel other jobs in a run if Docker build failed
         if: failure() && steps.docker-build.outcome == 'failure'
         uses: ./.github/actions/cancel-workflow-run

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -89,8 +89,6 @@ jobs:
       docker-tag: ${{ steps.docker-build.outputs.imageid }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true  # Fetch LFS files automatically
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Qdrant Docker image
@@ -100,9 +98,9 @@ jobs:
           context: .
           tags: qdrant/qdrant:test
           cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+            type=gha,scope=${{ github.ref }}-tests
+            type=gha,scope=${{ github.base_ref }}-tests
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}-tests
           outputs: type=docker,dest=/tmp/qdrant-image.tar
           build-args: |
             PROFILE=ci
@@ -253,6 +251,8 @@ jobs:
         run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
 
       - uses: actions/checkout@v4
+        with:
+          lfs: true  # Fetch LFS files automatically
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master, dev, ci-image-build-fail-fast ]
   pull_request:
     branches: [ '**' ]
 
@@ -11,202 +11,202 @@ env:
   POETRY_VERSION: 2.1.3
 
 jobs:
-  integration-tests:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          sudo apt-get install clang
-          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-
-          poetry -C tests check --lock
-          poetry -C tests install --no-root
-      - name: Build
-        run: cargo build --features "service_debug data-consistency-check" --locked
-      - name: Run integration tests
-        run: poetry --project tests run bash ./tests/integration-tests.sh
-        shell: bash
-
-  integration-tests-consensus:
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - name: Install dependencies
-        run: sudo apt-get install clang
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-
-          poetry -C tests check --lock
-          poetry -C tests install --no-root
-      - name: Build
-        run: cargo build --features "service_debug data-consistency-check" --locked
-      - name: Run integration tests - 1 peer
-        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
-        shell: bash
-      - name: Run integration tests - multiple peers - pytest
-        run: poetry --project tests run pytest tests/consensus_tests --durations=10
-        timeout-minutes: 60
-      - name: upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          path: consensus_test_logs
-          name: consensus-test-logs
-          retention-days: 10
-
-  test-consensus-compose:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-
-          poetry -C tests check --lock
-          poetry -C tests install --no-root
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: qdrant_consensus
-          cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Run integration tests - multiple peers - compose
-        run: poetry run bash ./test_restart.sh
-        working-directory: ./tests/consensus_tests
-
-  test-consistency:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install dependencies
-        run: sudo apt-get install -y clang jq
-      - name: Docker build
-        uses: docker/build-push-action@v6
-        with:
-          context: tools/schema2openapi
-          tags: schema2openapi
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-schema2openapi
-            type=gha,scope=${{ github.base_ref }}-schema2openapi
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: gRPC file consistency check
-        run: ./tests/grpc_consistency_check.sh
-      - name: OpenAPI file consistency check
-        run: ./tests/openapi_consistency_check.sh
-
-  test-shard-snapshot-api-s3-minio:
-    runs-on: ubuntu-latest
-    # Setup minio server
-    services:
-      minio:
-        image: satantime/minio-server
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ACCESS_KEY: "minioadmin"
-          MINIO_SECRET_KEY: "minioadmin"
-    steps:
-      - name: Setup test bucket
-        env:
-          AWS_ACCESS_KEY_ID: "minioadmin"
-          AWS_SECRET_ACCESS_KEY: "minioadmin"
-          AWS_EC2_METADATA_DISABLED: "true"
-        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        run: sudo apt-get install clang jq
-      - name: Build
-        run: cargo build --bin qdrant --locked
-      - name: Run Shard Snapshot API Tests (local)
-        shell: bash
-        run: |
-          cargo run &
-          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-          sleep 10
-
-          ./tests/shard-snapshot-api.sh test-all
-      - name: Run Shard Snapshot API Tests (s3)
-        shell: bash
-        run: |
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
-
-          cargo run &
-          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-          sleep 10
-
-          ./tests/shard-snapshot-api.sh test-all
+#  integration-tests:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: actions/checkout@v4
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Install dependencies
+#        run: |
+#          sudo apt-get install clang
+#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+#
+#          poetry -C tests check --lock
+#          poetry -C tests install --no-root
+#      - name: Build
+#        run: cargo build --features "service_debug data-consistency-check" --locked
+#      - name: Run integration tests
+#        run: poetry --project tests run bash ./tests/integration-tests.sh
+#        shell: bash
+#
+#  integration-tests-consensus:
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: actions/checkout@v4
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - name: Install dependencies
+#        run: sudo apt-get install clang
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Install dependencies
+#        run: |
+#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+#
+#          poetry -C tests check --lock
+#          poetry -C tests install --no-root
+#      - name: Build
+#        run: cargo build --features "service_debug data-consistency-check" --locked
+#      - name: Run integration tests - 1 peer
+#        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
+#        shell: bash
+#      - name: Run integration tests - multiple peers - pytest
+#        run: poetry --project tests run pytest tests/consensus_tests --durations=10
+#        timeout-minutes: 60
+#      - name: upload logs
+#        uses: actions/upload-artifact@v4
+#        if: always()
+#        with:
+#          path: consensus_test_logs
+#          name: consensus-test-logs
+#          retention-days: 10
+#
+#  test-consensus-compose:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Install dependencies
+#        run: |
+#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+#
+#          poetry -C tests check --lock
+#          poetry -C tests install --no-root
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#      - name: Docker build
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          tags: qdrant_consensus
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}
+#            type=gha,scope=${{ github.base_ref }}
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+#          load: true
+#          build-args: |
+#            PROFILE=ci
+#      - name: Run integration tests - multiple peers - compose
+#        run: poetry run bash ./test_restart.sh
+#        working-directory: ./tests/consensus_tests
+#
+#  test-consistency:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: actions/checkout@v4
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#      - name: Install dependencies
+#        run: sudo apt-get install -y clang jq
+#      - name: Docker build
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: tools/schema2openapi
+#          tags: schema2openapi
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}-schema2openapi
+#            type=gha,scope=${{ github.base_ref }}-schema2openapi
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
+#          load: true
+#          build-args: |
+#            PROFILE=ci
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: gRPC file consistency check
+#        run: ./tests/grpc_consistency_check.sh
+#      - name: OpenAPI file consistency check
+#        run: ./tests/openapi_consistency_check.sh
+#
+#  test-shard-snapshot-api-s3-minio:
+#    runs-on: ubuntu-latest
+#    # Setup minio server
+#    services:
+#      minio:
+#        image: satantime/minio-server
+#        ports:
+#          - 9000:9000
+#        env:
+#          MINIO_ACCESS_KEY: "minioadmin"
+#          MINIO_SECRET_KEY: "minioadmin"
+#    steps:
+#      - name: Setup test bucket
+#        env:
+#          AWS_ACCESS_KEY_ID: "minioadmin"
+#          AWS_SECRET_ACCESS_KEY: "minioadmin"
+#          AWS_EC2_METADATA_DISABLED: "true"
+#        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - uses: actions/checkout@v4
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Install dependencies
+#        run: sudo apt-get install clang jq
+#      - name: Build
+#        run: cargo build --bin qdrant --locked
+#      - name: Run Shard Snapshot API Tests (local)
+#        shell: bash
+#        run: |
+#          cargo run &
+#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+#          sleep 10
+#
+#          ./tests/shard-snapshot-api.sh test-all
+#      - name: Run Shard Snapshot API Tests (s3)
+#        shell: bash
+#        run: |
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+#
+#          cargo run &
+#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+#          sleep 10
+#
+#          ./tests/shard-snapshot-api.sh test-all
 
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master, dev, ci-image-build-fail-fast ]
   pull_request:
     branches: [ '**' ]
 
@@ -42,171 +42,178 @@ jobs:
         run: poetry --project tests run bash ./tests/integration-tests.sh
         shell: bash
 
-  integration-tests-consensus:
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - name: Install dependencies
-        run: sudo apt-get install clang
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-
-          poetry -C tests check --lock
-          poetry -C tests install --no-root
-      - name: Build
-        run: cargo build --features "service_debug data-consistency-check" --locked
-      - name: Run integration tests - 1 peer
-        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
-        shell: bash
-      - name: Run integration tests - multiple peers - pytest
-        run: poetry --project tests run pytest tests/consensus_tests --durations=10
-        timeout-minutes: 60
-      - name: upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          path: consensus_test_logs
-          name: consensus-test-logs
-          retention-days: 10
-
-  test-consensus-compose:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-
-          poetry -C tests check --lock
-          poetry -C tests install --no-root
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: qdrant_consensus
-          cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Run integration tests - multiple peers - compose
-        run: poetry run bash ./test_restart.sh
-        working-directory: ./tests/consensus_tests
-
-  test-consistency:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install dependencies
-        run: sudo apt-get install -y clang jq
-      - name: Docker build
-        uses: docker/build-push-action@v6
-        with:
-          context: tools/schema2openapi
-          tags: schema2openapi
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-schema2openapi
-            type=gha,scope=${{ github.base_ref }}-schema2openapi
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: gRPC file consistency check
-        run: ./tests/grpc_consistency_check.sh
-      - name: OpenAPI file consistency check
-        run: ./tests/openapi_consistency_check.sh
-
-  test-shard-snapshot-api-s3-minio:
-    runs-on: ubuntu-latest
-    # Setup minio server
-    services:
-      minio:
-        image: satantime/minio-server
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ACCESS_KEY: "minioadmin"
-          MINIO_SECRET_KEY: "minioadmin"
-    steps:
-      - name: Setup test bucket
-        env:
-          AWS_ACCESS_KEY_ID: "minioadmin"
-          AWS_SECRET_ACCESS_KEY: "minioadmin"
-          AWS_EC2_METADATA_DISABLED: "true"
-        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration-tests
-      - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        run: sudo apt-get install clang jq
-      - name: Build
-        run: cargo build --bin qdrant --locked
-      - name: Run Shard Snapshot API Tests (local)
-        shell: bash
-        run: |
-          cargo run &
-          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-          sleep 10
-
-          ./tests/shard-snapshot-api.sh test-all
-      - name: Run Shard Snapshot API Tests (s3)
-        shell: bash
-        run: |
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
-
-          cargo run &
-          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-          sleep 10
-
-          ./tests/shard-snapshot-api.sh test-all
+#  integration-tests-consensus:
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: actions/checkout@v4
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - name: Install dependencies
+#        run: sudo apt-get install clang
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Install dependencies
+#        run: |
+#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+#
+#          poetry -C tests check --lock
+#          poetry -C tests install --no-root
+#      - name: Build
+#        run: cargo build --features "service_debug data-consistency-check" --locked
+#      - name: Run integration tests - 1 peer
+#        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
+#        shell: bash
+#      - name: Run integration tests - multiple peers - pytest
+#        run: poetry --project tests run pytest tests/consensus_tests --durations=10
+#        timeout-minutes: 60
+#      - name: upload logs
+#        uses: actions/upload-artifact@v4
+#        if: always()
+#        with:
+#          path: consensus_test_logs
+#          name: consensus-test-logs
+#          retention-days: 10
+#
+#  test-consensus-compose:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Install dependencies
+#        run: |
+#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+#
+#          poetry -C tests check --lock
+#          poetry -C tests install --no-root
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#      - name: Docker build
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          tags: qdrant_consensus
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}
+#            type=gha,scope=${{ github.base_ref }}
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+#          load: true
+#          build-args: |
+#            PROFILE=ci
+#      - name: Cancel other jobs if Docker build failed
+#        if: failure() && steps.docker-build.outcome == 'failure'
+#        uses: ./.github/actions/cancel-other-running-jobs
+#      - name: Run integration tests - multiple peers - compose
+#        run: poetry run bash ./test_restart.sh
+#        working-directory: ./tests/consensus_tests
+#
+#  test-consistency:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: actions/checkout@v4
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#      - name: Install dependencies
+#        run: sudo apt-get install -y clang jq
+#      - name: Docker build
+#        id: docker-build
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: tools/schema2openapi
+#          tags: schema2openapi
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}-schema2openapi
+#            type=gha,scope=${{ github.base_ref }}-schema2openapi
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
+#          load: true
+#          build-args: |
+#            PROFILE=ci
+#      - name: Cancel other jobs if Docker build failed
+#        if: failure() && steps.docker-build.outcome == 'failure'
+#        uses: ./.github/actions/cancel-other-running-jobs
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: gRPC file consistency check
+#        run: ./tests/grpc_consistency_check.sh
+#      - name: OpenAPI file consistency check
+#        run: ./tests/openapi_consistency_check.sh
+#
+#  test-shard-snapshot-api-s3-minio:
+#    runs-on: ubuntu-latest
+#    # Setup minio server
+#    services:
+#      minio:
+#        image: satantime/minio-server
+#        ports:
+#          - 9000:9000
+#        env:
+#          MINIO_ACCESS_KEY: "minioadmin"
+#          MINIO_SECRET_KEY: "minioadmin"
+#    steps:
+#      - name: Setup test bucket
+#        env:
+#          AWS_ACCESS_KEY_ID: "minioadmin"
+#          AWS_SECRET_ACCESS_KEY: "minioadmin"
+#          AWS_EC2_METADATA_DISABLED: "true"
+#        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
+#      - name: Install minimal stable
+#        uses: dtolnay/rust-toolchain@stable
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          shared-key: integration-tests
+#      - uses: actions/checkout@v4
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v3
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Install dependencies
+#        run: sudo apt-get install clang jq
+#      - name: Build
+#        run: cargo build --bin qdrant --locked
+#      - name: Run Shard Snapshot API Tests (local)
+#        shell: bash
+#        run: |
+#          cargo run &
+#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+#          sleep 10
+#
+#          ./tests/shard-snapshot-api.sh test-all
+#      - name: Run Shard Snapshot API Tests (s3)
+#        shell: bash
+#        run: |
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
+#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+#
+#          cargo run &
+#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+#          sleep 10
+#
+#          ./tests/shard-snapshot-api.sh test-all
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -245,18 +252,28 @@ jobs:
         run: |
           poetry -C tests check --lock
           poetry -C tests install --no-root
+#      - name: Build Qdrant Docker image
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          tags: qdrant/qdrant:e2e-tests
+#          cache-from: |
+#            type=gha,scope=${{ github.ref }}-e2e
+#            type=gha,scope=${{ github.base_ref }}-e2e
+#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
+#          load: true
+#          build-args: |
+#            PROFILE=ci
       - name: Build Qdrant Docker image
-        uses: docker/build-push-action@v6
+        id: docker-build
+        run: |
+          echo "Failing for testing"
+          exit 1
+      - name: Cancel other jobs if Docker build failed
+        if: failure() && steps.docker-build.outcome == 'failure'
+        uses: ./.github/actions/cancel-other-running-jobs
         with:
-          context: .
-          tags: qdrant/qdrant:e2e-tests
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-e2e
-            type=gha,scope=${{ github.base_ref }}-e2e
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
-          load: true
-          build-args: |
-            PROFILE=ci
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Docker image
         run: docker images | grep qdrant
       - name: Run e2e tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -114,7 +114,7 @@ jobs:
 #            PROFILE=ci
 #      - name: Cancel other jobs if Docker build failed
 #        if: failure() && steps.docker-build.outcome == 'failure'
-#        uses: ./.github/actions/cancel-other-running-jobs
+#        uses: ./.github/actions/cancel-workflow-run
 #      - name: Run integration tests - multiple peers - compose
 #        run: poetry run bash ./test_restart.sh
 #        working-directory: ./tests/consensus_tests
@@ -149,7 +149,7 @@ jobs:
 #            PROFILE=ci
 #      - name: Cancel other jobs if Docker build failed
 #        if: failure() && steps.docker-build.outcome == 'failure'
-#        uses: ./.github/actions/cancel-other-running-jobs
+#        uses: ./.github/actions/cancel-workflow-run
 #      - name: Install Protoc
 #        uses: arduino/setup-protoc@v3
 #        with:
@@ -271,7 +271,7 @@ jobs:
           exit 1
       - name: Cancel other jobs if Docker build failed
         if: failure() && steps.docker-build.outcome == 'failure'
-        uses: ./.github/actions/cancel-other-running-jobs
+        uses: ./.github/actions/cancel-workflow-run
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Docker image

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker build
+        id: docker-build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -257,6 +258,7 @@ jobs:
           poetry -C tests check --lock
           poetry -C tests install --no-root
       - name: Build Qdrant Docker image
+        id: docker-build
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   push:
-    branches: [ master, dev, ci-image-build-fail-fast ]
+    branches: [ master, dev ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,178 +42,182 @@ jobs:
         run: poetry --project tests run bash ./tests/integration-tests.sh
         shell: bash
 
-#  integration-tests-consensus:
-#
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: actions/checkout@v4
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - name: Install dependencies
-#        run: sudo apt-get install clang
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#      - name: Install dependencies
-#        run: |
-#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-#
-#          poetry -C tests check --lock
-#          poetry -C tests install --no-root
-#      - name: Build
-#        run: cargo build --features "service_debug data-consistency-check" --locked
-#      - name: Run integration tests - 1 peer
-#        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
-#        shell: bash
-#      - name: Run integration tests - multiple peers - pytest
-#        run: poetry --project tests run pytest tests/consensus_tests --durations=10
-#        timeout-minutes: 60
-#      - name: upload logs
-#        uses: actions/upload-artifact@v4
-#        if: always()
-#        with:
-#          path: consensus_test_logs
-#          name: consensus-test-logs
-#          retention-days: 10
-#
-#  test-consensus-compose:
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#      - name: Install dependencies
-#        run: |
-#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-#
-#          poetry -C tests check --lock
-#          poetry -C tests install --no-root
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Docker build
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: .
-#          tags: qdrant_consensus
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}
-#            type=gha,scope=${{ github.base_ref }}
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-#          load: true
-#          build-args: |
-#            PROFILE=ci
-#      - name: Cancel other jobs if Docker build failed
-#        if: failure() && steps.docker-build.outcome == 'failure'
-#        uses: ./.github/actions/cancel-workflow-run
-#      - name: Run integration tests - multiple peers - compose
-#        run: poetry run bash ./test_restart.sh
-#        working-directory: ./tests/consensus_tests
-#
-#  test-consistency:
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: actions/checkout@v4
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Install dependencies
-#        run: sudo apt-get install -y clang jq
-#      - name: Docker build
-#        id: docker-build
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: tools/schema2openapi
-#          tags: schema2openapi
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}-schema2openapi
-#            type=gha,scope=${{ github.base_ref }}-schema2openapi
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
-#          load: true
-#          build-args: |
-#            PROFILE=ci
-#      - name: Cancel other jobs if Docker build failed
-#        if: failure() && steps.docker-build.outcome == 'failure'
-#        uses: ./.github/actions/cancel-workflow-run
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: gRPC file consistency check
-#        run: ./tests/grpc_consistency_check.sh
-#      - name: OpenAPI file consistency check
-#        run: ./tests/openapi_consistency_check.sh
-#
-#  test-shard-snapshot-api-s3-minio:
-#    runs-on: ubuntu-latest
-#    # Setup minio server
-#    services:
-#      minio:
-#        image: satantime/minio-server
-#        ports:
-#          - 9000:9000
-#        env:
-#          MINIO_ACCESS_KEY: "minioadmin"
-#          MINIO_SECRET_KEY: "minioadmin"
-#    steps:
-#      - name: Setup test bucket
-#        env:
-#          AWS_ACCESS_KEY_ID: "minioadmin"
-#          AWS_SECRET_ACCESS_KEY: "minioadmin"
-#          AWS_EC2_METADATA_DISABLED: "true"
-#        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - uses: actions/checkout@v4
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Install dependencies
-#        run: sudo apt-get install clang jq
-#      - name: Build
-#        run: cargo build --bin qdrant --locked
-#      - name: Run Shard Snapshot API Tests (local)
-#        shell: bash
-#        run: |
-#          cargo run &
-#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-#          sleep 10
-#
-#          ./tests/shard-snapshot-api.sh test-all
-#      - name: Run Shard Snapshot API Tests (s3)
-#        shell: bash
-#        run: |
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
-#
-#          cargo run &
-#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-#          sleep 10
-#
-#          ./tests/shard-snapshot-api.sh test-all
+  integration-tests-consensus:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - name: Install dependencies
+        run: sudo apt-get install clang
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+
+          poetry -C tests check --lock
+          poetry -C tests install --no-root
+      - name: Build
+        run: cargo build --features "service_debug data-consistency-check" --locked
+      - name: Run integration tests - 1 peer
+        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
+        shell: bash
+      - name: Run integration tests - multiple peers - pytest
+        run: poetry --project tests run pytest tests/consensus_tests --durations=10
+        timeout-minutes: 60
+      - name: upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          path: consensus_test_logs
+          name: consensus-test-logs
+          retention-days: 10
+
+  test-consensus-compose:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+
+          poetry -C tests check --lock
+          poetry -C tests install --no-root
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: qdrant_consensus
+          cache-from: |
+            type=gha,scope=${{ github.ref }}
+            type=gha,scope=${{ github.base_ref }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Cancel other jobs in a run if Docker build failed
+        if: failure() && steps.docker-build.outcome == 'failure'
+        uses: ./.github/actions/cancel-workflow-run
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run integration tests - multiple peers - compose
+        run: poetry run bash ./test_restart.sh
+        working-directory: ./tests/consensus_tests
+
+  test-consistency:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install dependencies
+        run: sudo apt-get install -y clang jq
+      - name: Docker build
+        id: docker-build
+        uses: docker/build-push-action@v6
+        with:
+          context: tools/schema2openapi
+          tags: schema2openapi
+          cache-from: |
+            type=gha,scope=${{ github.ref }}-schema2openapi
+            type=gha,scope=${{ github.base_ref }}-schema2openapi
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Cancel other jobs in a run if Docker build failed
+        if: failure() && steps.docker-build.outcome == 'failure'
+        uses: ./.github/actions/cancel-workflow-run
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: gRPC file consistency check
+        run: ./tests/grpc_consistency_check.sh
+      - name: OpenAPI file consistency check
+        run: ./tests/openapi_consistency_check.sh
+
+  test-shard-snapshot-api-s3-minio:
+    runs-on: ubuntu-latest
+    # Setup minio server
+    services:
+      minio:
+        image: satantime/minio-server
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ACCESS_KEY: "minioadmin"
+          MINIO_SECRET_KEY: "minioadmin"
+    steps:
+      - name: Setup test bucket
+        env:
+          AWS_ACCESS_KEY_ID: "minioadmin"
+          AWS_SECRET_ACCESS_KEY: "minioadmin"
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: sudo apt-get install clang jq
+      - name: Build
+        run: cargo build --bin qdrant --locked
+      - name: Run Shard Snapshot API Tests (local)
+        shell: bash
+        run: |
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all
+      - name: Run Shard Snapshot API Tests (s3)
+        shell: bash
+        run: |
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -252,24 +256,19 @@ jobs:
         run: |
           poetry -C tests check --lock
           poetry -C tests install --no-root
-#      - name: Build Qdrant Docker image
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: .
-#          tags: qdrant/qdrant:e2e-tests
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}-e2e
-#            type=gha,scope=${{ github.base_ref }}-e2e
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
-#          load: true
-#          build-args: |
-#            PROFILE=ci
       - name: Build Qdrant Docker image
-        id: docker-build
-        run: |
-          echo "Failing for testing"
-          exit 1
-      - name: Cancel other jobs if Docker build failed
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: qdrant/qdrant:e2e-tests
+          cache-from: |
+            type=gha,scope=${{ github.ref }}-e2e
+            type=gha,scope=${{ github.base_ref }}-e2e
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Cancel other jobs in a run if Docker build failed
         if: failure() && steps.docker-build.outcome == 'failure'
         uses: ./.github/actions/cancel-workflow-run
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,9 +83,39 @@ jobs:
           name: consensus-test-logs
           retention-days: 10
 
-  test-consensus-compose:
-
+  docker-build-tests-image:
     runs-on: ubuntu-latest
+    outputs:
+      docker-tag: ${{ steps.docker-build.outputs.imageid }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true  # Fetch LFS files automatically
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Qdrant Docker image
+        id: docker-build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: qdrant/qdrant:test
+          cache-from: |
+            type=gha,scope=${{ github.ref }}
+            type=gha,scope=${{ github.base_ref }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+          outputs: type=docker,dest=/tmp/qdrant-image.tar
+          build-args: |
+            PROFILE=ci
+      - name: Upload Docker image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdrant-docker-image
+          path: /tmp/qdrant-image.tar
+          retention-days: 1
+
+  test-consensus-compose:
+    runs-on: ubuntu-latest
+    needs: docker-build-tests-image
 
     steps:
       - uses: actions/checkout@v4
@@ -98,26 +128,15 @@ jobs:
 
           poetry -C tests check --lock
           poetry -C tests install --no-root
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker build
-        id: docker-build
-        uses: docker/build-push-action@v6
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          tags: qdrant_consensus
-          cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Cancel other jobs in a run if Docker build failed
-        if: failure() && steps.docker-build.outcome == 'failure'
-        uses: ./.github/actions/cancel-workflow-run
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: qdrant-docker-image
+          path: /tmp
+      - name: Load Docker image
+        run: |
+          docker load -i /tmp/qdrant-image.tar
+          docker tag qdrant/qdrant:test qdrant_consensus
       - name: Run integration tests - multiple peers - compose
         run: poetry run bash ./test_restart.sh
         working-directory: ./tests/consensus_tests
@@ -213,6 +232,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
+    needs: docker-build-tests-image
 
     # Setup minio server
     services:
@@ -233,13 +253,9 @@ jobs:
         run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
 
       - uses: actions/checkout@v4
-        with:
-          lfs: true  # Fetch LFS files automatically
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
@@ -248,24 +264,15 @@ jobs:
         run: |
           poetry -C tests check --lock
           poetry -C tests install --no-root
-      - name: Build Qdrant Docker image
-        id: docker-build
-        uses: docker/build-push-action@v6
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          tags: qdrant/qdrant:e2e-tests
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-e2e
-            type=gha,scope=${{ github.base_ref }}-e2e
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Cancel other jobs in a run if Docker build failed
-        if: failure() && steps.docker-build.outcome == 'failure'
-        uses: ./.github/actions/cancel-workflow-run
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: qdrant-docker-image
+          path: /tmp
+      - name: Load Docker image
+        run: |
+          docker load -i /tmp/qdrant-image.tar
+          docker tag qdrant/qdrant:test qdrant/qdrant:e2e-tests
       - name: Verify Docker image
         run: docker images | grep qdrant
       - name: Run e2e tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   push:
-    branches: [ master, dev, ci-image-build-fail-fast ]
+    branches: [ master, dev ]
   pull_request:
     branches: [ '**' ]
 
@@ -11,202 +11,202 @@ env:
   POETRY_VERSION: 2.1.3
 
 jobs:
-#  integration-tests:
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: actions/checkout@v4
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#      - name: Install dependencies
-#        run: |
-#          sudo apt-get install clang
-#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-#
-#          poetry -C tests check --lock
-#          poetry -C tests install --no-root
-#      - name: Build
-#        run: cargo build --features "service_debug data-consistency-check" --locked
-#      - name: Run integration tests
-#        run: poetry --project tests run bash ./tests/integration-tests.sh
-#        shell: bash
-#
-#  integration-tests-consensus:
-#
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: actions/checkout@v4
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - name: Install dependencies
-#        run: sudo apt-get install clang
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#      - name: Install dependencies
-#        run: |
-#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-#
-#          poetry -C tests check --lock
-#          poetry -C tests install --no-root
-#      - name: Build
-#        run: cargo build --features "service_debug data-consistency-check" --locked
-#      - name: Run integration tests - 1 peer
-#        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
-#        shell: bash
-#      - name: Run integration tests - multiple peers - pytest
-#        run: poetry --project tests run pytest tests/consensus_tests --durations=10
-#        timeout-minutes: 60
-#      - name: upload logs
-#        uses: actions/upload-artifact@v4
-#        if: always()
-#        with:
-#          path: consensus_test_logs
-#          name: consensus-test-logs
-#          retention-days: 10
-#
-#  test-consensus-compose:
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#      - name: Install dependencies
-#        run: |
-#          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-#
-#          poetry -C tests check --lock
-#          poetry -C tests install --no-root
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Docker build
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: .
-#          tags: qdrant_consensus
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}
-#            type=gha,scope=${{ github.base_ref }}
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-#          load: true
-#          build-args: |
-#            PROFILE=ci
-#      - name: Run integration tests - multiple peers - compose
-#        run: poetry run bash ./test_restart.sh
-#        working-directory: ./tests/consensus_tests
-#
-#  test-consistency:
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: actions/checkout@v4
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Install dependencies
-#        run: sudo apt-get install -y clang jq
-#      - name: Docker build
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: tools/schema2openapi
-#          tags: schema2openapi
-#          cache-from: |
-#            type=gha,scope=${{ github.ref }}-schema2openapi
-#            type=gha,scope=${{ github.base_ref }}-schema2openapi
-#          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
-#          load: true
-#          build-args: |
-#            PROFILE=ci
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: gRPC file consistency check
-#        run: ./tests/grpc_consistency_check.sh
-#      - name: OpenAPI file consistency check
-#        run: ./tests/openapi_consistency_check.sh
-#
-#  test-shard-snapshot-api-s3-minio:
-#    runs-on: ubuntu-latest
-#    # Setup minio server
-#    services:
-#      minio:
-#        image: satantime/minio-server
-#        ports:
-#          - 9000:9000
-#        env:
-#          MINIO_ACCESS_KEY: "minioadmin"
-#          MINIO_SECRET_KEY: "minioadmin"
-#    steps:
-#      - name: Setup test bucket
-#        env:
-#          AWS_ACCESS_KEY_ID: "minioadmin"
-#          AWS_SECRET_ACCESS_KEY: "minioadmin"
-#          AWS_EC2_METADATA_DISABLED: "true"
-#        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
-#      - name: Install minimal stable
-#        uses: dtolnay/rust-toolchain@stable
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          shared-key: integration-tests
-#      - uses: actions/checkout@v4
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v3
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Install dependencies
-#        run: sudo apt-get install clang jq
-#      - name: Build
-#        run: cargo build --bin qdrant --locked
-#      - name: Run Shard Snapshot API Tests (local)
-#        shell: bash
-#        run: |
-#          cargo run &
-#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-#          sleep 10
-#
-#          ./tests/shard-snapshot-api.sh test-all
-#      - name: Run Shard Snapshot API Tests (s3)
-#        shell: bash
-#        run: |
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
-#          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
-#
-#          cargo run &
-#          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-#          sleep 10
-#
-#          ./tests/shard-snapshot-api.sh test-all
+  integration-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          sudo apt-get install clang
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+
+          poetry -C tests check --lock
+          poetry -C tests install --no-root
+      - name: Build
+        run: cargo build --features "service_debug data-consistency-check" --locked
+      - name: Run integration tests
+        run: poetry --project tests run bash ./tests/integration-tests.sh
+        shell: bash
+
+  integration-tests-consensus:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - name: Install dependencies
+        run: sudo apt-get install clang
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+
+          poetry -C tests check --lock
+          poetry -C tests install --no-root
+      - name: Build
+        run: cargo build --features "service_debug data-consistency-check" --locked
+      - name: Run integration tests - 1 peer
+        run: poetry --project tests run bash ./tests/integration-tests.sh distributed
+        shell: bash
+      - name: Run integration tests - multiple peers - pytest
+        run: poetry --project tests run pytest tests/consensus_tests --durations=10
+        timeout-minutes: 60
+      - name: upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          path: consensus_test_logs
+          name: consensus-test-logs
+          retention-days: 10
+
+  test-consensus-compose:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+
+          poetry -C tests check --lock
+          poetry -C tests install --no-root
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: qdrant_consensus
+          cache-from: |
+            type=gha,scope=${{ github.ref }}
+            type=gha,scope=${{ github.base_ref }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Run integration tests - multiple peers - compose
+        run: poetry run bash ./test_restart.sh
+        working-directory: ./tests/consensus_tests
+
+  test-consistency:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install dependencies
+        run: sudo apt-get install -y clang jq
+      - name: Docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: tools/schema2openapi
+          tags: schema2openapi
+          cache-from: |
+            type=gha,scope=${{ github.ref }}-schema2openapi
+            type=gha,scope=${{ github.base_ref }}-schema2openapi
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: gRPC file consistency check
+        run: ./tests/grpc_consistency_check.sh
+      - name: OpenAPI file consistency check
+        run: ./tests/openapi_consistency_check.sh
+
+  test-shard-snapshot-api-s3-minio:
+    runs-on: ubuntu-latest
+    # Setup minio server
+    services:
+      minio:
+        image: satantime/minio-server
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ACCESS_KEY: "minioadmin"
+          MINIO_SECRET_KEY: "minioadmin"
+    steps:
+      - name: Setup test bucket
+        env:
+          AWS_ACCESS_KEY_ID: "minioadmin"
+          AWS_SECRET_ACCESS_KEY: "minioadmin"
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration-tests
+      - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: sudo apt-get install clang jq
+      - name: Build
+        run: cargo build --bin qdrant --locked
+      - name: Run Shard Snapshot API Tests (local)
+        shell: bash
+        run: |
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all
+      - name: Run Shard Snapshot API Tests (s3)
+        shell: bash
+        run: |
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all
 
   e2e-tests:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ ARG LINKER=mold
 # Enable GPU support
 ARG GPU
 
+# Download and extract web UI
+RUN mkdir /static && STATIC_DIR=/static ./tools/sync-web-ui.sh
+
 COPY --from=planner /qdrant/recipe.json recipe.json
 # `PKG_CONFIG=...` is a workaround for `xx-cargo` bug for crates using `pkg-config`!
 #
@@ -107,10 +110,6 @@ RUN PKG_CONFIG="/usr/bin/$(xx-info)-pkg-config" \
     xx-cargo build --profile $PROFILE ${FEATURES:+--features} $FEATURES --features=stacktrace ${GPU:+--features=gpu} --bin qdrant \
     && PROFILE_DIR=$(if [ "$PROFILE" = dev ]; then echo debug; else echo $PROFILE; fi) \
     && mv target/$(xx-cargo --print-target-triple)/$PROFILE_DIR/qdrant /qdrant/qdrant
-
-# Download and extract web UI
-RUN mkdir /static && STATIC_DIR=/static ./tools/sync-web-ui.sh
-
 
 # Dockerfile does not support conditional `FROM` directly.
 # To workaround this limitation, we use a multi-stage build with a different base images which have equal name to ARG value.

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,8 @@ ARG LINKER=mold
 ARG GPU
 
 # Download and extract web UI
+COPY tools/ tools/
+COPY docs/ docs/
 RUN mkdir /static && STATIC_DIR=/static ./tools/sync-web-ui.sh
 
 COPY --from=planner /qdrant/recipe.json recipe.json

--- a/tests/consensus_tests/test_restart.sh
+++ b/tests/consensus_tests/test_restart.sh
@@ -10,8 +10,14 @@ function clear_after_tests()
   docker compose down
 }
 
-# Prevent double building in docker-compose
-docker buildx build --build-arg=PROFILE=ci --load ../../ --tag=qdrant_consensus
+# Build image only if it doesn't exist (for local runs)
+# In CI, the image is already built and loaded by the workflow
+if ! docker image inspect qdrant_consensus >/dev/null 2>&1; then
+  echo "Building qdrant_consensus image..."
+  docker buildx build --build-arg=PROFILE=ci --load ../../ --tag=qdrant_consensus
+else
+  echo "Using existing qdrant_consensus image"
+fi
 docker compose down --volumes
 docker compose up -d --force-recreate
 trap clear_after_tests EXIT

--- a/tools/sync-web-ui.sh
+++ b/tools/sync-web-ui.sh
@@ -8,7 +8,32 @@ OPENAPI_FILE=${OPENAPI_DIR:-"./docs/redoc/master/openapi.json"}
 # Download `dist.zip` from the latest release of https://github.com/qdrant/qdrant-web-ui and unzip given folder
 
 # Get latest dist.zip, assume jq is installed
-DOWNLOAD_LINK=$(curl --retry 5 --retry-all-errors --silent "https://api.github.com/repos/qdrant/qdrant-web-ui/releases/latest" | jq -r '.assets[] | select(.name=="dist-qdrant.zip") | .browser_download_url')
+API_RESPONSE=$(curl --retry 5 --retry-all-errors --silent -w "\n%{http_code}" --connect-timeout 10 --max-time 30 "https://api.github.com/repos/qdrant/qdrant-web-ui/releases/latest")
+HTTP_CODE=$(echo "$API_RESPONSE" | tail -n1)
+API_RESPONSE=$(echo "$API_RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ]; then
+    echo "Error: GitHub API returned HTTP $HTTP_CODE"
+    if [ "$HTTP_CODE" = "403" ]; then
+        echo "This might be due to rate limiting. API Response:"
+        echo "$API_RESPONSE" | jq -r '.message // .' 2>/dev/null || echo "$API_RESPONSE"
+    fi
+    exit 1
+fi
+
+if [ -z "$API_RESPONSE" ]; then
+    echo "Error: Empty response from GitHub API"
+    exit 1
+fi
+
+DOWNLOAD_LINK=$(echo "$API_RESPONSE" | jq -r '.assets[] | select(.name=="dist-qdrant.zip") | .browser_download_url' 2>/dev/null)
+
+if [ -z "$DOWNLOAD_LINK" ] || [ "$DOWNLOAD_LINK" = "null" ]; then
+    echo "Error: Could not find dist-qdrant.zip in the latest release"
+    echo "Available assets:"
+    echo "$API_RESPONSE" | jq -r '.assets[]' 2>/dev/null || echo "Failed to parse assets"
+    exit 1
+fi
 
 if command -v wget &> /dev/null
 then

--- a/tools/sync-web-ui.sh
+++ b/tools/sync-web-ui.sh
@@ -6,34 +6,7 @@ STATIC_DIR=${STATIC_DIR:-"./static"}
 OPENAPI_FILE=${OPENAPI_DIR:-"./docs/redoc/master/openapi.json"}
 
 # Download `dist.zip` from the latest release of https://github.com/qdrant/qdrant-web-ui and unzip given folder
-
-# Get latest dist.zip, assume jq is installed
-API_RESPONSE=$(curl --retry 5 --retry-all-errors --silent -w "\n%{http_code}" --connect-timeout 10 --max-time 30 "https://api.github.com/repos/qdrant/qdrant-web-ui/releases/latest")
-HTTP_CODE=$(echo "$API_RESPONSE" | tail -n1)
-API_RESPONSE=$(echo "$API_RESPONSE" | sed '$d')
-
-if [ "$HTTP_CODE" != "200" ]; then
-    echo "Error: GitHub API returned HTTP $HTTP_CODE"
-    if [ "$HTTP_CODE" = "403" ]; then
-        echo "This might be due to rate limiting. API Response:"
-        echo "$API_RESPONSE" | jq -r '.message // .' 2>/dev/null || echo "$API_RESPONSE"
-    fi
-    exit 1
-fi
-
-if [ -z "$API_RESPONSE" ]; then
-    echo "Error: Empty response from GitHub API"
-    exit 1
-fi
-
-DOWNLOAD_LINK=$(echo "$API_RESPONSE" | jq -r '.assets[] | select(.name=="dist-qdrant.zip") | .browser_download_url' 2>/dev/null)
-
-if [ -z "$DOWNLOAD_LINK" ] || [ "$DOWNLOAD_LINK" = "null" ]; then
-    echo "Error: Could not find dist-qdrant.zip in the latest release"
-    echo "Available assets:"
-    echo "$API_RESPONSE" | jq -r '.assets[]' 2>/dev/null || echo "Failed to parse assets"
-    exit 1
-fi
+DOWNLOAD_LINK="https://github.com/qdrant/qdrant-web-ui/releases/latest/download/dist-qdrant.zip"
 
 if command -v wget &> /dev/null
 then


### PR DESCRIPTION
This adds a new step in GitHub job that cancels any running jobs in the same workflow according to the specified conditions. This behavior ensures the workflow cancels as soon as  any image build failed.

```
      - name: Docker build
        id: docker-build
        uses: docker/build-push-action@v6
        with:
          context: .
          ...
      - name: Cancel other jobs in a run if Docker build failed
        if: failure() && steps.docker-build.outcome == 'failure'
        uses: ./.github/actions/cancel-workflow-run
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
```

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

