### PR TITLE
Fix new shard crate always pulling in RocksDB dependencies

### DIFF
--- a/lib/shard/Cargo.toml
+++ b/lib/shard/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 [dependencies]
 api = { path = "../api" }
 common = { path = "../common/common" }
-segment = { path = "../segment" }
+segment = { path = "../segment", default-features = false }
 sparse = { path = "../sparse" }
 
 ahash = { workspace = true }


### PR DESCRIPTION
Without this change, the new `shard` crate will always pull in `rocksdb` dependencies, even if disabled at compile time.

Validate using:

```bash
cargo tree --no-default-features | grep rocksdb

# Before:
│   │   ├── rocksdb v0.23.0
│   │   │   └── librocksdb-sys v0.17.1+9.9.3

# After:
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?