### PR TITLE
Fix GPU build in CI due to outdated package index

### DIFF
--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -28,7 +28,7 @@ jobs:
       uses: taiki-e/install-action@nextest
     - name: Install Vulkan packages
       run: |
-        sudo apt-get update -yqq
+        sudo apt-get update -y
         sudo apt-get install clang mesa-vulkan-drivers libvulkan1 vulkan-tools vulkan-validationlayers
         /usr/bin/vulkaninfo --summary
     - name: Build


### PR DESCRIPTION
Fixes failing GPU CI job: https://github.com/qdrant/qdrant/actions/runs/16878499549/job/47808496357

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?