### PR TITLE
Sign container images with cosign

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,7 @@ jobs:
     # Run build on our self-hosted runner, we had trouble with shared runners
     runs-on: [self-hosted, linux, x64]
     permissions:
+      contents: read
       id-token: write # needed for cosign keyless signing with OIDC
     steps:
     - uses: actions/checkout@v5
@@ -79,6 +80,7 @@ jobs:
   build-gpu:
     runs-on: [self-hosted, linux, x64]
     permissions:
+      contents: read
       id-token: write # needed for cosign keyless signing with OIDC
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,9 +11,13 @@ jobs:
   build:
     # Run build on our self-hosted runner, we had trouble with shared runners
     runs-on: [self-hosted, linux, x64]
+    permissions:
+      id-token: write # needed for cosign keyless signing with OIDC
     steps:
     - uses: actions/checkout@v5
     - uses: Swatinem/rust-cache@v2
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v3.9.2
     - name: Get current tag
       id: vars
       run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
@@ -51,6 +55,9 @@ jobs:
         docker pull $DOCKERHUB_TAG
         docker tag $DOCKERHUB_TAG $GITHUB_TAG
         docker push $GITHUB_TAG
+        
+        DIGEST=$(docker buildx imagetools inspect ${DOCKERHUB_TAG} --format '{{ json .Manifest.Digest }}' | cut -d '"' -f 2)
+        cosign sign --yes "${DOCKERHUB_TAG}@${DIGEST}"
 
         # Build unprivileged image for Docker Hub
         DOCKERHUB_TAG_UNPRIVILEGED="qdrant/qdrant:${{ github.ref_name }}-unprivileged"
@@ -65,12 +72,19 @@ jobs:
         docker pull $DOCKERHUB_TAG_UNPRIVILEGED
         docker tag $DOCKERHUB_TAG_UNPRIVILEGED $GITHUB_TAG_UNPRIVILEGED
         docker push $GITHUB_TAG_UNPRIVILEGED
+        
+        DIGEST=$(docker buildx imagetools inspect ${DOCKERHUB_TAG_UNPRIVILEGED} --format '{{ json .Manifest.Digest }}' | cut -d '"' -f 2)
+        cosign sign --yes "${DOCKERHUB_TAG_UNPRIVILEGED}@${DIGEST}"
 
   build-gpu:
     runs-on: [self-hosted, linux, x64]
+    permissions:
+      id-token: write # needed for cosign keyless signing with OIDC
     steps:
     - uses: actions/checkout@v5
     - uses: Swatinem/rust-cache@v2
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v3.9.2
     - name: Get current tag
       id: vars
       run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
@@ -108,6 +122,9 @@ jobs:
         docker pull $DOCKERHUB_TAG
         docker tag $DOCKERHUB_TAG $GITHUB_TAG
         docker push $GITHUB_TAG
+        
+        DIGEST=$(docker buildx imagetools inspect ${DOCKERHUB_TAG} --format '{{ json .Manifest.Digest }}' | cut -d '"' -f 2)
+        cosign sign --yes "${DOCKERHUB_TAG}@${DIGEST}"
 
         # Build GPU AMD image for Docker Hub
         DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}-gpu-amd"
@@ -122,3 +139,6 @@ jobs:
         docker pull $DOCKERHUB_TAG
         docker tag $DOCKERHUB_TAG $GITHUB_TAG
         docker push $GITHUB_TAG
+        
+        DIGEST=$(docker buildx imagetools inspect ${DOCKERHUB_TAG} --format '{{ json .Manifest.Digest }}' | cut -d '"' -f 2)
+        cosign sign --yes "${DOCKERHUB_TAG}@${DIGEST}"


### PR DESCRIPTION
This allows users to securely verify that a Qdrant container image was created by us

Once merged and after the next release, a container image can be verified like this:

```
cosign verify qdrant/qdrant:v1.16.0 --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity-regexp='https://github.com/qdrant/.*'
```

All the details: https://docs.sigstore.dev/cosign/signing/signing_with_containers/

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

