### PR TITLE
Move `SegmentHolder::scroll_read_lock` to `LocalShard`

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use parking_lot::RwLock;
 use segment::types::SeqNumberType;
@@ -40,11 +42,11 @@ impl CollectionUpdater {
         segments: &RwLock<SegmentHolder>,
         op_num: SeqNumberType,
         operation: CollectionUpdateOperations,
+        scroll_lock: Arc<tokio::sync::RwLock<()>>,
         hw_counter: &HardwareCounterCell,
     ) -> CollectionResult<usize> {
         // Allow only one update at a time, ensure no data races between segments.
         // let _lock = self.update_lock.lock().unwrap();
-        let scroll_lock = segments.read().scroll_read_lock.clone();
 
         // Use block_in_place here to avoid blocking the current async executor
         let _scroll_lock = tokio::task::block_in_place(|| scroll_lock.blocking_write());

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -158,14 +158,6 @@ pub struct SegmentHolder {
 
     /// Holds the first uncorrected error happened with optimizer
     pub optimizer_errors: Option<CollectionError>,
-
-    /// Scroll read lock
-    /// The lock, which must prevent updates during scroll + retrieve operations
-    /// Consistency of scroll operations is especially important for internal processes like
-    /// re-sharding and shard transfer, so explicit lock for those operations is required.
-    ///
-    /// Write lock must be held for updates, while read lock must be held for scroll
-    pub scroll_read_lock: Arc<tokio::sync::RwLock<()>>,
 }
 
 pub type LockedSegmentHolder = Arc<RwLock<SegmentHolder>>;

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -153,14 +153,8 @@ impl LocalShard {
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
-        let (non_appendable, appendable, scroll_lock) = {
-            let segments_read = segments.read();
-            let (non_appendable, appendable) = segments_read.split_segments();
-            let scroll_lock = segments_read.scroll_read_lock.clone();
-            (non_appendable, appendable, scroll_lock)
-        };
-
-        let scroll_lock = scroll_lock.read().await;
+        let (non_appendable, appendable) = segments.read().split_segments();
+        let scroll_lock = self.scroll_read_lock.read().await;
 
         let read_filtered = |segment: LockedSegment, hw_counter: HardwareCounterCell| {
             let filter = filter.cloned();
@@ -244,14 +238,8 @@ impl LocalShard {
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
-        let (non_appendable, appendable, scroll_lock) = {
-            let segments_read = segments.read();
-            let (non_appendable, appendable) = segments_read.split_segments();
-            let scroll_lock = segments_read.scroll_read_lock.clone();
-            (non_appendable, appendable, scroll_lock)
-        };
-
-        let scroll_lock = scroll_lock.read().await;
+        let (non_appendable, appendable) = segments.read().split_segments();
+        let scroll_lock = self.scroll_read_lock.read().await;
 
         let read_ordered_filtered = |segment: LockedSegment, hw_counter: &HardwareCounterCell| {
             let is_stopped = stopping_guard.get_is_stopped();
@@ -349,14 +337,8 @@ impl LocalShard {
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
-        let (non_appendable, appendable, scroll_lock) = {
-            let segments_read = segments.read();
-            let (non_appendable, appendable) = segments_read.split_segments();
-            let scroll_lock = segments_read.scroll_read_lock.clone();
-            (non_appendable, appendable, scroll_lock)
-        };
-
-        let scroll_lock = scroll_lock.read().await;
+        let (non_appendable, appendable) = segments.read().split_segments();
+        let scroll_lock = self.scroll_read_lock.read().await;
 
         let read_filtered = |segment: LockedSegment, hw_counter: &HardwareCounterCell| {
             let is_stopped = stopping_guard.get_is_stopped();


### PR DESCRIPTION
This removes `tokio` dependency from `SegementHolder`, so it's easier to extract `SegmentHolder` into separate crate for Qdrant Edge. 😔

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
