### PR TITLE
Custom RRF `k` parameter

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -167,6 +167,7 @@
     - [Filter](#qdrant-Filter)
     - [Formula](#qdrant-Formula)
     - [Formula.DefaultsEntry](#qdrant-Formula-DefaultsEntry)
+    - [FusionParams](#qdrant-FusionParams)
     - [GeoBoundingBox](#qdrant-GeoBoundingBox)
     - [GeoDistance](#qdrant-GeoDistance)
     - [GeoLineString](#qdrant-GeoLineString)
@@ -236,7 +237,6 @@
     - [QueryResponse](#qdrant-QueryResponse)
     - [Range](#qdrant-Range)
     - [ReadConsistency](#qdrant-ReadConsistency)
-    - [ReciprocalRankFusion](#qdrant-ReciprocalRankFusion)
     - [RecommendBatchPoints](#qdrant-RecommendBatchPoints)
     - [RecommendBatchResponse](#qdrant-RecommendBatchResponse)
     - [RecommendGroupsResponse](#qdrant-RecommendGroupsResponse)
@@ -248,6 +248,7 @@
     - [RepeatedStrings](#qdrant-RepeatedStrings)
     - [RetrievedPoint](#qdrant-RetrievedPoint)
     - [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry)
+    - [RrfParams](#qdrant-RrfParams)
     - [ScoredPoint](#qdrant-ScoredPoint)
     - [ScoredPoint.PayloadEntry](#qdrant-ScoredPoint-PayloadEntry)
     - [ScrollPoints](#qdrant-ScrollPoints)
@@ -2990,6 +2991,21 @@ The JSON representation for `Value` is a JSON value.
 
 
 
+<a name="qdrant-FusionParams"></a>
+
+### FusionParams
+Parameterized fusion of multiple prefetches.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| rrf | [RrfParams](#qdrant-RrfParams) |  | Reciprocal Rank Fusion |
+
+
+
+
+
+
 <a name="qdrant-GeoBoundingBox"></a>
 
 ### GeoBoundingBox
@@ -4012,7 +4028,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | sample | [Sample](#qdrant-Sample) |  | Sample points from the collection. |
 | formula | [Formula](#qdrant-Formula) |  | Score boosting via an arbitrary formula |
 | nearest_with_mmr | [NearestInputWithMmr](#qdrant-NearestInputWithMmr) |  | Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm. |
-| rrf_custom | [ReciprocalRankFusion](#qdrant-ReciprocalRankFusion) |  | Reciprocal Rank Fusion with custom `k` parameter. |
+| fusion_params | [FusionParams](#qdrant-FusionParams) |  | Parameterized fusion of multiple prefetches. |
 
 
 
@@ -4176,21 +4192,6 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | type | [ReadConsistencyType](#qdrant-ReadConsistencyType) |  | Common read consistency configurations |
 | factor | [uint64](#uint64) |  | Send request to a specified number of nodes, and return points which are present on all of them |
-
-
-
-
-
-
-<a name="qdrant-ReciprocalRankFusion"></a>
-
-### ReciprocalRankFusion
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| k | [uint32](#uint32) |  |  |
 
 
 
@@ -4408,6 +4409,21 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | key | [string](#string) |  |  |
 | value | [Value](#qdrant-Value) |  |  |
+
+
+
+
+
+
+<a name="qdrant-RrfParams"></a>
+
+### RrfParams
+Parameterized reciprocal rank fusion
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| k | [uint32](#uint32) | optional | K parameter for reciprocal rank fusion |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -236,6 +236,7 @@
     - [QueryResponse](#qdrant-QueryResponse)
     - [Range](#qdrant-Range)
     - [ReadConsistency](#qdrant-ReadConsistency)
+    - [ReciprocalRankFusion](#qdrant-ReciprocalRankFusion)
     - [RecommendBatchPoints](#qdrant-RecommendBatchPoints)
     - [RecommendBatchResponse](#qdrant-RecommendBatchResponse)
     - [RecommendGroupsResponse](#qdrant-RecommendGroupsResponse)
@@ -4011,6 +4012,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | sample | [Sample](#qdrant-Sample) |  | Sample points from the collection. |
 | formula | [Formula](#qdrant-Formula) |  | Score boosting via an arbitrary formula |
 | nearest_with_mmr | [NearestInputWithMmr](#qdrant-NearestInputWithMmr) |  | Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm. |
+| rrf_custom | [ReciprocalRankFusion](#qdrant-ReciprocalRankFusion) |  | Reciprocal Rank Fusion with custom `k` parameter. |
 
 
 
@@ -4174,6 +4176,21 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | type | [ReadConsistencyType](#qdrant-ReadConsistencyType) |  | Common read consistency configurations |
 | factor | [uint64](#uint64) |  | Send request to a specified number of nodes, and return points which are present on all of them |
+
+
+
+
+
+
+<a name="qdrant-ReciprocalRankFusion"></a>
+
+### ReciprocalRankFusion
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| k | [uint32](#uint32) |  |  |
 
 
 
@@ -5216,7 +5233,7 @@ Vector type to be used in queries. Ids will be substituted with their correspond
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| RRF | 0 | Reciprocal Rank Fusion |
+| RRF | 0 | Reciprocal Rank Fusion (with k=2) |
 | DBSF | 1 | Distribution-Based Score Fusion |
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -167,7 +167,6 @@
     - [Filter](#qdrant-Filter)
     - [Formula](#qdrant-Formula)
     - [Formula.DefaultsEntry](#qdrant-Formula-DefaultsEntry)
-    - [FusionParams](#qdrant-FusionParams)
     - [GeoBoundingBox](#qdrant-GeoBoundingBox)
     - [GeoDistance](#qdrant-GeoDistance)
     - [GeoLineString](#qdrant-GeoLineString)
@@ -248,7 +247,7 @@
     - [RepeatedStrings](#qdrant-RepeatedStrings)
     - [RetrievedPoint](#qdrant-RetrievedPoint)
     - [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry)
-    - [RrfParams](#qdrant-RrfParams)
+    - [Rrf](#qdrant-Rrf)
     - [ScoredPoint](#qdrant-ScoredPoint)
     - [ScoredPoint.PayloadEntry](#qdrant-ScoredPoint-PayloadEntry)
     - [ScrollPoints](#qdrant-ScrollPoints)
@@ -2991,21 +2990,6 @@ The JSON representation for `Value` is a JSON value.
 
 
 
-<a name="qdrant-FusionParams"></a>
-
-### FusionParams
-Parameterized fusion of multiple prefetches.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| rrf | [RrfParams](#qdrant-RrfParams) |  | Reciprocal Rank Fusion |
-
-
-
-
-
-
 <a name="qdrant-GeoBoundingBox"></a>
 
 ### GeoBoundingBox
@@ -4028,7 +4012,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | sample | [Sample](#qdrant-Sample) |  | Sample points from the collection. |
 | formula | [Formula](#qdrant-Formula) |  | Score boosting via an arbitrary formula |
 | nearest_with_mmr | [NearestInputWithMmr](#qdrant-NearestInputWithMmr) |  | Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm. |
-| fusion_params | [FusionParams](#qdrant-FusionParams) |  | Parameterized fusion of multiple prefetches. |
+| rrf | [Rrf](#qdrant-Rrf) |  | Parameterized RRF fusion |
 
 
 
@@ -4415,9 +4399,9 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 
 
-<a name="qdrant-RrfParams"></a>
+<a name="qdrant-Rrf"></a>
 
-### RrfParams
+### Rrf
 Parameterized reciprocal rank fusion
 
 
@@ -5249,7 +5233,7 @@ Vector type to be used in queries. Ids will be substituted with their correspond
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| RRF | 0 | Reciprocal Rank Fusion (with k=2) |
+| RRF | 0 | Reciprocal Rank Fusion (with default parameters) |
 | DBSF | 1 | Distribution-Based Score Fusion |
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -4012,7 +4012,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | sample | [Sample](#qdrant-Sample) |  | Sample points from the collection. |
 | formula | [Formula](#qdrant-Formula) |  | Score boosting via an arbitrary formula |
 | nearest_with_mmr | [NearestInputWithMmr](#qdrant-NearestInputWithMmr) |  | Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm. |
-| rrf | [Rrf](#qdrant-Rrf) |  | Parameterized RRF fusion |
+| rrf | [Rrf](#qdrant-Rrf) |  | Parameterized reciprocal rank fusion |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15013,7 +15013,7 @@
         }
       },
       "Fusion": {
-        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion (with k=2) * `dbsf` - Distribution-Based Score Fusion",
+        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion (with default parameters) * `dbsf` - Distribution-Based Score Fusion",
         "type": "string",
         "enum": [
           "rrf",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14811,6 +14811,9 @@
             "$ref": "#/components/schemas/FusionQuery"
           },
           {
+            "$ref": "#/components/schemas/RrfQuery"
+          },
+          {
             "$ref": "#/components/schemas/FormulaQuery"
           },
           {
@@ -15005,37 +15008,33 @@
         ],
         "properties": {
           "fusion": {
-            "$ref": "#/components/schemas/FusionInterface"
+            "$ref": "#/components/schemas/Fusion"
           }
         }
       },
-      "FusionInterface": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/Fusion"
-          },
-          {
-            "$ref": "#/components/schemas/Rrf"
-          }
-        ]
-      },
       "Fusion": {
-        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion * `dbsf` - Distribution-Based Score Fusion",
+        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion (with k=2) * `dbsf` - Distribution-Based Score Fusion",
         "type": "string",
         "enum": [
           "rrf",
           "dbsf"
         ]
       },
-      "Rrf": {
+      "RrfQuery": {
         "type": "object",
         "required": [
-          "type"
+          "rrf"
         ],
         "properties": {
-          "type": {
-            "$ref": "#/components/schemas/RrfType"
-          },
+          "rrf": {
+            "$ref": "#/components/schemas/Rrf"
+          }
+        }
+      },
+      "Rrf": {
+        "description": "Parameters for Reciprocal Rank Fusion",
+        "type": "object",
+        "properties": {
           "k": {
             "description": "K parameter for reciprocal rank fusion",
             "default": null,
@@ -15045,12 +15044,6 @@
             "nullable": true
           }
         }
-      },
-      "RrfType": {
-        "type": "string",
-        "enum": [
-          "rrf"
-        ]
       },
       "FormulaQuery": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15005,34 +15005,58 @@
         ],
         "properties": {
           "fusion": {
-            "$ref": "#/components/schemas/Fusion"
+            "$ref": "#/components/schemas/FusionInterface"
           }
         }
       },
-      "Fusion": {
-        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion * `dbsf` - Distribution-Based Score Fusion",
-        "oneOf": [
+      "FusionInterface": {
+        "anyOf": [
           {
-            "type": "string",
-            "enum": [
-              "rrf",
-              "dbsf"
-            ]
+            "$ref": "#/components/schemas/Fusion"
           },
           {
-            "type": "object",
-            "required": [
-              "rrf_k"
-            ],
-            "properties": {
-              "rrf_k": {
-                "type": "integer",
-                "format": "uint",
-                "minimum": 0
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/components/schemas/FusionParams"
           }
+        ]
+      },
+      "Fusion": {
+        "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion * `dbsf` - Distribution-Based Score Fusion",
+        "type": "string",
+        "enum": [
+          "rrf",
+          "dbsf"
+        ]
+      },
+      "FusionParams": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RrfParams"
+          }
+        ]
+      },
+      "RrfParams": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/RrfType"
+          },
+          "k": {
+            "description": "K parameter for reciprocal rank fusion",
+            "default": null,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
+            "nullable": true
+          }
+        }
+      },
+      "RrfType": {
+        "type": "string",
+        "enum": [
+          "rrf"
         ]
       },
       "FormulaQuery": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15015,7 +15015,7 @@
             "$ref": "#/components/schemas/Fusion"
           },
           {
-            "$ref": "#/components/schemas/FusionParams"
+            "$ref": "#/components/schemas/Rrf"
           }
         ]
       },
@@ -15027,14 +15027,7 @@
           "dbsf"
         ]
       },
-      "FusionParams": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/RrfParams"
-          }
-        ]
-      },
-      "RrfParams": {
+      "Rrf": {
         "type": "object",
         "required": [
           "type"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15011,10 +15011,28 @@
       },
       "Fusion": {
         "description": "Fusion algorithm allows to combine results of multiple prefetches.\n\nAvailable fusion algorithms:\n\n* `rrf` - Reciprocal Rank Fusion * `dbsf` - Distribution-Based Score Fusion",
-        "type": "string",
-        "enum": [
-          "rrf",
-          "dbsf"
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "rrf",
+              "dbsf"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "rrf_k"
+            ],
+            "properties": {
+              "rrf_k": {
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              }
+            },
+            "additionalProperties": false
+          }
         ]
       },
       "FormulaQuery": {

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -297,6 +297,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("NearestInputWithMmr.mmr", ""),
             ("Mmr.diversity", "range(min = 0.0, max = 1.0)"),
             ("Mmr.candidates_limit", "range(max = 16_384)"),
+            ("ReciprocalRankFusion.k", "range(min = 1)"),
             ("Query.variant", ""),
             ("PrefetchQuery.prefetch", ""),
             ("PrefetchQuery.query", ""),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -297,7 +297,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("NearestInputWithMmr.mmr", ""),
             ("Mmr.diversity", "range(min = 0.0, max = 1.0)"),
             ("Mmr.candidates_limit", "range(max = 16_384)"),
-            ("RrfParams.k", "range(min = 1)"),
+            ("Rrf.k", "range(min = 1)"),
             ("Query.variant", ""),
             ("PrefetchQuery.prefetch", ""),
             ("PrefetchQuery.query", ""),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -297,7 +297,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("NearestInputWithMmr.mmr", ""),
             ("Mmr.diversity", "range(min = 0.0, max = 1.0)"),
             ("Mmr.candidates_limit", "range(max = 16_384)"),
-            ("ReciprocalRankFusion.k", "range(min = 1)"),
+            ("RrfParams.k", "range(min = 1)"),
             ("Query.variant", ""),
             ("PrefetchQuery.prefetch", ""),
             ("PrefetchQuery.query", ""),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -685,7 +685,7 @@ message Query {
     Sample sample = 7; // Sample points from the collection.
     Formula formula = 8; // Score boosting via an arbitrary formula
     NearestInputWithMmr nearest_with_mmr = 9; // Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
-    Rrf rrf = 10; // Parameterized RRF fusion
+    Rrf rrf = 10; // Parameterized reciprocal rank fusion
   }
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -669,8 +669,16 @@ message Mmr {
     optional uint32 candidates_limit = 3;
 }
 
-message ReciprocalRankFusion {
-    uint32 k = 1;
+// Parameterized reciprocal rank fusion
+message RrfParams {
+    optional uint32 k = 1; // K parameter for reciprocal rank fusion
+}
+
+// Parameterized fusion of multiple prefetches.
+message FusionParams {
+    oneof variant {
+        RrfParams rrf = 1; // Reciprocal Rank Fusion
+    }
 }
 
 message Query {
@@ -684,7 +692,7 @@ message Query {
     Sample sample = 7; // Sample points from the collection.
     Formula formula = 8; // Score boosting via an arbitrary formula
     NearestInputWithMmr nearest_with_mmr = 9; // Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
-    ReciprocalRankFusion rrf_custom = 10; // Reciprocal Rank Fusion with custom `k` parameter.
+    FusionParams fusion_params = 10; // Parameterized fusion of multiple prefetches.
   }
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -565,7 +565,7 @@ message ContextInput {
 }
 
 enum Fusion {
-    RRF = 0; // Reciprocal Rank Fusion
+    RRF = 0; // Reciprocal Rank Fusion (with k=2)
     DBSF = 1; // Distribution-Based Score Fusion
 }
 
@@ -669,6 +669,10 @@ message Mmr {
     optional uint32 candidates_limit = 3;
 }
 
+message ReciprocalRankFusion {
+    uint32 k = 1;
+}
+
 message Query {
   oneof variant {
     VectorInput nearest = 1; // Find the nearest neighbors to this vector.
@@ -680,6 +684,7 @@ message Query {
     Sample sample = 7; // Sample points from the collection.
     Formula formula = 8; // Score boosting via an arbitrary formula
     NearestInputWithMmr nearest_with_mmr = 9; // Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
+    ReciprocalRankFusion rrf_custom = 10; // Reciprocal Rank Fusion with custom `k` parameter.
   }
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -565,7 +565,7 @@ message ContextInput {
 }
 
 enum Fusion {
-    RRF = 0; // Reciprocal Rank Fusion (with k=2)
+    RRF = 0; // Reciprocal Rank Fusion (with default parameters)
     DBSF = 1; // Distribution-Based Score Fusion
 }
 
@@ -670,15 +670,8 @@ message Mmr {
 }
 
 // Parameterized reciprocal rank fusion
-message RrfParams {
+message Rrf {
     optional uint32 k = 1; // K parameter for reciprocal rank fusion
-}
-
-// Parameterized fusion of multiple prefetches.
-message FusionParams {
-    oneof variant {
-        RrfParams rrf = 1; // Reciprocal Rank Fusion
-    }
 }
 
 message Query {
@@ -692,7 +685,7 @@ message Query {
     Sample sample = 7; // Sample points from the collection.
     Formula formula = 8; // Score boosting via an arbitrary formula
     NearestInputWithMmr nearest_with_mmr = 9; // Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
-    FusionParams fusion_params = 10; // Parameterized fusion of multiple prefetches.
+    Rrf rrf = 10; // Parameterized RRF fusion
   }
 }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -279,7 +279,7 @@ message QueryShardPoints {
       Sample sample = 4; // Sample points
       Formula formula = 5; // Use an arbitrary formula to rescore points
       MmrInternal mmr = 6; // Maximal Marginal Relevance
-      FusionParams fusion_params = 7; // Parameterized fusion of multiple prefetches.
+      Rrf rrf = 7; // Parameterized RRF fusion
     }
   }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -279,6 +279,7 @@ message QueryShardPoints {
       Sample sample = 4; // Sample points
       Formula formula = 5; // Use an arbitrary formula to rescore points
       MmrInternal mmr = 6; // Maximal Marginal Relevance
+      ReciprocalRankFusion rrf_custom = 7; // Reciprocal Rank Fusion with custom parameters
     }
   }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -279,7 +279,7 @@ message QueryShardPoints {
       Sample sample = 4; // Sample points
       Formula formula = 5; // Use an arbitrary formula to rescore points
       MmrInternal mmr = 6; // Maximal Marginal Relevance
-      ReciprocalRankFusion rrf_custom = 7; // Reciprocal Rank Fusion with custom parameters
+      FusionParams fusion_params = 7; // Parameterized fusion of multiple prefetches.
     }
   }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5632,8 +5632,17 @@ pub struct Mmr {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReciprocalRankFusion {
+    #[prost(uint32, tag = "1")]
+    #[validate(range(min = 1))]
+    pub k: u32,
+}
+#[derive(validator::Validate)]
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Query {
-    #[prost(oneof = "query::Variant", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
+    #[prost(oneof = "query::Variant", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     #[validate(nested)]
     pub variant: ::core::option::Option<query::Variant>,
 }
@@ -5670,6 +5679,9 @@ pub mod query {
         /// Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
         #[prost(message, tag = "9")]
         NearestWithMmr(super::NearestInputWithMmr),
+        /// Reciprocal Rank Fusion with custom `k` parameter.
+        #[prost(message, tag = "10")]
+        RrfCustom(super::ReciprocalRankFusion),
     }
 }
 #[derive(validator::Validate)]
@@ -7106,7 +7118,7 @@ impl RecommendStrategy {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Fusion {
-    /// Reciprocal Rank Fusion
+    /// Reciprocal Rank Fusion (with k=2)
     Rrf = 0,
     /// Distribution-Based Score Fusion
     Dbsf = 1,
@@ -10161,7 +10173,7 @@ pub mod query_shard_points {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Query {
-        #[prost(oneof = "query::Score", tags = "1, 2, 3, 4, 5, 6")]
+        #[prost(oneof = "query::Score", tags = "1, 2, 3, 4, 5, 6, 7")]
         pub score: ::core::option::Option<query::Score>,
     }
     /// Nested message and enum types in `Query`.
@@ -10188,6 +10200,9 @@ pub mod query_shard_points {
             /// Maximal Marginal Relevance
             #[prost(message, tag = "6")]
             Mmr(super::super::MmrInternal),
+            /// Reciprocal Rank Fusion with custom parameters
+            #[prost(message, tag = "7")]
+            RrfCustom(super::super::ReciprocalRankFusion),
         }
     }
     #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5628,14 +5628,35 @@ pub struct Mmr {
     #[validate(range(max = 16_384))]
     pub candidates_limit: ::core::option::Option<u32>,
 }
+/// Parameterized reciprocal rank fusion
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ReciprocalRankFusion {
-    #[prost(uint32, tag = "1")]
+pub struct RrfParams {
+    /// K parameter for reciprocal rank fusion
+    #[prost(uint32, optional, tag = "1")]
     #[validate(range(min = 1))]
-    pub k: u32,
+    pub k: ::core::option::Option<u32>,
+}
+/// Parameterized fusion of multiple prefetches.
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FusionParams {
+    #[prost(oneof = "fusion_params::Variant", tags = "1")]
+    pub variant: ::core::option::Option<fusion_params::Variant>,
+}
+/// Nested message and enum types in `FusionParams`.
+pub mod fusion_params {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        /// Reciprocal Rank Fusion
+        #[prost(message, tag = "1")]
+        Rrf(super::RrfParams),
+    }
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -5679,9 +5700,9 @@ pub mod query {
         /// Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
         #[prost(message, tag = "9")]
         NearestWithMmr(super::NearestInputWithMmr),
-        /// Reciprocal Rank Fusion with custom `k` parameter.
+        /// Parameterized fusion of multiple prefetches.
         #[prost(message, tag = "10")]
-        RrfCustom(super::ReciprocalRankFusion),
+        FusionParams(super::FusionParams),
     }
 }
 #[derive(validator::Validate)]
@@ -10200,9 +10221,9 @@ pub mod query_shard_points {
             /// Maximal Marginal Relevance
             #[prost(message, tag = "6")]
             Mmr(super::super::MmrInternal),
-            /// Reciprocal Rank Fusion with custom parameters
+            /// Parameterized fusion of multiple prefetches.
             #[prost(message, tag = "7")]
-            RrfCustom(super::super::ReciprocalRankFusion),
+            FusionParams(super::super::FusionParams),
         }
     }
     #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5681,7 +5681,7 @@ pub mod query {
         /// Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
         #[prost(message, tag = "9")]
         NearestWithMmr(super::NearestInputWithMmr),
-        /// Parameterized RRF fusion
+        /// Parameterized reciprocal rank fusion
         #[prost(message, tag = "10")]
         Rrf(super::Rrf),
     }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5633,30 +5633,11 @@ pub struct Mmr {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RrfParams {
+pub struct Rrf {
     /// K parameter for reciprocal rank fusion
     #[prost(uint32, optional, tag = "1")]
     #[validate(range(min = 1))]
     pub k: ::core::option::Option<u32>,
-}
-/// Parameterized fusion of multiple prefetches.
-#[derive(serde::Serialize)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FusionParams {
-    #[prost(oneof = "fusion_params::Variant", tags = "1")]
-    pub variant: ::core::option::Option<fusion_params::Variant>,
-}
-/// Nested message and enum types in `FusionParams`.
-pub mod fusion_params {
-    #[derive(serde::Serialize)]
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Variant {
-        /// Reciprocal Rank Fusion
-        #[prost(message, tag = "1")]
-        Rrf(super::RrfParams),
-    }
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -5700,9 +5681,9 @@ pub mod query {
         /// Search nearest neighbors, but re-rank based on the Maximal Marginal Relevance algorithm.
         #[prost(message, tag = "9")]
         NearestWithMmr(super::NearestInputWithMmr),
-        /// Parameterized fusion of multiple prefetches.
+        /// Parameterized RRF fusion
         #[prost(message, tag = "10")]
-        FusionParams(super::FusionParams),
+        Rrf(super::Rrf),
     }
 }
 #[derive(validator::Validate)]
@@ -7139,7 +7120,7 @@ impl RecommendStrategy {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Fusion {
-    /// Reciprocal Rank Fusion (with k=2)
+    /// Reciprocal Rank Fusion (with default parameters)
     Rrf = 0,
     /// Distribution-Based Score Fusion
     Dbsf = 1,
@@ -10221,9 +10202,9 @@ pub mod query_shard_points {
             /// Maximal Marginal Relevance
             #[prost(message, tag = "6")]
             Mmr(super::super::MmrInternal),
-            /// Parameterized fusion of multiple prefetches.
+            /// Parameterized RRF fusion
             #[prost(message, tag = "7")]
-            FusionParams(super::super::FusionParams),
+            Rrf(super::super::Rrf),
         }
     }
     #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -344,9 +344,9 @@ impl Validate for super::qdrant::query::Variant {
             grpc::query::Variant::Discover(q) => q.validate(),
             grpc::query::Variant::Context(q) => q.validate(),
             grpc::query::Variant::Formula(q) => q.validate(),
+            grpc::query::Variant::Rrf(q) => q.validate(),
             grpc::query::Variant::Sample(_)
             | grpc::query::Variant::Fusion(_)
-            | grpc::query::Variant::FusionParams(_)
             | grpc::query::Variant::OrderBy(_) => Ok(()),
         }
     }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -346,7 +346,7 @@ impl Validate for super::qdrant::query::Variant {
             grpc::query::Variant::Formula(q) => q.validate(),
             grpc::query::Variant::Sample(_)
             | grpc::query::Variant::Fusion(_)
-            | grpc::query::Variant::RrfCustom(_)
+            | grpc::query::Variant::FusionParams(_)
             | grpc::query::Variant::OrderBy(_) => Ok(()),
         }
     }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -346,6 +346,7 @@ impl Validate for super::qdrant::query::Variant {
             grpc::query::Variant::Formula(q) => q.validate(),
             grpc::query::Variant::Sample(_)
             | grpc::query::Variant::Fusion(_)
+            | grpc::query::Variant::RrfCustom(_)
             | grpc::query::Variant::OrderBy(_) => Ok(()),
         }
     }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -516,13 +516,6 @@ pub enum Fusion {
     Rrf,
     Dbsf,
 }
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(untagged)]
-pub enum FusionParams {
-    Rrf(RrfParams),
-}
-
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RrfType {
@@ -532,7 +525,7 @@ pub enum RrfType {
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
-pub struct RrfParams {
+pub struct Rrf {
     pub r#type: RrfType,
 
     /// K parameter for reciprocal rank fusion
@@ -545,7 +538,7 @@ pub struct RrfParams {
 #[serde(untagged)]
 pub enum FusionInterface {
     Fusion(Fusion),
-    FusionParams(FusionParams),
+    RRF(Rrf),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -508,7 +508,7 @@ pub enum OrderByInterface {
 ///
 /// Available fusion algorithms:
 ///
-/// * `rrf` - Reciprocal Rank Fusion
+/// * `rrf` - Reciprocal Rank Fusion (with k=2)
 /// * `dbsf` - Distribution-Based Score Fusion
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -516,29 +516,15 @@ pub enum Fusion {
     Rrf,
     Dbsf,
 }
-#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum RrfType {
-    #[default]
-    Rrf,
-}
 
+/// Parameters for Reciprocal Rank Fusion
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct Rrf {
-    pub r#type: RrfType,
-
     /// K parameter for reciprocal rank fusion
     #[validate(range(min = 1))]
     #[serde(default)]
     pub k: Option<usize>,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(untagged)]
-pub enum FusionInterface {
-    Fusion(Fusion),
-    Rrf(Rrf),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -647,6 +633,9 @@ pub enum Query {
     /// Fuse the results of multiple prefetches.
     Fusion(FusionQuery),
 
+    /// Apply reciprocal rank fusion to multiple prefetches
+    Rrf(RrfQuery),
+
     /// Score boosting via an arbitrary formula
     Formula(FormulaQuery),
 
@@ -698,7 +687,14 @@ pub struct OrderByQuery {
 #[serde(rename_all = "snake_case")]
 pub struct FusionQuery {
     #[validate(nested)]
-    pub fusion: FusionInterface,
+    pub fusion: Fusion,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
+pub struct RrfQuery {
+    #[validate(nested)]
+    pub rrf: Rrf,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -538,7 +538,7 @@ pub struct Rrf {
 #[serde(untagged)]
 pub enum FusionInterface {
     Fusion(Fusion),
-    RRF(Rrf),
+    Rrf(Rrf),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -514,9 +514,38 @@ pub enum OrderByInterface {
 #[serde(rename_all = "snake_case")]
 pub enum Fusion {
     Rrf,
-    #[validate(range(min = 1))]
-    RrfK(usize),
     Dbsf,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum FusionParams {
+    Rrf(RrfParams),
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RrfType {
+    #[default]
+    Rrf,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
+pub struct RrfParams {
+    pub r#type: RrfType,
+
+    /// K parameter for reciprocal rank fusion
+    #[validate(range(min = 1))]
+    #[serde(default)]
+    pub k: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum FusionInterface {
+    Fusion(Fusion),
+    FusionParams(FusionParams),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -676,7 +705,7 @@ pub struct OrderByQuery {
 #[serde(rename_all = "snake_case")]
 pub struct FusionQuery {
     #[validate(nested)]
-    pub fusion: Fusion,
+    pub fusion: FusionInterface,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -514,6 +514,8 @@ pub enum OrderByInterface {
 #[serde(rename_all = "snake_case")]
 pub enum Fusion {
     Rrf,
+    #[validate(range(min = 1))]
+    RrfK(usize),
     Dbsf,
 }
 

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -508,7 +508,7 @@ pub enum OrderByInterface {
 ///
 /// Available fusion algorithms:
 ///
-/// * `rrf` - Reciprocal Rank Fusion (with k=2)
+/// * `rrf` - Reciprocal Rank Fusion (with default parameters)
 /// * `dbsf` - Distribution-Based Score Fusion
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -9,7 +9,7 @@ use super::{
     Batch, ContextInput, Expression, FormulaQuery, Fusion, OrderByInterface, PointVectors, Query,
     QueryInterface, RecommendInput, Sample, VectorInput,
 };
-use crate::rest::NamedVectorStruct;
+use crate::rest::{FusionInterface, FusionParams, NamedVectorStruct};
 
 impl Validate for NamedVectorStruct {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
@@ -96,7 +96,24 @@ impl Validate for ContextInput {
 impl Validate for Fusion {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
-            Fusion::Rrf | Fusion::RrfK(_) | Fusion::Dbsf => Ok(()),
+            Fusion::Rrf | Fusion::Dbsf => Ok(()),
+        }
+    }
+}
+
+impl Validate for FusionParams {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            FusionParams::Rrf(params) => params.validate(),
+        }
+    }
+}
+
+impl Validate for FusionInterface {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            FusionInterface::Fusion(fusion) => fusion.validate(),
+            FusionInterface::FusionParams(fusion_params) => fusion_params.validate(),
         }
     }
 }

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -9,7 +9,7 @@ use super::{
     Batch, ContextInput, Expression, FormulaQuery, Fusion, OrderByInterface, PointVectors, Query,
     QueryInterface, RecommendInput, Sample, VectorInput,
 };
-use crate::rest::{FusionInterface, FusionParams, NamedVectorStruct};
+use crate::rest::{FusionInterface, NamedVectorStruct};
 
 impl Validate for NamedVectorStruct {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
@@ -101,19 +101,11 @@ impl Validate for Fusion {
     }
 }
 
-impl Validate for FusionParams {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            FusionParams::Rrf(params) => params.validate(),
-        }
-    }
-}
-
 impl Validate for FusionInterface {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             FusionInterface::Fusion(fusion) => fusion.validate(),
-            FusionInterface::FusionParams(fusion_params) => fusion_params.validate(),
+            FusionInterface::RRF(rrf) => rrf.validate(),
         }
     }
 }

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -105,7 +105,7 @@ impl Validate for FusionInterface {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             FusionInterface::Fusion(fusion) => fusion.validate(),
-            FusionInterface::RRF(rrf) => rrf.validate(),
+            FusionInterface::Rrf(rrf) => rrf.validate(),
         }
     }
 }

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -4,12 +4,10 @@ use common::validation::validate_multi_vector;
 use segment::index::query_optimization::rescore_formula::parsed_formula::VariableId;
 use validator::{Validate, ValidationError, ValidationErrors};
 
-use super::schema::BatchVectorStruct;
 use super::{
-    Batch, ContextInput, Expression, FormulaQuery, Fusion, OrderByInterface, PointVectors, Query,
-    QueryInterface, RecommendInput, Sample, VectorInput,
+    Batch, BatchVectorStruct, ContextInput, Expression, FormulaQuery, Fusion, NamedVectorStruct,
+    OrderByInterface, PointVectors, Query, QueryInterface, RecommendInput, Sample, VectorInput,
 };
-use crate::rest::{FusionInterface, NamedVectorStruct};
 
 impl Validate for NamedVectorStruct {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
@@ -38,6 +36,7 @@ impl Validate for Query {
             Query::Discover(discover) => discover.validate(),
             Query::Context(context) => context.validate(),
             Query::Fusion(fusion) => fusion.validate(),
+            Query::Rrf(rrf) => rrf.validate(),
             Query::Formula(formula) => formula.validate(),
             Query::OrderBy(order_by) => order_by.validate(),
             Query::Sample(sample) => sample.validate(),
@@ -97,15 +96,6 @@ impl Validate for Fusion {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             Fusion::Rrf | Fusion::Dbsf => Ok(()),
-        }
-    }
-}
-
-impl Validate for FusionInterface {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            FusionInterface::Fusion(fusion) => fusion.validate(),
-            FusionInterface::Rrf(rrf) => rrf.validate(),
         }
     }
 }

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -96,7 +96,7 @@ impl Validate for ContextInput {
 impl Validate for Fusion {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
-            Fusion::Rrf | Fusion::Dbsf => Ok(()),
+            Fusion::Rrf | Fusion::RrfK(_) | Fusion::Dbsf => Ok(()),
         }
     }
 }

--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -19,6 +19,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::rng;
+use segment::common::reciprocal_rank_fusion::DEFAULT_RRF_K;
 use segment::data_types::vectors::{VectorStructInternal, only_default_vector};
 use segment::fixtures::payload_fixtures::random_vector;
 use segment::types::{
@@ -258,7 +259,7 @@ fn batch_rrf_query_bench(c: &mut Criterion) {
                                     score_threshold: None,
                                 },
                             ],
-                            query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+                            query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
                             filter: filter.clone(),
                             params: None,
                             limit: 10,

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -360,7 +360,7 @@ impl Collection {
             Some(ScoringQuery::Fusion(fusion)) => {
                 // If the root query is a Fusion, the returned results correspond to each the prefetches.
                 let mut fused = match fusion {
-                    FusionInternal::Rrf => rrf_scoring(intermediates),
+                    FusionInternal::RrfK(k) => rrf_scoring(intermediates, *k),
                     FusionInternal::Dbsf => score_fusion(intermediates, ScoreFusion::dbsf()),
                 };
                 if let Some(&score_threshold) = score_threshold.as_ref() {

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -710,13 +710,15 @@ impl CollectionQueryRequest {
 
 mod from_rest {
     use api::rest::schema as rest;
+    use segment::common::reciprocal_rank_fusion::DEFAULT_RRF_K;
 
     use super::*;
 
     impl From<rest::Fusion> for FusionInternal {
         fn from(value: rest::Fusion) -> Self {
             match value {
-                rest::Fusion::Rrf => FusionInternal::Rrf,
+                rest::Fusion::Rrf => FusionInternal::RrfK(DEFAULT_RRF_K),
+                rest::Fusion::RrfK(k) => FusionInternal::RrfK(k),
                 rest::Fusion::Dbsf => FusionInternal::Dbsf,
             }
         }

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -734,7 +734,7 @@ mod from_rest {
         fn from(value: rest::FusionInterface) -> Self {
             match value {
                 rest::FusionInterface::Fusion(fusion) => FusionInternal::from(fusion),
-                rest::FusionInterface::RRF(rrf) => FusionInternal::from(rrf),
+                rest::FusionInterface::Rrf(rrf) => FusionInternal::from(rrf),
             }
         }
     }

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -718,8 +718,28 @@ mod from_rest {
         fn from(value: rest::Fusion) -> Self {
             match value {
                 rest::Fusion::Rrf => FusionInternal::RrfK(DEFAULT_RRF_K),
-                rest::Fusion::RrfK(k) => FusionInternal::RrfK(k),
                 rest::Fusion::Dbsf => FusionInternal::Dbsf,
+            }
+        }
+    }
+
+    impl From<rest::FusionParams> for FusionInternal {
+        fn from(value: rest::FusionParams) -> Self {
+            match value {
+                rest::FusionParams::Rrf(rest::RrfParams { r#type: _, k }) => {
+                    FusionInternal::RrfK(k.unwrap_or(DEFAULT_RRF_K))
+                }
+            }
+        }
+    }
+
+    impl From<rest::FusionInterface> for FusionInternal {
+        fn from(value: rest::FusionInterface) -> Self {
+            match value {
+                rest::FusionInterface::Fusion(fusion) => FusionInternal::from(fusion),
+                rest::FusionInterface::FusionParams(fusion_params) => {
+                    FusionInternal::from(fusion_params)
+                }
             }
         }
     }

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -725,17 +725,8 @@ mod from_rest {
 
     impl From<rest::Rrf> for FusionInternal {
         fn from(value: rest::Rrf) -> Self {
-            let rest::Rrf { r#type: _, k } = value;
+            let rest::Rrf { k } = value;
             FusionInternal::RrfK(k.unwrap_or(DEFAULT_RRF_K))
-        }
-    }
-
-    impl From<rest::FusionInterface> for FusionInternal {
-        fn from(value: rest::FusionInterface) -> Self {
-            match value {
-                rest::FusionInterface::Fusion(fusion) => FusionInternal::from(fusion),
-                rest::FusionInterface::Rrf(rrf) => FusionInternal::from(rrf),
-            }
         }
     }
 

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -723,13 +723,10 @@ mod from_rest {
         }
     }
 
-    impl From<rest::FusionParams> for FusionInternal {
-        fn from(value: rest::FusionParams) -> Self {
-            match value {
-                rest::FusionParams::Rrf(rest::RrfParams { r#type: _, k }) => {
-                    FusionInternal::RrfK(k.unwrap_or(DEFAULT_RRF_K))
-                }
-            }
+    impl From<rest::Rrf> for FusionInternal {
+        fn from(value: rest::Rrf) -> Self {
+            let rest::Rrf { r#type: _, k } = value;
+            FusionInternal::RrfK(k.unwrap_or(DEFAULT_RRF_K))
         }
     }
 
@@ -737,9 +734,7 @@ mod from_rest {
         fn from(value: rest::FusionInterface) -> Self {
             match value {
                 rest::FusionInterface::Fusion(fusion) => FusionInternal::from(fusion),
-                rest::FusionInterface::FusionParams(fusion_params) => {
-                    FusionInternal::from(fusion_params)
-                }
+                rest::FusionInterface::RRF(rrf) => FusionInternal::from(rrf),
             }
         }
     }

--- a/lib/collection/src/operations/universal_query/planned_query.rs
+++ b/lib/collection/src/operations/universal_query/planned_query.rs
@@ -430,6 +430,7 @@ impl TryFrom<Vec<ShardQueryRequest>> for PlannedQuery {
 #[cfg(test)]
 mod tests {
     use ahash::AHashSet;
+    use segment::common::reciprocal_rank_fusion::DEFAULT_RRF_K;
     use segment::data_types::vectors::{MultiDenseVectorInternal, NamedQuery, VectorInternal};
     use segment::json_path::JsonPath;
     use segment::types::{
@@ -661,7 +662,7 @@ mod tests {
                     score_threshold: None,
                 },
             ],
-            query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+            query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
             filter: Some(filter_outer.clone()),
             score_threshold: None,
             limit: 50,
@@ -722,7 +723,7 @@ mod tests {
     fn test_try_from_rrf_without_source() {
         let request = ShardQueryRequest {
             prefetches: vec![],
-            query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+            query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
             filter: Some(Filter::default()),
             score_threshold: None,
             limit: 50,
@@ -765,7 +766,7 @@ mod tests {
                 filter: dummy_filter.clone(),
                 score_threshold: Some(0.1),
             }],
-            query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+            query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
             filter: Some(Filter::default()),
             score_threshold: Some(0.666),
             limit: 50,
@@ -981,7 +982,7 @@ mod tests {
                 prefetches: vec![
                     ShardPrefetch {
                         prefetches: vec![dummy_core_prefetch(30), dummy_core_prefetch(40)],
-                        query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+                        query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
                         filter: None,
                         params: None,
                         score_threshold: None,
@@ -989,7 +990,7 @@ mod tests {
                     },
                     dummy_scroll_prefetch(50),
                 ],
-                query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+                query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
                 filter: None,
                 score_threshold: None,
                 limit: 10,
@@ -1032,7 +1033,9 @@ mod tests {
                             Source::Prefetch(Box::from(MergePlan {
                                 sources: vec![Source::SearchesIdx(1), Source::SearchesIdx(2),],
                                 rescore_params: Some(RescoreParams {
-                                    rescore: ScoringQuery::Fusion(FusionInternal::Rrf),
+                                    rescore: ScoringQuery::Fusion(FusionInternal::RrfK(
+                                        DEFAULT_RRF_K
+                                    )),
                                     limit: 10,
                                     score_threshold: None,
                                     params: None,

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -406,7 +406,7 @@ impl LocalShard {
         limit: usize,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         let fused = match fusion {
-            FusionInternal::Rrf => rrf_scoring(sources),
+            FusionInternal::RrfK(k) => rrf_scoring(sources, k),
             FusionInternal::Dbsf => score_fusion(sources, ScoreFusion::dbsf()),
         };
 

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
+use segment::common::reciprocal_rank_fusion::DEFAULT_RRF_K;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery, VectorInternal};
 use segment::types::{PointIdType, WithPayloadInterface, WithVector};
 use tempfile::Builder;
@@ -58,7 +59,7 @@ async fn test_shard_query_rrf_rescoring() {
     // RRF query without prefetches
     let query = ShardQueryRequest {
         prefetches: vec![],
-        query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+        query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
         filter: None,
         score_threshold: None,
         limit: 0,
@@ -93,7 +94,7 @@ async fn test_shard_query_rrf_rescoring() {
     let outer_limit = 2;
     let query = ShardQueryRequest {
         prefetches: vec![nearest_query_prefetch.clone()],
-        query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+        query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
         filter: None,
         score_threshold: None,
         limit: outer_limit,
@@ -140,7 +141,7 @@ async fn test_shard_query_rrf_rescoring() {
             nearest_query_prefetch.clone(),
             nearest_query_prefetch.clone(),
         ],
-        query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+        query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
         filter: None,
         score_threshold: None,
         limit: outer_limit,
@@ -184,7 +185,7 @@ async fn test_shard_query_rrf_rescoring() {
                 ..nearest_query_prefetch.clone()
             },
         ],
-        query: Some(ScoringQuery::Fusion(FusionInternal::Rrf)),
+        query: Some(ScoringQuery::Fusion(FusionInternal::RrfK(DEFAULT_RRF_K))),
         filter: None,
         score_threshold: None,
         limit: outer_limit,

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -98,7 +98,11 @@ fn collect_query(query: &Query, batch: &mut BatchAccum) {
                 }
             }
         }
-        Query::OrderBy(_) | Query::Fusion(_) | Query::Formula(_) | Query::Sample(_) => {}
+        Query::OrderBy(_)
+        | Query::Fusion(_)
+        | Query::Rrf(_)
+        | Query::Formula(_)
+        | Query::Sample(_) => {}
     }
 }
 

--- a/src/common/inference/batch_processing_grpc.rs
+++ b/src/common/inference/batch_processing_grpc.rs
@@ -160,7 +160,7 @@ pub(crate) fn collect_query(query: &Query, batch: &mut BatchAccumGrpc) -> Result
         query::Variant::Context(context) => collect_context_input(context, batch)?,
         query::Variant::OrderBy(_) => {}
         query::Variant::Fusion(_) => {}
-        query::Variant::FusionParams(_) => {}
+        query::Variant::Rrf(_) => {}
         query::Variant::Sample(_) => {}
         query::Variant::Formula(_) => {}
         query::Variant::NearestWithMmr(nearest_with_mmr) => {

--- a/src/common/inference/batch_processing_grpc.rs
+++ b/src/common/inference/batch_processing_grpc.rs
@@ -160,7 +160,7 @@ pub(crate) fn collect_query(query: &Query, batch: &mut BatchAccumGrpc) -> Result
         query::Variant::Context(context) => collect_context_input(context, batch)?,
         query::Variant::OrderBy(_) => {}
         query::Variant::Fusion(_) => {}
-        query::Variant::RrfCustom(_) => {}
+        query::Variant::FusionParams(_) => {}
         query::Variant::Sample(_) => {}
         query::Variant::Formula(_) => {}
         query::Variant::NearestWithMmr(nearest_with_mmr) => {

--- a/src/common/inference/batch_processing_grpc.rs
+++ b/src/common/inference/batch_processing_grpc.rs
@@ -160,6 +160,7 @@ pub(crate) fn collect_query(query: &Query, batch: &mut BatchAccumGrpc) -> Result
         query::Variant::Context(context) => collect_context_input(context, batch)?,
         query::Variant::OrderBy(_) => {}
         query::Variant::Fusion(_) => {}
+        query::Variant::RrfCustom(_) => {}
         query::Variant::Sample(_) => {}
         query::Variant::Formula(_) => {}
         query::Variant::NearestWithMmr(nearest_with_mmr) => {

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -290,9 +290,7 @@ fn convert_query_with_inferred(
         }
         Variant::OrderBy(order_by) => Query::OrderBy(OrderBy::try_from(order_by)?),
         Variant::Fusion(fusion) => Query::Fusion(FusionInternal::try_from(fusion)?),
-        Variant::FusionParams(fusion_params) => {
-            Query::Fusion(FusionInternal::try_from(fusion_params)?)
-        }
+        Variant::Rrf(rrf) => Query::Fusion(FusionInternal::try_from(rrf)?),
         Variant::Formula(formula) => Query::Formula(FormulaInternal::try_from(formula)?),
         Variant::Sample(sample) => Query::Sample(SampleInternal::try_from(sample)?),
         Variant::NearestWithMmr(grpc::NearestInputWithMmr { nearest, mmr }) => {

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -290,6 +290,9 @@ fn convert_query_with_inferred(
         }
         Variant::OrderBy(order_by) => Query::OrderBy(OrderBy::try_from(order_by)?),
         Variant::Fusion(fusion) => Query::Fusion(FusionInternal::try_from(fusion)?),
+        Variant::RrfCustom(grpc::ReciprocalRankFusion { k }) => {
+            Query::Fusion(FusionInternal::RrfK(k as usize))
+        }
         Variant::Formula(formula) => Query::Formula(FormulaInternal::try_from(formula)?),
         Variant::Sample(sample) => Query::Sample(SampleInternal::try_from(sample)?),
         Variant::NearestWithMmr(grpc::NearestInputWithMmr { nearest, mmr }) => {

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -290,8 +290,8 @@ fn convert_query_with_inferred(
         }
         Variant::OrderBy(order_by) => Query::OrderBy(OrderBy::try_from(order_by)?),
         Variant::Fusion(fusion) => Query::Fusion(FusionInternal::try_from(fusion)?),
-        Variant::RrfCustom(grpc::ReciprocalRankFusion { k }) => {
-            Query::Fusion(FusionInternal::RrfK(k as usize))
+        Variant::FusionParams(fusion_params) => {
+            Query::Fusion(FusionInternal::try_from(fusion_params)?)
         }
         Variant::Formula(formula) => Query::Formula(FormulaInternal::try_from(formula)?),
         Variant::Sample(sample) => Query::Sample(SampleInternal::try_from(sample)?),

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -266,6 +266,7 @@ fn convert_query_with_inferred(
         }
         rest::Query::OrderBy(order_by) => Ok(Query::OrderBy(OrderBy::from(order_by.order_by))),
         rest::Query::Fusion(fusion) => Ok(Query::Fusion(FusionInternal::from(fusion.fusion))),
+        rest::Query::Rrf(rrf) => Ok(Query::Fusion(FusionInternal::from(rrf.rrf))),
         rest::Query::Formula(formula) => Ok(Query::Formula(FormulaInternal::from(formula))),
         rest::Query::Sample(sample) => Ok(Query::Sample(SampleInternal::from(sample.sample))),
     }


### PR DESCRIPTION
Allows the `k` parameter of reciprocal rank fusion formula to be provided by user, instead of just hardcoded to 2.

http example request would look like: (edited)
```http
{
    "prefetch": [ ... ],
    "query": { "rrf": { "k": 60 } }
}
```

or same as before:
```http
{
    "prefetch": [ ... ],
    "query": { "fusion":  "rrf" }
}
```