### PR TITLE
Make `update_worker_fn` a blocking task, instead of async

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1241,15 +1241,13 @@ impl LocalShardClocks {
     }
 
     /// Persist clock maps to disk
-    pub async fn store_if_changed(&self, shard_path: &Path) -> CollectionResult<()> {
+    pub fn store_if_changed(&self, shard_path: &Path) -> CollectionResult<()> {
         self.oldest_clocks
-            .lock()
-            .await
+            .blocking_lock()
             .store_if_changed(&Self::oldest_clocks_path(shard_path))?;
 
         self.newest_clocks
-            .lock()
-            .await
+            .blocking_lock()
             .store_if_changed(&Self::newest_clocks_path(shard_path))?;
 
         Ok(())


### PR DESCRIPTION
This PR tweaks `UpdateHandler::update_worker_fn` to make it a blocking call instead of async.

`update_worker_fn` is an `async fn`, even though it's almost entirely a blocking call (e.g., `CollectionUpdater::update` call, which makes up 99% of work that `update_worker_fn` does, is a blocking call).

I don't _expect_ this will have any immediate noticeable effect, but it _might_ improve perf somehow or resolve minor/rare issues, because we've seen a bunch of weird bugs caused by blocking async runtime before, and `update` is a pretty hot path (even if it's run on its own dedicated runtime).

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
