### PR TITLE
Quantization flusher

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use common::counter::hardware_counter::HardwareCounterCell;
 #[cfg(feature = "testing")]
 use memory::fadvise::OneshotFile;
+use memory::mmap_type::MmapFlusher;
 
 pub trait EncodedStorage {
     fn get_vector_data(&self, index: usize, vector_size: usize) -> &[u8];
@@ -26,6 +27,8 @@ pub trait EncodedStorage {
     ) -> std::io::Result<()>;
 
     fn vectors_count(&self, quantized_vector_size: usize) -> usize;
+
+    fn flusher(&self) -> MmapFlusher;
 }
 
 pub trait EncodedStorageBuilder {
@@ -82,6 +85,10 @@ impl EncodedStorage for TestEncodedStorage {
             .len()
             .checked_div(quantized_vector_size)
             .unwrap_or_default()
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        Box::new(|| Ok(()))
     }
 }
 

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use memory::mmap_type::MmapFlusher;
 use serde::{Deserialize, Serialize};
 
 use crate::EncodingError;
@@ -63,6 +64,8 @@ pub trait EncodedVectors: Sized {
     ) -> std::io::Result<()>;
 
     fn vectors_count(&self) -> usize;
+
+    fn flusher(&self) -> MmapFlusher;
 }
 
 pub trait EncodedVectorsBytes: EncodedVectors {

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use common::counter::hardware_counter::HardwareCounterCell;
 use io::file_operations::atomic_save_json;
 use memory::mmap_ops::{transmute_from_u8_to_slice, transmute_to_u8_slice};
+use memory::mmap_type::MmapFlusher;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
@@ -897,6 +898,10 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
     fn vectors_count(&self) -> usize {
         self.encoded_vectors
             .vectors_count(self.get_quantized_vector_size())
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        self.encoded_vectors.flusher()
     }
 }
 

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use io::file_operations::atomic_save_json;
+use memory::mmap_type::MmapFlusher;
 use serde::{Deserialize, Serialize};
 
 use crate::encoded_storage::{EncodedStorage, EncodedStorageBuilder};
@@ -584,6 +585,10 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
         // `vector_division` size is equal to quantized vector size because each chunk is replaced by one `u8` centroid index.
         self.encoded_vectors
             .vectors_count(self.metadata.vector_division.len())
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        self.encoded_vectors.flusher()
     }
 }
 

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use io::file_operations::atomic_save_json;
+use memory::mmap_type::MmapFlusher;
 use serde::{Deserialize, Serialize};
 
 use crate::EncodingError;
@@ -514,6 +515,10 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
             .vectors_count(Self::get_quantized_vector_size(
                 &self.metadata.vector_parameters,
             ))
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        self.encoded_vectors.flusher()
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -4,6 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use memmap2::{Mmap, MmapMut};
 use memory::madvise;
 use memory::madvise::Madviseable;
+use memory::mmap_type::MmapFlusher;
 
 #[derive(Debug)]
 pub struct QuantizedMmapStorage {
@@ -58,6 +59,11 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
 
     fn vectors_count(&self, quantized_vector_size: usize) -> usize {
         self.mmap.len() / quantized_vector_size
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        // Mmap storage does not need a flusher, as it is non-appendable and already backed by a file.
+        Box::new(|| Ok(()))
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use memory::fadvise::OneshotFile;
+use memory::mmap_type::MmapFlusher;
 
 use crate::common::operation_error::OperationResult;
 use crate::common::vector_utils::TrySetCapacityExact;
@@ -66,6 +67,10 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
 
     fn vectors_count(&self, _quantized_vector_size: usize) -> usize {
         self.vectors.len()
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        Box::new(|| Ok(()))
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -1243,9 +1243,6 @@ impl QuantizedVectors {
             QuantizedVectorStorage::BinaryRamMulti(q) => q.flusher(),
             QuantizedVectorStorage::BinaryMmapMulti(q) => q.flusher(),
         };
-        Box::new(move || {
-            flusher()?;
-            Ok(())
-        })
+        Box::new(move || flusher().map_err(OperationError::from))
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -16,6 +16,7 @@ use super::quantized_multivector_storage::{
     QuantizedMultivectorStorage, create_offsets_file_from_iter,
 };
 use super::quantized_scorer_builder::QuantizedScorerBuilder;
+use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{QueryVector, VectorElementType};
@@ -1225,5 +1226,26 @@ impl QuantizedVectors {
             clear_disk_cache(&file)?;
         }
         Ok(())
+    }
+
+    pub fn flusher(&self) -> Flusher {
+        let flusher = match &self.storage_impl {
+            QuantizedVectorStorage::ScalarRam(q) => q.flusher(),
+            QuantizedVectorStorage::ScalarMmap(q) => q.flusher(),
+            QuantizedVectorStorage::PQRam(q) => q.flusher(),
+            QuantizedVectorStorage::PQMmap(q) => q.flusher(),
+            QuantizedVectorStorage::BinaryRam(q) => q.flusher(),
+            QuantizedVectorStorage::BinaryMmap(q) => q.flusher(),
+            QuantizedVectorStorage::ScalarRamMulti(q) => q.flusher(),
+            QuantizedVectorStorage::ScalarMmapMulti(q) => q.flusher(),
+            QuantizedVectorStorage::PQRamMulti(q) => q.flusher(),
+            QuantizedVectorStorage::PQMmapMulti(q) => q.flusher(),
+            QuantizedVectorStorage::BinaryRamMulti(q) => q.flusher(),
+            QuantizedVectorStorage::BinaryMmapMulti(q) => q.flusher(),
+        };
+        Box::new(move || {
+            flusher()?;
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
This PR adds a `flush` function into quantization storage and integration of flush in the segment.

Because dev has no appendable quantization storage yet, all flush implementations are empty.