### PR TITLE
measure disk size of directories if available

### DIFF
--- a/lib/common/common/src/disk.rs
+++ b/lib/common/common/src/disk.rs
@@ -3,8 +3,9 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 /// How many bytes a directory takes on disk.
-/// Notes:
-/// - on non-unix systems, this is the same as `dir_size`
+///
+/// Note: on non-unix systems, this function returns the apparent/logical
+/// directory size rather than actual disk usage.
 pub fn dir_disk_size(path: impl Into<PathBuf>) -> std::io::Result<u64> {
     fn dir_disk_size(mut dir: std::fs::ReadDir) -> std::io::Result<u64> {
         dir.try_fold(0, |acc, file| {


### PR DESCRIPTION
If we merge a large amount of empty segments, logical disk size might be much higher than real disk size due to sparse files we use there.
In some corner cases it might cause not-enough-disk-error, which is not actually true.

This PR tries to use block-based file size estimation, which is supposed to closer to real size.