### PR TITLE
Open and load numeric payload indices in single stage

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -80,7 +80,9 @@ impl IndexSelector<'_> {
                     );
                 }
 
-                FieldIndex::IntIndex(self.numeric_new(field, create_if_missing)?)
+                return Ok(self
+                    .numeric_new(field, create_if_missing)?
+                    .map(FieldIndex::IntIndex));
             }
             (PayloadIndexType::IntMapIndex, PayloadSchemaParams::Integer(params)) => {
                 // IntMapIndex only gets created if `lookup` is true. This will only throw an error if storage is corrupt.
@@ -96,7 +98,9 @@ impl IndexSelector<'_> {
                 FieldIndex::IntMapIndex(self.map_new(field, create_if_missing)?)
             }
             (PayloadIndexType::DatetimeIndex, PayloadSchemaParams::Datetime(_)) => {
-                FieldIndex::DatetimeIndex(self.numeric_new(field, create_if_missing)?)
+                return Ok(self
+                    .numeric_new(field, create_if_missing)?
+                    .map(FieldIndex::DatetimeIndex));
             }
 
             (PayloadIndexType::KeywordIndex, PayloadSchemaParams::Keyword(_)) => {
@@ -104,7 +108,9 @@ impl IndexSelector<'_> {
             }
 
             (PayloadIndexType::FloatIndex, PayloadSchemaParams::Float(_)) => {
-                FieldIndex::FloatIndex(self.numeric_new(field, create_if_missing)?)
+                return Ok(self
+                    .numeric_new(field, create_if_missing)?
+                    .map(FieldIndex::FloatIndex));
             }
 
             (PayloadIndexType::GeoIndex, PayloadSchemaParams::Geo(_)) => {
@@ -162,32 +168,33 @@ impl IndexSelector<'_> {
             PayloadSchemaParams::Keyword(_) => Some(vec![FieldIndex::KeywordIndex(
                 self.map_new(field, create_if_missing)?,
             )]),
-            PayloadSchemaParams::Integer(integer_params) => Some(
-                itertools::chain(
-                    integer_params
-                        .lookup
-                        .unwrap_or(true)
-                        .then(|| {
-                            OperationResult::Ok(FieldIndex::IntMapIndex(
-                                self.map_new(field, create_if_missing)?,
-                            ))
-                        })
-                        .transpose()?,
-                    integer_params
-                        .range
-                        .unwrap_or(true)
-                        .then(|| {
-                            OperationResult::Ok(FieldIndex::IntIndex(
-                                self.numeric_new(field, create_if_missing)?,
-                            ))
-                        })
-                        .transpose()?,
-                )
-                .collect(),
-            ),
-            PayloadSchemaParams::Float(_) => Some(vec![FieldIndex::FloatIndex(
-                self.numeric_new(field, create_if_missing)?,
-            )]),
+            PayloadSchemaParams::Integer(integer_params) => {
+                let use_lookup = integer_params.lookup.unwrap_or(true);
+                let use_range = integer_params.range.unwrap_or(true);
+
+                let lookup = if use_lookup {
+                    Some(FieldIndex::IntMapIndex(
+                        self.map_new(field, create_if_missing)?,
+                    ))
+                } else {
+                    None
+                };
+                let range = if use_range {
+                    match self.numeric_new(field, create_if_missing)? {
+                        Some(index) => Some(FieldIndex::IntIndex(index)),
+                        None => return Ok(None),
+                    }
+                } else {
+                    None
+                };
+
+                Some(lookup.into_iter().chain(range).collect())
+            }
+            PayloadSchemaParams::Float(_) => {
+                return Ok(self
+                    .numeric_new(field, create_if_missing)?
+                    .map(|index| vec![FieldIndex::FloatIndex(index)]));
+            }
             PayloadSchemaParams::Geo(_) => Some(vec![FieldIndex::GeoIndex(
                 self.geo_new(field, create_if_missing)?,
             )]),
@@ -195,9 +202,11 @@ impl IndexSelector<'_> {
                 self.text_new(field, text_index_params.clone(), create_if_missing)?,
             )]),
             PayloadSchemaParams::Bool(_) => Some(vec![self.bool_new(field, create_if_missing)?]),
-            PayloadSchemaParams::Datetime(_) => Some(vec![FieldIndex::DatetimeIndex(
-                self.numeric_new(field, create_if_missing)?,
-            )]),
+            PayloadSchemaParams::Datetime(_) => {
+                return Ok(self
+                    .numeric_new(field, create_if_missing)?
+                    .map(|index| vec![FieldIndex::DatetimeIndex(index)]));
+            }
             PayloadSchemaParams::Uuid(_) => Some(vec![FieldIndex::UuidMapIndex(
                 self.map_new(field, create_if_missing)?,
             )]),
@@ -222,27 +231,36 @@ impl IndexSelector<'_> {
                     FieldIndexBuilder::KeywordGridstoreIndex,
                 )]
             }
-            PayloadSchemaParams::Integer(integer_params) => itertools::chain(
-                integer_params.lookup.unwrap_or(true).then(|| {
-                    self.map_builder(
+            PayloadSchemaParams::Integer(integer_params) => {
+                let use_lookup = integer_params.lookup.unwrap_or(true);
+                let use_range = integer_params.range.unwrap_or(true);
+
+                let lookup = if use_lookup {
+                    Some(self.map_builder(
                         field,
                         #[cfg(feature = "rocksdb")]
                         FieldIndexBuilder::IntMapIndex,
                         FieldIndexBuilder::IntMapMmapIndex,
                         FieldIndexBuilder::IntMapGridstoreIndex,
-                    )
-                }),
-                integer_params.range.unwrap_or(true).then(|| {
-                    self.numeric_builder(
+                    ))
+                } else {
+                    None
+                };
+
+                let range = if use_range {
+                    Some(self.numeric_builder(
                         field,
                         #[cfg(feature = "rocksdb")]
                         FieldIndexBuilder::IntIndex,
                         FieldIndexBuilder::IntMmapIndex,
                         FieldIndexBuilder::IntGridstoreIndex,
-                    )
-                }),
-            )
-            .collect(),
+                    )?)
+                } else {
+                    None
+                };
+
+                lookup.into_iter().chain(range).collect()
+            }
             PayloadSchemaParams::Float(_) => {
                 vec![self.numeric_builder(
                     field,
@@ -250,7 +268,7 @@ impl IndexSelector<'_> {
                     FieldIndexBuilder::FloatIndex,
                     FieldIndexBuilder::FloatMmapIndex,
                     FieldIndexBuilder::FloatGridstoreIndex,
-                )]
+                )?]
             }
             PayloadSchemaParams::Geo(_) => {
                 vec![self.geo_builder(
@@ -274,7 +292,7 @@ impl IndexSelector<'_> {
                     FieldIndexBuilder::DatetimeIndex,
                     FieldIndexBuilder::DatetimeMmapIndex,
                     FieldIndexBuilder::DatetimeGridstoreIndex,
-                )]
+                )?]
             }
             PayloadSchemaParams::Uuid(_) => {
                 vec![self.map_builder(
@@ -342,18 +360,23 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
-    ) -> OperationResult<NumericIndex<T, P>>
+    ) -> OperationResult<Option<NumericIndex<T, P>>>
     where
         Vec<T>: Blob,
     {
         Ok(match self {
             #[cfg(feature = "rocksdb")]
             IndexSelector::RocksDb(IndexSelectorRocksDb { db, is_appendable }) => {
-                NumericIndex::new_rocksdb(Arc::clone(db), &field.to_string(), *is_appendable)
+                NumericIndex::new_rocksdb(
+                    Arc::clone(db),
+                    &field.to_string(),
+                    *is_appendable,
+                    create_if_missing,
+                )?
             }
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk)?
-            }
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => Some(
+                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk)?,
+            ),
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
             }
@@ -368,7 +391,7 @@ impl IndexSelector<'_> {
         ) -> FieldIndexBuilder,
         make_mmap: fn(NumericIndexMmapBuilder<T, P>) -> FieldIndexBuilder,
         make_gridstore: fn(NumericIndexGridstoreBuilder<T, P>) -> FieldIndexBuilder,
-    ) -> FieldIndexBuilder
+    ) -> OperationResult<FieldIndexBuilder>
     where
         NumericIndex<T, P>: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
         Vec<T>: Blob,
@@ -378,16 +401,16 @@ impl IndexSelector<'_> {
             IndexSelector::RocksDb(IndexSelectorRocksDb {
                 db,
                 is_appendable: _,
-            }) => make_rocksdb(NumericIndex::builder_rocksdb(
+            }) => Ok(make_rocksdb(NumericIndex::builder_rocksdb(
                 Arc::clone(db),
                 &field.to_string(),
-            )),
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
+            )?)),
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => Ok(make_mmap(
                 NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk),
-            ),
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
-                make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))
-            }
+            )),
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => Ok(make_gridstore(
+                NumericIndex::builder_gridstore(numeric_dir(dir, field)),
+            )),
         }
     }
 

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -374,9 +374,9 @@ impl IndexSelector<'_> {
                     create_if_missing,
                 )?
             }
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => Some(
-                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk)?,
-            ),
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk)?
+            }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
             }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -464,13 +464,13 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         total_point_count: usize,
         create_if_missing: bool,
-    ) -> OperationResult<Option<FieldIndex>> {
+    ) -> OperationResult<FieldIndex> {
         // null index is always on disk and is appendable
-        Ok(Some(FieldIndex::NullIndex(MutableNullIndex::open(
+        Ok(FieldIndex::NullIndex(MutableNullIndex::open(
             &null_dir(dir, field),
             total_point_count,
             create_if_missing,
-        )?)))
+        )?))
     }
 
     fn text_new(

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -227,7 +227,12 @@ where
             ));
         };
 
-        let mut mutable = MutableNumericIndex::<T>::open_rocksdb_db_wrapper(db_wrapper.clone());
+        let Some(mutable) =
+            MutableNumericIndex::<T>::open_rocksdb_db_wrapper(db_wrapper.clone(), false)?
+        else {
+            return Ok(false);
+        };
+        // TODO(payload-index-remove-load): remove load when single stage open/load is implemented
         mutable.load()?;
         let InMemoryNumericIndex {
             map,

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -178,11 +178,21 @@ where
     Vec<T>: Blob,
 {
     #[cfg(feature = "rocksdb")]
-    pub fn new_rocksdb(db: Arc<RwLock<DB>>, field: &str, is_appendable: bool) -> Self {
+    pub fn new_rocksdb(
+        db: Arc<RwLock<DB>>,
+        field: &str,
+        is_appendable: bool,
+        create_if_missing: bool,
+    ) -> OperationResult<Option<Self>> {
         if is_appendable {
-            NumericIndexInner::Mutable(MutableNumericIndex::open_rocksdb(db, field))
+            Ok(
+                MutableNumericIndex::open_rocksdb(db, field, create_if_missing)?
+                    .map(NumericIndexInner::Mutable),
+            )
         } else {
-            NumericIndexInner::Immutable(ImmutableNumericIndex::open_rocksdb(db, field))
+            Ok(Some(NumericIndexInner::Immutable(
+                ImmutableNumericIndex::open_rocksdb(db, field),
+            )))
         }
     }
 
@@ -200,10 +210,9 @@ where
         }
     }
 
-    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
-        Ok(NumericIndexInner::Mutable(
-            MutableNumericIndex::open_gridstore(dir, create_if_missing)?,
-        ))
+    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
+        Ok(MutableNumericIndex::open_gridstore(dir, create_if_missing)?
+            .map(NumericIndexInner::Mutable))
     }
 
     pub fn load(&mut self) -> OperationResult<bool> {
@@ -516,11 +525,20 @@ where
     Vec<T>: Blob,
 {
     #[cfg(feature = "rocksdb")]
-    pub fn new_rocksdb(db: Arc<RwLock<DB>>, field: &str, is_appendable: bool) -> Self {
-        Self {
-            inner: NumericIndexInner::new_rocksdb(db, field, is_appendable),
-            _phantom: PhantomData,
-        }
+    pub fn new_rocksdb(
+        db: Arc<RwLock<DB>>,
+        field: &str,
+        is_appendable: bool,
+        create_if_missing: bool,
+    ) -> OperationResult<Option<Self>> {
+        Ok(
+            NumericIndexInner::new_rocksdb(db, field, is_appendable, create_if_missing)?.map(
+                |inner| Self {
+                    inner,
+                    _phantom: PhantomData,
+                },
+            ),
+        )
     }
 
     /// Load immutable mmap based index, either in RAM or on disk
@@ -531,19 +549,30 @@ where
         })
     }
 
-    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Self> {
-        Ok(Self {
-            inner: NumericIndexInner::new_gridstore(dir, create_if_missing)?,
+    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
+        let index = NumericIndexInner::new_gridstore(dir, create_if_missing)?;
+
+        Ok(index.map(|inner| Self {
+            inner,
             _phantom: PhantomData,
-        })
+        }))
     }
 
     #[cfg(feature = "rocksdb")]
-    pub fn builder_rocksdb(db: Arc<RwLock<DB>>, field: &str) -> NumericIndexBuilder<T, P>
+    pub fn builder_rocksdb(
+        db: Arc<RwLock<DB>>,
+        field: &str,
+    ) -> OperationResult<NumericIndexBuilder<T, P>>
     where
         Self: ValueIndexer<ValueType = P>,
     {
-        NumericIndexBuilder(Self::new_rocksdb(db, field, true))
+        Ok(NumericIndexBuilder(
+            Self::new_rocksdb(db, field, true, true)?.ok_or_else(|| {
+                OperationError::service_error(format!(
+                    "Failed to create and load mutable numeric index builder for field '{field}'",
+                ))
+            })?,
+        ))
     }
 
     #[cfg(all(test, feature = "rocksdb"))]
@@ -555,7 +584,10 @@ where
         Self: ValueIndexer<ValueType = P>,
     {
         NumericIndexImmutableBuilder {
-            index: Self::new_rocksdb(db.clone(), field, true),
+            index: Self::new_rocksdb(db.clone(), field, true, true)
+                // unwrap safety: only used in testing
+                .unwrap()
+                .unwrap(),
             field: field.to_owned(),
             db,
         }
@@ -710,7 +742,9 @@ where
         self.index.inner.flusher()()?;
         drop(self.index);
         let mut inner: NumericIndexInner<T> =
-            NumericIndexInner::new_rocksdb(self.db, &self.field, false);
+            NumericIndexInner::new_rocksdb(self.db, &self.field, false, false)?
+                // unwrap safety: only used in testing
+                .unwrap();
         inner.load()?;
         Ok(NumericIndex {
             inner,
@@ -812,8 +846,11 @@ where
             self.index.is_none(),
             "index must be initialized exactly once",
         );
-        self.index
-            .replace(NumericIndex::new_gridstore(self.dir.clone(), true)?);
+        self.index.replace(
+            NumericIndex::new_gridstore(self.dir.clone(), true)?
+                // unwrap safety: cannot fail because create_if_missing is true
+                .unwrap(),
+        );
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -196,7 +196,11 @@ where
 
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
-        let mmap_index = MmapNumericIndex::open(path, is_on_disk)?;
+        let Some(mmap_index) = MmapNumericIndex::open(path, is_on_disk)? else {
+            // Files don't exist, cannot load
+            return Ok(None);
+        };
+
         if is_on_disk {
             // Use on mmap directly
             Ok(Some(NumericIndexInner::Mmap(mmap_index)))

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -71,10 +71,10 @@ fn get_index_builder(index_type: IndexType) -> (TempDir, IndexBuilder) {
     let db = open_db_with_existing_cf(temp_dir.path()).unwrap();
     let mut builder = match index_type {
         #[cfg(feature = "rocksdb")]
-        IndexType::Mutable => IndexBuilder::Mutable(NumericIndex::<
-            FloatPayloadType,
-            FloatPayloadType,
-        >::builder_rocksdb(db, COLUMN_NAME)),
+        IndexType::Mutable => IndexBuilder::Mutable(
+            NumericIndex::<FloatPayloadType, FloatPayloadType>::builder_rocksdb(db, COLUMN_NAME)
+                .unwrap(),
+        ),
         IndexType::MutableGridstore => IndexBuilder::MutableGridstore(NumericIndex::<
             FloatPayloadType,
             FloatPayloadType,
@@ -387,17 +387,25 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
     let mut new_index = match index_type {
         #[cfg(feature = "rocksdb")]
         IndexType::Mutable => {
-            NumericIndexInner::<FloatPayloadType>::new_rocksdb(db.unwrap(), COLUMN_NAME, true)
+            NumericIndexInner::<FloatPayloadType>::new_rocksdb(db.unwrap(), COLUMN_NAME, true, true)
+                .unwrap()
+                .unwrap()
         }
         IndexType::MutableGridstore => NumericIndexInner::<FloatPayloadType>::new_gridstore(
             temp_dir.path().to_path_buf(),
             true,
         )
+        .unwrap()
         .unwrap(),
         #[cfg(feature = "rocksdb")]
-        IndexType::Immutable => {
-            NumericIndexInner::<FloatPayloadType>::new_rocksdb(db.unwrap(), COLUMN_NAME, false)
-        }
+        IndexType::Immutable => NumericIndexInner::<FloatPayloadType>::new_rocksdb(
+            db.unwrap(),
+            COLUMN_NAME,
+            false,
+            true,
+        )
+        .unwrap()
+        .unwrap(),
         IndexType::Mmap => {
             NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true).unwrap()
         }

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -406,11 +406,13 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         )
         .unwrap()
         .unwrap(),
-        IndexType::Mmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true).unwrap()
-        }
+        IndexType::Mmap => NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true)
+            .unwrap()
+            .unwrap(),
         IndexType::RamMmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false).unwrap()
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false)
+                .unwrap()
+                .unwrap()
         }
     };
     new_index.load().unwrap();

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -198,17 +198,15 @@ impl StructPayloadIndex {
                     "index selector is not expected to provide null index",
                 );
 
-                // Special null index complements every index
-                if let Some(null_index) = IndexSelector::new_null_index(
+                // Special null index complements every index.
+                let null_index = IndexSelector::new_null_index(
                     &self.path,
                     field,
                     total_point_count,
                     create_if_missing,
-                )? {
-                    // TODO: This means that null index will not be built if it is not loaded here.
-                    //       Maybe we should set `rebuild` to true to trigger index building.
-                    indexes.push(null_index);
-                }
+                )?;
+
+                indexes.push(null_index);
 
                 // Persist exact payload index types
                 is_dirty = true;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -180,61 +180,72 @@ impl StructPayloadIndex {
         create_if_missing: bool,
     ) -> OperationResult<(Vec<FieldIndex>, bool)> {
         let total_point_count = self.id_tracker.borrow().total_point_count();
+        let mut rebuild = false;
         let mut is_dirty = false;
 
         let mut indexes = if payload_schema.types.is_empty() {
-            let mut indexes = self.selector(&payload_schema.schema).new_index(
+            let indexes = self.selector(&payload_schema.schema).new_index(
                 field,
                 &payload_schema.schema,
                 create_if_missing,
             )?;
 
-            debug_assert!(
-                !indexes
-                    .iter()
-                    .any(|index| matches!(index, FieldIndex::NullIndex(_))),
-                "index selector is not expected to provide null index",
-            );
+            if let Some(mut indexes) = indexes {
+                debug_assert!(
+                    !indexes
+                        .iter()
+                        .any(|index| matches!(index, FieldIndex::NullIndex(_))),
+                    "index selector is not expected to provide null index",
+                );
 
-            // Special null index complements every index
-            if let Some(null_index) = IndexSelector::new_null_index(
-                &self.path,
-                field,
-                total_point_count,
-                create_if_missing,
-            )? {
-                // TODO: This means that null index will not be built if it is not loaded here.
-                //       Maybe we should set `rebuild` to true to trigger index building.
-                indexes.push(null_index);
+                // Special null index complements every index
+                if let Some(null_index) = IndexSelector::new_null_index(
+                    &self.path,
+                    field,
+                    total_point_count,
+                    create_if_missing,
+                )? {
+                    // TODO: This means that null index will not be built if it is not loaded here.
+                    //       Maybe we should set `rebuild` to true to trigger index building.
+                    indexes.push(null_index);
+                }
+
+                // Persist exact payload index types
+                is_dirty = true;
+                payload_schema.types = indexes.iter().map(|i| i.get_full_index_type()).collect();
+
+                indexes
+            } else {
+                rebuild = true;
+                vec![]
             }
-
-            // Persist exact payload index types
-            is_dirty = true;
-            payload_schema.types = indexes.iter().map(|i| i.get_full_index_type()).collect();
-
-            indexes
         } else {
             payload_schema
                 .types
                 .iter()
-                .filter_map(|index| {
-                    self.selector_with_type(index)
-                        .and_then(|selector| {
-                            selector.new_index_with_type(
-                                field,
-                                &payload_schema.schema,
-                                index,
-                                &self.path,
-                                total_point_count,
-                                create_if_missing,
-                            )
-                        })
-                        .transpose()
+                // Load each index
+                .map(|index| {
+                    self.selector_with_type(index).and_then(|selector| {
+                        selector.new_index_with_type(
+                            field,
+                            &payload_schema.schema,
+                            index,
+                            &self.path,
+                            total_point_count,
+                            create_if_missing,
+                        )
+                    })
                 })
+                // Interrupt loading indices if one fails to load
+                // Set rebuild flag if any index fails to load
+                .take_while(|index| {
+                    let is_loaded = index.as_ref().is_ok_and(|index| index.is_some());
+                    rebuild |= !is_loaded;
+                    is_loaded
+                })
+                .filter_map(|index| index.transpose())
                 .collect::<OperationResult<Vec<_>>>()?
         };
-
-        let mut rebuild = false;
 
         // Actively migrate away from RocksDB indices
         // Naively implemented by just rebuilding the indices from scratch


### PR DESCRIPTION
A [stack of PRs](https://github.com/qdrant/qdrant/milestone/34) with the goal of simplifying our payload index internals.

Rather than having a two stage approach - open and load a payload index - this changes to a single stage approach. This now opens and loads payload indices in a single function call.

By using a single stage, we eliminate a bunch of intermediate states we had to keep before. It required explicit handling of this using `Option`s in all payload indices, which is error prone. This now allow us to remove the intermediate variants, simplifying state handling across all our payload indices. It now follows the RAII philosophy.

The full stack of PRs kept all logic in payload indices the same, except that it merged opening and loading into a single function. No changes have been made in how we interpret our data structures nor how we respond to index queries.

Further in this PR stack we have two PRs that remove a lot of lines as a result of this:
- https://github.com/qdrant/qdrant/pull/7040
- https://github.com/qdrant/qdrant/pull/7041

### Open questions
- [ ] Return `Result<Option<Index>>` where `None` is used if files don't exist, or create a special enum?
      _I  think we can use `Result<Option<Index>>` now and revisit this once all PRs are merged._

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?