### PR TITLE
Wrap quantization chunked vectors in a separate structure

### DIFF
--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -4,5 +4,6 @@ mod quantized_multi_custom_query_scorer;
 mod quantized_multi_query_scorer;
 pub mod quantized_multivector_storage;
 pub mod quantized_query_scorer;
+mod quantized_ram_storage;
 mod quantized_scorer_builder;
 pub mod quantized_vectors;

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -1,0 +1,98 @@
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use memory::fadvise::OneshotFile;
+
+use crate::common::operation_error::OperationResult;
+use crate::common::vector_utils::TrySetCapacityExact;
+use crate::vector_storage::chunked_vectors::ChunkedVectors;
+
+#[derive(Debug)]
+pub struct QuantizedRamStorage {
+    vectors: ChunkedVectors<u8>,
+}
+
+impl quantization::EncodedStorage for QuantizedRamStorage {
+    fn get_vector_data(&self, index: usize, _vector_size: usize) -> &[u8] {
+        self.vectors.get(index)
+    }
+
+    fn push_vector(
+        &mut self,
+        vector: &[u8],
+        _hw_counter: &HardwareCounterCell,
+    ) -> std::io::Result<()> {
+        // Skip hardware counter increment because it's a RAM storage.
+        self.vectors
+            .push(vector)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::OutOfMemory, err.to_string()))?;
+        Ok(())
+    }
+
+    fn from_file(path: &Path, quantized_vector_size: usize) -> std::io::Result<Self> {
+        let mut vectors = ChunkedVectors::<u8>::new(quantized_vector_size);
+        let file = OneshotFile::open(path)?;
+        let mut reader = BufReader::new(file);
+        let mut buffer = vec![0u8; quantized_vector_size];
+        while reader.read_exact(&mut buffer).is_ok() {
+            vectors.push(&buffer).map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::OutOfMemory,
+                    format!("Failed to load quantized vectors from file: {err}"),
+                )
+            })?;
+        }
+        reader.into_inner().drop_cache()?;
+        Ok(QuantizedRamStorage { vectors })
+    }
+
+    fn save_to_file(&self, path: &Path) -> std::io::Result<()> {
+        let mut buffer = BufWriter::new(File::create(path)?);
+        for i in 0..self.vectors.len() {
+            buffer.write_all(self.vectors.get(i))?;
+        }
+
+        // Explicitly flush write buffer so we can catch IO errors
+        buffer.flush()?;
+        buffer.into_inner()?.sync_all()?;
+        Ok(())
+    }
+
+    fn is_on_disk(&self) -> bool {
+        false
+    }
+
+    fn vectors_count(&self, _quantized_vector_size: usize) -> usize {
+        self.vectors.len()
+    }
+}
+
+pub struct QuantizedRamStorageBuilder {
+    pub vectors: ChunkedVectors<u8>,
+}
+
+impl QuantizedRamStorageBuilder {
+    pub fn new(count: usize, dim: usize) -> OperationResult<Self> {
+        let mut vectors = ChunkedVectors::new(dim);
+        vectors.try_set_capacity_exact(count)?;
+        Ok(Self { vectors })
+    }
+}
+
+impl quantization::EncodedStorageBuilder for QuantizedRamStorageBuilder {
+    type Storage = QuantizedRamStorage;
+
+    fn build(self) -> std::io::Result<QuantizedRamStorage> {
+        Ok(QuantizedRamStorage {
+            vectors: self.vectors,
+        })
+    }
+
+    fn push_vector_data(&mut self, other: &[u8]) {
+        // Memory for ChunkedVectors are already pre-allocated,
+        // so we do not expect any errors here.
+        self.vectors.push(other).unwrap();
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -16,7 +16,6 @@ use super::quantized_multivector_storage::{
 };
 use super::quantized_scorer_builder::QuantizedScorerBuilder;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::common::vector_utils::TrySetCapacityExact;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{QueryVector, VectorElementType};
 use crate::types::{
@@ -25,12 +24,14 @@ use crate::types::{
     ProductQuantization, ProductQuantizationConfig, QuantizationConfig, ScalarQuantization,
     ScalarQuantizationConfig, VectorStorageDatatype,
 };
-use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::quantized::quantized_mmap_storage::{
     QuantizedMmapStorage, QuantizedMmapStorageBuilder,
 };
 use crate::vector_storage::quantized::quantized_query_scorer::{
     InternalScorerUnsupported, QuantizedQueryScorer,
+};
+use crate::vector_storage::quantized::quantized_ram_storage::{
+    QuantizedRamStorage, QuantizedRamStorageBuilder,
 };
 use crate::vector_storage::query_scorer::QueryScorerBytes;
 use crate::vector_storage::{
@@ -58,7 +59,7 @@ impl fmt::Debug for QuantizedVectorsConfig {
 }
 
 type ScalarRamMulti =
-    QuantizedMultivectorStorage<EncodedVectorsU8<ChunkedVectors<u8>>, Vec<MultivectorOffset>>;
+    QuantizedMultivectorStorage<EncodedVectorsU8<QuantizedRamStorage>, Vec<MultivectorOffset>>;
 
 type ScalarMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsU8<QuantizedMmapStorage>,
@@ -66,7 +67,7 @@ type ScalarMmapMulti = QuantizedMultivectorStorage<
 >;
 
 type PQRamMulti =
-    QuantizedMultivectorStorage<EncodedVectorsPQ<ChunkedVectors<u8>>, Vec<MultivectorOffset>>;
+    QuantizedMultivectorStorage<EncodedVectorsPQ<QuantizedRamStorage>, Vec<MultivectorOffset>>;
 
 type PQMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsPQ<QuantizedMmapStorage>,
@@ -74,7 +75,7 @@ type PQMmapMulti = QuantizedMultivectorStorage<
 >;
 
 type BinaryRamMulti =
-    QuantizedMultivectorStorage<EncodedVectorsBin<u8, ChunkedVectors<u8>>, Vec<MultivectorOffset>>;
+    QuantizedMultivectorStorage<EncodedVectorsBin<u8, QuantizedRamStorage>, Vec<MultivectorOffset>>;
 
 type BinaryMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsBin<u8, QuantizedMmapStorage>,
@@ -82,11 +83,11 @@ type BinaryMmapMulti = QuantizedMultivectorStorage<
 >;
 
 pub enum QuantizedVectorStorage {
-    ScalarRam(EncodedVectorsU8<ChunkedVectors<u8>>),
+    ScalarRam(EncodedVectorsU8<QuantizedRamStorage>),
     ScalarMmap(EncodedVectorsU8<QuantizedMmapStorage>),
-    PQRam(EncodedVectorsPQ<ChunkedVectors<u8>>),
+    PQRam(EncodedVectorsPQ<QuantizedRamStorage>),
     PQMmap(EncodedVectorsPQ<QuantizedMmapStorage>),
-    BinaryRam(EncodedVectorsBin<u128, ChunkedVectors<u8>>),
+    BinaryRam(EncodedVectorsBin<u128, QuantizedRamStorage>),
     BinaryMmap(EncodedVectorsBin<u128, QuantizedMmapStorage>),
     ScalarRamMulti(ScalarRamMulti),
     ScalarMmapMulti(ScalarMmapMulti),
@@ -739,8 +740,8 @@ impl QuantizedVectors {
             EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(vector_parameters);
         let in_ram = Self::is_ram(scalar_config.always_ram, on_disk_vector_storage);
         if in_ram {
-            let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_set_capacity_exact(vectors_count)?;
+            let storage_builder =
+                QuantizedRamStorageBuilder::new(vectors_count, quantized_vector_size)?;
             Ok(QuantizedVectorStorage::ScalarRam(EncodedVectorsU8::encode(
                 vectors,
                 storage_builder,
@@ -786,8 +787,8 @@ impl QuantizedVectors {
             EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(vector_parameters);
         let in_ram = Self::is_ram(scalar_config.always_ram, on_disk_vector_storage);
         if in_ram {
-            let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_set_capacity_exact(inner_vectors_count)?;
+            let storage_builder =
+                QuantizedRamStorageBuilder::new(inner_vectors_count, quantized_vector_size)?;
             let quantized_storage = EncodedVectorsU8::encode(
                 vectors,
                 storage_builder,
@@ -851,8 +852,8 @@ impl QuantizedVectors {
             );
         let in_ram = Self::is_ram(pq_config.always_ram, on_disk_vector_storage);
         if in_ram {
-            let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_set_capacity_exact(vectors_count)?;
+            let storage_builder =
+                QuantizedRamStorageBuilder::new(vectors_count, quantized_vector_size)?;
             Ok(QuantizedVectorStorage::PQRam(EncodedVectorsPQ::encode(
                 vectors,
                 storage_builder,
@@ -903,8 +904,8 @@ impl QuantizedVectors {
             );
         let in_ram = Self::is_ram(pq_config.always_ram, on_disk_vector_storage);
         if in_ram {
-            let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_set_capacity_exact(inner_vectors_count)?;
+            let storage_builder =
+                QuantizedRamStorageBuilder::new(inner_vectors_count, quantized_vector_size)?;
             let quantized_storage = EncodedVectorsPQ::encode(
                 vectors,
                 storage_builder,
@@ -994,8 +995,8 @@ impl QuantizedVectors {
             );
         let in_ram = Self::is_ram(binary_config.always_ram, on_disk_vector_storage);
         if in_ram {
-            let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_set_capacity_exact(vectors_count)?;
+            let storage_builder =
+                QuantizedRamStorageBuilder::new(vectors_count, quantized_vector_size)?;
             Ok(QuantizedVectorStorage::BinaryRam(
                 EncodedVectorsBin::encode(
                     vectors,
@@ -1073,8 +1074,8 @@ impl QuantizedVectors {
             );
         let in_ram = Self::is_ram(binary_config.always_ram, on_disk_vector_storage);
         if in_ram {
-            let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_set_capacity_exact(inner_vectors_count)?;
+            let storage_builder =
+                QuantizedRamStorageBuilder::new(inner_vectors_count, quantized_vector_size)?;
             let quantized_storage = EncodedVectorsBin::encode(
                 vectors,
                 storage_builder,


### PR DESCRIPTION
This PR changes implementation for RAM quantization storage.

Previously, RAM quantization storage was declared as a trait impl:
```
impl quantization::EncodedStorage for ChunkedVectors<u8> {
...
}
```

Now, new `struct QuantizedRamStorage` was introduced:
```
pub struct QuantizedRamStorage {
    vectors: ChunkedVectors<u8>,
}

impl quantization::EncodedStorage for QuantizedRamStorage {
...
}
```

All implementations are copied without changes to the logic.

This change is required for the appendable quantization storage, where I'm goig to add additional fields into `QuantizedRamStorage` to describe snapshot file for this data.