### PR TITLE
Move `PayloadIndexSchema` into `shard` crate

### DIFF
--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use segment::json_path::JsonPath;
-use segment::types::{Filter, PayloadFieldSchema, PayloadKeyType};
-use serde::{Deserialize, Serialize};
+use segment::types::{Filter, PayloadFieldSchema};
+pub use shard::payload_index_schema::PayloadIndexSchema;
 
 use crate::collection::Collection;
 use crate::operations::types::{CollectionResult, UpdateResult};
@@ -14,11 +13,6 @@ use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOpera
 use crate::problems::unindexed_field;
 
 pub const PAYLOAD_INDEX_CONFIG_FILE: &str = "payload_index.json";
-
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
-pub struct PayloadIndexSchema {
-    pub schema: HashMap<PayloadKeyType, PayloadFieldSchema>,
-}
 
 impl Collection {
     pub(crate) fn payload_index_file(collection_path: &Path) -> PathBuf {
@@ -108,18 +102,14 @@ impl Collection {
         &self,
         filter: &Filter,
     ) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
-        self.payload_index_schema
-            .read()
-            .one_unindexed_filter_key(filter)
+        one_unindexed_filter_key(&self.payload_index_schema.read(), filter)
     }
 
     pub fn one_unindexed_expression_key(
         &self,
         expr: &ExpressionInternal,
     ) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
-        self.payload_index_schema
-            .read()
-            .one_unindexed_expression_key(expr)
+        one_unindexed_expression_key(&self.payload_index_schema.read(), expr)
     }
 }
 
@@ -128,47 +118,45 @@ enum PotentiallyUnindexed<'a> {
     Expression(&'a ExpressionInternal),
 }
 
-impl PayloadIndexSchema {
-    /// Returns an arbitrary payload key with acceptable schemas
-    /// used by `filter` which can be indexed but currently is not.
-    /// If this function returns `None` all indexable keys in `filter` are indexed.
-    fn one_unindexed_key(
-        &self,
-        suspect: PotentiallyUnindexed<'_>,
-    ) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
-        let mut extractor = unindexed_field::Extractor::new(&self.schema);
+/// Returns an arbitrary payload key with acceptable schemas
+/// used by `filter` which can be indexed but currently is not.
+/// If this function returns `None` all indexable keys in `filter` are indexed.
+fn one_unindexed_key(
+    schema: &PayloadIndexSchema,
+    suspect: PotentiallyUnindexed<'_>,
+) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
+    let mut extractor = unindexed_field::Extractor::new(&schema.schema);
 
-        match suspect {
-            PotentiallyUnindexed::Filter(filter) => {
-                extractor.update_from_filter_once(None, filter);
-            }
-            PotentiallyUnindexed::Expression(expression) => {
-                extractor.update_from_expression(expression);
-            }
+    match suspect {
+        PotentiallyUnindexed::Filter(filter) => {
+            extractor.update_from_filter_once(None, filter);
         }
-
-        // Get the first unindexed field from the extractor.
-        extractor
-            .unindexed_schema()
-            .iter()
-            .next()
-            .map(|(key, schema)| (key.clone(), schema.clone()))
+        PotentiallyUnindexed::Expression(expression) => {
+            extractor.update_from_expression(expression);
+        }
     }
 
-    /// Returns an arbitrary payload key with acceptable schemas
-    /// used by `filter` which can be indexed but currently is not.
-    /// If this function returns `None` all indexable keys in `filter` are indexed.
-    pub fn one_unindexed_filter_key(
-        &self,
-        filter: &Filter,
-    ) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
-        self.one_unindexed_key(PotentiallyUnindexed::Filter(filter))
-    }
+    // Get the first unindexed field from the extractor.
+    extractor
+        .unindexed_schema()
+        .iter()
+        .next()
+        .map(|(key, schema)| (key.clone(), schema.clone()))
+}
 
-    pub fn one_unindexed_expression_key(
-        &self,
-        expr: &ExpressionInternal,
-    ) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
-        self.one_unindexed_key(PotentiallyUnindexed::Expression(expr))
-    }
+/// Returns an arbitrary payload key with acceptable schemas
+/// used by `filter` which can be indexed but currently is not.
+/// If this function returns `None` all indexable keys in `filter` are indexed.
+pub fn one_unindexed_filter_key(
+    schema: &PayloadIndexSchema,
+    filter: &Filter,
+) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
+    one_unindexed_key(schema, PotentiallyUnindexed::Filter(filter))
+}
+
+pub fn one_unindexed_expression_key(
+    schema: &PayloadIndexSchema,
+    expr: &ExpressionInternal,
+) -> Option<(JsonPath, Vec<PayloadFieldSchema>)> {
+    one_unindexed_key(schema, PotentiallyUnindexed::Expression(expr))
 }

--- a/lib/collection/src/tests/payload.rs
+++ b/lib/collection/src/tests/payload.rs
@@ -13,7 +13,7 @@ use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
-use crate::collection::payload_index_schema::PayloadIndexSchema;
+use crate::collection::payload_index_schema::{self, PayloadIndexSchema};
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
@@ -66,11 +66,11 @@ async fn test_payload_missing_index_check() {
 
     // No index yet => Filter has unindexed field
     assert_eq!(
-        shard
-            .payload_index_schema
-            .read()
-            .one_unindexed_filter_key(&geo_filter)
-            .map(|(x, _)| x),
+        payload_index_schema::one_unindexed_filter_key(
+            &shard.payload_index_schema.read(),
+            &geo_filter
+        )
+        .map(|(x, _)| x),
         Some(JsonPath::from_str("location").unwrap())
     );
 
@@ -85,10 +85,10 @@ async fn test_payload_missing_index_check() {
 
     // Index created => Filter shouldn't have any unindexed field anymore
     assert_eq!(
-        shard
-            .payload_index_schema
-            .read()
-            .one_unindexed_filter_key(&geo_filter),
+        payload_index_schema::one_unindexed_filter_key(
+            &shard.payload_index_schema.read(),
+            &geo_filter
+        ),
         None
     );
 
@@ -108,11 +108,11 @@ async fn test_payload_missing_index_check() {
     // Index only exists for 'location' but not 'location.lat'
     // so we expect it to be detected as unindexed
     assert_eq!(
-        shard
-            .payload_index_schema
-            .read()
-            .one_unindexed_filter_key(&num_filter)
-            .map(|(x, _)| x),
+        payload_index_schema::one_unindexed_filter_key(
+            &shard.payload_index_schema.read(),
+            &num_filter
+        )
+        .map(|(x, _)| x),
         Some("location.lat".parse().unwrap())
     );
 
@@ -127,20 +127,20 @@ async fn test_payload_missing_index_check() {
 
     // Nested field also gets detected as indexed and unindexed fields in the query are empty.
     assert_eq!(
-        shard
-            .payload_index_schema
-            .read()
-            .one_unindexed_filter_key(&num_filter),
+        payload_index_schema::one_unindexed_filter_key(
+            &shard.payload_index_schema.read(),
+            &num_filter
+        ),
         None,
     );
 
     // Filters combined also completely indexed!
     let combined_filter = geo_filter.merge(&num_filter);
     assert_eq!(
-        shard
-            .payload_index_schema
-            .read()
-            .one_unindexed_filter_key(&combined_filter),
+        payload_index_schema::one_unindexed_filter_key(
+            &shard.payload_index_schema.read(),
+            &combined_filter
+        ),
         None,
     );
 }

--- a/lib/shard/src/lib.rs
+++ b/lib/shard/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod locked_segment;
 pub mod operations;
+pub mod payload_index_schema;
 pub mod proxy_segment;
 
 #[cfg(test)]

--- a/lib/shard/src/payload_index_schema.rs
+++ b/lib/shard/src/payload_index_schema.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+
+use segment::types::{PayloadFieldSchema, PayloadKeyType};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct PayloadIndexSchema {
+    pub schema: HashMap<PayloadKeyType, PayloadFieldSchema>,
+}


### PR DESCRIPTION
Another one for Qdrant on Edge.

This one is super simple:
1) move `PayloadIndexSchema` struct into `shard`
2) and refactor a few `PayloadIndexSchema` methods into standalone functions, so that we can leave them in `collection` crate

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
