### PR TITLE
Allow updating WAL config in collection after creation

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10323,6 +10323,17 @@
               }
             ]
           },
+          "wal_config": {
+            "description": "WAL parameters for the collection. Changes are effective only on Qdrant restart. If none - it is left unchanged.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WalConfigDiff"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "quantization_config": {
             "description": "Quantization parameters to update. If none - it is left unchanged.",
             "default": null,

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -505,6 +505,8 @@ message UpdateCollection {
   // Arbitrary JSON-like metadata for the collection, will be merged with
   // already stored metadata
   map<string, Value> metadata = 10;
+  // New WAL parameters for the collection
+  optional WalConfigDiff wal_config = 11;
 }
 
 message DeleteCollection {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1244,6 +1244,9 @@ pub struct UpdateCollection {
     /// already stored metadata
     #[prost(map = "string, message", tag = "10")]
     pub metadata: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
+    /// New WAL parameters for the collection
+    #[prost(message, optional, tag = "11")]
+    pub wal_config: ::core::option::Option<WalConfigDiff>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -61,9 +61,6 @@ impl Collection {
 
     /// Updates WAL config:
     /// Saves new params on disk
-    ///
-    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
-    /// the updated configuration.
     pub async fn update_wal_config_from_diff(
         &self,
         wal_config_diff: WalConfigDiff,

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -59,6 +59,23 @@ impl Collection {
         Ok(())
     }
 
+    /// Updates WAL config:
+    /// Saves new params on disk
+    ///
+    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
+    /// the updated configuration.
+    pub async fn update_wal_config_from_diff(
+        &self,
+        wal_config_diff: WalConfigDiff,
+    ) -> CollectionResult<()> {
+        {
+            let mut config = self.collection_config.write().await;
+            config.wal_config = wal_config_diff.update(&config.wal_config)?;
+        }
+        self.collection_config.read().await.save(&self.path)?;
+        Ok(())
+    }
+
     /// Updates vectors config:
     /// Saves new params on disk
     ///

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -70,7 +70,7 @@ impl Collection {
     ) -> CollectionResult<()> {
         {
             let mut config = self.collection_config.write().await;
-            config.wal_config = wal_config_diff.update(&config.wal_config)?;
+            config.wal_config = config.wal_config.update(&wal_config_diff);
         }
         self.collection_config.read().await.save(&self.path)?;
         Ok(())

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -242,6 +242,9 @@ pub struct UpdateCollection {
     /// HNSW parameters to update for the collection index. If none - it is left unchanged.
     #[validate(nested)]
     pub hnsw_config: Option<HnswConfigDiff>,
+    /// WAL parameters for the collection. If none - it is left unchanged.
+    #[validate(nested)]
+    pub wal_config: Option<WalConfigDiff>,
     /// Quantization parameters to update. If none - it is left unchanged.
     #[serde(default, alias = "quantization")]
     #[validate(nested)]
@@ -273,6 +276,7 @@ impl UpdateCollectionOperation {
             update_collection: UpdateCollection {
                 vectors: None,
                 hnsw_config: None,
+                wal_config: None,
                 params: None,
                 optimizers_config: None,
                 quantization_config: None,

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -242,7 +242,7 @@ pub struct UpdateCollection {
     /// HNSW parameters to update for the collection index. If none - it is left unchanged.
     #[validate(nested)]
     pub hnsw_config: Option<HnswConfigDiff>,
-    /// WAL parameters for the collection. If none - it is left unchanged.
+    /// WAL parameters for the collection. Changes are effective only on Qdrant restart. If none - it is left unchanged.
     #[validate(nested)]
     pub wal_config: Option<WalConfigDiff>,
     /// Quantization parameters to update. If none - it is left unchanged.

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 
 use api::conversions::json;
 use collection::operations::config_diff::{
-    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff, WalConfigDiff,
+    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
+    WalConfigDiff,
 };
 use collection::operations::conversions::sharding_method_from_proto;
 use collection::operations::types::{SparseVectorsConfig, VectorsConfigDiff};
@@ -188,7 +189,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                     .map(VectorsConfigDiff::try_from)
                     .transpose()?,
                 hnsw_config: hnsw_config.map(HnswConfigDiff::from),
-                wal_config:  wal_config.map(WalConfigDiff::from),
+                wal_config: wal_config.map(WalConfigDiff::from),
                 params: params.map(CollectionParamsDiff::try_from).transpose()?,
                 optimizers_config: optimizers_config
                     .map(OptimizersConfigDiff::try_from)

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use api::conversions::json;
 use collection::operations::config_diff::{
-    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
+    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff, WalConfigDiff,
 };
 use collection::operations::conversions::sharding_method_from_proto;
 use collection::operations::types::{SparseVectorsConfig, VectorsConfigDiff};
@@ -178,6 +178,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
             sparse_vectors_config,
             strict_mode_config,
             metadata,
+            wal_config,
         } = value;
         Ok(Self::UpdateCollection(UpdateCollectionOperation::new(
             collection_name,
@@ -187,6 +188,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                     .map(VectorsConfigDiff::try_from)
                     .transpose()?,
                 hnsw_config: hnsw_config.map(HnswConfigDiff::from),
+                wal_config:  wal_config.map(WalConfigDiff::from),
                 params: params.map(CollectionParamsDiff::try_from).transpose()?,
                 optimizers_config: optimizers_config
                     .map(OptimizersConfigDiff::try_from)

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -134,6 +134,7 @@ pub mod consensus_ops {
                     optimizers_config: None,
                     params: None,
                     hnsw_config: None,
+                    wal_config: None,
                     quantization_config: None,
                     sparse_vectors: None,
                     strict_mode_config: None,

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -166,7 +166,6 @@ impl TableOfContent {
         }
         if let Some(diff) = wal_config {
             collection.update_wal_config_from_diff(diff).await?;
-            recreate_optimizers = true;
         }
         if let Some(diff) = vectors {
             collection.update_vectors_from_diff(&diff).await?;

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -139,6 +139,7 @@ impl TableOfContent {
         let UpdateCollection {
             vectors,
             hnsw_config,
+            wal_config,
             params,
             optimizers_config,
             quantization_config,
@@ -161,6 +162,10 @@ impl TableOfContent {
         }
         if let Some(diff) = hnsw_config {
             collection.update_hnsw_config_from_diff(diff).await?;
+            recreate_optimizers = true;
+        }
+        if let Some(diff) = wal_config {
+            collection.update_wal_config_from_diff(diff).await?;
             recreate_optimizers = true;
         }
         if let Some(diff) = vectors {


### PR DESCRIPTION
Allow directly modifying WAL config via API call even after collection is created:

```http
PATCH /collections/benchmark
{
  "wal_config": {
    "wal_capacity_mb": "20",
    "wal_segments_ahead": "10",
    "wal_retain_closed": 3
  }
}
```

This makes it more likely for Qdrant to do WAL delta transfers (which is faster and preferred for large clusters)

Note that changes are effectively only after restarting Qdrant node.

Related to https://github.com/qdrant/qdrant/pull/6976#pullrequestreview-3088049521