### PR TITLE
Using quantization in plain segment

### DIFF
--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -12,6 +12,7 @@ pub mod sparse_index;
 mod struct_filter_context;
 pub mod struct_payload_index;
 pub mod vector_index_base;
+mod vector_index_search_common;
 mod visited_pool;
 
 pub use payload_index_base::*;

--- a/lib/segment/src/index/vector_index_search_common.rs
+++ b/lib/segment/src/index/vector_index_search_common.rs
@@ -1,0 +1,86 @@
+use bitvec::slice::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::ScoredPointOffset;
+use itertools::Itertools;
+
+use crate::common::operation_error::OperationResult;
+use crate::data_types::vectors::QueryVector;
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::types::{
+    SearchParams, default_quantization_ignore_value, default_quantization_oversampling_value,
+};
+use crate::vector_storage::VectorStorageEnum;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+
+pub fn is_quantized_search(
+    quantized_storage: Option<&QuantizedVectors>,
+    params: Option<&SearchParams>,
+) -> bool {
+    let ignore_quantization = params
+        .and_then(|p| p.quantization)
+        .map(|q| q.ignore)
+        .unwrap_or(default_quantization_ignore_value());
+    quantized_storage.is_some() && !ignore_quantization
+}
+
+pub fn get_oversampled_top(
+    quantized_storage: Option<&QuantizedVectors>,
+    params: Option<&SearchParams>,
+    top: usize,
+) -> usize {
+    let quantization_enabled = is_quantized_search(quantized_storage, params);
+
+    let oversampling_value = params
+        .and_then(|p| p.quantization)
+        .map(|q| q.oversampling)
+        .unwrap_or(default_quantization_oversampling_value());
+
+    match oversampling_value {
+        Some(oversampling) if quantization_enabled && oversampling > 1.0 => {
+            (oversampling * top as f64) as usize
+        }
+        _ => top,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn postprocess_search_result(
+    mut search_result: Vec<ScoredPointOffset>,
+    point_deleted: &BitSlice,
+    vector_storage: &VectorStorageEnum,
+    quantized_vectors: Option<&QuantizedVectors>,
+    vector: &QueryVector,
+    params: Option<&SearchParams>,
+    top: usize,
+    hardware_counter: HardwareCounterCell,
+) -> OperationResult<Vec<ScoredPointOffset>> {
+    let quantization_enabled = is_quantized_search(quantized_vectors, params);
+
+    let default_rescoring = quantized_vectors
+        .as_ref()
+        .map(|q| q.default_rescoring())
+        .unwrap_or(false);
+    let rescore = quantization_enabled
+        && params
+            .and_then(|p| p.quantization)
+            .and_then(|q| q.rescore)
+            .unwrap_or(default_rescoring);
+    if rescore {
+        let mut scorer = FilteredScorer::new(
+            vector.to_owned(),
+            vector_storage,
+            None,
+            None,
+            point_deleted,
+            hardware_counter,
+        )?;
+
+        search_result = scorer
+            .score_points(&mut search_result.iter().map(|x| x.idx).collect_vec(), 0)
+            .collect();
+        search_result.sort_unstable();
+        search_result.reverse();
+    }
+    search_result.truncate(top);
+    Ok(search_result)
+}

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -303,6 +303,7 @@ pub(crate) fn open_vector_index(
         Indexes::Plain {} => VectorIndexEnum::Plain(PlainVectorIndex::new(
             id_tracker,
             vector_storage,
+            quantized_vectors,
             payload_index,
         )),
         Indexes::Hnsw(hnsw_config) => VectorIndexEnum::Hnsw(HNSWIndex::open(HnswIndexOpenArgs {
@@ -332,6 +333,7 @@ pub(crate) fn build_vector_index<R: Rng + ?Sized>(
         Indexes::Plain {} => VectorIndexEnum::Plain(PlainVectorIndex::new(
             id_tracker,
             vector_storage,
+            quantized_vectors,
             payload_index,
         )),
         Indexes::Hnsw(hnsw_config) => VectorIndexEnum::Hnsw(HNSWIndex::build(


### PR DESCRIPTION
Depends on https://github.com/qdrant/qdrant/pull/7048

This PR integrates quantization storage into plain vector index.

It calls vector insert and use quantization for search.

Common code between HNSW and plain search (quantization checks, oversampling code, etc) is moved to the separate file without changes