### PR TITLE
Fix potential deadlock by unproxifying in reverse order when snapshot…

### DIFF
--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -939,6 +939,9 @@ impl SegmentHolder {
             payload_index_schema,
         )?;
 
+        // Release proxies in reverse order
+        proxies.reverse();
+
         // Apply provided function
         log::trace!("Applying function on all proxied shard segments");
         let mut result = Ok(());


### PR DESCRIPTION
This change appears to fix the following deadlock for me.

I am not 100% sure why it works in that case, but releasing locks in opposite order is good hygiene anyway,

Crasher will validate this after merge in any case.

```
2025-08-29T09:31:54.306330Z ERROR qdrant: 1 deadlocks detected
Deadlock #0
Thread Id 140478223742656
   0:     0x55aa5c7650e7 - trace
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.67/src/backtrace/libunwind.rs:93:5
                           trace_unsynchronized<backtrace::capture::{impl#1}::create::{closure_env#0}>
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.67/src/backtrace/mod.rs:66:5
   1:     0x55aa5c765072 - backtrace::backtrace::trace::hba7f459a58d1031e
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.67/src/backtrace/mod.rs:53:14
   2:     0x55aa5c72b22e - backtrace::capture::Backtrace::create::hdfa85b3e2d36f99e
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.67/src/capture.rs:176:9
   3:     0x55aa5c72b143 - backtrace::capture::Backtrace::new::h3ca878181193a20a
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.67/src/capture.rs:140:22
   4:     0x55aa5c6f21cb - on_unpark
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:1211:32
   5:     0x55aa5c6c1dc7 - parking_lot_core::parking_lot::deadlock::on_unpark::hb413745073bc9a78
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:1144:9
   6:     0x55aa5c6bf648 - parking_lot_core::parking_lot::park::{{closure}}::h1b736bb921f7ecb8
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:637:17
   7:     0x55aa5c6bd864 - with_thread_data<parking_lot_core::parking_lot::ParkResult, parking_lot_core::parking_lot::park::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#0}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#1}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#2}>>
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:207:5
                           park<parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#0}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#1}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#2}>
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:600:5
   8:     0x55aa5c6c8831 - wait_for_readers
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot-0.12.4/src/raw_rwlock.rs:1022:17
   9:     0x55aa5c6c7e6b - parking_lot::raw_rwlock::RawRwLock::upgrade_slow::h45bc131b636b3f9a
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot-0.12.4/src/raw_rwlock.rs:875:14
  10:     0x55aa5864bef8 - <parking_lot::raw_rwlock::RawRwLock as lock_api::rwlock::RawRwLockUpgrade>::upgrade::h4cb953d80e0e38cf
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot-0.12.4/src/raw_rwlock.rs:374:31
  11:     0x55aa58612bdd - lock_api::rwlock::RwLockUpgradableReadGuard<R,T>::upgrade::h6c3ec7dcabba2ca1
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lock_api-0.4.13/src/rwlock.rs:1946:26
  12:     0x55aa5860804e - try_unproxy_segment
                               at /home/runner/work/crasher/crasher/qdrant-src/lib/shard/src/segment_holder/mod.rs:1182:34
  13:     0x55aa5860587b - proxy_all_segments_and_apply<shard::segment_holder::{impl#2}::snapshot_all_segments::{closure_env#0}>
                               at /home/runner/work/crasher/crasher/qdrant-src/lib/shard/src/segment_holder/mod.rs:972:19
  14:     0x55aa58609dbb - shard::segment_holder::SegmentHolder::snapshot_all_segments::hbe3f5a4d26512143
                               at /home/runner/work/crasher/crasher/qdrant-src/lib/shard/src/segment_holder/mod.rs:1291:9
  15:     0x55aa571d1c99 - collection::shards::local_shard::LocalShard::create_snapshot::{{closure}}::{{closure}}::hf9d874baa20eebc3
                               at /home/runner/work/crasher/crasher/qdrant-src/lib/collection/src/shards/local_shard/mod.rs:890:13
  16:     0x55aa57226113 - <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll::h9499b71fdbfb7b4d
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/task.rs:42:21
  17:     0x55aa571b5e3b - tokio::runtime::task::core::Core<T,S>::poll::{{closure}}::hf7f02d7dc8fdd89a
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:365:24
  18:     0x55aa571b011a - with_mut<tokio::runtime::task::core::Stage<tokio::runtime::blocking::task::BlockingTask<collection::shards::local_shard::{impl#0}::create_snapshot::{async_fn#0}::{closure_env#0}>>, core::task::poll::Poll<core::result::Result<(), collection::operations::types::CollectionError>>, tokio::runtime::task::core::{impl#6}::poll::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<collection::shards::local_shard::{impl#0}::create_snapshot::{async_fn#0}::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/loom/std/unsafe_cell.rs:16:9
                           poll<tokio::runtime::blocking::task::BlockingTask<collection::shards::local_shard::{impl#0}::create_snapshot::{async_fn#0}::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:354:30
  19:     0x55aa571fd740 - tokio::runtime::task::harness::poll_future::{{closure}}::h26ecbe3b049dd694
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:535:30
  20:     0x55aa574d1a8d - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h4439e19fbf8d75a6
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/panic/unwind_safe.rs:272:9
  21:     0x55aa574e69de - do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<collection::shards::local_shard::{impl#0}::create_snapshot::{async_fn#0}::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>, core::task::poll::Poll<core::result::Result<(), collection::operations::types::CollectionError>>>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/panicking.rs:589:40
  22:     0x55aa57340f7b - __rust_try
  23:     0x55aa5731c39c - catch_unwind<core::task::poll::Poll<core::result::Result<(), collection::operations::types::CollectionError>>, core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<collection::shards::local_shard::{impl#0}::create_snapshot::{async_fn#0}::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/panicking.rs:552:19
                           catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<collection::shards::local_shard::{impl#0}::create_snapshot::{async_fn#0}::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>, core::task::poll::Poll<core::result::Result<(), collection::operations::types::CollectionError>>>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/panic.rs:359:14
  24:     0x55aa571f69a1 - tokio::runtime::task::harness::poll_future::h59d4c580a8ef02dd
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:523:18
  25:     0x55aa57204543 - tokio::runtime::task::harness::Harness<T,S>::poll_inner::h7e67e89a1e9355fe
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:210:27
  26:     0x55aa572105c7 - tokio::runtime::task::harness::Harness<T,S>::poll::h694c5fe5c53ccce8
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:155:20
  27:     0x55aa575e0eb0 - tokio::runtime::task::raw::poll::h08206866063d15f1
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/raw.rs:325:13
  28:     0x55aa5c674b5b - tokio::runtime::task::raw::RawTask::poll::h4eaf278e0d4650b7
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/raw.rs:255:18
  29:     0x55aa5c691c8d - tokio::runtime::task::UnownedTask<S>::run::hbccfa8b2ee3e9e88
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/mod.rs:546:13
  30:     0x55aa5c6429d6 - tokio::runtime::blocking::pool::Task::run::h196e68956bdf5a4e
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/pool.rs:161:19
  31:     0x55aa5c6473ad - run
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/pool.rs:516:22
  32:     0x55aa5c6470e4 - tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}::h141e30b2a10857a8
                               at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/pool.rs:474:47
  33:     0x55aa5c64ddc6 - __rust_begin_short_backtrace<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/sys/backtrace.rs:152:18
  34:     0x55aa5c64f352 - std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}::he5eea275499aaeb9
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/thread/mod.rs:559:17
  35:     0x55aa5c64d9b1 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h3dbfe0220a50d8af
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/panic/unwind_safe.rs:272:9
  36:     0x55aa5c6705d1 - do_call<core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>>, ()>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/panicking.rs:589:40
  37:     0x55aa5c655f7b - __rust_try
  38:     0x55aa5c64eff8 - catch_unwind<(), core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>>>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/panicking.rs:552:19
                           catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>>, ()>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/panic.rs:359:14
                           {closure#1}<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/thread/mod.rs:557:30
  39:     0x55aa5c62ab57 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h0ffcd92d1a7a5a31
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/ops/function.rs:250:5
  40:     0x55aa5c81f3cf - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h8703e59bc8145d18
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/alloc/src/boxed.rs:1966:9
                           std::sys::pal::unix::thread::Thread::new::thread_start::h1ff51d6e85162efd
                               at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/sys/pal/unix/thread.rs:107:17
  41:     0x7fc3b8a9caa4 - <unknown>
  42:     0x7fc3b8b29c3c - <unknown>
  43:                0x0 - <unknown>
```