### PR TITLE
Remove `async` from `SegmentHolder::deduplicate_points`

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1320,7 +1320,7 @@ impl SegmentHolder {
     /// Checks all segments and removes duplicated and outdated points.
     /// If two points have the same id, the point with the highest version is kept.
     /// If two points have the same id and version, one of them is kept.
-    pub fn deduplicate_points_task(&self) -> Vec<impl Fn() -> OperationResult<usize> + 'static> {
+    pub fn deduplicate_points_tasks(&self) -> Vec<impl Fn() -> OperationResult<usize> + 'static> {
         let points_to_remove = self.find_duplicated_points();
 
         points_to_remove
@@ -1953,7 +1953,7 @@ mod tests {
     fn deduplicate_points_sync(holder: &SegmentHolder) -> OperationResult<usize> {
         let mut removed_points = 0;
 
-        for task in holder.deduplicate_points_task() {
+        for task in holder.deduplicate_points_tasks() {
             removed_points += task()?;
         }
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1182,7 +1182,7 @@ fn deduplicate_points_async(
     holder: &SegmentHolder,
 ) -> impl Future<Output = CollectionResult<usize>> + 'static {
     let mut tasks: FuturesUnordered<_> = holder
-        .deduplicate_points_task()
+        .deduplicate_points_tasks()
         .into_iter()
         .map(tokio::task::spawn_blocking)
         .collect();

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -23,6 +23,8 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::rate_limiting::RateLimiter;
 use common::{panic, tar_ext};
+use futures::StreamExt as _;
+use futures::stream::FuturesUnordered;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use parking_lot::{Mutex as ParkingMutex, RwLock};
@@ -388,7 +390,7 @@ impl LocalShard {
             segment_holder.add_new(segment);
         }
 
-        let res = segment_holder.deduplicate_points().await?;
+        let res = deduplicate_points_async(&segment_holder).await?;
         if res > 0 {
             log::debug!("Deduplicated {res} points");
         }
@@ -1173,6 +1175,38 @@ impl Drop for LocalShard {
                 });
             handle.expect("Failed to create thread for shard drop");
         })
+    }
+}
+
+fn deduplicate_points_async(
+    holder: &SegmentHolder,
+) -> impl Future<Output = CollectionResult<usize>> + 'static {
+    let mut tasks: FuturesUnordered<_> = holder
+        .deduplicate_points_task()
+        .into_iter()
+        .map(tokio::task::spawn_blocking)
+        .collect();
+
+    async move {
+        let mut total_removed_points = 0;
+
+        while let Some(res) = tasks.next().await {
+            let removed_points = res
+                .map_err(|join_err| {
+                    CollectionError::service_error(format!(
+                        "failed to deduplicate points: {join_err}"
+                    ))
+                })?
+                .map_err(|dedup_err| {
+                    CollectionError::service_error(format!(
+                        "failed to deduplicate points: {dedup_err}"
+                    ))
+                })?;
+
+            total_removed_points += removed_points;
+        }
+
+        Ok(total_removed_points)
     }
 }
 


### PR DESCRIPTION
Small refactoring for Qdrant on Edge. We need to move `SegmentHolder` into `shard` crate, but we don't want `async` in `shard`, and `deduplicate_points` is the only `async` method of `SegmentHolder`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
