### PR TITLE
Retrieve files list from quantization storage

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -33,6 +33,10 @@ pub trait EncodedStorage {
     fn vectors_count(&self) -> usize;
 
     fn flusher(&self) -> MmapFlusher;
+
+    fn files(&self) -> Vec<PathBuf>;
+
+    fn immutable_files(&self) -> Vec<PathBuf>;
 }
 
 pub trait EncodedStorageBuilder {
@@ -47,6 +51,7 @@ pub trait EncodedStorageBuilder {
 pub struct TestEncodedStorage {
     data: Vec<u8>,
     quantized_vector_size: NonZeroUsize,
+    path: Option<PathBuf>,
 }
 
 #[cfg(feature = "testing")]
@@ -113,6 +118,7 @@ impl EncodedStorage for TestEncodedStorage {
         Ok(Self {
             data: buffer,
             quantized_vector_size,
+            path: Some(path.to_path_buf()),
         })
     }
 
@@ -126,6 +132,18 @@ impl EncodedStorage for TestEncodedStorage {
 
     fn flusher(&self) -> MmapFlusher {
         Box::new(|| Ok(()))
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        if let Some(ref path) = self.path {
+            vec![path.clone()]
+        } else {
+            vec![]
+        }
+    }
+
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        self.files()
     }
 }
 
@@ -170,6 +188,7 @@ impl EncodedStorageBuilder for TestEncodedStorageBuilder {
         Ok(TestEncodedStorage {
             data: self.data,
             quantized_vector_size: self.quantized_vector_size,
+            path: self.path,
         })
     }
 

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::TBool;
@@ -72,6 +72,10 @@ pub trait EncodedVectors: Sized {
     fn vectors_count(&self) -> usize;
 
     fn flusher(&self) -> MmapFlusher;
+
+    fn files(&self) -> Vec<PathBuf>;
+
+    fn immutable_files(&self) -> Vec<PathBuf>;
 
     type SupportsBytes: TBool;
     fn score_bytes(

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -1,5 +1,5 @@
 use std::num::NonZeroUsize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -12,6 +12,7 @@ use memory::mmap_type::MmapFlusher;
 pub struct QuantizedMmapStorage {
     mmap: Mmap,
     quantized_vector_size: NonZeroUsize,
+    path: PathBuf,
 }
 
 impl QuantizedMmapStorage {
@@ -24,6 +25,7 @@ pub struct QuantizedMmapStorageBuilder {
     mmap: MmapMut,
     cursor_pos: usize,
     quantized_vector_size: NonZeroUsize,
+    path: PathBuf,
 }
 
 impl quantization::EncodedStorage for QuantizedMmapStorage {
@@ -72,6 +74,7 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
         Ok(Self {
             mmap,
             quantized_vector_size,
+            path: path.to_path_buf(),
         })
     }
 
@@ -87,6 +90,14 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
         // Mmap storage does not need a flusher, as it is non-appendable and already backed by a file.
         Box::new(|| Ok(()))
     }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![self.path.clone()]
+    }
+
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        vec![self.path.clone()]
+    }
 }
 
 impl quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder {
@@ -98,6 +109,7 @@ impl quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder {
         Ok(QuantizedMmapStorage {
             mmap,
             quantized_vector_size: self.quantized_vector_size,
+            path: self.path,
         })
     }
 
@@ -149,6 +161,7 @@ impl QuantizedMmapStorageBuilder {
                     "`quantized_vector_size` must be non-zero",
                 )
             })?,
+            path: path.to_path_buf(),
         })
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -15,6 +15,7 @@ use crate::vector_storage::chunked_vectors::ChunkedVectors;
 #[derive(Debug)]
 pub struct QuantizedRamStorage {
     vectors: ChunkedVectors<u8>,
+    path: PathBuf,
 }
 
 impl quantization::EncodedStorage for QuantizedRamStorage {
@@ -49,7 +50,10 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
             })?;
         }
         reader.into_inner().drop_cache()?;
-        Ok(QuantizedRamStorage { vectors })
+        Ok(QuantizedRamStorage {
+            vectors,
+            path: path.to_path_buf(),
+        })
     }
 
     fn is_on_disk(&self) -> bool {
@@ -62,6 +66,14 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
 
     fn flusher(&self) -> MmapFlusher {
         Box::new(|| Ok(()))
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![self.path.clone()]
+    }
+
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        vec![self.path.clone()]
     }
 }
 
@@ -99,6 +111,7 @@ impl quantization::EncodedStorageBuilder for QuantizedRamStorageBuilder {
 
         Ok(QuantizedRamStorage {
             vectors: self.vectors,
+            path: self.path,
         })
     }
 


### PR DESCRIPTION
This PR refactors `QuantizedVectors::files` function. In `dev`, `QuantizedVectors::files` returns hardcoded filenames and does not use actual info from quantization storage. It was a part of an old design where quantization had a save/load function and `QuantizedVectors` owned files list.

Now it's incorrect, and `QuantizedVectors` files ownership does not allow the use `ChunkedVectorsMmap` as quantization storage because `ChunkedVectorsMmap` generates files by itself.

This PR provides `files` function down to quantization storage implementation and quantization storages know its file if it was saved to disk.