### PR TITLE
Update if

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3928,6 +3928,7 @@ If not specified, the `limit` value is used. |
 | ----- | ---- | ----- | ----------- |
 | points | [PointVectors](#qdrant-PointVectors) | repeated | List of points and vectors to update |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
+| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated |
 
 
 
@@ -4905,6 +4906,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | points | [PointVectors](#qdrant-PointVectors) | repeated | List of points and vectors to update |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
+| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3877,7 +3877,7 @@ If not specified, the `limit` value is used. |
 | ----- | ---- | ----- | ----------- |
 | points | [PointStruct](#qdrant-PointStruct) | repeated |  |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
-| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated, others will be inserted |
+| update_filter | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated, others will be inserted |
 
 
 
@@ -3928,7 +3928,7 @@ If not specified, the `limit` value is used. |
 | ----- | ---- | ----- | ----------- |
 | points | [PointVectors](#qdrant-PointVectors) | repeated | List of points and vectors to update |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
-| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated |
+| update_filter | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated |
 
 
 
@@ -4906,7 +4906,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | points | [PointVectors](#qdrant-PointVectors) | repeated | List of points and vectors to update |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
-| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated |
+| update_filter | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated |
 
 
 
@@ -4942,7 +4942,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | points | [PointStruct](#qdrant-PointStruct) | repeated |  |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
-| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated, others will be inserted |
+| update_filter | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated, others will be inserted |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3877,6 +3877,7 @@ If not specified, the `limit` value is used. |
 | ----- | ---- | ----- | ----------- |
 | points | [PointStruct](#qdrant-PointStruct) | repeated |  |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
+| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated, others will be inserted |
 
 
 
@@ -4939,6 +4940,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | points | [PointStruct](#qdrant-PointStruct) | repeated |  |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
+| update_if | [Filter](#qdrant-Filter) | optional | If specified, only points that match this filter will be updated, others will be inserted |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10399,6 +10399,17 @@
                 "nullable": true
               }
             ]
+          },
+          "update_if": {
+            "description": "If specified, only points that match this filter will be updated, others will be inserted",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -10706,6 +10717,17 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "update_if": {
+            "description": "If specified, only points that match this filter will be updated, others will be inserted",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
               },
               {
                 "nullable": true

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10400,7 +10400,7 @@
               }
             ]
           },
-          "update_if": {
+          "update_filter": {
             "description": "If specified, only points that match this filter will be updated, others will be inserted",
             "anyOf": [
               {
@@ -10723,7 +10723,7 @@
               }
             ]
           },
-          "update_if": {
+          "update_filter": {
             "description": "If specified, only points that match this filter will be updated, others will be inserted",
             "anyOf": [
               {
@@ -13742,7 +13742,7 @@
               }
             ]
           },
-          "update_if": {
+          "update_filter": {
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Filter"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -13741,6 +13741,16 @@
                 "nullable": true
               }
             ]
+          },
+          "update_if": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -193,9 +193,11 @@ fn configure_validation(builder: Builder) -> Builder {
         .validates(&[
             ("UpsertPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("UpsertPoints.points", ""),
+            ("UpsertPoints.update_filter", ""),
             ("DeletePoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("UpdatePointVectors.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("UpdatePointVectors.points", ""),
+            ("UpdatePointVectors.update_filter", ""),
             ("DeletePointVectors.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("DeletePointVectors.vector_names", "length(min = 1, message = \"must specify vector names to delete\")"),
             ("PointVectors.vectors", ""),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -135,7 +135,7 @@ message UpsertPoints {
   repeated PointStruct points = 3;
   optional WriteOrdering ordering = 4; // Write ordering guarantees
   optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
-  optional Filter update_if = 6; // If specified, only points that match this filter will be updated, others will be inserted
+  optional Filter update_filter = 6; // If specified, only points that match this filter will be updated, others will be inserted
 }
 
 message DeletePoints {
@@ -163,7 +163,7 @@ message UpdatePointVectors {
   repeated PointVectors points = 3; // List of points and vectors to update
   optional WriteOrdering ordering = 4; // Write ordering guarantees
   optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
-  optional Filter update_if = 6; // If specified, only points that match this filter will be updated
+  optional Filter update_filter = 6; // If specified, only points that match this filter will be updated
 }
 
 message PointVectors {
@@ -796,7 +796,7 @@ message PointsUpdateOperation {
   message PointStructList {
     repeated PointStruct points = 1;
     optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
-    optional Filter update_if = 3; // If specified, only points that match this filter will be updated, others will be inserted
+    optional Filter update_filter = 3; // If specified, only points that match this filter will be updated, others will be inserted
   }
   message SetPayload {
       map<string, Value> payload = 1;
@@ -818,7 +818,7 @@ message PointsUpdateOperation {
   message UpdateVectors {
     repeated PointVectors points = 1; // List of points and vectors to update
     optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
-    optional Filter update_if = 3; // If specified, only points that match this filter will be updated
+    optional Filter update_filter = 3; // If specified, only points that match this filter will be updated
   }
   message DeleteVectors {
     PointsSelector points_selector = 1; // Affected points

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -135,6 +135,7 @@ message UpsertPoints {
   repeated PointStruct points = 3;
   optional WriteOrdering ordering = 4; // Write ordering guarantees
   optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
+  optional Filter update_if = 6; // If specified, only points that match this filter will be updated, others will be inserted
 }
 
 message DeletePoints {
@@ -794,6 +795,7 @@ message PointsUpdateOperation {
   message PointStructList {
     repeated PointStruct points = 1;
     optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
+    optional Filter update_if = 3; // If specified, only points that match this filter will be updated, others will be inserted
   }
   message SetPayload {
       map<string, Value> payload = 1;

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -163,6 +163,7 @@ message UpdatePointVectors {
   repeated PointVectors points = 3; // List of points and vectors to update
   optional WriteOrdering ordering = 4; // Write ordering guarantees
   optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
+  optional Filter update_if = 6; // If specified, only points that match this filter will be updated
 }
 
 message PointVectors {
@@ -817,6 +818,7 @@ message PointsUpdateOperation {
   message UpdateVectors {
     repeated PointVectors points = 1; // List of points and vectors to update
     optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
+    optional Filter update_if = 3; // If specified, only points that match this filter will be updated
   }
   message DeleteVectors {
     PointsSelector points_selector = 1; // Affected points

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4368,7 +4368,7 @@ pub struct UpsertPoints {
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
     /// If specified, only points that match this filter will be updated, others will be inserted
     #[prost(message, optional, tag = "6")]
-    pub update_if: ::core::option::Option<Filter>,
+    pub update_filter: ::core::option::Option<Filter>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -4453,7 +4453,7 @@ pub struct UpdatePointVectors {
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
     /// If specified, only points that match this filter will be updated
     #[prost(message, optional, tag = "6")]
-    pub update_if: ::core::option::Option<Filter>,
+    pub update_filter: ::core::option::Option<Filter>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -6029,7 +6029,7 @@ pub mod points_update_operation {
         pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
         /// If specified, only points that match this filter will be updated, others will be inserted
         #[prost(message, optional, tag = "3")]
-        pub update_if: ::core::option::Option<super::Filter>,
+        pub update_filter: ::core::option::Option<super::Filter>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -6094,7 +6094,7 @@ pub mod points_update_operation {
         pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
         /// If specified, only points that match this filter will be updated
         #[prost(message, optional, tag = "3")]
-        pub update_if: ::core::option::Option<super::Filter>,
+        pub update_filter: ::core::option::Option<super::Filter>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4366,6 +4366,9 @@ pub struct UpsertPoints {
     /// Option for custom sharding to specify used shard keys
     #[prost(message, optional, tag = "5")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+    /// If specified, only points that match this filter will be updated, others will be inserted
+    #[prost(message, optional, tag = "6")]
+    pub update_if: ::core::option::Option<Filter>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -6021,6 +6024,9 @@ pub mod points_update_operation {
         /// Option for custom sharding to specify used shard keys
         #[prost(message, optional, tag = "2")]
         pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
+        /// If specified, only points that match this filter will be updated, others will be inserted
+        #[prost(message, optional, tag = "3")]
+        pub update_if: ::core::option::Option<super::Filter>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4451,6 +4451,9 @@ pub struct UpdatePointVectors {
     /// Option for custom sharding to specify used shard keys
     #[prost(message, optional, tag = "5")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+    /// If specified, only points that match this filter will be updated
+    #[prost(message, optional, tag = "6")]
+    pub update_if: ::core::option::Option<Filter>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -6089,6 +6092,9 @@ pub mod points_update_operation {
         /// Option for custom sharding to specify used shard keys
         #[prost(message, optional, tag = "2")]
         pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
+        /// If specified, only points that match this filter will be updated
+        #[prost(message, optional, tag = "3")]
+        pub update_if: ::core::option::Option<super::Filter>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4368,6 +4368,7 @@ pub struct UpsertPoints {
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
     /// If specified, only points that match this filter will be updated, others will be inserted
     #[prost(message, optional, tag = "6")]
+    #[validate(nested)]
     pub update_filter: ::core::option::Option<Filter>,
 }
 #[derive(validator::Validate)]
@@ -4453,6 +4454,7 @@ pub struct UpdatePointVectors {
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
     /// If specified, only points that match this filter will be updated
     #[prost(message, optional, tag = "6")]
+    #[validate(nested)]
     pub update_filter: ::core::option::Option<Filter>,
 }
 #[derive(validator::Validate)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1347,6 +1347,9 @@ pub struct UpdateVectors {
     pub points: Vec<PointVectors>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(nested)]
+    pub update_if: Option<Filter>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, Validate)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1323,6 +1323,11 @@ pub struct PointsBatch {
     pub batch: Batch,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
+
+    /// If specified, only points that match this filter will be updated, others will be inserted
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(nested)]
+    pub update_if: Option<Filter>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -1350,6 +1355,10 @@ pub struct PointsList {
     pub points: Vec<PointStruct>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
+    /// If specified, only points that match this filter will be updated, others will be inserted
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(nested)]
+    pub update_if: Option<Filter>,
 }
 
 impl<'de> serde::Deserialize<'de> for PointInsertOperations {

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1327,7 +1327,7 @@ pub struct PointsBatch {
     /// If specified, only points that match this filter will be updated, others will be inserted
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
-    pub update_if: Option<Filter>,
+    pub update_filter: Option<Filter>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -1349,7 +1349,7 @@ pub struct UpdateVectors {
     pub shard_key: Option<ShardKeySelector>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
-    pub update_if: Option<Filter>,
+    pub update_filter: Option<Filter>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, Validate)]
@@ -1361,7 +1361,7 @@ pub struct PointsList {
     /// If specified, only points that match this filter will be updated, others will be inserted
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
-    pub update_if: Option<Filter>,
+    pub update_filter: Option<Filter>,
 }
 
 impl<'de> serde::Deserialize<'de> for PointInsertOperations {

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -605,7 +605,7 @@ fn select_excluded_by_filter_ids(
 ) -> CollectionResult<AHashSet<PointIdType>> {
     // Filter for points that doesn't match the condition, and have matching
     let non_match_filter =
-        Filter::new_must_not(Condition::Filter(filter)).merge_with_ids(point_ids);
+        Filter::new_must_not(Condition::Filter(filter)).with_point_ids(point_ids);
 
     Ok(points_by_filter(segments, &non_match_filter, hw_counter)?
         .into_iter()

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -12,18 +12,18 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
 use segment::json_path::JsonPath;
 use segment::types::{
-    Condition, Filter, Payload, PayloadFieldSchema, PayloadKeyType,
-    PayloadKeyTypeRef, PointIdType, SeqNumberType, VectorNameBuf,
+    Condition, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PointIdType,
+    SeqNumberType, VectorNameBuf,
 };
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
+use crate::operations::FieldIndexOperations;
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{
     ConditionalInsertOperationInternal, PointOperations, PointStructPersisted,
 };
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::vector_ops::{PointVectorsPersisted, VectorOperations};
-use crate::operations::FieldIndexOperations;
 
 pub(crate) fn check_unprocessed_points(
     points: &[PointIdType],

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -110,10 +110,10 @@ pub(crate) fn update_vectors_conditional(
 ) -> CollectionResult<usize> {
     let UpdateVectorsOp {
         mut points,
-        update_if,
+        update_filter,
     } = points;
 
-    let Some(filter_condition) = update_if else {
+    let Some(filter_condition) = update_filter else {
         return update_vectors(segments, op_num, points, hw_counter);
     };
 

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -604,12 +604,8 @@ fn select_excluded_by_filter_ids(
     hw_counter: &HardwareCounterCell,
 ) -> CollectionResult<AHashSet<PointIdType>> {
     // Filter for points that doesn't match the condition, and have matching
-    let non_match_filter = segment::types::Filter {
-        should: None,
-        min_should: None,
-        must: Some(vec![Condition::HasId(point_ids.into_iter().collect())]),
-        must_not: Some(vec![Condition::Filter(filter)]),
-    };
+    let non_match_filter =
+        Filter::new_must_not(Condition::Filter(filter)).merge_with_ids(point_ids);
 
     Ok(points_by_filter(segments, &non_match_filter, hw_counter)?
         .into_iter()

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -442,7 +442,7 @@ mod tests {
         fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
             let update = Self::UpdateVectors(UpdateVectorsOp {
                 points: Vec::new(),
-                update_if: None,
+                update_filter: None,
             });
 
             let delete = Self::DeleteVectors(

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -440,7 +440,10 @@ mod tests {
         type Strategy = BoxedStrategy<Self>;
 
         fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-            let update = Self::UpdateVectors(UpdateVectorsOp { points: Vec::new() });
+            let update = Self::UpdateVectors(UpdateVectorsOp {
+                points: Vec::new(),
+                update_if: None,
+            });
 
             let delete = Self::DeleteVectors(
                 PointIdsList {

--- a/lib/collection/src/operations/operation_effect.rs
+++ b/lib/collection/src/operations/operation_effect.rs
@@ -50,6 +50,9 @@ impl EstimateOperationEffectArea for point_ops::PointOperations {
             point_ops::PointOperations::UpsertPoints(insert_operations) => {
                 insert_operations.estimate_effect_area()
             }
+            point_ops::PointOperations::UpsertPointsConditional(conditional_upsert) => {
+                conditional_upsert.points_op.estimate_effect_area()
+            }
             point_ops::PointOperations::DeletePoints { ids } => {
                 OperationEffectArea::Points(Cow::Borrowed(ids))
             }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -642,7 +642,7 @@ impl PointInsertOperationsInternal {
                                 SetPayloadOp {
                                     points: None,
                                     payload,
-                                    filter: Some(update_filter.merge_with_ids(vec![id])),
+                                    filter: Some(update_filter.with_point_ids(vec![id])),
                                     key: None,
                                 }
                             } else {
@@ -682,7 +682,7 @@ impl PointInsertOperationsInternal {
                             SetPayloadOp {
                                 points: None,
                                 payload,
-                                filter: Some(update_filter.merge_with_ids(vec![point.id])),
+                                filter: Some(update_filter.with_point_ids(vec![point.id])),
                                 key: None,
                             }
                         } else {

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -568,14 +568,17 @@ impl PointInsertOperationsInternal {
         }
     }
 
-    pub fn into_update_only(self, update_if: Option<Filter>) -> Vec<CollectionUpdateOperations> {
+    pub fn into_update_only(
+        self,
+        update_filter: Option<Filter>,
+    ) -> Vec<CollectionUpdateOperations> {
         let mut operations = Vec::new();
 
         match self {
             Self::PointsBatch(batch) => {
                 let mut update_vectors = UpdateVectorsOp {
                     points: Vec::new(),
-                    update_if: update_if.clone(),
+                    update_filter: update_filter.clone(),
                 };
 
                 match batch.vectors {
@@ -635,7 +638,7 @@ impl PointInsertOperationsInternal {
 
                     for (id, payload) in ids.zip(payloads) {
                         if let Some(payload) = payload {
-                            let set_payload = if let Some(update_filter) = update_if.clone() {
+                            let set_payload = if let Some(update_filter) = update_filter.clone() {
                                 SetPayloadOp {
                                     points: None,
                                     payload,
@@ -665,7 +668,7 @@ impl PointInsertOperationsInternal {
             Self::PointsList(points) => {
                 let mut update_vectors = UpdateVectorsOp {
                     points: Vec::new(),
-                    update_if: update_if.clone(),
+                    update_filter: update_filter.clone(),
                 };
 
                 for point in points {
@@ -675,7 +678,7 @@ impl PointInsertOperationsInternal {
                     });
 
                     if let Some(payload) = point.payload {
-                        let set_payload = if let Some(update_filter) = update_if.clone() {
+                        let set_payload = if let Some(update_filter) = update_filter.clone() {
                             SetPayloadOp {
                                 points: None,
                                 payload,
@@ -1122,7 +1125,7 @@ mod tests {
                 payloads: None,
             },
             shard_key: None,
-            update_if: None,
+            update_filter: None,
         });
         assert!(batch.validate().is_err());
 
@@ -1133,7 +1136,7 @@ mod tests {
                 payloads: None,
             },
             shard_key: None,
-            update_if: None,
+            update_filter: None,
         });
         assert!(batch.validate().is_ok());
 
@@ -1144,7 +1147,7 @@ mod tests {
                 payloads: Some(vec![]),
             },
             shard_key: None,
-            update_if: None,
+            update_filter: None,
         });
         assert!(batch.validate().is_err());
     }

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -41,7 +41,7 @@ pub struct UpdateVectorsOp {
     pub points: Vec<PointVectorsPersisted>,
     /// Condition to check before updating vectors
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub update_if: Option<Filter>,
+    pub update_filter: Option<Filter>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants)]
@@ -94,7 +94,10 @@ impl SplitByShard for Vec<PointVectors> {
 impl SplitByShard for VectorOperations {
     fn split_by_shard(self, ring: &HashRingRouter) -> OperationToShard<Self> {
         match self {
-            VectorOperations::UpdateVectors(UpdateVectorsOp { points, update_if }) => {
+            VectorOperations::UpdateVectors(UpdateVectorsOp {
+                points,
+                update_filter,
+            }) => {
                 let shard_points = points
                     .into_iter()
                     .flat_map(|point| {
@@ -114,7 +117,7 @@ impl SplitByShard for VectorOperations {
                         shard_id,
                         VectorOperations::UpdateVectors(UpdateVectorsOp {
                             points,
-                            update_if: update_if.clone(),
+                            update_filter: update_filter.clone(),
                         }),
                     )
                 });

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -1,5 +1,6 @@
 use api::rest::{
-    BatchVectorStruct, MultiDenseVector, PointInsertOperations, UpdateVectors, Vector, VectorStruct,
+    BatchVectorStruct, MultiDenseVector, PointInsertOperations, PointsBatch, PointsList,
+    UpdateVectors, Vector, VectorStruct,
 };
 use segment::data_types::tiny_map::TinyMap;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
@@ -155,7 +156,21 @@ impl StrictModeVerification for PointInsertOperations {
     }
 
     fn indexed_filter_write(&self) -> Option<&Filter> {
-        None
+        // Update filter doesn't require strict mode checks
+        // as it is only used on a limited and small subset of points.
+        // Reading from payload storage is acceptable in this case.
+        match self {
+            PointInsertOperations::PointsBatch(PointsBatch {
+                batch: _,
+                shard_key: _,
+                update_filter: _,
+            }) => None,
+            PointInsertOperations::PointsList(PointsList {
+                points: _,
+                shard_key: _,
+                update_filter: _,
+            }) => None,
+        }
     }
 
     fn request_exact(&self) -> Option<bool> {
@@ -201,6 +216,14 @@ impl StrictModeVerification for UpdateVectors {
     }
 
     fn indexed_filter_write(&self) -> Option<&Filter> {
+        let UpdateVectors {
+            points: _,
+            shard_key: _,
+            // Update filter doesn't require strict mode checks
+            // as it is only used on a limited and small subset of points.
+            // Reading from payload storage is acceptable in this case.
+            update_filter: _,
+        } = self;
         None
     }
 

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -80,7 +80,7 @@ pub fn internal_upsert_points(
             },
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
-            update_if: None,
+            update_filter: None,
         }),
     })
 }
@@ -113,7 +113,7 @@ pub fn internal_conditional_upsert_points(
             },
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
-            update_if: Some(grpc::Filter::from(condition)),
+            update_filter: Some(grpc::Filter::from(condition)),
         }),
     })
 }
@@ -174,7 +174,10 @@ pub fn internal_update_vectors(
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<UpdateVectorsInternal> {
-    let UpdateVectorsOp { points, update_if } = update_vectors;
+    let UpdateVectorsOp {
+        points,
+        update_filter,
+    } = update_vectors;
     let points: Result<Vec<_>, _> = points
         .into_iter()
         .map(|point| {
@@ -194,7 +197,7 @@ pub fn internal_update_vectors(
             points: points?,
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
-            update_if: update_if.map(grpc::Filter::from),
+            update_filter: update_filter.map(grpc::Filter::from),
         }),
     })
 }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -1,5 +1,4 @@
 use api::conversions::json::payload_to_proto;
-use api::grpc;
 use api::grpc::conversions::convert_shard_key_from_grpc_opt;
 use api::grpc::qdrant::points_selector::PointsSelectorOneOf;
 use api::grpc::qdrant::{
@@ -113,7 +112,7 @@ pub fn internal_conditional_upsert_points(
             },
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
-            update_filter: Some(grpc::Filter::from(condition)),
+            update_filter: Some(api::grpc::Filter::from(condition)),
         }),
     })
 }
@@ -197,7 +196,7 @@ pub fn internal_update_vectors(
             points: points?,
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
-            update_filter: update_filter.map(grpc::Filter::from),
+            update_filter: update_filter.map(api::grpc::Filter::from),
         }),
     })
 }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -174,7 +174,7 @@ pub fn internal_update_vectors(
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<UpdateVectorsInternal> {
-    let UpdateVectorsOp { points } = update_vectors;
+    let UpdateVectorsOp { points, update_if } = update_vectors;
     let points: Result<Vec<_>, _> = points
         .into_iter()
         .map(|point| {
@@ -194,6 +194,7 @@ pub fn internal_update_vectors(
             points: points?,
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
+            update_if: update_if.map(grpc::Filter::from),
         }),
     })
 }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -1,13 +1,3 @@
-use crate::operations::conversions::write_ordering_to_proto;
-use crate::operations::payload_ops::{DeletePayloadOp, SetPayloadOp};
-use crate::operations::point_ops::{
-    ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointSyncOperation,
-    WriteOrdering,
-};
-use crate::operations::types::CollectionResult;
-use crate::operations::vector_ops::UpdateVectorsOp;
-use crate::operations::{ClockTag, CreateIndex};
-use crate::shards::shard::ShardId;
 use api::conversions::json::payload_to_proto;
 use api::grpc;
 use api::grpc::conversions::convert_shard_key_from_grpc_opt;
@@ -25,6 +15,17 @@ use segment::data_types::vectors::VectorStructInternal;
 use segment::json_path::JsonPath;
 use segment::types::{Filter, PayloadFieldSchema, PointIdType, ScoredPoint, VectorNameBuf};
 use tonic::Status;
+
+use crate::operations::conversions::write_ordering_to_proto;
+use crate::operations::payload_ops::{DeletePayloadOp, SetPayloadOp};
+use crate::operations::point_ops::{
+    ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointSyncOperation,
+    WriteOrdering,
+};
+use crate::operations::types::CollectionResult;
+use crate::operations::vector_ops::UpdateVectorsOp;
+use crate::operations::{ClockTag, CreateIndex};
+use crate::shards::shard::ShardId;
 
 pub fn internal_sync_points(
     shard_id: Option<ShardId>,

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -35,9 +35,9 @@ use segment::types::{
 };
 use semver::Version;
 use tokio::runtime::Handle;
+use tonic::Status;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Channel, Uri};
-use tonic::Status;
 use url::Url;
 
 use super::conversions::{
@@ -57,6 +57,7 @@ use crate::operations::types::{
 use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::vector_ops::VectorOperations;
 use crate::operations::{CollectionUpdateOperations, FieldIndexOperations, OperationWithClockTag};
+use crate::shards::CollectionId;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::conversions::{
     internal_clear_payload, internal_clear_payload_by_filter, internal_create_index,
@@ -67,7 +68,6 @@ use crate::shards::conversions::{
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::RemoteShardTelemetry;
-use crate::shards::CollectionId;
 
 /// Timeout for transferring and recovering a shard snapshot on a remote peer.
 const SHARD_SNAPSHOT_TRANSFER_RECOVER_TIMEOUT: Duration = MAX_GRPC_CHANNEL_TIMEOUT;

--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -69,7 +69,7 @@ fn validate_error_sparse_vector_points_list() {
     check_validation_error(PointsList {
         points: vec![wrong_point_struct()],
         shard_key: None,
-        update_if: None,
+        update_filter: None,
     });
 }
 

--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -69,6 +69,7 @@ fn validate_error_sparse_vector_points_list() {
     check_validation_error(PointsList {
         points: vec![wrong_point_struct()],
         shard_key: None,
+        update_if: None,
     });
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3297,6 +3297,33 @@ impl Filter {
         }
     }
 
+    /// Create an extended filtering condition, which would also include filter by given list of IDs.
+    pub fn merge_with_ids(self, ids: impl IntoIterator<Item = PointIdType>) -> Filter {
+        let has_id_condition: HasIdCondition = ids.into_iter().collect();
+
+        let Filter {
+            should,
+            min_should,
+            must,
+            must_not,
+        } = self;
+
+        let new_must = match must {
+            Some(mut must) => {
+                must.push(Condition::HasId(has_id_condition));
+                Some(must)
+            }
+            None => Some(vec![Condition::HasId(has_id_condition)]),
+        };
+
+        Filter {
+            should,
+            min_should,
+            must: new_must,
+            must_not,
+        }
+    }
+
     pub fn merge(&self, other: &Filter) -> Filter {
         self.clone().merge_owned(other.clone())
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3298,7 +3298,7 @@ impl Filter {
     }
 
     /// Create an extended filtering condition, which would also include filter by given list of IDs.
-    pub fn merge_with_ids(self, ids: impl IntoIterator<Item = PointIdType>) -> Filter {
+    pub fn with_point_ids(self, ids: impl IntoIterator<Item = PointIdType>) -> Filter {
         let has_id_condition: HasIdCondition = ids.into_iter().collect();
 
         let Filter {

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -1275,7 +1275,7 @@ mod tests_ops {
                             id: ExtendedPointId::NumId(12345),
                             vector: VectorStructPersisted::Single(vec![0.0, 1.0, 2.0]),
                         }],
-                        update_if: None,
+                        update_filter: None,
                     }),
                 );
                 assert_requires_whole_write_access(&op);

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -1275,6 +1275,7 @@ mod tests_ops {
                             id: ExtendedPointId::NumId(12345),
                             vector: VectorStructPersisted::Single(vec![0.0, 1.0, 2.0]),
                         }],
+                        update_if: None,
                     }),
                 );
                 assert_requires_whole_write_access(&op);

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -347,13 +347,17 @@ pub async fn do_update_vectors(
         .check_strict_mode(&operation, &collection_name, None, &access)
         .await?;
 
-    let UpdateVectors { points, shard_key } = operation;
+    let UpdateVectors {
+        points,
+        shard_key,
+        update_if,
+    } = operation;
 
     let (points, usage) =
         convert_point_vectors(points, InferenceType::Update, inference_token).await?;
 
     let operation = CollectionUpdateOperations::VectorOperation(VectorOperations::UpdateVectors(
-        UpdateVectorsOp { points },
+        UpdateVectorsOp { points, update_if },
     ));
 
     let result = update(

--- a/src/tonic/api/update_common.rs
+++ b/src/tonic/api/update_common.rs
@@ -1,11 +1,6 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::common::inference::InferenceToken;
-use crate::common::inference::service::InferenceType;
-use crate::common::inference::update_requests::convert_point_struct;
-use crate::common::strict_mode::*;
-use crate::common::update::*;
 use api::conversions::json::{json_path_from_proto, proto_to_payloads};
 use api::grpc;
 use api::grpc::qdrant::payload_index_params::IndexParams;
@@ -35,6 +30,12 @@ use storage::content_manager::toc::request_hw_counter::RequestHwCounter;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::Access;
 use tonic::{Response, Status};
+
+use crate::common::inference::InferenceToken;
+use crate::common::inference::service::InferenceType;
+use crate::common::inference::update_requests::convert_point_struct;
+use crate::common::strict_mode::*;
+use crate::common::update::*;
 
 pub async fn upsert(
     toc_provider: impl CheckedTocProvider,

--- a/src/tonic/api/update_common.rs
+++ b/src/tonic/api/update_common.rs
@@ -137,6 +137,7 @@ pub async fn update_vectors(
         points,
         ordering,
         shard_key_selector,
+        update_if,
     } = update_point_vectors;
 
     // Build list of operation points
@@ -156,6 +157,9 @@ pub async fn update_vectors(
     let operation = UpdateVectors {
         points: op_points,
         shard_key: shard_key_selector.map(ShardKeySelector::from),
+        update_if: update_if
+            .map(segment::types::Filter::try_from)
+            .transpose()?,
     };
 
     let timing = Instant::now();
@@ -554,6 +558,7 @@ pub async fn update_batch(
                 points_update_operation::UpdateVectors {
                     points,
                     shard_key_selector,
+                    update_if,
                 },
             ) => {
                 update_vectors(
@@ -564,6 +569,7 @@ pub async fn update_batch(
                         points,
                         ordering,
                         shard_key_selector,
+                        update_if,
                     },
                     internal_params,
                     access.clone(),

--- a/src/tonic/api/update_common.rs
+++ b/src/tonic/api/update_common.rs
@@ -51,7 +51,7 @@ pub async fn upsert(
         points,
         ordering,
         shard_key_selector,
-        update_if,
+        update_filter,
     } = upsert_points;
 
     let points: Result<_, _> = points.into_iter().map(PointStruct::try_from).collect();
@@ -59,7 +59,7 @@ pub async fn upsert(
     let operation = PointInsertOperations::PointsList(PointsList {
         points: points?,
         shard_key: shard_key_selector.map(ShardKeySelector::from),
-        update_if: update_if
+        update_filter: update_filter
             .map(segment::types::Filter::try_from)
             .transpose()?,
     });
@@ -137,7 +137,7 @@ pub async fn update_vectors(
         points,
         ordering,
         shard_key_selector,
-        update_if,
+        update_filter,
     } = update_point_vectors;
 
     // Build list of operation points
@@ -157,7 +157,7 @@ pub async fn update_vectors(
     let operation = UpdateVectors {
         points: op_points,
         shard_key: shard_key_selector.map(ShardKeySelector::from),
-        update_if: update_if
+        update_filter: update_filter
             .map(segment::types::Filter::try_from)
             .transpose()?,
     };
@@ -426,7 +426,7 @@ pub async fn update_batch(
             points_update_operation::Operation::Upsert(PointStructList {
                 points,
                 shard_key_selector,
-                update_if,
+                update_filter,
             }) => {
                 upsert(
                     StrictModeCheckedTocProvider::new(dispatcher),
@@ -436,7 +436,7 @@ pub async fn update_batch(
                         points,
                         ordering,
                         shard_key_selector,
-                        update_if,
+                        update_filter,
                     },
                     internal_params,
                     access.clone(),
@@ -558,7 +558,7 @@ pub async fn update_batch(
                 points_update_operation::UpdateVectors {
                     points,
                     shard_key_selector,
-                    update_if,
+                    update_filter,
                 },
             ) => {
                 update_vectors(
@@ -569,7 +569,7 @@ pub async fn update_batch(
                         points,
                         ordering,
                         shard_key_selector,
-                        update_if,
+                        update_filter,
                     },
                     internal_params,
                     access.clone(),

--- a/tests/openapi/test_conditional_update.py
+++ b/tests/openapi/test_conditional_update.py
@@ -1,0 +1,155 @@
+from operator import itemgetter
+
+import pytest
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+
+
+@pytest.fixture(autouse=True)
+def setup(on_disk_vectors, on_disk_payload, collection_name):
+    basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors,
+                           on_disk_payload=on_disk_payload)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_conditional_update(collection_name):
+
+    # Upsert and delete points
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/payload",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "points": [6],
+            "payload": {
+                "version": 5
+            }
+        },
+        query_params={"wait": "true"},
+    )
+    assert response.ok
+
+    # Upsert and delete points
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "points": [
+                {
+                    "id": 6,
+                    "vector": [1.1, 1.2, 1.3, 1.4],
+                    "payload": {
+                        "version": 4,
+                        "test": "test_value"
+                    }
+                }
+            ],
+            "update_filter": {
+                "must": {
+                    "key": "version",
+                    "range": {
+                        "lt": 4,
+                    }
+                }
+            }
+        },
+        query_params={"wait": "true"},
+    )
+    assert response.ok
+
+    # Check that the point was not updated
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/{id}",
+        method="GET",
+        path_params={
+            "collection_name": collection_name,
+            "id": 6
+        },
+        query_params={},
+    )
+    assert response.ok
+    assert response.json()["result"]["payload"]["version"] == 5
+
+
+    # Upsert and delete points
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "points": [
+                {
+                    "id": 6,
+                    "vector": [1.1, 1.2, 1.3, 1.4],
+                    "payload": {
+                        "version": 6,
+                        "test": "test_value"
+                    }
+                }
+            ],
+            "update_filter": {
+                "must": {
+                    "key": "version",
+                    "range": {
+                        "lt": 6,
+                    }
+                }
+            }
+        },
+        query_params={"wait": "true"},
+    )
+    assert response.ok
+
+    # Check that the point was not updated
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/{id}",
+        method="GET",
+        path_params={
+            "collection_name": collection_name,
+            "id": 6
+        },
+        query_params={},
+    )
+    assert response.ok
+    assert response.json()["result"]["payload"]["version"] == 6
+
+    # Upsert and delete points
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/vectors",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "points": [
+                {
+                    "id": 6,
+                    "vector": [2.1, 2.2, 2.3, 2.4],
+                }
+            ],
+            "update_filter": {
+                "must": {
+                    "key": "version",
+                    "range": {
+                        "lt": 4,
+                    }
+                }
+            }
+        },
+        query_params={"wait": "true"},
+    )
+    assert response.ok
+
+    # Check that the point was not updated
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/{id}",
+        method="GET",
+        path_params={
+            "collection_name": collection_name,
+            "id": 6
+        },
+        query_params={},
+    )
+    assert response.ok
+    assert response.json()["result"]["vector"][0] < 2.0

--- a/tests/openapi/test_conditional_update.py
+++ b/tests/openapi/test_conditional_update.py
@@ -116,6 +116,9 @@ def test_conditional_update(collection_name):
     assert response.ok
     assert response.json()["result"]["payload"]["version"] == 6
 
+    # First vector element must be in expected range, confirms we don't normalize
+    assert 1.05 < response.json()["result"]["vector"][0] < 1.15
+
     # Upsert and delete points
     response = request_with_validation(
         api="/collections/{collection_name}/points/vectors",


### PR DESCRIPTION
This PR introduces optional condition to the update operation (upsert and update vectors).

The condition might be useful, if updates of the same point are coming from multiple sources and we need to make sure that there are no data races with the update. For example, conditional update may be used to update only those points, which `last_updated` timestamp is earlier them `now`.

Example:

```
PUT collection/my-collection/points
{
    "points": [
        {
            "id": 6,
            "vector": [1.1, 1.2, 1.3, 1.4],
            "payload": {
                "version": 4,
                "test": "test_value"
            }
        }
    ],
    "update_filter": {
        "must": {
            "key": "version",
            "range": {
                "lt": 4
            }
        }
    }
}
```

~ToDo: rename `update_if` into `update_filter`, as looks to be more consistent with the rest of API~
~ToDo: tests~