### PR TITLE
Qdrant on Edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "edge"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "common",
+ "log",
+ "parking_lot",
+ "segment",
+ "shard",
+ "thiserror 2.0.16",
+ "wal",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,6 +310,7 @@ members = [
     "lib/api",
     "lib/collection",
     "lib/common/*",
+    "lib/edge",
     "lib/gridstore",
     "lib/macros",
     "lib/posting_list",

--- a/lib/collection/src/collection_manager/mod.rs
+++ b/lib/collection/src/collection_manager/mod.rs
@@ -4,7 +4,6 @@ pub mod optimizers;
 pub mod segments_searcher;
 
 pub mod probabilistic_search_sampling;
-mod search_result_aggregator;
 
 #[cfg(test)]
 pub(crate) mod fixtures;

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -18,6 +18,7 @@ use segment::types::{
     Filter, Indexes, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SeqNumberType,
     VectorName, WithPayload, WithPayloadInterface, WithVector,
 };
+use shard::search_result_aggregator::BatchResultAggregator;
 use tinyvec::TinyVec;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
@@ -25,7 +26,6 @@ use tokio::task::JoinHandle;
 use super::holders::segment_holder::LockedSegmentHolder;
 use crate::collection_manager::holders::segment_holder::LockedSegment;
 use crate::collection_manager::probabilistic_search_sampling::find_search_sampling_over_point_distribution;
-use crate::collection_manager::search_result_aggregator::BatchResultAggregator;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::config::CollectionConfigInternal;
 use crate::operations::query_enum::QueryEnum;

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -286,11 +286,9 @@ impl LocalShard {
         let wal_path = Self::wal_path(shard_path);
         let segments_path = Self::segments_path(shard_path);
 
-        let wal: SerdeWal<OperationWithClockTag> = SerdeWal::new(
-            wal_path.to_str().unwrap(),
-            (&collection_config_read.wal_config).into(),
-        )
-        .map_err(|e| CollectionError::service_error(format!("Wal error: {e}")))?;
+        let wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(&wal_path, (&collection_config_read.wal_config).into())
+                .map_err(|e| CollectionError::service_error(format!("Wal error: {e}")))?;
 
         // Walk over segments directory and collect all directory entries now
         // Collect now and error early to prevent errors while we've already spawned load threads
@@ -573,7 +571,7 @@ impl LocalShard {
         }
 
         let wal: SerdeWal<OperationWithClockTag> =
-            SerdeWal::new(wal_path.to_str().unwrap(), (&config.wal_config).into())?;
+            SerdeWal::new(&wal_path, (&config.wal_config).into())?;
 
         let optimizers = build_optimizers(
             shard_path,

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -288,7 +288,7 @@ mod tests {
             segment_queue_len: 0,
             retain_closed: NonZeroUsize::new(1).unwrap(),
         };
-        let wal = SerdeWal::new(dir.path().to_str().unwrap(), options).unwrap();
+        let wal = SerdeWal::new(dir.path(), options).unwrap();
         (
             RecoverableWal::new(
                 Arc::new(Mutex::new(wal)),

--- a/lib/edge/Cargo.toml
+++ b/lib/edge/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "edge"
+version = "0.1.0"
+authors = ["Qdrant Team <info@qdrant.tech>"]
+license = "Apache-2.0"
+edition = "2024"
+
+
+[dependencies]
+common = { path = "../common/common" }
+segment = { path = "../segment", default-features = false }
+shard = { path = "../shard" }
+
+log = { workspace = true }
+parking_lot = { workspace = true }
+thiserror = { workspace = true }
+wal = { workspace = true }
+
+
+[dev-dependencies]
+anyhow = "1.0"

--- a/lib/edge/examples/edge-cli.rs
+++ b/lib/edge/examples/edge-cli.rs
@@ -1,0 +1,13 @@
+use std::env;
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<_> = env::args().skip(1).take(2).collect();
+
+    let [edge_shard_path] = args
+        .try_into()
+        .map_err(|args| anyhow::format_err!("unexpected arguments {args:?}"))?;
+
+    let _edge_shard = edge::Shard::load(Path::new(&edge_shard_path), None)?;
+    Ok(())
+}

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -59,7 +59,7 @@ impl Shard {
         if !segments_path.exists() {
             fs::create_dir(&segments_path).map_err(|err| {
                 OperationError::service_error(format!(
-                    "failed to create segmens directory {}: {err}",
+                    "failed to create segments directory {}: {err}",
                     segments_path.display(),
                 ))
             })?;

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -1,0 +1,319 @@
+use std::num::NonZero;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::{fmt, fs};
+
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::save_on_disk::SaveOnDisk;
+use parking_lot::Mutex;
+use segment::common::operation_error::{OperationError, OperationResult};
+use segment::data_types::query_context::QueryContext;
+use segment::data_types::vectors::QueryVector;
+use segment::entry::SegmentEntry;
+use segment::segment_constructor::load_segment;
+use segment::types::{DEFAULT_FULL_SCAN_THRESHOLD, ScoredPoint, SegmentConfig, WithPayload};
+use shard::operations::CollectionUpdateOperations;
+use shard::search::CoreSearchRequest;
+use shard::search_result_aggregator::BatchResultAggregator;
+use shard::segment_holder::{LockedSegmentHolder, SegmentHolder};
+use shard::update::*;
+use shard::wal::SerdeWal;
+use wal::WalOptions;
+
+#[derive(Debug)]
+pub struct Shard {
+    _path: PathBuf,
+    config: SegmentConfig,
+    wal: Mutex<SerdeWal<CollectionUpdateOperations>>,
+    segments: LockedSegmentHolder,
+}
+
+const WAL_PATH: &str = "wal";
+const SEGMENTS_PATH: &str = "segments";
+
+impl Shard {
+    pub fn load(path: &Path, mut config: Option<SegmentConfig>) -> OperationResult<Self> {
+        let wal_path = path.join(WAL_PATH);
+        let wal: SerdeWal<CollectionUpdateOperations> =
+            SerdeWal::new(&wal_path, default_wal_options()).map_err(|err| {
+                OperationError::service_error(format!(
+                    "failed to open WAL {}: {err}",
+                    wal_path.display()
+                ))
+            })?;
+
+        let segments_path = path.join(SEGMENTS_PATH);
+        let segments_dir = fs::read_dir(&segments_path).map_err(|err| {
+            OperationError::service_error(format!(
+                "failed to read segments directory {}: {err}",
+                segments_path.display()
+            ))
+        })?;
+
+        let mut segments = SegmentHolder::default();
+
+        for entry in segments_dir {
+            let entry = entry.map_err(|err| {
+                OperationError::service_error(format!(
+                    "failed to read entry in segments directory {}: {err}",
+                    segments_path.display()
+                ))
+            })?;
+
+            let segment_path = entry.path();
+
+            if !segment_path.is_dir() {
+                log::warn!(
+                    "Skipping non-directory segment entry {}",
+                    segment_path.display(),
+                );
+
+                continue;
+            }
+
+            if let Some(name) = segment_path.file_name()
+                && let Some(name) = name.to_str()
+                && name.starts_with(".")
+            {
+                log::warn!(
+                    "Skipping hidden segment directory {}",
+                    segment_path.display()
+                );
+                continue;
+            }
+
+            let segment = load_segment(&segment_path, &AtomicBool::new(false)).map_err(|err| {
+                OperationError::service_error(format!(
+                    "failed to load segment {}: {err}",
+                    segment_path.display()
+                ))
+            })?;
+
+            let Some(mut segment) = segment else {
+                fs::remove_dir_all(&segment_path).map_err(|err| {
+                    OperationError::service_error(format!(
+                        "failed to remove leftover segment {}: {err}",
+                        segment_path.display(),
+                    ))
+                })?;
+
+                continue;
+            };
+
+            if let Some(config) = &config {
+                if !config.is_compatible(segment.config()) {
+                    return Err(OperationError::service_error(format!(
+                        "segment {} is incompatible with provided config or previously loaded segments: \
+                         expected {:?}, but received {:?}",
+                        segment_path.display(),
+                        config,
+                        segment.config(),
+                    )));
+                }
+            } else {
+                config = Some(segment.config().clone());
+            }
+
+            segment.check_consistency_and_repair().map_err(|err| {
+                OperationError::service_error(format!(
+                    "failed to repair segment {}: {err}",
+                    segment_path.display()
+                ))
+            })?;
+
+            segments.add_new(segment);
+        }
+
+        if !segments.has_appendable_segment() {
+            let Some(config) = &config else {
+                return Err(OperationError::service_error(
+                    "segment config is not provided and no segments were loaded",
+                ));
+            };
+
+            let payload_index_schema_path = path.join("payload_index.json");
+            let payload_index_schema = SaveOnDisk::load_or_init_default(&payload_index_schema_path)
+                .map_err(|err| {
+                    OperationError::service_error(format!(
+                        "failed to initialize temporary payload index schema file {}: {err}",
+                        payload_index_schema_path.display(),
+                    ))
+                })?;
+
+            segments.create_appendable_segment(
+                &segments_path,
+                config.clone(),
+                Arc::new(payload_index_schema),
+            )?;
+
+            debug_assert!(segments.has_appendable_segment());
+        }
+
+        let shard = Self {
+            _path: path.into(),
+            config: config.expect("config was provided or at least one segment was loaded"),
+            wal: parking_lot::Mutex::new(wal),
+            segments: Arc::new(parking_lot::RwLock::new(segments)),
+        };
+
+        Ok(shard)
+    }
+
+    pub fn config(&self) -> &SegmentConfig {
+        &self.config
+    }
+
+    pub fn update(&self, operation: CollectionUpdateOperations) -> OperationResult<()> {
+        let mut wal = self.wal.lock();
+
+        let operation_id = wal.write(&operation).map_err(service_error)?;
+        let hw_counter = HardwareCounterCell::disposable();
+
+        let result = match operation {
+            CollectionUpdateOperations::PointOperation(point_operation) => {
+                process_point_operation(&self.segments, operation_id, point_operation, &hw_counter)
+            }
+            CollectionUpdateOperations::VectorOperation(vector_operation) => {
+                process_vector_operation(
+                    &self.segments,
+                    operation_id,
+                    vector_operation,
+                    &hw_counter,
+                )
+            }
+            CollectionUpdateOperations::PayloadOperation(payload_operation) => {
+                process_payload_operation(
+                    &self.segments,
+                    operation_id,
+                    payload_operation,
+                    &hw_counter,
+                )
+            }
+            CollectionUpdateOperations::FieldIndexOperation(index_operation) => {
+                process_field_index_operation(
+                    &self.segments,
+                    operation_id,
+                    &index_operation,
+                    &hw_counter,
+                )
+            }
+        };
+
+        result.map(|_| ())
+    }
+
+    pub fn search(&self, search: CoreSearchRequest) -> OperationResult<Vec<ScoredPoint>> {
+        let segments: Vec<_> = self
+            .segments
+            .read()
+            .non_appendable_then_appendable_segments()
+            .collect();
+
+        let CoreSearchRequest {
+            query,
+            filter,
+            params,
+            limit,
+            offset,
+            with_payload,
+            with_vector,
+            score_threshold,
+        } = search;
+
+        let vector_name = query.get_vector_name().to_string();
+        let query_vector = QueryVector::from(query);
+        let with_payload = WithPayload::from(with_payload.unwrap_or_default());
+        let with_vector = with_vector.unwrap_or_default();
+
+        let context =
+            QueryContext::new(DEFAULT_FULL_SCAN_THRESHOLD, HwMeasurementAcc::disposable());
+
+        let mut points_by_segment = Vec::with_capacity(segments.len());
+
+        for segment in segments {
+            let batched_points = segment.get().read().search_batch(
+                &vector_name,
+                &[&query_vector],
+                &with_payload,
+                &with_vector,
+                filter.as_ref(),
+                offset + limit,
+                params.as_ref(),
+                &context.get_segment_query_context(),
+            )?;
+
+            debug_assert_eq!(batched_points.len(), 1);
+
+            let [points] = batched_points
+                .try_into()
+                .expect("single batched search result");
+
+            points_by_segment.push(points);
+        }
+
+        let mut aggregator = BatchResultAggregator::new([offset + limit]);
+        aggregator.update_point_versions(points_by_segment.iter().flatten());
+
+        for points in points_by_segment {
+            aggregator.update_batch_results(0, points);
+        }
+
+        let [mut points] = aggregator
+            .into_topk()
+            .try_into()
+            .expect("single batched search result");
+
+        let distance = self
+            .config
+            .vector_data
+            .get(&vector_name)
+            .expect("vector config exist")
+            .distance;
+
+        match &query_vector {
+            QueryVector::Nearest(_) => {
+                for point in &mut points {
+                    point.score = distance.postprocess_score(point.score);
+                }
+            }
+
+            QueryVector::RecommendBestScore(_) => (),
+            QueryVector::RecommendSumScores(_) => (),
+            QueryVector::Discovery(_) => (),
+            QueryVector::Context(_) => (),
+        }
+
+        if let Some(score_threshold) = score_threshold {
+            debug_assert!(
+                points.is_sorted_by(|left, right| distance.is_ordered(left.score, right.score)),
+            );
+
+            let below_threshold = points
+                .iter()
+                .enumerate()
+                .find(|(_, point)| !distance.check_threshold(point.score, score_threshold));
+
+            if let Some((below_threshold_idx, _)) = below_threshold {
+                points.truncate(below_threshold_idx);
+            }
+        }
+
+        let _ = points.drain(..offset);
+
+        Ok(points)
+    }
+}
+
+fn default_wal_options() -> WalOptions {
+    WalOptions {
+        segment_capacity: 32 * 1024 * 1024,
+        segment_queue_len: 0,
+        retain_closed: NonZero::new(1).unwrap(),
+    }
+}
+
+fn service_error(err: impl fmt::Display) -> OperationError {
+    OperationError::service_error(err.to_string())
+}

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3298,22 +3298,28 @@ impl From<bool> for WithPayload {
     }
 }
 
-impl From<&WithPayloadInterface> for WithPayload {
-    fn from(interface: &WithPayloadInterface) -> Self {
+impl From<WithPayloadInterface> for WithPayload {
+    fn from(interface: WithPayloadInterface) -> Self {
         match interface {
-            WithPayloadInterface::Bool(x) => WithPayload {
-                enable: *x,
+            WithPayloadInterface::Bool(enable) => WithPayload {
+                enable,
                 payload_selector: None,
             },
-            WithPayloadInterface::Fields(x) => WithPayload {
+            WithPayloadInterface::Fields(fields) => WithPayload {
                 enable: true,
-                payload_selector: Some(PayloadSelector::new_include(x.clone())),
+                payload_selector: Some(PayloadSelector::new_include(fields)),
             },
-            WithPayloadInterface::Selector(x) => WithPayload {
+            WithPayloadInterface::Selector(selector) => WithPayload {
                 enable: true,
-                payload_selector: Some(x.clone()),
+                payload_selector: Some(selector),
             },
         }
+    }
+}
+
+impl From<&WithPayloadInterface> for WithPayload {
+    fn from(interface: &WithPayloadInterface) -> Self {
+        WithPayload::from(interface.clone())
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -331,6 +331,13 @@ impl Distance {
         }
     }
 
+    pub fn is_ordered(&self, left: ScoreType, right: ScoreType) -> bool {
+        match self.distance_order() {
+            Order::LargeBetter => left >= right,
+            Order::SmallBetter => left <= right,
+        }
+    }
+
     /// Checks if score satisfies threshold condition
     pub fn check_threshold(&self, score: ScoreType, threshold: ScoreType) -> bool {
         match self.distance_order() {
@@ -1328,7 +1335,7 @@ impl PayloadStorageType {
     }
 }
 
-#[derive(Anonymize, Default, Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, JsonSchema, Anonymize)]
 #[serde(rename_all = "snake_case")]
 pub struct SegmentConfig {
     #[serde(default)]
@@ -1398,6 +1405,56 @@ impl SegmentConfig {
             )
             .all(|v| v)
     }
+
+    pub fn is_compatible(&self, other: &Self) -> bool {
+        // Vector data have to be compatible between two segments.
+        // Sparse vector data can be different, but a placeholder check is implemented to catch
+        // and enforce compatibility check for future changes.
+        // Payload storage type can be different.
+
+        // Assert segment config fields
+        let Self {
+            vector_data: _,
+            sparse_vector_data: _,
+            payload_storage_type: _,
+        } = self;
+
+        let is_vector_config_compatible = is_map_compatible(
+            &self.vector_data,
+            &other.vector_data,
+            VectorDataConfig::is_compatible,
+        );
+
+        let is_sparse_vector_config_compatible = is_map_compatible(
+            &self.sparse_vector_data,
+            &other.sparse_vector_data,
+            SparseVectorDataConfig::is_compatible,
+        );
+
+        is_vector_config_compatible && is_sparse_vector_config_compatible
+    }
+}
+
+fn is_map_compatible<V, C, F>(this: &HashMap<V, C>, other: &HashMap<V, C>, check: F) -> bool
+where
+    V: Eq + Hash,
+    F: Fn(&C, &C) -> bool,
+{
+    if this.len() != other.len() {
+        return false;
+    }
+
+    for (vector_name, config) in this {
+        let Some(other_config) = other.get(vector_name) else {
+            return false;
+        };
+
+        if !check(config, other_config) {
+            return false;
+        }
+    }
+
+    true
 }
 
 /// Storage types for vectors
@@ -1461,6 +1518,17 @@ pub struct MultiVectorConfig {
     pub comparator: MultiVectorComparator,
 }
 
+impl MultiVectorConfig {
+    fn is_compatible(&self, other: &Self) -> bool {
+        // TODO: Does comparator have to be same for two segments to be compatible? 🤔
+
+        // Assert multi-vector config fields
+        let Self { comparator: _ } = self;
+
+        self.comparator == other.comparator // TODO: 🤔
+    }
+}
+
 #[derive(
     Debug, Default, Deserialize, Serialize, JsonSchema, Anonymize, Eq, PartialEq, Copy, Clone, Hash,
 )]
@@ -1481,7 +1549,7 @@ impl VectorStorageType {
 }
 
 /// Config of single vector data storage
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Anonymize, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema, Anonymize)]
 #[serde(rename_all = "snake_case")]
 pub struct VectorDataConfig {
     /// Size/dimensionality of the vectors used
@@ -1519,9 +1587,46 @@ impl VectorDataConfig {
         };
         is_index_appendable && is_storage_appendable
     }
+
+    pub fn is_compatible(&self, other: &Self) -> bool {
+        // Size and distance have to be the same for both segments.
+        // Storage type, index and quantization config can be different.
+        //
+        // TODO: Can multivector config and datatype be different?
+
+        // Assert vector data config fields
+        let Self {
+            size: _,
+            distance: _,
+            storage_type: _,
+            index: _,
+            quantization_config: _,
+            multivector_config: _,
+            datatype: _,
+        } = self;
+
+        self.size == other.size
+            && self.distance == other.distance
+            && self.datatype == other.datatype // TODO: 🤔
+            && is_opt_compatible(
+                self.multivector_config.as_ref(),
+                other.multivector_config.as_ref(),
+                MultiVectorConfig::is_compatible,
+            )
+    }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Anonymize, Clone, Copy, Default)]
+fn is_opt_compatible<T, F: Fn(T, T) -> bool>(this: Option<T>, other: Option<T>, check: F) -> bool {
+    match (this, other) {
+        (Some(this), Some(other)) => check(this, other),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+#[derive(
+    Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize, JsonSchema, Anonymize,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum SparseVectorStorageType {
     /// Storage on disk (rocksdb storage)
@@ -1546,7 +1651,7 @@ impl SparseVectorStorageType {
 }
 
 /// Config of single sparse vector data storage
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Anonymize, Clone, Validate)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema, Validate, Anonymize)]
 #[serde(rename_all = "snake_case")]
 pub struct SparseVectorDataConfig {
     /// Sparse inverted index config
@@ -1571,6 +1676,18 @@ fn default_sparse_vector_storage_type_when_not_in_config() -> SparseVectorStorag
 
 impl SparseVectorDataConfig {
     pub fn is_indexed(&self) -> bool {
+        true
+    }
+
+    pub fn is_compatible(&self, _other: &Self) -> bool {
+        // Both index and storage type can be different for two segments to be compatible
+
+        // Assert sparse vector config fields
+        let Self {
+            index: _,
+            storage_type: _,
+        } = self;
+
         true
     }
 }

--- a/lib/shard/src/lib.rs
+++ b/lib/shard/src/lib.rs
@@ -3,6 +3,7 @@ pub mod operations;
 pub mod payload_index_schema;
 pub mod proxy_segment;
 pub mod search;
+pub mod search_result_aggregator;
 pub mod segment_holder;
 pub mod update;
 pub mod wal;

--- a/lib/shard/src/search_result_aggregator.rs
+++ b/lib/shard/src/search_result_aggregator.rs
@@ -45,7 +45,7 @@ pub struct BatchResultAggregator {
 }
 
 impl BatchResultAggregator {
-    pub fn new(tops: impl Iterator<Item = usize>) -> Self {
+    pub fn new(tops: impl IntoIterator<Item = usize>) -> Self {
         let mut merged_results_per_batch = vec![];
         for top in tops {
             merged_results_per_batch.push(SearchResultAggregator::new(top));
@@ -59,7 +59,7 @@ impl BatchResultAggregator {
 
     pub fn update_point_versions<'a>(
         &mut self,
-        all_searches_results: impl Iterator<Item = &'a ScoredPoint>,
+        all_searches_results: impl IntoIterator<Item = &'a ScoredPoint>,
     ) {
         for point in all_searches_results {
             let point_id = point.id;
@@ -79,7 +79,7 @@ impl BatchResultAggregator {
     pub fn update_batch_results(
         &mut self,
         batch_id: usize,
-        search_results: impl Iterator<Item = ScoredPoint>,
+        search_results: impl IntoIterator<Item = ScoredPoint>,
     ) {
         let aggregator = &mut self.batch_aggregators[batch_id];
         for scored_point in search_results {

--- a/lib/shard/src/wal.rs
+++ b/lib/shard/src/wal.rs
@@ -27,11 +27,11 @@ pub struct SerdeWal<R> {
 const FIRST_INDEX_FILE: &str = "first-index";
 
 impl<R: DeserializeOwned + Serialize> SerdeWal<R> {
-    pub fn new(dir: &str, wal_options: WalOptions) -> Result<SerdeWal<R>> {
+    pub fn new(dir: &Path, wal_options: WalOptions) -> Result<SerdeWal<R>> {
         let wal = Wal::with_options(dir, &wal_options)
             .map_err(|err| WalError::InitWalError(format!("{err:?}")))?;
 
-        let first_index_path = Path::new(dir).join(FIRST_INDEX_FILE);
+        let first_index_path = dir.join(FIRST_INDEX_FILE);
 
         let first_index = if first_index_path.exists() {
             let wal_state: WalState = read_json(&first_index_path).map_err(|err| {
@@ -281,8 +281,7 @@ mod tests {
             retain_closed: NonZeroUsize::new(1).unwrap(),
         };
 
-        let mut serde_wal: SerdeWal<TestRecord> =
-            SerdeWal::new(dir.path().to_str().unwrap(), wal_options).unwrap();
+        let mut serde_wal: SerdeWal<TestRecord> = SerdeWal::new(dir.path(), wal_options).unwrap();
 
         let record = TestRecord::Struct1(TestInternalStruct1 { data: 10 });
 

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -57,7 +57,7 @@ fn print_consensus_wal(wal_path: &Path) {
 
 fn print_collection_wal(wal_path: &Path) {
     let wal: Result<SerdeWal<OperationWithClockTag>, _> =
-        SerdeWal::new(wal_path.to_str().unwrap(), WalOptions::default());
+        SerdeWal::new(wal_path, WalOptions::default());
 
     match wal {
         Err(error) => {


### PR DESCRIPTION
Adds `edge` crate with a simplified `LocalShard` re-implementation, that could be used as "embeddable" (e.g., SQLite) version of Qdrant. Only implements update and search, but more stuff would be added in follow-up PRs.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
