### PR TITLE
Fix anchor link for Demo Projects in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Qdrant offers the following client libraries to help you integrate it into your 
 - Detailed [Documentation](https://qdrant.tech/documentation/) are great starting points
 - [Step-by-Step Tutorial](https://qdrant.to/qdrant-tutorial) to create your first neural network project with Qdrant
 
-## Demo Projects  <a href="https://replit.com/@qdrant"><img align="right" src="https://replit.com/badge/github/qdrant/qdrant" alt="Run on Repl.it"></a>
+## Demo Projects<a href="https://replit.com/@qdrant"><img align="right" src="https://replit.com/badge/github/qdrant/qdrant" alt="Run on Repl.it"></a>
 
 ### Discover Semantic Text Search 🔍
 


### PR DESCRIPTION
Hello!

I noticed the "Demo Projects" link at the top wasn't working.

It looks like the two extra spaces between the header text and the "Run on Repl.it" badge were causing GitHub to create a slightly off anchor link (#demo-projects--).

I removed those two extra spaces and the link works as expected now.
