### PR TITLE
Bump dev version to v1.15.5-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "api"
-version = "1.15.4-dev"
+version = "1.15.5-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -4738,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.15.4-dev"
+version = "1.15.5-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.15.4-dev"
+version = "1.15.5-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.15.4-dev"
+version = "1.15.5-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.15.4-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.15.5-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to 1.15.5-dev for the https://github.com/qdrant/qdrant/pull/7150 release.

Follows the pattern of https://github.com/qdrant/qdrant/pull/7062