### PR TITLE
Load appendable quantization

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11746,6 +11746,11 @@
             "description": "Migrate RocksDB based payload indices into new format on start.\n\nRebuilds a new payload index from scratch.",
             "default": false,
             "type": "boolean"
+          },
+          "appendable_quantization": {
+            "description": "Use appendable quantization in appendable plain segments.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -55,6 +55,10 @@ pub struct FeatureFlags {
     /// Rebuilds a new payload index from scratch.
     // TODO(1.16.1): enable by default
     pub migrate_rocksdb_payload_indices: bool,
+
+    /// Use appendable quantization in appendable plain segments.
+    // TODO(1.16.0): enable by default
+    pub appendable_quantization: bool,
 }
 
 impl Default for FeatureFlags {
@@ -69,6 +73,7 @@ impl Default for FeatureFlags {
             migrate_rocksdb_vector_storage: false,
             migrate_rocksdb_payload_storage: false,
             migrate_rocksdb_payload_indices: false,
+            appendable_quantization: false,
         }
     }
 }
@@ -93,6 +98,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         migrate_rocksdb_vector_storage,
         migrate_rocksdb_payload_storage,
         migrate_rocksdb_payload_indices,
+        appendable_quantization,
     } = &mut flags;
 
     // If all is set, explicitly set all feature flags
@@ -105,6 +111,7 @@ pub fn init_feature_flags(mut flags: FeatureFlags) {
         *migrate_rocksdb_vector_storage = true;
         *migrate_rocksdb_payload_storage = true;
         *migrate_rocksdb_payload_indices = true;
+        *appendable_quantization = true;
     }
 
     let res = FEATURE_FLAGS.set(flags);

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -526,18 +526,18 @@ fn create_segment(
             );
         }
 
-        let quantized_vectors = sp(if config.quantization_config(vector_name).is_some() {
-            let quantized_data_path = vector_storage_path;
-            if QuantizedVectors::config_exists(&quantized_data_path) {
-                let quantized_vectors =
-                    QuantizedVectors::load(&vector_storage.borrow(), &quantized_data_path)?;
-                Some(quantized_vectors)
+        let quantized_vectors = sp(
+            if let Some(quantization_config) = config.quantization_config(vector_name) {
+                let quantized_data_path = vector_storage_path;
+                QuantizedVectors::load(
+                    quantization_config,
+                    &vector_storage.borrow(),
+                    &quantized_data_path,
+                )?
             } else {
                 None
-            }
-        } else {
-            None
-        });
+            },
+        );
 
         let vector_index: Arc<AtomicRefCell<VectorIndexEnum>> = sp(open_vector_index(
             vector_config,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -774,6 +774,10 @@ impl QuantizationConfig {
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         self != other
     }
+
+    pub fn is_appendable(&self) -> bool {
+        matches!(self, QuantizationConfig::Binary(_))
+    }
 }
 
 impl Validate for QuantizationConfig {

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -771,7 +771,9 @@ mod tests {
         let quantization_files = quantized_vectors.files();
 
         // test save-load
-        let quantized_vectors = QuantizedVectors::load(&storage, dir.path()).unwrap();
+        let quantized_vectors = QuantizedVectors::load(&config, &storage, dir.path())
+            .unwrap()
+            .unwrap();
         assert_eq!(files, storage.files());
         assert_eq!(quantization_files, quantized_vectors.files());
         let hardware_counter = HardwareCounterCell::new();

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -311,7 +311,9 @@ fn test_score_quantized_points(storage: &mut VectorStorageEnum) {
     let quantization_files = quantized_vectors.files();
 
     // test save-load
-    let quantized_vectors = QuantizedVectors::load(storage, dir.path()).unwrap();
+    let quantized_vectors = QuantizedVectors::load(&config, storage, dir.path())
+        .unwrap()
+        .unwrap();
     assert_eq!(files, storage.files());
     assert_eq!(quantization_files, quantized_vectors.files());
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -365,6 +365,52 @@ impl VectorStorageEnum {
         }
     }
 
+    pub(crate) fn try_vector_dim(&self) -> Option<usize> {
+        match self {
+            #[cfg(feature = "rocksdb")]
+            VectorStorageEnum::DenseSimple(v) => Some(v.vector_dim()),
+            #[cfg(feature = "rocksdb")]
+            VectorStorageEnum::DenseSimpleByte(v) => Some(v.vector_dim()),
+            #[cfg(feature = "rocksdb")]
+            VectorStorageEnum::DenseSimpleHalf(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseVolatile(v) => Some(v.vector_dim()),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => Some(v.vector_dim()),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseMemmap(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseMemmapByte(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseMemmapHalf(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseAppendableMemmap(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseAppendableInRam(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseAppendableInRamByte(v) => Some(v.vector_dim()),
+            VectorStorageEnum::DenseAppendableInRamHalf(v) => Some(v.vector_dim()),
+            #[cfg(feature = "rocksdb")]
+            VectorStorageEnum::SparseSimple(_) => None,
+            VectorStorageEnum::SparseVolatile(_) => None,
+            VectorStorageEnum::SparseMmap(_) => None,
+            #[cfg(feature = "rocksdb")]
+            VectorStorageEnum::MultiDenseSimple(v) => Some(v.vector_dim()),
+            #[cfg(feature = "rocksdb")]
+            VectorStorageEnum::MultiDenseSimpleByte(v) => Some(v.vector_dim()),
+            #[cfg(feature = "rocksdb")]
+            VectorStorageEnum::MultiDenseSimpleHalf(v) => Some(v.vector_dim()),
+            VectorStorageEnum::MultiDenseVolatile(v) => Some(v.vector_dim()),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => Some(v.vector_dim()),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => Some(v.vector_dim()),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => Some(v.vector_dim()),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => Some(v.vector_dim()),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => Some(v.vector_dim()),
+            VectorStorageEnum::MultiDenseAppendableInRam(v) => Some(v.vector_dim()),
+            VectorStorageEnum::MultiDenseAppendableInRamByte(v) => Some(v.vector_dim()),
+            VectorStorageEnum::MultiDenseAppendableInRamHalf(v) => Some(v.vector_dim()),
+        }
+    }
+
     pub(crate) fn default_vector(&self) -> VectorInternal {
         match self {
             #[cfg(feature = "rocksdb")]

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -293,9 +293,13 @@ fn test_multivector_quantization_hnsw(
             .unwrap();
         }
         // test persistence, load quantized vectors
-        let quantized_vectors =
-            QuantizedVectors::load(&vector_storage.vector_storage.borrow(), quantized_data_path)
-                .unwrap();
+        let quantized_vectors = QuantizedVectors::load(
+            &quantization_config,
+            &vector_storage.vector_storage.borrow(),
+            quantized_data_path,
+        )
+        .unwrap()
+        .unwrap();
         vector_storage.quantized_vectors = Arc::new(AtomicRefCell::new(Some(quantized_vectors)));
     });
 


### PR DESCRIPTION
This PR is a continue of [`https://github.com/qdrant/qdrant/pull/7116`](https://github.com/qdrant/qdrant/pull/7116) where we introduced a new appendable quantization storage type based on `ChunkedMmapVectors<u8>`.

This PR enables the load/create mechanism for this storage type.

Also, this PR changes the quantization config and adds a new field to separate appendable and non-appendable cases.

Please pay additional attention to `mlock`, `Advice`, and `Populate` parameters of `ChunkedMmapVectors::open`
