### PR TITLE
Show unique index types in error message

### DIFF
--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -11,6 +11,7 @@ mod update;
 
 use std::fmt::Display;
 
+use itertools::Itertools;
 use segment::json_path::JsonPath;
 use segment::types::{Filter, SearchParams, StrictModeConfig};
 
@@ -117,6 +118,8 @@ pub trait StrictModeVerification {
                 let possible_schemas_str = schemas
                     .iter()
                     .map(|schema| schema.to_string())
+                    .sorted()
+                    .dedup()
                     .collect::<Vec<_>>()
                     .join(", ");
 

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 use segment::types::{Filter, StrictModeConfig};
 
@@ -21,6 +22,8 @@ impl Query {
             let possible_schemas_str = schemas
                 .iter()
                 .map(|schema| schema.to_string())
+                .sorted()
+                .dedup()
                 .collect::<Vec<_>>()
                 .join(", ");
 


### PR DESCRIPTION
Fixes: 

<img width="866" height="118" alt="image" src="https://github.com/user-attachments/assets/91ef79f3-6245-4bf7-ae00-046d3c6135fe" />

It now shows each element once like `[float, integer]`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?