### PR TITLE
Don't push tag with commit id to dockerhub

### DIFF
--- a/.github/actions/branch-build-and-push/action.yaml
+++ b/.github/actions/branch-build-and-push/action.yaml
@@ -65,7 +65,7 @@ runs:
           tags+=("ghcr.io/qdrant/qdrant:${branch}")
         fi
         if [ "${{ inputs.push-to-dockerhub }}" = "true" ]; then
-          tags+=("qdrant/qdrant:${branch}-${GIT_COMMIT_ID}")
+          # Don't push commit tag to Docker Hub to avoid excessive image creation
           tags+=("qdrant/qdrant:${branch}")
         fi
 


### PR DESCRIPTION
We don't want to bloat https://hub.docker.com/r/qdrant/qdrant/tags with `dev` commit ID images. It's only useful for development hence we should keep it only in ghcr