### PR TITLE
Introduce shard key fallback that can be used to route read/write requests

### DIFF
--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -174,7 +174,7 @@ impl Collection {
             .shards_holder
             .read()
             .await
-            .get_shard_ids_by_key(&shard_key)
+            .get_shard_ids_by_key(&shard_key) // also touched. double check if change is required.
         {
             Ok(shard_ids) => self.invalidate_clean_local_shards(shard_ids).await,
             Err(err) => {

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -174,7 +174,7 @@ impl Collection {
             .shards_holder
             .read()
             .await
-            .get_shard_ids_by_key(&shard_key) // also touched. double check if change is required.
+            .get_shard_ids_by_key(&shard_key)
         {
             Ok(shard_ids) => self.invalidate_clean_local_shards(shard_ids).await,
             Err(err) => {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -543,18 +543,16 @@ impl ShardHolder {
         shard_key: &'a ShardKey,
     ) -> CollectionResult<(Option<&'a ShardKey>, HashSet<ShardId>)> {
         match self.get_shard_ids_by_key(shard_key) {
-            Ok(ids) => {
-                return Ok((Some(shard_key), ids));
-            }
+            Ok(ids) => Ok((Some(shard_key), ids)),
             Err(err) => {
                 if let Some(fallback_shard_key) = &self.fallback_shard_key {
                     if let Ok(fallback_ids) = self.get_shard_ids_by_key(fallback_shard_key) {
-                        return Ok((Some(fallback_shard_key), fallback_ids));
+                        Ok((Some(fallback_shard_key), fallback_ids))
                     } else {
-                        return Err(err); // Return the original error if fallback also fails
+                        Err(err) // Return the original error if fallback also fails
                     }
                 } else {
-                    return Err(err); // Return the original error if no fallback key is set
+                    Err(err) // Return the original error if no fallback key is set
                 }
             }
         }


### PR DESCRIPTION
If `shard_key` specified by an upsert doesn't exist, points will be upserted into a `fallback` shard key (if that exists). Otherwise, we throw error. Same will happen with read requests (scroll, query, count, etc)

So if you create a fallback custom shard like this:
```http
PUT /collections/benchmark/shards
{
  "shard_key": "fallback"
}

GET /collections/benchmark/cluster
# Response:
{
  "result": {
    "peer_id": 5190255624632758,
    "shard_count": 1,
    "local_shards": [
      {
        "shard_id": 1,
        "shard_key": "fallback",
        "points_count": 0,
        "state": "Active"
      }
    ],
    "remote_shards": [],
    "shard_transfers": []
  },
  "status": "ok",
  "time": 0.000217938
}
```

Example upsert
```http
PUT /collections/benchmark/points
{
    "points": [
        {
            "id": 1,
            "vector": [0.1, 0.2, 0.3]
        }
    ],
    "shard_key": "org1"
}
```

Now if you do a scroll (read) request

```http
POST /collections/benchmark/points/scroll
{
  "shard_key": "org1"
}

# Response:
{
  "result": {
    "points": [
      {
        "id": 1,
        "shard_key": "fallback"
      }
    ],
    "next_page_offset": null
  },
  "status": "ok",
  "time": 0.001306022
}
``` 

Same happens with query (and other read requests)

```http
POST /collections/benchmark/points/query
{
  "query": [0.1, 0.2, 0.3],
  "shard_key": "org1"
}

## Response:

{
  "result": {
    "points": [
      {
        "id": 1,
        "version": 0,
        "score": 0.9999998,
        "shard_key": "fallback"
      }
    ]
  },
  "status": "ok",
  "time": 0.002821458
}
```