### PR TITLE
Remove quantization load from trait

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -4,7 +4,9 @@ use std::fs::File;
 use std::io::{Read, Write};
 #[cfg(feature = "testing")]
 use std::num::NonZeroUsize;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "testing")]
+use std::path::Path;
+use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::TBool;
@@ -30,12 +30,6 @@ pub struct VectorParameters {
 
 pub trait EncodedVectors: Sized {
     type EncodedQuery;
-
-    fn load(
-        data_path: &Path,
-        meta_path: &Path,
-        vector_parameters: &VectorParameters,
-    ) -> std::io::Result<Self>;
 
     fn is_on_disk(&self) -> bool;
 

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -137,6 +137,17 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         }
     }
 
+    pub fn load(encoded_vectors: TStorage, meta_path: &Path) -> std::io::Result<Self> {
+        let contents = std::fs::read_to_string(meta_path)?;
+        let metadata: Metadata = serde_json::from_str(&contents)?;
+        let result = Self {
+            encoded_vectors,
+            metadata,
+            metadata_path: Some(meta_path.to_path_buf()),
+        };
+        Ok(result)
+    }
+
     pub fn get_quantized_vector_size(
         vector_parameters: &VectorParameters,
         chunk_size: usize,
@@ -474,23 +485,6 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
 
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
     type EncodedQuery = EncodedQueryPQ;
-
-    fn load(
-        data_path: &Path,
-        meta_path: &Path,
-        _vector_parameters: &VectorParameters,
-    ) -> std::io::Result<Self> {
-        let contents = std::fs::read_to_string(meta_path)?;
-        let metadata: Metadata = serde_json::from_str(&contents)?;
-        let quantized_vector_size = metadata.vector_division.len();
-        let encoded_vectors = TStorage::from_file(data_path, quantized_vector_size)?;
-        let result = Self {
-            encoded_vectors,
-            metadata,
-            metadata_path: Some(meta_path.to_path_buf()),
-        };
-        Ok(result)
-    }
 
     fn is_on_disk(&self) -> bool {
         self.encoded_vectors.is_on_disk()

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -199,6 +199,17 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         })
     }
 
+    pub fn load(encoded_vectors: TStorage, meta_path: &Path) -> std::io::Result<Self> {
+        let contents = std::fs::read_to_string(meta_path)?;
+        let metadata: Metadata = serde_json::from_str(&contents)?;
+        let result = Self {
+            encoded_vectors,
+            metadata,
+            metadata_path: Some(meta_path.to_path_buf()),
+        };
+        Ok(result)
+    }
+
     pub fn score_point_simple(&self, query: &EncodedQueryU8, i: u32) -> f32 {
         let (vector_offset, v_ptr) = self.get_vec_ptr(i);
 
@@ -352,23 +363,6 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
 
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
     type EncodedQuery = EncodedQueryU8;
-
-    fn load(
-        data_path: &Path,
-        meta_path: &Path,
-        vector_parameters: &VectorParameters,
-    ) -> std::io::Result<Self> {
-        let contents = std::fs::read_to_string(meta_path)?;
-        let metadata: Metadata = serde_json::from_str(&contents)?;
-        let quantized_vector_size = Self::get_quantized_vector_size(vector_parameters);
-        let encoded_vectors = TStorage::from_file(data_path, quantized_vector_size)?;
-        let result = Self {
-            encoded_vectors,
-            metadata,
-            metadata_path: Some(meta_path.to_path_buf()),
-        };
-        Ok(result)
-    }
 
     fn is_on_disk(&self) -> bool {
         self.encoded_vectors.is_on_disk()

--- a/lib/quantization/tests/integration/empty_storage.rs
+++ b/lib/quantization/tests/integration/empty_storage.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use quantization::EncodedVectorsPQ;
     use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
-    use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
+    use quantization::encoded_vectors::{DistanceType, VectorParameters};
     use quantization::encoded_vectors_binary::{EncodedVectorsBin, QueryEncoding};
     use quantization::encoded_vectors_u8::EncodedVectorsU8;
     use tempfile::Builder;
@@ -39,9 +39,8 @@ mod tests {
         .unwrap();
 
         EncodedVectorsU8::<TestEncodedStorage>::load(
-            data_path.as_path(),
+            TestEncodedStorage::from_file(data_path.as_path(), quantized_vector_size).unwrap(),
             meta_path.as_path(),
-            &vector_parameters,
         )
         .unwrap();
     }
@@ -80,9 +79,8 @@ mod tests {
         .unwrap();
 
         EncodedVectorsPQ::<TestEncodedStorage>::load(
-            data_path.as_path(),
+            TestEncodedStorage::from_file(data_path.as_path(), quantized_vector_size).unwrap(),
             meta_path.as_path(),
-            &vector_parameters,
         )
         .unwrap();
     }
@@ -119,9 +117,8 @@ mod tests {
         .unwrap();
 
         EncodedVectorsBin::<u8, TestEncodedStorage>::load(
-            data_path.as_path(),
+            TestEncodedStorage::from_file(data_path.as_path(), quantized_vector_size).unwrap(),
             meta_path.as_path(),
-            &vector_parameters,
         )
         .unwrap();
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -28,26 +28,8 @@ pub struct QuantizedMmapStorageBuilder {
     path: PathBuf,
 }
 
-impl quantization::EncodedStorage for QuantizedMmapStorage {
-    fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
-        let start = self.quantized_vector_size.get() * index as usize;
-        let end = self.quantized_vector_size.get() * (index + 1) as usize;
-        self.mmap.get(start..end).unwrap_or(&[])
-    }
-
-    fn upsert_vector(
-        &mut self,
-        _id: PointOffsetType,
-        _vector: &[u8],
-        _hw_counter: &HardwareCounterCell,
-    ) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "Cannot upsert vector in mmap storage",
-        ))
-    }
-
-    fn from_file(
+impl QuantizedMmapStorage {
+    pub fn from_file(
         path: &Path,
         quantized_vector_size: usize,
     ) -> std::io::Result<QuantizedMmapStorage> {
@@ -76,6 +58,26 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
             quantized_vector_size,
             path: path.to_path_buf(),
         })
+    }
+}
+
+impl quantization::EncodedStorage for QuantizedMmapStorage {
+    fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
+        let start = self.quantized_vector_size.get() * index as usize;
+        let end = self.quantized_vector_size.get() * (index + 1) as usize;
+        self.mmap.get(start..end).unwrap_or(&[])
+    }
+
+    fn upsert_vector(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: &[u8],
+        _hw_counter: &HardwareCounterCell,
+    ) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Cannot upsert vector in mmap storage",
+        ))
     }
 
     fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -6,7 +6,7 @@ use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
 use memmap2::MmapMut;
 use memory::mmap_type::{MmapFlusher, MmapSlice};
-use quantization::{EncodedVectors, VectorParameters};
+use quantization::EncodedVectors;
 use serde::{Deserialize, Serialize};
 
 use crate::common::operation_error::OperationResult;
@@ -25,8 +25,6 @@ pub trait MultivectorOffsets {
 
 #[allow(clippy::len_without_is_empty)]
 pub trait MultivectorOffsetsStorage: Sized {
-    fn load(path: &Path) -> OperationResult<Self>;
-
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset;
 
     fn len(&self) -> usize;
@@ -64,8 +62,8 @@ impl MultivectorOffsetsStorageRam {
     }
 }
 
-impl MultivectorOffsetsStorage for MultivectorOffsetsStorageRam {
-    fn load(path: &Path) -> OperationResult<Self> {
+impl MultivectorOffsetsStorageRam {
+    pub fn load(path: &Path) -> OperationResult<Self> {
         let offsets_file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -78,7 +76,9 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageRam {
             path: path.to_path_buf(),
         })
     }
+}
 
+impl MultivectorOffsetsStorage for MultivectorOffsetsStorageRam {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         self.offsets[idx as usize]
     }
@@ -132,8 +132,8 @@ impl MultivectorOffsetsStorageMmap {
     }
 }
 
-impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
-    fn load(path: &Path) -> OperationResult<Self> {
+impl MultivectorOffsetsStorageMmap {
+    pub fn load(path: &Path) -> OperationResult<Self> {
         let offsets_file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -145,7 +145,9 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
             path: path.to_path_buf(),
         })
     }
+}
 
+impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         self.offsets[idx as usize]
     }
@@ -213,23 +215,6 @@ where
             dim,
             multi_vector_config,
         }
-    }
-
-    pub fn load_multi(
-        data_path: &Path,
-        meta_path: &Path,
-        offsets_path: &Path,
-        vector_parameters: &VectorParameters,
-        multi_vector_config: &MultiVectorConfig,
-    ) -> OperationResult<Self> {
-        let offsets = TMultivectorOffsetsStorage::load(offsets_path)?;
-        let quantized_storage = QuantizedStorage::load(data_path, meta_path, vector_parameters)?;
-        Ok(Self {
-            dim: vector_parameters.dim,
-            quantized_storage,
-            offsets,
-            multi_vector_config: *multi_vector_config,
-        })
     }
 
     /// Custom `score_max_similarity` implementation for quantized vectors
@@ -308,17 +293,6 @@ where
 {
     // TODO(colbert): refactor `EncodedVectors` to support multi vector storage after quantization migration
     type EncodedQuery = Vec<QuantizedStorage::EncodedQuery>;
-
-    // TODO(colbert): refactor `EncodedVectors` to support multi vector storage after quantization migration
-    fn load(
-        _data_path: &Path,
-        _meta_path: &Path,
-        _vector_parameters: &quantization::VectorParameters,
-    ) -> std::io::Result<Self> {
-        unreachable!(
-            "multivector quantized storage should be loaded using `self.load_multi` method"
-        )
-    }
 
     fn is_on_disk(&self) -> bool {
         self.quantized_storage.is_on_disk()

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -18,25 +18,8 @@ pub struct QuantizedRamStorage {
     path: PathBuf,
 }
 
-impl quantization::EncodedStorage for QuantizedRamStorage {
-    fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
-        self.vectors.get(index as VectorOffsetType)
-    }
-
-    fn upsert_vector(
-        &mut self,
-        id: PointOffsetType,
-        vector: &[u8],
-        _hw_counter: &HardwareCounterCell,
-    ) -> std::io::Result<()> {
-        // Skip hardware counter increment because it's a RAM storage.
-        self.vectors
-            .insert(id as usize, vector)
-            .map_err(|err| std::io::Error::other(err.to_string()))?;
-        Ok(())
-    }
-
-    fn from_file(path: &Path, quantized_vector_size: usize) -> std::io::Result<Self> {
+impl QuantizedRamStorage {
+    pub fn from_file(path: &Path, quantized_vector_size: usize) -> std::io::Result<Self> {
         let mut vectors = ChunkedVectors::<u8>::new(quantized_vector_size);
         let file = OneshotFile::open(path)?;
         let mut reader = BufReader::new(file);
@@ -54,6 +37,25 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
             vectors,
             path: path.to_path_buf(),
         })
+    }
+}
+
+impl quantization::EncodedStorage for QuantizedRamStorage {
+    fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
+        self.vectors.get(index as VectorOffsetType)
+    }
+
+    fn upsert_vector(
+        &mut self,
+        id: PointOffsetType,
+        vector: &[u8],
+        _hw_counter: &HardwareCounterCell,
+    ) -> std::io::Result<()> {
+        // Skip hardware counter increment because it's a RAM storage.
+        self.vectors
+            .insert(id as usize, vector)
+            .map_err(|err| std::io::Error::other(err.to_string()))?;
+        Ok(())
     }
 
     fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -854,7 +854,7 @@ impl QuantizedVectors {
         let data_path = Self::get_data_path(path);
         let meta_path = Self::get_meta_path(path);
         if Self::is_ram(binary_config.always_ram, on_disk_vector_storage) {
-            let quantized_vector_size = 
+            let quantized_vector_size =
                 EncodedVectorsBin::<u128, QuantizedRamStorage>::get_quantized_vector_size_from_params(
                     config.vector_parameters.dim,
                     Self::convert_binary_encoding(binary_config.encoding),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -619,237 +619,50 @@ impl QuantizedVectors {
     }
 
     pub fn load(vector_storage: &VectorStorageEnum, path: &Path) -> OperationResult<Self> {
-        let on_disk_vector_storage = vector_storage.is_on_disk();
-        let distance = vector_storage.distance();
-        let datatype = vector_storage.datatype();
-
-        let data_path = Self::get_data_path(path);
-        let meta_path = Self::get_meta_path(path);
         let config_path = Self::get_config_path(path);
         let config: QuantizedVectorsConfig = read_json(&config_path)?;
         let quantized_store = if let Some(multivector_config) =
             vector_storage.try_multi_vector_config()
         {
-            let offsets_path = path.join(QUANTIZED_OFFSETS_PATH);
             match &config.quantization_config {
                 QuantizationConfig::Scalar(ScalarQuantization { scalar }) => {
-                    if Self::is_ram(scalar.always_ram, on_disk_vector_storage) {
-                        let quantized_vector_size =
-                            EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                            );
-                        let inner_vectors_storage = QuantizedRamStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        let inner_vectors_storage =
-                            EncodedVectorsU8::load(inner_vectors_storage, &meta_path)?;
-                        let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
-                        QuantizedVectorStorage::ScalarRamMulti(QuantizedMultivectorStorage::new(
-                            config.vector_parameters.dim,
-                            inner_vectors_storage,
-                            offsets,
-                            *multivector_config,
-                        ))
-                    } else {
-                        let quantized_vector_size =
-                            EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                            );
-                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        let inner_vectors_storage =
-                            EncodedVectorsU8::load(inner_vectors_storage, &meta_path)?;
-                        let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
-                        QuantizedVectorStorage::ScalarMmapMulti(QuantizedMultivectorStorage::new(
-                            config.vector_parameters.dim,
-                            inner_vectors_storage,
-                            offsets,
-                            *multivector_config,
-                        ))
-                    }
+                    Self::load_scalar_multi(
+                        vector_storage,
+                        path,
+                        &config,
+                        scalar,
+                        multivector_config,
+                    )?
                 }
-                QuantizationConfig::Product(ProductQuantization { product: pq }) => {
-                    if Self::is_ram(pq.always_ram, on_disk_vector_storage) {
-                        let bucket_size = Self::get_bucket_size(pq.compression);
-                        let quantized_vector_size =
-                            EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                                bucket_size,
-                            );
-                        let inner_vectors_storage = QuantizedRamStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        let inner_vectors_storage =
-                            EncodedVectorsPQ::load(inner_vectors_storage, &meta_path)?;
-                        let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
-                        QuantizedVectorStorage::PQRamMulti(QuantizedMultivectorStorage::new(
-                            config.vector_parameters.dim,
-                            inner_vectors_storage,
-                            offsets,
-                            *multivector_config,
-                        ))
-                    } else {
-                        let bucket_size = Self::get_bucket_size(pq.compression);
-                        let quantized_vector_size =
-                            EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                                bucket_size,
-                            );
-                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        let inner_vectors_storage =
-                            EncodedVectorsPQ::load(inner_vectors_storage, &meta_path)?;
-                        let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
-                        QuantizedVectorStorage::PQMmapMulti(QuantizedMultivectorStorage::new(
-                            config.vector_parameters.dim,
-                            inner_vectors_storage,
-                            offsets,
-                            *multivector_config,
-                        ))
-                    }
+                QuantizationConfig::Product(ProductQuantization { product }) => {
+                    Self::load_pq_multi(vector_storage, path, &config, product, multivector_config)?
                 }
                 QuantizationConfig::Binary(BinaryQuantization { binary }) => {
-                    if Self::is_ram(binary.always_ram, on_disk_vector_storage) {
-                        let quantized_vector_size = EncodedVectorsBin::<u8, QuantizedRamStorage>::get_quantized_vector_size_from_params(
-                            config.vector_parameters.dim,
-                            Self::convert_binary_encoding(binary.encoding),
-                        );
-                        let inner_vectors_storage = QuantizedRamStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        let inner_vectors_storage =
-                            EncodedVectorsBin::load(inner_vectors_storage, &meta_path)?;
-                        let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
-                        QuantizedVectorStorage::BinaryRamMulti(QuantizedMultivectorStorage::new(
-                            config.vector_parameters.dim,
-                            inner_vectors_storage,
-                            offsets,
-                            *multivector_config,
-                        ))
-                    } else {
-                        let quantized_vector_size = EncodedVectorsBin::<u8, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
-                            config.vector_parameters.dim,
-                            Self::convert_binary_encoding(binary.encoding),
-                        );
-                        let inner_vectors_storage = QuantizedMmapStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        let inner_vectors_storage =
-                            EncodedVectorsBin::load(inner_vectors_storage, &meta_path)?;
-                        let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
-                        QuantizedVectorStorage::BinaryMmapMulti(QuantizedMultivectorStorage::new(
-                            config.vector_parameters.dim,
-                            inner_vectors_storage,
-                            offsets,
-                            *multivector_config,
-                        ))
-                    }
+                    Self::load_binary_multi(
+                        vector_storage,
+                        path,
+                        &config,
+                        binary,
+                        multivector_config,
+                    )?
                 }
             }
         } else {
             match &config.quantization_config {
                 QuantizationConfig::Scalar(ScalarQuantization { scalar }) => {
-                    if Self::is_ram(scalar.always_ram, on_disk_vector_storage) {
-                        let quantized_vector_size =
-                            EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                            );
-                        let quantized_vector_size = QuantizedRamStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        QuantizedVectorStorage::ScalarRam(EncodedVectorsU8::load(
-                            quantized_vector_size,
-                            &meta_path,
-                        )?)
-                    } else {
-                        let quantized_vector_size =
-                            EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                            );
-                        let quantized_vector_size = QuantizedMmapStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        QuantizedVectorStorage::ScalarMmap(EncodedVectorsU8::load(
-                            quantized_vector_size,
-                            &meta_path,
-                        )?)
-                    }
+                    Self::load_scalar(vector_storage, path, &config, scalar)?
                 }
-                QuantizationConfig::Product(ProductQuantization { product: pq }) => {
-                    if Self::is_ram(pq.always_ram, on_disk_vector_storage) {
-                        let bucket_size = Self::get_bucket_size(pq.compression);
-                        let quantized_vector_size =
-                            EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                                bucket_size,
-                            );
-                        let quantized_vectors_storage = QuantizedRamStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        QuantizedVectorStorage::PQRam(EncodedVectorsPQ::load(
-                            quantized_vectors_storage,
-                            &meta_path,
-                        )?)
-                    } else {
-                        let bucket_size = Self::get_bucket_size(pq.compression);
-                        let quantized_vector_size =
-                            EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                                &config.vector_parameters,
-                                bucket_size,
-                            );
-                        let quantized_vectors_storage = QuantizedMmapStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        QuantizedVectorStorage::PQMmap(EncodedVectorsPQ::load(
-                            quantized_vectors_storage,
-                            &meta_path,
-                        )?)
-                    }
+                QuantizationConfig::Product(ProductQuantization { product }) => {
+                    Self::load_pq(vector_storage, path, &config, product)?
                 }
                 QuantizationConfig::Binary(BinaryQuantization { binary }) => {
-                    if Self::is_ram(binary.always_ram, on_disk_vector_storage) {
-                        let quantized_vector_size = EncodedVectorsBin::<u128, QuantizedRamStorage>::get_quantized_vector_size_from_params(
-                            config.vector_parameters.dim,
-                            Self::convert_binary_encoding(binary.encoding),
-                        );
-                        let quantized_vectors_storage = QuantizedRamStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        QuantizedVectorStorage::BinaryRam(EncodedVectorsBin::load(
-                            quantized_vectors_storage,
-                            &meta_path,
-                        )?)
-                    } else {
-                        let quantized_vector_size = EncodedVectorsBin::<u128, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
-                            config.vector_parameters.dim,
-                            Self::convert_binary_encoding(binary.encoding),
-                        );
-                        let quantized_vectors_storage = QuantizedMmapStorage::from_file(
-                            data_path.as_path(),
-                            quantized_vector_size,
-                        )?;
-                        QuantizedVectorStorage::BinaryMmap(EncodedVectorsBin::load(
-                            quantized_vectors_storage,
-                            &meta_path,
-                        )?)
-                    }
+                    Self::load_binary(vector_storage, path, &config, binary)?
                 }
             }
         };
 
+        let distance = vector_storage.distance();
+        let datatype = vector_storage.datatype();
         Ok(QuantizedVectors {
             storage_impl: quantized_store,
             config,
@@ -857,6 +670,264 @@ impl QuantizedVectors {
             distance,
             datatype,
         })
+    }
+
+    fn load_scalar(
+        vector_storage: &VectorStorageEnum,
+        path: &Path,
+        config: &QuantizedVectorsConfig,
+        scalar_config: &ScalarQuantizationConfig,
+    ) -> OperationResult<QuantizedVectorStorage> {
+        let on_disk_vector_storage = vector_storage.is_on_disk();
+        let data_path = Self::get_data_path(path);
+        let meta_path = Self::get_meta_path(path);
+        if Self::is_ram(scalar_config.always_ram, on_disk_vector_storage) {
+            let quantized_vector_size =
+                EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                );
+            let quantized_vector_size =
+                QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            Ok(QuantizedVectorStorage::ScalarRam(EncodedVectorsU8::load(
+                quantized_vector_size,
+                &meta_path,
+            )?))
+        } else {
+            let quantized_vector_size =
+                EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                );
+            let quantized_vector_size =
+                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            Ok(QuantizedVectorStorage::ScalarMmap(EncodedVectorsU8::load(
+                quantized_vector_size,
+                &meta_path,
+            )?))
+        }
+    }
+
+    fn load_scalar_multi(
+        vector_storage: &VectorStorageEnum,
+        path: &Path,
+        config: &QuantizedVectorsConfig,
+        scalar_config: &ScalarQuantizationConfig,
+        multivector_config: &MultiVectorConfig,
+    ) -> OperationResult<QuantizedVectorStorage> {
+        let on_disk_vector_storage = vector_storage.is_on_disk();
+        let data_path = Self::get_data_path(path);
+        let meta_path = Self::get_meta_path(path);
+        let offsets_path = Self::get_offsets_path(path);
+        if Self::is_ram(scalar_config.always_ram, on_disk_vector_storage) {
+            let quantized_vector_size =
+                EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                );
+            let inner_vectors_storage =
+                QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            let inner_vectors_storage = EncodedVectorsU8::load(inner_vectors_storage, &meta_path)?;
+            let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
+            Ok(QuantizedVectorStorage::ScalarRamMulti(
+                QuantizedMultivectorStorage::new(
+                    config.vector_parameters.dim,
+                    inner_vectors_storage,
+                    offsets,
+                    *multivector_config,
+                ),
+            ))
+        } else {
+            let quantized_vector_size =
+                EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                );
+            let inner_vectors_storage =
+                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            let inner_vectors_storage = EncodedVectorsU8::load(inner_vectors_storage, &meta_path)?;
+            let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
+            Ok(QuantizedVectorStorage::ScalarMmapMulti(
+                QuantizedMultivectorStorage::new(
+                    config.vector_parameters.dim,
+                    inner_vectors_storage,
+                    offsets,
+                    *multivector_config,
+                ),
+            ))
+        }
+    }
+
+    fn load_pq(
+        vector_storage: &VectorStorageEnum,
+        path: &Path,
+        config: &QuantizedVectorsConfig,
+        pq_config: &ProductQuantizationConfig,
+    ) -> OperationResult<QuantizedVectorStorage> {
+        let on_disk_vector_storage = vector_storage.is_on_disk();
+        let data_path = Self::get_data_path(path);
+        let meta_path = Self::get_meta_path(path);
+        if Self::is_ram(pq_config.always_ram, on_disk_vector_storage) {
+            let bucket_size = Self::get_bucket_size(pq_config.compression);
+            let quantized_vector_size =
+                EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bucket_size,
+                );
+            let quantized_vectors_storage =
+                QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            Ok(QuantizedVectorStorage::PQRam(EncodedVectorsPQ::load(
+                quantized_vectors_storage,
+                &meta_path,
+            )?))
+        } else {
+            let bucket_size = Self::get_bucket_size(pq_config.compression);
+            let quantized_vector_size =
+                EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bucket_size,
+                );
+            let quantized_vectors_storage =
+                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            Ok(QuantizedVectorStorage::PQMmap(EncodedVectorsPQ::load(
+                quantized_vectors_storage,
+                &meta_path,
+            )?))
+        }
+    }
+
+    fn load_pq_multi(
+        vector_storage: &VectorStorageEnum,
+        path: &Path,
+        config: &QuantizedVectorsConfig,
+        pq_config: &ProductQuantizationConfig,
+        multivector_config: &MultiVectorConfig,
+    ) -> OperationResult<QuantizedVectorStorage> {
+        let on_disk_vector_storage = vector_storage.is_on_disk();
+        let data_path = Self::get_data_path(path);
+        let meta_path = Self::get_meta_path(path);
+        let offsets_path = Self::get_offsets_path(path);
+        if Self::is_ram(pq_config.always_ram, on_disk_vector_storage) {
+            let bucket_size = Self::get_bucket_size(pq_config.compression);
+            let quantized_vector_size =
+                EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bucket_size,
+                );
+            let inner_vectors_storage =
+                QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            let inner_vectors_storage = EncodedVectorsPQ::load(inner_vectors_storage, &meta_path)?;
+            let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
+            Ok(QuantizedVectorStorage::PQRamMulti(
+                QuantizedMultivectorStorage::new(
+                    config.vector_parameters.dim,
+                    inner_vectors_storage,
+                    offsets,
+                    *multivector_config,
+                ),
+            ))
+        } else {
+            let bucket_size = Self::get_bucket_size(pq_config.compression);
+            let quantized_vector_size =
+                EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bucket_size,
+                );
+            let inner_vectors_storage =
+                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            let inner_vectors_storage = EncodedVectorsPQ::load(inner_vectors_storage, &meta_path)?;
+            let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
+            Ok(QuantizedVectorStorage::PQMmapMulti(
+                QuantizedMultivectorStorage::new(
+                    config.vector_parameters.dim,
+                    inner_vectors_storage,
+                    offsets,
+                    *multivector_config,
+                ),
+            ))
+        }
+    }
+
+    fn load_binary(
+        vector_storage: &VectorStorageEnum,
+        path: &Path,
+        config: &QuantizedVectorsConfig,
+        binary_config: &BinaryQuantizationConfig,
+    ) -> OperationResult<QuantizedVectorStorage> {
+        let on_disk_vector_storage = vector_storage.is_on_disk();
+        let data_path = Self::get_data_path(path);
+        let meta_path = Self::get_meta_path(path);
+        if Self::is_ram(binary_config.always_ram, on_disk_vector_storage) {
+            let quantized_vector_size = 
+                EncodedVectorsBin::<u128, QuantizedRamStorage>::get_quantized_vector_size_from_params(
+                    config.vector_parameters.dim,
+                    Self::convert_binary_encoding(binary_config.encoding),
+                );
+            let quantized_vectors_storage =
+                QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            Ok(QuantizedVectorStorage::BinaryRam(EncodedVectorsBin::load(
+                quantized_vectors_storage,
+                &meta_path,
+            )?))
+        } else {
+            let quantized_vector_size =
+                EncodedVectorsBin::<u128, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
+                    config.vector_parameters.dim,
+                    Self::convert_binary_encoding(binary_config.encoding),
+                );
+            let quantized_vectors_storage =
+                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            Ok(QuantizedVectorStorage::BinaryMmap(EncodedVectorsBin::load(
+                quantized_vectors_storage,
+                &meta_path,
+            )?))
+        }
+    }
+
+    fn load_binary_multi(
+        vector_storage: &VectorStorageEnum,
+        path: &Path,
+        config: &QuantizedVectorsConfig,
+        binary_config: &BinaryQuantizationConfig,
+        multivector_config: &MultiVectorConfig,
+    ) -> OperationResult<QuantizedVectorStorage> {
+        let on_disk_vector_storage = vector_storage.is_on_disk();
+        let data_path = Self::get_data_path(path);
+        let meta_path = Self::get_meta_path(path);
+        let offsets_path = Self::get_offsets_path(path);
+        if Self::is_ram(binary_config.always_ram, on_disk_vector_storage) {
+            let quantized_vector_size =
+                EncodedVectorsBin::<u8, QuantizedRamStorage>::get_quantized_vector_size_from_params(
+                    config.vector_parameters.dim,
+                    Self::convert_binary_encoding(binary_config.encoding),
+                );
+            let inner_vectors_storage =
+                QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            let inner_vectors_storage = EncodedVectorsBin::load(inner_vectors_storage, &meta_path)?;
+            let offsets = MultivectorOffsetsStorageRam::load(&offsets_path)?;
+            Ok(QuantizedVectorStorage::BinaryRamMulti(
+                QuantizedMultivectorStorage::new(
+                    config.vector_parameters.dim,
+                    inner_vectors_storage,
+                    offsets,
+                    *multivector_config,
+                ),
+            ))
+        } else {
+            let quantized_vector_size =
+                EncodedVectorsBin::<u8, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
+                    config.vector_parameters.dim,
+                    Self::convert_binary_encoding(binary_config.encoding),
+                );
+            let inner_vectors_storage =
+                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+            let inner_vectors_storage = EncodedVectorsBin::load(inner_vectors_storage, &meta_path)?;
+            let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
+            Ok(QuantizedVectorStorage::BinaryMmapMulti(
+                QuantizedMultivectorStorage::new(
+                    config.vector_parameters.dim,
+                    inner_vectors_storage,
+                    offsets,
+                    *multivector_config,
+                ),
+            ))
+        }
     }
 
     fn create_scalar<'a>(


### PR DESCRIPTION
This PR removes loading function from this traits:
```
EncodedVectors::load
EncodedStorage::from_file
MultivectorOffsetsStorage::load
```

It's a step before using `ChunkedMmapVectors`, where loading differs from other types of quantization storages.

No new unit tests are required here, each loading case is covered by storage combatibility CI
