### PR TITLE
In proxy segment, don't return deleted point versions

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -32,6 +32,8 @@ pub trait SegmentEntry: SnapshotEntry {
     fn version(&self) -> SeqNumberType;
 
     /// Get version of specified point
+    ///
+    /// Returns `None` if point does not exist or is soft-deleted.
     fn point_version(&self, point_id: PointIdType) -> Option<SeqNumberType>;
 
     #[allow(clippy::too_many_arguments)]

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -37,15 +37,20 @@ impl SegmentEntry for ProxySegment {
             .read()
             .point_version(point_id)
             .or_else(|| {
-                // Ignore point from wrapped segment if already marked for deletion
-                // By `point_version` semantics we don't expect to get a version if the point
-                // is deleted. This also prevents `move_if_exists` from moving an old point
-                // into the write segment again.
-                if self.deleted_points.read().contains_key(&point_id) {
-                    return None;
-                }
-
-                self.wrapped_segment.get().read().point_version(point_id)
+                self.wrapped_segment
+                    .get()
+                    .read()
+                    .point_version(point_id)
+                    // Ignore point from wrapped segment if already marked for deletion
+                    // By `point_version` semantics we don't expect to get a version if the point
+                    // is deleted. This also prevents `move_if_exists` from moving an old point
+                    // into the write segment again.
+                    .filter(|version| {
+                        self.deleted_points
+                            .read()
+                            .get(&point_id)
+                            .is_none_or(|delete| version > &delete.local_version)
+                    })
             })
     }
 


### PR DESCRIPTION
More specifically, don't return a point version from the wrapped segment if that point is already marked for deletion within the proxy.

In some places we rely on `point_version` to tell us if (and what) point (version) exists in a segment. When a proxy segment marks a wrapped point for deletion, we should not expose its point version anymore.

The old behavior broke the following places (and potentially others):
- https://github.com/qdrant/qdrant/blob/5ffe70d3217790cf09a1f2406803de4bdbfa6931/lib/collection/src/collection_manager/holders/segment_holder.rs#L395
- https://github.com/qdrant/qdrant/blob/5ffe70d3217790cf09a1f2406803de4bdbfa6931/lib/collection/src/collection_manager/holders/segment_holder.rs#L564

I'm currently still evaluating if stuff around this code is also sound.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?