### PR TITLE
Don't use quantization in exact plain search

### DIFF
--- a/lib/segment/src/index/vector_index_search_common.rs
+++ b/lib/segment/src/index/vector_index_search_common.rs
@@ -20,7 +20,8 @@ pub fn is_quantized_search(
         .and_then(|p| p.quantization)
         .map(|q| q.ignore)
         .unwrap_or(default_quantization_ignore_value());
-    quantized_storage.is_some() && !ignore_quantization
+    let exact = params.map(|p| p.exact).unwrap_or(false);
+    quantized_storage.is_some() && !ignore_quantization && !exact
 }
 
 pub fn get_oversampled_top(


### PR DESCRIPTION
This PR skips quantization in plain segment when search parameter `exact` is `true`.

For HNSW case it's safe, HNSW exact changes search params config, and disables quantization