### PR TITLE
Move `segments_updater` from `collection` into `shard` crate

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use parking_lot::RwLock;
 use segment::types::SeqNumberType;
+use shard::update::*;
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
-use crate::collection_manager::segments_updater::*;
 use crate::operations::CollectionUpdateOperations;
-use crate::operations::types::CollectionResult;
+use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::update_tracker::UpdateTracker;
 
 /// Implementation of the update operation
@@ -71,8 +71,8 @@ impl CollectionUpdater {
             }
         });
 
+        let operation_result = operation_result.map_err(CollectionError::from);
         CollectionUpdater::handle_update_result(segments, op_num, &operation_result);
-
         operation_result
     }
 }
@@ -94,6 +94,7 @@ mod tests {
     use segment::types::PayloadSchemaType::Keyword;
     use segment::types::{Payload, PayloadContainer, PayloadFieldSchema, WithPayload};
     use serde_json::json;
+    use shard::update::upsert_points;
     use tempfile::Builder;
 
     use super::*;
@@ -102,7 +103,6 @@ mod tests {
     };
     use crate::collection_manager::holders::segment_holder::LockedSegment::Original;
     use crate::collection_manager::segments_searcher::SegmentsSearcher;
-    use crate::collection_manager::segments_updater::upsert_points;
     use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
     use crate::operations::point_ops::{
         PointOperations, PointStructPersisted, VectorStructPersisted,

--- a/lib/collection/src/collection_manager/mod.rs
+++ b/lib/collection/src/collection_manager/mod.rs
@@ -5,7 +5,6 @@ pub mod segments_searcher;
 
 pub mod probabilistic_search_sampling;
 mod search_result_aggregator;
-mod segments_updater;
 
 #[cfg(test)]
 pub(crate) mod fixtures;

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -302,15 +302,13 @@ mod tests {
     use segment::payload_json;
     use segment::segment_constructor::simple_segment_constructor::{VECTOR1_NAME, VECTOR2_NAME};
     use segment::types::{Distance, PayloadSchemaType, VectorNameBuf};
+    use shard::update::{process_field_index_operation, process_point_operation};
     use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::{random_multi_vec_segment, random_segment};
     use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
     use crate::collection_manager::optimizers::config_mismatch_optimizer::ConfigMismatchOptimizer;
-    use crate::collection_manager::segments_updater::{
-        process_field_index_operation, process_point_operation,
-    };
     use crate::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
     };

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -13,17 +13,16 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::json_path::JsonPath;
 use segment::payload_json;
 use segment::types::{ExtendedPointId, PayloadContainer, PointIdType, WithPayload, WithVector};
+use shard::update::{delete_points, set_payload, upsert_points};
 use tempfile::Builder;
 
 use super::holders::proxy_segment;
-use super::segments_updater::delete_points;
 use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
 };
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
-use crate::collection_manager::segments_updater::{set_payload, upsert_points};
 use crate::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
 use crate::operations::types::RecordInternal;
 

--- a/lib/shard/src/lib.rs
+++ b/lib/shard/src/lib.rs
@@ -3,6 +3,7 @@ pub mod operations;
 pub mod payload_index_schema;
 pub mod proxy_segment;
 pub mod segment_holder;
+pub mod update;
 pub mod wal;
 
 #[cfg(test)]

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -24,612 +24,6 @@ use crate::operations::point_ops::{
 use crate::operations::vector_ops::{PointVectorsPersisted, UpdateVectorsOp, VectorOperations};
 use crate::segment_holder::SegmentHolder;
 
-fn check_unprocessed_points(
-    points: &[PointIdType],
-    processed: &AHashSet<PointIdType>,
-) -> OperationResult<usize> {
-    let first_missed_point = points.iter().copied().find(|p| !processed.contains(p));
-
-    match first_missed_point {
-        None => Ok(processed.len()),
-        Some(missed_point_id) => Err(OperationError::PointIdError { missed_point_id }),
-    }
-}
-
-/// Tries to delete points from all segments, returns number of actually deleted points
-pub fn delete_points(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    ids: &[PointIdType],
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let mut total_deleted_points = 0;
-
-    for batch in ids.chunks(VECTOR_OP_BATCH_SIZE) {
-        let deleted_points = segments.apply_points(
-            batch,
-            |_| (),
-            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
-        )?;
-
-        total_deleted_points += deleted_points;
-    }
-
-    Ok(total_deleted_points)
-}
-
-/// Update the specified named vectors of a point, keeping unspecified vectors intact.
-pub fn update_vectors(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: Vec<PointVectorsPersisted>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    // Build a map of vectors to update per point, merge updates on same point ID
-    let mut points_map: AHashMap<PointIdType, NamedVectors> = AHashMap::new();
-    for point in points {
-        let PointVectorsPersisted { id, vector } = point;
-        let named_vector = NamedVectors::from(vector);
-
-        let entry = points_map.entry(id).or_default();
-        entry.merge(named_vector);
-    }
-
-    let ids: Vec<PointIdType> = points_map.keys().copied().collect();
-
-    let mut total_updated_points = 0;
-    for batch in ids.chunks(VECTOR_OP_BATCH_SIZE) {
-        let updated_points = segments.apply_points_with_conditional_move(
-            op_num,
-            batch,
-            |id, write_segment| {
-                let vectors = points_map[&id].clone();
-                write_segment.update_vectors(op_num, id, vectors, hw_counter)
-            },
-            |id, owned_vectors, _| {
-                for (vector_name, vector_ref) in points_map[&id].iter() {
-                    owned_vectors.insert(vector_name.to_owned(), vector_ref.to_owned());
-                }
-            },
-            |_| false,
-            hw_counter,
-        )?;
-        check_unprocessed_points(batch, &updated_points)?;
-        total_updated_points += updated_points.len();
-    }
-
-    Ok(total_updated_points)
-}
-
-pub fn update_vectors_conditional(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: UpdateVectorsOp,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let UpdateVectorsOp {
-        mut points,
-        update_filter,
-    } = points;
-
-    let Some(filter_condition) = update_filter else {
-        return update_vectors(segments, op_num, points, hw_counter);
-    };
-
-    let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
-
-    let points_to_exclude =
-        select_excluded_by_filter_ids(segments, point_ids, filter_condition, hw_counter)?;
-
-    points.retain(|p| !points_to_exclude.contains(&p.id));
-    update_vectors(segments, op_num, points, hw_counter)
-}
-
-const VECTOR_OP_BATCH_SIZE: usize = 512;
-
-/// Delete the given named vectors for the given points, keeping other vectors intact.
-pub fn delete_vectors(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: &[PointIdType],
-    vector_names: &[VectorNameBuf],
-) -> OperationResult<usize> {
-    let mut total_deleted_points = 0;
-
-    for batch in points.chunks(VECTOR_OP_BATCH_SIZE) {
-        let deleted_points = segments.apply_points(
-            batch,
-            |_| (),
-            |id, _idx, write_segment, ()| {
-                let mut res = true;
-                for name in vector_names {
-                    res &= write_segment.delete_vector(op_num, id, name)?;
-                }
-                Ok(res)
-            },
-        )?;
-
-        total_deleted_points += deleted_points;
-    }
-
-    Ok(total_deleted_points)
-}
-
-/// Delete the given named vectors for points matching the given filter, keeping other vectors intact.
-pub fn delete_vectors_by_filter(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    filter: &Filter,
-    vector_names: &[VectorNameBuf],
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    delete_vectors(segments, op_num, &affected_points, vector_names)
-}
-
-/// Batch size when modifying payload.
-const PAYLOAD_OP_BATCH_SIZE: usize = 512;
-
-pub fn overwrite_payload(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    payload: &Payload,
-    points: &[PointIdType],
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let mut total_updated_points = 0;
-
-    for batch in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
-        let updated_points = segments.apply_points_with_conditional_move(
-            op_num,
-            batch,
-            |id, write_segment| write_segment.set_full_payload(op_num, id, payload, hw_counter),
-            |_, _, old_payload| {
-                *old_payload = payload.clone();
-            },
-            |segment| segment.get_indexed_fields().is_empty(),
-            hw_counter,
-        )?;
-
-        total_updated_points += updated_points.len();
-        check_unprocessed_points(batch, &updated_points)?;
-    }
-
-    Ok(total_updated_points)
-}
-
-pub fn overwrite_payload_by_filter(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    payload: &Payload,
-    filter: &Filter,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    overwrite_payload(segments, op_num, payload, &affected_points, hw_counter)
-}
-
-pub fn set_payload(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    payload: &Payload,
-    points: &[PointIdType],
-    key: &Option<JsonPath>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let mut total_updated_points = 0;
-
-    for chunk in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
-        let updated_points = segments.apply_points_with_conditional_move(
-            op_num,
-            chunk,
-            |id, write_segment| write_segment.set_payload(op_num, id, payload, key, hw_counter),
-            |_, _, old_payload| match key {
-                Some(key) => old_payload.merge_by_key(payload, key),
-                None => old_payload.merge(payload),
-            },
-            |segment| {
-                segment.get_indexed_fields().keys().all(|indexed_path| {
-                    !indexed_path.is_affected_by_value_set(&payload.0, key.as_ref())
-                })
-            },
-            hw_counter,
-        )?;
-
-        check_unprocessed_points(chunk, &updated_points)?;
-        total_updated_points += updated_points.len();
-    }
-
-    Ok(total_updated_points)
-}
-
-fn points_by_filter(
-    segments: &SegmentHolder,
-    filter: &Filter,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<Vec<PointIdType>> {
-    let mut affected_points: Vec<PointIdType> = Vec::new();
-    // we don’t want to cancel this filtered read
-    let is_stopped = AtomicBool::new(false);
-    segments.for_each_segment(|s| {
-        let points = s.read_filtered(None, None, Some(filter), &is_stopped, hw_counter);
-        affected_points.extend_from_slice(points.as_slice());
-        Ok(true)
-    })?;
-    Ok(affected_points)
-}
-
-pub fn set_payload_by_filter(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    payload: &Payload,
-    filter: &Filter,
-    key: &Option<JsonPath>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    set_payload(segments, op_num, payload, &affected_points, key, hw_counter)
-}
-
-pub fn delete_payload(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: &[PointIdType],
-    keys: &[PayloadKeyType],
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let mut total_deleted_points = 0;
-
-    for batch in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
-        let updated_points = segments.apply_points_with_conditional_move(
-            op_num,
-            batch,
-            |id, write_segment| {
-                let mut res = true;
-                for key in keys {
-                    res &= write_segment.delete_payload(op_num, id, key, hw_counter)?;
-                }
-                Ok(res)
-            },
-            |_, _, payload| {
-                for key in keys {
-                    payload.remove(key);
-                }
-            },
-            |segment| {
-                iproduct!(segment.get_indexed_fields().keys(), keys).all(
-                    |(indexed_path, path_to_delete)| {
-                        !indexed_path.is_affected_by_value_remove(path_to_delete)
-                    },
-                )
-            },
-            hw_counter,
-        )?;
-
-        check_unprocessed_points(batch, &updated_points)?;
-        total_deleted_points += updated_points.len();
-    }
-
-    Ok(total_deleted_points)
-}
-
-pub fn delete_payload_by_filter(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    filter: &Filter,
-    keys: &[PayloadKeyType],
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    delete_payload(segments, op_num, &affected_points, keys, hw_counter)
-}
-
-pub fn clear_payload(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: &[PointIdType],
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let mut total_updated_points = 0;
-
-    for batch in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
-        let updated_points = segments.apply_points_with_conditional_move(
-            op_num,
-            batch,
-            |id, write_segment| write_segment.clear_payload(op_num, id, hw_counter),
-            |_, _, payload| payload.0.clear(),
-            |segment| segment.get_indexed_fields().is_empty(),
-            hw_counter,
-        )?;
-        check_unprocessed_points(batch, &updated_points)?;
-        total_updated_points += updated_points.len();
-    }
-
-    Ok(total_updated_points)
-}
-
-/// Clear Payloads from all segments matching the given filter
-pub fn clear_payload_by_filter(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    filter: &Filter,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let points_to_clear = points_by_filter(segments, filter, hw_counter)?;
-    clear_payload(segments, op_num, &points_to_clear, hw_counter)
-}
-
-pub fn create_field_index(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    field_name: PayloadKeyTypeRef,
-    field_schema: Option<&PayloadFieldSchema>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    let Some(field_schema) = field_schema else {
-        return Err(OperationError::TypeInferenceError {
-            field_name: field_name.to_owned(),
-        });
-    };
-
-    segments.apply_segments(|write_segment| {
-        write_segment.with_upgraded(|segment| {
-            segment.delete_field_index_if_incompatible(op_num, field_name, field_schema)
-        })?;
-
-        let (schema, indexes) =
-            match write_segment.build_field_index(op_num, field_name, field_schema, hw_counter)? {
-                BuildFieldIndexResult::SkippedByVersion => {
-                    return Ok(false);
-                }
-                BuildFieldIndexResult::AlreadyExists => {
-                    return Ok(false);
-                }
-                BuildFieldIndexResult::IncompatibleSchema => {
-                    // This is a service error, as we should have just removed the old index
-                    // So it should not be possible to get this error
-                    return Err(OperationError::service_error(format!(
-                        "Incompatible schema for field index on field {field_name}",
-                    )));
-                }
-                BuildFieldIndexResult::Built { schema, indexes } => (schema, indexes),
-            };
-
-        write_segment.with_upgraded(|segment| {
-            segment.apply_field_index(op_num, field_name.to_owned(), schema, indexes)
-        })
-    })
-}
-
-pub fn delete_field_index(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    field_name: PayloadKeyTypeRef,
-) -> OperationResult<usize> {
-    segments.apply_segments(|write_segment| {
-        write_segment.with_upgraded(|segment| segment.delete_field_index(op_num, field_name))
-    })
-}
-
-/// Upsert to a point ID with the specified vectors and payload in the given segment.
-///
-/// If the payload is None, the existing payload will be cleared.
-///
-/// Returns
-/// - Ok(true) if the operation was successful and point replaced existing value
-/// - Ok(false) if the operation was successful and point was inserted
-/// - Err if the operation failed
-fn upsert_with_payload(
-    segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
-    op_num: SeqNumberType,
-    point_id: PointIdType,
-    vectors: NamedVectors,
-    payload: Option<&Payload>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<bool> {
-    let mut res = segment.upsert_point(op_num, point_id, vectors, hw_counter)?;
-    if let Some(full_payload) = payload {
-        res &= segment.set_full_payload(op_num, point_id, full_payload, hw_counter)?;
-    } else {
-        res &= segment.clear_payload(op_num, point_id, hw_counter)?;
-    }
-    Ok(res)
-}
-
-/// Sync points within a given [from_id; to_id) range.
-///
-/// 1. Retrieve existing points for a range
-/// 2. Remove points, which are not present in the sync operation
-/// 3. Retrieve overlapping points, detect which one of them are changed
-/// 4. Select new points
-/// 5. Upsert points which differ from the stored ones
-///
-/// Returns:
-///     (number of deleted points, number of new points, number of updated points)
-pub fn sync_points(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    from_id: Option<PointIdType>,
-    to_id: Option<PointIdType>,
-    points: &[PointStructPersisted],
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<(usize, usize, usize)> {
-    let id_to_point: AHashMap<PointIdType, _> = points.iter().map(|p| (p.id, p)).collect();
-    let sync_points: AHashSet<_> = points.iter().map(|p| p.id).collect();
-    // 1. Retrieve existing points for a range
-    let stored_point_ids: AHashSet<_> = segments
-        .iter()
-        .flat_map(|(_, segment)| segment.get().read().read_range(from_id, to_id))
-        .collect();
-    // 2. Remove points, which are not present in the sync operation
-    let points_to_remove: Vec<_> = stored_point_ids.difference(&sync_points).copied().collect();
-    let deleted = delete_points(segments, op_num, points_to_remove.as_slice(), hw_counter)?;
-    // 3. Retrieve overlapping points, detect which one of them are changed
-    let existing_point_ids: Vec<_> = stored_point_ids
-        .intersection(&sync_points)
-        .copied()
-        .collect();
-
-    let mut points_to_update: Vec<_> = Vec::new();
-    // we don’t want to cancel this filtered read
-    let is_stopped = AtomicBool::new(false);
-    let _num_updated =
-        segments.read_points(existing_point_ids.as_slice(), &is_stopped, |id, segment| {
-            let all_vectors = match segment.all_vectors(id, hw_counter) {
-                Ok(v) => v,
-                Err(OperationError::InconsistentStorage { .. }) => NamedVectors::default(),
-                Err(e) => return Err(e),
-            };
-            let payload = segment.payload(id, hw_counter)?;
-            let point = id_to_point.get(&id).unwrap();
-            if point.get_vectors() != all_vectors {
-                points_to_update.push(*point);
-                Ok(true)
-            } else {
-                let payload_match = match point.payload {
-                    Some(ref p) => p == &payload,
-                    None => Payload::default() == payload,
-                };
-                if !payload_match {
-                    points_to_update.push(*point);
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-        })?;
-
-    // 4. Select new points
-    let num_updated = points_to_update.len();
-    let mut num_new = 0;
-    sync_points.difference(&stored_point_ids).for_each(|id| {
-        num_new += 1;
-        points_to_update.push(*id_to_point.get(id).unwrap());
-    });
-
-    // 5. Upsert points which differ from the stored ones
-    let num_replaced = upsert_points(segments, op_num, points_to_update, hw_counter)?;
-    debug_assert!(
-        num_replaced <= num_updated,
-        "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",
-    );
-
-    Ok((deleted, num_new, num_updated))
-}
-
-/// Checks point id in each segment, update point if found.
-/// All not found points are inserted into random segment.
-/// Returns: number of updated points.
-pub fn upsert_points<'a, T>(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: T,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize>
-where
-    T: IntoIterator<Item = &'a PointStructPersisted>,
-{
-    // Conserve initial order of points
-    let (ids, points_map) = points
-        .into_iter()
-        .map(|p| (p.id, (p.id, p)))
-        .collect::<(Vec<_>, AHashMap<_, _>)>();
-
-    // Update points in writable segments
-    let updated_points = segments.apply_points_with_conditional_move(
-        op_num,
-        &ids,
-        |id, write_segment| {
-            let point = points_map[&id];
-            upsert_with_payload(
-                write_segment,
-                op_num,
-                id,
-                point.get_vectors(),
-                point.payload.as_ref(),
-                hw_counter,
-            )
-        },
-        |id, vectors, old_payload| {
-            let point = points_map[&id];
-            for (name, vec) in point.get_vectors() {
-                vectors.insert(name.into(), vec.to_owned());
-            }
-            if let Some(payload) = &point.payload {
-                *old_payload = payload.clone();
-            }
-        },
-        |_| false,
-        hw_counter,
-    )?;
-
-    let mut res = updated_points.len();
-    // Insert new points, which was not updated or existed
-    let new_point_ids = ids.iter().copied().filter(|x| !updated_points.contains(x));
-
-    {
-        let default_write_segment = segments.smallest_appendable_segment().ok_or_else(|| {
-            OperationError::service_error("No appendable segments exist, expected at least one")
-        })?;
-
-        let segment_arc = default_write_segment.get();
-        let mut write_segment = segment_arc.write();
-        for point_id in new_point_ids {
-            let point = points_map[&point_id];
-            res += usize::from(upsert_with_payload(
-                &mut write_segment,
-                op_num,
-                point_id,
-                point.get_vectors(),
-                point.payload.as_ref(),
-                hw_counter,
-            )?);
-        }
-        RwLockWriteGuard::unlock_fair(write_segment);
-    };
-
-    Ok(res)
-}
-
-fn select_excluded_by_filter_ids(
-    segments: &SegmentHolder,
-    point_ids: impl IntoIterator<Item = PointIdType>,
-    filter: Filter,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<AHashSet<PointIdType>> {
-    // Filter for points that doesn't match the condition, and have matching
-    let non_match_filter =
-        Filter::new_must_not(Condition::Filter(filter)).with_point_ids(point_ids);
-
-    Ok(points_by_filter(segments, &non_match_filter, hw_counter)?
-        .into_iter()
-        .collect())
-}
-
-pub fn conditional_upsert(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    operation: ConditionalInsertOperationInternal,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
-    // Find points, which do exist, but don't match the condition.
-    // Exclude those points from the upsert operation.
-
-    let ConditionalInsertOperationInternal {
-        mut points_op,
-        condition,
-    } = operation;
-
-    let point_ids = points_op.point_ids();
-
-    let points_to_exclude =
-        select_excluded_by_filter_ids(segments, point_ids, condition, hw_counter)?;
-
-    points_op.retain_point_ids(|idx| !points_to_exclude.contains(idx));
-    let points = points_op.into_point_vec();
-    upsert_points(segments, op_num, points.iter(), hw_counter)
-}
-
 pub fn process_point_operation(
     segments: &RwLock<SegmentHolder>,
     op_num: SeqNumberType,
@@ -637,9 +31,6 @@ pub fn process_point_operation(
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match point_operation {
-        PointOperations::DeletePoints { ids, .. } => {
-            delete_points(&segments.read(), op_num, &ids, hw_counter)
-        }
         PointOperations::UpsertPoints(operation) => {
             let points = operation.into_point_vec();
             let res = upsert_points(&segments.read(), op_num, points.iter(), hw_counter)?;
@@ -647,6 +38,9 @@ pub fn process_point_operation(
         }
         PointOperations::UpsertPointsConditional(operation) => {
             conditional_upsert(&segments.read(), op_num, operation, hw_counter)
+        }
+        PointOperations::DeletePoints { ids, .. } => {
+            delete_points(&segments.read(), op_num, &ids, hw_counter)
         }
         PointOperations::DeletePointsByFilter(filter) => {
             delete_points_by_filter(&segments.read(), op_num, &filter, hw_counter)
@@ -772,8 +166,153 @@ pub fn process_field_index_operation(
     }
 }
 
-/// Max amount of points to delete in a batched deletion iteration.
+/// Checks point id in each segment, update point if found.
+/// All not found points are inserted into random segment.
+/// Returns: number of updated points.
+pub fn upsert_points<'a, T>(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: T,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize>
+where
+    T: IntoIterator<Item = &'a PointStructPersisted>,
+{
+    // Conserve initial order of points
+    let (ids, points_map) = points
+        .into_iter()
+        .map(|p| (p.id, (p.id, p)))
+        .collect::<(Vec<_>, AHashMap<_, _>)>();
+
+    // Update points in writable segments
+    let updated_points = segments.apply_points_with_conditional_move(
+        op_num,
+        &ids,
+        |id, write_segment| {
+            let point = points_map[&id];
+            upsert_with_payload(
+                write_segment,
+                op_num,
+                id,
+                point.get_vectors(),
+                point.payload.as_ref(),
+                hw_counter,
+            )
+        },
+        |id, vectors, old_payload| {
+            let point = points_map[&id];
+            for (name, vec) in point.get_vectors() {
+                vectors.insert(name.into(), vec.to_owned());
+            }
+            if let Some(payload) = &point.payload {
+                *old_payload = payload.clone();
+            }
+        },
+        |_| false,
+        hw_counter,
+    )?;
+
+    let mut res = updated_points.len();
+    // Insert new points, which was not updated or existed
+    let new_point_ids = ids.iter().copied().filter(|x| !updated_points.contains(x));
+
+    {
+        let default_write_segment = segments.smallest_appendable_segment().ok_or_else(|| {
+            OperationError::service_error("No appendable segments exist, expected at least one")
+        })?;
+
+        let segment_arc = default_write_segment.get();
+        let mut write_segment = segment_arc.write();
+        for point_id in new_point_ids {
+            let point = points_map[&point_id];
+            res += usize::from(upsert_with_payload(
+                &mut write_segment,
+                op_num,
+                point_id,
+                point.get_vectors(),
+                point.payload.as_ref(),
+                hw_counter,
+            )?);
+        }
+        RwLockWriteGuard::unlock_fair(write_segment);
+    };
+
+    Ok(res)
+}
+
+pub fn conditional_upsert(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    operation: ConditionalInsertOperationInternal,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    // Find points, which do exist, but don't match the condition.
+    // Exclude those points from the upsert operation.
+
+    let ConditionalInsertOperationInternal {
+        mut points_op,
+        condition,
+    } = operation;
+
+    let point_ids = points_op.point_ids();
+
+    let points_to_exclude =
+        select_excluded_by_filter_ids(segments, point_ids, condition, hw_counter)?;
+
+    points_op.retain_point_ids(|idx| !points_to_exclude.contains(idx));
+    let points = points_op.into_point_vec();
+    upsert_points(segments, op_num, points.iter(), hw_counter)
+}
+
+/// Upsert to a point ID with the specified vectors and payload in the given segment.
+///
+/// If the payload is None, the existing payload will be cleared.
+///
+/// Returns
+/// - Ok(true) if the operation was successful and point replaced existing value
+/// - Ok(false) if the operation was successful and point was inserted
+/// - Err if the operation failed
+fn upsert_with_payload(
+    segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
+    op_num: SeqNumberType,
+    point_id: PointIdType,
+    vectors: NamedVectors,
+    payload: Option<&Payload>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<bool> {
+    let mut res = segment.upsert_point(op_num, point_id, vectors, hw_counter)?;
+    if let Some(full_payload) = payload {
+        res &= segment.set_full_payload(op_num, point_id, full_payload, hw_counter)?;
+    } else {
+        res &= segment.clear_payload(op_num, point_id, hw_counter)?;
+    }
+    Ok(res)
+}
+
+/// Max amount of points to delete in a batched deletion iteration
 const DELETION_BATCH_SIZE: usize = 512;
+
+/// Tries to delete points from all segments, returns number of actually deleted points
+pub fn delete_points(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    ids: &[PointIdType],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let mut total_deleted_points = 0;
+
+    for batch in ids.chunks(DELETION_BATCH_SIZE) {
+        let deleted_points = segments.apply_points(
+            batch,
+            |_| (),
+            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id, hw_counter),
+        )?;
+
+        total_deleted_points += deleted_points;
+    }
+
+    Ok(total_deleted_points)
+}
 
 /// Deletes points from all segments matching the given filter
 pub fn delete_points_by_filter(
@@ -825,4 +364,466 @@ pub fn delete_points_by_filter(
     })?;
 
     Ok(total_deleted)
+}
+
+/// Sync points within a given [from_id; to_id) range.
+///
+/// 1. Retrieve existing points for a range
+/// 2. Remove points, which are not present in the sync operation
+/// 3. Retrieve overlapping points, detect which one of them are changed
+/// 4. Select new points
+/// 5. Upsert points which differ from the stored ones
+///
+/// Returns:
+///     (number of deleted points, number of new points, number of updated points)
+pub fn sync_points(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    from_id: Option<PointIdType>,
+    to_id: Option<PointIdType>,
+    points: &[PointStructPersisted],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<(usize, usize, usize)> {
+    let id_to_point: AHashMap<PointIdType, _> = points.iter().map(|p| (p.id, p)).collect();
+    let sync_points: AHashSet<_> = points.iter().map(|p| p.id).collect();
+    // 1. Retrieve existing points for a range
+    let stored_point_ids: AHashSet<_> = segments
+        .iter()
+        .flat_map(|(_, segment)| segment.get().read().read_range(from_id, to_id))
+        .collect();
+    // 2. Remove points, which are not present in the sync operation
+    let points_to_remove: Vec<_> = stored_point_ids.difference(&sync_points).copied().collect();
+    let deleted = delete_points(segments, op_num, points_to_remove.as_slice(), hw_counter)?;
+    // 3. Retrieve overlapping points, detect which one of them are changed
+    let existing_point_ids: Vec<_> = stored_point_ids
+        .intersection(&sync_points)
+        .copied()
+        .collect();
+
+    let mut points_to_update: Vec<_> = Vec::new();
+    // we don’t want to cancel this filtered read
+    let is_stopped = AtomicBool::new(false);
+    let _num_updated =
+        segments.read_points(existing_point_ids.as_slice(), &is_stopped, |id, segment| {
+            let all_vectors = match segment.all_vectors(id, hw_counter) {
+                Ok(v) => v,
+                Err(OperationError::InconsistentStorage { .. }) => NamedVectors::default(),
+                Err(e) => return Err(e),
+            };
+            let payload = segment.payload(id, hw_counter)?;
+            let point = id_to_point.get(&id).unwrap();
+            if point.get_vectors() != all_vectors {
+                points_to_update.push(*point);
+                Ok(true)
+            } else {
+                let payload_match = match point.payload {
+                    Some(ref p) => p == &payload,
+                    None => Payload::default() == payload,
+                };
+                if !payload_match {
+                    points_to_update.push(*point);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+        })?;
+
+    // 4. Select new points
+    let num_updated = points_to_update.len();
+    let mut num_new = 0;
+    sync_points.difference(&stored_point_ids).for_each(|id| {
+        num_new += 1;
+        points_to_update.push(*id_to_point.get(id).unwrap());
+    });
+
+    // 5. Upsert points which differ from the stored ones
+    let num_replaced = upsert_points(segments, op_num, points_to_update, hw_counter)?;
+    debug_assert!(
+        num_replaced <= num_updated,
+        "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",
+    );
+
+    Ok((deleted, num_new, num_updated))
+}
+
+/// Batch size when modifying vector
+const VECTOR_OP_BATCH_SIZE: usize = 512;
+
+pub fn update_vectors_conditional(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: UpdateVectorsOp,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let UpdateVectorsOp {
+        mut points,
+        update_filter,
+    } = points;
+
+    let Some(filter_condition) = update_filter else {
+        return update_vectors(segments, op_num, points, hw_counter);
+    };
+
+    let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
+
+    let points_to_exclude =
+        select_excluded_by_filter_ids(segments, point_ids, filter_condition, hw_counter)?;
+
+    points.retain(|p| !points_to_exclude.contains(&p.id));
+    update_vectors(segments, op_num, points, hw_counter)
+}
+
+/// Update the specified named vectors of a point, keeping unspecified vectors intact.
+fn update_vectors(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: Vec<PointVectorsPersisted>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    // Build a map of vectors to update per point, merge updates on same point ID
+    let mut points_map: AHashMap<PointIdType, NamedVectors> = AHashMap::new();
+    for point in points {
+        let PointVectorsPersisted { id, vector } = point;
+        let named_vector = NamedVectors::from(vector);
+
+        let entry = points_map.entry(id).or_default();
+        entry.merge(named_vector);
+    }
+
+    let ids: Vec<PointIdType> = points_map.keys().copied().collect();
+
+    let mut total_updated_points = 0;
+    for batch in ids.chunks(VECTOR_OP_BATCH_SIZE) {
+        let updated_points = segments.apply_points_with_conditional_move(
+            op_num,
+            batch,
+            |id, write_segment| {
+                let vectors = points_map[&id].clone();
+                write_segment.update_vectors(op_num, id, vectors, hw_counter)
+            },
+            |id, owned_vectors, _| {
+                for (vector_name, vector_ref) in points_map[&id].iter() {
+                    owned_vectors.insert(vector_name.to_owned(), vector_ref.to_owned());
+                }
+            },
+            |_| false,
+            hw_counter,
+        )?;
+        check_unprocessed_points(batch, &updated_points)?;
+        total_updated_points += updated_points.len();
+    }
+
+    Ok(total_updated_points)
+}
+
+/// Delete the given named vectors for the given points, keeping other vectors intact.
+pub fn delete_vectors(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: &[PointIdType],
+    vector_names: &[VectorNameBuf],
+) -> OperationResult<usize> {
+    let mut total_deleted_points = 0;
+
+    for batch in points.chunks(VECTOR_OP_BATCH_SIZE) {
+        let deleted_points = segments.apply_points(
+            batch,
+            |_| (),
+            |id, _idx, write_segment, ()| {
+                let mut res = true;
+                for name in vector_names {
+                    res &= write_segment.delete_vector(op_num, id, name)?;
+                }
+                Ok(res)
+            },
+        )?;
+
+        total_deleted_points += deleted_points;
+    }
+
+    Ok(total_deleted_points)
+}
+
+/// Delete the given named vectors for points matching the given filter, keeping other vectors intact.
+pub fn delete_vectors_by_filter(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    filter: &Filter,
+    vector_names: &[VectorNameBuf],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let affected_points = points_by_filter(segments, filter, hw_counter)?;
+    delete_vectors(segments, op_num, &affected_points, vector_names)
+}
+
+/// Batch size when modifying payload
+const PAYLOAD_OP_BATCH_SIZE: usize = 512;
+
+pub fn set_payload(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    payload: &Payload,
+    points: &[PointIdType],
+    key: &Option<JsonPath>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let mut total_updated_points = 0;
+
+    for chunk in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
+        let updated_points = segments.apply_points_with_conditional_move(
+            op_num,
+            chunk,
+            |id, write_segment| write_segment.set_payload(op_num, id, payload, key, hw_counter),
+            |_, _, old_payload| match key {
+                Some(key) => old_payload.merge_by_key(payload, key),
+                None => old_payload.merge(payload),
+            },
+            |segment| {
+                segment.get_indexed_fields().keys().all(|indexed_path| {
+                    !indexed_path.is_affected_by_value_set(&payload.0, key.as_ref())
+                })
+            },
+            hw_counter,
+        )?;
+
+        check_unprocessed_points(chunk, &updated_points)?;
+        total_updated_points += updated_points.len();
+    }
+
+    Ok(total_updated_points)
+}
+
+pub fn set_payload_by_filter(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    payload: &Payload,
+    filter: &Filter,
+    key: &Option<JsonPath>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let affected_points = points_by_filter(segments, filter, hw_counter)?;
+    set_payload(segments, op_num, payload, &affected_points, key, hw_counter)
+}
+
+pub fn delete_payload(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: &[PointIdType],
+    keys: &[PayloadKeyType],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let mut total_deleted_points = 0;
+
+    for batch in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
+        let updated_points = segments.apply_points_with_conditional_move(
+            op_num,
+            batch,
+            |id, write_segment| {
+                let mut res = true;
+                for key in keys {
+                    res &= write_segment.delete_payload(op_num, id, key, hw_counter)?;
+                }
+                Ok(res)
+            },
+            |_, _, payload| {
+                for key in keys {
+                    payload.remove(key);
+                }
+            },
+            |segment| {
+                iproduct!(segment.get_indexed_fields().keys(), keys).all(
+                    |(indexed_path, path_to_delete)| {
+                        !indexed_path.is_affected_by_value_remove(path_to_delete)
+                    },
+                )
+            },
+            hw_counter,
+        )?;
+
+        check_unprocessed_points(batch, &updated_points)?;
+        total_deleted_points += updated_points.len();
+    }
+
+    Ok(total_deleted_points)
+}
+
+pub fn delete_payload_by_filter(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    filter: &Filter,
+    keys: &[PayloadKeyType],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let affected_points = points_by_filter(segments, filter, hw_counter)?;
+    delete_payload(segments, op_num, &affected_points, keys, hw_counter)
+}
+
+pub fn clear_payload(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: &[PointIdType],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let mut total_updated_points = 0;
+
+    for batch in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
+        let updated_points = segments.apply_points_with_conditional_move(
+            op_num,
+            batch,
+            |id, write_segment| write_segment.clear_payload(op_num, id, hw_counter),
+            |_, _, payload| payload.0.clear(),
+            |segment| segment.get_indexed_fields().is_empty(),
+            hw_counter,
+        )?;
+        check_unprocessed_points(batch, &updated_points)?;
+        total_updated_points += updated_points.len();
+    }
+
+    Ok(total_updated_points)
+}
+
+/// Clear Payloads from all segments matching the given filter
+pub fn clear_payload_by_filter(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    filter: &Filter,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let points_to_clear = points_by_filter(segments, filter, hw_counter)?;
+    clear_payload(segments, op_num, &points_to_clear, hw_counter)
+}
+
+pub fn overwrite_payload(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    payload: &Payload,
+    points: &[PointIdType],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let mut total_updated_points = 0;
+
+    for batch in points.chunks(PAYLOAD_OP_BATCH_SIZE) {
+        let updated_points = segments.apply_points_with_conditional_move(
+            op_num,
+            batch,
+            |id, write_segment| write_segment.set_full_payload(op_num, id, payload, hw_counter),
+            |_, _, old_payload| {
+                *old_payload = payload.clone();
+            },
+            |segment| segment.get_indexed_fields().is_empty(),
+            hw_counter,
+        )?;
+
+        total_updated_points += updated_points.len();
+        check_unprocessed_points(batch, &updated_points)?;
+    }
+
+    Ok(total_updated_points)
+}
+
+pub fn overwrite_payload_by_filter(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    payload: &Payload,
+    filter: &Filter,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let affected_points = points_by_filter(segments, filter, hw_counter)?;
+    overwrite_payload(segments, op_num, payload, &affected_points, hw_counter)
+}
+
+pub fn create_field_index(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    field_name: PayloadKeyTypeRef,
+    field_schema: Option<&PayloadFieldSchema>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
+    let Some(field_schema) = field_schema else {
+        return Err(OperationError::TypeInferenceError {
+            field_name: field_name.to_owned(),
+        });
+    };
+
+    segments.apply_segments(|write_segment| {
+        write_segment.with_upgraded(|segment| {
+            segment.delete_field_index_if_incompatible(op_num, field_name, field_schema)
+        })?;
+
+        let (schema, indexes) =
+            match write_segment.build_field_index(op_num, field_name, field_schema, hw_counter)? {
+                BuildFieldIndexResult::SkippedByVersion => {
+                    return Ok(false);
+                }
+                BuildFieldIndexResult::AlreadyExists => {
+                    return Ok(false);
+                }
+                BuildFieldIndexResult::IncompatibleSchema => {
+                    // This is a service error, as we should have just removed the old index
+                    // So it should not be possible to get this error
+                    return Err(OperationError::service_error(format!(
+                        "Incompatible schema for field index on field {field_name}",
+                    )));
+                }
+                BuildFieldIndexResult::Built { schema, indexes } => (schema, indexes),
+            };
+
+        write_segment.with_upgraded(|segment| {
+            segment.apply_field_index(op_num, field_name.to_owned(), schema, indexes)
+        })
+    })
+}
+
+pub fn delete_field_index(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    field_name: PayloadKeyTypeRef,
+) -> OperationResult<usize> {
+    segments.apply_segments(|write_segment| {
+        write_segment.with_upgraded(|segment| segment.delete_field_index(op_num, field_name))
+    })
+}
+
+fn select_excluded_by_filter_ids(
+    segments: &SegmentHolder,
+    point_ids: impl IntoIterator<Item = PointIdType>,
+    filter: Filter,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<AHashSet<PointIdType>> {
+    // Filter for points that doesn't match the condition, and have matching
+    let non_match_filter =
+        Filter::new_must_not(Condition::Filter(filter)).with_point_ids(point_ids);
+
+    Ok(points_by_filter(segments, &non_match_filter, hw_counter)?
+        .into_iter()
+        .collect())
+}
+
+fn points_by_filter(
+    segments: &SegmentHolder,
+    filter: &Filter,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<Vec<PointIdType>> {
+    let mut affected_points: Vec<PointIdType> = Vec::new();
+    // we don’t want to cancel this filtered read
+    let is_stopped = AtomicBool::new(false);
+    segments.for_each_segment(|s| {
+        let points = s.read_filtered(None, None, Some(filter), &is_stopped, hw_counter);
+        affected_points.extend_from_slice(points.as_slice());
+        Ok(true)
+    })?;
+    Ok(affected_points)
+}
+
+fn check_unprocessed_points(
+    points: &[PointIdType],
+    processed: &AHashSet<PointIdType>,
+) -> OperationResult<usize> {
+    let first_missed_point = points.iter().copied().find(|p| !processed.contains(p));
+
+    match first_missed_point {
+        None => Ok(processed.len()),
+        Some(missed_point_id) => Err(OperationError::PointIdError { missed_point_id }),
+    }
 }

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -24,7 +24,7 @@ use crate::operations::point_ops::{
 use crate::operations::vector_ops::{PointVectorsPersisted, UpdateVectorsOp, VectorOperations};
 use crate::segment_holder::SegmentHolder;
 
-pub fn check_unprocessed_points(
+fn check_unprocessed_points(
     points: &[PointIdType],
     processed: &AHashSet<PointIdType>,
 ) -> OperationResult<usize> {
@@ -569,7 +569,7 @@ where
 
     {
         let default_write_segment = segments.smallest_appendable_segment().ok_or_else(|| {
-            OperationError::service_error("No appendable segments exists, expected at least one")
+            OperationError::service_error("No appendable segments exist, expected at least one")
         })?;
 
         let segment_arc = default_write_segment.get();


### PR DESCRIPTION
Qdrant on Edge. We need this in `shard` to be reused by edge.

Last commit in the PR moves stuff around in `segment_updater`/`shard::update` module, but makes no code changes.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
