### PR TITLE
[WIP] Continous snapshot bug

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -20,6 +20,7 @@ impl CollectionUpdater {
         op_num: SeqNumberType,
         operation_result: &CollectionResult<usize>,
     ) {
+        log::debug!("handle_update_result ok:{}", operation_result.is_ok());
         match operation_result {
             Ok(_) => {
                 if !segments.read().failed_operation.is_empty() {
@@ -54,7 +55,7 @@ impl CollectionUpdater {
 
             let _scroll_lock = scroll_lock.blocking_write();
             let _update_guard = update_tracker.update();
-
+            log::debug!("collection update op_num:{op_num}");
             match operation {
                 CollectionUpdateOperations::PointOperation(point_operation) => {
                     process_point_operation(segments, op_num, point_operation, hw_counter)

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -380,6 +380,7 @@ impl SegmentsSearcher {
         runtime_handle: &Handle,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
+        log::debug!("SegmentSearch retrieve");
         let stopping_guard = StoppingGuard::new();
         runtime_handle
             .spawn_blocking({
@@ -411,6 +412,7 @@ impl SegmentsSearcher {
         is_stopped: &AtomicBool,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
+        log::debug!("retrieve blocking");
         let mut point_version: AHashMap<PointIdType, SeqNumberType> = Default::default();
         let mut point_records: AHashMap<PointIdType, RecordInternal> = Default::default();
 

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -235,6 +235,7 @@ impl ShardOperation for LocalShard {
         timeout: Option<Duration>,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
+        log::debug!("shard retrieve");
         // Check read rate limiter before proceeding
         self.check_read_rate_limiter(&hw_measurement_acc, "retrieve", || request.ids.len())?;
         let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
@@ -251,6 +252,10 @@ impl ShardOperation for LocalShard {
         )
         .await
         .map_err(|_: Elapsed| CollectionError::timeout(timeout.as_secs() as usize, "retrieve"))??;
+
+        if records_map.is_empty() {
+            log::error!("empty retrieve result!");
+        }
 
         let ordered_records = request
             .ids

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -128,6 +128,7 @@ impl ShardReplicaSet {
         local_only: bool,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
+        log::debug!("collection retrieve");
         let with_payload = Arc::new(with_payload.clone());
         let with_vector = Arc::new(with_vector.clone());
 

--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -104,7 +104,7 @@ async fn test_continuous_snapshot() {
     let stop_flag = Arc::new(AtomicBool::new(false));
 
     // Continuously insert the same point
-    let points_count = 1;
+    let points_count = 3;
     let points_task = {
         let collection = Arc::clone(&collection);
         let stop_flag = Arc::clone(&stop_flag);

--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -125,8 +125,8 @@ async fn test_continuous_snapshot() {
                     )
                     .await?;
 
+                // Insert one point at a time
                 for i in 0..points_count {
-                    // Insert one point at a time
                     let point = PointStructPersisted {
                         id: i.into(),
                         vector: VectorStructPersisted::Single(vec![i as f32, 0.0, 0.0, 0.0]),

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -284,6 +284,7 @@ impl Segment {
                 .internal_version(point_offset)
                 .is_some_and(|current_version| current_version > op_num)
         {
+            log::debug!("ignoring point_offset:{op_point_offset:?} op_num:{op_num}");
             return Ok(false);
         }
 

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -343,7 +343,7 @@ impl ProxySegment {
             let deleted_points = self.deleted_points.upgradable_read();
             if !deleted_points.is_empty() {
                 log::debug!(
-                    "{:?} UPGRADE upgradable read wrapped to propagate",
+                    "{:?} UPGRADE upgradable read wrapped to propagate {deleted_points:?}",
                     wrapped_segment.data_path()
                 );
                 wrapped_segment.with_upgraded(|wrapped_segment| {
@@ -355,6 +355,10 @@ impl ProxySegment {
                         // different proxy segments can share state through a common write segment.
                         // See: <https://github.com/qdrant/qdrant/pull/7208>
                         if wrapped_segment.has_point(*point_id) {
+                            log::debug!(
+                                "{:?} propagate delete point_id:{point_id} versions:{versions:?}",
+                                wrapped_segment.data_path()
+                            );
                             wrapped_segment.delete_point(
                                 versions.operation_version,
                                 *point_id,

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -574,7 +574,7 @@ impl SegmentHolder {
             for point_id in points {
                 let version = write_segment.point_version(point_id).unwrap_or_default();
                 log::debug!(
-                    "applying delete for point_id:{point_id} on segment:{:?}",
+                    "{:?} applying delete for point_id:{point_id} on segment_id:{segment_id}",
                     write_segment.data_path()
                 );
                 write_segment.delete_point(
@@ -595,7 +595,7 @@ impl SegmentHolder {
             let segment_data = segment_data(write_segment.deref());
             for point_id in points {
                 log::debug!(
-                    "applying update point_id:{point_id} on segment:{:?}",
+                    "{:?} applying update point_id:{point_id} on segment_id:{segment_id}",
                     write_segment.data_path()
                 );
                 let is_applied =


### PR DESCRIPTION
```
❯ RUST_LOG=info cargo nextest run --all continuous --nocapture
[2025-09-09T15:19:07Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-09-15-19-07.snapshot into "/tmp/test_snapshotsH4iD4u/test-0-2025-09-09-15-19-07.snapshot"
[2025-09-09T15:19:07Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-09T15:19:07Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-09T15:19:07Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-09T15:19:07Z WARN  collection::collection_manager::collection_updater] Update operation declined: No point with id 0 found
[2025-09-09T15:19:07Z WARN  collection::shards::replica_set::update] Failed to update shard test:0 on peer 0, error: No point with id 0 found

thread 'continuous_snapshot_test::test_continuous_snapshot' panicked at lib/collection/tests/integration/continuous_snapshot_test.rs:201:31:
points_task error: No point with id 0 found
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[2025-09-09T15:19:07Z ERROR collection::update_handler] Optimization error: Service internal error: IO Error: No such file or directory (os error 2)

thread 'tokio-runtime-worker' panicked at lib/collection/src/update_handler.rs:447:41:
Optimization error: Service internal error: IO Error: No such file or directory (os error 2)
[2025-09-09T15:19:07Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 29 was cancelled
[2025-09-09T15:19:07Z INFO  wal] segment creator shutting down
test continuous_snapshot_test::test_continuous_snapshot ... FAILED

failures:

failures:
    continuous_snapshot_test::test_continuous_snapshot

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 40 filtered out; finished in 1.27s
```        