### PR TITLE
Fix Clippy 1.89

### DIFF
--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -219,14 +219,14 @@ impl Validate for Batch {
             BatchVectorStruct::Image(_) => {}
             BatchVectorStruct::Object(_) => {}
         }
-        if let Some(payload_vector) = &batch.payloads {
-            if payload_vector.len() != batch.ids.len() {
-                return Err(create_error(format!(
-                    "number of ids and payloads must be equal ({} != {})",
-                    batch.ids.len(),
-                    payload_vector.len(),
-                )));
-            }
+        if let Some(payload_vector) = &batch.payloads
+            && payload_vector.len() != batch.ids.len()
+        {
+            return Err(create_error(format!(
+                "number of ids and payloads must be equal ({} != {})",
+                batch.ids.len(),
+                payload_vector.len(),
+            )));
         }
         Ok(())
     }

--- a/lib/collection/src/collection/mmr/maximal_marginal_relevance.rs
+++ b/lib/collection/src/collection/mmr/maximal_marginal_relevance.rs
@@ -167,7 +167,7 @@ fn similarity_matrix(
     volatile_storage: &VectorStorageEnum,
     vectors: Vec<VectorInternal>,
     hw_measurement_acc: HwMeasurementAcc,
-) -> CollectionResult<LazyMatrix> {
+) -> CollectionResult<LazyMatrix<'_>> {
     let num_vectors = vectors.len();
 
     // if we have less than 2 points, we can't build a matrix

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -469,10 +469,8 @@ impl Collection {
             let is_resharding = current_state
                 .as_ref()
                 .is_some_and(ReplicaState::is_resharding);
-            if is_resharding {
-                if let Some(state) = resharding_state {
-                    abort_resharding_result = self.abort_resharding(state.key(), false).await;
-                }
+            if is_resharding && let Some(state) = resharding_state {
+                abort_resharding_result = self.abort_resharding(state.key(), false).await;
             }
 
             // Terminate transfer if source or target replicas are now dead
@@ -573,13 +571,13 @@ impl Collection {
             .await
             .filter(|state| state.peer_id == peer_id);
 
-        if let Some(state) = resharding_state {
-            if let Err(err) = self.abort_resharding(state.key(), true).await {
-                log::error!(
-                    "Failed to abort resharding {} while removing peer {peer_id}: {err}",
-                    state.key(),
-                );
-            }
+        if let Some(state) = resharding_state
+            && let Err(err) = self.abort_resharding(state.key(), true).await
+        {
+            log::error!(
+                "Failed to abort resharding {} while removing peer {peer_id}: {err}",
+                state.key(),
+            );
         }
 
         for transfer in self.get_related_transfers(peer_id).await {
@@ -855,7 +853,7 @@ impl Collection {
         }
     }
 
-    pub async fn lock_updates(&self) -> RwLockWriteGuard<()> {
+    pub async fn lock_updates(&self) -> RwLockWriteGuard<'_, ()> {
         self.updates_lock.write().await
     }
 

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -188,10 +188,10 @@ impl Collection {
                             )
                             .await;
 
-                        if let Err(err) = &res {
-                            if err.is_missing_point() {
-                                continue;
-                            }
+                        if let Err(err) = &res
+                            && err.is_missing_point()
+                        {
+                            continue;
                         }
 
                         result = res?;

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -654,9 +654,11 @@ impl Collection {
                 // Prevents undersampling warning in case there are not enough data to merge.
                 let is_enough = merged.len() == query_info.take;
 
-                if number_of_shards > 1 && is_enough && best_last_result.is_some() {
+                if let Some(best_last_result) = best_last_result
+                    && number_of_shards > 1
+                    && is_enough
+                {
                     let worst_merged_point = merged.last();
-                    let best_last_result = best_last_result.unwrap();
                     if let Some(worst_merged_point) = worst_merged_point {
                         self.check_undersampling(worst_merged_point, &best_last_result, order);
                     }

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -160,13 +160,13 @@ impl Collection {
             .await
             .filter(|state| state.shard_key.as_ref() == Some(&shard_key));
 
-        if let Some(state) = resharding_state {
-            if let Err(err) = self.abort_resharding(state.key(), true).await {
-                log::error!(
-                    "failed to abort resharding {} while deleting shard key {shard_key}: {err}",
-                    state.key(),
-                );
-            }
+        if let Some(state) = resharding_state
+            && let Err(err) = self.abort_resharding(state.key(), true).await
+        {
+            log::error!(
+                "failed to abort resharding {} while deleting shard key {shard_key}: {err}",
+                state.key(),
+            );
         }
 
         // Invalidate local shard cleaning tasks

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -44,10 +44,10 @@ impl PointIdGenerator {
     pub fn unique(&mut self) -> PointIdType {
         for _ in 0..100_000 {
             let id = self.random();
-            if let PointIdType::NumId(num) = id {
-                if self.used.insert(num) {
-                    return id;
-                }
+            if let PointIdType::NumId(num) = id
+                && self.used.insert(num)
+            {
+                return id;
             }
         }
         panic!("failed to generate unique point ID after 100000 attempts");

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -683,7 +683,7 @@ impl SegmentEntry for ProxySegment {
         &self,
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<NamedVectors> {
+    ) -> OperationResult<NamedVectors<'_>> {
         let mut result = NamedVectors::default();
         for vector_name in self
             .wrapped_segment
@@ -1258,10 +1258,10 @@ impl SegmentEntry for ProxySegment {
                     indexed_fields.remove(field_name);
                 }
                 ProxyIndexChange::DeleteIfIncompatible(_, schema) => {
-                    if let Some(existing_schema) = indexed_fields.get(field_name) {
-                        if existing_schema != schema {
-                            indexed_fields.remove(field_name);
-                        }
+                    if let Some(existing_schema) = indexed_fields.get(field_name)
+                        && existing_schema != schema
+                    {
+                        indexed_fields.remove(field_name);
                     }
                 }
             }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -759,11 +759,11 @@ impl SegmentHolder {
             ids,
             update_nonappendable,
             |point_id, _idx, write_segment, &update_nonappendable| {
-                if let Some(point_version) = write_segment.point_version(point_id) {
-                    if point_version >= op_num {
-                        applied_points.insert(point_id);
-                        return Ok(false);
-                    }
+                if let Some(point_version) = write_segment.point_version(point_id)
+                    && point_version >= op_num
+                {
+                    applied_points.insert(point_id);
+                    return Ok(false);
                 }
 
                 let is_applied = if update_nonappendable || write_segment.is_appendable() {

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -77,7 +77,7 @@ impl ConfigMismatchOptimizer {
     /// with current configuration.
     ///
     /// Takes vector-specific HNSW config (if any) and merges it with the collection-wide config.
-    fn get_required_hnsw_config(&self, vector_name: &VectorName) -> Cow<HnswConfig> {
+    fn get_required_hnsw_config(&self, vector_name: &VectorName) -> Cow<'_, HnswConfig> {
         let target_hnsw_collection = &self.hnsw_config;
         // Select vector specific target HNSW config
         let target_hnsw_vector = self
@@ -150,10 +150,9 @@ impl ConfigMismatchOptimizer {
 
                             if let Some(is_required_on_disk) =
                                 self.check_if_vectors_on_disk(vector_name)
+                                && is_required_on_disk != vector_data.storage_type.is_on_disk()
                             {
-                                if is_required_on_disk != vector_data.storage_type.is_on_disk() {
-                                    return true;
-                                }
+                                return true;
                             }
 
                             // Check quantization mismatch

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -279,11 +279,10 @@ pub trait SegmentOptimizer {
 
                 // If we explicitly configure on_disk, but the segment storage type uses something
                 // that doesn't match, warn about it
-                if let Some(config_on_disk) = config_on_disk {
-                    if config_on_disk != config.storage_type.is_on_disk() {
+                if let Some(config_on_disk) = config_on_disk
+                    && config_on_disk != config.storage_type.is_on_disk() {
                         log::warn!("Collection config for vector {vector_name} has on_disk={config_on_disk:?} configured, but storage type for segment doesn't match it");
                     }
-                }
             });
         }
 
@@ -291,24 +290,24 @@ pub trait SegmentOptimizer {
             .iter_mut()
             .for_each(|(vector_name, config)| {
                 // Assign sparse index on disk
-                if let Some(sparse_config) = &collection_params.sparse_vectors {
-                    if let Some(params) = sparse_config.get(vector_name) {
-                        let config_on_disk = params
-                            .index
-                            .and_then(|index_params| index_params.on_disk)
-                            .unwrap_or(threshold_is_on_disk);
+                if let Some(sparse_config) = &collection_params.sparse_vectors
+                    && let Some(params) = sparse_config.get(vector_name)
+                {
+                    let config_on_disk = params
+                        .index
+                        .and_then(|index_params| index_params.on_disk)
+                        .unwrap_or(threshold_is_on_disk);
 
-                        // If mmap OR index is exceeded
-                        let is_big = threshold_is_on_disk || threshold_is_indexed;
+                    // If mmap OR index is exceeded
+                    let is_big = threshold_is_on_disk || threshold_is_indexed;
 
-                        let index_type = match (is_big, config_on_disk) {
-                            (true, true) => SparseIndexType::Mmap, // Big and configured on disk
-                            (true, false) => SparseIndexType::ImmutableRam, // Big and not on disk nor reached threshold
-                            (false, _) => SparseIndexType::MutableRam,      // Small
-                        };
+                    let index_type = match (is_big, config_on_disk) {
+                        (true, true) => SparseIndexType::Mmap, // Big and configured on disk
+                        (true, false) => SparseIndexType::ImmutableRam, // Big and not on disk nor reached threshold
+                        (false, _) => SparseIndexType::MutableRam,      // Small
+                    };
 
-                        config.index.index_type = index_type;
-                    }
+                    config.index.index_type = index_type;
                 }
             });
 

--- a/lib/collection/src/collection_manager/search_result_aggregator.rs
+++ b/lib/collection/src/collection_manager/search_result_aggregator.rs
@@ -84,10 +84,10 @@ impl BatchResultAggregator {
         let aggregator = &mut self.batch_aggregators[batch_id];
         for scored_point in search_results {
             debug_assert!(self.point_versions.contains_key(&scored_point.id));
-            if let Some(point_max_version) = self.point_versions.get(&scored_point.id) {
-                if scored_point.version >= *point_max_version {
-                    aggregator.push(scored_point);
-                }
+            if let Some(point_max_version) = self.point_versions.get(&scored_point.id)
+                && scored_point.version >= *point_max_version
+            {
+                aggregator.push(scored_point);
             }
         }
     }

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -191,12 +191,10 @@ impl SegmentsSearcher {
             if let Some(sparse_vector_params) = collection_config
                 .params
                 .get_sparse_vector_params_opt(vector_name)
+                && sparse_vector_params.modifier == Some(Modifier::Idf)
+                && !idf_vectors.contains(&vector_name)
             {
-                if sparse_vector_params.modifier == Some(Modifier::Idf)
-                    && !idf_vectors.contains(&vector_name)
-                {
-                    idf_vectors.push(vector_name);
-                }
+                idf_vectors.push(vector_name);
             }
         }
 

--- a/lib/collection/src/common/file_utils.rs
+++ b/lib/collection/src/common/file_utils.rs
@@ -104,9 +104,9 @@ pub async fn move_file(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Collecti
 
 /// Remove the file if it exists. Print a warning if the file can't be removed.
 async fn cleanup_file(path: &Path) {
-    if let Err(err) = tokio::fs::remove_file(path).await {
-        if err.kind() != std::io::ErrorKind::NotFound {
-            log::warn!("Failed to remove file {}: {err}", path.display());
-        }
+    if let Err(err) = tokio::fs::remove_file(path).await
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        log::warn!("Failed to remove file {}: {err}", path.display());
     }
 }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -298,10 +298,10 @@ impl SnapshotStorageLocalFS {
         storage_path: &Path,
         local_path: &Path,
     ) -> CollectionResult<()> {
-        if let Some(target_dir) = local_path.parent() {
-            if !target_dir.exists() {
-                std::fs::create_dir_all(target_dir)?;
-            }
+        if let Some(target_dir) = local_path.parent()
+            && !target_dir.exists()
+        {
+            std::fs::create_dir_all(target_dir)?;
         }
 
         if storage_path != local_path {
@@ -412,10 +412,10 @@ impl SnapshotStorageCloud {
         storage_path: &Path,
         local_path: &Path,
     ) -> CollectionResult<()> {
-        if let Some(target_dir) = local_path.parent() {
-            if !target_dir.exists() {
-                std::fs::create_dir_all(target_dir)?;
-            }
+        if let Some(target_dir) = local_path.parent()
+            && !target_dir.exists()
+        {
+            std::fs::create_dir_all(target_dir)?;
         }
         if storage_path != local_path {
             // download snapshot from cloud storage to local path

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -149,13 +149,13 @@ mod tests {
         assert!(handle.is_finished());
 
         // Expect task counter to be between [5, 25], we cannot be exact on busy systems
-        if let Some(handle) = handle.stop() {
-            if let Some(count) = handle.await.unwrap() {
-                assert!(
-                    count < 25,
-                    "Stoppable task should have count should be less than 25, but it is {count}",
-                );
-            }
+        if let Some(handle) = handle.stop()
+            && let Some(count) = handle.await.unwrap()
+        {
+            assert!(
+                count < 25,
+                "Stoppable task should have count should be less than 25, but it is {count}",
+            );
         }
     }
 
@@ -176,13 +176,13 @@ mod tests {
 
         // Expect task counters to be between [5, 30], we cannot be exact on busy systems
         for handle in handles {
-            if let Some(handle) = handle.stop() {
-                if let Some(count) = handle.await.unwrap() {
-                    assert!(
-                        count < 30, // 10 extra steps to stop all tasks
-                        "Stoppable task should have count should be less than 30, but it is {count}",
-                    );
-                }
+            if let Some(handle) = handle.stop()
+                && let Some(count) = handle.await.unwrap()
+            {
+                assert!(
+                    count < 30, // 10 extra steps to stop all tasks
+                    "Stoppable task should have count should be less than 30, but it is {count}",
+                );
             }
         }
     }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -298,11 +298,11 @@ impl CollectionParams {
                 description: "Vectors are not configured in this collection".into(),
             }
         } else if available_names == vec![DEFAULT_VECTOR_NAME] {
-            return CollectionError::BadInput {
+            CollectionError::BadInput {
                 description: format!(
                     "Vector with name {vector_name} is not configured in this collection"
                 ),
-            };
+            }
         } else {
             let available_names = available_names.join(", ");
             if vector_name == DEFAULT_VECTOR_NAME {
@@ -325,10 +325,10 @@ impl CollectionParams {
         match self.vectors.get_params(vector_name) {
             Some(params) => Ok(params.distance),
             None => {
-                if let Some(sparse_vectors) = &self.sparse_vectors {
-                    if let Some(_params) = sparse_vectors.get(vector_name) {
-                        return Ok(Distance::Dot);
-                    }
+                if let Some(sparse_vectors) = &self.sparse_vectors
+                    && let Some(_params) = sparse_vectors.get(vector_name)
+                {
+                    return Ok(Distance::Dot);
                 }
                 Err(self.missing_vector_error(vector_name))
             }

--- a/lib/collection/src/operations/operation_effect.rs
+++ b/lib/collection/src/operations/operation_effect.rs
@@ -24,11 +24,11 @@ pub enum PointsOperationEffect {
 }
 
 pub trait EstimateOperationEffectArea {
-    fn estimate_effect_area(&self) -> OperationEffectArea;
+    fn estimate_effect_area(&self) -> OperationEffectArea<'_>;
 }
 
 impl EstimateOperationEffectArea for CollectionUpdateOperations {
-    fn estimate_effect_area(&self) -> OperationEffectArea {
+    fn estimate_effect_area(&self) -> OperationEffectArea<'_> {
         match self {
             CollectionUpdateOperations::PointOperation(point_operation) => {
                 point_operation.estimate_effect_area()
@@ -45,7 +45,7 @@ impl EstimateOperationEffectArea for CollectionUpdateOperations {
 }
 
 impl EstimateOperationEffectArea for point_ops::PointOperations {
-    fn estimate_effect_area(&self) -> OperationEffectArea {
+    fn estimate_effect_area(&self) -> OperationEffectArea<'_> {
         match self {
             point_ops::PointOperations::UpsertPoints(insert_operations) => {
                 insert_operations.estimate_effect_area()
@@ -70,7 +70,7 @@ impl EstimateOperationEffectArea for point_ops::PointOperations {
 }
 
 impl EstimateOperationEffectArea for vector_ops::VectorOperations {
-    fn estimate_effect_area(&self) -> OperationEffectArea {
+    fn estimate_effect_area(&self) -> OperationEffectArea<'_> {
         match self {
             vector_ops::VectorOperations::UpdateVectors(update_operation) => {
                 let ids = update_operation.points.iter().map(|p| p.id).collect();
@@ -87,7 +87,7 @@ impl EstimateOperationEffectArea for vector_ops::VectorOperations {
 }
 
 impl EstimateOperationEffectArea for point_ops::PointInsertOperationsInternal {
-    fn estimate_effect_area(&self) -> OperationEffectArea {
+    fn estimate_effect_area(&self) -> OperationEffectArea<'_> {
         match self {
             point_ops::PointInsertOperationsInternal::PointsBatch(batch) => {
                 OperationEffectArea::Points(Cow::Borrowed(&batch.ids))
@@ -100,7 +100,7 @@ impl EstimateOperationEffectArea for point_ops::PointInsertOperationsInternal {
 }
 
 impl EstimateOperationEffectArea for PayloadOps {
-    fn estimate_effect_area(&self) -> OperationEffectArea {
+    fn estimate_effect_area(&self) -> OperationEffectArea<'_> {
         match self {
             PayloadOps::SetPayload(set_payload) => {
                 if let Some(points) = &set_payload.points {

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -360,7 +360,7 @@ pub struct PointStructPersisted {
 }
 
 impl PointStructPersisted {
-    pub fn get_vectors(&self) -> NamedVectors {
+    pub fn get_vectors(&self) -> NamedVectors<'_> {
         let mut named_vectors = NamedVectors::default();
         match &self.vector {
             VectorStructPersisted::Single(vector) => named_vectors.insert(

--- a/lib/collection/src/operations/snapshot_storage_ops.rs
+++ b/lib/collection/src/operations/snapshot_storage_ops.rs
@@ -206,10 +206,10 @@ pub async fn download_snapshot(
     let mut stream = download.into_stream();
 
     // Create the target directory if it does not exist
-    if let Some(target_dir) = target_path.parent() {
-        if !target_dir.exists() {
-            std::fs::create_dir_all(target_dir)?;
-        }
+    if let Some(target_dir) = target_path.parent()
+        && !target_dir.exists()
+    {
+        std::fs::create_dir_all(target_dir)?;
     }
 
     let mut file = tokio::fs::File::create(target_path)

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1482,7 +1482,7 @@ impl From<tempfile::PathPersistError> for CollectionError {
 pub type CollectionResult<T> = Result<T, CollectionError>;
 
 impl RecordInternal {
-    pub fn get_vector_by_name(&self, name: &VectorName) -> Option<VectorRef> {
+    pub fn get_vector_by_name(&self, name: &VectorName) -> Option<VectorRef<'_>> {
         match &self.vector {
             Some(VectorStructInternal::Single(vector)) => {
                 (name == DEFAULT_VECTOR_NAME).then_some(VectorRef::from(vector))

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -481,14 +481,12 @@ impl CollectionPrefetch {
             lookup_other_collection = lookup_collection != collection
         };
 
-        if !lookup_other_collection {
-            if let Some(Query::Vector(vector_query)) = &self.query {
-                if let VectorQuery::Nearest(VectorInputInternal::Id(id)) = vector_query {
-                    refs.push(*id);
-                }
-                refs.extend(vector_query.get_referenced_ids())
-            };
-        }
+        if !lookup_other_collection && let Some(Query::Vector(vector_query)) = &self.query {
+            if let VectorQuery::Nearest(VectorInputInternal::Id(id)) = vector_query {
+                refs.push(*id);
+            }
+            refs.extend(vector_query.get_referenced_ids())
+        };
 
         for prefetch in &self.prefetch {
             refs.extend(prefetch.get_referenced_point_ids_on_collection(collection))
@@ -590,14 +588,12 @@ impl CollectionQueryRequest {
             lookup_other_collection = lookup_collection != collection
         };
 
-        if !lookup_other_collection {
-            if let Some(Query::Vector(vector_query)) = &self.query {
-                if let VectorQuery::Nearest(VectorInputInternal::Id(id)) = vector_query {
-                    refs.push(*id);
-                }
-                refs.extend(vector_query.get_referenced_ids())
-            };
-        }
+        if !lookup_other_collection && let Some(Query::Vector(vector_query)) = &self.query {
+            if let VectorQuery::Nearest(VectorInputInternal::Id(id)) = vector_query {
+                refs.push(*id);
+            }
+            refs.extend(vector_query.get_referenced_ids())
+        };
 
         for prefetch in &self.prefetch {
             refs.extend(prefetch.get_referenced_point_ids_on_collection(collection))
@@ -700,12 +696,12 @@ impl CollectionQueryRequest {
         }
 
         // Check that fusion queries are not combined with a using vector name
-        if let Some(Query::Fusion(_)) = query {
-            if using != DEFAULT_VECTOR_NAME {
-                return Err(CollectionError::bad_request(
-                    "Fusion queries cannot be combined with the 'using' field.",
-                ));
-            }
+        if let Some(Query::Fusion(_)) = query
+            && using != DEFAULT_VECTOR_NAME
+        {
+            return Err(CollectionError::bad_request(
+                "Fusion queries cannot be combined with the 'using' field.",
+            ));
         }
 
         Ok(())

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -111,21 +111,21 @@ pub trait StrictModeVerification {
             };
 
             // Check for filter indices
-            if allow_unindexed_filter == Some(false) {
-                if let Some((key, schemas)) = collection.one_unindexed_key(filter) {
-                    let possible_schemas_str = schemas
-                        .iter()
-                        .map(|schema| schema.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ");
+            if allow_unindexed_filter == Some(false)
+                && let Some((key, schemas)) = collection.one_unindexed_key(filter)
+            {
+                let possible_schemas_str = schemas
+                    .iter()
+                    .map(|schema| schema.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
 
-                    return Err(CollectionError::strict_mode(
-                        format!(
-                            "Index required but not found for \"{key}\" of one of the following types: [{possible_schemas_str}]",
-                        ),
-                        "Create an index for this key or use a different filter.",
-                    ));
-                }
+                return Err(CollectionError::strict_mode(
+                    format!(
+                        "Index required but not found for \"{key}\" of one of the following types: [{possible_schemas_str}]",
+                    ),
+                    "Create an index for this key or use a different filter.",
+                ));
             }
 
             check_filter_limits(filter, strict_mode_config)?;

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -14,25 +14,22 @@ impl Query {
         collection: &Collection,
         strict_mode_config: &StrictModeConfig,
     ) -> CollectionResult<()> {
-        if strict_mode_config.unindexed_filtering_retrieve == Some(false) {
-            if let Query::Formula(formula) = self {
-                if let Some((key, schemas)) =
-                    collection.one_unindexed_expression_key(&formula.formula)
-                {
-                    let possible_schemas_str = schemas
-                        .iter()
-                        .map(|schema| schema.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ");
+        if strict_mode_config.unindexed_filtering_retrieve == Some(false)
+            && let Query::Formula(formula) = self
+            && let Some((key, schemas)) = collection.one_unindexed_expression_key(&formula.formula)
+        {
+            let possible_schemas_str = schemas
+                .iter()
+                .map(|schema| schema.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
 
-                    return Err(CollectionError::strict_mode(
-                        format!(
-                            "Index required but not found for \"{key}\" of one of the following types: [{possible_schemas_str}]",
-                        ),
-                        "Create an index for this key or use a different formula expression.",
-                    ));
-                }
-            }
+            return Err(CollectionError::strict_mode(
+                format!(
+                    "Index required but not found for \"{key}\" of one of the following types: [{possible_schemas_str}]",
+                ),
+                "Create an index for this key or use a different formula expression.",
+            ));
         }
         Ok(())
     }

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -70,10 +70,9 @@ impl StrictModeVerification for SetPayload {
         strict_mode_config: &StrictModeConfig,
     ) -> CollectionResult<()> {
         if let Some(payload_size_limit_bytes) = strict_mode_config.max_collection_payload_size_bytes
+            && let Some(local_stats) = collection.estimated_collection_stats().await
         {
-            if let Some(local_stats) = collection.estimated_collection_stats().await {
-                check_collection_payload_size_limit(payload_size_limit_bytes, local_stats)?;
-            }
+            check_collection_payload_size_limit(payload_size_limit_bytes, local_stats)?;
         }
 
         Ok(())
@@ -451,10 +450,10 @@ fn check_named_sparse_vec_limit(
     vector: &Vector,
     sparse_max_size_by_name: &TinyMap<&VectorName, usize>,
 ) -> CollectionResult<()> {
-    if let Vector::Sparse(sparse) = vector {
-        if let Some(strict_sparse_limit) = sparse_max_size_by_name.get(name) {
-            check_sparse_vector_limit(name, sparse, *strict_sparse_limit)?;
-        }
+    if let Vector::Sparse(sparse) = vector
+        && let Some(strict_sparse_limit) = sparse_max_size_by_name.get(name)
+    {
+        check_sparse_vector_limit(name, sparse, *strict_sparse_limit)?;
     }
     Ok(())
 }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -23,10 +23,10 @@ impl ClockMap {
     pub fn load_or_default(path: &Path) -> Result<Self> {
         let result = Self::load(path);
 
-        if let Err(Error::Io(err)) = &result {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                return Ok(Self::default());
-            }
+        if let Err(Error::Io(err)) = &result
+            && err.kind() == std::io::ErrorKind::NotFound
+        {
+            return Ok(Self::default());
         }
 
         result
@@ -284,10 +284,10 @@ impl RecoveryPoint {
     /// Remove clocks from this recovery point, that are equal to the clocks in the `other`.
     pub fn remove_clocks_equal_to(&mut self, other: &Self) {
         for (key, (other_tick, _)) in &other.clocks {
-            if let Some((tick, _)) = self.clocks.get(key) {
-                if tick == other_tick {
-                    self.clocks.remove(key);
-                }
+            if let Some((tick, _)) = self.clocks.get(key)
+                && tick == other_tick
+            {
+                self.clocks.remove(key);
             }
         }
     }
@@ -301,11 +301,11 @@ impl RecoveryPoint {
 
         let mut is_equal = false;
 
-        if let Some(&(tick, _)) = self.clocks.get(&key) {
-            if tick >= tag.clock_tick {
-                self.clocks.remove(&key);
-                is_equal = tick == tag.clock_tick;
-            }
+        if let Some(&(tick, _)) = self.clocks.get(&key)
+            && tick >= tag.clock_tick
+        {
+            self.clocks.remove(&key);
+            is_equal = tick == tag.clock_tick;
         }
 
         is_equal

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -772,16 +772,15 @@ impl LocalShard {
     pub async fn on_strict_mode_config_update(&mut self) {
         let config = self.collection_config.read().await;
 
-        if let Some(strict_mode_config) = &config.strict_mode_config {
-            if strict_mode_config.enabled == Some(true) {
-                // update read rate limiter
-                if let Some(read_rate_limit_per_min) = strict_mode_config.read_rate_limit {
-                    let new_read_rate_limiter =
-                        RateLimiter::new_per_minute(read_rate_limit_per_min);
-                    self.read_rate_limiter
-                        .replace(parking_lot::Mutex::new(new_read_rate_limiter));
-                    return;
-                }
+        if let Some(strict_mode_config) = &config.strict_mode_config
+            && strict_mode_config.enabled == Some(true)
+        {
+            // update read rate limiter
+            if let Some(read_rate_limit_per_min) = strict_mode_config.read_rate_limit {
+                let new_read_rate_limiter = RateLimiter::new_per_minute(read_rate_limit_per_min);
+                self.read_rate_limiter
+                    .replace(parking_lot::Mutex::new(new_read_rate_limiter));
+                return;
             }
         }
         // remove read rate limiter for all other situations

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -175,9 +175,8 @@ pub async fn revert_proxy_shard_to_local(
     shard_holder: &ShardHolder,
     shard_id: ShardId,
 ) -> CollectionResult<bool> {
-    let replica_set = match shard_holder.get_shard(shard_id) {
-        None => return Ok(false),
-        Some(replica_set) => replica_set,
+    let Some(replica_set) = shard_holder.get_shard(shard_id) else {
+        return Ok(false);
     };
 
     // Revert queue proxy if we still have any and forget all collected updates

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -205,10 +205,10 @@ impl UpdateHandler {
     }
 
     pub fn stop_flush_worker(&mut self) {
-        if let Some(flush_stop) = self.flush_stop.take() {
-            if let Err(()) = flush_stop.send(()) {
-                warn!("Failed to stop flush worker as it is already stopped.");
-            }
+        if let Some(flush_stop) = self.flush_stop.take()
+            && let Err(()) = flush_stop.send(())
+        {
+            warn!("Failed to stop flush worker as it is already stopped.");
         }
     }
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -36,14 +36,6 @@ struct TestInternalStruct2 {
     b: i32,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
-enum TestRecord {
-    Struct1(TestInternalStruct1),
-    Struct2(TestInternalStruct2),
-}
-
 pub(super) type Result<T> = result::Result<T, WalError>;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -270,6 +262,14 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    #[serde(untagged)]
+    enum TestRecord {
+        Struct1(TestInternalStruct1),
+        Struct2(TestInternalStruct2),
+    }
 
     #[test]
     fn test_wal() {

--- a/lib/common/common/src/bitpacking_links.rs
+++ b/lib/common/common/src/bitpacking_links.rs
@@ -65,7 +65,7 @@ pub fn iterate_packed_links(
     links: &[u8],
     bits_per_unsorted: u8,
     sorted_count: usize,
-) -> PackedLinksIterator {
+) -> PackedLinksIterator<'_> {
     let mut reader = BitReader::new(links);
 
     let mut remaining_bits = links.len() * u8::BITS as usize;

--- a/lib/common/common/src/counter/counter_cell.rs
+++ b/lib/common/common/src/counter/counter_cell.rs
@@ -66,7 +66,7 @@ impl CounterCell {
     /// Creates a write-back counter for best performance possible.
     /// For more information on when and why to use, see [`WriteBackCounterCell`]
     #[inline]
-    pub fn write_back_counter(&self) -> WritebackCounterCell {
+    pub fn write_back_counter(&self) -> WritebackCounterCell<'_> {
         WritebackCounterCell::new(self)
     }
 }

--- a/lib/common/common/src/counter/referenced_counter.rs
+++ b/lib/common/common/src/counter/referenced_counter.rs
@@ -28,22 +28,22 @@ impl Deref for HwMetricRefCounter<'_> {
 // Implement referenced functions here to prevent exposing `HwMetricRefCounter::new()`.
 impl HardwareCounterCell {
     #[inline]
-    pub fn ref_payload_io_write_counter(&self) -> HwMetricRefCounter {
+    pub fn ref_payload_io_write_counter(&self) -> HwMetricRefCounter<'_> {
         HwMetricRefCounter::new(&self.payload_io_write_counter)
     }
 
     #[inline]
-    pub fn ref_payload_io_read_counter(&self) -> HwMetricRefCounter {
+    pub fn ref_payload_io_read_counter(&self) -> HwMetricRefCounter<'_> {
         HwMetricRefCounter::new(&self.payload_io_read_counter)
     }
 
     #[inline]
-    pub fn ref_vector_io_write_counter(&self) -> HwMetricRefCounter {
+    pub fn ref_vector_io_write_counter(&self) -> HwMetricRefCounter<'_> {
         HwMetricRefCounter::new(&self.vector_io_write_counter)
     }
 
     #[inline]
-    pub fn ref_payload_index_io_write_counter(&self) -> HwMetricRefCounter {
+    pub fn ref_payload_index_io_write_counter(&self) -> HwMetricRefCounter<'_> {
         HwMetricRefCounter::new(&self.payload_index_io_write_counter)
     }
 }

--- a/lib/gpu/src/allocation_callbacks.rs
+++ b/lib/gpu/src/allocation_callbacks.rs
@@ -5,5 +5,5 @@ use ash::vk;
 /// GPU memory allocation is managed by the `gpu-allocator` crate.
 /// Even though Vulkan provides default allocation callbacks, it's helpful at least for debugging purposes.
 pub trait AllocationCallbacks: Send + Sync + 'static {
-    fn allocation_callbacks(&self) -> &vk::AllocationCallbacks;
+    fn allocation_callbacks(&self) -> &vk::AllocationCallbacks<'_>;
 }

--- a/lib/gpu/src/basic_test.rs
+++ b/lib/gpu/src/basic_test.rs
@@ -131,7 +131,9 @@ fn basic_gpu_test() {
     // Run computeation command. Threads count is the inputs count.
     context.dispatch(numbers_count, 1, 1).unwrap();
     // Add barrier to ensure that all writes to the storage buffer are visible to the next command.
-    context.barrier_buffers(&[storage_buffer.clone()]).unwrap();
+    context
+        .barrier_buffers(std::slice::from_ref(&storage_buffer))
+        .unwrap();
     // Run GPU and wait finish.
     context.run().unwrap();
     context.wait_finish(context_timeout).unwrap();

--- a/lib/gpu/src/device.rs
+++ b/lib/gpu/src/device.rs
@@ -314,7 +314,7 @@ impl Device {
     }
 
     /// Get CPU allocator.
-    pub fn cpu_allocation_callbacks(&self) -> Option<&vk::AllocationCallbacks> {
+    pub fn cpu_allocation_callbacks(&self) -> Option<&vk::AllocationCallbacks<'_>> {
         self.instance.cpu_allocation_callbacks()
     }
 

--- a/lib/posting_list/src/iterator.rs
+++ b/lib/posting_list/src/iterator.rs
@@ -31,10 +31,10 @@ impl<'a, V: PostingValue> PostingIterator<'a, V> {
         &mut self,
         target_id: PointOffsetType,
     ) -> Option<PostingElement<V>> {
-        if let Some(current) = &self.current_elem {
-            if current.id >= target_id {
-                return Some(current.clone());
-            }
+        if let Some(current) = &self.current_elem
+            && current.id >= target_id
+        {
+            return Some(current.clone());
         }
 
         if self.offset >= self.visitor.len() {

--- a/lib/posting_list/src/posting_list.rs
+++ b/lib/posting_list/src/posting_list.rs
@@ -86,7 +86,7 @@ impl<S: Sized> PostingChunk<S> {
 }
 
 impl<V: PostingValue> PostingList<V> {
-    pub fn view(&self) -> PostingListView<V> {
+    pub fn view(&self) -> PostingListView<'_, V> {
         let PostingList {
             id_data,
             chunks,

--- a/lib/posting_list/src/view.rs
+++ b/lib/posting_list/src/view.rs
@@ -58,7 +58,7 @@ impl<'a, V: PostingValue> PostingListView<'a, V> {
         }
     }
 
-    pub fn components(&self) -> PostingListComponents<SizedTypeFor<V>> {
+    pub fn components(&self) -> PostingListComponents<'_, SizedTypeFor<V>> {
         let Self {
             id_data,
             chunks,

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -363,10 +363,10 @@ fn convert_histogram(
             prev = None;
         }
     }
-    if let Some(prev) = prev {
-        if cumulative_count != total_count {
-            result.push((prev, cumulative_count));
-        }
+    if let Some(prev) = prev
+        && cumulative_count != total_count
+    {
+        result.push((prev, cumulative_count));
     }
     result
 }

--- a/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_buffered_update_wrapper.rs
@@ -100,7 +100,7 @@ impl DatabaseColumnScheduledUpdateWrapper {
         })
     }
 
-    pub fn lock_db(&self) -> LockedDatabaseColumnWrapper {
+    pub fn lock_db(&self) -> LockedDatabaseColumnWrapper<'_> {
         self.db.lock_db()
     }
 

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -204,7 +204,7 @@ impl DatabaseColumnWrapper {
         Ok(())
     }
 
-    pub fn lock_db(&self) -> LockedDatabaseColumnWrapper {
+    pub fn lock_db(&self) -> LockedDatabaseColumnWrapper<'_> {
         LockedDatabaseColumnWrapper {
             guard: self.database.read(),
             column_name: &self.column_name,
@@ -298,7 +298,7 @@ impl DatabaseColumnWrapper {
 }
 
 impl LockedDatabaseColumnWrapper<'_> {
-    pub fn iter(&self) -> OperationResult<DatabaseColumnIterator> {
+    pub fn iter(&self) -> OperationResult<DatabaseColumnIterator<'_>> {
         DatabaseColumnIterator::new(&self.guard, self.column_name)
     }
 }

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -100,7 +100,7 @@ impl CowVector<'_> {
         }
     }
 
-    pub fn as_vec_ref(&self) -> VectorRef {
+    pub fn as_vec_ref(&self) -> VectorRef<'_> {
         match self {
             CowVector::Dense(v) => VectorRef::Dense(v.as_ref()),
             CowVector::Sparse(v) => VectorRef::Sparse(v.as_ref()),

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -107,7 +107,7 @@ impl QueryContext {
         &mut self.idf_stats
     }
 
-    pub fn get_segment_query_context(&self) -> SegmentQueryContext {
+    pub fn get_segment_query_context(&self) -> SegmentQueryContext<'_> {
         SegmentQueryContext {
             query_context: self,
             deleted_points: None,
@@ -140,7 +140,7 @@ impl<'a> SegmentQueryContext<'a> {
         self.query_context.available_point_count()
     }
 
-    pub fn get_vector_context(&self, vector_name: &VectorName) -> VectorQueryContext {
+    pub fn get_vector_context(&self, vector_name: &VectorName) -> VectorQueryContext<'_> {
         VectorQueryContext {
             search_optimized_threshold_kb: self.query_context.search_optimized_threshold_kb,
             is_stopped: Some(&self.query_context.is_stopped),

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -468,11 +468,11 @@ pub fn default_multi_vector(vec: MultiDenseVectorInternal) -> NamedVectors<'stat
     named_vectors
 }
 
-pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors {
+pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors<'_> {
     NamedVectors::from_ref(DEFAULT_VECTOR_NAME, VectorRef::from(vec))
 }
 
-pub fn only_default_multi_vector(vec: &MultiDenseVectorInternal) -> NamedVectors {
+pub fn only_default_multi_vector(vec: &MultiDenseVectorInternal) -> NamedVectors<'_> {
     NamedVectors::from_ref(
         DEFAULT_VECTOR_NAME,
         VectorRef::MultiDense(TypedMultiDenseVectorRef::from(vec)),
@@ -524,7 +524,7 @@ impl From<NamedVectors<'_>> for VectorStructInternal {
 }
 
 impl VectorStructInternal {
-    pub fn get(&self, name: &VectorName) -> Option<VectorRef> {
+    pub fn get(&self, name: &VectorName) -> Option<VectorRef<'_>> {
         match self {
             VectorStructInternal::Single(v) => {
                 (name == DEFAULT_VECTOR_NAME).then_some(VectorRef::from(v))
@@ -648,7 +648,7 @@ impl NamedVectorStruct {
         }
     }
 
-    pub fn get_vector(&self) -> VectorRef {
+    pub fn get_vector(&self) -> VectorRef<'_> {
         match self {
             NamedVectorStruct::Default(v) => v.as_slice().into(),
             NamedVectorStruct::Dense(v) => v.vector.as_slice().into(),

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -129,7 +129,7 @@ pub trait SegmentEntry: SnapshotEntry {
         &self,
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<NamedVectors>;
+    ) -> OperationResult<NamedVectors<'_>>;
 
     /// Retrieve payload for the point
     /// If not found, return empty payload

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -62,15 +62,15 @@ impl<TMetric: Metric<VectorElementType>> VectorStorage for TestRawScorerProducer
         self.vectors.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector(key)
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors.get_opt(key as _).map(|v| v.into())
     }
 

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -242,7 +242,7 @@ impl FacetIndex for BoolIndex {
     fn get_point_values(
         &self,
         point_id: PointOffsetType,
-    ) -> impl Iterator<Item = FacetValueRef> + '_ {
+    ) -> impl Iterator<Item = FacetValueRef<'_>> + '_ {
         self.get_point_values(point_id)
             .into_iter()
             .map(FacetValueRef::Bool)

--- a/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
@@ -244,7 +244,7 @@ impl SimpleBoolIndex {
         self.memory.get(point_id).has_false()
     }
 
-    pub fn iter_values_map(&self) -> impl Iterator<Item = (bool, IdIter)> {
+    pub fn iter_values_map(&self) -> impl Iterator<Item = (bool, IdIter<'_>)> {
         [
             (false, Box::new(self.memory.iter_has_false()) as IdIter),
             (true, Box::new(self.memory.iter_has_true()) as IdIter),

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -11,7 +11,7 @@ pub trait FacetIndex {
     fn get_point_values(
         &self,
         point_id: PointOffsetType,
-    ) -> impl Iterator<Item = FacetValueRef> + '_;
+    ) -> impl Iterator<Item = FacetValueRef<'_>> + '_;
 
     /// Get all values in the index
     fn iter_values(&self) -> impl Iterator<Item = FacetValueRef<'_>> + '_;

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -396,7 +396,7 @@ impl FieldIndex {
         }
     }
 
-    pub fn as_numeric(&self) -> Option<NumericFieldIndex> {
+    pub fn as_numeric(&self) -> Option<NumericFieldIndex<'_>> {
         match self {
             FieldIndex::IntIndex(index) => Some(NumericFieldIndex::IntIndex(index.inner())),
             FieldIndex::DatetimeIndex(index) => Some(NumericFieldIndex::IntIndex(index.inner())),
@@ -412,7 +412,7 @@ impl FieldIndex {
         }
     }
 
-    pub fn as_facet_index(&self) -> Option<FacetIndexEnum> {
+    pub fn as_facet_index(&self) -> Option<FacetIndexEnum<'_>> {
         match self {
             FieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::Keyword(index)),
             FieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::Int(index)),

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
@@ -64,7 +64,7 @@ impl MultilingualTokenizer {
 
 // Tokenize::tokenize() function from charabia unrolled due to lifetime issues
 // when using .tokenize() on a `str` directly.
-fn charabia_token_iter(inp: &str) -> NormalizedTokenIter {
+fn charabia_token_iter(inp: &str) -> NormalizedTokenIter<'_, '_, '_, '_> {
     inp.segment().normalize(&DEFAULT_NORMALIZER)
 }
 

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -420,11 +420,11 @@ impl MmapGeoMapIndex {
         };
 
         let idx = idx as usize;
-        if let Some(deleted) = storage.deleted.get(idx) {
-            if !deleted {
-                storage.deleted.set(idx, true);
-                self.deleted_count += 1;
-            }
+        if let Some(deleted) = storage.deleted.get(idx)
+            && !deleted
+        {
+            storage.deleted.set(idx, true);
+            self.deleted_count += 1;
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -510,7 +510,7 @@ where
             .map(|(k, entry)| (k.borrow(), entry.count as usize))
     }
 
-    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter)> {
+    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> {
         self.value_to_points.keys().map(move |k| {
             (
                 k.borrow(),

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -198,11 +198,11 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         };
 
         let idx = idx as usize;
-        if let Some(deleted) = storage.deleted.get(idx) {
-            if !deleted {
-                storage.deleted.set(idx, true);
-                self.deleted_count += 1;
-            }
+        if let Some(deleted) = storage.deleted.get(idx)
+            && !deleted
+        {
+            storage.deleted.set(idx, true);
+            self.deleted_count += 1;
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -1220,7 +1220,7 @@ where
     fn get_point_values(
         &self,
         point_id: PointOffsetType,
-    ) -> impl Iterator<Item = FacetValueRef> + '_ {
+    ) -> impl Iterator<Item = FacetValueRef<'_>> + '_ {
         MapIndex::get_values(self, point_id)
             .into_iter()
             .flatten()

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -447,7 +447,7 @@ where
         self.map.iter().map(|(k, v)| (k.borrow(), v.len() as usize))
     }
 
-    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter)> {
+    pub fn iter_values_map(&self) -> impl Iterator<Item = (&N, IdIter<'_>)> {
         self.map
             .iter()
             .map(move |(k, v)| (k.borrow(), Box::new(v.iter()) as IdIter))

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -69,14 +69,14 @@ impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
     }
 
     fn remove(&mut self, key: &Point<T>) -> bool {
-        if let Ok(index) = self.data.binary_search(key) {
-            if let Some(is_deleted) = self.deleted.get_mut(index).as_deref_mut() {
-                if !*is_deleted {
-                    self.deleted_count += 1;
-                    *is_deleted = true;
-                }
-                return true;
+        if let Ok(index) = self.data.binary_search(key)
+            && let Some(is_deleted) = self.deleted.get_mut(index).as_deref_mut()
+        {
+            if !*is_deleted {
+                self.deleted_count += 1;
+                *is_deleted = true;
             }
+            return true;
         }
         false
     }

--- a/lib/segment/src/index/hnsw_index/gpu/batched_points.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/batched_points.rs
@@ -93,7 +93,7 @@ impl BatchedPoints {
         &self.points
     }
 
-    pub fn iter_batches(&self, skip_count: usize) -> impl Iterator<Item = Batch> {
+    pub fn iter_batches(&self, skip_count: usize) -> impl Iterator<Item = Batch<'_>> {
         self.batches
             .iter()
             .filter(move |batch| batch.end > skip_count)

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -117,7 +117,10 @@ impl GpuDevicesMaganer {
         })
     }
 
-    pub fn lock_device(&self, stopped: &AtomicBool) -> OperationResult<Option<LockedGpuDevice>> {
+    pub fn lock_device(
+        &self,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Option<LockedGpuDevice<'_>>> {
         if self.devices.is_empty() {
             return Ok(None);
         }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_heap_tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_heap_tests.rs
@@ -175,7 +175,7 @@ fn test_gpu_nearest_heap(#[values(true, false)] linear: bool) {
         .unwrap();
 
     context
-        .bind_pipeline(pipeline, &[descriptor_set.clone()])
+        .bind_pipeline(pipeline, std::slice::from_ref(&descriptor_set))
         .unwrap();
     context.dispatch(groups_count, 1, 1).unwrap();
     context.run().unwrap();
@@ -369,7 +369,7 @@ fn test_gpu_candidates_heap(#[values(true, false)] linear: bool) {
         .unwrap();
 
     context
-        .bind_pipeline(pipeline, &[descriptor_set.clone()])
+        .bind_pipeline(pipeline, std::slice::from_ref(&descriptor_set))
         .unwrap();
     context.dispatch(groups_count, 1, 1).unwrap();
     context.run().unwrap();

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -336,7 +336,9 @@ impl<'a> GpuInsertContext<'a> {
         )?;
         self.context.dispatch(requests.len(), 1, 1)?;
         self.context
-            .barrier_buffers(&[self.insert_resources.responses_buffer.clone()])
+            .barrier_buffers(std::slice::from_ref(
+                &self.insert_resources.responses_buffer,
+            ))
             .unwrap();
         self.context.run()?;
         self.context.wait_finish(GPU_TIMEOUT)?;

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -45,7 +45,7 @@ pub struct GraphLayers {
 }
 
 pub trait GraphLayersBase {
-    fn get_visited_list_from_pool(&self) -> VisitedListHandle;
+    fn get_visited_list_from_pool(&self) -> VisitedListHandle<'_>;
 
     fn links_map<F>(&self, point_id: PointOffsetType, level: usize, f: F)
     where
@@ -195,7 +195,7 @@ pub trait GraphLayersBase {
 }
 
 impl GraphLayersBase for GraphLayers {
-    fn get_visited_list_from_pool(&self) -> VisitedListHandle {
+    fn get_visited_list_from_pool(&self) -> VisitedListHandle<'_> {
         self.visited_pool.get(self.links.num_points())
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -47,7 +47,7 @@ pub struct GraphLayersBuilder {
 }
 
 impl GraphLayersBase for GraphLayersBuilder {
-    fn get_visited_list_from_pool(&self) -> VisitedListHandle {
+    fn get_visited_list_from_pool(&self) -> VisitedListHandle<'_> {
         self.visited_pool.get(self.num_points())
     }
 
@@ -73,7 +73,7 @@ impl GraphLayersBase for GraphLayersBuilder {
 const SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET: usize = 64;
 
 impl GraphLayersBuilder {
-    pub fn get_entry_points(&self) -> MutexGuard<EntryPoints> {
+    pub fn get_entry_points(&self) -> MutexGuard<'_, EntryPoints> {
         self.entry_points.lock()
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -71,7 +71,7 @@ enum GraphLinksEnum {
 }
 
 impl GraphLinksEnum {
-    fn load_view(&self, format: GraphLinksFormat) -> OperationResult<GraphLinksView> {
+    fn load_view(&self, format: GraphLinksFormat) -> OperationResult<GraphLinksView<'_>> {
         let data = match self {
             GraphLinksEnum::Ram(data) => data.as_slice(),
             GraphLinksEnum::Mmap(mmap) => &mmap[..],
@@ -93,7 +93,7 @@ impl GraphLinks {
         })
     }
 
-    fn view(&self) -> &GraphLinksView {
+    fn view(&self) -> &GraphLinksView<'_> {
         self.borrow_dependent()
     }
 
@@ -122,7 +122,7 @@ impl GraphLinks {
     }
 
     #[inline]
-    pub fn links(&self, point_id: PointOffsetType, level: usize) -> LinksIterator {
+    pub fn links(&self, point_id: PointOffsetType, level: usize) -> LinksIterator<'_> {
         self.view().links(point_id, level)
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -44,14 +44,17 @@ pub(super) enum CompressionInfo<'a> {
 }
 
 impl GraphLinksView<'_> {
-    pub(super) fn load(data: &[u8], format: GraphLinksFormat) -> OperationResult<GraphLinksView> {
+    pub(super) fn load(
+        data: &[u8],
+        format: GraphLinksFormat,
+    ) -> OperationResult<GraphLinksView<'_>> {
         match format {
             GraphLinksFormat::Compressed => Self::load_compressed(data),
             GraphLinksFormat::Plain => Self::load_plain(data),
         }
     }
 
-    fn load_plain(data: &[u8]) -> OperationResult<GraphLinksView> {
+    fn load_plain(data: &[u8]) -> OperationResult<GraphLinksView<'_>> {
         let (header, data) =
             HeaderPlain::ref_from_prefix(data).map_err(|_| error_unsufficent_size())?;
         let (level_offsets, data) =
@@ -67,7 +70,7 @@ impl GraphLinksView<'_> {
         })
     }
 
-    fn load_compressed(data: &[u8]) -> OperationResult<GraphLinksView> {
+    fn load_compressed(data: &[u8]) -> OperationResult<GraphLinksView<'_>> {
         let (header, data) =
             HeaderCompressed::ref_from_prefix(data).map_err(|_| error_unsufficent_size())?;
         debug_assert_eq!(header.version.get(), HEADER_VERSION_COMPRESSED);
@@ -98,7 +101,7 @@ impl GraphLinksView<'_> {
         })
     }
 
-    pub(super) fn links(&self, point_id: PointOffsetType, level: usize) -> LinksIterator {
+    pub(super) fn links(&self, point_id: PointOffsetType, level: usize) -> LinksIterator<'_> {
         let idx = if level == 0 {
             point_id as usize
         } else {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -551,20 +551,21 @@ impl HNSWIndex {
                         &vector_storage_ref,
                     );
 
-                    if !is_tenant && index_pos > 0 {
-                        if let Some(required_connectivity) = required_connectivity {
-                            // Always build for tenants
-                            let graph_connectivity = graph_layers_builder
-                                .subgraph_connectivity(&points_to_index, percolation);
+                    if !is_tenant
+                        && index_pos > 0
+                        && let Some(required_connectivity) = required_connectivity
+                    {
+                        // Always build for tenants
+                        let graph_connectivity = graph_layers_builder
+                            .subgraph_connectivity(&points_to_index, percolation);
 
-                            if graph_connectivity >= required_connectivity {
-                                trace!(
-                                    "skip building additional HNSW links for {field}, connectivity {graph_connectivity:.4} >= {required_connectivity:.4}"
-                                );
-                                continue;
-                            }
-                            trace!("graph connectivity: {graph_connectivity} for {field}");
+                        if graph_connectivity >= required_connectivity {
+                            trace!(
+                                "skip building additional HNSW links for {field}, connectivity {graph_connectivity:.4} >= {required_connectivity:.4}"
+                            );
+                            continue;
                         }
+                        trace!("graph connectivity: {graph_connectivity} for {field}");
                     }
 
                     // ToDo: reuse graph layer for same payload

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -21,12 +21,11 @@ fn search_in_builder(
     ef: usize,
     mut points_scorer: FilteredScorer,
 ) -> Vec<ScoredPointOffset> {
-    let entry_point = match builder
+    let Some(entry_point) = builder
         .get_entry_points()
         .get_entry_point(|point_id| points_scorer.check_vector(point_id))
-    {
-        None => return vec![],
-        Some(ep) => ep,
+    else {
+        return vec![];
     };
 
     let zero_level_entry = builder

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -258,7 +258,7 @@ pub fn get_geo_polygon_checkers(
     index: &FieldIndex,
     geo_polygon: GeoPolygon,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     let polygon_wrapper = geo_polygon.convert();
     let hw_counter = hw_acc.get_counter_cell();
     match index {
@@ -284,7 +284,7 @@ pub fn get_geo_radius_checkers(
     index: &FieldIndex,
     geo_radius: GeoRadius,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     let hw_counter = hw_acc.get_counter_cell();
     match index {
         FieldIndex::GeoIndex(geo_index) => Some(Box::new(move |point_id: PointOffsetType| {
@@ -307,7 +307,7 @@ pub fn get_geo_bounding_box_checkers(
     index: &FieldIndex,
     geo_bounding_box: GeoBoundingBox,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     let hw_counter = hw_acc.get_counter_cell();
     match index {
         FieldIndex::GeoIndex(geo_index) => Some(Box::new(move |point_id: PointOffsetType| {
@@ -332,7 +332,7 @@ pub fn get_range_checkers(
     index: &FieldIndex,
     range: RangeInterface,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     match range {
         RangeInterface::Float(range) => get_float_range_checkers(index, range, hw_acc),
         RangeInterface::DateTime(range) => get_datetime_range_checkers(index, range, hw_acc),
@@ -343,7 +343,7 @@ pub fn get_float_range_checkers(
     index: &FieldIndex,
     range: Range<FloatPayloadType>,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     let hw_counter = hw_acc.get_counter_cell();
     match index {
         FieldIndex::IntIndex(num_index) => {
@@ -371,7 +371,7 @@ pub fn get_datetime_range_checkers(
     index: &FieldIndex,
     range: Range<DateTimePayloadType>,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     match index {
         FieldIndex::DatetimeIndex(num_index) => {
             let range = range.map(|dt| dt.timestamp());
@@ -414,7 +414,7 @@ fn get_is_empty_indexes(indexes: &[FieldIndex]) -> (Option<&MmapNullIndex>, Opti
 fn get_null_index_is_empty_checker(
     null_index: &MmapNullIndex,
     is_empty: bool,
-) -> ConditionCheckerFn {
+) -> ConditionCheckerFn<'_> {
     Box::new(move |point_id: PointOffsetType| null_index.values_is_empty(point_id) == is_empty)
 }
 
@@ -439,7 +439,7 @@ fn get_fallback_is_empty_checker<'a>(
 ///
 /// * `index` - index to check
 /// * `is_empty` - if the field should be empty
-fn get_is_empty_checker(index: &FieldIndex, is_empty: bool) -> Option<ConditionCheckerFn> {
+fn get_is_empty_checker(index: &FieldIndex, is_empty: bool) -> Option<ConditionCheckerFn<'_>> {
     match index {
         FieldIndex::NullIndex(null_index) => {
             Some(get_null_index_is_empty_checker(null_index, is_empty))
@@ -457,7 +457,7 @@ fn get_is_empty_checker(index: &FieldIndex, is_empty: bool) -> Option<ConditionC
     }
 }
 
-fn get_is_null_checker(index: &FieldIndex, is_null: bool) -> Option<ConditionCheckerFn> {
+fn get_is_null_checker(index: &FieldIndex, is_null: bool) -> Option<ConditionCheckerFn<'_>> {
     match index {
         FieldIndex::NullIndex(null_index) => Some(Box::new(move |point_id: PointOffsetType| {
             null_index.values_is_null(point_id) == is_null

--- a/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
@@ -14,7 +14,7 @@ pub fn get_match_checkers(
     index: &FieldIndex,
     cond_match: Match,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     match cond_match {
         Match::Value(MatchValue { value }) => get_match_value_checker(value, index, hw_acc),
         Match::Text(MatchText { text }) => get_match_text_checker::<false>(text, index, hw_acc),
@@ -30,7 +30,7 @@ fn get_match_value_checker(
     value_variant: ValueVariants,
     index: &FieldIndex,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     match (value_variant, index) {
         (ValueVariants::String(keyword), FieldIndex::KeywordIndex(index)) => {
             let hw_counter = hw_acc.get_counter_cell();
@@ -93,7 +93,7 @@ fn get_match_any_checker(
     any_variant: AnyVariants,
     index: &FieldIndex,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     match (any_variant, index) {
         (AnyVariants::Strings(list), FieldIndex::KeywordIndex(index)) => {
             if list.len() < INDEXSET_ITER_THRESHOLD {
@@ -169,7 +169,7 @@ fn get_match_except_checker(
     except: AnyVariants,
     index: &FieldIndex,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     let checker: Option<ConditionCheckerFn> = match (except, index) {
         (AnyVariants::Strings(list), FieldIndex::KeywordIndex(index)) => {
             let hw_counter = hw_acc.get_counter_cell();
@@ -253,7 +253,7 @@ fn get_match_text_checker<const IS_PHRASE: bool>(
     text: String,
     index: &FieldIndex,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn> {
+) -> Option<ConditionCheckerFn<'_>> {
     let hw_counter = hw_acc.get_counter_cell();
     match index {
         FieldIndex::FullTextIndex(full_text_index) => {

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -202,10 +202,10 @@ impl FormulaScorer<'_> {
                 }
                 let right = self.eval_expression(right, point_id)?;
 
-                if right == 0.0 {
-                    if let Some(default) = by_zero_default {
-                        return Ok(*default);
-                    }
+                if right == 0.0
+                    && let Some(default) = by_zero_default
+                {
+                    return Ok(*default);
                 }
 
                 let div_value = left / right;

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -69,7 +69,7 @@ fn payload_variable_retriever(
     payload_provider: PayloadProvider,
     json_path: JsonPath,
     hw_counter: &HardwareCounterCell,
-) -> VariableRetrieverFn {
+) -> VariableRetrieverFn<'_> {
     let retriever_fn = move |point_id: PointOffsetType| {
         payload_provider.with_payload(
             point_id,
@@ -103,7 +103,7 @@ fn payload_variable_retriever(
 /// Returns function to extract all the values a point has in the index
 ///
 /// If there is no appropriate index, returns None
-fn indexed_variable_retriever(index: &FieldIndex) -> Option<VariableRetrieverFn> {
+fn indexed_variable_retriever(index: &FieldIndex) -> Option<VariableRetrieverFn<'_>> {
     match index {
         FieldIndex::IntIndex(numeric_index) => {
             let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -254,11 +254,11 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
         let mut unique_record_ids = std::collections::HashSet::new();
         for dim_id in query_vector.indices.iter() {
-            if let Some(dim_id) = self.indices_tracker.remap_index(*dim_id) {
-                if let Some(posting_list_iter) = self.inverted_index.get(dim_id, &hw_counter) {
-                    for element in posting_list_iter.into_std_iter() {
-                        unique_record_ids.insert(element.record_id);
-                    }
+            if let Some(dim_id) = self.indices_tracker.remap_index(*dim_id)
+                && let Some(posting_list_iter) = self.inverted_index.get(dim_id, &hw_counter)
+            {
+                for element in posting_list_iter.into_std_iter() {
+                    unique_record_ids.insert(element.record_id);
                 }
             }
         }
@@ -528,13 +528,12 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         hw_counter: &HardwareCounterCell,
     ) {
         for (dim_id, count) in idf.iter_mut() {
-            if let Some(remapped_dim_id) = self.indices_tracker.remap_index(*dim_id) {
-                if let Some(posting_list_len) = self
+            if let Some(remapped_dim_id) = self.indices_tracker.remap_index(*dim_id)
+                && let Some(posting_list_len) = self
                     .inverted_index
                     .posting_list_len(&remapped_dim_id, hw_counter)
-                {
-                    *count += posting_list_len
-                }
+            {
+                *count += posting_list_len
             }
         }
     }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -684,7 +684,7 @@ impl StructPayloadIndex {
     }
 
     /// Select which type of PayloadIndex to use for the field
-    fn selector(&self, payload_schema: &PayloadFieldSchema) -> IndexSelector {
+    fn selector(&self, payload_schema: &PayloadFieldSchema) -> IndexSelector<'_> {
         let is_on_disk = payload_schema.is_on_disk();
 
         match &self.storage_type {
@@ -721,7 +721,7 @@ impl StructPayloadIndex {
     fn selector_with_type(
         &self,
         index_type: &FullPayloadIndexType,
-    ) -> OperationResult<IndexSelector> {
+    ) -> OperationResult<IndexSelector<'_>> {
         let selector = match index_type.storage_type {
             payload_config::StorageType::Gridstore => {
                 IndexSelector::Gridstore(IndexSelectorGridstore { dir: &self.path })
@@ -771,7 +771,7 @@ impl StructPayloadIndex {
         Ok(selector)
     }
 
-    pub fn get_facet_index(&self, key: &JsonPath) -> OperationResult<FacetIndexEnum> {
+    pub fn get_facet_index(&self, key: &JsonPath) -> OperationResult<FacetIndexEnum<'_>> {
         self.field_indexes
             .get(key)
             .and_then(|index| index.iter().find_map(|index| index.as_facet_index()))

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -105,7 +105,7 @@ impl VisitedPool {
         }
     }
 
-    pub fn get(&self, num_points: usize) -> VisitedListHandle {
+    pub fn get(&self, num_points: usize) -> VisitedListHandle<'_> {
         // If there are more concurrent requests, a new temporary list is created dynamically.
         // This limit is implemented to prevent memory leakage.
         match self.pool.write().pop() {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -336,7 +336,7 @@ impl SegmentEntry for Segment {
         &self,
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<NamedVectors> {
+    ) -> OperationResult<NamedVectors<'_>> {
         let mut result = NamedVectors::default();
         for vector_name in self.vector_data.keys() {
             if let Some(vec) = self.vector(vector_name, point_id, hw_counter)? {

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -132,10 +132,10 @@ impl Drop for Segment {
                 log::error!("Failed to clear cache of vector storage {name}: {e}");
             }
 
-            if let Some(quantized_vectors) = quantized_vectors.borrow().as_ref() {
-                if let Err(e) = quantized_vectors.clear_cache() {
-                    log::error!("Failed to clear cache of quantized vectors {name}: {e}");
-                }
+            if let Some(quantized_vectors) = quantized_vectors.borrow().as_ref()
+                && let Err(e) = quantized_vectors.clear_cache()
+            {
+                log::error!("Failed to clear cache of quantized vectors {name}: {e}");
             }
         }
     }

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -252,18 +252,18 @@ pub fn snapshot_files(
     // TODO: Version RocksDB!? 🤯
 
     #[cfg(feature = "rocksdb")]
-    if include_if(ROCKS_DB_VIRT_FILE.as_ref()) {
-        if let Some(db) = &segment.database {
-            let db_backup_path = temp_path.join(super::DB_BACKUP_PATH);
+    if include_if(ROCKS_DB_VIRT_FILE.as_ref())
+        && let Some(db) = &segment.database
+    {
+        let db_backup_path = temp_path.join(super::DB_BACKUP_PATH);
 
-            let db = db.read();
-            crate::rocksdb_backup::create(&db, &db_backup_path).map_err(|err| {
-                OperationError::service_error(format!(
-                    "failed to create RocksDB backup at {}: {err}",
-                    db_backup_path.display()
-                ))
-            })?;
-        }
+        let db = db.read();
+        crate::rocksdb_backup::create(&db, &db_backup_path).map_err(|err| {
+            OperationError::service_error(format!(
+                "failed to create RocksDB backup at {}: {err}",
+                db_backup_path.display()
+            ))
+        })?;
     }
 
     #[cfg(feature = "rocksdb")]

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -177,10 +177,10 @@ impl SegmentBuilder {
         field: &PayloadKeyType,
         schema: &PayloadFieldSchema,
     ) {
-        if let Some(existing_schema) = self.indexed_fields.get(field) {
-            if existing_schema != schema {
-                self.indexed_fields.remove(field);
-            }
+        if let Some(existing_schema) = self.indexed_fields.get(field)
+            && existing_schema != schema
+        {
+            self.indexed_fields.remove(field);
         }
     }
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1443,13 +1443,13 @@ pub fn migrate_rocksdb_payload_storage_to_mmap(
         // On migration error, clean up and remove all new storage files
         Err(err) => {
             let storage_dir = mmap_payload_storage::storage_dir(segment_path);
-            if storage_dir.is_dir() {
-                if let Err(err) = std::fs::remove_dir_all(&storage_dir) {
-                    log::error!(
-                        "Payload storage migration to mmap failed, failed to remove mmap files in {} for cleanup: {err}",
-                        storage_dir.display(),
-                    );
-                }
+            if storage_dir.is_dir()
+                && let Err(err) = std::fs::remove_dir_all(&storage_dir)
+            {
+                log::error!(
+                    "Payload storage migration to mmap failed, failed to remove mmap files in {} for cleanup: {err}",
+                    storage_dir.display(),
+                );
             }
             return Err(err);
         }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2521,16 +2521,15 @@ impl GeoPolygon {
             });
         }
 
-        if let (Some(first), Some(last)) = (line.points.first(), line.points.last()) {
-            if (first.lat - last.lat).abs() > f64::EPSILON
-                || (first.lon - last.lon).abs() > f64::EPSILON
-            {
-                return Err(OperationError::ValidationError {
-                    description: String::from(
-                        "polygon invalid, the first and the last points should be the same to form a closed line",
-                    ),
-                });
-            }
+        if let (Some(first), Some(last)) = (line.points.first(), line.points.last())
+            && ((first.lat - last.lat).abs() > f64::EPSILON
+                || (first.lon - last.lon).abs() > f64::EPSILON)
+        {
+            return Err(OperationError::ValidationError {
+                description: String::from(
+                    "polygon invalid, the first and the last points should be the same to form a closed line",
+                ),
+            });
         }
 
         Ok(())

--- a/lib/segment/src/utils/fs.rs
+++ b/lib/segment/src/utils/fs.rs
@@ -44,16 +44,16 @@ fn move_all_impl(base: &Path, dir: &Path, dest_dir: &Path) -> OperationResult<()
             move_all_impl(base, &path, &dest_path)?;
             std::fs::remove_dir(path)?;
         } else {
-            if let Some(dir) = dest_path.parent() {
-                if !dir.exists() {
-                    fs::create_dir_all(dir).map_err(|err| {
-                        failed_to_move_error(
-                            &path,
-                            &dest_path,
-                            format!("failed to create {dir:?} directory: {err}"),
-                        )
-                    })?;
-                }
+            if let Some(dir) = dest_path.parent()
+                && !dir.exists()
+            {
+                fs::create_dir_all(dir).map_err(|err| {
+                    failed_to_move_error(
+                        &path,
+                        &dest_path,
+                        format!("failed to create {dir:?} directory: {err}"),
+                    )
+                })?;
             }
 
             fs::rename(&path, &dest_path)

--- a/lib/segment/src/utils/mem.rs
+++ b/lib/segment/src/utils/mem.rs
@@ -26,10 +26,10 @@ impl Mem {
 
     pub fn total_memory_bytes(&self) -> u64 {
         #[cfg(target_os = "linux")]
-        if let Some(cgroups) = &self.cgroups {
-            if let Some(memory_limit_bytes) = cgroups.memory_limit_bytes() {
-                return memory_limit_bytes;
-            }
+        if let Some(cgroups) = &self.cgroups
+            && let Some(memory_limit_bytes) = cgroups.memory_limit_bytes()
+        {
+            return memory_limit_bytes;
         }
 
         self.sysinfo.total_memory_bytes()
@@ -37,10 +37,10 @@ impl Mem {
 
     pub fn available_memory_bytes(&self) -> u64 {
         #[cfg(target_os = "linux")]
-        if let Some(cgroups) = &self.cgroups {
-            if let Some(memory_limit_bytes) = cgroups.memory_limit_bytes() {
-                return memory_limit_bytes.saturating_sub(cgroups.used_memory_bytes());
-            }
+        if let Some(cgroups) = &self.cgroups
+            && let Some(memory_limit_bytes) = cgroups.memory_limit_bytes()
+        {
+            return memory_limit_bytes.saturating_sub(cgroups.used_memory_bytes());
         }
 
         self.sysinfo.available_memory_bytes()

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -125,18 +125,18 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
         self.vectors.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
             .get_sequential(key as VectorOffsetType)
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
             .expect("Vector not found")
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get(key as VectorOffsetType)
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -187,11 +187,11 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
         self.mmap_store.as_ref().unwrap().num_vectors
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         self.mmap_store
             .as_ref()
             .unwrap()
@@ -200,7 +200,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
             .expect("Vector not found")
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.mmap_store
             .as_ref()
             .unwrap()

--- a/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/mmap_dense_vectors.rs
@@ -269,10 +269,10 @@ fn ensure_mmap_file_size(path: &Path, header: &[u8], size: Option<u64>) -> Opera
     // Create file, and make it the correct size
     let mut file = File::create(path)?;
     file.write_all(header)?;
-    if let Some(size) = size {
-        if size > header.len() as u64 {
-            file.set_len(size)?;
-        }
+    if let Some(size) = size
+        && size > header.len() as u64
+    {
+        file.set_len(size)?;
     }
     Ok(())
 }

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -259,17 +259,17 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleDenseVectorStorage<T> {
         self.vectors.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         // In memory so no optimization to be done here.
         self.get_vector(key)
     }
 
     /// Get vector by key, if it exists.
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get_opt(key as VectorOffsetType)
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -106,17 +106,17 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> 
         self.vectors.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         // In memory so no optimization to be done here.
         self.get_vector(key)
     }
 
     /// Get vector by key, if it exists.
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get_opt(key as VectorOffsetType)
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -98,12 +98,12 @@ impl<
     }
 
     /// Panics if key is not found
-    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T> {
+    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
         self.get_multi_opt(key).expect("vector not found")
     }
 
     /// Returns None if key is not found
-    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<T>> {
+    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<'_, T>> {
         self.offsets
             .get(key as VectorOffsetType)
             .and_then(|mmap_offset| {
@@ -123,7 +123,7 @@ impl<
     fn get_multi_opt_sequential(
         &self,
         key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<T>> {
+    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
         self.offsets
             .get_sequential(key as VectorOffsetType)
             .and_then(|mmap_offset| {
@@ -192,11 +192,11 @@ impl<
         self.offsets.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_multi_opt_sequential(key)
             .map(|multi_dense_vector| {
                 CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
@@ -206,7 +206,7 @@ impl<
             .expect("vector not found")
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.get_multi_opt(key).map(|multi_dense_vector| {
             CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
                 multi_dense_vector,

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -241,7 +241,7 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
         &self,
         key: PointOffsetType,
         deleted: bool,
-        vector: Option<TypedMultiDenseVectorRef<T>>,
+        vector: Option<TypedMultiDenseVectorRef<'_, T>>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let mut record = StoredMultiDenseVector {
@@ -335,12 +335,12 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     }
 
     /// Panics if key is out of bounds
-    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T> {
+    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
         self.get_multi_opt(key).expect("vector not found")
     }
 
     /// None if key is out of bounds
-    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<T>> {
+    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<'_, T>> {
         self.vectors_metadata.get(key as usize).map(|metadata| {
             let flattened_vectors = self
                 .vectors
@@ -356,7 +356,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     fn get_multi_opt_sequential(
         &self,
         key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<T>> {
+    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
         // No sequential optimizations available for in memory storage.
         self.get_multi_opt(key)
     }
@@ -400,15 +400,15 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
         self.vectors_metadata.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector(key)
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.get_multi_opt(key).map(|multi_dense_vector| {
             CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
                 multi_dense_vector,

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -181,12 +181,12 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
     }
 
     /// Panics if key is out of bounds
-    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T> {
+    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
         self.get_multi_opt(key).expect("vector not found")
     }
 
     /// None if key is out of bounds
-    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<T>> {
+    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<'_, T>> {
         self.vectors_metadata.get(key as usize).map(|metadata| {
             let flattened_vectors = self
                 .vectors
@@ -202,7 +202,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
     fn get_multi_opt_sequential(
         &self,
         key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<T>> {
+    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
         // No sequential optimizations available for in memory storage.
         self.get_multi_opt(key)
     }
@@ -246,15 +246,15 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileMultiDenseVectorStorag
         self.vectors_metadata.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector(key)
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.get_multi_opt(key).map(|multi_dense_vector| {
             CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
                 multi_dense_vector,

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -49,8 +49,8 @@ pub trait QueryScorerBytes {
 /// In that case the score value will be different but the ranking will be the same.
 /// We do that because of performance reasons and complex sort ordering of the vectors when applying the post-processing step.
 pub fn score_max_similarity<T: PrimitiveVectorElement, TMetric: Metric<T>>(
-    multi_dense_a: TypedMultiDenseVectorRef<T>,
-    multi_dense_b: TypedMultiDenseVectorRef<T>,
+    multi_dense_a: TypedMultiDenseVectorRef<'_, T>,
+    multi_dense_b: TypedMultiDenseVectorRef<'_, T>,
 ) -> ScoreType {
     debug_assert!(!multi_dense_a.is_empty());
     debug_assert!(!multi_dense_b.is_empty());
@@ -72,8 +72,8 @@ pub fn score_max_similarity<T: PrimitiveVectorElement, TMetric: Metric<T>>(
 
 fn score_multi<T: PrimitiveVectorElement, TMetric: Metric<T>>(
     multi_vector_config: &MultiVectorConfig,
-    multi_dense_a: TypedMultiDenseVectorRef<T>,
-    multi_dense_b: TypedMultiDenseVectorRef<T>,
+    multi_dense_a: TypedMultiDenseVectorRef<'_, T>,
+    multi_dense_b: TypedMultiDenseVectorRef<'_, T>,
 ) -> ScoreType {
     match multi_vector_config.comparator {
         MultiVectorComparator::MaxSim => {

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -229,12 +229,12 @@ impl VectorStorage for MmapSparseVectorStorage {
         self.next_point_offset
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         let vector = self.get_vector_opt(key);
         vector.unwrap_or_else(CowVector::default_sparse)
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_sparse_sequential(key)
             .map(CowVector::from)
             .unwrap_or_else(|_| CowVector::default_sparse())
@@ -243,7 +243,7 @@ impl VectorStorage for MmapSparseVectorStorage {
     /// Get vector by key, if it exists.
     ///
     /// Ignore any error
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         match self.get_sparse_opt(key) {
             Ok(Some(vector)) => Some(CowVector::from(vector)),
             _ => None,

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -195,12 +195,12 @@ impl VectorStorage for SimpleSparseVectorStorage {
         self.total_vector_count
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         let vector = self.get_vector_opt(key);
         vector.unwrap_or_else(CowVector::default_sparse)
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         // In memory, so no sequential read optimization.
         self.get_vector(key)
     }
@@ -208,7 +208,7 @@ impl VectorStorage for SimpleSparseVectorStorage {
     /// Get vector by key, if it exists.
     ///
     /// ignore any error
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         match self.get_sparse_opt(key) {
             Ok(Some(vector)) => Some(CowVector::from(vector)),
             _ => None,

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -134,12 +134,12 @@ impl VectorStorage for VolatileSparseVectorStorage {
         self.total_vector_count
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         let vector = self.get_vector_opt(key);
         vector.unwrap_or_else(CowVector::default_sparse)
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         // In memory, so no sequential read optimization.
         self.get_vector(key)
     }
@@ -147,7 +147,7 @@ impl VectorStorage for VolatileSparseVectorStorage {
     /// Get vector by key, if it exists.
     ///
     /// ignore any error
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         match self.get_sparse_opt(key) {
             Ok(Some(vector)) => Some(CowVector::from(vector)),
             _ => None,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -65,13 +65,13 @@ pub trait VectorStorage {
     }
 
     /// Get the vector by the given key
-    fn get_vector(&self, key: PointOffsetType) -> CowVector;
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_>;
 
     /// Get the vector by the given key with potential optimizations for sequential reads.
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector;
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_>;
 
     /// Get the vector by the given key if it exists
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector>;
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>>;
 
     fn insert_vector(
         &mut self,
@@ -162,10 +162,12 @@ pub trait SparseVectorStorage: VectorStorage {
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     fn vector_dim(&self) -> usize;
-    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T>;
-    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<T>>;
-    fn get_multi_opt_sequential(&self, key: PointOffsetType)
-    -> Option<TypedMultiDenseVectorRef<T>>;
+    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T>;
+    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<'_, T>>;
+    fn get_multi_opt_sequential(
+        &self,
+        key: PointOffsetType,
+    ) -> Option<TypedMultiDenseVectorRef<'_, T>>;
     fn get_batch_multi<'a>(
         &'a self,
         keys: &[PointOffsetType],
@@ -809,7 +811,7 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
         match self {
             #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.get_vector(key),
@@ -855,7 +857,7 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector {
+    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
         match self {
             #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.get_vector_sequential(key),
@@ -901,7 +903,7 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         match self {
             #[cfg(feature = "rocksdb")]
             VectorStorageEnum::DenseSimple(v) => v.get_vector_opt(key),

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -38,7 +38,10 @@ fn convert_to_sparse_vector(vector: &[VectorElementType]) -> SparseVector {
     sparse_vector
 }
 
-fn random_named_vector<R: Rng + ?Sized>(rnd: &mut R, dim: usize) -> (NamedVectors, NamedVectors) {
+fn random_named_vector<R: Rng + ?Sized>(
+    rnd: &mut R,
+    dim: usize,
+) -> (NamedVectors<'_>, NamedVectors<'_>) {
     let dense_vector = random_vector(rnd, dim);
     let sparse_vector = convert_to_sparse_vector(&dense_vector);
 

--- a/lib/sparse/src/common/scores_memory_pool.rs
+++ b/lib/sparse/src/common/scores_memory_pool.rs
@@ -34,7 +34,7 @@ impl ScoresMemoryPool {
         }
     }
 
-    pub fn get(&self) -> PooledScoresHandle {
+    pub fn get(&self) -> PooledScoresHandle<'_> {
         match self.pool.lock().pop() {
             None => PooledScoresHandle::new(self, vec![]),
             Some(data) => PooledScoresHandle::new(self, data),

--- a/lib/sparse/src/index/compressed_posting_list.rs
+++ b/lib/sparse/src/index/compressed_posting_list.rs
@@ -511,11 +511,11 @@ impl<W: Weight> PostingListIter for CompressedPostingListIterator<'_, W> {
         // 2. If current, change the position to the element and do peek
 
         // Shortcut peeking into memory
-        if let Some(current_record_id) = self.pos.1.as_ref() {
-            if record_id < *current_record_id {
-                // We are already ahead
-                return None;
-            }
+        if let Some(current_record_id) = self.pos.1.as_ref()
+            && record_id < *current_record_id
+        {
+            // We are already ahead
+            return None;
         }
 
         // If None, we are already reading remainder

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -109,7 +109,7 @@ impl PostingList {
         }
     }
 
-    pub fn iter(&self) -> PostingListIterator {
+    pub fn iter(&self) -> PostingListIterator<'_> {
         PostingListIterator::new(&self.elements)
     }
 }

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -51,26 +51,26 @@ impl<'a, 'b, T: PostingListIter> SearchContext<'a, 'b, T> {
         let mut min_record_id = u32::MAX;
         // iterate over query indices
         for (query_weight_offset, id) in query.indices.iter().enumerate() {
-            if let Some(mut it) = inverted_index.get(*id, hardware_counter) {
-                if let (Some(first), Some(last_id)) = (it.peek(), it.last_id()) {
-                    // check if new min
-                    let min_record_id_posting = first.record_id;
-                    min_record_id = min(min_record_id, min_record_id_posting);
+            if let Some(mut it) = inverted_index.get(*id, hardware_counter)
+                && let (Some(first), Some(last_id)) = (it.peek(), it.last_id())
+            {
+                // check if new min
+                let min_record_id_posting = first.record_id;
+                min_record_id = min(min_record_id, min_record_id_posting);
 
-                    // check if new max
-                    let max_record_id_posting = last_id;
-                    max_record_id = max(max_record_id, max_record_id_posting);
+                // check if new max
+                let max_record_id_posting = last_id;
+                max_record_id = max(max_record_id, max_record_id_posting);
 
-                    // capture query info
-                    let query_index = *id;
-                    let query_weight = query.values[query_weight_offset];
+                // capture query info
+                let query_index = *id;
+                let query_weight = query.values[query_weight_offset];
 
-                    postings_iterators.push(IndexedPostingListIterator {
-                        posting_list_iterator: it,
-                        query_index,
-                        query_weight,
-                    });
-                }
+                postings_iterators.push(IndexedPostingListIterator {
+                    posting_list_iterator: it,
+                    query_index,
+                    query_weight,
+                });
             }
         }
         let top_results = TopK::new(top);

--- a/lib/storage/src/content_manager/collection_verification.rs
+++ b/lib/storage/src/content_manager/collection_verification.rs
@@ -30,17 +30,17 @@ where
     let collection_pass =
         access.check_collection_access(collection_name, AccessRequirements::new())?;
     let collection = toc.get_collection(&collection_pass).await?;
-    if let Some(strict_mode_config) = &collection.strict_mode_config().await {
-        if strict_mode_config.enabled.unwrap_or_default() {
-            for request in requests {
-                request
-                    .check_strict_mode(&collection, strict_mode_config)
-                    .await?;
-            }
+    if let Some(strict_mode_config) = &collection.strict_mode_config().await
+        && strict_mode_config.enabled.unwrap_or_default()
+    {
+        for request in requests {
+            request
+                .check_strict_mode(&collection, strict_mode_config)
+                .await?;
+        }
 
-            if let Some(timeout) = timeout {
-                check_timeout(timeout, strict_mode_config)?;
-            }
+        if let Some(timeout) = timeout {
+            check_timeout(timeout, strict_mode_config)?;
         }
     }
 
@@ -112,10 +112,10 @@ pub async fn check_strict_mode_timeout(
         access.check_collection_access(collection_name, AccessRequirements::new())?;
     let collection = toc.get_collection(&collection_pass).await?;
 
-    if let Some(strict_mode_config) = &collection.strict_mode_config().await {
-        if strict_mode_config.enabled.unwrap_or_default() {
-            check_timeout(timeout, strict_mode_config)?;
-        }
+    if let Some(strict_mode_config) = &collection.strict_mode_config().await
+        && strict_mode_config.enabled.unwrap_or_default()
+    {
+        check_timeout(timeout, strict_mode_config)?;
     }
 
     // It's checked now

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -286,12 +286,12 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         };
         let operation = ConsensusOperations::RemovePeer(peer_id);
         let on_apply = self.on_consensus_op_apply.lock().remove(&operation);
-        if let Some(on_apply) = on_apply {
-            if on_apply.send(report).is_err() {
-                log::warn!(
-                    "Failed to notify on consensus operation completion: channel receiver is dropped",
-                )
-            }
+        if let Some(on_apply) = on_apply
+            && on_apply.send(report).is_err()
+        {
+            log::warn!(
+                "Failed to notify on consensus operation completion: channel receiver is dropped",
+            )
         }
         Ok(stop_consensus)
     }
@@ -454,12 +454,12 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                                 uri: peer_uri.to_string(),
                             };
                             let on_apply = self.on_consensus_op_apply.lock().remove(&operation);
-                            if let Some(on_apply) = on_apply {
-                                if on_apply.send(Ok(true)).is_err() {
-                                    log::warn!(
-                                        "Failed to notify on consensus operation completion: channel receiver is dropped",
-                                    )
-                                }
+                            if let Some(on_apply) = on_apply
+                                && on_apply.send(Ok(true)).is_err()
+                            {
+                                log::warn!(
+                                    "Failed to notify on consensus operation completion: channel receiver is dropped",
+                                )
                             }
                         }
                     } else if entry.get_context().is_empty() {
@@ -527,12 +527,12 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             }
         };
 
-        if let Some(on_apply) = on_apply {
-            if on_apply.send(result.clone()).is_err() {
-                log::warn!(
-                    "Failed to notify on consensus operation completion: channel receiver is dropped",
-                )
-            }
+        if let Some(on_apply) = on_apply
+            && on_apply.send(result.clone()).is_err()
+        {
+            log::warn!(
+                "Failed to notify on consensus operation completion: channel receiver is dropped",
+            )
         }
         result
     }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -194,14 +194,14 @@ impl TableOfContent {
 
             let path = self.get_collection_path(collection_name);
 
-            if let Some(state) = removed.resharding_state().await {
-                if let Err(err) = removed.abort_resharding(state.key(), true).await {
-                    log::error!(
-                        "Failed to abort resharding {} when deleting collection {collection_name}: \
+            if let Some(state) = removed.resharding_state().await
+                && let Err(err) = removed.abort_resharding(state.key(), true).await
+            {
+                log::error!(
+                    "Failed to abort resharding {} when deleting collection {collection_name}: \
                          {err}",
-                        state.key(),
-                    );
-                }
+                    state.key(),
+                );
             }
 
             drop(removed);

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -54,12 +54,12 @@ impl TableOfContent {
             let collections = self.collections.read().await;
             collections.validate_collection_not_exists(collection_name)?;
 
-            if let Some(max_collections) = self.storage_config.max_collections {
-                if collections.len() >= max_collections {
-                    return Err(StorageError::bad_request(format!(
-                        "Can't create collection with name {collection_name}. Max collections limit reached: {max_collections}",
-                    )));
-                }
+            if let Some(max_collections) = self.storage_config.max_collections
+                && collections.len() >= max_collections
+            {
+                return Err(StorageError::bad_request(format!(
+                    "Can't create collection with name {collection_name}. Max collections limit reached: {max_collections}",
+                )));
             }
         }
 

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -263,7 +263,7 @@ impl TableOfContent {
     async fn get_collection_unchecked(
         &self,
         collection_name: &str,
-    ) -> Result<RwLockReadGuard<Collection>, StorageError> {
+    ) -> Result<RwLockReadGuard<'_, Collection>, StorageError> {
         let read_collection = self.collections.read().await;
 
         let real_collection_name = {
@@ -279,14 +279,14 @@ impl TableOfContent {
     pub async fn get_collection(
         &self,
         collection: &CollectionPass<'_>,
-    ) -> Result<RwLockReadGuard<Collection>, StorageError> {
+    ) -> Result<RwLockReadGuard<'_, Collection>, StorageError> {
         self.get_collection_unchecked(collection.name()).await
     }
 
     async fn get_collection_opt(
         &self,
         collection_name: String,
-    ) -> Option<RwLockReadGuard<Collection>> {
+    ) -> Option<RwLockReadGuard<'_, Collection>> {
         self.get_collection_unchecked(&collection_name).await.ok()
     }
 

--- a/lib/storage/src/content_manager/toc/temp_directories.rs
+++ b/lib/storage/src/content_manager/toc/temp_directories.rs
@@ -163,16 +163,16 @@ impl TableOfContent {
             })?;
         }
 
-        if let Some(path) = optional_temp_path {
-            if path.exists() {
-                std::fs::remove_dir_all(&path).map_err(|e| {
-                    CollectionError::service_error(format!(
-                        "Failed to remove optional temp directory at {}: {:?}",
-                        path.display(),
-                        e,
-                    ))
-                })?;
-            }
+        if let Some(path) = optional_temp_path
+            && path.exists()
+        {
+            std::fs::remove_dir_all(&path).map_err(|e| {
+                CollectionError::service_error(format!(
+                    "Failed to remove optional temp directory at {}: {:?}",
+                    path.display(),
+                    e,
+                ))
+            })?;
         }
 
         Ok(())

--- a/lib/storage/src/rbac/mod.rs
+++ b/lib/storage/src/rbac/mod.rs
@@ -44,7 +44,7 @@ pub struct CollectionAccess {
 }
 
 impl CollectionAccess {
-    fn view(&self) -> CollectionAccessView {
+    fn view(&self) -> CollectionAccessView<'_> {
         CollectionAccessView {
             collection: &self.collection,
             access: self.access,


### PR DESCRIPTION
Clippy fixes for Rust [1.89](https://releases.rs/docs/1.89.0/)

Most of the diff is caused by

> [Add a warn-by-default mismatched_lifetime_syntaxes lint.](https://github.com/rust-lang/rust/pull/138677) This lint detects when the same lifetime is referred to by different syntax categories between function arguments and return values, which can be confusing to read, especially in unsafe code.