### PR TITLE
Remove old shard key mapping format

### DIFF
--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -85,9 +85,6 @@ impl ShardHolder {
         let key_mapping: SaveOnDisk<ShardKeyMapping> =
             SaveOnDisk::load_or_init_default(collection_path.join(SHARD_KEY_MAPPING_FILE))?;
 
-        // TODO(shardkey): Remove once the old shardkey format has been removed entirely.
-        Self::migrate_shard_key_if_needed(&key_mapping)?;
-
         let mut shard_id_to_key_mapping = AHashMap::new();
 
         for (shard_key, shard_ids) in key_mapping.read().iter() {
@@ -1251,23 +1248,6 @@ impl ShardHolder {
         stream::iter(self.shards.iter())
             .any(|i| async { i.1.has_remote_shard().await })
             .await
-    }
-
-    /// Migrates the old shard-key format to the new one if necessary.
-    /// TODO(shardkey): Remove once the old shardkey format has been removed entirely.
-    fn migrate_shard_key_if_needed(
-        key_mapping: &SaveOnDisk<ShardKeyMapping>,
-    ) -> CollectionResult<()> {
-        if key_mapping.read().was_old_format {
-            // We automatically migrate to the new format when writing once, which we do here.
-            log::debug!("Migrating persisted shard key mapping to new format");
-            key_mapping.write(|i| {
-                // Also set this to true for consistency. However it should never be read.
-                i.was_old_format = false;
-            })?;
-        }
-
-        Ok(())
     }
 }
 

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -13,11 +13,6 @@ use crate::shards::shard::ShardId;
 #[serde(from = "SerdeHelper", into = "SerdeHelper")]
 pub struct ShardKeyMapping {
     shard_key_to_shard_ids: HashMap<ShardKey, HashSet<ShardId>>,
-
-    /// `true` if the ShardKeyMapping was specified in the old format.
-    /// TODO(shardkey): Remove once all keys are migrated.
-    #[serde(skip)]
-    pub(crate) was_old_format: bool,
 }
 
 impl ops::Deref for ShardKeyMapping {
@@ -81,7 +76,6 @@ impl From<SerdeHelper> for ShardKeyMapping {
     fn from(helper: SerdeHelper) -> Self {
         Self {
             shard_key_to_shard_ids: helper.0.into_iter().map(KeyIdsPair::into_parts).collect(),
-            was_old_format: false,
         }
     }
 }
@@ -124,164 +118,5 @@ impl KeyIdsPair {
 impl From<(ShardKey, HashSet<ShardId>)> for KeyIdsPair {
     fn from((key, shard_ids): (ShardKey, HashSet<ShardId>)) -> Self {
         Self { key, shard_ids }
-    }
-}
-
-#[cfg(test)]
-mod test {
-
-    use std::sync::Arc;
-
-    use common::budget::ResourceBudget;
-    use common::counter::hardware_accumulator::HwMeasurementAcc;
-    use fs_err::File;
-    use segment::types::{PayloadFieldSchema, PayloadSchemaType};
-    use tempfile::{Builder, TempDir};
-
-    use super::*;
-    use crate::collection::{Collection, RequestShardTransfer};
-    use crate::config::{CollectionConfigInternal, CollectionParams, ShardingMethod, WalConfig};
-    use crate::operations::shared_storage_config::SharedStorageConfig;
-    use crate::optimizers_builder::OptimizersConfig;
-    use crate::shards::channel_service::ChannelService;
-    use crate::shards::collection_shard_distribution::CollectionShardDistribution;
-    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState, ReplicaState};
-    use crate::shards::shard_holder::SHARD_KEY_MAPPING_FILE;
-
-    const COLLECTION_TEST_NAME: &str = "shard_key_test";
-
-    async fn make_collection(collection_name: &str, collection_dir: &TempDir) -> Collection {
-        let wal_config = WalConfig::default();
-        let mut collection_params = CollectionParams::empty();
-        collection_params.sharding_method = Some(ShardingMethod::Custom);
-
-        let config = CollectionConfigInternal {
-            params: collection_params,
-            optimizer_config: OptimizersConfig::fixture(),
-            wal_config,
-            hnsw_config: Default::default(),
-            quantization_config: Default::default(),
-            strict_mode_config: None,
-            uuid: None,
-            metadata: None,
-        };
-
-        let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
-
-        let collection = Collection::new(
-            collection_name.to_string(),
-            0,
-            collection_dir.path(),
-            snapshots_path.path(),
-            &config,
-            Arc::new(SharedStorageConfig::default()),
-            CollectionShardDistribution::all_local(None, 0),
-            None,
-            ChannelService::default(),
-            dummy_on_replica_failure(),
-            dummy_request_shard_transfer(),
-            dummy_abort_shard_transfer(),
-            None,
-            None,
-            ResourceBudget::default(),
-            None,
-        )
-        .await
-        .expect("Failed to create new fixture collection");
-
-        collection
-            .create_payload_index(
-                "field".parse().unwrap(),
-                PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
-                HwMeasurementAcc::new(),
-            )
-            .await
-            .expect("failed to create payload index");
-
-        collection
-    }
-
-    pub fn dummy_on_replica_failure() -> ChangePeerFromState {
-        Arc::new(move |_peer_id, _shard_id, _from_state| {})
-    }
-
-    pub fn dummy_request_shard_transfer() -> RequestShardTransfer {
-        Arc::new(move |_transfer| {})
-    }
-
-    pub fn dummy_abort_shard_transfer() -> AbortShardTransfer {
-        Arc::new(|_transfer, _reason| {})
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_shard_key_migration() {
-        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
-
-        {
-            let collection = make_collection(COLLECTION_TEST_NAME, &collection_dir).await;
-            collection
-                .create_shard_key(
-                    ShardKey::Keyword("helloworld".into()),
-                    vec![vec![]],
-                    ReplicaState::Active,
-                )
-                .await
-                .unwrap();
-        }
-
-        let shard_mapping_file = collection_dir.path().join(SHARD_KEY_MAPPING_FILE);
-
-        let shard_key_data: SerdeHelper = {
-            let file = File::open(&shard_mapping_file).unwrap();
-            serde_json::from_reader(file).unwrap()
-        };
-
-        let shard_key_data = ShardKeyMapping::from(shard_key_data);
-
-        // Ensure we have at least one shard key.
-        assert!(!shard_key_data.is_empty());
-
-        // Convert to old shard key and overwrite file on disk.
-        {
-            let old_shard_key_data = SerdeHelper::Old(shard_key_data.shard_key_to_shard_ids);
-            let mut writer = File::create(&shard_mapping_file).unwrap();
-            serde_json::to_writer(&mut writer, &old_shard_key_data).unwrap();
-        }
-
-        // Ensure on disk is now the old version.
-        {
-            let shard_key_data: SerdeHelper =
-                serde_json::from_reader(File::open(&shard_mapping_file).unwrap()).unwrap();
-
-            assert!(matches!(shard_key_data, SerdeHelper::Old(..)));
-        }
-
-        let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
-
-        // Load collection once to trigger mirgation to the new shard-key format.
-        {
-            Collection::load(
-                COLLECTION_TEST_NAME.to_string(),
-                0,
-                collection_dir.path(),
-                snapshots_path.path(),
-                Default::default(),
-                ChannelService::default(),
-                dummy_on_replica_failure(),
-                dummy_request_shard_transfer(),
-                dummy_abort_shard_transfer(),
-                None,
-                None,
-                ResourceBudget::default(),
-                None,
-            )
-            .await;
-        }
-
-        let shard_key_data: SerdeHelper =
-            { serde_json::from_reader(File::open(&shard_mapping_file).unwrap()).unwrap() };
-
-        // Now we have the new key on disk!
-        assert!(matches!(shard_key_data, SerdeHelper::New(..)));
     }
 }


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/5838> and <https://github.com/qdrant/qdrant/pull/6209> we switched to a new shard key mapping format on disk. This was necessary for compatibility with numeric keys.

Support for the old format was kept to allow forward/backward compatibility. Qdrant 1.14 forces the new format and migrates the file if needed. The plan was to remove support for the old format in Qdrant 1.15.

This now removes the old format. The change will land in 1.16.0.

### Tasks
- [x] Release <https://github.com/qdrant/qdrant/pull/7110> in a previous minor version first! ([1.15.4](https://github.com/qdrant/qdrant/releases/tag/v1.15.4))
- [x] Bump storage compatibility files, only use new shard key format
- [x] Merge before 1.16.0 release

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?