### PR TITLE
Partial snapshots update recovery ts

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -115,7 +115,7 @@ pub struct ShardReplicaSet {
     /// Local clock set, used to tag new operations on this shard.
     clock_set: Mutex<ClockSet>,
     write_rate_limiter: Option<parking_lot::Mutex<RateLimiter>>,
-    partial_snapshot_meta: PartialSnapshotMeta,
+    pub partial_snapshot_meta: PartialSnapshotMeta,
 }
 
 pub type AbortShardTransfer = Arc<dyn Fn(ShardTransfer, &str) + Send + Sync>;

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1243,7 +1243,7 @@ pub(crate) enum ShardTransferChange {
     Abort(ShardTransferKey),
 }
 
-pub(crate) fn shard_not_found_error(shard_id: ShardId) -> CollectionError {
+pub fn shard_not_found_error(shard_id: ShardId) -> CollectionError {
     CollectionError::NotFound {
         what: format!("shard {shard_id}"),
     }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -12,7 +12,8 @@ use collection::operations::snapshot_ops::{
 };
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::replica_set::snapshots::RecoveryType;
-use collection::shards::{shard::ShardId, shard_holder::shard_not_found_error};
+use collection::shards::shard::ShardId;
+use collection::shards::shard_holder::shard_not_found_error;
 use futures::{FutureExt as _, StreamExt as _, TryFutureExt as _};
 use reqwest::Url;
 use schemars::JsonSchema;

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -250,3 +250,10 @@ def get_telemetry_hw_info(peer_url, collection):
         return hw[collection]
     else:
         return None
+
+def get_telemetry(peer_url):
+    r_search = requests.get(
+        f"{peer_url}/telemetry", params="details_level=3"
+    )
+    assert_http_ok(r_search)
+    return r_search.json()["result"]


### PR DESCRIPTION
Minor improvement on top of https://github.com/qdrant/qdrant/pull/6924

We want to set recovery timestamp even on empty partial snapshots since it's used to decide the replicas to sync. 