### PR TITLE
Remove unused `GraphLinks::on_disk` method

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -228,10 +228,6 @@ impl GraphLinks {
         }
     }
 
-    pub fn on_disk(&self) -> bool {
-        matches!(self.borrow_owner(), GraphLinksEnum::Ram(_))
-    }
-
     pub fn num_points(&self) -> usize {
         self.view().reindex.len()
     }


### PR DESCRIPTION
Coderabbit found a typo/blunder in an unused method: https://github.com/qdrant/qdrant/pull/7118#discussion_r2292743772. Since this method is not used, it would be better to just remove it.