### PR TITLE
Refactor quantization save/load/snapshots to support multiple files

### DIFF
--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::TBool;
@@ -30,12 +30,6 @@ pub struct VectorParameters {
 
 pub trait EncodedVectors: Sized {
     type EncodedQuery;
-
-    fn load(
-        data_path: &Path,
-        meta_path: &Path,
-        vector_parameters: &VectorParameters,
-    ) -> std::io::Result<Self>;
 
     fn is_on_disk(&self) -> bool;
 

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -137,6 +137,17 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         }
     }
 
+    pub fn load(meta_path: &Path, encoded_vectors: TStorage) -> std::io::Result<Self> {
+        let contents = std::fs::read_to_string(meta_path)?;
+        let metadata: Metadata = serde_json::from_str(&contents)?;
+        let result = Self {
+            encoded_vectors,
+            metadata,
+            metadata_path: Some(meta_path.to_path_buf()),
+        };
+        Ok(result)
+    }
+
     pub fn get_quantized_vector_size(
         vector_parameters: &VectorParameters,
         chunk_size: usize,
@@ -475,23 +486,6 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
     type EncodedQuery = EncodedQueryPQ;
 
-    fn load(
-        data_path: &Path,
-        meta_path: &Path,
-        _vector_parameters: &VectorParameters,
-    ) -> std::io::Result<Self> {
-        let contents = std::fs::read_to_string(meta_path)?;
-        let metadata: Metadata = serde_json::from_str(&contents)?;
-        let quantized_vector_size = metadata.vector_division.len();
-        let encoded_vectors = TStorage::from_file(data_path, quantized_vector_size)?;
-        let result = Self {
-            encoded_vectors,
-            metadata,
-            metadata_path: Some(meta_path.to_path_buf()),
-        };
-        Ok(result)
-    }
-
     fn is_on_disk(&self) -> bool {
         self.encoded_vectors.is_on_disk()
     }
@@ -603,7 +597,6 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
     }
 
     fn vectors_count(&self) -> usize {
-        // `vector_division` size is equal to quantized vector size because each chunk is replaced by one `u8` centroid index.
         self.encoded_vectors.vectors_count()
     }
 

--- a/lib/quantization/tests/integration/empty_storage.rs
+++ b/lib/quantization/tests/integration/empty_storage.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use quantization::EncodedVectorsPQ;
     use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
-    use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
+    use quantization::encoded_vectors::{DistanceType, VectorParameters};
     use quantization::encoded_vectors_binary::{EncodedVectorsBin, QueryEncoding};
     use quantization::encoded_vectors_u8::EncodedVectorsU8;
     use tempfile::Builder;
@@ -39,9 +39,8 @@ mod tests {
         .unwrap();
 
         EncodedVectorsU8::<TestEncodedStorage>::load(
-            data_path.as_path(),
             meta_path.as_path(),
-            &vector_parameters,
+            TestEncodedStorage::load(data_path.as_path(), quantized_vector_size).unwrap(),
         )
         .unwrap();
     }
@@ -80,9 +79,8 @@ mod tests {
         .unwrap();
 
         EncodedVectorsPQ::<TestEncodedStorage>::load(
-            data_path.as_path(),
             meta_path.as_path(),
-            &vector_parameters,
+            TestEncodedStorage::load(data_path.as_path(), quantized_vector_size).unwrap(),
         )
         .unwrap();
     }
@@ -119,9 +117,8 @@ mod tests {
         .unwrap();
 
         EncodedVectorsBin::<u8, TestEncodedStorage>::load(
-            data_path.as_path(),
             meta_path.as_path(),
-            &vector_parameters,
+            TestEncodedStorage::load(data_path.as_path(), quantized_vector_size).unwrap(),
         )
         .unwrap();
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -19,35 +19,8 @@ impl QuantizedMmapStorage {
     pub fn populate(&self) {
         self.mmap.populate();
     }
-}
 
-pub struct QuantizedMmapStorageBuilder {
-    mmap: MmapMut,
-    cursor_pos: usize,
-    quantized_vector_size: NonZeroUsize,
-    path: PathBuf,
-}
-
-impl quantization::EncodedStorage for QuantizedMmapStorage {
-    fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
-        let start = self.quantized_vector_size.get() * index as usize;
-        let end = self.quantized_vector_size.get() * (index + 1) as usize;
-        self.mmap.get(start..end).unwrap_or(&[])
-    }
-
-    fn upsert_vector(
-        &mut self,
-        _id: PointOffsetType,
-        _vector: &[u8],
-        _hw_counter: &HardwareCounterCell,
-    ) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "Cannot upsert vector in mmap storage",
-        ))
-    }
-
-    fn from_file(
+    pub fn from_file(
         path: &Path,
         quantized_vector_size: usize,
     ) -> std::io::Result<QuantizedMmapStorage> {
@@ -76,6 +49,33 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
             quantized_vector_size,
             path: path.to_path_buf(),
         })
+    }
+}
+
+pub struct QuantizedMmapStorageBuilder {
+    mmap: MmapMut,
+    cursor_pos: usize,
+    quantized_vector_size: NonZeroUsize,
+    path: PathBuf,
+}
+
+impl quantization::EncodedStorage for QuantizedMmapStorage {
+    fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
+        let start = self.quantized_vector_size.get() * index as usize;
+        let end = self.quantized_vector_size.get() * (index + 1) as usize;
+        self.mmap.get(start..end).unwrap_or(&[])
+    }
+
+    fn upsert_vector(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: &[u8],
+        _hw_counter: &HardwareCounterCell,
+    ) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Cannot upsert vector in mmap storage",
+        ))
     }
 
     fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -619,7 +619,7 @@ impl QuantizedVectors {
         let distance = vector_storage.distance();
         let datatype = vector_storage.datatype();
 
-        let data_path = path.join(QUANTIZED_DATA_PATH);
+        let data_path = Self::get_data_path(path);
         let meta_path = path.join(QUANTIZED_META_PATH);
         let config_path = path.join(QUANTIZED_CONFIG_PATH);
         let config: QuantizedVectorsConfig = read_json(&config_path)?;
@@ -630,69 +630,117 @@ impl QuantizedVectors {
             match &config.quantization_config {
                 QuantizationConfig::Scalar(ScalarQuantization { scalar }) => {
                     if Self::is_ram(scalar.always_ram, on_disk_vector_storage) {
-                        QuantizedVectorStorage::ScalarRamMulti(
-                            QuantizedMultivectorStorage::load_multi(
-                                &data_path,
-                                &meta_path,
-                                &offsets_path,
+                        let quantized_vector_size =
+                            EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
                                 &config.vector_parameters,
-                                multivector_config,
-                            )?,
-                        )
+                            );
+                        let inner_vectors_storage =
+                            QuantizedRamStorage::load(data_path.as_path(), quantized_vector_size)?;
+                        let inner_vectors_storage =
+                            EncodedVectorsU8::load(&meta_path, inner_vectors_storage)?;
+                        let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
+                        QuantizedVectorStorage::ScalarRamMulti(QuantizedMultivectorStorage::new(
+                            config.vector_parameters.dim,
+                            inner_vectors_storage,
+                            offsets,
+                            *multivector_config,
+                        ))
                     } else {
-                        QuantizedVectorStorage::ScalarMmapMulti(
-                            QuantizedMultivectorStorage::load_multi(
-                                &data_path,
-                                &meta_path,
-                                &offsets_path,
+                        let quantized_vector_size =
+                            EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
                                 &config.vector_parameters,
-                                multivector_config,
-                            )?,
-                        )
+                            );
+                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
+                            data_path.as_path(),
+                            quantized_vector_size,
+                        )?;
+                        let inner_vectors_storage =
+                            EncodedVectorsU8::load(&meta_path, inner_vectors_storage)?;
+                        let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
+                        QuantizedVectorStorage::ScalarMmapMulti(QuantizedMultivectorStorage::new(
+                            config.vector_parameters.dim,
+                            inner_vectors_storage,
+                            offsets,
+                            *multivector_config,
+                        ))
                     }
                 }
                 QuantizationConfig::Product(ProductQuantization { product: pq }) => {
                     if Self::is_ram(pq.always_ram, on_disk_vector_storage) {
-                        QuantizedVectorStorage::PQRamMulti(QuantizedMultivectorStorage::load_multi(
-                            &data_path,
-                            &meta_path,
-                            &offsets_path,
-                            &config.vector_parameters,
-                            multivector_config,
-                        )?)
-                    } else {
-                        QuantizedVectorStorage::PQMmapMulti(
-                            QuantizedMultivectorStorage::load_multi(
-                                &data_path,
-                                &meta_path,
-                                &offsets_path,
+                        let bucket_size = Self::get_bucket_size(pq.compression);
+                        let quantized_vector_size =
+                            EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
                                 &config.vector_parameters,
-                                multivector_config,
-                            )?,
-                        )
+                                bucket_size,
+                            );
+                        let inner_vectors_storage =
+                            QuantizedRamStorage::load(data_path.as_path(), quantized_vector_size)?;
+                        let inner_vectors_storage =
+                            EncodedVectorsPQ::load(&meta_path, inner_vectors_storage)?;
+                        let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
+                        QuantizedVectorStorage::PQRamMulti(QuantizedMultivectorStorage::new(
+                            config.vector_parameters.dim,
+                            inner_vectors_storage,
+                            offsets,
+                            *multivector_config,
+                        ))
+                    } else {
+                        let bucket_size = Self::get_bucket_size(pq.compression);
+                        let quantized_vector_size =
+                            EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
+                                &config.vector_parameters,
+                                bucket_size,
+                            );
+                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
+                            data_path.as_path(),
+                            quantized_vector_size,
+                        )?;
+                        let inner_vectors_storage =
+                            EncodedVectorsPQ::load(&meta_path, inner_vectors_storage)?;
+                        let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
+                        QuantizedVectorStorage::PQMmapMulti(QuantizedMultivectorStorage::new(
+                            config.vector_parameters.dim,
+                            inner_vectors_storage,
+                            offsets,
+                            *multivector_config,
+                        ))
                     }
                 }
                 QuantizationConfig::Binary(BinaryQuantization { binary }) => {
                     if Self::is_ram(binary.always_ram, on_disk_vector_storage) {
-                        QuantizedVectorStorage::BinaryRamMulti(
-                            QuantizedMultivectorStorage::load_multi(
-                                &data_path,
-                                &meta_path,
-                                &offsets_path,
-                                &config.vector_parameters,
-                                multivector_config,
-                            )?,
-                        )
+                        let quantized_vector_size = EncodedVectorsBin::<u8, QuantizedRamStorage>::get_quantized_vector_size_from_params(
+                            config.vector_parameters.dim,
+                            Self::convert_binary_encoding(binary.encoding),
+                        );
+                        let inner_vectors_storage =
+                            QuantizedRamStorage::load(data_path.as_path(), quantized_vector_size)?;
+                        let inner_vectors_storage =
+                            EncodedVectorsBin::load(&meta_path, inner_vectors_storage)?;
+                        let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
+                        QuantizedVectorStorage::BinaryRamMulti(QuantizedMultivectorStorage::new(
+                            config.vector_parameters.dim,
+                            inner_vectors_storage,
+                            offsets,
+                            *multivector_config,
+                        ))
                     } else {
-                        QuantizedVectorStorage::BinaryMmapMulti(
-                            QuantizedMultivectorStorage::load_multi(
-                                &data_path,
-                                &meta_path,
-                                &offsets_path,
-                                &config.vector_parameters,
-                                multivector_config,
-                            )?,
-                        )
+                        let quantized_vector_size = EncodedVectorsBin::<u8, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
+                            config.vector_parameters.dim,
+                            Self::convert_binary_encoding(binary.encoding),
+                        );
+                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
+                            data_path.as_path(),
+                            quantized_vector_size,
+                        )?;
+                        let inner_vectors_storage =
+                            EncodedVectorsBin::load(&meta_path, inner_vectors_storage)?;
+                        let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
+                        QuantizedVectorStorage::BinaryMmapMulti(QuantizedMultivectorStorage::new(
+                            config.vector_parameters.dim,
+                            inner_vectors_storage,
+                            offsets,
+                            *multivector_config,
+                        ))
                     }
                 }
             }
@@ -700,46 +748,86 @@ impl QuantizedVectors {
             match &config.quantization_config {
                 QuantizationConfig::Scalar(ScalarQuantization { scalar }) => {
                     if Self::is_ram(scalar.always_ram, on_disk_vector_storage) {
+                        let quantized_vector_size =
+                            EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
+                                &config.vector_parameters,
+                            );
+                        let inner_vectors_storage =
+                            QuantizedRamStorage::load(data_path.as_path(), quantized_vector_size)?;
                         QuantizedVectorStorage::ScalarRam(EncodedVectorsU8::load(
-                            &data_path,
                             &meta_path,
-                            &config.vector_parameters,
+                            inner_vectors_storage,
                         )?)
                     } else {
+                        let quantized_vector_size =
+                            EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
+                                &config.vector_parameters,
+                            );
+                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
+                            data_path.as_path(),
+                            quantized_vector_size,
+                        )?;
                         QuantizedVectorStorage::ScalarMmap(EncodedVectorsU8::load(
-                            &data_path,
                             &meta_path,
-                            &config.vector_parameters,
+                            inner_vectors_storage,
                         )?)
                     }
                 }
                 QuantizationConfig::Product(ProductQuantization { product: pq }) => {
                     if Self::is_ram(pq.always_ram, on_disk_vector_storage) {
+                        let bucket_size = Self::get_bucket_size(pq.compression);
+                        let quantized_vector_size =
+                            EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
+                                &config.vector_parameters,
+                                bucket_size,
+                            );
+                        let inner_vectors_storage =
+                            QuantizedRamStorage::load(data_path.as_path(), quantized_vector_size)?;
                         QuantizedVectorStorage::PQRam(EncodedVectorsPQ::load(
-                            &data_path,
                             &meta_path,
-                            &config.vector_parameters,
+                            inner_vectors_storage,
                         )?)
                     } else {
+                        let bucket_size = Self::get_bucket_size(pq.compression);
+                        let quantized_vector_size =
+                            EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
+                                &config.vector_parameters,
+                                bucket_size,
+                            );
+                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
+                            data_path.as_path(),
+                            quantized_vector_size,
+                        )?;
                         QuantizedVectorStorage::PQMmap(EncodedVectorsPQ::load(
-                            &data_path,
                             &meta_path,
-                            &config.vector_parameters,
+                            inner_vectors_storage,
                         )?)
                     }
                 }
                 QuantizationConfig::Binary(BinaryQuantization { binary }) => {
                     if Self::is_ram(binary.always_ram, on_disk_vector_storage) {
+                        let quantized_vector_size = EncodedVectorsBin::<u128, QuantizedRamStorage>::get_quantized_vector_size_from_params(
+                            config.vector_parameters.dim,
+                            Self::convert_binary_encoding(binary.encoding),
+                        );
+                        let inner_vectors_storage =
+                            QuantizedRamStorage::load(data_path.as_path(), quantized_vector_size)?;
                         QuantizedVectorStorage::BinaryRam(EncodedVectorsBin::load(
-                            &data_path,
                             &meta_path,
-                            &config.vector_parameters,
+                            inner_vectors_storage,
                         )?)
                     } else {
+                        let quantized_vector_size = EncodedVectorsBin::<u128, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
+                            config.vector_parameters.dim,
+                            Self::convert_binary_encoding(binary.encoding),
+                        );
+                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
+                            data_path.as_path(),
+                            quantized_vector_size,
+                        )?;
                         QuantizedVectorStorage::BinaryMmap(EncodedVectorsBin::load(
-                            &data_path,
                             &meta_path,
-                            &config.vector_parameters,
+                            inner_vectors_storage,
                         )?)
                     }
                 }
@@ -980,8 +1068,9 @@ impl QuantizedVectors {
                 ),
             ))
         } else {
+            let mmap_data_path = Self::get_data_path(path);
             let storage_builder = QuantizedMmapStorageBuilder::new(
-                data_path.as_path(),
+                mmap_data_path.as_path(),
                 inner_vectors_count,
                 quantized_vector_size,
             )?;
@@ -1113,8 +1202,9 @@ impl QuantizedVectors {
                 ),
             ))
         } else {
+            let mmap_data_path = Self::get_data_path(path);
             let storage_builder = QuantizedMmapStorageBuilder::new(
-                data_path.as_path(),
+                mmap_data_path.as_path(),
                 inner_vectors_count,
                 quantized_vector_size,
             )?;


### PR DESCRIPTION
This PR refactors save&loading&snapshot strategy for quantization.

The main motivation is about the number of files. Previously files list of quantization was owned by high level `QuantizedVectorStorage` and provided down into strorage implementations.

For next change to integrate `ChunkedMmapVectors` it's completely wrong architecture. `ChunkedMmapVectors` owns their files and we cannot own filenames in `QuantizedVectorStorage`.

Main changes are in `EncodedStorage` and `EncodedVectors` traits, where `load`, `save` are removed and `files` was added.

Please make additional attention to multivectors while review.

No additional CI tests are required because it's a refactoring without new functionality, current tests cover this logic.