### PR TITLE
make sure that grpc::Vector can always use new format

### DIFF
--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -411,8 +411,8 @@ impl TryFrom<grpc::VectorsOutput> for VectorStructInternal {
 
 impl From<VectorInternal> for grpc::Vector {
     fn from(vector: VectorInternal) -> Self {
-        // ToDo: before deprecating `data`, `indices`, and `vectors_count`, ensure
-        // ToDo: that `vector` field is generated here.
+        // ToDo(v1.18): before deprecating `data`, `indices`, and `vectors_count`, ensure
+        //             that `vector` field is generated here.
         match vector {
             VectorInternal::Dense(vector) => Self {
                 data: vector,

--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -411,7 +411,7 @@ impl TryFrom<grpc::VectorsOutput> for VectorStructInternal {
 
 impl From<VectorInternal> for grpc::Vector {
     fn from(vector: VectorInternal) -> Self {
-        // ToDo(v1.18): before deprecating `data`, `indices`, and `vectors_count`, ensure
+        // ToDo(v1.17): before deprecating `data`, `indices`, and `vectors_count`, ensure
         //             that `vector` field is generated here.
         match vector {
             VectorInternal::Dense(vector) => Self {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -182,7 +182,7 @@ pub fn try_discover_request_from_grpc(
         shard_key_selector,
     } = value;
 
-    let target = target.map(TryInto::try_into).transpose()?;
+    let target = target.map(RecommendExample::try_from).transpose()?;
 
     let context = context
         .into_iter()
@@ -1023,7 +1023,7 @@ impl<'a> From<CollectionCoreSearchRequest<'a>> for api::grpc::qdrant::CoreSearch
         } = request;
         Self {
             collection_name: collection_id,
-            query: Some(query.clone().into()),
+            query: Some(api::grpc::QueryEnum::from(query.clone())),
             filter: filter.clone().map(|f| f.into()),
             limit: *limit as u64,
             with_vectors: with_vector.clone().map(|wv| wv.into()),
@@ -1184,8 +1184,8 @@ impl TryFrom<api::grpc::qdrant::VectorExample> for RecommendExample {
                     let api::grpc::qdrant::Vector {
                         data,
                         indices,
-                        vectors_count: _,
-                        vector: _,
+                        vectors_count: _, // Ignored, since only used in old API
+                        vector: _,        // Ignored, since only used in old API
                     } = vector;
                     match indices {
                         Some(indices) => {
@@ -1233,23 +1233,23 @@ impl TryFrom<api::grpc::qdrant::RecommendPoints> for RecommendRequestInternal {
         } = value;
         let positive_ids = positive
             .into_iter()
-            .map(TryInto::try_into)
+            .map(RecommendExample::try_from)
             .collect::<Result<Vec<RecommendExample>, Self::Error>>()?;
 
         let positive_vectors = positive_vectors
             .into_iter()
-            .map(TryInto::try_into)
+            .map(RecommendExample::try_from)
             .collect::<Result<_, _>>()?;
         let positive = [positive_ids, positive_vectors].concat();
 
         let negative_ids = negative
             .into_iter()
-            .map(TryInto::try_into)
+            .map(RecommendExample::try_from)
             .collect::<Result<Vec<RecommendExample>, Self::Error>>()?;
 
         let negative_vectors = negative_vectors
             .into_iter()
-            .map(TryInto::try_into)
+            .map(RecommendExample::try_from)
             .collect::<Result<_, _>>()?;
         let negative = [negative_ids, negative_vectors].concat();
 

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sparse::common::sparse_vector::SparseVector;
+use sparse::common::types::DimId;
 use validator::Validate;
 
 use super::named_vectors::NamedVectors;
@@ -47,6 +48,17 @@ impl VectorInternal {
                 }
             }
             VectorInternal::MultiDense(_) => {}
+        }
+    }
+
+    pub fn from_vector_and_indices(vector: DenseVector, indices: Option<Vec<DimId>>) -> Self {
+        if let Some(indices) = indices {
+            VectorInternal::Sparse(SparseVector {
+                indices,
+                values: vector,
+            })
+        } else {
+            VectorInternal::Dense(vector)
         }
     }
 }

--- a/lib/shard/src/search.rs
+++ b/lib/shard/src/search.rs
@@ -76,11 +76,11 @@ impl TryFrom<api::grpc::qdrant::CoreSearchPoints> for CoreSearchRequest {
             .map(|query| {
                 Ok(match query {
                     api::grpc::qdrant::query_enum::Query::NearestNeighbors(vector) => {
+                        let vector_internal = VectorInternal::try_from(vector)?;
                         QueryEnum::Nearest(NamedQuery::from(
                             api::grpc::conversions::into_named_vector_struct(
                                 value.vector_name,
-                                vector.data,
-                                vector.indices,
+                                vector_internal,
                             )?,
                         ))
                     }
@@ -192,8 +192,11 @@ impl TryFrom<api::grpc::qdrant::SearchPoints> for CoreSearchRequest {
             })?;
         }
 
+        let vector_internal =
+            VectorInternal::from_vector_and_indices(vector, sparse_indices.map(|v| v.data));
+
         let vector_struct =
-            api::grpc::conversions::into_named_vector_struct(vector_name, vector, sparse_indices)?;
+            api::grpc::conversions::into_named_vector_struct(vector_name, vector_internal)?;
 
         Ok(Self {
             query: QueryEnum::Nearest(NamedQuery::from(vector_struct)),


### PR DESCRIPTION
Some internal APIs were still relying on the old format of `grpc::Vector`. 
This PR covers last missing parts of missing conversions, so that in the next version we can deprecate old format and always generate structures using a new one