### PR TITLE
Quantization storage builder for chunked mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4823,6 +4823,7 @@ dependencies = [
  "memory",
  "num-traits",
  "num_threads",
+ "parking_lot",
  "permutation_iterator",
  "quantization",
  "rand 0.9.2",

--- a/lib/quantization/Cargo.toml
+++ b/lib/quantization/Cargo.toml
@@ -29,6 +29,7 @@ common = { path = "../common/common" }
 io = { path = "../common/io" }
 strum = { workspace = true }
 bytemuck = { workspace = true }
+parking_lot = { workspace = true }
 
 [dev-dependencies]
 quantization = { path = ".", features = ["testing"] }

--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -40,7 +40,7 @@ pub trait EncodedStorageBuilder {
 
     fn build(self) -> std::io::Result<Self::Storage>;
 
-    fn push_vector_data(&mut self, other: &[u8]);
+    fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()>;
 }
 
 #[cfg(feature = "testing")]
@@ -191,8 +191,9 @@ impl EncodedStorageBuilder for TestEncodedStorageBuilder {
         })
     }
 
-    fn push_vector_data(&mut self, other: &[u8]) {
+    fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {
         debug_assert_eq!(other.len(), self.quantized_vector_size.get());
         self.data.extend_from_slice(other);
+        Ok(())
     }
 }

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -471,7 +471,9 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
             let encoded_vector = Self::encode_vector(vector.as_ref(), &vector_stats, encoding);
             let encoded_vector_slice = encoded_vector.encoded_vector.as_slice();
             let bytes = transmute_to_u8_slice(encoded_vector_slice);
-            storage_builder.push_vector_data(bytes);
+            storage_builder.push_vector_data(bytes).map_err(|e| {
+                EncodingError::EncodingError(format!("Failed to push encoded vector: {e}",))
+            })?;
         }
 
         let encoded_vectors = storage_builder

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -148,7 +148,11 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
             };
             encoded_vector[0..std::mem::size_of::<f32>()]
                 .copy_from_slice(&vector_offset.to_ne_bytes());
-            storage_builder.push_vector_data(&encoded_vector);
+            storage_builder
+                .push_vector_data(&encoded_vector)
+                .map_err(|e| {
+                    EncodingError::EncodingError(format!("Failed to push encoded vector: {e}",))
+                })?;
         }
         let multiplier = match vector_parameters.distance_type {
             DistanceType::Dot => alpha * alpha,

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -88,13 +88,13 @@ impl QuantizedChunkedMmapStorageBuilder {
 }
 
 impl quantization::EncodedStorageBuilder for QuantizedChunkedMmapStorageBuilder {
-    type Storage = ChunkedMmapVectors<u8>;
+    type Storage = QuantizedChunkedMmapStorage;
 
-    fn build(self) -> std::io::Result<ChunkedMmapVectors<u8>> {
+    fn build(self) -> std::io::Result<QuantizedChunkedMmapStorage> {
         self.data.flusher()().map_err(|e| {
             std::io::Error::other(format!("Failed to flush quantization storage: {e}"))
         })?;
-        Ok(self.data)
+        Ok(QuantizedChunkedMmapStorage { data: self.data })
     }
 
     fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -1,6 +1,8 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use memory::madvise::{Advice, AdviceSetting};
 use memory::mmap_type::MmapFlusher;
 
 use crate::common::operation_error::OperationResult;
@@ -55,5 +57,50 @@ impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         ChunkedMmapVectors::immutable_files(&self.data)
+    }
+}
+
+#[allow(dead_code)]
+pub struct QuantizedChunkedMmapStorageBuilder {
+    data: ChunkedMmapVectors<u8>,
+    hw_counter: HardwareCounterCell,
+}
+
+impl QuantizedChunkedMmapStorageBuilder {
+    #[allow(dead_code)]
+    pub fn new(path: &Path, quantized_vector_size: usize, in_ram: bool) -> OperationResult<Self> {
+        let advice = if in_ram {
+            AdviceSetting::from(Advice::Normal)
+        } else {
+            AdviceSetting::Global
+        };
+        let data = ChunkedMmapVectors::<u8>::open(
+            path,
+            quantized_vector_size,
+            advice,
+            Some(in_ram), // populate
+        )?;
+        Ok(Self {
+            data,
+            hw_counter: HardwareCounterCell::disposable(),
+        })
+    }
+}
+
+impl quantization::EncodedStorageBuilder for QuantizedChunkedMmapStorageBuilder {
+    type Storage = ChunkedMmapVectors<u8>;
+
+    fn build(self) -> std::io::Result<ChunkedMmapVectors<u8>> {
+        self.data.flusher()().map_err(|e| {
+            std::io::Error::other(format!("Failed to flush quantization storage: {e}"))
+        })?;
+        Ok(self.data)
+    }
+
+    fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {
+        self.data
+            .push(other, &self.hw_counter)
+            .map(|_| ())
+            .map_err(|e| std::io::Error::other(format!("Failed to push vector data: {e}")))
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -91,10 +91,16 @@ impl quantization::EncodedStorageBuilder for QuantizedChunkedMmapStorageBuilder 
     type Storage = QuantizedChunkedMmapStorage;
 
     fn build(self) -> std::io::Result<QuantizedChunkedMmapStorage> {
-        self.data.flusher()().map_err(|e| {
+        let Self {
+            data,
+            hw_counter: _,
+        } = self;
+
+        data.flusher()().map_err(|e| {
             std::io::Error::other(format!("Failed to flush quantization storage: {e}"))
         })?;
-        Ok(QuantizedChunkedMmapStorage { data: self.data })
+
+        Ok(QuantizedChunkedMmapStorage { data })
     }
 
     fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -115,9 +115,22 @@ impl quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder {
         })
     }
 
-    fn push_vector_data(&mut self, other: &[u8]) {
+    fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {
+        debug_assert_eq!(
+            self.quantized_vector_size.get(),
+            other.len(),
+            "Pushed vector size does not match expected quantized vector size"
+        );
+        debug_assert!(
+            self.cursor_pos + other.len() <= self.mmap.len(),
+            "Overflow allocated quantization storage mmap file (cursor_pos {} + len {} > total {})",
+            self.cursor_pos,
+            other.len(),
+            self.mmap.len()
+        );
         self.mmap[self.cursor_pos..self.cursor_pos + other.len()].copy_from_slice(other);
         self.cursor_pos += other.len();
+        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -117,9 +117,10 @@ impl quantization::EncodedStorageBuilder for QuantizedRamStorageBuilder {
         })
     }
 
-    fn push_vector_data(&mut self, other: &[u8]) {
-        // Memory for ChunkedVectors are already pre-allocated,
-        // so we do not expect any errors here.
-        self.vectors.push(other).unwrap();
+    fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {
+        self.vectors
+            .push(other)
+            .map(|_| ())
+            .map_err(|e| std::io::Error::other(format!("Failed to push vector data: {e}")))
     }
 }


### PR DESCRIPTION
This PR implements quantization storage builder for `ChunkedMmap`.

It allows the use of `ChunkedMmap` for the `encoding` function in the quantization crate, which is required to build quantization from non-empty `VectorStorage`.

Because `ChunkedMmap::push` returns `Result`, this PR also changed `EncodedStorageBuilder` trait and adds `Result` to `push_vector_data` function to avoid unwarps.