### PR TITLE
Add warning to development.yaml config

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,3 +1,10 @@
+# -> Warning! <-
+#
+# This config is only used in development profiles (debug/perf/..)
+# Always make sure implementations relying on configurations here also work on release.
+# Also don't forget to copy temporary configurations into config/config.yaml if they need
+# default values when released.
+
 log_level: DEBUG
 
 feature_flags:


### PR DESCRIPTION
Depends on #7050 

Adds a warning comment to development.yaml to make clear that the changes there should be tested on release profile as well.