### PR TITLE
Fix clippy warnings when compiling without RocksDB feature flag

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -324,6 +324,7 @@ impl IndexSelector<'_> {
         })
     }
 
+    #[cfg_attr(not(feature = "rocksdb"), expect(clippy::unnecessary_wraps))]
     fn map_builder<N: MapIndexKey + ?Sized>(
         &self,
         field: &JsonPath,
@@ -377,6 +378,7 @@ impl IndexSelector<'_> {
         })
     }
 
+    #[cfg_attr(not(feature = "rocksdb"), expect(clippy::unnecessary_wraps))]
     fn numeric_builder<T: Encodable + Numericable + MmapValue + Send + Sync + Default, P>(
         &self,
         field: &JsonPath,
@@ -432,6 +434,7 @@ impl IndexSelector<'_> {
         })
     }
 
+    #[cfg_attr(not(feature = "rocksdb"), expect(clippy::unnecessary_wraps))]
     fn geo_builder(
         &self,
         field: &JsonPath,
@@ -501,6 +504,7 @@ impl IndexSelector<'_> {
         })
     }
 
+    #[cfg_attr(not(feature = "rocksdb"), expect(clippy::unnecessary_wraps))]
     fn text_builder(
         &self,
         field: &JsonPath,


### PR DESCRIPTION
Fix some clippy warnings when linting with:

```bash
cargo clippy --workspace --all-targets --no-default-features -- -D warnings
```

This came up while implementing <https://github.com/qdrant/qdrant/milestone/34>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?