### PR TITLE
Misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,11 +2406,11 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
- "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
  "serde",
+ "zerocopy 0.8.26",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,9 +214,9 @@ futures-util = "0.3.31"
 generic-tests = "0.1.3"
 half = { version = "2.6.0", features = [
     "alloc",
-    "bytemuck",
     "serde",
     "num-traits",
+    "zerocopy",
 ] }
 http = "1.3.1"
 humantime = "2.2.0"

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use half::f16;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use zerocopy::{Immutable, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::named_vectors::CowMultiVector;
 use super::vectors::TypedMultiDenseVector;
@@ -14,7 +14,7 @@ pub trait PrimitiveVectorElement
 where
     Self: Copy + Clone + Default + Send + Sync + 'static,
     Self: Serialize + for<'a> Deserialize<'a>,
-    Self: Immutable + IntoBytes,
+    Self: FromBytes + Immutable + IntoBytes + KnownLayout,
 {
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]>;
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -192,9 +192,9 @@ pub trait GraphLayersWithVectors {
     /// # Panics
     ///
     /// Panics when using a format that does not support vectors.
-    fn for_each_link_with_vector<F>(&self, point_id: PointOffsetType, level: usize, f: F)
+    fn for_each_link_with_vector<'a, F>(&'a self, point_id: PointOffsetType, level: usize, f: F)
     where
-        F: FnMut(PointOffsetType, &[u8]);
+        F: FnMut(PointOffsetType, &'a [u8]);
 }
 
 impl GraphLayersBase for GraphLayers {
@@ -215,9 +215,9 @@ impl GraphLayersBase for GraphLayers {
 }
 
 impl GraphLayersWithVectors for GraphLayers {
-    fn for_each_link_with_vector<F>(&self, point_id: PointOffsetType, level: usize, mut f: F)
+    fn for_each_link_with_vector<'a, F>(&'a self, point_id: PointOffsetType, level: usize, mut f: F)
     where
-        F: FnMut(PointOffsetType, &[u8]),
+        F: FnMut(PointOffsetType, &'a [u8]),
     {
         self.links
             .links_with_vectors(point_id, level)


### PR DESCRIPTION
This PR is a collection of small fixes.

- `PrimitiveVectorElement: use zerocopy`
   ```rust
   trait PrimitiveVectorElement: … {
       …
       /// Cast elements to a byte slice. Typically a wrapper around [`zerocopy`]
       /// or [`bytemuck`] methods.
       ///
       /// TODO: once [`half::f16`] support the latest [`zerocopy`], we could
       /// remove this method in favor of using [`zerocopy::IntoBytes`] directly.
       fn as_bytes(vector: &[Self]) -> &[u8];
   }
   ```
   The current `half::f16` supports `zerocopy`, so we can drop our wrapper.

- `PrimitiveVectorElement: also use zerocopy::FromBytes`
  Since we use zerocopy now, we can get this bound for free (and it could be useful in hnsw-with-vectors implementation).

- `serialize_graph_links: back_index is Vec<PointOffsetType>`
  Previously `usize` was used in place where `PointOffsetType` makes more sense.

- `for_each_link_with_vector: loosen lifetimes`
  I've found that this function is not usable without this fix.
  Note: this function currently is not used anywhere (but it will be used in hnsw-with-vectors).