### PR TITLE
Generic AccessPattern

### DIFF
--- a/lib/collection/src/collection/mmr/lazy_matrix.rs
+++ b/lib/collection/src/collection/mmr/lazy_matrix.rs
@@ -2,7 +2,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::{PointOffsetType, ScoreType};
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 #[cfg(debug_assertions)]
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::{Random, VectorStorage};
 use segment::vector_storage::{RawScorer, VectorStorageEnum, new_raw_scorer};
 
 use crate::operations::types::CollectionResult;
@@ -33,7 +33,7 @@ impl<'storage> LazyMatrix<'storage> {
         #[cfg(debug_assertions)]
         {
             for (i, vector) in vectors.iter().enumerate() {
-                let stored_vector = storage.get_vector(i as u32);
+                let stored_vector = storage.get_vector::<Random>(i as u32);
                 assert_eq!(stored_vector.to_owned(), *vector);
             }
         }

--- a/lib/gridstore/benches/bustle_bench/payload_storage.rs
+++ b/lib/gridstore/benches/bustle_bench/payload_storage.rs
@@ -31,7 +31,8 @@ impl Collection for ArcStorage<PayloadStorage> {
 
 impl SequentialCollectionHandle for PayloadStorage {
     fn get(&self, key: &u32) -> bool {
-        self.get_value(*key, &HardwareCounterCell::new()).is_some() // No measurements needed in benches
+        self.get_value::<false>(*key, &HardwareCounterCell::new()) // No measurements needed in benches
+            .is_some()
     }
 
     fn insert(&mut self, key: u32, payload: &Payload) -> bool {

--- a/lib/gridstore/benches/random_data_bench.rs
+++ b/lib/gridstore/benches/random_data_bench.rs
@@ -26,7 +26,7 @@ pub fn random_data_bench(c: &mut Criterion) {
         let hw_counter = HardwareCounterCell::new();
         b.iter(|| {
             for i in 0..PAYLOAD_COUNT {
-                let res = storage.get_value(i, &hw_counter);
+                let res = storage.get_value::<false>(i, &hw_counter);
                 assert!(res.is_some());
             }
         });

--- a/lib/gridstore/benches/real_data_bench.rs
+++ b/lib/gridstore/benches/real_data_bench.rs
@@ -88,7 +88,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
         let hw_counter = HardwareCounterCell::new();
         b.iter(|| {
             for i in 0..storage.max_point_id() {
-                let res = storage.get_value(i, &hw_counter).unwrap();
+                let res = storage.get_value::<false>(i, &hw_counter).unwrap();
                 assert!(res.0.contains_key("article_id"));
             }
         });

--- a/lib/segment/benches/sparse_vector_storage.rs
+++ b/lib/segment/benches/sparse_vector_storage.rs
@@ -9,9 +9,9 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use segment::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
-use segment::vector_storage::VectorStorage;
 use segment::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use segment::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use segment::vector_storage::{Random, VectorStorage};
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use tempfile::Builder;
 
@@ -45,7 +45,8 @@ fn sparse_vector_storage_benchmark(c: &mut Criterion) {
     group.bench_function("read-rocksdb", |b| {
         b.iter(|| {
             for idx in 0..NUM_VECTORS {
-                let vec = rocksdb_sparse_vector_storage.get_vector_opt(idx as PointOffsetType);
+                let vec =
+                    rocksdb_sparse_vector_storage.get_vector_opt::<Random>(idx as PointOffsetType);
                 assert!(vec.is_some());
             }
         })
@@ -71,7 +72,8 @@ fn sparse_vector_storage_benchmark(c: &mut Criterion) {
     group.bench_function("read-mmap-compression", |b| {
         b.iter(|| {
             for idx in 0..NUM_VECTORS {
-                let vec = mmap_sparse_vector_storage.get_vector_opt(idx as PointOffsetType);
+                let vec =
+                    mmap_sparse_vector_storage.get_vector_opt::<Random>(idx as PointOffsetType);
                 assert!(vec.is_some());
             }
         })

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -321,7 +321,7 @@ impl MutableFullTextIndex {
             }
             Storage::Gridstore(gridstore) => gridstore
                 .read()
-                .get_value(idx, &HardwareCounterCell::disposable())
+                .get_value::<false>(idx, &HardwareCounterCell::disposable())
                 .map(|bytes| FullTextIndex::deserialize_document(&bytes).unwrap()),
         }
     }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_insert_context.rs
@@ -491,7 +491,7 @@ mod tests {
     use crate::index::hnsw_index::links_container::LinksContainer;
     use crate::types::Distance;
     use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
-    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage};
+    use crate::vector_storage::{DEFAULT_STOPPED, Random, VectorStorage};
 
     #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
     #[repr(C)]
@@ -529,7 +529,7 @@ mod tests {
         // upload vectors to storage
         let mut storage = new_volatile_dense_vector_storage(dim, Distance::Dot);
         for idx in 0..(num_vectors + groups_count) as PointOffsetType {
-            let v = vector_holder.storage().get_vector(idx);
+            let v = vector_holder.storage().get_vector::<Random>(idx);
             storage
                 .insert_vector(idx, v.as_vec_ref(), &HardwareCounterCell::new())
                 .unwrap();

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
@@ -11,10 +11,10 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::index::hnsw_index::gpu::GPU_TIMEOUT;
 use crate::index::hnsw_index::gpu::shader_builder::ShaderBuilderParameters;
-use crate::vector_storage::MultiVectorStorage;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
     MultivectorOffsetsStorage, QuantizedMultivectorStorage,
 };
+use crate::vector_storage::{MultiVectorStorage, Random};
 
 // Multivector shader binding is after vectot data and quantization data bindings.
 const START_MULTIVECTORS_BINDING: usize = STORAGES_COUNT + MAX_QUANTIZATION_BINDINGS;
@@ -89,7 +89,7 @@ impl GpuMultivectors {
                 // map ID to count of vectors in multivector
                 .map(|id| {
                     vector_storage
-                        .get_multi(id as PointOffsetType)
+                        .get_multi::<Random>(id as PointOffsetType)
                         .vectors_count()
                 })
                 // Map count of vectors to start and count of vectors in multivector.

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -26,7 +26,7 @@ use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectorStorage, QuantizedVectors,
 };
 use crate::vector_storage::{
-    DenseVectorStorage, MultiVectorStorage, VectorStorage, VectorStorageEnum,
+    DenseVectorStorage, MultiVectorStorage, Random, VectorStorage, VectorStorageEnum,
 };
 
 pub const ELEMENTS_PER_SUBGROUP: usize = 4;
@@ -526,7 +526,7 @@ impl GpuVectorStorage {
                 vector_storage.vector_dim(),
                 (0..vector_storage.total_vector_count()).map(|id| {
                     VectorElementTypeHalf::slice_from_float_cow(Cow::Borrowed(
-                        vector_storage.get_dense(id as PointOffsetType),
+                        vector_storage.get_dense::<Random>(id as PointOffsetType),
                     ))
                 }),
                 None,
@@ -554,7 +554,7 @@ impl GpuVectorStorage {
                 vector_storage.vector_dim(),
                 (0..vector_storage.total_vector_count()).map(|id| {
                     VectorElementTypeHalf::slice_to_float_cow(Cow::Borrowed(
-                        vector_storage.get_dense(id as PointOffsetType),
+                        vector_storage.get_dense::<Random>(id as PointOffsetType),
                     ))
                 }),
                 None,
@@ -576,7 +576,7 @@ impl GpuVectorStorage {
             vector_storage.total_vector_count(),
             vector_storage.vector_dim(),
             (0..vector_storage.total_vector_count())
-                .map(|id| Cow::Borrowed(vector_storage.get_dense(id as PointOffsetType))),
+                .map(|id| Cow::Borrowed(vector_storage.get_dense::<Random>(id as PointOffsetType))),
             None,
             None,
             stopped,
@@ -596,7 +596,7 @@ impl GpuVectorStorage {
                 (0..vector_storage.total_vector_count())
                     .map(|id| {
                         vector_storage
-                            .get_multi(id as PointOffsetType)
+                            .get_multi::<Random>(id as PointOffsetType)
                             .vectors_count()
                     })
                     .sum(),
@@ -628,7 +628,7 @@ impl GpuVectorStorage {
                 (0..vector_storage.total_vector_count())
                     .map(|id| {
                         vector_storage
-                            .get_multi(id as PointOffsetType)
+                            .get_multi::<Random>(id as PointOffsetType)
                             .vectors_count()
                     })
                     .sum(),
@@ -655,7 +655,7 @@ impl GpuVectorStorage {
             (0..vector_storage.total_vector_count())
                 .map(|id| {
                     vector_storage
-                        .get_multi(id as PointOffsetType)
+                        .get_multi::<Random>(id as PointOffsetType)
                         .vectors_count()
                 })
                 .sum(),

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -846,7 +846,7 @@ fn test_gpu_vector_storage_impl(
 
     let gpu_scores = staging_buffer.download_vec(0, num_vectors).unwrap();
 
-    let query = QueryVector::Nearest(storage.get_vector(test_point_id).to_owned());
+    let query = QueryVector::Nearest(storage.get_vector::<Random>(test_point_id).to_owned());
 
     let hardware_counter = HardwareCounterCell::new();
     let scorer: Box<dyn RawScorer> = if let Some(quantized_vectors) = quantized_vectors.as_ref() {

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -108,7 +108,7 @@ mod tests {
     use crate::index::hnsw_index::graph_links::GraphLinksFormatParam;
     use crate::types::Distance;
     use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
-    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
+    use crate::vector_storage::{DEFAULT_STOPPED, Random, VectorStorage, VectorStorageEnum};
 
     pub struct GpuGraphTestData {
         pub vector_storage: VectorStorageEnum,
@@ -132,7 +132,7 @@ mod tests {
         // upload vectors to storage
         let mut storage = new_volatile_dense_vector_storage(dim, Distance::Cosine);
         for idx in 0..num_vectors as PointOffsetType {
-            let v = vector_holder.storage().get_vector(idx);
+            let v = vector_holder.storage().get_vector::<Random>(idx);
             storage
                 .insert_vector(idx, v.as_vec_ref(), &HardwareCounterCell::new())
                 .unwrap();

--- a/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
@@ -12,7 +12,7 @@ use crate::index::hnsw_index::graph_layers_builder::{GraphLayersBuilder, LockedL
 use crate::index::hnsw_index::links_container::{ItemsBuffer, LinksContainer};
 use crate::index::visited_pool::VisitedPool;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::{Random, RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer};
 
 pub struct GraphLayersHealer<'a> {
     links_layers: Vec<LockedLayersContainer>,
@@ -217,7 +217,10 @@ impl<'a> GraphLayersHealer<'a> {
                 .try_for_each(|(offset, level)| {
                     // Internal operation. No measurements needed.
                     let internal_hardware_counter = HardwareCounterCell::disposable();
-                    let query = vector_storage.get_vector(offset).as_vec_ref().into();
+                    let query = vector_storage
+                        .get_vector::<Random>(offset)
+                        .as_vec_ref()
+                        .into();
                     let scorer = if let Some(quantized_vectors) = quantized_vectors {
                         quantized_vectors.raw_scorer(query, internal_hardware_counter)?
                     } else {

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -14,7 +14,7 @@ use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsu
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query_scorer::QueryScorerBytes;
 use crate::vector_storage::{
-    RawScorer, VectorStorage, VectorStorageEnum, check_deleted_condition, new_raw_scorer,
+    Random, RawScorer, VectorStorage, VectorStorageEnum, check_deleted_condition, new_raw_scorer,
 };
 
 /// Scorers composition:
@@ -126,7 +126,7 @@ impl<'a> FilteredScorer<'a> {
         // This is a fallback function, which is used if quantized vector storage
         // is not capable of reconstructing the query vector.
         let original_query_fn = || {
-            let query = vectors.get_vector(point_id);
+            let query = vectors.get_vector::<Random>(point_id);
             let query: QueryVector = query.as_vec_ref().into();
             query
         };

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -106,7 +106,7 @@ impl PayloadStorage for MmapPayloadStorage {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let mut guard = self.storage.write();
-        match guard.get_value(point_id, hw_counter) {
+        match guard.get_value::<false>(point_id, hw_counter) {
             Some(mut point_payload) => {
                 point_payload.merge(payload);
                 guard
@@ -134,7 +134,7 @@ impl PayloadStorage for MmapPayloadStorage {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let mut guard = self.storage.write();
-        match guard.get_value(point_id, hw_counter) {
+        match guard.get_value::<false>(point_id, hw_counter) {
             Some(mut point_payload) => {
                 point_payload.merge_by_key(payload, key);
                 guard
@@ -165,7 +165,7 @@ impl PayloadStorage for MmapPayloadStorage {
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
-        match self.storage.read().get_value(point_id, hw_counter) {
+        match self.storage.read().get_value::<false>(point_id, hw_counter) {
             Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }
@@ -176,11 +176,7 @@ impl PayloadStorage for MmapPayloadStorage {
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
-        match self
-            .storage
-            .read()
-            .get_value_sequential(point_id, hw_counter)
-        {
+        match self.storage.read().get_value::<true>(point_id, hw_counter) {
             Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }
@@ -193,7 +189,7 @@ impl PayloadStorage for MmapPayloadStorage {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<Value>> {
         let mut guard = self.storage.write();
-        match guard.get_value(point_id, hw_counter) {
+        match guard.get_value::<false>(point_id, hw_counter) {
             Some(mut payload) => {
                 let res = payload.remove(key);
                 if !res.is_empty() {

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -24,7 +24,7 @@ use crate::types::{
     SnapshotFormat, VectorName,
 };
 use crate::utils;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::{Random, VectorStorage};
 
 impl Segment {
     /// Replace vectors in-place
@@ -378,7 +378,7 @@ impl Segment {
                     ),
                 })
             } else {
-                let vector = vector_storage.get_vector(point_offset);
+                let vector = vector_storage.get_vector::<Random>(point_offset);
                 if vector_storage.is_on_disk() {
                     hw_counter
                         .vector_io_read()
@@ -606,7 +606,7 @@ impl Segment {
                 let vector_storage = vector_data.vector_storage.borrow();
                 let is_vector_deleted_storage = vector_storage.is_deleted_vector(internal_id);
                 let is_vector_deleted_tracker = id_tracker.is_deleted_point(internal_id);
-                let vector_stored = vector_storage.get_vector_opt(internal_id);
+                let vector_stored = vector_storage.get_vector_opt::<Random>(internal_id);
                 if !is_vector_deleted_storage
                     && !is_vector_deleted_tracker
                     && vector_stored.is_none()

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -8,7 +8,7 @@ use common::types::PointOffsetType;
 
 use crate::data_types::named_vectors::CowVector;
 use crate::types::CompactExtendedPointId;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{Sequential, VectorStorage, VectorStorageEnum};
 
 const BATCH_SIZE: usize = 256;
 
@@ -83,7 +83,7 @@ impl<'a> BatchedVectorReader<'a> {
         for (segment_index, points) in self.seg_to_points_buffer.drain() {
             let source_vector_storage = &self.source_vector_storages[segment_index.get() as usize];
             for (point_data, offset_in_batch) in points {
-                let vec = source_vector_storage.get_vector_sequential(point_data.internal_id);
+                let vec = source_vector_storage.get_vector::<Sequential>(point_data.internal_id);
                 let vector_deleted =
                     source_vector_storage.is_deleted_vector(point_data.internal_id);
                 self.buffer[offset_in_batch] = (vec, vector_deleted);

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1051,6 +1051,7 @@ pub fn migrate_rocksdb_dense_vector_storage_to_mmap(
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::types::PointOffsetType;
 
+    use crate::vector_storage::Sequential;
     use crate::vector_storage::dense::appendable_dense_vector_storage::find_storage_files;
 
     log::info!(
@@ -1079,7 +1080,7 @@ pub fn migrate_rocksdb_dense_vector_storage_to_mmap(
         // Copy all vectors and deletes into new storage
         let hw_counter = HardwareCounterCell::disposable();
         for internal_id in 0..old_storage.total_vector_count() as PointOffsetType {
-            let vector = old_storage.get_vector_sequential(internal_id);
+            let vector = old_storage.get_vector::<Sequential>(internal_id);
             new_storage.insert_vector(internal_id, vector.as_vec_ref(), &hw_counter)?;
 
             let is_deleted = old_storage.is_deleted_vector(internal_id);
@@ -1139,6 +1140,7 @@ pub fn migrate_rocksdb_multi_dense_vector_storage_to_mmap(
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::types::PointOffsetType;
 
+    use crate::vector_storage::Sequential;
     use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::find_storage_files;
 
     log::info!(
@@ -1169,7 +1171,7 @@ pub fn migrate_rocksdb_multi_dense_vector_storage_to_mmap(
         // Copy all vectors and deletes into new storage
         let hw_counter = HardwareCounterCell::disposable();
         for internal_id in 0..old_storage.total_vector_count() as PointOffsetType {
-            let vector = old_storage.get_vector_sequential(internal_id);
+            let vector = old_storage.get_vector::<Sequential>(internal_id);
             new_storage.insert_vector(internal_id, vector.as_vec_ref(), &hw_counter)?;
 
             let is_deleted = old_storage.is_deleted_vector(internal_id);
@@ -1276,6 +1278,7 @@ pub fn migrate_rocksdb_sparse_vector_storage_to_mmap(
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::types::PointOffsetType;
 
+    use crate::vector_storage::Sequential;
     use crate::vector_storage::sparse::mmap_sparse_vector_storage::find_storage_files;
 
     log::info!(
@@ -1300,7 +1303,7 @@ pub fn migrate_rocksdb_sparse_vector_storage_to_mmap(
         // Copy all vectors and deletes into new storage
         let hw_counter = HardwareCounterCell::disposable();
         for internal_id in 0..old_storage.total_vector_count() as PointOffsetType {
-            let vector = old_storage.get_vector_sequential(internal_id);
+            let vector = old_storage.get_vector::<Sequential>(internal_id);
             new_storage.insert_vector(internal_id, vector.as_vec_ref(), &hw_counter)?;
 
             let is_deleted = old_storage.is_deleted_vector(internal_id);

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::vector_storage::AccessPattern;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
 use crate::vector_storage::common::{CHUNK_SIZE, PAGE_SIZE_BYTES, VECTOR_READ_BATCH_SIZE};
 use crate::vector_storage::query_scorer::is_read_with_prefetch_efficient_vectors;
@@ -346,12 +347,8 @@ impl<T: Sized + Copy + 'static> ChunkedVectorStorage<T> for ChunkedMmapVectors<T
     }
 
     #[inline]
-    fn get(&self, key: VectorOffsetType) -> Option<&[T]> {
-        ChunkedMmapVectors::get(self, key, false)
-    }
-
-    fn get_sequential(&self, key: VectorOffsetType) -> Option<&[T]> {
-        ChunkedMmapVectors::get(self, key, true)
+    fn get<P: AccessPattern>(&self, key: VectorOffsetType) -> Option<&[T]> {
+        ChunkedMmapVectors::get(self, key, P::IS_SEQUENTIAL)
     }
 
     #[inline]
@@ -400,13 +397,8 @@ impl<T: Sized + Copy + 'static> ChunkedVectorStorage<T> for ChunkedMmapVectors<T
     }
 
     #[inline]
-    fn get_many(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
-        ChunkedMmapVectors::get_many(self, key, count, false)
-    }
-
-    #[inline]
-    fn get_many_sequential(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
-        ChunkedMmapVectors::get_many(self, key, count, true)
+    fn get_many<P: AccessPattern>(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
+        ChunkedMmapVectors::get_many(self, key, count, P::IS_SEQUENTIAL)
     }
 
     #[inline]

--- a/lib/segment/src/vector_storage/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/chunked_vector_storage.rs
@@ -5,6 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::vector_storage::AccessPattern;
 
 /// In case of simple vector storage, vector offset is the same as PointOffsetType.
 /// But in case of multivectors, it requires an additional lookup.
@@ -16,9 +17,9 @@ pub trait ChunkedVectorStorage<T> {
 
     fn dim(&self) -> usize;
 
-    fn get(&self, key: VectorOffsetType) -> Option<&[T]>;
-
-    fn get_sequential(&self, key: VectorOffsetType) -> Option<&[T]>;
+    fn get<P: AccessPattern>(&self, key: VectorOffsetType) -> Option<&[T]>
+    where
+        Self: Sized;
 
     fn files(&self) -> Vec<PathBuf>;
 
@@ -48,10 +49,7 @@ pub trait ChunkedVectorStorage<T> {
     ) -> OperationResult<()>;
 
     /// Returns `count` flattened vectors starting from key. if chunk boundary is crossed, returns None
-    fn get_many(&self, key: VectorOffsetType, count: usize) -> Option<&[T]>;
-
-    /// Returns `count` flattened vectors starting from key. if chunk boundary is crossed, returns None
-    fn get_many_sequential(&self, key: VectorOffsetType, count: usize) -> Option<&[T]>;
+    fn get_many<P: AccessPattern>(&self, key: VectorOffsetType, count: usize) -> Option<&[T]>;
 
     /// Returns batch of vectors by keys.
     /// Underlying storage might apply some optimizations to prefetch vectors.

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -23,7 +23,7 @@ use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::in_ram_persisted_vectors::InRamPersistedVectors;
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{AccessPattern, DenseVectorStorage, VectorStorage, VectorStorageEnum};
 
 const VECTORS_DIR_PATH: &str = "vectors";
 const DELETED_DIR_PATH: &str = "deleted";
@@ -85,15 +85,9 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> DenseVectorStorage<T
         self.vectors.dim()
     }
 
-    fn get_dense(&self, key: PointOffsetType) -> &[T] {
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> &[T] {
         self.vectors
-            .get(key as VectorOffsetType)
-            .expect("mmap vector not found")
-    }
-
-    fn get_dense_sequential(&self, key: PointOffsetType) -> &[T] {
-        self.vectors
-            .get_sequential(key as VectorOffsetType)
+            .get::<P>(key as VectorOffsetType)
             .expect("mmap vector not found")
     }
 
@@ -131,20 +125,16 @@ impl<T: PrimitiveVectorElement, S: ChunkedVectorStorage<T>> VectorStorage
         self.vectors.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
-        self.get_vector_opt(key).expect("vector not found")
-    }
-
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
+    fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
-            .get_sequential(key as VectorOffsetType)
+            .get::<P>(key as VectorOffsetType)
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
             .expect("Vector not found")
     }
 
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
+    fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
-            .get(key as VectorOffsetType)
+            .get::<P>(key as VectorOffsetType)
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
     }
 

--- a/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
+++ b/lib/segment/src/vector_storage/in_ram_persisted_vectors.rs
@@ -6,6 +6,7 @@ use memory::madvise::{Advice, AdviceSetting};
 
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::vector_storage::AccessPattern;
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
 
@@ -40,12 +41,8 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
     }
 
     #[inline]
-    fn get(&self, key: VectorOffsetType) -> Option<&[T]> {
-        self.mmap_storage.get(key)
-    }
-
-    fn get_sequential(&self, key: VectorOffsetType) -> Option<&[T]> {
-        self.mmap_storage.get_sequential(key)
+    fn get<P: AccessPattern>(&self, key: VectorOffsetType) -> Option<&[T]> {
+        self.mmap_storage.get::<P>(key)
     }
 
     #[inline]
@@ -95,13 +92,8 @@ impl<T: Sized + Copy + Clone + Default + 'static> ChunkedVectorStorage<T>
     }
 
     #[inline]
-    fn get_many(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
-        self.mmap_storage.get_many(key, count)
-    }
-
-    #[inline]
-    fn get_many_sequential(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
-        self.mmap_storage.get_many_sequential(key, count)
+    fn get_many<P: AccessPattern>(&self, key: VectorOffsetType, count: usize) -> Option<&[T]> {
+        self.mmap_storage.get_many::<P>(key, count)
     }
 
     #[inline]

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -23,7 +23,7 @@ use crate::vector_storage::bitvec::bitvec_set_deleted;
 use crate::vector_storage::chunked_vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::common::{CHUNK_SIZE, StoredRecord};
-use crate::vector_storage::{MultiVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{AccessPattern, MultiVectorStorage, VectorStorage, VectorStorageEnum};
 
 type StoredMultiDenseVector<T> = StoredRecord<TypedMultiDenseVector<T>>;
 
@@ -335,12 +335,16 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     }
 
     /// Panics if key is out of bounds
-    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
-        self.get_multi_opt(key).expect("vector not found")
+    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
+        self.get_multi_opt::<P>(key).expect("vector not found")
     }
 
     /// None if key is out of bounds
-    fn get_multi_opt(&self, key: PointOffsetType) -> Option<TypedMultiDenseVectorRef<'_, T>> {
+    fn get_multi_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
+        // No sequential optimizations available for in memory storage.
         self.vectors_metadata.get(key as usize).map(|metadata| {
             let flattened_vectors = self
                 .vectors
@@ -351,14 +355,6 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
                 dim: self.dim,
             }
         })
-    }
-
-    fn get_multi_opt_sequential(
-        &self,
-        key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
-        // No sequential optimizations available for in memory storage.
-        self.get_multi_opt(key)
     }
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {
@@ -400,16 +396,12 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
         self.vectors_metadata.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> CowVector<'_> {
-        self.get_vector_opt(key).expect("vector not found")
+    fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
+        self.get_vector_opt::<P>(key).expect("vector not found")
     }
 
-    fn get_vector_sequential(&self, key: PointOffsetType) -> CowVector<'_> {
-        self.get_vector(key)
-    }
-
-    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
-        self.get_multi_opt(key).map(|multi_dense_vector| {
+    fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
+        self.get_multi_opt::<P>(key).map(|multi_dense_vector| {
             CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
                 multi_dense_vector,
             )))
@@ -487,6 +479,7 @@ mod tests {
     use crate::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
     use crate::data_types::vectors::MultiDenseVectorInternal;
     use crate::segment_constructor::migrate_rocksdb_multi_dense_vector_storage_to_mmap;
+    use crate::vector_storage::Sequential;
 
     const RAND_SEED: u64 = 42;
 
@@ -576,7 +569,7 @@ mod tests {
             .collect::<Vec<Vec<_>>>();
             let multivec = MultiDenseVectorInternal::try_from(vectors).unwrap();
             assert_eq!(
-                new_storage.get_vector_sequential(internal_id),
+                new_storage.get_vector::<Sequential>(internal_id),
                 CowVector::from(&multivec),
             );
             assert_eq!(

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -4,6 +4,7 @@ use common::types::PointOffsetType;
 use memory::mmap_type::MmapFlusher;
 
 use crate::common::operation_error::OperationResult;
+use crate::vector_storage::Random;
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
 
@@ -19,7 +20,8 @@ impl QuantizedChunkedMmapStorage {
 
 impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
     fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
-        ChunkedVectorStorage::get(&self.data, index as VectorOffsetType).unwrap_or_default()
+        ChunkedVectorStorage::get::<Random>(&self.data, index as VectorOffsetType)
+            .unwrap_or_default()
     }
 
     fn upsert_vector(

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType};
 use crate::types::{MultiVectorComparator, MultiVectorConfig};
+use crate::vector_storage::Random;
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
 
@@ -198,7 +199,7 @@ impl MultivectorOffsetsStorageChunkedMmap {
 
 impl MultivectorOffsetsStorage for MultivectorOffsetsStorageChunkedMmap {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
-        ChunkedVectorStorage::get(&self.data, idx as VectorOffsetType)
+        ChunkedVectorStorage::get::<Random>(&self.data, idx as VectorOffsetType)
             .and_then(|offsets| offsets.first())
             .cloned()
             .unwrap_or_default()

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -39,8 +39,8 @@ use crate::vector_storage::quantized::quantized_ram_storage::{
     QuantizedRamStorage, QuantizedRamStorageBuilder,
 };
 use crate::vector_storage::{
-    DenseVectorStorage, MultiVectorStorage, RawScorer, RawScorerImpl, VectorStorage,
-    VectorStorageEnum,
+    DenseVectorStorage, MultiVectorStorage, Random, RawScorer, RawScorerImpl, Sequential,
+    VectorStorage, VectorStorageEnum,
 };
 
 pub const QUANTIZED_CONFIG_PATH: &str = "quantized.config.json";
@@ -532,7 +532,7 @@ impl QuantizedVectors {
             PrimitiveVectorElement::quantization_preprocess(
                 quantization_config,
                 distance,
-                vector_storage.get_dense_sequential(i),
+                vector_storage.get_dense::<Sequential>(i),
             )
         });
         let on_disk_vector_storage = vector_storage.is_on_disk();
@@ -618,7 +618,7 @@ impl QuantizedVectors {
             Self::construct_vector_parameters(distance, dim, inner_vectors_count);
 
         let offsets = (0..vectors_count as PointOffsetType)
-            .map(|idx| vector_storage.get_multi(idx).vectors_count() as PointOffsetType)
+            .map(|idx| vector_storage.get_multi::<Random>(idx).vectors_count() as PointOffsetType)
             .scan(0, |offset_acc, multi_vector_len| {
                 let offset = *offset_acc;
                 *offset_acc += multi_vector_len;

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -9,10 +9,10 @@ use common::types::{PointOffsetType, ScoreType};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{DenseVector, TypedDenseVector};
 use crate::spaces::metric::Metric;
-use crate::vector_storage::DenseVectorStorage;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
+use crate::vector_storage::{DenseVectorStorage, Random};
 
 pub struct CustomQueryScorer<
     'a,
@@ -84,7 +84,7 @@ impl<
 
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        let stored = self.vector_storage.get_dense(idx);
+        let stored = self.vector_storage.get_dense::<Random>(idx);
         self.hardware_counter.vector_io_read().incr();
 
         self.score(stored)

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -9,9 +9,9 @@ use common::types::{PointOffsetType, ScoreType};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{TypedDenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
-use crate::vector_storage::DenseVectorStorage;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query_scorer::QueryScorer;
+use crate::vector_storage::{DenseVectorStorage, Random};
 
 pub struct MetricQueryScorer<
     'a,
@@ -70,7 +70,7 @@ impl<
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.hardware_counter.cpu_counter().incr();
         self.hardware_counter.vector_io_read().incr();
-        TMetric::similarity(&self.query, self.vector_storage.get_dense(idx))
+        TMetric::similarity(&self.query, self.vector_storage.get_dense::<Random>(idx))
     }
 
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
@@ -98,8 +98,8 @@ impl<
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         self.hardware_counter.cpu_counter().incr();
-        let v1 = self.vector_storage.get_dense(point_a);
-        let v2 = self.vector_storage.get_dense(point_b);
+        let v1 = self.vector_storage.get_dense::<Random>(point_a);
+        let v2 = self.vector_storage.get_dense::<Random>(point_b);
         TMetric::similarity(v1, v2)
     }
 

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -12,10 +12,10 @@ use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef,
 };
 use crate::spaces::metric::Metric;
-use crate::vector_storage::MultiVectorStorage;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
+use crate::vector_storage::{MultiVectorStorage, Random};
 
 pub struct MultiCustomQueryScorer<
     'a,
@@ -117,7 +117,7 @@ impl<
 
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        let stored = self.vector_storage.get_multi(idx);
+        let stored = self.vector_storage.get_multi::<Random>(idx);
         self.hardware_counter
             .vector_io_read()
             .incr_delta(stored.vectors_count());

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -12,9 +12,9 @@ use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef,
 };
 use crate::spaces::metric::Metric;
-use crate::vector_storage::MultiVectorStorage;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query_scorer::QueryScorer;
+use crate::vector_storage::{MultiVectorStorage, Random};
 
 pub struct MultiMetricQueryScorer<
     'a,
@@ -94,7 +94,7 @@ impl<
 
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        let stored = self.vector_storage.get_multi(idx);
+        let stored = self.vector_storage.get_multi::<Random>(idx);
         self.hardware_counter
             .vector_io_read()
             .incr_delta(stored.vectors_count());
@@ -131,8 +131,8 @@ impl<
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
-        let v1 = self.vector_storage.get_multi(point_a);
-        let v2 = self.vector_storage.get_multi(point_b);
+        let v1 = self.vector_storage.get_multi::<Random>(point_a);
+        let v2 = self.vector_storage.get_multi::<Random>(point_b);
         self.hardware_counter
             .vector_io_read()
             .incr_delta(v1.vectors_count() + v2.vectors_count());

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -4,9 +4,9 @@ use common::types::{PointOffsetType, ScoreType};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::{DimId, DimWeight};
 
-use crate::vector_storage::SparseVectorStorage;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
+use crate::vector_storage::{Random, SparseVectorStorage};
 
 pub struct SparseCustomQueryScorer<
     'a,
@@ -60,7 +60,7 @@ impl<TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScor
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let stored = self
             .vector_storage
-            .get_sparse(idx)
+            .get_sparse::<Random>(idx)
             .expect("Failed to get sparse vector");
 
         // not exactly correct for Gridstore where the indices are compressed into u8

--- a/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
@@ -3,9 +3,9 @@ use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
 use sparse::common::sparse_vector::SparseVector;
 
-use crate::vector_storage::SparseVectorStorage;
 use crate::vector_storage::query_scorer::QueryScorer;
 use crate::vector_storage::sparse::volatile_sparse_vector_storage::VolatileSparseVectorStorage;
+use crate::vector_storage::{Random, SparseVectorStorage};
 
 pub struct SparseMetricQueryScorer<'a> {
     vector_storage: &'a VolatileSparseVectorStorage,
@@ -54,7 +54,7 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let stored = self
             .vector_storage
-            .get_sparse(idx)
+            .get_sparse::<Random>(idx)
             .expect("Sparse vector not found");
 
         self.score_ref(&stored)
@@ -72,7 +72,7 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
             scores[idx] = self.score_ref(
                 &self
                     .vector_storage
-                    .get_sparse(ids[idx])
+                    .get_sparse::<Random>(ids[idx])
                     .expect("Sparse vector not found"),
             );
         }
@@ -81,11 +81,11 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         let v1 = self
             .vector_storage
-            .get_sparse(point_a)
+            .get_sparse::<Random>(point_a)
             .expect("Sparse vector not found");
         let v2 = self
             .vector_storage
-            .get_sparse(point_b)
+            .get_sparse::<Random>(point_b)
             .expect("Sparse vector not found");
 
         self.score_sparse(&v1, &v2)

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -11,10 +11,10 @@ use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTracker;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::Distance;
-use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use crate::vector_storage::vector_storage_base::VectorStorage;
+use crate::vector_storage::{Random, VectorStorageEnum};
 
 #[test]
 fn async_raw_scorer_cosine() -> Result<()> {
@@ -66,7 +66,7 @@ fn test_async_raw_scorer(
 
         let mut iter = (0..points).map(|i| {
             let i = i as PointOffsetType;
-            let vec = volatile_storage.get_vector(i);
+            let vec = volatile_storage.get_vector::<Random>(i);
             let deleted = volatile_storage.is_deleted_vector(i);
             (vec, deleted)
         });

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -21,12 +21,12 @@ use crate::types::{
     BinaryQuantizationConfig, Distance, ProductQuantizationConfig, QuantizationConfig,
     ScalarQuantizationConfig,
 };
-use crate::vector_storage::VectorStorageEnum;
 #[cfg(target_os = "linux")]
 use crate::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::vector_storage_base::VectorStorage;
+use crate::vector_storage::{Random, VectorStorageEnum};
 
 const DIMS: usize = 128;
 const NUM_POINTS: usize = 600;
@@ -143,7 +143,7 @@ fn scoring_equivalency(
 
     let mut iter = (0..NUM_POINTS).map(|i| {
         let i = i as PointOffsetType;
-        let vec = raw_storage.get_vector(i);
+        let vec = raw_storage.get_vector::<Random>(i);
         let deleted = raw_storage.is_deleted_vector(i);
         (vec, deleted)
     });

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -18,7 +18,9 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendab
 use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_full_vector_storage;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::{
+    DEFAULT_STOPPED, Random, VectorStorage, VectorStorageEnum, new_raw_scorer,
+};
 
 fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     let points = [
@@ -136,7 +138,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         }
         let mut iter = (0..points.len()).map(|i| {
             let i = i as PointOffsetType;
-            let vec = storage2.get_vector(i);
+            let vec = storage2.get_vector::<Random>(i);
             let deleted = storage2.is_deleted_vector(i);
             (vec, deleted)
         });

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -19,7 +19,7 @@ use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_full;
 use crate::vector_storage::multi_dense::volatile_multi_dense_vector_storage::new_volatile_multi_dense_vector_storage;
 use crate::vector_storage::{
-    DEFAULT_STOPPED, MultiVectorStorage, VectorStorage, VectorStorageEnum,
+    DEFAULT_STOPPED, MultiVectorStorage, Random, VectorStorage, VectorStorageEnum,
 };
 
 #[derive(Clone, Copy)]
@@ -67,7 +67,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     }
     // Check that all points are inserted
     for (i, vec) in points.iter().enumerate() {
-        let stored_vec = storage.get_vector(i as PointOffsetType);
+        let stored_vec = storage.get_vector::<Random>(i as PointOffsetType);
         let multi_dense: TypedMultiDenseVectorRef<_> = stored_vec.as_vec_ref().try_into().unwrap();
         assert_eq!(multi_dense.to_owned(), vec.clone());
     }
@@ -223,7 +223,7 @@ fn do_test_update_from_delete_points(
         }
         let mut iter = (0..points.len()).map(|i| {
             let i = i as PointOffsetType;
-            let vec = storage2.get_vector(i);
+            let vec = storage2.get_vector::<Random>(i);
             let deleted = storage2.is_deleted_vector(i);
             (vec, deleted)
         });
@@ -318,7 +318,11 @@ fn test_delete_points_in_multi_dense_vector_storage(#[case] storage_type: MultiD
     );
     // retrieve all vectors from storage
     for id in 0..total_vector_count {
-        assert!(storage.get_vector_opt(id as PointOffsetType).is_some());
+        assert!(
+            storage
+                .get_vector_opt::<Random>(id as PointOffsetType)
+                .is_some()
+        );
     }
 }
 
@@ -346,7 +350,11 @@ fn test_update_from_delete_points_multi_dense_vector_storage(
     );
     // retrieve all vectors from storage
     for id in 0..total_vector_count {
-        assert!(storage.get_vector_opt(id as PointOffsetType).is_some());
+        assert!(
+            storage
+                .get_vector_opt::<Random>(id as PointOffsetType)
+                .is_some()
+        );
     }
 }
 
@@ -389,7 +397,11 @@ fn test_delete_points_in_volatile_multi_dense_vector_storage() {
 
     // retrieve all vectors from storage
     for id in 0..storage.total_vector_count() {
-        assert!(storage.get_vector_opt(id as PointOffsetType).is_some());
+        assert!(
+            storage
+                .get_vector_opt::<Random>(id as PointOffsetType)
+                .is_some()
+        );
     }
 }
 
@@ -406,7 +418,11 @@ fn test_update_from_delete_points_volatile_multi_dense_vector_storage() {
 
     // retrieve all vectors from storage
     for id in 0..storage.total_vector_count() {
-        assert!(storage.get_vector_opt(id as PointOffsetType).is_some());
+        assert!(
+            storage
+                .get_vector_opt::<Random>(id as PointOffsetType)
+                .is_some()
+        );
     }
 }
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -20,7 +20,7 @@ use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorS
 #[cfg(feature = "rocksdb")]
 use crate::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use crate::vector_storage::sparse::volatile_sparse_vector_storage::new_volatile_sparse_vector_storage;
-use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{DEFAULT_STOPPED, Random, VectorStorage, VectorStorageEnum};
 
 fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     let points: Vec<SparseVector> = vec![
@@ -51,7 +51,7 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
 
     // Check that all points are inserted
     for (i, vec) in points.iter().enumerate() {
-        let stored_vec = storage.get_vector(i as PointOffsetType);
+        let stored_vec = storage.get_vector::<Random>(i as PointOffsetType);
         let sparse: &SparseVector = stored_vec.as_vec_ref().try_into().unwrap();
         assert_eq!(sparse, vec);
     }
@@ -150,7 +150,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
 
         let mut iter = (0..points.len()).map(|i| {
             let i = i as PointOffsetType;
-            let vec = storage2.get_vector(i);
+            let vec = storage2.get_vector::<Random>(i);
             let deleted = storage2.is_deleted_vector(i);
             (vec, deleted)
         });
@@ -244,15 +244,15 @@ fn do_test_persistence(open: impl Fn(&Path) -> VectorStorageEnum) {
 
     // Check deleted vectors are still marked as deleted
     assert!(storage.is_deleted_vector(1));
-    assert!(storage.get_vector_opt(1).is_none());
+    assert!(storage.get_vector_opt::<Random>(1).is_none());
 
     assert!(storage.is_deleted_vector(3));
-    assert!(storage.get_vector_opt(3).is_none());
+    assert!(storage.get_vector_opt::<Random>(3).is_none());
 
     // Check non-deleted vectors still have correct data
     let verify_idx = [0, 2, 4];
     for idx in verify_idx {
-        let stored = storage.get_vector(idx);
+        let stored = storage.get_vector::<Random>(idx);
         let sparse: &SparseVector = stored.as_vec_ref().try_into().unwrap();
         assert_eq!(sparse, &points[idx as usize]);
     }

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -30,7 +30,7 @@ use segment::types::{
     SegmentConfig, SeqNumberType, SparseVectorDataConfig, SparseVectorStorageType, VectorName,
     VectorStorageDatatype,
 };
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::{Random, VectorStorage};
 use segment::{fixture_for_all_indices, payload_json};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_full_sparse_vector, random_sparse_vector};
@@ -147,14 +147,13 @@ fn sparse_vector_index_fallback_plain_search() {
 }
 
 /// Checks that the sparse vector index is consistent with the underlying storage
-#[cfg(test)]
 fn check_index_storage_consistency<T: InvertedIndex>(sparse_vector_index: &SparseVectorIndex<T>) {
     let borrowed_vector_storage = sparse_vector_index.vector_storage().borrow();
     let point_count = borrowed_vector_storage.available_vector_count();
     let hw_counter = HardwareCounterCell::disposable();
     for id in 0..point_count as PointOffsetType {
         // assuming no deleted points
-        let vector = borrowed_vector_storage.get_vector(id);
+        let vector = borrowed_vector_storage.get_vector::<Random>(id);
         let vector: &SparseVector = vector.as_vec_ref().try_into().unwrap();
         let remapped_vector = sparse_vector_index
             .indices_tracker()


### PR DESCRIPTION
This PR removes duplications of `get_something`/`get_something_sequential` by replacing them with a single generic method. Similar to #6750.

Before this PR:
```rust
fn get_dense(&self, key: PointOffsetType) -> &[T] {
    self.mmap_store
        .as_ref()
        .unwrap()
        .get_vector_opt(key)
        .unwrap_or_else(|| panic!("vector not found: {key}"))
}

fn get_dense_sequential(&self, key: PointOffsetType) -> &[T] {
    self.mmap_store
        .as_ref()
        .unwrap()
        .get_vector_opt_sequential(key)
        .unwrap_or_else(|| panic!("vector not found: {key}"))
}

let _ = vector_storage.get_dense(i);
let _ = vector_storage.get_dense_sequential(i);
```

After this PR:
```rust
fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> &[T] {
    self.mmap_store
        .as_ref()
        .unwrap()
        .get_vector_opt::<P>(key)
        .unwrap_or_else(|| panic!("vector not found: {key}"))
}

let _ = vector_storage.get_dense::<Random>(i);
let _ = vector_storage.get_dense::<Sequential>(i);
```