### PR TITLE
Revert "Fix flaky save_on_disk test race condition (#7126)"

### DIFF
--- a/lib/common/common/src/save_on_disk.rs
+++ b/lib/common/common/src/save_on_disk.rs
@@ -94,7 +94,7 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             let notification_guard = self.notification_lock.lock();
             // Based on https://github.com/Amanieu/parking_lot/issues/165
             RwLockReadGuard::unlocked(&mut data_read_guard, || {
-                // Move the guard in so it gets unlocked before we re-lock g
+                // Move the guard in so it gets unlocked before we re-lock the RwLock read guard
                 let mut guard = notification_guard;
                 self.change_notification.wait_for(&mut guard, timeout);
             });


### PR DESCRIPTION
This reverts commit 80f0b53ceaf0572d29ad3691c0ab1d2441f49d28 from https://github.com/qdrant/qdrant/pull/7126.

It seems to have introduced more flakiness than it resolved.

Related flakiness reports:
- https://github.com/qdrant/qdrant/issues/7156
- https://github.com/qdrant/qdrant/issues/7181

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?