### PR TITLE
Added custom error raising for DateTime + RangeInterface deserialization

### DIFF
--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2949,6 +2949,12 @@ impl NestedCondition {
     }
 }
 
+/// Defines an enum with custom deserialization that prioritizes errors from specific variants.
+/// 
+/// # Arguments
+/// * `priority`: Variants whose deserialization errors take precedence
+/// * `normal`: Variants that use standard serde deserialization  
+/// * `skip`: Variants that are skipped during serialization/deserialization
 macro_rules! define_enum_with_custom_deser {
     (
         $(#[$meta:meta])*


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
^Competing Bounty

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

/claim #3531

This is done via metadata forwarding when deserializing RangeInterface, and using a macro to define `Condition` that allows the separation of fields requiring custom deserialization from those that were fine with `Derive` from `serde`. I opted for a definition macro rather than a separate enum def in the function locally, to avoid the need for maintainers to duplicate field declarations. The macro setup will handle all required separation on its own, without the need to cross-check field declarations.

<img width="1512" height="481" alt="image" src="https://github.com/user-attachments/assets/2fbbb268-aae1-45ec-af94-fa492bbe5e30" />