### PR TITLE
Chunked mmap as a quantization storage

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -172,6 +172,14 @@ impl GpuVectorStorage {
                 None,
                 stopped,
             ),
+            QuantizedVectorStorage::ScalarChunkedMmap(quantized_storage) => Self::new_sq(
+                device.clone(),
+                distance,
+                quantized_storage.vectors_count(),
+                quantized_storage,
+                None,
+                stopped,
+            ),
             QuantizedVectorStorage::PQRam(quantized_storage) => Self::new_pq(
                 device.clone(),
                 distance,
@@ -181,6 +189,14 @@ impl GpuVectorStorage {
                 stopped,
             ),
             QuantizedVectorStorage::PQMmap(quantized_storage) => Self::new_pq(
+                device.clone(),
+                distance,
+                quantized_storage.vectors_count(),
+                quantized_storage,
+                None,
+                stopped,
+            ),
+            QuantizedVectorStorage::PQChunkedMmap(quantized_storage) => Self::new_pq(
                 device.clone(),
                 distance,
                 quantized_storage.vectors_count(),
@@ -204,6 +220,14 @@ impl GpuVectorStorage {
                 None,
                 stopped,
             ),
+            QuantizedVectorStorage::BinaryChunkedMmap(quantized_storage) => Self::new_bq(
+                device.clone(),
+                distance,
+                quantized_storage.vectors_count(),
+                quantized_storage,
+                None,
+                stopped,
+            ),
             QuantizedVectorStorage::ScalarRamMulti(quantized_storage) => Self::new_sq(
                 device.clone(),
                 distance,
@@ -213,6 +237,14 @@ impl GpuVectorStorage {
                 stopped,
             ),
             QuantizedVectorStorage::ScalarMmapMulti(quantized_storage) => Self::new_sq(
+                device.clone(),
+                distance,
+                quantized_storage.vectors_count(),
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+            QuantizedVectorStorage::ScalarChunkedMmapMulti(quantized_storage) => Self::new_sq(
                 device.clone(),
                 distance,
                 quantized_storage.vectors_count(),
@@ -236,6 +268,14 @@ impl GpuVectorStorage {
                 Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
                 stopped,
             ),
+            QuantizedVectorStorage::PQChunkedMmapMulti(quantized_storage) => Self::new_pq(
+                device.clone(),
+                distance,
+                quantized_storage.vectors_count(),
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
             QuantizedVectorStorage::BinaryRamMulti(quantized_storage) => Self::new_bq(
                 device.clone(),
                 distance,
@@ -245,6 +285,14 @@ impl GpuVectorStorage {
                 stopped,
             ),
             QuantizedVectorStorage::BinaryMmapMulti(quantized_storage) => Self::new_bq(
+                device.clone(),
+                distance,
+                quantized_storage.vectors_count(),
+                quantized_storage.inner_storage(),
+                Some(GpuMultivectors::new_quantized(device, quantized_storage)?),
+                stopped,
+            ),
+            QuantizedVectorStorage::BinaryChunkedMmapMulti(quantized_storage) => Self::new_bq(
                 device.clone(),
                 distance,
                 quantized_storage.vectors_count(),

--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -1,3 +1,4 @@
+mod quantized_chunked_mmap_storage;
 mod quantized_custom_query_scorer;
 mod quantized_mmap_storage;
 mod quantized_multi_custom_query_scorer;

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+
+use common::types::PointOffsetType;
+use memory::mmap_type::MmapFlusher;
+
+use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
+use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
+
+impl quantization::EncodedStorage for ChunkedMmapVectors<u8> {
+    fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
+        ChunkedVectorStorage::get(self, index as VectorOffsetType).unwrap_or_default()
+    }
+
+    fn upsert_vector(
+        &mut self,
+        id: PointOffsetType,
+        vector: &[u8],
+        hw_counter: &common::counter::hardware_counter::HardwareCounterCell,
+    ) -> std::io::Result<()> {
+        ChunkedVectorStorage::insert(self, id as VectorOffsetType, vector, hw_counter)
+            .map_err(std::io::Error::other)
+    }
+
+    fn is_on_disk(&self) -> bool {
+        true
+    }
+
+    fn vectors_count(&self) -> usize {
+        self.len()
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        let flusher = self.flusher();
+        Box::new(move || {
+            Ok(flusher().map_err(|e| {
+                std::io::Error::other(format!("Failed to flush quantization storage: {e}"))
+            })?)
+        })
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        ChunkedMmapVectors::files(self)
+    }
+
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        ChunkedMmapVectors::immutable_files(self)
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -97,10 +97,16 @@ impl<'a> QuantizedScorerBuilder<'a> {
             QuantizedVectorStorage::ScalarMmap(storage) => {
                 self.new_quantized_scorer::<TElement, TMetric>(storage)
             }
+            QuantizedVectorStorage::ScalarChunkedMmap(storage) => {
+                self.new_quantized_scorer::<TElement, TMetric>(storage)
+            }
             QuantizedVectorStorage::PQRam(storage) => {
                 self.new_quantized_scorer::<TElement, TMetric>(storage)
             }
             QuantizedVectorStorage::PQMmap(storage) => {
+                self.new_quantized_scorer::<TElement, TMetric>(storage)
+            }
+            QuantizedVectorStorage::PQChunkedMmap(storage) => {
                 self.new_quantized_scorer::<TElement, TMetric>(storage)
             }
             QuantizedVectorStorage::BinaryRam(storage) => {
@@ -109,10 +115,16 @@ impl<'a> QuantizedScorerBuilder<'a> {
             QuantizedVectorStorage::BinaryMmap(storage) => {
                 self.new_quantized_scorer::<TElement, TMetric>(storage)
             }
+            QuantizedVectorStorage::BinaryChunkedMmap(storage) => {
+                self.new_quantized_scorer::<TElement, TMetric>(storage)
+            }
             QuantizedVectorStorage::ScalarRamMulti(storage) => {
                 self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
             }
             QuantizedVectorStorage::ScalarMmapMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+            }
+            QuantizedVectorStorage::ScalarChunkedMmapMulti(storage) => {
                 self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
             }
             QuantizedVectorStorage::PQRamMulti(storage) => {
@@ -121,10 +133,16 @@ impl<'a> QuantizedScorerBuilder<'a> {
             QuantizedVectorStorage::PQMmapMulti(storage) => {
                 self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
             }
+            QuantizedVectorStorage::PQChunkedMmapMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+            }
             QuantizedVectorStorage::BinaryRamMulti(storage) => {
                 self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
             }
             QuantizedVectorStorage::BinaryMmapMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+            }
+            QuantizedVectorStorage::BinaryChunkedMmapMulti(storage) => {
                 self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
             }
         }


### PR DESCRIPTION
This PR adds implementation of quantization storage for `ChunkedMmap` with persist `upsert` and `flush` implementation.

Also this PR adds `ChunkedMmap` variant as a quantization storage.

This PR does not have unit test because `ChunkedMmap` does not have any usage and `QuantizedVectors` does not have a create/load mechanism. This PR is mostly about compilation correctness; unit tests are the next step