### PR TITLE
Triggering assertion with continous snapshot

### DIFF
--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -1,0 +1,191 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use collection::collection::Collection;
+use collection::config::{CollectionConfigInternal, CollectionParams};
+use collection::operations::CollectionUpdateOperations;
+use collection::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
+    WriteOrdering,
+};
+use collection::operations::shared_storage_config::SharedStorageConfig;
+use collection::operations::types::{CollectionResult, NodeType, UpdateStatus, VectorsConfig};
+use collection::operations::vector_params_builder::VectorParamsBuilder;
+use collection::shards::channel_service::ChannelService;
+use collection::shards::collection_shard_distribution::CollectionShardDistribution;
+use collection::shards::replica_set::ReplicaState;
+use common::budget::ResourceBudget;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::flags::{FeatureFlags, init_feature_flags};
+use segment::types::Distance;
+use tempfile::Builder;
+use tokio::time::sleep;
+
+use crate::common::{
+    REST_PORT, TEST_OPTIMIZERS_CONFIG, dummy_abort_shard_transfer, dummy_on_replica_failure,
+    dummy_request_shard_transfer,
+};
+
+// RUST_LOG=trace cargo nextest run --all continuous --nocapture
+#[tokio::test(flavor = "multi_thread")]
+async fn test_continuous_snapshot() {
+    // Initialize logger for tests
+    let _ = env_logger::builder().is_test(true).try_init();
+    // Feature flags
+    init_feature_flags(FeatureFlags::default());
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
+        ..CollectionParams::empty()
+    };
+
+    let config = CollectionConfigInternal {
+        params: collection_params,
+        optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
+        wal_config: Default::default(),
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+        strict_mode_config: Default::default(),
+        uuid: None,
+        metadata: None,
+    };
+
+    let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let collection_name = "test".to_string();
+
+    let storage_config: SharedStorageConfig = SharedStorageConfig {
+        node_type: NodeType::Normal,
+        ..Default::default()
+    };
+
+    let this_peer_id = 0;
+    let shard_distribution = CollectionShardDistribution::all_local(
+        Some(config.params.shard_number.into()),
+        this_peer_id,
+    );
+
+    let collection = Collection::new(
+        collection_name,
+        this_peer_id,
+        collection_dir.path(),
+        snapshots_path.path(),
+        &config,
+        Arc::new(storage_config),
+        shard_distribution,
+        None,
+        ChannelService::new(REST_PORT, None),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let local_shards = collection.get_local_shards().await;
+    for shard_id in local_shards {
+        collection
+            .set_shard_replica_state(shard_id, 0, ReplicaState::Active, None)
+            .await
+            .unwrap();
+    }
+
+    let collection = Arc::new(collection);
+    let stop_flag = Arc::new(AtomicBool::new(false));
+
+    // Continuously insert the same point
+    let points_count = 1;
+    let points_task = {
+        let collection = Arc::clone(&collection);
+        let stop_flag = Arc::clone(&stop_flag);
+        tokio::spawn(async move {
+            while !stop_flag.load(Ordering::Relaxed) {
+                // Delete all points
+                let delete_points =
+                    CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+                        ids: (0..points_count).map(|i| i.into()).collect(),
+                    });
+                let hw_counter = HwMeasurementAcc::disposable();
+                collection
+                    .update_from_client_simple(
+                        delete_points,
+                        true,
+                        WriteOrdering::default(),
+                        hw_counter,
+                    )
+                    .await?;
+
+                for i in 0..points_count {
+                    // Insert one point at a time
+                    let point = PointStructPersisted {
+                        id: i.into(),
+                        vector: VectorStructPersisted::Single(vec![i as f32, 0.0, 0.0, 0.0]),
+                        payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
+                    };
+                    let insert_points =
+                        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+                            PointInsertOperationsInternal::PointsList(vec![point]),
+                        ));
+                    let hw_counter = HwMeasurementAcc::disposable();
+                    let insert = collection
+                        .update_from_client_simple(
+                            insert_points,
+                            true,
+                            WriteOrdering::default(),
+                            hw_counter,
+                        )
+                        .await?;
+                    assert_eq!(insert.status, UpdateStatus::Completed);
+                }
+            }
+            CollectionResult::Ok(())
+        })
+    };
+
+    // Loop taking snapshots and deletions of snapshots
+    let snapshot_task = {
+        let collection = Arc::clone(&collection);
+        let stop_flag = Arc::clone(&stop_flag);
+        let snapshots_temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+        tokio::spawn(async move {
+            while !stop_flag.load(Ordering::Relaxed) {
+                // Take snapshot
+                let _snapshot = collection
+                    .create_snapshot(snapshots_temp_dir.path(), 0)
+                    .await?;
+            }
+            CollectionResult::Ok(())
+        })
+    };
+
+    let timeout = sleep(Duration::from_secs(20));
+    tokio::pin!(timeout);
+
+    tokio::select! {
+        res = points_task => {
+            stop_flag.store(true, Ordering::Relaxed);
+            match res {
+                Ok(Ok(())) => {},
+                Ok(Err(e)) => panic!("points_task error: {e}"),
+                Err(e) => panic!("points_task panicked: {e}"),
+            }
+        }
+        res = snapshot_task => {
+            stop_flag.store(true, Ordering::Relaxed);
+            match res {
+                Ok(Ok(())) => {},
+                Ok(Err(e)) => panic!("snapshot_task error: {e}"),
+                Err(e) => panic!("snapshot_task panicked: {e}"),
+            }
+        }
+        _ = &mut timeout => {
+            stop_flag.store(true, Ordering::Relaxed);
+            log::info!("Timeout reached, stopping test");
+        }
+    }
+}

--- a/lib/collection/tests/integration/main.rs
+++ b/lib/collection/tests/integration/main.rs
@@ -1,6 +1,7 @@
 mod collection_restore_test;
 mod collection_test;
 mod common;
+mod continuous_snapshot_test;
 mod distance_matrix_test;
 mod grouping_test;
 mod lookup_test;


### PR DESCRIPTION
The test used to fail before https://github.com/qdrant/qdrant/pull/7208

```
❯ RUST_LOG=info cargo nextest run --all conti --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.24s
────────────
 Nextest run ID bf351662-3499-4b57-81b3-77b35e71b89c with nextest profile: default
    Starting 2 tests across 22 binaries (1343 tests skipped)
       START             collection::integration continuous_snapshot_test::test_continuous_snapshot

running 1 test
[2025-08-25T14:27:23Z INFO  wal] Wal { path: "/tmp/test_collectionSTP6GR/0/wal", segment-count: 1, entries: [0, 0)  }: opened
[2025-08-25T14:27:23Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-08-25-14-27-23.snapshot into "/tmp/test_snapshotsfDHEPS/test-0-2025-08-25-14-27-23.snapshot"
[2025-08-25T14:27:23Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-08-25-14-27-23.snapshot into "/tmp/test_snapshotsfDHEPS/test-0-2025-08-25-14-27-23.snapshot"
[2025-08-25T14:27:23Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-08-25T14:27:23Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment

thread 'tokio-runtime-worker' panicked at lib/shard/src/proxy_segment/mod.rs:318:25:
proxied point deletes should have newer version than point in segment (ProxyDeletedPoint { local_version: 36, operation_version: 36 } >= 37)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'continuous_snapshot_test::test_continuous_snapshot' panicked at lib/collection/tests/integration/continuous_snapshot_test.rs:186:31:
snapshot_task error: Service internal error: failed to create snapshot: Service internal error: task 82 panicked with message "proxied point deletes should have newer version than point in segment (ProxyDeletedPoint { local_version: 36, operation_version: 36 } >= 37)"
[2025-08-25T14:27:24Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2025-08-25T14:27:24Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 30 was cancelled
[2025-08-25T14:27:24Z INFO  wal] segment creator shutting down
test continuous_snapshot_test::test_continuous_snapshot ... FAILED

failures:

failures:
    continuous_snapshot_test::test_continuous_snapshot

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 40 filtered out; finished in 0.18s

        FAIL [   0.204s] collection::integration continuous_snapshot_test::test_continuous_snapshot
        ```