### PR TITLE
avx512 for binary quantization

### DIFF
--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -285,12 +285,12 @@ impl BitsStoreType for u128 {
         debug_assert!(v1.len() == v2.len());
 
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("avx2")
-            && is_x86_feature_detected!("avx")
-            && is_x86_feature_detected!("sse2")
-            && is_x86_feature_detected!("sse4.1")
-            && is_x86_feature_detected!("avx512vl")
+        if is_x86_feature_detected!("avx512vl")
             && is_x86_feature_detected!("avx512vpopcntdq")
+            && is_x86_feature_detected!("avx2")
+            && is_x86_feature_detected!("avx")
+            && is_x86_feature_detected!("sse4.1")
+            && is_x86_feature_detected!("sse2")
         {
             unsafe {
                 return impl_xor_popcnt_avx512_uint128(
@@ -1042,12 +1042,12 @@ unsafe extern "C" {
 
 #[allow(missing_docs)]
 #[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx")]
-#[target_feature(enable = "avx2")]
-#[target_feature(enable = "sse2")]
-#[target_feature(enable = "sse4.1")]
 #[target_feature(enable = "avx512vl")]
 #[target_feature(enable = "avx512vpopcntdq")]
+#[target_feature(enable = "avx2")]
+#[target_feature(enable = "avx")]
+#[target_feature(enable = "sse4.1")]
+#[target_feature(enable = "sse2")]
 unsafe fn impl_xor_popcnt_avx512_uint128(
     query_ptr: *const u8,
     vector_ptr: *const u8,


### PR DESCRIPTION
This PR adds AVX512 support for BQ.

It speeds up BQ scoring because of `_mm256_popcnt_epi64`, which calculates POPCNT for 4 values.

Criterion benches:
```
encode/score binary linear access u128
                        time:   [614.89 µs 615.02 µs 615.13 µs]
                        change: [−22.744% −22.646% −22.548%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
encode/score binary random access u128
                        time:   [1.3676 ms 1.3794 ms 1.3914 ms]
                        change: [−26.581% −25.563% −24.412%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

dbpedia 1M, `qdrant-bq-rps-m-64-ef-256` without rescoring
```
"mean_time": 0.0008151541272178293,
vs
"mean_time": 0.000877215038286522,
```

Test docker image: https://github.com/qdrant/qdrant/actions/runs/16938730067