### PR TITLE
Remove mlock flag from chunked mmap vectors

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -266,13 +266,8 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
 
     let populate = false;
 
-    let vectors = ChunkedMmapVectors::<T>::open(
-        &vectors_path,
-        dim,
-        Some(false),
-        AdviceSetting::Global,
-        Some(populate),
-    )?;
+    let vectors =
+        ChunkedMmapVectors::<T>::open(&vectors_path, dim, AdviceSetting::Global, Some(populate))?;
 
     let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?);
     let deleted_count = deleted.count_trues();

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -19,7 +19,6 @@ impl<T: Sized + Copy + Clone + Default + 'static> InRamPersistedVectors<T> {
         let mmap_storage = ChunkedMmapVectors::open(
             directory,
             dim,
-            Some(false),
             AdviceSetting::from(Advice::Normal),
             Some(true),
         )?;

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -435,20 +435,10 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
 
     let populate = false;
 
-    let vectors = ChunkedMmapVectors::open(
-        &vectors_path,
-        dim,
-        Some(false),
-        AdviceSetting::Global,
-        Some(populate),
-    )?;
-    let offsets = ChunkedMmapVectors::open(
-        &offsets_path,
-        1,
-        Some(false),
-        AdviceSetting::Global,
-        Some(populate),
-    )?;
+    let vectors =
+        ChunkedMmapVectors::open(&vectors_path, dim, AdviceSetting::Global, Some(populate))?;
+    let offsets =
+        ChunkedMmapVectors::open(&offsets_path, 1, AdviceSetting::Global, Some(populate))?;
 
     let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?);
     let deleted_count = deleted.count_trues();


### PR DESCRIPTION
Remove the `mlock` flag, because it is always `false`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?