### PR TITLE
Refactor `SegmentHolder` to use `SegmentConfig` (instead of `CollectionParams`)

### DIFF
--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -11,9 +11,9 @@ use segment::common::anonymize::Anonymize;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::types::{
-    Distance, HnswConfig, Indexes, PayloadStorageType, QuantizationConfig, SparseVectorDataConfig,
-    StrictModeConfig, VectorDataConfig, VectorName, VectorNameBuf, VectorStorageDatatype,
-    VectorStorageType,
+    Distance, HnswConfig, Indexes, PayloadStorageType, QuantizationConfig, SegmentConfig,
+    SparseVectorDataConfig, StrictModeConfig, VectorDataConfig, VectorName, VectorNameBuf,
+    VectorStorageDatatype, VectorStorageType,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -522,5 +522,29 @@ impl CollectionParams {
         } else {
             Ok(Default::default())
         }
+    }
+
+    pub fn to_segment_config(&self) -> CollectionResult<SegmentConfig> {
+        let vector_data = self.to_base_vector_data().map_err(|err| {
+            CollectionError::service_error(format!(
+                "Failed to source dense vector configuration from collection parameters: {err:?}"
+            ))
+        })?;
+
+        let sparse_vector_data = self.to_sparse_vector_data().map_err(|err| {
+            CollectionError::service_error(format!(
+                "Failed to source sparse vector configuration from collection parameters: {err:?}"
+            ))
+        })?;
+
+        let payload_storage_type = self.payload_storage_type();
+
+        let segment_config = SegmentConfig {
+            vector_data,
+            sparse_vector_data,
+            payload_storage_type,
+        };
+
+        Ok(segment_config)
     }
 }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -11,7 +11,7 @@ use common::panic;
 use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
 use parking_lot::Mutex;
-use segment::common::operation_error::OperationResult;
+use segment::common::operation_error::{OperationError, OperationResult};
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::types::SeqNumberType;
 use tokio::runtime::Handle;
@@ -477,9 +477,14 @@ impl UpdateHandler {
 
         if no_segment_with_capacity {
             log::debug!("Creating new appendable segment, all existing segments are over capacity");
+
+            let segment_config = collection_params
+                .to_segment_config()
+                .map_err(|err| OperationError::service_error(err.to_string()))?;
+
             segments.write().create_appendable_segment(
                 segments_path,
-                collection_params,
+                segment_config,
                 payload_index_schema,
             )?;
         }


### PR DESCRIPTION
Based on #7094. Also required for Qdrant on Edge. Removes `CollectionParams` from `SegmentHolder`, so that it could be cleanly moved into `shard` crate.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
