### PR TITLE
Populate multivector quantization offsets

### DIFF
--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -3,12 +3,23 @@ use std::path::PathBuf;
 use common::types::PointOffsetType;
 use memory::mmap_type::MmapFlusher;
 
+use crate::common::operation_error::OperationResult;
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::chunked_vector_storage::{ChunkedVectorStorage, VectorOffsetType};
 
-impl quantization::EncodedStorage for ChunkedMmapVectors<u8> {
+pub struct QuantizedChunkedMmapStorage {
+    data: ChunkedMmapVectors<u8>,
+}
+
+impl QuantizedChunkedMmapStorage {
+    pub fn populate(&self) -> OperationResult<()> {
+        self.data.populate()
+    }
+}
+
+impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
     fn get_vector_data(&self, index: PointOffsetType) -> &[u8] {
-        ChunkedVectorStorage::get(self, index as VectorOffsetType).unwrap_or_default()
+        ChunkedVectorStorage::get(&self.data, index as VectorOffsetType).unwrap_or_default()
     }
 
     fn upsert_vector(
@@ -17,7 +28,7 @@ impl quantization::EncodedStorage for ChunkedMmapVectors<u8> {
         vector: &[u8],
         hw_counter: &common::counter::hardware_counter::HardwareCounterCell,
     ) -> std::io::Result<()> {
-        ChunkedVectorStorage::insert(self, id as VectorOffsetType, vector, hw_counter)
+        ChunkedVectorStorage::insert(&mut self.data, id as VectorOffsetType, vector, hw_counter)
             .map_err(std::io::Error::other)
     }
 
@@ -26,11 +37,11 @@ impl quantization::EncodedStorage for ChunkedMmapVectors<u8> {
     }
 
     fn vectors_count(&self) -> usize {
-        self.len()
+        self.data.len()
     }
 
     fn flusher(&self) -> MmapFlusher {
-        let flusher = self.flusher();
+        let flusher = self.data.flusher();
         Box::new(move || {
             Ok(flusher().map_err(|e| {
                 std::io::Error::other(format!("Failed to flush quantization storage: {e}"))
@@ -39,10 +50,10 @@ impl quantization::EncodedStorage for ChunkedMmapVectors<u8> {
     }
 
     fn files(&self) -> Vec<PathBuf> {
-        ChunkedMmapVectors::files(self)
+        ChunkedMmapVectors::files(&self.data)
     }
 
     fn immutable_files(&self) -> Vec<PathBuf> {
-        ChunkedMmapVectors::immutable_files(self)
+        ChunkedMmapVectors::immutable_files(&self.data)
     }
 }


### PR DESCRIPTION
In dev there is a bug which is hard to catch. When we call popuate for quantized multivectors, we forget to call populate for multivector offsets file, only for inner vectors.

This PR fixes it. Also, it wraps `ChunkedMmapStorage` in a separate struct to make `quantized_vectors.rs` in the segment more readable.