### PR TITLE
bump test_get_storage_size value to accommodate MacOS change

### DIFF
--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -487,7 +487,7 @@ mod tests {
         // loose assertion because value not stable across different OS
         let storage_size = storage.get_storage_size_bytes().unwrap();
         assert!(
-            storage_size > 2000 && storage_size < 2400,
+            storage_size > 2000 && storage_size < 2500,
             "storage_size = {storage_size}"
         );
     }


### PR DESCRIPTION
Fixing https://github.com/qdrant/qdrant/issues/7102#issuecomment-3204890297

This is currently blocking our CI pipeline.

My investigation shows that the value did not change for Ubuntu test runs.

I propose to bump the value to unblock CI and check if anything changed on the MacOS runner from Github Actions.